### PR TITLE
test: Update gh actions so they can run outside of PR to main

### DIFF
--- a/.github/workflows/test_cognee_llama_index_notebook.yml
+++ b/.github/workflows/test_cognee_llama_index_notebook.yml
@@ -3,8 +3,6 @@ name: test | llama index notebook
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 concurrency:

--- a/.github/workflows/test_cognee_multimedia_notebook.yml
+++ b/.github/workflows/test_cognee_multimedia_notebook.yml
@@ -3,8 +3,6 @@ name: test | multimedia notebook
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 concurrency:

--- a/.github/workflows/test_dynamic_steps_example.yml
+++ b/.github/workflows/test_dynamic_steps_example.yml
@@ -3,8 +3,6 @@ name: test | dynamic steps example
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 

--- a/.github/workflows/test_milvus.yml
+++ b/.github/workflows/test_milvus.yml
@@ -3,8 +3,6 @@ name: test | milvus
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 concurrency:

--- a/.github/workflows/test_multimedia_example.yaml
+++ b/.github/workflows/test_multimedia_example.yaml
@@ -3,8 +3,6 @@ name: test | multimedia example
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 

--- a/.github/workflows/test_neo4j.yml
+++ b/.github/workflows/test_neo4j.yml
@@ -3,8 +3,6 @@ name: test | neo4j
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 concurrency:

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -3,8 +3,6 @@ name: test | notebook
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 

--- a/.github/workflows/test_pgvector.yml
+++ b/.github/workflows/test_pgvector.yml
@@ -3,8 +3,6 @@ name: test | pgvector
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 

--- a/.github/workflows/test_python_3_10.yml
+++ b/.github/workflows/test_python_3_10.yml
@@ -3,8 +3,6 @@ name: test | python 3.10
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 concurrency:

--- a/.github/workflows/test_python_3_11.yml
+++ b/.github/workflows/test_python_3_11.yml
@@ -3,8 +3,6 @@ name: test | python 3.11
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 concurrency:

--- a/.github/workflows/test_python_3_9.yml
+++ b/.github/workflows/test_python_3_9.yml
@@ -3,8 +3,6 @@ name: test | python 3.9
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 concurrency:

--- a/.github/workflows/test_qdrant.yml
+++ b/.github/workflows/test_qdrant.yml
@@ -3,8 +3,6 @@ name: test | qdrant
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 

--- a/.github/workflows/test_simple_example.yml
+++ b/.github/workflows/test_simple_example.yml
@@ -3,8 +3,6 @@ name: test | simple example
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 

--- a/.github/workflows/test_weaviate.yml
+++ b/.github/workflows/test_weaviate.yml
@@ -3,8 +3,6 @@ name: test | weaviate
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
     types: [labeled, synchronize]
 
 


### PR DESCRIPTION
Allow github actions to run on PRs that aren't targeting main

Test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Workflow triggers for pull requests have been updated to allow execution on any branch, enhancing flexibility for testing across different development branches.

- **Bug Fixes**
	- Removed branch restrictions from multiple workflows to ensure they trigger correctly for pull requests not limited to the `main` branch.

- **Chores**
	- Minor adjustments made to workflow configurations to streamline testing processes without altering job definitions or concurrency settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->