### PR TITLE
Add manual execution for python-3.X tests

### DIFF
--- a/.github/workflows/test_python_3_10.yml
+++ b/.github/workflows/test_python_3_10.yml
@@ -1,13 +1,14 @@
 name: test | python 3.10
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
+    types: [labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }} | ${{ github.event.label.name == 'run-checks' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test_python_3_11.yml
+++ b/.github/workflows/test_python_3_11.yml
@@ -1,13 +1,14 @@
 name: test | python 3.11
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
+    types: [labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }} | ${{ github.event.label.name == 'run-checks' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test_python_3_9.yml
+++ b/.github/workflows/test_python_3_9.yml
@@ -1,13 +1,14 @@
 name: test | python 3.9
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
+    types: [labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }} | ${{ github.event.label.name == 'run-checks' }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added manual triggering capabilities for workflows in Python 3.9, 3.10, and 3.11.
	- Enhanced concurrency management based on the presence of a 'run-checks' label.

- **Bug Fixes**
	- Adjusted workflow triggers to respond correctly to labeled events, improving workflow execution control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->