### PR TITLE
Chore: fix Commutity Greetings workflow permissions

### DIFF
--- a/.github/workflows/community_greetings.yml
+++ b/.github/workflows/community_greetings.yml
@@ -1,6 +1,14 @@
 name: community | Greetings
 
-on: [pull_request, issues]
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   greeting:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Fix “Resource not accessible by integration” error in greetings workflow

This PR updates the community | Greetings GitHub Actions workflow to ensure it can successfully post greeting comments on newly opened issues and pull requests — including PRs from forks — without hitting the “Resource not accessible by integration” error.

## Changes
- Switched PR trigger from `pull_request` to `pull_request_target` to run in the context of the base repository and grant write-scoped `GITHUB_TOKEN` for commenting on forked PRs.  
- Added explicit `permissions` block with:
  - `issues: write`  
  - `pull-requests: write`  
- Limited triggers to `types: [opened]` for both issues and PRs to avoid unnecessary runs.  
- Preserved existing greeting messages for issues and pull requests.

## Reason for change
The workflow was failing because the default `GITHUB_TOKEN` in `pull_request` events is read-only for forks, preventing the bot from posting comments.  
`pull_request_target` with explicit permissions solves this while maintaining security.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
