### PR TITLE
Switch to gpt-4o-mini by default

### DIFF
--- a/.github/workflows/test_cognee_llama_index_notebook.yml
+++ b/.github/workflows/test_cognee_llama_index_notebook.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --no-interaction
+          poetry install --no-interaction --all-extras 
           poetry add jupyter --no-interaction
 
       - name: Execute Jupyter Notebook

--- a/.github/workflows/test_cognee_llama_index_notebook.yml
+++ b/.github/workflows/test_cognee_llama_index_notebook.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --no-interaction --all-extras --no-root
+          poetry install --no-interaction
           poetry add jupyter --no-interaction
 
       - name: Execute Jupyter Notebook

--- a/cognee-frontend/src/ui/Partials/SettingsModal/Settings.tsx
+++ b/cognee-frontend/src/ui/Partials/SettingsModal/Settings.tsx
@@ -30,8 +30,8 @@ const defaultProvider = {
 };
 
 const defaultModel = {
-  label: 'gpt-4o',
-  value: 'gpt-4o',
+  label: 'gpt-4o-mini',
+  value: 'gpt-4o-mini',
 };
 
 export default function Settings({ onDone = () => {}, submitButtonText = 'Save' }) {

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class LLMConfig(BaseSettings):
     llm_provider: str = "openai"
-    llm_model: str = "gpt-4o"
+    llm_model: str = "gpt-4o-mini"
     llm_endpoint: str = ""
     llm_api_key: Optional[str] = None
     llm_temperature: float = 0.0

--- a/cognee/modules/settings/get_settings.py
+++ b/cognee/modules/settings/get_settings.py
@@ -73,6 +73,9 @@ def get_settings() -> SettingsDict:
             "providers": llm_providers,
             "models": {
                 "openai": [{
+                    "value": "gpt-4o-mini",
+                    "label": "gpt-4o-mini",
+                }, {
                     "value": "gpt-4o",
                     "label": "gpt-4o",
                 }, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new model option, "gpt-4o-mini," in the settings for improved user choice.

- **Bug Fixes**
	- Updated the default model representation in the settings to reflect the new "gpt-4o-mini" designation.

These changes enhance the user experience by providing more accurate model options in the settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->