### PR TITLE
CI: Retrieve full doc or neighbor chunks via MCP (Contributor PR rob-9)

### DIFF
--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -433,6 +433,8 @@ Some features are only available in direct mode:
 - `prune` (data reset)
 - `get_developer_rules` (developer rules retrieval)
 - `list_data` with specific dataset_id (detailed data listing)
+- `get_document` (full document retrieval)
+- `get_chunk_neighbors` (neighboring chunk retrieval)
 
 Basic operations like `cognify`, `search`, `delete`, and `list_data` (all datasets) work in both modes.
 
@@ -461,6 +463,10 @@ The MCP server exposes its functionality through tools. Call them from any MCP c
 
 - **search**: Query memory – supports GRAPH_COMPLETION, RAG_COMPLETION, CODE, CHUNKS, SUMMARIES, CYPHER, and FEELING_LUCKY
 
+- **get_document**: Retrieve complete documents with all chunks by document ID
+
+- **get_chunk_neighbors**: Retrieve surrounding chunks by chunk_index for narrative context
+
 - **cognify_status / codify_status**: Track pipeline progress
 
 **Data Management Examples:**
@@ -476,6 +482,18 @@ delete(data_id="data-uuid", dataset_id="dataset-uuid", mode="soft")
 
 # Delete specific data (hard deletion - removes orphaned entities)
 delete(data_id="data-uuid", dataset_id="dataset-uuid", mode="hard")
