### PR TITLE
fix: silence optional dependency import warnings

### DIFF
--- a/cognee/tasks/web_scraper/default_url_crawler.py
+++ b/cognee/tasks/web_scraper/default_url_crawler.py
@@ -14,13 +14,13 @@ logger = get_logger()
 try:
     from protego import Protego
 except ImportError:
-    logger.warning("Failed to import protego, make sure to install using pip install protego>=0.1")
+    logger.debug("Failed to import protego, make sure to install using pip install protego>=0.1")
     Protego = None
 
 try:
     from playwright.async_api import async_playwright
 except ImportError:
-    logger.warning(
+    logger.debug(
         "Failed to import playwright, make sure to install using pip install playwright>=1.9.0"
     )
     async_playwright = None


### PR DESCRIPTION
## Summary
- Downgrade `protego` and `playwright` import failure logs from `warning` to `debug` level in `default_url_crawler.py`
- These are optional extras (for web scraping) — their absence should not produce visible warnings for users who don't use that functionality

## Test plan
- [ ] Verify warnings no longer appear on normal import/startup
- [ ] Verify messages still appear when log level is set to DEBUG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity for missing optional dependencies to provide cleaner console output during normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->