### PR TITLE
Add logging to S3 data operations for better monitoring

### DIFF
--- a/cognee/modules/ingestion/data_types/S3BinaryData.py
+++ b/cognee/modules/ingestion/data_types/S3BinaryData.py
@@ -1,13 +1,14 @@
 import os
-import logging
 import time
-from typing import Optional
+from typing import Optional, Any
 from contextlib import asynccontextmanager
 from cognee.infrastructure.files import get_file_metadata, FileMetadata
 from cognee.infrastructure.utils import run_sync
 from .IngestionData import IngestionData
+from cognee.infrastructure.files.storage.S3FileStorage import S3FileStorage
+from cognee.shared.logging_utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Define thresholds for slow operations (in seconds)
 SLOW_METADATA_FETCH_THRESHOLD = 2.0  # Example: 2 seconds
@@ -15,12 +16,21 @@ SLOW_DATA_READ_THRESHOLD = 5.0  # Example: 5 seconds
 
 
 def create_s3_binary_data(s3_path: str, name: Optional[str] = None) -> "S3BinaryData":
+    """Factory function to create an S3BinaryData instance.
+
+    Args:
+        s3_path: The S3 path to the binary data.
+        name: Optional name for the data.
+
+    Returns:
+        An instance of S3BinaryData.
+    """
     logger.debug(f"Creating S3BinaryData for path: {s3_path}, name: {name}")
     return S3BinaryData(s3_path, name=name)
 
 
 class S3BinaryData(IngestionData):
-    name: Optional[str] = None
+    name: str | None = None
     s3_path: str = None
     metadata: Optional[FileMetadata] = None
 
@@ -31,13 +41,16 @@ class S3BinaryData(IngestionData):
 
     def get_identifier(self):
         logger.debug(f"Getting identifier for s3_path: {self.s3_path}")
-        metadata = self.get_metadata()  # This will ensure metadata is fetched if not already
-        identifier = metadata.get("content_hash")
+        # Ensure metadata is fetched before getting identifier
+        self.get_metadata()
+        # Access self.metadata directly after ensuring it's fetched
+        identifier = self.metadata.get("content_hash") if self.metadata else None
         logger.debug(f"Identifier for {self.s3_path}: {identifier}")
         return identifier
 
     def get_metadata(self):
         logger.debug(f"Getting metadata for s3_path: {self.s3_path}")
+        # Use run_sync to ensure async ensure_metadata is called in sync context
         run_sync(self.ensure_metadata())
         logger.debug(f"Metadata retrieved: {self.metadata}")
         return self.metadata
@@ -45,8 +58,6 @@ class S3BinaryData(IngestionData):
     async def ensure_metadata(self):
         if self.metadata is None:
             logger.info(f"Metadata not cached, fetching for s3_path: {self.s3_path}")
-            from cognee.infrastructure.files.storage.S3FileStorage import S3FileStorage
-
             file_dir_path = os.path.dirname(self.s3_path)
             file_path = os.path.basename(self.s3_path)
 
@@ -57,10 +68,9 @@ class S3BinaryData(IngestionData):
             try:
                 start_time = time.time()
                 async with file_storage.open(file_path, "rb") as file:
-                    # Assuming get_file_metadata can provide file size directly or through the file object
-                    # If not, we might need to adjust how file size is obtained.
                     self.metadata = await get_file_metadata(file)
-                    file_size = self.metadata.get("size")  # Assuming metadata contains size
+                    # Use the correct key 'file_size'
+                    file_size = self.metadata.get("file_size")
                     end_time = time.time()
                     elapsed_time = end_time - start_time
 
@@ -82,7 +92,8 @@ class S3BinaryData(IngestionData):
                 logger.error(f"Error fetching metadata for {self.s3_path}: {e}", exc_info=True)
                 raise
 
