### PR TITLE
fix int does not have .split function

### DIFF
--- a/cognee/infrastructure/files/utils/get_file_metadata.py
+++ b/cognee/infrastructure/files/utils/get_file_metadata.py
@@ -21,7 +21,7 @@ def get_file_metadata(file: BinaryIO) -> FileMetadata:
     file_type = guess_file_type(file)
 
     file_path = file.name
-    file_name = file_path.split("/")[-1].split(".")[0] if file_path else None
+    file_name = str(file_path).split("/")[-1].split(".")[0] if file_path else None
 
     return FileMetadata(
         name=file_name,

--- a/cognee/modules/ingestion/classify.py
+++ b/cognee/modules/ingestion/classify.py
@@ -11,7 +11,7 @@ def classify(data: Union[str, BinaryIO], filename: str = None):
         return TextData(data)
 
     if isinstance(data, BufferedReader) or isinstance(data, SpooledTemporaryFile):
-        return BinaryData(data, data.name.split("/")[-1] if data.name else filename)
+        return BinaryData(data, str(data.name).split("/")[-1] if data.name else filename)
 
     raise IngestionError(
         message=f"Type of data sent to classify(data: Union[str, BinaryIO) not supported: {type(data)}"


### PR DESCRIPTION
## Description

fix int unable find method .split, not sure why its a int

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
