### PR TITLE
Fix: Disable faulty graph metrics calculation in demos

### DIFF
--- a/examples/python/dynamic_steps_example.py
+++ b/examples/python/dynamic_steps_example.py
@@ -1,7 +1,6 @@
 import cognee
 import asyncio
 from cognee.shared.logging_utils import get_logger, ERROR
-from cognee.modules.metrics.operations import get_pipeline_run_metrics
 
 from cognee.api.v1.search import SearchType
 
@@ -180,15 +179,10 @@ async def main(enable_steps):
 
     # Step 3: Create knowledge graph
     if enable_steps.get("cognify"):
-        pipeline_run = await cognee.cognify()
+        await cognee.cognify()
         print("Knowledge graph created.")
 
-    # Step 4: Calculate descriptive metrics
-    if enable_steps.get("graph_metrics"):
-        await get_pipeline_run_metrics(pipeline_run, include_optional=True)
-        print("Descriptive graph metrics saved to database.")
-
-    # Step 5: Query insights
+    # Step 4: Query insights
     if enable_steps.get("retriever"):
         search_results = await cognee.search(
             query_type=SearchType.GRAPH_COMPLETION, query_text="Who has experience in design tools?"

--- a/examples/python/ontology_demo_example.py
+++ b/examples/python/ontology_demo_example.py
@@ -1,6 +1,5 @@
 import cognee
 import asyncio
-from cognee.modules.metrics.operations import get_pipeline_run_metrics
 from cognee.shared.logging_utils import get_logger
 import os
 
@@ -62,14 +61,10 @@ async def main():
         os.path.dirname(os.path.abspath(__file__)), "ontology_input_example/basic_ontology.owl"
     )
 
-    pipeline_run = await cognee.cognify(ontology_file_path=ontology_path)
+    await cognee.cognify(ontology_file_path=ontology_path)
     print("Knowledge with ontology created.")
 
-    # Step 4: Calculate descriptive metrics
-    await get_pipeline_run_metrics(pipeline_run, include_optional=True)
-    print("Descriptive graph metrics saved to database.")
-
-    # Step 5: Query insights
+    # Step 4: Query insights
     search_results = await cognee.search(
         query_type=SearchType.GRAPH_COMPLETION,
         query_text="What are the exact cars and their types produced by Audi?",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Removes graph metrics calculation from dynamic steps and ontology demos

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
