### PR TITLE
fix: Add missing LLM_PROVIDER check in environment validation

### DIFF
--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -41,6 +41,7 @@ class LLMConfig(BaseSettings):
         # 1. Check LLM environment variables
         #
         llm_env_vars = {
+            "LLM_PROVIDER": is_env_set("LLM_PROVIDER"),
             "LLM_MODEL": is_env_set("LLM_MODEL"),
             "LLM_ENDPOINT": is_env_set("LLM_ENDPOINT"),
             "LLM_API_KEY": is_env_set("LLM_API_KEY"),
@@ -49,7 +50,7 @@ class LLMConfig(BaseSettings):
             missing_llm = [key for key, is_set in llm_env_vars.items() if not is_set]
             raise ValueError(
                 "You have set some but not all of the required environment variables "
-                f"for LLM usage (LLM_MODEL, LLM_ENDPOINT, LLM_API_KEY). Missing: {missing_llm}"
+                f"for LLM usage (LLM_PROVIDER, LLM_MODEL, LLM_ENDPOINT, LLM_API_KEY). Missing: {missing_llm}"
             )
 
         #


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Resolves #601

Previously, LLMConfig's environment validation logic did not verify if the LLM_PROVIDER variable was set, potentially causing unintended defaulting behavior. This commit explicitly adds LLM_PROVIDER to the set of required environment variables, ensuring consistency and correctness in configuration checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the configuration process to require that all expected environment variables are set together.
  - Updated the error messaging to accurately inform users when the configuration is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->