### PR TITLE
CI: Extract Windows and MacOS tests to separate job

### DIFF
--- a/.github/workflows/test_different_operating_systems.yml
+++ b/.github/workflows/test_different_operating_systems.yml
@@ -13,7 +13,7 @@ on:
       os: 
         required: false
         type: string
-        default: '["ubuntu-22.04", "macos-15", "windows-latest"]'        
+        default: '["ubuntu-22.04", "macos-15", "windows-latest"]'
     secrets:
       LLM_PROVIDER:
         required: true
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         python-version: ${{ fromJSON(inputs.python-versions) }}
-        os: ${{ fromJSON(inputs.os) }}        
+        os: ${{ fromJSON(inputs.os) }}
       fail-fast: false
     steps:
       - name: Check out

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -96,7 +96,7 @@ jobs:
     with:
       python-versions: '["3.13.x"]'
       os: '["macos-15", "windows-latest"]'
-    secrets: inherit  
+    secrets: inherit
 
   # Matrix-based vector database tests
   vector-db-tests:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Reduces the amount of macOS and Windows jobs by running these tests only for the latest python version in the list.
`different-os-tests-basic` runs tests on ubuntu and python `'["3.10.x", "3.11.x", "3.12.x", "3.13.x"]'`
`different-os-tests-extended` runs windows and macOS tests for python `3.13.x`. 
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please specify):

## Screenshots/Videos (if applicable)
<!-- Add screenshots or videos to help explain your changes -->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR**
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
