### PR TITLE
fix: Resolve reflection issue when running cognee a second time after…

### DIFF
--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -113,12 +113,10 @@ class SQLAlchemyAdapter():
         """
         async with self.engine.begin() as connection:
             if self.engine.dialect.name == "sqlite":
-                # Create a MetaData instance to load table information
-                metadata = MetaData()
-                # Load table information from schema into MetaData
-                await connection.run_sync(metadata.reflect)
-                if table_name in metadata.tables:
-                    return metadata.tables[table_name]
+                # Load the schema information into the MetaData object
+                await connection.run_sync(Base.metadata.reflect)
+                if table_name in Base.metadata.tables:
+                    return Base.metadata.tables[table_name]
                 else:
                     raise EntityNotFoundError(message=f"Table '{table_name}' not found.")
             else:
@@ -140,11 +138,8 @@ class SQLAlchemyAdapter():
         table_names = []
         async with self.engine.begin() as connection:
             if self.engine.dialect.name == "sqlite":
-                # Create a MetaData instance to load table information
-                metadata = MetaData()
-                # Load table information from schema into MetaData
-                await connection.run_sync(metadata.reflect)
-                for table in metadata.tables:
+                await connection.run_sync(Base.metadata.reflect)
+                for table in Base.metadata.tables:
                     table_names.append(str(table))
             else:
                 schema_list = await self.get_schema_list()

--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -113,10 +113,12 @@ class SQLAlchemyAdapter():
         """
         async with self.engine.begin() as connection:
             if self.engine.dialect.name == "sqlite":
-                # Load the schema information into the MetaData object
-                await connection.run_sync(Base.metadata.reflect)
-                if table_name in Base.metadata.tables:
-                    return Base.metadata.tables[table_name]
+                # Create a MetaData instance to load table information
+                metadata = MetaData()
+                # Load table information from schema into MetaData
+                await connection.run_sync(metadata.reflect)
+                if table_name in metadata.tables:
+                    return metadata.tables[table_name]
                 else:
                     raise EntityNotFoundError(message=f"Table '{table_name}' not found.")
             else:
@@ -138,8 +140,11 @@ class SQLAlchemyAdapter():
         table_names = []
         async with self.engine.begin() as connection:
             if self.engine.dialect.name == "sqlite":
-                await connection.run_sync(Base.metadata.reflect)
-                for table in Base.metadata.tables:
+                # Create a MetaData instance to load table information
+                metadata = MetaData()
+                # Load table information from schema into MetaData
+                await connection.run_sync(metadata.reflect)
+                for table in metadata.tables:
                     table_names.append(str(table))
             else:
                 schema_list = await self.get_schema_list()

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -2,7 +2,7 @@ import asyncio
 from uuid import UUID
 from typing import List, Optional, get_type_hints
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy import JSON, Column, Table, select, delete
+from sqlalchemy import JSON, Column, Table, select, delete, MetaData
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 from cognee.exceptions import InvalidValueError
@@ -48,10 +48,12 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
 
     async def has_collection(self, collection_name: str) -> bool:
         async with self.engine.begin() as connection:
-            # Load the schema information into the MetaData object
-            await connection.run_sync(Base.metadata.reflect)
+            # Create a MetaData instance to load table information
+            metadata = MetaData()
+            # Load table information from schema into MetaData
+            await connection.run_sync(metadata.reflect)
 
-            if collection_name in Base.metadata.tables:
+            if collection_name in metadata.tables:
                 return True
             else:
                 return False
@@ -145,10 +147,12 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
         with an async engine.
         """
         async with self.engine.begin() as connection:
-            # Load the schema information into the MetaData object
-            await connection.run_sync(Base.metadata.reflect)
-            if collection_name in Base.metadata.tables:
-                return Base.metadata.tables[collection_name]
+            # Create a MetaData instance to load table information
+            metadata = MetaData()
+            # Load table information from schema into MetaData
+            await connection.run_sync(metadata.reflect)
+            if collection_name in metadata.tables:
+                return metadata.tables[collection_name]
             else:
                 raise EntityNotFoundError(message=f"Table '{collection_name}' not found.")
 


### PR DESCRIPTION
… pruning data

When running cognee a second time after pruning data some metadata doesn't get pruned. This makes cognee believe some tables exist that have been deleted

Fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of database schema reflection and table access.
- **Refactor**
	- Enhanced modularity by centralizing metadata management for dynamic table access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->