### PR TITLE
Add open mcp marketplace api support

### DIFF
--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -103,3 +103,29 @@ After that add the following snippet to the same file (`cognee-mcp/pyproject.tom
 [tool.uv.sources]
 cognee = { path = "sources/cognee-0.1.38-py3-none-any.whl" }
 ```
+
+
+## Resources 
+
+<details>
+<summary><b>Open MCP Marketplace API Support</b></summary>
+
+![MCP Marketplace User Review Rating Badge](http://www.deepnlp.org/api/marketplace/svg?topoteretes/cognee)|[Reviews](http://www.deepnlp.org/store/ai-agent/mcp-server/pub-topoteretes/cognee)|[GitHub](https://github.com/AI-Agent-Hub/mcp-marketplace)|[Doc](http://www.deepnlp.org/doc/mcp_marketplace)|[MCP Marketplace](http://www.deepnlp.org/store/ai-agent/mcp-server)
+
+Allow AI/Agent/LLM to find this MCP Server via common python/typescript API, search and explore relevant servers and tools
+
+***Example: Search Server and Tools***
+```python
+import anthropic
+import mcp_marketplace as mcpm
+
+result_q = mcpm.search(query="cognee", mode="list", page_id=0, count_per_page=100, config_name="deepnlp") # search server by category choose various endpoint
+result_id = mcpm.search(id="topoteretes/cognee", mode="list", page_id=0, count_per_page=100, config_name="deepnlp")      # search server by id choose various endpoint 
+tools = mcpm.list_tools(id="topoteretes/cognee", config_name="deepnlp_tool")
+# Call Claude to Choose Tools Function Calls 
+# client = anthropic.Anthropic()
+# response = client.messages.create(model="claude-opus-4-20250514", max_tokens=1024, tools=tools, messages=[])
+```
+
+</details>
+


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->

Hi cognee team , 
Your MCP Server is awesome. And I would like to introduce MCP Marketplace Python and Typescript API and add support to your MCP Server, which allow any LLM AI Agent to integrate your MCP servers easily into the workflow, by searching relevant servers and tools meta and schemas, and give LLM more chances to know more about your MCP tools, increase usage from thousands of AI Agents or Applications. And here is a demo backend codes in python to integrate your servers tools for Claude function calls API...

## Resources 

<details>
<summary><b>Open MCP Marketplace API Support</b></summary>

![MCP Marketplace User Review Rating Badge](http://www.deepnlp.org/api/marketplace/svg?topoteretes/cognee)|[Reviews](http://www.deepnlp.org/store/ai-agent/mcp-server/pub-topoteretes/cognee)|[GitHub](https://github.com/AI-Agent-Hub/mcp-marketplace)|[Doc](http://www.deepnlp.org/doc/mcp_marketplace)|[MCP Marketplace](http://www.deepnlp.org/store/ai-agent/mcp-server)

Allow AI/Agent/LLM to find this MCP Server via common python/typescript API, search and explore relevant servers and tools

***Example: Search Server and Tools***
```python
import anthropic
import mcp_marketplace as mcpm

result_q = mcpm.search(query="cognee", mode="list", page_id=0, count_per_page=100, config_name="deepnlp") # search server by category choose various endpoint
result_id = mcpm.search(id="topoteretes/cognee", mode="list", page_id=0, count_per_page=100, config_name="deepnlp")      # search server by id choose various endpoint 
tools = mcpm.list_tools(id="topoteretes/cognee", config_name="deepnlp_tool")
# Call Claude to Choose Tools Function Calls 
# client = anthropic.Anthropic()
# response = client.messages.create(model="claude-opus-4-20250514", max_tokens=1024, tools=tools, messages=[])
```

</details>




## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
