### PR TITLE
Remove automatic execution of test that require LLM inputs from merge…

### DIFF
--- a/.github/workflows/test_neo4j.yml
+++ b/.github/workflows/test_neo4j.yml
@@ -2,6 +2,10 @@ name: test | neo4j
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,6 +15,8 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
+  if: ${{ github.event.label.name == 'run-checks' }}
+
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml

--- a/.github/workflows/test_neo4j.yml
+++ b/.github/workflows/test_neo4j.yml
@@ -1,9 +1,6 @@
 name: test | neo4j
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test_neo4j.yml
+++ b/.github/workflows/test_neo4j.yml
@@ -15,8 +15,6 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
-  if: ${{ github.event.label.name == 'run-checks' }}
-
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml
@@ -24,7 +22,7 @@ jobs:
   run_neo4j_integration_test:
     name: test
     needs: get_docs_changes
-    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true' | ${{ github.event.label.name == 'run-checks' }}
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -16,8 +16,6 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
-  if: ${{ github.event.label.name == 'run-checks' }}
-
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml
@@ -25,7 +23,7 @@ jobs:
   run_notebook_test:
     name: test
     needs: get_docs_changes
-    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true' | ${{ github.event.label.name == 'run-checks' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -2,6 +2,11 @@ name: test | notebook
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [labeled]
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,6 +16,8 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
+  if: ${{ github.event.label.name == 'run-checks' }}
+
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -1,9 +1,6 @@
 name: test | notebook
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test_pgvector.yml
+++ b/.github/workflows/test_pgvector.yml
@@ -1,9 +1,6 @@
 name: test | pgvector
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test_pgvector.yml
+++ b/.github/workflows/test_pgvector.yml
@@ -16,8 +16,6 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
-  if: ${{ github.event.label.name == 'run-checks' }}
-
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml
@@ -25,7 +23,7 @@ jobs:
   run_pgvector_integration_test:
     name: test
     needs: get_docs_changes
-    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true' | ${{ github.event.label.name == 'run-checks' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/test_pgvector.yml
+++ b/.github/workflows/test_pgvector.yml
@@ -2,6 +2,11 @@ name: test | pgvector
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [labeled]
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,6 +16,8 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
+  if: ${{ github.event.label.name == 'run-checks' }}
+
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml

--- a/.github/workflows/test_qdrant.yml
+++ b/.github/workflows/test_qdrant.yml
@@ -1,9 +1,6 @@
 name: test | qdrant
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test_qdrant.yml
+++ b/.github/workflows/test_qdrant.yml
@@ -2,6 +2,11 @@ name: test | qdrant
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [labeled]
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,6 +16,8 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
+  if: ${{ github.event.label.name == 'run-checks' }}
+
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml

--- a/.github/workflows/test_qdrant.yml
+++ b/.github/workflows/test_qdrant.yml
@@ -16,8 +16,6 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
-  if: ${{ github.event.label.name == 'run-checks' }}
-
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml
@@ -25,7 +23,7 @@ jobs:
   run_qdrant_integration_test:
     name: test
     needs: get_docs_changes
-    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true' | ${{ github.event.label.name == 'run-checks' }}
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/test_weaviate.yml
+++ b/.github/workflows/test_weaviate.yml
@@ -16,8 +16,6 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
-  if: ${{ github.event.label.name == 'run-checks' }}
-
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml
@@ -25,7 +23,7 @@ jobs:
   run_weaviate_integration_test:
     name: test
     needs: get_docs_changes
-    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true' | ${{ github.event.label.name == 'run-checks' }}
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/test_weaviate.yml
+++ b/.github/workflows/test_weaviate.yml
@@ -1,9 +1,6 @@
 name: test | weaviate
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test_weaviate.yml
+++ b/.github/workflows/test_weaviate.yml
@@ -2,6 +2,11 @@ name: test | weaviate
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [labeled]
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,6 +16,8 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
+  if: ${{ github.event.label.name == 'run-checks' }}
+
   get_docs_changes:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml


### PR DESCRIPTION
… requests onto main.

To save money on OpenAI credits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Workflows for Neo4j, Notebook, pgvector, Qdrant, and Weaviate can now be manually triggered, simplifying the initiation process.
  
- **Bug Fixes**
	- Removed automatic triggers for pull requests targeting the `main` branch across multiple workflows, ensuring more controlled execution.
  
- **Improvements**
	- Workflows now respond to pull requests labeled with `run-checks`, allowing for conditional execution based on specific criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->