### PR TITLE
Comment out the postgres configuration from .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -42,8 +42,8 @@ DB_PROVIDER="sqlite"
 # Database name
 DB_NAME=cognee_db
 
-# Postgres specific parameters (Only if Postgres or PGVector is used)
-DB_HOST=127.0.0.1
-DB_PORT=5432
-DB_USERNAME=cognee
-DB_PASSWORD=cognee
+# Postgres specific parameters (Only if Postgres or PGVector is used). Do not use for cognee default simplest setup of SQLite-NetworkX-LanceDB
+# DB_HOST=127.0.0.1
+# DB_PORT=5432
+# DB_USERNAME=cognee
+# DB_PASSWORD=cognee


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Simplest cognee docker setup of SQLite-NetworkX-LanceDB should not enable  postgres configuration in the .env.template by default.  I think leaving postgres details commented is better than removing them entirely. This keeps simple optionality visible for newcomers.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration template to remove database parameters not used in the default setup, with clearer guidance to ensure the intended configuration is maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->