### PR TITLE
Rename remaining 'query' keyword args in cognee.search to 'query_text'

### DIFF
--- a/cognee/tests/test_code_generation.py
+++ b/cognee/tests/test_code_generation.py
@@ -26,7 +26,7 @@ async def  main():
 
     await render_graph(None, include_nodes = True, include_labels = True)
 
-    search_results = await cognee.search(SearchType.CHUNKS, query = "Student")
+    search_results = await cognee.search(SearchType.CHUNKS, query_text = "Student")
     assert len(search_results) != 0, "The search results list is empty."
     print("\n\nExtracted chunks are:\n")
     for result in search_results:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,7 +59,7 @@ await cognee.add(text) # Add a new piece of information
 
 await cognee.cognify() # Use LLMs and cognee to create knowledge
 
-search_results = await cognee.search("INSIGHTS", {'query_text': 'Tell me about NLP'}) # Query cognee for the knowledge
+search_results = await cognee.search(SearchType.INSIGHTS, query_text='Tell me about NLP')  # Query cognee for the knowledge
 
 for result_text in search_results:
     print(result_text)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,7 +59,7 @@ await cognee.add(text) # Add a new piece of information
 
 await cognee.cognify() # Use LLMs and cognee to create knowledge
 
-search_results = await cognee.search("INSIGHTS", {'query': 'Tell me about NLP'}) # Query cognee for the knowledge
+search_results = await cognee.search("INSIGHTS", {'query_text': 'Tell me about NLP'}) # Query cognee for the knowledge
 
 for result_text in search_results:
     print(result_text)

--- a/examples/python/dynamic_steps_example.py
+++ b/examples/python/dynamic_steps_example.py
@@ -209,7 +209,7 @@ async def main(enable_steps):
     if enable_steps.get("search_insights"):
         search_results = await cognee.search(
             SearchType.INSIGHTS,
-            {'query': 'Which applicant has the most relevant experience in data science?'}
+            query_text='Which applicant has the most relevant experience in data science?'
         )
         print("Search results:")
         for result_text in search_results:

--- a/examples/python/simple_example.py
+++ b/examples/python/simple_example.py
@@ -27,7 +27,7 @@ async def main():
 
     # Query cognee for insights on the added text
     search_results = await cognee.search(
-        SearchType.INSIGHTS, query='Tell me about NLP'
+        SearchType.INSIGHTS, query_text='Tell me about NLP'
     )
 
     # Display search results


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `search` method to use `query_text` instead of `query` for improved clarity in function calls.

- **Documentation**
	- Revised documentation to reflect the updated parameter name in the `search` function, ensuring users are informed of the correct usage.

- **Examples**
	- Adjusted example scripts to demonstrate the new parameter name for the `search` method, enhancing readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->