### PR TITLE
Add search range (top_k) input to search UI (Fixes #1194)

### DIFF
--- a/cognee-frontend/src/modules/chat/hooks/useChat.ts
+++ b/cognee-frontend/src/modules/chat/hooks/useChat.ts
@@ -14,17 +14,24 @@ const fetchMessages = () => {
     .then(response => response.json());
 };
 
-const sendMessage = (message: string, searchType: string) => {
+const sendMessage = (message: string, searchType: string, topK?: number) => {
+  const payload: any = {
+    query: message,
+    searchType,
+    datasets: ["main_dataset"],
+  };
+  
+  // Add topK (top_k) parameter if provided
+  if (topK !== undefined) {
+    payload.top_k = topK;
+  }
+
   return fetch("/v1/search/", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      query: message,
-      searchType,
-      datasets: ["main_dataset"],
-    }),
+    body: JSON.stringify(payload),
   })
     .then(response => response.json());
 };
@@ -33,7 +40,6 @@ const sendMessage = (message: string, searchType: string) => {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function useChat(dataset: Dataset) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-
   const {
     value: isSearchRunning,
     setTrue: disableSearchRun,
@@ -45,9 +51,8 @@ export default function useChat(dataset: Dataset) {
     return setMessages(data);
   }, []);
 
-  const handleMessageSending = useCallback((message: string, searchType: string) => {
+  const handleMessageSending = useCallback((message: string, searchType: string, topK?: number) => {
     const sentMessageId = v4();
-
     setMessages((messages) => [
       ...messages,
       {
@@ -56,10 +61,8 @@ export default function useChat(dataset: Dataset) {
         text: message,
       },
     ]);
-
     disableSearchRun();
-
-    return sendMessage(message, searchType)
+    return sendMessage(message, searchType, topK)
       .then(newMessages => {
         setMessages((messages) => [
           ...messages,
@@ -86,7 +89,6 @@ export default function useChat(dataset: Dataset) {
     isSearchRunning,
   };
 }
-
 
 interface Node {
   name: string;

--- a/cognee-frontend/src/ui/Partials/SearchView/SearchView.tsx
+++ b/cognee-frontend/src/ui/Partials/SearchView/SearchView.tsx
@@ -1,12 +1,9 @@
 "use client";
-
 import classNames from "classnames";
 import { useCallback, useEffect, useRef, useState } from "react";
-
 import { LoadingIndicator } from "@/ui/App";
 import { CTAButton, Select, TextArea } from "@/ui/elements";
 import useChat from "@/modules/chat/hooks/useChat";
-
 import styles from "./SearchView.module.css";
 
 interface SelectOption {
@@ -16,6 +13,8 @@ interface SelectOption {
 
 interface SearchFormPayload extends HTMLFormElement {
   chatInput: HTMLInputElement;
+  searchType: HTMLSelectElement;
+  maxResults: HTMLInputElement;
 }
 
 const MAIN_DATASET = {
@@ -39,7 +38,6 @@ export default function SearchView() {
       const messagesContainerElement = document.getElementById("messages");
       if (messagesContainerElement) {
         const messagesElements = messagesContainerElement.children[0];
-
         if (messagesElements) {
           messagesContainerElement.scrollTo({
             top: messagesElements.scrollHeight,
@@ -59,30 +57,35 @@ export default function SearchView() {
   }, [refreshChat, scrollToBottom]);
 
   const [searchInputValue, setSearchInputValue] = useState("");
+  const [maxResults, setMaxResults] = useState(10);
 
   const handleSearchInputChange = useCallback((value: string) => {
     setSearchInputValue(value);
   }, []);
 
+  const handleMaxResultsChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(event.target.value, 10);
+    if (!isNaN(value) && value >= 1 && value <= 100) {
+      setMaxResults(value);
+    }
+  }, []);
+
   const handleChatMessageSubmit = useCallback((event: React.FormEvent<SearchFormPayload>) => {
     event.preventDefault();
-
     const formElements = event.currentTarget;
-
     const searchType = formElements.searchType.value;
     const chatInput = searchInputValue.trim();
+    const topK = maxResults;
 
     if (chatInput === "") {
       return;
     }
 
     scrollToBottom();
-
     setSearchInputValue("");
-
-    sendMessage(chatInput, searchType)
+    sendMessage(chatInput, searchType, topK)
       .then(scrollToBottom)
-  }, [scrollToBottom, sendMessage, searchInputValue]);
+  }, [scrollToBottom, sendMessage, searchInputValue, maxResults]);
 
   const chatFormRef = useRef<HTMLFormElement>(null);
 
@@ -94,7 +97,7 @@ export default function SearchView() {
 
   return (
     <div className="flex flex-col h-full bg-gray-500 p-6 pt-16 rounded-3xl border-indigo-600 border-2 shadow-xl">
-      <form onSubmit={handleChatMessageSubmit} ref={chatFormRef} className="flex flex-col gap-4 h-full">
+      <form className="flex flex-col gap-4 h-full" onSubmit={handleChatMessageSubmit} ref={chatFormRef}>
         <div className="h-full overflow-y-auto" id="messages">
           <div className="flex flex-col gap-2 items-end justify-end min-h-full px-6 pb-4">
             {messages.map((message) => (
@@ -112,7 +115,6 @@ export default function SearchView() {
             ))}
           </div>
         </div>
-
         <div className="p-4 bg-gray-300 rounded-xl flex flex-col gap-2">
           <TextArea
             value={searchInputValue}
@@ -125,13 +127,28 @@ export default function SearchView() {
             className="resize-none min-h-14 max-h-96 overflow-y-auto"
           />
           <div className="flex flex-row items-center justify-between gap-4">
-            <div className="flex flex-row items-center gap-2">
-              <label className="text-gray-600 whitespace-nowrap">Search type:</label>
-              <Select name="searchType" defaultValue={searchOptions[0].value} className="max-w-2xs">
-                {searchOptions.map((option) => (
-                  <option key={option.value} value={option.value}>{option.label}</option>
-                ))}
-              </Select>
+            <div className="flex flex-row items-center gap-4">
+              <div className="flex flex-row items-center gap-2">
+                <label className="text-gray-600 whitespace-nowrap">Search type:</label>
+                <Select className="max-w-2xs" defaultValue={searchOptions[0].value} name="searchType">
+                  {searchOptions.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </Select>
+              </div>
+              <div className="flex flex-row items-center gap-2">
+                <label className="text-gray-600 whitespace-nowrap" title="Maximum number of results to return (1-100)">Max results:</label>
+                <input
+                  type="number"
+                  name="maxResults"
+                  value={maxResults}
+                  onChange={handleMaxResultsChange}
+                  min={1}
+                  max={100}
+                  className="w-16 px-2 py-1 border border-gray-400 rounded text-center"
+                  title="Set the maximum number of search results (default: 10, range: 1-100)"
+                />
+              </div>
             </div>
             <CTAButton disabled={isSearchRunning} type="submit">
               {isSearchRunning? "Searching..." : "Search"}


### PR DESCRIPTION
This PR adds a Max Results number input to the search UI, allowing users to control the top_k parameter (default 10, min 1, max 100) now sent to the backend, enabling better search result control. Fixes #1194.

## DCO Affirmation
This PR adds a Max Results number input to the search UI, allowing users to control the top_k parameter (default 10, min 1, max 100) now sent to the backend, enabling better search result control. Fixes #1194.

## DCO Affirmation
This PR adds a Max Results number input to the search UI, allowing users to control the top_k parameter (default 10, min 1, max 100) now sent to the backend, enabling better search result control. Fixes #1194.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.<!-- .github/pull_request_template.md -->

## Description
<!-- Provide a clear description of the changes in this PR -->

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
