### PR TITLE
CI: Telemetry non-blocking + request timeout (Contributor PR mdehsan873)

### DIFF
--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -1,24 +1,28 @@
 """This module contains utility functions for the cognee."""
 
-import os
-import ssl
-import requests
-from datetime import datetime, timezone
 import http.server
-import socketserver
-from threading import Thread
+import os
 import pathlib
-from typing import Union, Any, Dict, List
-from uuid import uuid4, uuid5, NAMESPACE_OID, UUID
+import socketserver
+import ssl
+from datetime import datetime, timezone
+from threading import Thread
+from typing import Any, Dict, List, Union
+from uuid import NAMESPACE_OID, UUID, uuid4, uuid5
+
+import requests
 
 from cognee.base_config import get_base_config
-from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
 
 # Analytics Proxy Url, currently hosted by Vercel
 proxy_url = "https://test.prometh.ai"
+
+# Timeout for telemetry HTTP request; short to avoid blocking if proxy is unreachable
+TELEMETRY_REQUEST_TIMEOUT: int = int(os.getenv("TELEMETRY_REQUEST_TIMEOUT", "5"))
 
 
 def create_secure_ssl_context() -> ssl.SSLContext:
@@ -79,6 +83,16 @@ def _sanitize_nested_properties(obj: Any, property_names: list[str]) -> Any:
         return obj
 
 
+def _send_telemetry_request(payload: dict) -> None:
+    """Send telemetry payload via HTTP. Runs in a background thread; never blocks."""
+    try:
+        response = requests.post(proxy_url, json=payload, timeout=TELEMETRY_REQUEST_TIMEOUT)
+        if response.status_code != 200:
+            logger.debug("Telemetry proxy returned status %s", response.status_code)
+    except requests.RequestException as e:
+        logger.debug("Telemetry request failed: %s", e)
+
+
 def send_telemetry(event_name: str, user_id: Union[str, UUID], additional_properties: dict = {}):
     if additional_properties is None:
         additional_properties = {}
@@ -105,10 +119,9 @@ def send_telemetry(event_name: str, user_id: Union[str, UUID], additional_proper
         },
     }
 
-    response = requests.post(proxy_url, json=payload)
-
-    if response.status_code != 200:
-        print(f"Error sending telemetry through proxy: {response.status_code}")
+    # Fire-and-forget in a daemon thread so we never block the event loop or pipeline
+    thread = Thread(target=_send_telemetry_request, args=(payload,), daemon=True)
+    thread.start()
 
 
 def embed_logo(p: Any, layout_scale: float, logo_alpha: float, position: str):


### PR DESCRIPTION
## Summary
- Fresh branch for CI/CD testing of contributor PR #2121 by @mdehsan873
- Makes send_telemetry non-blocking via daemon thread
- Adds configurable TELEMETRY_REQUEST_TIMEOUT env var (default 5s)
- Tests cover timeout, error handling, and background thread behavior

## Original PR
#2121

## Test plan
- [ ] CI/CD passes
- [ ] Telemetry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry data is now sent asynchronously in the background, preventing blocking operations.
  * Added configurable timeout for telemetry requests (default 5 seconds).

* **Tests**
  * Added comprehensive tests validating telemetry timeout and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->