### PR TITLE
Enable S3-aware Kuzu migration + adapter auto-migration (#1179)

### DIFF
--- a/cognee/tests/unit/infrastructure/databases/graph/kuzu/test_adapter_s3_migration.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/kuzu/test_adapter_s3_migration.py
@@ -1,0 +1,191 @@
+import importlib.util
+import os
+import sys
+import types
+from types import ModuleType
+
+
+class _DBOpenError(RuntimeError):
+    pass
+
+
+class _FakeDatabase:
+    """Fake kuzu.Database that fails first, then succeeds."""
+
+    calls = 0
+
+    def __init__(self, path: str, **kwargs):
+        _FakeDatabase.calls += 1
+        if _FakeDatabase.calls == 1:
+            raise _DBOpenError("version mismatch")
+
+    def init_database(self):
+        pass
+
+
+class _FakeConnection:
+    def __init__(self, db):
+        pass
+
+    def execute(self, query: str, params=None):
+        class _Res:
+            def has_next(self):
+                return False
+
+            def get_next(self):
+                return []
+
+        return _Res()
+
+
+def _install_stub(name: str, module: ModuleType | None = None) -> ModuleType:
+    mod = module or ModuleType(name)
+    # Mark as package so submodule imports succeed when needed
+    if not hasattr(mod, "__path__"):
+        mod.__path__ = []  # type: ignore[attr-defined]
+    sys.modules[name] = mod
+    return mod
+
+
+def _find_repo_root(start_path: str) -> str:
+    """Walk up directories until we find pyproject.toml (repo root)."""
+    cur = os.path.abspath(start_path)
+    while True:
+        if os.path.exists(os.path.join(cur, "pyproject.toml")):
+            return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            raise RuntimeError("Could not locate repository root from: " + start_path)
+        cur = parent
+
+
+def _load_adapter_with_stubs(monkeypatch):
+    # Provide fake 'kuzu' and submodules used by adapter imports
+    kuzu_mod = _install_stub("kuzu")
+    kuzu_mod.__dict__["__version__"] = "0.11.0"
+
+    # Placeholders to satisfy adapter's "from kuzu import Connection" and "from kuzu.database import Database"
+    class _PlaceholderConn:
+        pass
+
+    kuzu_mod.Connection = _PlaceholderConn
+    kuzu_db_mod = _install_stub("kuzu.database")
+
+    class _PlaceholderDB:
+        pass
+
+    kuzu_db_mod.Database = _PlaceholderDB
+
+    # Create minimal stub tree for required cognee imports to avoid executing package __init__
+    root = _install_stub("cognee")
+    infra = _install_stub("cognee.infrastructure")
+    databases = _install_stub("cognee.infrastructure.databases")
+    graph = _install_stub("cognee.infrastructure.databases.graph")
+    kuzu_pkg = _install_stub("cognee.infrastructure.databases.graph.kuzu")
+
+    # graph_db_interface stub
+    gdi_mod = _install_stub("cognee.infrastructure.databases.graph.graph_db_interface")
+
+    class _GraphDBInterface:  # bare minimum
+        pass
+
+    def record_graph_changes(fn):
+        return fn
+
+    gdi_mod.GraphDBInterface = _GraphDBInterface
+    gdi_mod.record_graph_changes = record_graph_changes
+
+    # engine.DataPoint stub
+    engine_mod = _install_stub("cognee.infrastructure.engine")
+
+    class _DataPoint:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    engine_mod.DataPoint = _DataPoint
+
+    # files.storage.get_file_storage stub
+    files_storage_pkg = _install_stub("cognee.infrastructure.files")
+    storage_pkg = _install_stub("cognee.infrastructure.files.storage")
+    storage_pkg.get_file_storage = lambda path: types.SimpleNamespace(
+        ensure_directory_exists=lambda: None
+    )
+
+    # utils.run_sync stub
+    utils_pkg = _install_stub("cognee.infrastructure.utils")
+    run_sync_mod = _install_stub("cognee.infrastructure.utils.run_sync")
+    run_sync_mod.run_sync = lambda coro: None
+
+    # modules.storage.utils JSONEncoder stub
+    modules_pkg = _install_stub("cognee.modules")
+    storage_pkg2 = _install_stub("cognee.modules.storage")
+    utils_mod2 = _install_stub("cognee.modules.storage.utils")
+    utils_mod2.JSONEncoder = object
+
+    # shared.logging_utils.get_logger stub
+    shared_pkg = _install_stub("cognee.shared")
+    logging_utils_mod = _install_stub("cognee.shared.logging_utils")
+
+    class _Logger:
+        def debug(self, *a, **k):
+            pass
+
+        def error(self, *a, **k):
+            pass
+
+    logging_utils_mod.get_logger = lambda: _Logger()
+
+    # Now load adapter.py by path
+    repo_root = _find_repo_root(os.path.dirname(__file__))
+    adapter_path = os.path.join(
+        repo_root, "cognee", "infrastructure", "databases", "graph", "kuzu", "adapter.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "cognee.infrastructure.databases.graph.kuzu.adapter", adapter_path
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+
+    # Replace Database/Connection in the loaded module
+    monkeypatch.setattr(mod, "Database", _FakeDatabase, raising=True)
+    monkeypatch.setattr(mod, "Connection", _FakeConnection, raising=True)
+
+    # Patch migration helpers inside the kuzu_migrate module used by adapter
+    # Load kuzu_migrate similarly
+    km_path = os.path.join(
+        repo_root, "cognee", "infrastructure", "databases", "graph", "kuzu", "kuzu_migrate.py"
+    )
+    km_spec = importlib.util.spec_from_file_location("kuzu_migrate_under_test", km_path)
+    km_mod = importlib.util.module_from_spec(km_spec)
+    assert km_spec and km_spec.loader
+    km_spec.loader.exec_module(km_mod)  # type: ignore[attr-defined]
+
+    calls = {"migrated": False}
+
+    def fake_read_version(_):
+        return "0.9.0"
+
+    def fake_migration(**kwargs):
+        calls["migrated"] = True
+
+    monkeypatch.setattr(km_mod, "read_kuzu_storage_version", fake_read_version)
+    monkeypatch.setattr(km_mod, "kuzu_migration", fake_migration)
+
+    # Ensure adapter refers to our loaded km_mod
+    monkeypatch.setitem(
+        sys.modules, "cognee.infrastructure.databases.graph.kuzu.kuzu_migrate", km_mod
+    )
+
+    return mod, calls
+
+
+def test_adapter_s3_auto_migration(monkeypatch):
+    mod, calls = _load_adapter_with_stubs(monkeypatch)
+
+    # ensure pull/push do not touch real S3
+    monkeypatch.setattr(mod.KuzuAdapter, "pull_from_s3", lambda self: None)
+    monkeypatch.setattr(mod.KuzuAdapter, "push_to_s3", lambda self: None)
+
+    adapter = mod.KuzuAdapter("s3://bucket/db")
+    assert calls["migrated"] is True

--- a/cognee/tests/unit/infrastructure/databases/graph/kuzu/test_kuzu_migrate_s3.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/kuzu/test_kuzu_migrate_s3.py
@@ -1,0 +1,195 @@
+import io
+import os
+import struct
+import importlib.util
+from types import ModuleType
+from typing import Dict
+
+import pytest
+
+
+class _FakeS3:
+    """
+    Minimal fake S3 client implementing the subset used by kuzu_migrate helpers.
+
+    Store layout is a dict mapping string keys to bytes (files). Directories are
+    implicit via key prefixes. Methods operate on s3:// style keys.
+    """
+
+    def __init__(self, initial: Dict[str, bytes] | None = None):
+        self.store: Dict[str, bytes] = dict(initial or {})
+
+    # Helpers
+    def _norm(self, path: str) -> str:
+        return path.rstrip("/")
+
+    def _is_prefix(self, prefix: str, key: str) -> bool:
+        p = self._norm(prefix)
+        return key == p or key.startswith(p + "/")
+
+    # API used by kuzu_migrate
+    def exists(self, path: str) -> bool:
+        p = self._norm(path)
+        if p in self.store:
+            return True
+        # any key under this prefix implies existence as a directory
+        return any(self._is_prefix(p, k) for k in self.store)
+
+    def isdir(self, path: str) -> bool:
+        p = self._norm(path)
+        # A directory is assumed if there is any key with this prefix and that key isn't exactly the same
+        return any(self._is_prefix(p, k) and k != p for k in self.store)
+
+    def isfile(self, path: str) -> bool:
+        p = self._norm(path)
+        return p in self.store
+
+    def open(self, path: str, mode: str = "rb"):
+        p = self._norm(path)
+        if "r" in mode:
+            if p not in self.store:
+                raise FileNotFoundError(p)
+            return io.BytesIO(self.store[p])
+        elif "w" in mode:
+            buf = io.BytesIO()
+
+            def _close():
+                self.store[p] = buf.getvalue()
+
+            # monkeypatch close so that written data is persisted on close
+            orig_close = buf.close
+
+            def close_wrapper():
+                _close()
+                orig_close()
+
+            buf.close = close_wrapper  # type: ignore[assignment]
+            return buf
+        else:
+            raise ValueError(f"Unsupported mode: {mode}")
+
+    def copy(self, src: str, dst: str, recursive: bool = True):
+        s = self._norm(src)
+        d = self._norm(dst)
+        if recursive:
+            # copy all keys under src prefix to dst prefix
+            to_copy = [k for k in self.store if self._is_prefix(s, k)]
+            for key in to_copy:
+                new_key = key.replace(s, d, 1)
+                self.store[new_key] = self.store[key]
+        else:
+            if s not in self.store:
+                raise FileNotFoundError(s)
+            self.store[d] = self.store[s]
+
+    def rm(self, path: str, recursive: bool = False):
+        p = self._norm(path)
+        if recursive:
+            for key in list(self.store.keys()):
+                if self._is_prefix(p, key):
+                    del self.store[key]
+        else:
+            if p in self.store:
+                del self.store[p]
+            else:
+                raise FileNotFoundError(p)
+
+
+def _load_module_by_path(path: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("kuzu_migrate_under_test", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+def _find_repo_root(start_path: str) -> str:
+    cur = os.path.abspath(start_path)
+    while True:
+        if os.path.exists(os.path.join(cur, "pyproject.toml")):
+            return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            raise RuntimeError("Could not locate repository root from: " + start_path)
+        cur = parent
+
+
+@pytest.fixture
+def km_module(monkeypatch):
+    # Load the kuzu_migrate module directly from file to avoid importing package __init__
+    repo_root = _find_repo_root(os.path.dirname(__file__))
+    target = os.path.join(
+        repo_root, "cognee", "infrastructure", "databases", "graph", "kuzu", "kuzu_migrate.py"
+    )
+    mod = _load_module_by_path(target)
+    return mod
+
+
+@pytest.fixture
+def patch_get_s3_client(monkeypatch, km_module):
+    # Provide each test with its own fake client instance
+    client = _FakeS3()
+    monkeypatch.setattr(km_module, "_get_s3_client", lambda: client)
+    return client
+
+
+def _make_catalog_bytes(version_code: int) -> bytes:
+    # 4 bytes header skipped + 8 bytes little-endian version code
+    return b"KUZ\x00" + struct.pack("<Q", version_code) + b"padding"
+
+
+def test_read_kuzu_storage_version_from_s3_directory(monkeypatch, patch_get_s3_client, km_module):
+    s3 = patch_get_s3_client
+    # Simulate a directory with catalog.kz
+    dir_key = "s3://bucket/db"
+    catalog_key = dir_key + "/catalog.kz"
+    s3.store[catalog_key] = _make_catalog_bytes(39)  # maps to 0.11.0
+
+    assert km_module.read_kuzu_storage_version(dir_key) == "0.11.0"
+
+
+def test_s3_rename_file_backup(monkeypatch, patch_get_s3_client, km_module):
+    s3 = patch_get_s3_client
+
+    old_db = "s3://bucket/graph.db"
+    new_db = "s3://bucket/graph_new.db"
+    # seed store
+    s3.store[old_db] = b"OLD"
+    s3.store[new_db] = b"NEW"
+
+    km_module._s3_rename_databases(old_db, "0.9.0", new_db, delete_old=False)
+
+    # old is replaced with new
+    assert s3.store.get(old_db) == b"NEW"
+    # backup exists with version suffix
+    backup = "s3://bucket/graph.db_old_0_9_0"
+    assert s3.store.get(backup) == b"OLD"
+    # staging removed
+    assert new_db not in s3.store
+
+
+def test_s3_rename_directory_delete_old(monkeypatch, patch_get_s3_client, km_module):
+    s3 = patch_get_s3_client
+
+    old_dir = "s3://bucket/graph_dir"
+    new_dir = "s3://bucket/graph_dir_new"
+
+    # Represent a directory by multiple keys under the prefix
+    s3.store[old_dir + "/catalog.kz"] = b"OLD1"
+    s3.store[old_dir + "/data.bin"] = b"OLD2"
+
+    s3.store[new_dir + "/catalog.kz"] = b"NEW1"
+    s3.store[new_dir + "/data.bin"] = b"NEW2"
+
+    km_module._s3_rename_databases(old_dir, "0.9.0", new_dir, delete_old=True)
+
+    # old dir contents replaced by new
+    assert s3.store.get(old_dir + "/catalog.kz") == b"NEW1"
+    assert s3.store.get(old_dir + "/data.bin") == b"NEW2"
+
+    # no backup created when delete_old=True
+    backup_prefix = os.path.dirname(old_dir) + "/" + os.path.basename(old_dir) + "_old_0_9_0"
+    assert not any(k.startswith(backup_prefix) for k in s3.store)
+
+    # staging removed
+    assert not any(k.startswith(new_dir) for k in s3.store)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->

## Summary
This PR adds **S3-aware Kuzu DB migration** support, enabling automatic upgrades of databases stored on S3 or local paths when storage versions differ. It integrates migration logic directly into `KuzuAdapter` and includes targeted unit tests.

## Motivation
Some deployments keep Kuzu graph DBs on S3. Opening an older DB with a newer Kuzu version fails due to storage version mismatches. This PR implements a seamless migration process for S3-hosted DBs while preserving current behavior for local paths.
Fixes **#1179**.

## What’s in this PR

### 1. Kuzu S3 Migration Orchestration

* Detects `s3://` paths and reads version from S3’s `catalog.kz` without a full download.
* Stages DB locally, runs EXPORT/IMPORT Cypher in version-pinned venvs.
* Uploads migrated DB to S3.
* Implements safe S3 rename via copy+remove with optional backup or `delete_old`.

### 2. Adapter Auto-Migration

* **S3 paths:** Pulls DB to temp, attempts open; on failure, reads version, migrates to current `kuzu.__version__`, pushes back, and retries.
* **Local paths:** Runs similar migration without S3 sync.
* Ensures type safety by casting `kuzu.__version__` to `str`.

### 3. Tests

* **`test_kuzu_migrate_s3.py`** — Fake S3 client; verifies version read and S3 rename (file/dir, with/without backup).
* **`test_adapter_s3_migration.py`** — Module stubs to avoid package side-effects; verifies S3 auto-migration path triggers.

### 4. Additional Notes

* Alembic migrations remain untouched.
* S3 ops use the project’s `S3FileStorage`-backed `s3fs` client.


## Checklist

* [x] Code formatted with Ruff
* [x] Signed commits per DCO
* [x] Unit tests included

## How It Works (High-Level)

* Migration uses EXPORT/IMPORT Cypher in venvs pinned to old and new Kuzu versions.
* For S3, DB is pulled locally, migrated, then pushed back.
* Storage version detection is done by reading `catalog.kz`.
* S3 rename is handled via copy+remove with optional backup handling.


## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
