### PR TITLE
feat(api): add readiness and detailed health endpoints

### DIFF
--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -342,12 +342,14 @@ async def _check_llm_provider() -> dict:
     except Exception as exc:
         duration = int((time.perf_counter() - started) * 1000)
         # Non-critical -> degraded when failing
-        return {
-            "status": "degraded",
-            "provider": llm_provider,
-            "response_time_ms": duration,
-            "details": f"LLM client initialization failed: {type(exc).__name__}",
-        }
+except Exception as exc:
+    duration = int((time.perf_counter() - started) * 1000)
+    return {
+        "status": "degraded",
+        "provider": emb_provider,
+        "response_time_ms": duration,
+        "details": f"Embedding check failed: {type(exc).__name__}",
+    }
 
 
 async def _check_embedding_service() -> dict:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Added async, parallel health checks that measure response times and report provider details:
Relational DB: open connection and run SELECT 1
Vector DB: open a connection or check a collection
Graph DB: fetch basic metrics
File Storage: write/remove a small temp file
LLM provider: instantiate client (non-critical)
Embedding service: run a tiny embed (non-critical)
Tracked version via get_cognee_version() and uptime since API start.
Endpoints:
GET /health: unchanged fast liveness (200)
GET /health/ready: readiness probe; checks only critical services; returns 200 or 503 with JSON
GET /health/detailed: comprehensive status for all components; returns 200; returns 503 only if critical components fail
Response shape includes status, timestamp, version, uptime, and detailed per-component objects per your spec.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
