### PR TITLE
fix: correct typo 'occured' to 'occurred'

### DIFF
--- a/cognee/cli/commands/delete_command.py
+++ b/cognee/cli/commands/delete_command.py
@@ -55,7 +55,7 @@ Be careful with deletion operations as they are irreversible.
                         )
                     )
                 except CliCommandException as e:
-                    fmt.error(f"Error occured when fetching preview data: {str(e)}")
+                    fmt.error(f"Error occurred when fetching preview data: {str(e)}")
                     return
 
                 if not preview_data:


### PR DESCRIPTION
Fixes a typo in delete_command.py error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in an error message to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->