### PR TITLE
Fix ChromaDBAdapter AttributeError

### DIFF
--- a/cognee/infrastructure/databases/vector/chromadb/ChromaDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/chromadb/ChromaDBAdapter.py
@@ -538,7 +538,7 @@ class ChromaDBAdapter(VectorDBInterface):
             Returns True upon successful deletion of all collections.
         """
         client = await self.get_connection()
-        collections = await self.list_collections()
+        collections = await client.list_collections()
         for collection_name in collections:
             await client.delete_collection(collection_name)
         return True


### PR DESCRIPTION
## Description
Pretty self-explanatory! list_collections() is an attribute of the AsyncHttpClient, not of the ChromaDBAdapter, so line 541 should say client.list_collections() (as indeed line 556 correctly already does). This will fix the AttributeError I was getting.

This is my first ever PR so let me know if there is anything else I need to do :)

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
