### PR TITLE
Fix: removes ontology resolver initialization at import 

### DIFF
--- a/cognee/modules/graph/utils/expand_with_nodes_and_edges.py
+++ b/cognee/modules/graph/utils/expand_with_nodes_and_edges.py
@@ -15,11 +15,14 @@ from cognee.modules.ontology.rdf_xml.OntologyResolver import OntologyResolver
 def expand_with_nodes_and_edges(
     data_chunks: list[DocumentChunk],
     chunk_graphs: list[KnowledgeGraph],
-    ontology_resolver: OntologyResolver = OntologyResolver(),
+    ontology_resolver: OntologyResolver = None,
     existing_edges_map: Optional[dict[str, bool]] = None,
 ):
     if existing_edges_map is None:
         existing_edges_map = {}
+
+    if ontology_resolver is None:
+        ontology_resolver = OntologyResolver()
 
     added_nodes_map = {}
     added_ontology_nodes_map = {}


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Removes ontology resolver initialization at import.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
