### PR TITLE
add_cl_graphs() fixed - config change - graph model -> KnowledgeGraph

### DIFF
--- a/cognee/infrastructure/databases/graph/config.py
+++ b/cognee/infrastructure/databases/graph/config.py
@@ -1,9 +1,11 @@
 """ This module contains the configuration for the graph database. """
+
 import os
 from functools import lru_cache
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from cognee.infrastructure.databases.relational.config import get_relationaldb_config
-from cognee.shared.data_models import DefaultGraphModel, GraphDBType
+from cognee.shared.data_models import DefaultGraphModel, GraphDBType, KnowledgeGraph
+
 
 class GraphConfig(BaseSettings):
     graph_filename: str = "cognee_graph.pkl"
@@ -12,11 +14,13 @@ class GraphConfig(BaseSettings):
     graph_database_username: str = ""
     graph_database_password: str = ""
     graph_database_port: int = 123
-    graph_file_path: str = os.path.join(get_relationaldb_config().db_path, graph_filename)
-    graph_engine: object =  GraphDBType.NETWORKX
-    graph_model: object = DefaultGraphModel
+    graph_file_path: str = os.path.join(
+        get_relationaldb_config().db_path, graph_filename
+    )
+    graph_engine: object = GraphDBType.NETWORKX
+    graph_model: object = KnowledgeGraph
 
-    model_config = SettingsConfigDict(env_file = ".env", extra = "allow")
+    model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
     def to_dict(self) -> dict:
         return {
@@ -28,9 +32,9 @@ class GraphConfig(BaseSettings):
             "graph_database_username": self.graph_database_username,
             "graph_database_password": self.graph_database_password,
             "graph_database_port": self.graph_database_port,
-            "graph_engine": self.graph_engine
-
+            "graph_engine": self.graph_engine,
         }
+
 
 @lru_cache
 def get_graph_config():

--- a/cognee/modules/cognify/graph/add_cognitive_layer_graphs.py
+++ b/cognee/modules/cognify/graph/add_cognitive_layer_graphs.py
@@ -3,9 +3,11 @@ from uuid import uuid4
 from typing import List, Tuple, TypedDict
 from pydantic import BaseModel
 from cognee.infrastructure.databases.vector import DataPoint
+
 # from cognee.utils import extract_pos_tags, extract_named_entities, extract_sentiment_vader
 from cognee.infrastructure.databases.graph.config import get_graph_config
 from cognee.infrastructure.databases.vector.config import get_vectordb_config
+
 
 class GraphLike(TypedDict):
     nodes: List


### PR DESCRIPTION
The cognitive layer graphs can now be correctly added. 

The key change is the following line: 

`graph_model: object = KnowledgeGraph` from the` graph/config`

Given that the graph model was set to `DefaultGraphModel` there was a mismatch of pydantic models in this code block: 

```
        if not isinstance(layer_graph, graph_model):
            layer_graph = graph_model.parse_obj(layer_graph)
```

from the `cognee/modules/cognify/graph/add_cognitive_layer_graphs.py`
