### PR TITLE
Removed automatic config of structlog on import, fixes 855

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -54,10 +54,11 @@ async def cognify(text: str, graph_model_file: str = None, graph_model_name: str
         )
     )
 
+    log_file = get_log_file_location()
     text = (
         f"Background process launched due to MCP timeout limitations.\n"
         f"To check current cognify status use the cognify_status tool\n"
-        f"or check the log file at: {get_log_file_location()}"
+        f"or check the log file at: {log_file}"
     )
 
     return [
@@ -86,10 +87,11 @@ async def codify(repo_path: str) -> list:
 
     asyncio.create_task(codify_task(repo_path))
 
+    log_file = get_log_file_location()
     text = (
         f"Background process launched due to MCP timeout limitations.\n"
         f"To check current codify status use the codify_status tool\n"
-        f"or you can check the log file at: {get_log_file_location()}"
+        f"or you can check the log file at: {log_file}"
     )
 
     return [

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -4,7 +4,7 @@ import sys
 import argparse
 import cognee
 import asyncio
-from cognee.shared.logging_utils import get_logger, get_log_file_location
+from cognee.shared.logging_utils import get_logger, setup_logging, get_log_file_location
 import importlib.util
 from contextlib import redirect_stdout
 import mcp.types as types
@@ -20,7 +20,6 @@ from cognee.modules.storage.utils import JSONEncoder
 mcp = FastMCP("Cognee")
 
 logger = get_logger()
-log_file = get_log_file_location()
 
 
 @mcp.tool()
@@ -58,7 +57,7 @@ async def cognify(text: str, graph_model_file: str = None, graph_model_name: str
     text = (
         f"Background process launched due to MCP timeout limitations.\n"
         f"To check current cognify status use the cognify_status tool\n"
-        f"or check the log file at: {log_file}"
+        f"or check the log file at: {get_log_file_location()}"
     )
 
     return [
@@ -90,7 +89,7 @@ async def codify(repo_path: str) -> list:
     text = (
         f"Background process launched due to MCP timeout limitations.\n"
         f"To check current codify status use the codify_status tool\n"
-        f"or you can check the log file at: {log_file}"
+        f"or you can check the log file at: {get_log_file_location()}"
     )
 
     return [
@@ -214,6 +213,8 @@ async def main():
 
 
 if __name__ == "__main__":
+    logger = setup_logging()
+
     try:
         asyncio.run(main())
     except Exception as e:

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -2,7 +2,7 @@
 
 import os
 import uvicorn
-from cognee.shared.logging_utils import get_logger
+from cognee.shared.logging_utils import get_logger, setup_logging
 import sentry_sdk
 from fastapi import FastAPI, status
 from fastapi.responses import JSONResponse, Response
@@ -190,4 +190,5 @@ def start_api_server(host: str = "0.0.0.0", port: int = 8000):
 
 
 if __name__ == "__main__":
+    logger = setup_logging()
     start_api_server()

--- a/cognee/api/v1/cognify/code_graph_pipeline.py
+++ b/cognee/api/v1/cognify/code_graph_pipeline.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import asyncio
 from uuid import NAMESPACE_OID, uuid5
-from cognee.shared.logging_utils import get_logger
+from cognee.shared.logging_utils import get_logger, setup_logging
 from cognee.modules.observability.get_observe import get_observe
 
 from cognee.api.v1.search import SearchType, search
@@ -97,4 +97,5 @@ if __name__ == "__main__":
         for file in search_results:
             print(file["name"])
 
+    logger = setup_logging("code_graph_pipeline")
     asyncio.run(main())

--- a/cognee/api/v1/visualize/visualize.py
+++ b/cognee/api/v1/visualize/visualize.py
@@ -2,7 +2,7 @@ from cognee.modules.visualization.cognee_network_visualization import (
     cognee_network_visualization,
 )
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.shared.logging_utils import get_logger, ERROR
+from cognee.shared.logging_utils import get_logger, setup_logging, ERROR
 
 
 import asyncio
@@ -28,7 +28,7 @@ async def visualize_graph(destination_file_path: str = None):
 
 
 if __name__ == "__main__":
-    logger = get_logger(level=ERROR)
+    logger = setup_logging(log_level=ERROR)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:

--- a/cognee/modules/retrieval/utils/description_to_codepart_search.py
+++ b/cognee/modules/retrieval/utils/description_to_codepart_search.py
@@ -1,5 +1,5 @@
 import asyncio
-from cognee.shared.logging_utils import get_logger, ERROR
+from cognee.shared.logging_utils import get_logger, setup_logging, ERROR
 
 from typing import List
 from cognee.infrastructure.databases.graph import get_graph_engine
@@ -144,6 +144,7 @@ async def code_description_to_code_part(
 
 
 if __name__ == "__main__":
+    logger = setup_logging(log_level=ERROR)
 
     async def main():
         query = "I am looking for a class with blue eyes"

--- a/examples/python/code_graph_example.py
+++ b/examples/python/code_graph_example.py
@@ -2,7 +2,7 @@ import argparse
 import asyncio
 import cognee
 from cognee import SearchType
-from cognee.shared.logging_utils import get_logger, ERROR
+from cognee.shared.logging_utils import setup_logging, ERROR
 
 from cognee.api.v1.cognify.code_graph_pipeline import run_code_graph_pipeline
 
@@ -41,7 +41,7 @@ def parse_args():
 
 
 if __name__ == "__main__":
-    logger = get_logger(level=ERROR)
+    logger = setup_logging(log_level=ERROR)
 
     args = parse_args()
 

--- a/examples/python/dynamic_steps_example.py
+++ b/examples/python/dynamic_steps_example.py
@@ -1,6 +1,6 @@
 import cognee
 import asyncio
-from cognee.shared.logging_utils import get_logger, ERROR
+from cognee.shared.logging_utils import setup_logging, ERROR
 from cognee.modules.metrics.operations import get_pipeline_run_metrics
 
 from cognee.api.v1.search import SearchType
@@ -197,7 +197,7 @@ async def main(enable_steps):
 
 
 if __name__ == "__main__":
-    logger = get_logger(level=ERROR)
+    logger = setup_logging(log_level=ERROR)
 
     rebuild_kg = True
     retrieve = True

--- a/examples/python/graphiti_example.py
+++ b/examples/python/graphiti_example.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import cognee
-from cognee.shared.logging_utils import get_logger, ERROR
+from cognee.shared.logging_utils import setup_logging, ERROR
 from cognee.modules.pipelines import Task, run_tasks
 from cognee.tasks.temporal_awareness import build_graph_with_temporal_awareness
 from cognee.infrastructure.databases.relational import (
@@ -74,7 +74,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    logger = get_logger(level=ERROR)
+    logger = setup_logging(log_level=ERROR)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:

--- a/examples/python/multimedia_example.py
+++ b/examples/python/multimedia_example.py
@@ -1,7 +1,7 @@
 import os
 import asyncio
 import pathlib
-from cognee.shared.logging_utils import get_logger, ERROR
+from cognee.shared.logging_utils import setup_logging, ERROR
 
 import cognee
 from cognee.api.v1.search import SearchType
@@ -46,7 +46,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    logger = get_logger(level=ERROR)
+    logger = setup_logging(log_level=ERROR)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:

--- a/examples/python/ontology_demo_example.py
+++ b/examples/python/ontology_demo_example.py
@@ -1,7 +1,7 @@
 import cognee
 import asyncio
 from cognee.modules.metrics.operations import get_pipeline_run_metrics
-from cognee.shared.logging_utils import get_logger
+from cognee.shared.logging_utils import setup_logging
 import os
 
 from cognee.api.v1.search import SearchType
@@ -80,7 +80,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    logger = get_logger()
+    logger = setup_logging()
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)

--- a/examples/python/ontology_demo_example_2.py
+++ b/examples/python/ontology_demo_example_2.py
@@ -1,6 +1,6 @@
 import cognee
 import asyncio
-from cognee.shared.logging_utils import get_logger
+from cognee.shared.logging_utils import setup_logging
 import os
 import textwrap
 from cognee.api.v1.search import SearchType
@@ -92,7 +92,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    logger = get_logger()
+    logger = setup_logging()
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)

--- a/examples/python/simple_example.py
+++ b/examples/python/simple_example.py
@@ -1,6 +1,6 @@
 import asyncio
 import cognee
-from cognee.shared.logging_utils import get_logger, ERROR
+from cognee.shared.logging_utils import setup_logging, ERROR
 from cognee.api.v1.search import SearchType
 
 # Prerequisites:
@@ -67,7 +67,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    logger = get_logger(level=ERROR)
+    logger = setup_logging(log_level=ERROR)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:

--- a/examples/python/simple_node_set_example.py
+++ b/examples/python/simple_node_set_example.py
@@ -2,7 +2,7 @@ import os
 import asyncio
 import cognee
 from cognee.api.v1.visualize.visualize import visualize_graph
-from cognee.shared.logging_utils import get_logger, ERROR
+from cognee.shared.logging_utils import setup_logging, ERROR
 
 text_a = """
     AI is revolutionizing financial services through intelligent fraud detection
@@ -39,6 +39,6 @@ async def main():
 
 
 if __name__ == "__main__":
-    logger = get_logger(level=ERROR)
+    logger = setup_logging(log_level=ERROR)
     loop = asyncio.new_event_loop()
     asyncio.run(main())


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Per [855](https://github.com/topoteretes/cognee/issues/885)

* Changed the automatic setup of structlog (and consequential changing of all existing log handlers) to a standalone routine `setup_logging` that can be called if desired rather than on import
* Removed the thread locking that stopped multiple setups from occurring at the same time, no longer needed as each module will not try and install it automatically
* Modified existing code with clear entry points (with `__main__` fence) to call `setup_logging` for some backward compatibility.

Net effect: `import cognee` will no longer change the importing application's log setup.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.