### PR TITLE
Set LiteLLM logging level

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -58,3 +58,6 @@ DB_NAME=cognee_db
 # MIGRATION_DB_PASSWORD=cognee
 # MIGRATION_DB_HOST="127.0.0.1"
 # MIGRATION_DB_PORT=5432
+
+# LITELLM Logging Level. Set to quiten down logging
+LITELLM_LOG="ERROR"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
LiteLLM adds the debugging lines: LiteLLM:INFO to the output when running and can flood the output making actual cognee debugging difficult. This .env config will suppress logging to ERROR level only.

Note there is an open bug with LiteLLM  here [https://github.com/BerriAI/litellm/issues/9815](https://github.com/BerriAI/litellm/issues/9815) as  'cost calculation' lines will still be shown despite ERROR level logging

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