+```
+
+**Document Retrieval Examples:**
+```bash
+# Retrieve a complete document with all chunks
+get_document(document_id="doc-uuid-here", include_metadata=True)
+
+# Retrieve surrounding chunks for context (2 chunks before and after)
+get_chunk_neighbors(chunk_id="chunk-uuid-here", neighbor_count=2, include_target=True)
+
+# Get only surrounding chunks without the target chunk
+get_chunk_neighbors(chunk_id="chunk-uuid-here", neighbor_count=3, include_target=False)
 ```
 
 

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -518,6 +518,343 @@ async def search(search_query: str, search_type: str, top_k: int = 10) -> list:
 
 
 @mcp.tool()
+@log_usage(function_name="MCP get_document", log_type="mcp_tool")
+async def get_document(document_id: str, include_metadata: bool = True) -> list:
+    """
+    Retrieve a complete document by its ID with all chunks and metadata.
+
+    Use this after a CHUNKS search to fetch the full source document that a chunk
+    belongs to. The document ID is found in the 'parent_document' field of enriched
+    chunk search results. Returns the document with all chunks in reading order.
+
+    Parameters
+    ----------
+    document_id : str
+        The unique identifier of the document to retrieve.
+        Obtained from chunk search results: result['parent_document']['id']
+
+    include_metadata : bool, optional
+        Whether to include document metadata (default: True).
+        Set to False for faster retrieval when metadata is not needed.
+
+    Returns
+    -------
+    list
+        A list containing a single TextContent object with JSON-formatted document data.
+
+        Response structure:
+        {
+            "document_id": str,
+            "name": str,
+            "type": str,
+            "chunk_count": int,
+            "chunks": [{"chunk_id": str, "chunk_index": int, "text": str, "word_count": int}],
+            "metadata": dict  (if include_metadata=True)
+        }
+
+        Returns error object if document not found:
+        {"error": str, "document_id": str}
+
+    Notes
+    -----
+    - Requires graph database to be accessible with Document nodes
+    - Chunks are returned sorted by chunk_index in reading order
+    - Document must have been processed via cognify to exist in graph
+    """
+
+    async def get_document_task(document_id: str, include_metadata: bool) -> str:
+        """
+        Internal task to retrieve document from graph database.
+
+        Parameters
+        ----------
+        document_id : str
+            Document identifier to retrieve
+        include_metadata : bool
+            Whether to include metadata in response
+
+        Returns
+        -------
+        str
+            JSON string containing document data or error information
+        """
+        # NOTE: MCP uses stdout to communicate, we must redirect all output
+        #       going to stdout ( like the print function ) to stderr.
+        with redirect_stdout(sys.stderr):
+            if cognee_client.use_api:
+                return json.dumps(
+                    {
+                        "error": "get_document is not supported in API mode",
+                        "document_id": document_id,
+                    },
+                    cls=JSONEncoder,
+                )
+
+            try:
+                from cognee.infrastructure.databases.graph import get_graph_engine
+
+                graph_engine = await get_graph_engine()
+
+                # query doc with all its chunks (flat cols)
+                query = """
+                MATCH (doc:Document {id: $doc_id})
+                OPTIONAL MATCH (doc)<-[:is_part_of]-(chunk:DocumentChunk)
+                RETURN doc, chunk.id as chunk_id, chunk.chunk_index as chunk_index,
+                       chunk.text as chunk_text, chunk.word_count as chunk_word_count
+                ORDER BY chunk.chunk_index
+                """
+
+                result = await graph_engine.query(query, params={"doc_id": document_id})
+
+                if not result or not result[0].get("doc"):
+                    return json.dumps(
+                        {"error": "Document not found", "document_id": document_id}, cls=JSONEncoder
+                    )
+
+                doc = result[0]["doc"]
+
+                # Assemble chunks from flat rows
+                chunks = []
+                for row in result:
+                    if row.get("chunk_id") is not None:
+                        chunks.append(
+                            {
+                                "id": row["chunk_id"],
+                                "chunk_index": row.get("chunk_index", 0),
+                                "text": row.get("chunk_text", ""),
+                                "word_count": row.get("chunk_word_count", 0),
+                            }
+                        )
+
+                # Build response
+                response = {
+                    "document_id": str(doc.id) if hasattr(doc, "id") else str(doc.get("id", "")),
+                    "name": doc.name if hasattr(doc, "name") else doc.get("name", "Unknown"),
+                    "type": doc.type if hasattr(doc, "type") else doc.get("type", "unknown"),
+                    "chunk_count": len(chunks),
+                    "chunks": chunks,
+                }
+
+                if include_metadata:
+                    if hasattr(doc, "metadata"):
+                        response["metadata"] = doc.metadata
+                    elif isinstance(doc, dict) and "metadata" in doc:
+                        response["metadata"] = doc["metadata"]
+
+                logger.info(f"Retrieved document {document_id} with {len(chunks)} chunks")
+                return json.dumps(response, indent=2, cls=JSONEncoder)
+
+            except Exception as error:
+                logger.error(f"Failed to retrieve document {document_id}: {error}")
+                return json.dumps(
+                    {
+                        "error": f"Failed to retrieve document: {str(error)}",
+                        "document_id": document_id,
+                    },
+                    cls=JSONEncoder,
+                )
+
+    result = await get_document_task(document_id, include_metadata)
+    return [types.TextContent(type="text", text=result)]
+
+
+@mcp.tool()
+@log_usage(function_name="MCP get_chunk_neighbors", log_type="mcp_tool")
+async def get_chunk_neighbors(
+    chunk_id: str,
+    neighbor_count: int = 2,
+    include_target: bool = True,
+) -> list:
+    """
+    Retrieve neighboring chunks around a target chunk by chunk_index position.
+
+    Use this after a CHUNKS search to get surrounding context from the same document.
+    Fetches chunks before and after the target chunk to provide narrative context
+    around search results. Chunks are retrieved by sequential chunk_index values.
+
+    Parameters
+    ----------
+    chunk_id : str
+        The unique identifier of the target chunk from search results.
+        Obtained from CHUNKS search: result[0]['id']
+
+    neighbor_count : int, optional
+        Number of chunks to retrieve on each side of the target (default: 2).
+        Maximum value: 10 (capped)
+
+    include_target : bool, optional
+        Whether to include the target chunk in results (default: True).
+        Set to False to retrieve only surrounding chunks without the target.
+
+    Returns
+    -------
+    list
+        A list containing a single TextContent object with JSON-formatted neighbor data.
+
+        Response structure:
+        {
+            "document_id": str,
+            "document_name": str,
+            "target_chunk_index": int,
+            "neighbor_count": int,
+            "chunks_returned": int,
+            "chunks": [
+                {
+                    "chunk_id": str,
+                    "chunk_index": int,
+                    "text": str,
+                    "word_count": int,
+                    "is_target": bool
+                }
+            ]
+        }
+
+        Returns error object if chunk not found:
+        {"error": str, "chunk_id": str}
+
+    Notes
+    -----
+    - Requires graph database to be accessible with DocumentChunk nodes
+    - Chunks are always returned sorted by chunk_index in ascending order
+    - Target chunk is marked with "is_target": true in results
+    - Automatically handles document boundaries (first/last chunks)
+    - Only retrieves chunks from the same parent document
+    """
+
+    async def get_neighbors_task(chunk_id: str, neighbor_count: int, include_target: bool) -> str:
+        """
+        Internal task to retrieve neighboring chunks from graph database.
+
+        Parameters
+        ----------
+        chunk_id : str
+            Target chunk identifier
+        neighbor_count : int
+            Chunks to retrieve on each side
+        include_target : bool
+            Whether to include target in results
+
+        Returns
+        -------
+        str
+            JSON string containing neighbor data or error information
+        """
+        # NOTE: MCP uses stdout to communicate, we must redirect all output
+        #       going to stdout ( like the print function ) to stderr.
+        with redirect_stdout(sys.stderr):
+            if cognee_client.use_api:
+                return json.dumps(
+                    {
+                        "error": "get_chunk_neighbors is not supported in API mode",
+                        "chunk_id": chunk_id,
+                    },
+                    cls=JSONEncoder,
+                )
+
+            try:
+                # validate / cap neighbor count, range 1 to 10
+                neighbor_count = min(max(neighbor_count, 1), 10)
+
+                from cognee.infrastructure.databases.graph import get_graph_engine
+
+                graph_engine = await get_graph_engine()
+
+                # get chunk index
+                target_query = """
+                MATCH (chunk:DocumentChunk {id: $chunk_id})-[:is_part_of]->(doc:Document)
+                RETURN chunk.chunk_index as target_index, doc.id as doc_id, doc.name as doc_name
+                """
+
+                target_result = await graph_engine.query(
+                    target_query, params={"chunk_id": chunk_id}
+                )
+
+                # chunk DNE in graph DB
+                if not target_result:
+                    logger.warning(f"Chunk not found in graph database: {chunk_id}")
+                    return json.dumps(
+                        {
+                            "error": "Chunk not found",
+                            "chunk_id": chunk_id,
+                            "suggestion": "Verify the chunk ID from search results or check if data was cognified",
+                        },
+                        cls=JSONEncoder,
+                    )
+
+                target_index = target_result[0]["target_index"]
+                doc_id = target_result[0]["doc_id"]
+                doc_name = target_result[0]["doc_name"]
+
+                # calculate index range and retrieve neighboring chunks
+                min_index = target_index - neighbor_count
+                max_index = target_index + neighbor_count
+
+                neighbors_query = """
+                MATCH (chunk:DocumentChunk)-[:is_part_of]->(doc:Document {id: $doc_id})
+                WHERE chunk.chunk_index >= $min_index
+                  AND chunk.chunk_index <= $max_index
+                RETURN chunk.id as chunk_id,
+                       chunk.chunk_index as chunk_index,
+                       chunk.text as text,
+                       chunk.word_count as word_count
+                ORDER BY chunk.chunk_index
+                """
+
+                neighbors_result = await graph_engine.query(
+                    neighbors_query,
+                    params={"doc_id": str(doc_id), "min_index": min_index, "max_index": max_index},
+                )
+
+                # format response and filter based on include_target
+                chunks = []
+                for row in neighbors_result:
+                    is_target = row["chunk_index"] == target_index
+
+                    if not include_target and is_target:
+                        continue
+
+                    chunks.append(
+                        {
+                            "chunk_id": str(row["chunk_id"]),
+                            "chunk_index": row["chunk_index"],
+                            "text": row["text"],
+                            "word_count": row.get("word_count", 0),
+                            "is_target": is_target,
+                        }
+                    )
+
+                # Chunks are already sorted by ORDER BY in query, but chunks_returned
+                # reflects actual count after include_target filtering
+                response = {
+                    "document_id": str(doc_id),
+                    "document_name": doc_name,
+                    "target_chunk_index": target_index,
+                    "neighbor_count": neighbor_count,
+                    "chunks_returned": len(chunks),
+                    "chunks": chunks,
+                }
+
+                logger.info(f"Retrieved {len(chunks)} neighbors for chunk {chunk_id}")
+                return json.dumps(response, indent=2, cls=JSONEncoder)
+
+            except Exception as error:
+                logger.error(
+                    f"Failed to retrieve neighbors for chunk {chunk_id}: {error}", exc_info=True
+                )
+                return json.dumps(
+                    {
+                        "error": f"Failed to retrieve neighbors: {str(error)}",
+                        "chunk_id": chunk_id,
+                        "details": "Check if graph database is accessible and chunk exists",
+                    },
+                    cls=JSONEncoder,
+                )
+
+    result = await get_neighbors_task(chunk_id, neighbor_count, include_target)
+    return [types.TextContent(type="text", text=result)]
+
+
+@mcp.tool()
 @log_usage(function_name="MCP list_data", log_type="mcp_tool")
 async def list_data(dataset_id: str = None) -> list:
     """

--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -2,6 +2,7 @@ from typing import Any, Optional, List, Union
 from cognee.modules.retrieval.utils.access_tracking import update_node_access_timestamps
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.modules.retrieval.base_retriever import BaseRetriever
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
@@ -25,8 +26,10 @@ class ChunksRetriever(BaseRetriever):
     def __init__(
         self,
         top_k: Optional[int] = 5,
+        strict_enrichment: bool = False,
     ):
         self.top_k = top_k
+        self.strict_enrichment = strict_enrichment
 
     async def get_completion_from_context(
         self, query: str, retrieved_objects: Any, context: Any
@@ -100,10 +103,145 @@ class ChunksRetriever(BaseRetriever):
                 "DocumentChunk_text", query, limit=self.top_k, include_payload=True
             )
             logger.info(f"Found {len(found_chunks)} chunks from vector search")
-            await update_node_access_timestamps(found_chunks)
-
-            return found_chunks
-
         except CollectionNotFoundError as error:
             logger.error("DocumentChunk_text collection not found in vector database")
             raise NoDataError("No data found in the system, please add data first.") from error
+
+        if not found_chunks:
+            return found_chunks
+
+        try:
+            await update_node_access_timestamps(found_chunks)
+        except Exception as error:
+            logger.warning(f"Failed to update timestamps: {error}")
+            if self.strict_enrichment:
+                raise NoDataError(f"Failed to update timestamps: {error}") from error
+
+        # Get graph engine (stores chunk-document relationships)
+        try:
+            graph_engine = await get_graph_engine()
+        except Exception as error:
+            error_msg = f"Graph engine unavailable: {error}"
+            if self.strict_enrichment:
+                logger.error(error_msg)
+                raise NoDataError(error_msg) from error
+            else:
+                logger.warning(f"{error_msg}, skipping enrichment")
+                return found_chunks
+
+        chunk_ids = []
+        chunk_id_map = {}
+
+        # Extract all chunk IDs for lookup
+        for chunk in found_chunks:
+            chunk_id = None
+            try:
+                if hasattr(chunk, "id"):
+                    chunk_id = str(chunk.id)
+                elif hasattr(chunk, "payload") and "id" in chunk.payload:
+                    chunk_id = str(chunk.payload["id"])
+
+                if chunk_id:
+                    chunk_ids.append(chunk_id)
+                    chunk_id_map[chunk_id] = chunk
+                elif self.strict_enrichment:
+                    raise ValueError(f"Chunk missing ID: {chunk}")
+            except Exception as error:
+                if self.strict_enrichment:
+                    raise NoDataError(f"Failed to extract chunk ID: {error}") from error
+                logger.debug(f"Failed to extract chunk ID: {error}")
+
+        if not chunk_ids:
+            logger.warning("No valid chunk IDs found, skipping enrichment")
+            return found_chunks
+
+        # Try batched query
+        parent_map = {}
+
+        try:
+            logger.debug(f"Attempting batched parent lookup for {len(chunk_ids)} chunks")
+
+            cypher_query = """
+            MATCH (chunk:DocumentChunk)-[:is_part_of]->(doc:Document)
+            WHERE chunk.id IN $chunk_ids
+            RETURN chunk.id as chunk_id, doc.id as doc_id, doc.name as doc_name, doc.type as doc_type
+            """
+
+            result = await graph_engine.query(cypher_query, params={"chunk_ids": chunk_ids})
+
+            for row in result:
+                try:
+                    chunk_id = str(row["chunk_id"])
+                    parent_map[chunk_id] = {
+                        "id": str(row.get("doc_id", "")),
+                        "name": row.get("doc_name", "Unknown"),
+                    }
+                    if "doc_type" in row and row["doc_type"]:
+                        parent_map[chunk_id]["type"] = row["doc_type"]
+                except Exception as error:
+                    logger.warning(f"Failed to parse batch result row: {error}")
+
+            logger.info(
+                f"Batched query found parents for {len(parent_map)}/{len(chunk_ids)} chunks"
+            )
+
+        except Exception as error:
+            # fallback to individual queries
+            logger.warning(f"Batched lookup failed, falling back to individual queries: {error}")
+
+            for chunk_id in chunk_ids:
+                try:
+                    cypher_query = """
+                    MATCH (chunk:DocumentChunk {id: $chunk_id})-[:is_part_of]->(doc:Document)
+                    RETURN doc.id as doc_id, doc.name as doc_name, doc.type as doc_type
+                    LIMIT 1
+                    """
+
+                    result = await graph_engine.query(cypher_query, params={"chunk_id": chunk_id})
+
+                    if result and len(result) > 0:
+                        row = result[0]
+                        parent_map[chunk_id] = {
+                            "id": str(row.get("doc_id", "")),
+                            "name": row.get("doc_name", "Unknown"),
+                        }
+                        if "doc_type" in row and row["doc_type"]:
+                            parent_map[chunk_id]["type"] = row["doc_type"]
+
+                except Exception as individual_error:
+                    if self.strict_enrichment:
+                        raise NoDataError(
+                            f"Failed to fetch parent for {chunk_id}: {individual_error}"
+                        ) from individual_error
+                    logger.debug(f"Individual query failed for {chunk_id}: {individual_error}")
+
+        # modify chunk payloads
+        enriched_count = 0
+        for chunk_id, chunk in chunk_id_map.items():
+            if chunk_id in parent_map:
+                try:
+                    parent_info = parent_map[chunk_id]
+
+                    if hasattr(chunk, "payload") and isinstance(chunk.payload, dict):
+                        chunk.payload["parent_document"] = parent_info
+                    elif isinstance(chunk, dict):
+                        chunk["parent_document"] = parent_info
+                    enriched_count += 1
+                except Exception as error:
+                    if self.strict_enrichment:
+                        raise NoDataError(f"Failed to add parent info: {error}") from error
+                    logger.warning(f"Failed to add parent info to chunk: {error}")
+            elif self.strict_enrichment:
+                raise NoDataError(f"No parent found for chunk {chunk_id}")
+
+        success_rate = (enriched_count / len(found_chunks) * 100) if found_chunks else 0
+        logger.info(f"Enriched {enriched_count}/{len(found_chunks)} chunks ({success_rate:.1f}%)")
+
+        # vector and graph db out of sync
+        if success_rate < 50 and len(found_chunks) > 0 and not self.strict_enrichment:
+            logger.warning(
+                f"Low enrichment rate ({success_rate:.1f}%) suggests vector/graph DB inconsistency. "
+                "Consider running cognee.prune() and re-cognifying."
+            )
+
+        return found_chunks

--- a/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
@@ -9,7 +9,6 @@ from cognee.infrastructure.databases.vector.exceptions import CollectionNotFound
 
 @pytest.fixture
 def mock_vector_engine():
-    """Create a mock vector engine."""
     engine = AsyncMock()
     engine.search = AsyncMock()
     return engine
@@ -17,7 +16,6 @@ def mock_vector_engine():
 
 @pytest.mark.asyncio
 async def test_get_context_success(mock_vector_engine):
-    """Test successful retrieval of chunk context."""
     mock_result1 = MagicMock()
     mock_result1.payload = {"text": "Steve Rodger", "chunk_index": 0}
     mock_result2 = MagicMock()
@@ -104,7 +102,6 @@ async def test_get_context(mock_vector_engine):
         {"payload": {"text": "Steve Rodger"}},
         {"payload": {"text": "Mike Broski"}},
     ]
-    # Wrap the outer dictionary so payload is an attribute
     mock_objects = [SimpleNamespace(**obj) for obj in retrieved_objects]
 
     context = await retriever.get_context_from_objects("test query", retrieved_objects=mock_objects)
@@ -153,3 +150,587 @@ async def test_get_context_empty_payload(mock_vector_engine):
         )
 
     assert context == ""
+
+
+@pytest.fixture
+def mock_graph_engine():
+    """Create a mock graph engine for testing parent document enrichment."""
+    engine = AsyncMock()
+    engine.query = AsyncMock()
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_enrichment_successful_batched_query(mock_vector_engine, mock_graph_engine):
+    """Test successful enrichment with batched graph query."""
+    mock_chunk1 = MagicMock()
+    mock_chunk1.id = "chunk-123"
+    mock_chunk1.payload = {"id": "chunk-123", "text": "Python is great", "chunk_index": 0}
+
+    mock_chunk2 = MagicMock()
+    mock_chunk2.id = "chunk-456"
+    mock_chunk2.payload = {"id": "chunk-456", "text": "Python was created", "chunk_index": 1}
+
+    mock_vector_engine.search.return_value = [mock_chunk1, mock_chunk2]
+
+    mock_graph_engine.query.return_value = [
+        {
+            "chunk_id": "chunk-123",
+            "doc_id": "doc-789",
+            "doc_name": "python_tutorial.pdf",
+            "doc_type": "pdf",
+        },
+        {
+            "chunk_id": "chunk-456",
+            "doc_id": "doc-789",
+            "doc_name": "python_tutorial.pdf",
+            "doc_type": "pdf",
+        },
+    ]
+
+    retriever = ChunksRetriever(top_k=5)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert len(chunks) == 2
+    assert "parent_document" in chunks[0].payload
+    assert chunks[0].payload["parent_document"]["id"] == "doc-789"
+    assert chunks[0].payload["parent_document"]["name"] == "python_tutorial.pdf"
+
+    assert "parent_document" in chunks[1].payload
+    assert chunks[1].payload["parent_document"]["id"] == "doc-789"
+
+    mock_graph_engine.query.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enrichment_batched_query_fails_falls_back_to_individual(
+    mock_vector_engine, mock_graph_engine
+):
+    """Test that batched query failure triggers fallback to individual queries."""
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+
+    mock_graph_engine.query.side_effect = [
+        Exception("Batched query failed"),
+        [{"doc_id": "doc-789", "doc_name": "python_tutorial.pdf"}],
+    ]
+
+    retriever = ChunksRetriever(top_k=5)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert "parent_document" in chunks[0].payload
+    assert chunks[0].payload["parent_document"]["id"] == "doc-789"
+
+    assert mock_graph_engine.query.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_enrichment_graph_engine_unavailable_graceful_degradation(mock_vector_engine):
+    """Test that unavailable graph engine doesn't break search (graceful degradation)."""
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=False)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            side_effect=Exception("Graph DB unavailable"),
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert len(chunks) == 1
+    assert "parent_document" not in chunks[0].payload
+
+
+@pytest.mark.asyncio
+async def test_enrichment_strict_mode_raises_on_graph_unavailable(mock_vector_engine):
+    """Test that strict_enrichment mode raises error when graph DB unavailable."""
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=True)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            side_effect=Exception("Graph DB unavailable"),
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                with pytest.raises(NoDataError, match="Graph engine unavailable"):
+                    await retriever.get_retrieved_objects("test query")
+
+
+@pytest.mark.asyncio
+async def test_enrichment_no_parent_found_graceful(mock_vector_engine, mock_graph_engine):
+    """Test that missing parent document doesn't break search (non-strict mode)."""
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+
+    mock_graph_engine.query.return_value = []
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=False)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert len(chunks) == 1
+    assert "parent_document" not in chunks[0].payload
+
+
+@pytest.mark.asyncio
+async def test_enrichment_strict_mode_raises_on_no_parent(mock_vector_engine, mock_graph_engine):
+    """Test that strict mode raises error when no parent found."""
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+    mock_graph_engine.query.return_value = []
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=True)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                with pytest.raises(NoDataError, match="No parent found for chunk"):
+                    await retriever.get_retrieved_objects("test query")
+
+
+@pytest.mark.asyncio
+async def test_enrichment_partial_success(mock_vector_engine, mock_graph_engine):
+    """Test that partial enrichment works (some chunks enriched, others not)."""
+    mock_chunk1 = MagicMock()
+    mock_chunk1.id = "chunk-123"
+    mock_chunk1.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_chunk2 = MagicMock()
+    mock_chunk2.id = "chunk-456"
+    mock_chunk2.payload = {"id": "chunk-456", "text": "Python was created"}
+
+    mock_vector_engine.search.return_value = [mock_chunk1, mock_chunk2]
+
+    mock_graph_engine.query.return_value = [
+        {"chunk_id": "chunk-123", "doc_id": "doc-789", "doc_name": "python_tutorial.pdf"},
+    ]
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=False)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert "parent_document" in chunks[0].payload
+    assert "parent_document" not in chunks[1].payload
+
+
+@pytest.mark.asyncio
+async def test_enrichment_empty_chunks_list(mock_vector_engine, mock_graph_engine):
+    """Test that empty chunks list is handled correctly."""
+    mock_vector_engine.search.return_value = []
+
+    retriever = ChunksRetriever(top_k=5)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            chunks = await retriever.get_retrieved_objects("test query")
+
+    assert chunks == []
+    mock_graph_engine.query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enrichment_chunk_without_id(mock_vector_engine, mock_graph_engine):
+    """Test handling of chunks without ID field."""
+    mock_chunk = MagicMock(spec=[])
+    mock_chunk.payload = {"text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+    mock_graph_engine.query.return_value = []
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=False)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert len(chunks) == 1
+
+
+@pytest.mark.asyncio
+async def test_init_strict_enrichment_default():
+    """Test ChunksRetriever initialization with strict_enrichment default."""
+    retriever = ChunksRetriever()
+
+    assert retriever.strict_enrichment is False
+
+
+@pytest.mark.asyncio
+async def test_init_strict_enrichment_enabled():
+    """Test ChunksRetriever initialization with strict_enrichment enabled."""
+    retriever = ChunksRetriever(strict_enrichment=True)
+
+    assert retriever.strict_enrichment is True
+
+
+@pytest.mark.asyncio
+async def test_enrichment_low_success_rate_warning(mock_vector_engine, mock_graph_engine):
+    """Test warning logged when enrichment success rate is below 50%."""
+    chunks = []
+    for i in range(10):
+        chunk = MagicMock()
+        chunk.id = f"chunk-{i}"
+        chunk.payload = {"id": f"chunk-{i}", "text": f"Text {i}"}
+        chunks.append(chunk)
+
+    mock_vector_engine.search.return_value = chunks
+    mock_graph_engine.query.return_value = [
+        {"chunk_id": "chunk-0", "doc_id": "doc-1", "doc_name": "doc1.pdf"},
+        {"chunk_id": "chunk-1", "doc_id": "doc-1", "doc_name": "doc1.pdf"},
+    ]
+
+    retriever = ChunksRetriever(top_k=10, strict_enrichment=False)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                with patch("cognee.modules.retrieval.chunks_retriever.logger") as mock_logger:
+                    result = await retriever.get_retrieved_objects("test query")
+
+    assert len(result) == 10
+    assert sum(1 for c in result if "parent_document" in c.payload) == 2
+    mock_logger.warning.assert_called()
+    warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+    assert any("Low enrichment rate" in str(call) or "20.0%" in str(call) for call in warning_calls)
+
+
+@pytest.mark.asyncio
+async def test_enrichment_timestamp_update_failure_non_strict(
+    mock_vector_engine, mock_graph_engine
+):
+    """Test that timestamp update failure doesn't break search in non-strict mode."""
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+    mock_graph_engine.query.return_value = [
+        {"chunk_id": "chunk-123", "doc_id": "doc-789", "doc_name": "doc.pdf"}
+    ]
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=False)
+
+    mock_update = AsyncMock(side_effect=Exception("Timestamp update failed"))
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                mock_update,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert len(chunks) == 1
+    assert "parent_document" in chunks[0].payload
+
+
+@pytest.mark.asyncio
+async def test_enrichment_timestamp_update_failure_strict(mock_vector_engine):
+    """Test that timestamp update failure raises error in strict mode."""
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=True)
+
+    mock_update = AsyncMock(side_effect=Exception("Timestamp update failed"))
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps", mock_update
+        ):
+            with pytest.raises(NoDataError, match="Failed to update timestamps"):
+                await retriever.get_retrieved_objects("test query")
+
+
+@pytest.mark.asyncio
+async def test_get_completion_from_context_with_objects():
+    """Test get_completion_from_context returns chunk payloads."""
+    retriever = ChunksRetriever()
+
+    mock_chunk1 = MagicMock()
+    mock_chunk1.payload = {"text": "Python is great", "chunk_index": 0}
+
+    mock_chunk2 = MagicMock()
+    mock_chunk2.payload = {"text": "Python was created", "chunk_index": 1}
+
+    retrieved_objects = [mock_chunk1, mock_chunk2]
+
+    result = await retriever.get_completion_from_context(
+        "test query", retrieved_objects=retrieved_objects, context=None
+    )
+
+    assert len(result) == 2
+    assert result[0] == {"text": "Python is great", "chunk_index": 0}
+    assert result[1] == {"text": "Python was created", "chunk_index": 1}
+
+
+@pytest.mark.asyncio
+async def test_get_completion_from_context_empty():
+    """Test get_completion_from_context returns empty list when no objects."""
+    retriever = ChunksRetriever()
+
+    result = await retriever.get_completion_from_context(
+        "test query", retrieved_objects=[], context=None
+    )
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_enrichment_chunk_missing_id_strict_mode(mock_vector_engine, mock_graph_engine):
+    """Test that chunk missing ID raises NoDataError in strict mode."""
+    mock_chunk = MagicMock(spec=[])
+    mock_chunk.payload = {"text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=True)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+            new_callable=AsyncMock,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+                new_callable=AsyncMock,
+                return_value=mock_graph_engine,
+            ):
+                with pytest.raises(NoDataError, match="Failed to extract chunk ID"):
+                    await retriever.get_retrieved_objects("test query")
+
+
+@pytest.mark.asyncio
+async def test_enrichment_batched_row_parse_error(mock_vector_engine, mock_graph_engine):
+    """Test that a malformed row in batched query results is skipped gracefully."""
+    mock_chunk1 = MagicMock()
+    mock_chunk1.id = "chunk-123"
+    mock_chunk1.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_chunk2 = MagicMock()
+    mock_chunk2.id = "chunk-456"
+    mock_chunk2.payload = {"id": "chunk-456", "text": "Python was created"}
+
+    mock_vector_engine.search.return_value = [mock_chunk1, mock_chunk2]
+
+    good_row = {"chunk_id": "chunk-123", "doc_id": "doc-789", "doc_name": "tutorial.pdf"}
+    bad_row = MagicMock()
+    bad_row.__getitem__ = MagicMock(side_effect=KeyError("chunk_id"))
+    bad_row.__contains__ = MagicMock(return_value=False)
+
+    mock_graph_engine.query.return_value = [good_row, bad_row]
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=False)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert "parent_document" in chunks[0].payload
+    assert "parent_document" not in chunks[1].payload
+
+
+@pytest.mark.asyncio
+async def test_enrichment_individual_query_fails_strict_mode(mock_vector_engine, mock_graph_engine):
+    """Test that individual query failure raises NoDataError in strict mode during fallback."""
+    mock_chunk = MagicMock()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+
+    mock_graph_engine.query.side_effect = [
+        Exception("Batched query failed"),
+        Exception("Individual query also failed"),
+    ]
+
+    retriever = ChunksRetriever(top_k=5, strict_enrichment=True)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                with pytest.raises(NoDataError, match="Failed to fetch parent for chunk-123"):
+                    await retriever.get_retrieved_objects("test query")
+
+
+@pytest.mark.asyncio
+async def test_enrichment_handles_dict_chunks(mock_vector_engine, mock_graph_engine):
+    """Test enrichment works when modifying chunk.payload on dict-type chunks."""
+    mock_chunk = SimpleNamespace()
+    mock_chunk.id = "chunk-123"
+    mock_chunk.payload = {"id": "chunk-123", "text": "Python is great"}
+
+    mock_vector_engine.search.return_value = [mock_chunk]
+    mock_graph_engine.query.return_value = [
+        {"chunk_id": "chunk-123", "doc_id": "doc-789", "doc_name": "doc.pdf"}
+    ]
+
+    retriever = ChunksRetriever(top_k=5)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        with patch(
+            "cognee.modules.retrieval.chunks_retriever.get_graph_engine",
+            return_value=mock_graph_engine,
+        ):
+            with patch(
+                "cognee.modules.retrieval.chunks_retriever.update_node_access_timestamps",
+                new_callable=AsyncMock,
+            ):
+                chunks = await retriever.get_retrieved_objects("test query")
+
+    assert len(chunks) == 1
+    assert "parent_document" in chunks[0].payload
+    assert chunks[0].payload["parent_document"]["id"] == "doc-789"


### PR DESCRIPTION
## Summary
- Fresh branch for CI/CD testing of contributor PR #2154 by @rob-9
- Adds get_document and get_chunk_neighbors MCP tools
- Enhances ChunksRetriever with optional strict enrichment and parent document metadata
- Comprehensive unit tests for enrichment scenarios

## Original PR
#2154

## Test plan
- [ ] CI/CD passes
- [ ] ChunksRetriever unit tests pass
- [ ] MCP server tools functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)