### PR TITLE
fix: remove redundant S3 file path check in StorageManager

### DIFF
--- a/cognee/infrastructure/files/storage/StorageManager.py
+++ b/cognee/infrastructure/files/storage/StorageManager.py
@@ -90,7 +90,7 @@ class StorageManager:
         """
         # Check the actual storage type by class name to determine if open() is async or sync
 
-        if self.storage.__class__.__name__ == "S3FileStorage" and file_path.startswith("s3://"):
+        if self.storage.__class__.__name__ == "S3FileStorage":
             # S3FileStorage.open() is async
             async with self.storage.open(file_path, *args, **kwargs) as file:
                 yield file


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

When using S3 File Storage, sync is failing as S3FileStorage is mistakenly treated as sync context manager:
```

2025-09-01T16:08:33.574379 [error    ] Error uploading file car_and_tech_companies: '_AsyncGeneratorContextManager' object does not support the context manager protocol [cognee.shared.logging_utils] exception_message="'_AsyncGeneratorContextManager' object does not support the context manager protocol" traceback=True
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/daulet/Desktop/dev/cognee-claude/cognee/api/v1/sync/sync.py:414 in _upload_missing_files  │
│                                                                                                  │
│   411 │   │   │   │   file_name = os.path.basename(file_info.raw_data_location)                  │
│   412 │   │   │   │   file_storage = get_file_storage(file_dir)                                  │
│   413 │   │   │   │                                                                              │
│ ❱ 414 │   │   │   │   async with file_storage.open(file_name, mode="rb") as file:                │
│   415 │   │   │   │   │   file_content = file.read()                                             │
│   416 │   │   │   │                                                                              │
│   417 │   │   │   │   # Upload file                                                              │
│                                                                                                  │
```

This is because current `open` implementation expects file path to start with s3 prefix:
```python
@asynccontextmanager
    async def open(self, file_path: str, encoding: str = None, *args, **kwargs):
        """
        Retrieve data from the specified file path.

        Parameters:
        -----------

            - file_path (str): The path from which to retrieve the data.

        Returns:
        --------

            Returns the retrieved data, as defined by the storage implementation.
        """
        # Check the actual storage type by class name to determine if open() is async or sync

        if self.storage.__class__.__name__ == "S3FileStorage" and file_path.startswith("s3://"):
            # S3FileStorage.open() is async
            async with self.storage.open(file_path, *args, **kwargs) as file:
                yield file
        else:
            # LocalFileStorage.open() is sync
            with self.storage.open(file_path, *args, **kwargs) as file:
                yield file
```

In `sync.py`, we currentlty prune file_path to get the raw file name (like `text_9872fa283651dcb36f474cc7f8a86a4b.txt`)
```python
file_name = os.path.basename(file_info.raw_data_location)
...
```

Since S3FileStorage doesn't need full path, + S3Storage doesn't need additional `s3://` prefix check, we can remove it.
https://github.com/topoteretes/cognee/blob/main/cognee/infrastructure/files/storage/S3FileStorage.py#L80-L100
<!-- Provide a clear description of the changes in this PR -->



## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
