### PR TITLE
fix: preserve full model name 

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -251,7 +251,8 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
         """
         logger.debug(f"Loading tokenizer for model {self.model}...")
         # If model also contains provider information, extract only model information
-        model = self.model.split("/")[-1]
+        # Split only on the first "/" to preserve model names like "BAAI/bge-m3"
+        model = self.model.split("/", 1)[-1] if "/" in self.model else self.model
 
         if "openai" in self.provider.lower():
             tokenizer = TikTokenTokenizer(


### PR DESCRIPTION
when stripping provider prefix in embeding engine

The get_tokenizer method used split("/")[-1] which incorrectly truncated model names containing slashes (e.g. "openai/BAAI/bge-m3" became "bge-m3" instead of "BAAI/bge-m3"). Use split("/", 1) to only strip the provider prefix.

<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of embedding models with complex naming structures containing multiple path separators, ensuring correct model identification for tokenization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->