### PR TITLE
fix: use default threading in Fastembed

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py
@@ -44,7 +44,7 @@ class FastembedEmbeddingEngine(EmbeddingEngine):
                 embeddings = self.embedding_model.embed(
                     text,
                     batch_size=len(text),
-                    parallel=0,
+                    parallel=None,
                 )
 
                 return list(embeddings)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->
- set the parallel option to None in Fastembed's embedding function

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
