### PR TITLE
Potential fix for code scanning alert no. 147: Clear-text logging of sensitive information

### DIFF
--- a/cognee-mcp/src/test_client.py
+++ b/cognee-mcp/src/test_client.py
@@ -57,7 +57,7 @@ class CogneeTestClient:
             print("   Some tests may fail without proper LLM API configuration.")
             print("   Set OPENAI_API_KEY environment variable for full functionality.")
         else:
-            print(f"✅ API key configured (key ending in: ...{api_key[-4:]})")
+            print("✅ API key configured.")
 
         # Create temporary test files
         self.test_data_dir = tempfile.mkdtemp(prefix="cognee_test_")


### PR DESCRIPTION
Potential fix for [https://github.com/topoteretes/cognee/security/code-scanning/147](https://github.com/topoteretes/cognee/security/code-scanning/147)

To fix the problem, we should avoid logging any part of the API key. Instead, we can log a generic message indicating that an API key is configured, without revealing any part of the key. This maintains the functionality of confirming that the key is present, while eliminating the risk of exposing sensitive information. The change should be made in `cognee-mcp/src/test_client.py`, specifically on line 60, replacing the log statement with a safer alternative. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
