### PR TITLE
Feature/delete preview

### DIFF
--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_edge_cases.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_edge_cases.py
@@ -13,6 +13,7 @@ from cognee.cli.commands.cognify_command import CognifyCommand
 from cognee.cli.commands.delete_command import DeleteCommand
 from cognee.cli.commands.config_command import ConfigCommand
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.modules.data.methods.get_deletion_counts import DeletionCountsPreview
 
 
 # Mock asyncio.run to properly handle coroutines
@@ -396,13 +397,17 @@ class TestDeleteCommandEdgeCases:
             command.execute(args)
 
         mock_confirm.assert_called_once_with("Delete ALL data from cognee?")
-        mock_asyncio_run.assert_called_once()
+        assert mock_asyncio_run.call_count == 2
         assert asyncio.iscoroutine(mock_asyncio_run.call_args[0][0])
         mock_cognee.delete.assert_awaited_once_with(dataset_name=None, user_id="test_user")
 
+    @patch("cognee.cli.commands.delete_command.get_deletion_counts")
     @patch("cognee.cli.commands.delete_command.fmt.confirm")
-    def test_delete_confirmation_keyboard_interrupt(self, mock_confirm):
+    def test_delete_confirmation_keyboard_interrupt(self, mock_confirm, mock_get_deletion_counts):
         """Test delete command when user interrupts confirmation"""
+        mock_get_deletion_counts = AsyncMock()
+        mock_get_deletion_counts.return_value = DeletionCountsPreview()
+
         command = DeleteCommand()
         args = argparse.Namespace(dataset_name="test_dataset", user_id=None, all=False, force=False)
 


### PR DESCRIPTION
## Description

This pull request introduces a preview step to the `cognee delete` command, fulfilling the requirements of issue #1366 

When a user runs the delete command, it now first queries the database to calculate the scope of the deletion and presents a summary (number of datasets, data entries, users) before asking for final confirmation. This improves the safety and usability of the command, preventing accidental data loss.

This PR also adds the `--force` flag to bypass the preview, which is useful for scripting and automation.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`cognee/cli/commands/delete_command.py`**: Modified to include the preview logic. It now calls the counting function, displays the results, and proceeds with deletion only after confirmation.
- **`cognee/modules/data/methods/get_deletion_counts.py`**: Added this new file to contain the logic for querying the database and calculating the deletion counts for datasets, data entries, and users.

## Testing

I have tested the changes through **Manual CLI Testing**: I ran the `cognee delete` command with the `--dataset-name`, `--user-id`, and `--all` flags to manually verify that the preview output is correct.

### Terminal Output
Here are screenshots of the command working with the all possible flags:
<img width="1898" height="1087" alt="cognee1" src="https://github.com/user-attachments/assets/939aa4d0-748c-45e4-a2a6-f5e7982c1fc0" />
<img width="1788" height="748" alt="cognee2" src="https://github.com/user-attachments/assets/213884be-cce1-4007-90f9-5e6d3a302ced" />

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my feature works
- [ ] I have not added or changed documentation (as it was not required for this CLI change)
- [x] I have searched existing PRs to ensure this change has been submitted already
- [x] I have linked the relevant issue in the description

## Related Issues

Fixes #1366 

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.