### PR TITLE
chore: fix typo in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -49,7 +49,7 @@ EMBEDDING_DIMENSIONS = 4096
 HUGGINGFACE_TOKENIZER = "Salesforce/SFR-Embedding-Mistral"
 
 ###
-### openrouter, also frewe
+### openrouter, also free
 ###
 
 LLM_API_KEY="<<go-get-one-yourself"


### PR DESCRIPTION
## Description
Fixed a minor typo in `.env.template`. Not the biggest change, but that's a start ¯\_(ツ)_/¯

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.