### PR TITLE
docs: Fix postgres install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ If you have questions, join our  <a href="https://discord.gg/NQPKmU5CCg">Discord
 pip install cognee
 ```
 
+### With pip with PostgreSQL support
+
+```bash
+pip install 'cognee[postgres]'
+```
 
 ### With poetry
 


### PR DESCRIPTION
Fix instruction on how to install postgres

Docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added new installation instructions for PostgreSQL support using `pip` and `poetry`. 
		- New command for `pip`: `pip install 'cognee[postgres]'`
		- New command for `poetry`: `poetry add cognee -E postgres`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->