### PR TITLE
fix: Resolve llama-index integration issue with new cognee version [ COG-1270]

### DIFF
--- a/.github/workflows/test_llama_index_cognee_integration_notebook.yml
+++ b/.github/workflows/test_llama_index_cognee_integration_notebook.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install jupyter
-          pip install llama-index-graph-rag-cognee==0.1.2
+          pip install llama-index-graph-rag-cognee==0.1.3
 
       - name: Execute Jupyter Notebook
         env:

--- a/notebooks/llama_index_cognee_integration.ipynb
+++ b/notebooks/llama_index_cognee_integration.ipynb
@@ -57,7 +57,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "!pip install llama-index-graph-rag-cognee==0.1.2"
+   "source": "!pip install llama-index-graph-rag-cognee==0.1.3"
   },
   {
    "metadata": {},


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Change version to latest llama index cognee integration version which has a proper fix for the failing notebook

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated an AI integration dependency to version 0.1.3 in both the testing workflow and the Jupyter notebook, ensuring that the environment uses the latest version for improved consistency during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->