### PR TITLE
COG-546 local script dependencies

### DIFF
--- a/cognee/tasks/repo_processor/__init__.py
+++ b/cognee/tasks/repo_processor/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("task:repo_processor")

--- a/cognee/tasks/repo_processor/local_script_dependencies.py
+++ b/cognee/tasks/repo_processor/local_script_dependencies.py
@@ -1,13 +1,14 @@
-from contextlib import contextmanager
-from typing import List, Dict, Optional
+import argparse
 import asyncio
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import List, Dict, Optional
+
 import aiofiles
 import jedi
 import parso
-import sys
-from pathlib import Path
 from parso.tree import BaseNode
-
 
 @contextmanager
 def add_sys_path(path):
@@ -91,10 +92,20 @@ async def get_local_script_dependencies(script_path: str, repo_path: Optional[st
         dependencies = await _extract_dependencies(script_path)
     return dependencies
 
+
 if __name__ == "__main__":
-    # Simple execution example, use absolute paths
-    script_path = ".../cognee/examples/python/simple_example.py"
-    repo_path = ".../cognee"
+    parser = argparse.ArgumentParser(description="Get local script dependencies.")
+
+    # Suggested path: .../cognee/examples/python/simple_example.py
+    parser.add_argument("script_path", type=str, help="Absolute path to the Python script file")
+
+    # Suggested path: .../cognee
+    parser.add_argument("repo_path", type=str, help="Absolute path to the repository root")
+
+    args = parser.parse_args()
+
+    script_path = args.script_path
+    repo_path = args.repo_path
 
     dependencies = asyncio.run(get_local_script_dependencies(script_path, repo_path))
 

--- a/cognee/tasks/repo_processor/local_script_dependencies.py
+++ b/cognee/tasks/repo_processor/local_script_dependencies.py
@@ -54,8 +54,12 @@ def _update_code_entity(script: jedi.Script, code_entity: Dict[str, any]) -> Non
         code_entity["module_path"] = getattr(results[0], "module_path", None)
 
 def _extract_dependencies(script_path: str) -> List[str]:
-    with open(script_path, "r") as file:
-        source_code = file.read()
+    try:
+        with open(script_path, "r") as file:
+            source_code = file.read()
+    except IOError as e:
+        print(f"Error opening {script_path}: {e}")
+        return []
 
     script = jedi.Script(code=source_code, path=script_path)
 

--- a/cognee/tasks/repo_processor/local_script_dependencies.py
+++ b/cognee/tasks/repo_processor/local_script_dependencies.py
@@ -49,11 +49,16 @@ def _update_code_entity(script: jedi.Script, code_entity: Dict[str, any]) -> Non
     """
     Update a code_entity with (full_name, module_name, module_path) using Jedi
     """
-    results = script.goto(code_entity["line"], code_entity["column"], follow_imports=True)
-    if results:
-        code_entity["full_name"] = getattr(results[0], "full_name", None)
-        code_entity["module_name"] = getattr(results[0], "module_name", None)
-        code_entity["module_path"] = getattr(results[0], "module_path", None)
+    try:
+        results = script.goto(code_entity["line"], code_entity["column"], follow_imports=True)
+        if results:
+            result = results[0]
+            code_entity["full_name"] = getattr(result, "full_name", None)
+            code_entity["module_name"] = getattr(result, "module_name", None)
+            code_entity["module_path"] = getattr(result, "module_path", None)
+    except Exception as e:
+        # logging.warning(f"Failed to analyze code entity {code_entity['name']}: {e}")
+        print(f"Failed to analyze code entity {code_entity['name']}: {e}")
 
 async def _extract_dependencies(script_path: str) -> List[str]:
     try:
@@ -63,6 +68,7 @@ async def _extract_dependencies(script_path: str) -> List[str]:
         print(f"Error opening {script_path}: {e}")
         return []
 
+    jedi.set_debug_function(lambda color, str_out: None)
     script = jedi.Script(code=source_code, path=script_path)
 
     tree = parso.parse(source_code)

--- a/cognee/tasks/repo_processor/local_script_dependencies.py
+++ b/cognee/tasks/repo_processor/local_script_dependencies.py
@@ -87,7 +87,15 @@ async def _extract_dependencies(script_path: str) -> List[str]:
         if entity.get("module_path") is not None
     }
 
-    return sorted(str(path) for path in module_paths)
+    str_paths = []
+    for module_path in module_paths:
+        try:
+            str_paths.append(str(module_path))
+        except Exception as e:
+            logger.error(f"Error converting path to string: {e}")
+
+    return sorted(str_paths)
+
 
 async def get_local_script_dependencies(script_path: str, repo_path: Optional[str] = None) -> List[str]:
     """

--- a/cognee/tasks/repo_processor/local_script_dependencies.py
+++ b/cognee/tasks/repo_processor/local_script_dependencies.py
@@ -84,7 +84,7 @@ async def _extract_dependencies(script_path: str) -> List[str]:
     module_paths = {
         entity.get("module_path")
         for entity in code_entities
-        if entity.get("module_path")
+        if entity.get("module_path") is not None
     }
 
     return sorted(str(path) for path in module_paths)

--- a/cognee/tasks/repo_processor/local_script_dependencies.py
+++ b/cognee/tasks/repo_processor/local_script_dependencies.py
@@ -10,6 +10,9 @@ import jedi
 import parso
 from parso.tree import BaseNode
 
+from cognee.tasks.repo_processor import logger
+
+
 @contextmanager
 def add_sys_path(path):
     original_sys_path = sys.path.copy()
@@ -58,14 +61,15 @@ def _update_code_entity(script: jedi.Script, code_entity: Dict[str, any]) -> Non
             code_entity["module_path"] = getattr(result, "module_path", None)
     except Exception as e:
         # logging.warning(f"Failed to analyze code entity {code_entity['name']}: {e}")
-        print(f"Failed to analyze code entity {code_entity['name']}: {e}")
+        logger.error(f"Failed to analyze code entity {code_entity['name']}: {e}")
+
 
 async def _extract_dependencies(script_path: str) -> List[str]:
     try:
         async with aiofiles.open(script_path, "r") as file:
             source_code = await file.read()
     except IOError as e:
-        print(f"Error opening {script_path}: {e}")
+        logger.error(f"Error opening {script_path}: {e}")
         return []
 
     jedi.set_debug_function(lambda color, str_out: None)

--- a/cognee/tasks/repo_processor/local_script_dependencies.py
+++ b/cognee/tasks/repo_processor/local_script_dependencies.py
@@ -1,0 +1,83 @@
+from typing import List, Dict, Optional
+import jedi
+import parso
+import sys
+from pathlib import Path
+from parso.tree import BaseNode
+
+
+def get_code_entities(node: parso.tree.NodeOrLeaf) -> List[Dict[str, any]]:
+    """
+    Recursively extract code entities using parso.
+    """
+    code_entity_list = []
+
+    if not hasattr(node, 'children'):
+        return code_entity_list
+
+    # Process nodes of type 'name', which correspond to code entities
+    name_nodes = (child for child in node.children if child.type == 'name')
+    for name_node in name_nodes:
+        code_entity = {
+            'name': name_node.value,
+            'line': name_node.start_pos[0],
+            'column': name_node.start_pos[1]
+        }
+        code_entity_list.append(code_entity)
+
+    # Recursively process child nodes
+    for child in node.children:
+        code_entity_list.extend(get_code_entities(child))
+
+    return code_entity_list
+
+
+def update_code_entity(script: jedi.Script, code_entity: Dict[str, any]) -> None:
+    """
+    Update a code_entity with (full_name, module_name, module_path) using Jedi
+    """
+    results = script.goto(code_entity["line"], code_entity["column"], follow_imports=True)
+    if results:
+        code_entity["full_name"] = getattr(results[0], "full_name", None)
+        code_entity["module_name"] = getattr(results[0], "module_name", None)
+        code_entity["module_path"] = getattr(results[0], "module_path", None)
+
+
+def get_local_script_dependencies(script_path: str, repo_path: Optional[str] = None) -> List[str]:
+    """
+    Extract and return a list of unique module paths that the script depends on.
+    """
+    if repo_path:
+        sys.path.insert(0, str(Path(repo_path).resolve()))
+
+    with open(script_path, "r") as file:
+        source_code = file.read()
+
+    script = jedi.Script(code=source_code, path=script_path)
+
+    tree = parso.parse(source_code)
+    code_entities = get_code_entities(tree)
+
+    for code_entity in code_entities:
+        update_code_entity(script, code_entity)
+
+    module_paths = {
+        entity.get("module_path")
+        for entity in code_entities
+        if entity.get("module_path")
+    }
+    if repo_path:
+        repo_path_resolved = str(Path(repo_path).resolve(strict=False))
+        module_paths = {path for path in module_paths if str(path).startswith(repo_path_resolved)}
+
+    return sorted(path for path in module_paths if path)
+
+if __name__ == "__main__":
+    # Simple execution example, use absolute paths
+    script_path = ".../cognee/examples/python/simple_example.py"
+    repo_path = ".../cognee"
+
+    dependencies = get_local_script_dependencies(script_path, repo_path)
+    print("Dependencies:")
+    for dependency in dependencies:
+        print(dependency)

--- a/cognee/tasks/repo_processor/local_script_dependencies.py
+++ b/cognee/tasks/repo_processor/local_script_dependencies.py
@@ -26,7 +26,6 @@ def _get_code_entities(node: parso.tree.NodeOrLeaf) -> List[Dict[str, any]]:
     if not hasattr(node, 'children'):
         return code_entity_list
 
-    # Process nodes of type 'name', which correspond to code entities
     name_nodes = (child for child in node.children if child.type == 'name')
     for name_node in name_nodes:
         code_entity = {


### PR DESCRIPTION
A utility function, `get_local_script_dependencies`: 
- Extracts and resolves local dependencies of a Python script using `jedi` and `parso`. 
- Returns a sorted list of unique module paths 
- Optionally dependencies outside a specified repository path are filtered out

Will be used for creating a graph from a repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functionality for extracting and updating code entities from Python scripts.
	- Added a method to retrieve unique module paths that a script depends on.
	- Implemented a context manager for temporary system path modifications.
	- Included asynchronous handling for dependency extraction.
	- Demonstrated the new functionality with example paths.
	- Added a structured logging mechanism for improved tracking and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->