### PR TITLE
changing telemetry to be standlone outside run_tasks

### DIFF
--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -56,6 +56,7 @@ async def run_tasks(
     user: User = None,
     pipeline_name: str = "unknown_pipeline",
     context: dict = None,
+    telemetry_handler=None,  # Add telemetry handler argument
 ):
     if not user:
         user = get_default_user()
@@ -87,6 +88,7 @@ async def run_tasks(
             user=user,
             pipeline_name=pipeline_id,
             context=context,
+            telemetry_handler=telemetry_handler,  # Pass telemetry handler
         ):
             yield PipelineRunYield(
                 pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/pipelines/operations/run_tasks_base.py
+++ b/cognee/modules/pipelines/operations/run_tasks_base.py
@@ -1,7 +1,6 @@
 import inspect
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.users.models import User
-from cognee.shared.utils import send_telemetry
 
 from ..tasks.task import Task
 
@@ -15,18 +14,20 @@ async def handle_task(
     next_task_batch_size: int,
     user: User,
     context: dict = None,
+    telemetry_handler=None,  # Injected telemetry handler
 ):
     """Handle common task workflow with logging, telemetry, and error handling around the core execution logic."""
     task_type = running_task.task_type
 
     logger.info(f"{task_type} task started: `{running_task.executable.__name__}`")
-    send_telemetry(
-        f"{task_type} Task Started",
-        user_id=user.id,
-        additional_properties={
-            "task_name": running_task.executable.__name__,
-        },
-    )
+    if telemetry_handler:
+        telemetry_handler(
+            f"{task_type} Task Started",
+            user_id=user.id if user else None,
+            additional_properties={
+                "task_name": running_task.executable.__name__,
+            },
+        )
 
     has_context = any(
         [key == "context" for key in inspect.signature(running_task.executable).parameters.keys()]
@@ -37,33 +38,35 @@ async def handle_task(
 
     try:
         async for result_data in running_task.execute(args, next_task_batch_size):
-            async for result in run_tasks_base(leftover_tasks, result_data, user, context):
+            async for result in run_tasks_base(leftover_tasks, result_data, user, context, telemetry_handler):
                 yield result
 
         logger.info(f"{task_type} task completed: `{running_task.executable.__name__}`")
-        send_telemetry(
-            f"{task_type} Task Completed",
-            user_id=user.id,
-            additional_properties={
-                "task_name": running_task.executable.__name__,
-            },
-        )
+        if telemetry_handler:
+            telemetry_handler(
+                f"{task_type} Task Completed",
+                user_id=user.id if user else None,
+                additional_properties={
+                    "task_name": running_task.executable.__name__,
+                },
+            )
     except Exception as error:
         logger.error(
             f"{task_type} task errored: `{running_task.executable.__name__}`\n{str(error)}\n",
             exc_info=True,
         )
-        send_telemetry(
-            f"{task_type} Task Errored",
-            user_id=user.id,
-            additional_properties={
-                "task_name": running_task.executable.__name__,
-            },
-        )
+        if telemetry_handler:
+            telemetry_handler(
+                f"{task_type} Task Errored",
+                user_id=user.id if user else None,
+                additional_properties={
+                    "task_name": running_task.executable.__name__,
+                },
+            )
         raise error
 
 
-async def run_tasks_base(tasks: list[Task], data=None, user: User = None, context: dict = None):
+async def run_tasks_base(tasks: list[Task], data=None, user: User = None, context: dict = None, telemetry_handler=None):
     """Base function to execute tasks in a pipeline, handling task type detection and execution."""
     if len(tasks) == 0:
         yield data
@@ -77,6 +80,6 @@ async def run_tasks_base(tasks: list[Task], data=None, user: User = None, contex
     next_task_batch_size = next_task.task_config["batch_size"] if next_task else 1
 
     async for result in handle_task(
-        running_task, args, leftover_tasks, next_task_batch_size, user, context
+        running_task, args, leftover_tasks, next_task_batch_size, user, context, telemetry_handler
     ):
         yield result

--- a/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
+++ b/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
@@ -13,15 +13,18 @@ logger = get_logger("run_tasks_with_telemetry()")
 
 
 async def run_tasks_with_telemetry(
-    tasks: list[Task], data, user: User, pipeline_name: str, context: dict = None
+    tasks: list[Task], data, user: User, pipeline_name: str, context: dict = None, telemetry_handler=None
 ):
     config = get_current_settings()
 
     logger.debug("\nRunning pipeline with configuration:\n%s\n", json.dumps(config, indent=1))
 
+    # Use injected telemetry_handler or fallback to send_telemetry
+    handler = telemetry_handler if telemetry_handler else send_telemetry
+
     try:
         logger.info("Pipeline run started: `%s`", pipeline_name)
-        send_telemetry(
+        handler(
             "Pipeline Run Started",
             user.id,
             additional_properties={
@@ -30,11 +33,11 @@ async def run_tasks_with_telemetry(
             | config,
         )
 
-        async for result in run_tasks_base(tasks, data, user, context):
+        async for result in run_tasks_base(tasks, data, user, context, handler):
             yield result
 
         logger.info("Pipeline run completed: `%s`", pipeline_name)
-        send_telemetry(
+        handler(
             "Pipeline Run Completed",
             user.id,
             additional_properties={
@@ -48,7 +51,7 @@ async def run_tasks_with_telemetry(
             str(error),
             exc_info=True,
         )
-        send_telemetry(
+        handler(
             "Pipeline Run Errored",
             user.id,
             additional_properties={


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
- Decoupled telemetry logic from pipeline task execution functions.
- Telemetry handler is now injected and propagated, enabling easier testing and separation of concerns.
- Removed dependency on default user from database for telemetry.
- Updated run_tasks, run_tasks_with_telemetry, and run_tasks_base to support telemetry injection.


## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
