### PR TITLE
Fix: Raise InvalidConfigAttributeError for invalid config attributes

### DIFF
--- a/cognee/api/v1/config/config.py
+++ b/cognee/api/v1/config/config.py
@@ -165,7 +165,7 @@ class config:
             if hasattr(vector_db_config, key):
                 object.__setattr__(vector_db_config, key, value)
             else:
-                InvalidConfigAttributeError(attribute=key)
+                raise InvalidConfigAttributeError(attribute=key)
 
     @staticmethod
     def set_vector_db_key(db_key: str):


### PR DESCRIPTION
This fixes an issue where InvaligConfigAttributeError was instantiated but not raised in set_vector_db_config.

The change ensures that invalid configuration keys correctly raise an exception, matching expected Python error-handling behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where invalid vector database configuration attributes were not properly reported to users, ensuring error notifications are now displayed when misconfigurations are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->