### PR TITLE
Fix Python 3.12 SyntaxError caused by JS regex escape sequences

### DIFF
--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -92,7 +92,7 @@ async def cognee_network_visualization(graph_data, destination_file_path: str = 
         }
         links_list.append(link_data)
 
-    html_template = """
+    html_template = r"""
     <!DOCTYPE html>
     <html>
     <head>


### PR DESCRIPTION
### Fix Python 3.12 SyntaxError caused by invalid escape sequences

#### Problem
Importing `cognee` on Python 3.12+ raises:

SyntaxError: invalid escape sequence '\s'

This occurs because JavaScript regex patterns (e.g. `/\s+/g`) are embedded
inside a regular Python triple-quoted string, which Python 3.12 strictly
validates.

#### Solution
Converted the HTML template string to a raw string (`r"""`) so Python does not
interpret JavaScript regex escape sequences.

#### Files Changed
- cognee/modules/visualization/cognee_network_visualization.py

Fixes #1929


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the network visualization module through enhanced HTML template handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->