### PR TITLE
fix: Escape backslashes in JS regex for Python 3.12+ compatibility

### DIFF
--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -192,7 +192,7 @@ async def cognee_network_visualization(graph_data, destination_file_path: str = 
                 if (n.type) entries.push({k:'Type', v: n.type});
                 if (n.id) entries.push({k:'ID', v: n.id});
                 var desc = pickDescription(n) || pickDescription(n.properties);
-                if (desc) entries.push({k:'Description', v: truncate(desc.replace(/\s+/g,' ').trim(), 280)});
+                if (desc) entries.push({k:'Description', v: truncate(desc.replace(/\\s+/g,' ').trim(), 280)});
                 if (n.properties) {
                     Object.keys(n.properties).slice(0, 12).forEach(function(key){
                         var v = n.properties[key];
@@ -210,7 +210,7 @@ async def cognee_network_visualization(graph_data, destination_file_path: str = 
                 }
                 if (e.relationship_type) entries.push({k:'Type', v: e.relationship_type});
                 var edesc = pickDescription(e.edge_info);
-                if (edesc) entries.push({k:'Description', v: truncate(edesc.replace(/\s+/g,' ').trim(), 280)});
+                if (edesc) entries.push({k:'Description', v: truncate(edesc.replace(/\\s+/g,' ').trim(), 280)});
                 renderInfo('Edge', entries);
             }
 


### PR DESCRIPTION
## Summary
- Fixes Python 3.12+ SyntaxError caused by invalid escape sequences in embedded JavaScript regex patterns
- Escapes `\s` → `\\s` in two regex patterns within the HTML template

## Details
Python 3.12 made invalid escape sequences a hard SyntaxError (previously just a DeprecationWarning). The embedded JavaScript code in `cognee_network_visualization.py` contains regex patterns like `/\s+/g` which Python incorrectly interprets as escape sequences.

The fix escapes the backslashes (`\\s`) so Python passes the literal `\s` to JavaScript, which is what the regex needs.

Fixes #1929

## Test plan
- [x] Verified import works on Python 3.12
- [x] Fix is backwards compatible with Python 3.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected whitespace handling in network visualization node and edge descriptions to ensure proper text normalization and sanitization during display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->