### PR TITLE
Creation of default user to have is_superuser=True by default

### DIFF
--- a/cognee/modules/users/methods/create_default_user.py
+++ b/cognee/modules/users/methods/create_default_user.py
@@ -8,7 +8,7 @@ async def create_default_user():
     user = await create_user(
         email=default_user_email,
         password=default_user_password,
-        is_superuser=False,
+        is_superuser=True,
         is_active=True,
         is_verified=True,
         auto_login=True,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->

God mode turned on by default for the default user creation.
is_superuser=True in create_default_user.py

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The default user is now created with elevated (superuser) privileges, which may affect access control and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->