-            if self.metadata.get("name") is None:
+            # Set name from metadata if not provided and if it exists in metadata
+            if self.metadata and self.metadata.get("name") is None:
                 self.metadata["name"] = self.name or file_path
                 logger.debug(f"Set metadata name to: {self.metadata['name']}")
         else:
@@ -91,7 +102,6 @@ class S3BinaryData(IngestionData):
     @asynccontextmanager
     async def get_data(self):
         logger.info(f"Opening S3 file for reading: {self.s3_path}")
-        from cognee.infrastructure.files.storage.S3FileStorage import S3FileStorage
 
         file_dir_path = os.path.dirname(self.s3_path)
         file_path = os.path.basename(self.s3_path)
@@ -101,24 +111,34 @@ class S3BinaryData(IngestionData):
         file_storage = S3FileStorage(file_dir_path)
 
         try:
+            # Start timing before opening the file for reading
             start_time = time.time()
             async with file_storage.open(file_path, "rb") as file:
                 logger.debug(f"Successfully opened S3 file: {self.s3_path}")
-                # Attempt to get file size if possible from the file object or cached metadata
-                file_size = "unknown"
-                if self.metadata and "size" in self.metadata:
-                    file_size = self.metadata["size"]
-                elif hasattr(file, "size"):  # Check if file object has size attribute
-                    file_size = file.size
 
+                # Attempt to get file size if possible from the file object or cached metadata
+                file_size_val: Any = "unknown"
+                if self.metadata and "file_size" in self.metadata:
+                    file_size_val = self.metadata["file_size"]
+                # Check if the file object has a 'size' attribute (common for file-like objects)
+                elif hasattr(file, "seek") and hasattr(
+                    file, "tell"
+                ):  # Seekable objects might have size information
+                    current_pos = file.tell()
+                    file.seek(0, os.SEEK_END)  # Go to the end of the file
+                    file_size_val = file.tell()  # Get the size
+                    file.seek(current_pos)  # Go back to original position
+
+                # Yield the file object to the caller
                 yield file
 
+                # Record time after the file has been used and closed (implicitly by async with)
                 end_time = time.time()
                 elapsed_time = end_time - start_time
 
-                if file_size != "unknown":
+                if file_size_val != "unknown":
                     logger.debug(
-                        f"Read {file_size} bytes from S3 file: {self.s3_path} in {elapsed_time:.2f}s"
+                        f"Read {file_size_val} bytes from S3 file: {self.s3_path} in {elapsed_time:.2f}s"
                     )
                 else:
                     logger.debug(f"Read data from S3 file: {self.s3_path} in {elapsed_time:.2f}s")


### PR DESCRIPTION
I have updated the S3BinaryData.py file to include more comprehensive logging as per issue #2048. The changes include:

1.  Added time import: To measure the duration of operations.
2.  Defined Thresholds: Introduced **_SLOW_METADATA_FETCH_THRESHOLD_** and **_SLOW_DATA_READ_THRESHOLD_** constants to identify slow operations.
3.  Timed Metadata Fetching: In ensure_metadata, the time taken to fetch metadata is now measured and logged.
4.  Logged File Size: If available, the file size is logged along with successful metadata fetching.
5.  Warning for Slow Metadata Fetch: A **_logger.warning_** is added if metadata fetching exceeds the **_SLOW_METADATA_FETCH_THRESHOLD_**.
6.  Timed Data Reading: In get_data, the time taken to read the file is measured.
7.  Logged File Size During Read: An attempt is made to log the file size when data is read, either from cached metadata or directly from the file object if available.
8.  Warning for Slow Data Read: A **_logger.warning_** is added if data reading exceeds the **_SLOW_DATA_READ_THRESHOLD_**.
9.  Enhanced Error Logging Context: Error messages in **_ensure_metadata_** and **_get_data_** are more specific about the operation that failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved runtime monitoring and logging for S3 data operations, including timing and slow-operation warnings.
  * More robust metadata retrieval with better error handling and automatic name inference when missing.
  * Improved logging around data reads with duration tracking and slow-read alerts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->