### PR TITLE
CI: Chunk associations task for memify pipeline (Contributor PR deidaraiorek)

### DIFF
--- a/cognee/infrastructure/llm/prompts/chunk_association_system.txt
+++ b/cognee/infrastructure/llm/prompts/chunk_association_system.txt
@@ -1,0 +1,28 @@
+You are a semantic similarity analyzer for knowledge graph construction.
+
+Determine if two text chunks should be associated based on their semantic relationship.
+
+Chunks should be associated if they:
+- Discuss related topics or concepts
+- Provide complementary information about the same subject
+- Have causal, temporal, or logical relationships
+- One elaborates on or provides context for the other
+- Share key entities, events, or themes
+
+Chunks should NOT be associated if they:
+- Are completely unrelated in topic
+- Only share common words without semantic connection
+- Discuss different aspects with no meaningful connection
+
+Provide:
+1. Boolean decision (are_similar)
+2. Numeric similarity score from 0.0 to 1.0
+3. Type of association (topical, causal, temporal, elaboration, contextual, or null)
+4. Brief reasoning (1-2 sentences max)
+
+Similarity score ranges:
+- 0.0-0.3: Unrelated or minimal connection
+- 0.3-0.6: Loosely related
+- 0.6-0.8: Clearly related topics
+- 0.8-0.95: Very closely related
+- 0.95-1.0: Near-duplicate or identical content

--- a/cognee/infrastructure/llm/prompts/chunk_association_user.txt
+++ b/cognee/infrastructure/llm/prompts/chunk_association_user.txt
@@ -1,0 +1,13 @@
+Compare these two text chunks and determine their semantic similarity:
+
+**Chunk 1:**
+```
+{{ chunk_1 }}
+```
+
+**Chunk 2:**
+```
+{{ chunk_2 }}
+```
+
+Analyze their relationship and provide your assessment.

--- a/cognee/tasks/chunks/__init__.py
+++ b/cognee/tasks/chunks/__init__.py
@@ -2,9 +2,10 @@
 Text chunking and chunk management tasks.
 
 This module provides functionality for splitting text into chunks using
-different strategies (word, sentence, paragraph, or row-based) and for
-cleaning up disconnected or obsolete chunks to support downstream
-processing and knowledge graph workflows.
+different strategies (word, sentence, paragraph, or row-based), cleaning
+up disconnected or obsolete chunks, and creating semantic association
+edges between related chunks to support downstream processing and
+knowledge graph workflows.
 """
 
 from .chunk_by_word import chunk_by_word
@@ -12,3 +13,4 @@ from .chunk_by_sentence import chunk_by_sentence
 from .chunk_by_paragraph import chunk_by_paragraph
 from .chunk_by_row import chunk_by_row
 from .remove_disconnected_chunks import remove_disconnected_chunks
+from .create_chunk_associations import create_chunk_associations

--- a/cognee/tasks/chunks/create_chunk_associations.py
+++ b/cognee/tasks/chunks/create_chunk_associations.py
@@ -1,0 +1,221 @@
+"""
+Chunk association task for creating semantic links between document chunks.
+
+This module uses vector similarity search to identify candidate chunk pairs,
+then applies LLM-based comparison to determine whether chunks should be
+linked with weighted "associated_with" edges in the knowledge graph.
+"""
+
+from typing import AsyncGenerator, List, Optional, Union
+from pydantic import BaseModel, Field
+
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.llm import LLMGateway
+from cognee.infrastructure.llm.prompts import render_prompt, read_query_prompt
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.storage import index_graph_edges
+
+logger = get_logger("chunk_associations")
+
+
+class ChunkSimilarity(BaseModel):
+    """LLM-structured output representing the semantic similarity between two chunks."""
+
+    are_similar: bool = Field(description="Whether chunks are semantically related")
+    similarity_score: float = Field(ge=0.0, le=1.0, description="Similarity score 0.0-1.0")
+    reasoning: str = Field(description="Brief explanation of similarity assessment")
+    association_type: Optional[str] = Field(
+        default=None, description="Type: topical, causal, temporal, elaboration, contextual"
+    )
+
+
+async def _compare_chunks(
+    chunk_1: str,
+    chunk_2: str,
+    user_prompt_location: str,
+    system_prompt_location: str,
+) -> Optional[ChunkSimilarity]:
+    """Compare two text chunks for semantic similarity using an LLM.
+
+    Renders the user and system prompts with the chunk texts and calls the LLM
+    to produce a structured ChunkSimilarity response. Returns a fallback
+    ChunkSimilarity with are_similar=False on LLM failure.
+
+    Args:
+        chunk_1: Text content of the first chunk.
+        chunk_2: Text content of the second chunk.
+        user_prompt_location: Filename of the user prompt template.
+        system_prompt_location: Filename of the system prompt template.
+
+    Returns:
+        A ChunkSimilarity object, or a fallback with score 0.0 on error.
+    """
+    context = {"chunk_1": chunk_1, "chunk_2": chunk_2}
+    user_prompt = render_prompt(user_prompt_location, context)
+    system_prompt = read_query_prompt(system_prompt_location)
+
+    try:
+        return await LLMGateway.acreate_structured_output(
+            text_input=user_prompt,
+            system_prompt=system_prompt,
+            response_model=ChunkSimilarity,
+        )
+    except Exception as e:
+        logger.warning(f"LLM comparison failed: {e}")
+        return ChunkSimilarity(
+            are_similar=False, similarity_score=0.0, reasoning="LLM error", association_type=None
+        )
+
+
+def _create_edge(chunk_1_id: str, chunk_2_id: str, similarity: ChunkSimilarity):
+    """Build a graph edge tuple from two chunk IDs and their similarity result.
+
+    Args:
+        chunk_1_id: UUID of the source chunk node.
+        chunk_2_id: UUID of the target chunk node.
+        similarity: The LLM-produced similarity assessment.
+
+    Returns:
+        A tuple of (source_id, target_id, relationship_name, properties_dict).
+    """
+    return (
+        chunk_1_id,
+        chunk_2_id,
+        "associated_with",
+        {
+            "relationship_name": "associated_with",
+            "source_node_id": chunk_1_id,
+            "target_node_id": chunk_2_id,
+            "weight": similarity.similarity_score,
+            "association_type": similarity.association_type,
+            "reasoning": similarity.reasoning,
+            "ontology_valid": False,
+        },
+    )
+
+
+async def create_chunk_associations(
+    chunks: Union[List[str], str],
+    similarity_threshold: float = 0.7,
+    min_chunk_length: int = 10,
+    top_k_candidates: Optional[int] = None,
+    user_prompt_location: str = "chunk_association_user.txt",
+    system_prompt_location: str = "chunk_association_system.txt",
+) -> AsyncGenerator[str, None]:
+    """Create semantic association edges between document chunks in the knowledge graph.
+
+    For each valid chunk, performs a vector similarity search to find candidate
+    pairs, then uses an LLM to assess semantic relatedness. Pairs that meet the
+    similarity threshold are persisted as weighted "associated_with" edges.
+
+    This is an async generator that yields the original chunks after processing,
+    allowing it to be composed in cognee pipelines.
+
+    Args:
+        chunks: List of chunk text strings, or a single string, to evaluate.
+        similarity_threshold: Minimum LLM similarity score (0.0-1.0) required
+            to create an association edge. (default 0.7)
+        min_chunk_length: Minimum character length for a chunk to be considered.
+            Chunks shorter than this are skipped. (default 10)
+        top_k_candidates: Maximum number of vector search candidates per chunk.
+            None means no limit. (default None)
+        user_prompt_location: Filename of the user prompt template. (default
+            "chunk_association_user.txt")
+        system_prompt_location: Filename of the system prompt template. (default
+            "chunk_association_system.txt")
+
+    Yields:
+        Each chunk from the input list, unchanged.
+
+    Raises:
+        Exception: Re-raised if persisting edges to the graph database fails.
+    """
+    if not isinstance(chunks, list):
+        chunks = [chunks]
+
+    valid_chunks = [
+        chunk
+        for chunk in chunks
+        if chunk and isinstance(chunk, str) and len(chunk) >= min_chunk_length
+    ]
+
+    if len(valid_chunks) < 2:
+        logger.info(f"Less than 2 valid chunks ({len(valid_chunks)}), skipping associations")
+        for chunk in chunks:
+            yield chunk
+        return
+
+    logger.info(
+        f"Creating associations for {len(valid_chunks)} chunks with threshold {similarity_threshold}"
+    )
+
+    vector_engine = get_vector_engine()
+
+    id_to_text = {}
+    for chunk_text in valid_chunks:
+        try:
+            results = await vector_engine.search("DocumentChunk_text", chunk_text, limit=1)
+            if results:
+                chunk_id = str(results[0].id)
+                id_to_text[chunk_id] = chunk_text
+        except Exception as e:
+            logger.warning(f"Failed to find chunk ID for text: {chunk_text[:50]}... Error: {e}")
+
+    logger.info(f"Found {len(id_to_text)} chunk IDs from vector search")
+
+    edges = []
+    compared_pairs = set()
+
+    search_limit = (top_k_candidates + 1) if top_k_candidates is not None else None
+
+    for chunk_id, chunk_text in id_to_text.items():
+        try:
+            candidates = await vector_engine.search(
+                "DocumentChunk_text", chunk_text, limit=search_limit
+            )
+        except Exception as e:
+            logger.warning(f"Vector search failed for chunk: {chunk_text[:50]}... Error: {e}")
+            continue
+
+        for candidate in candidates:
+            candidate_id = str(candidate.id)
+
+            if candidate_id == chunk_id or candidate_id not in id_to_text:
+                continue
+
+            pair_key = tuple(sorted([chunk_id, candidate_id]))
+            if pair_key in compared_pairs:
+                continue
+            compared_pairs.add(pair_key)
+
+            candidate_text = id_to_text[candidate_id]
+
+            similarity = await _compare_chunks(
+                chunk_text, candidate_text, user_prompt_location, system_prompt_location
+            )
+
+            if (
+                similarity
+                and similarity.are_similar
+                and similarity.similarity_score >= similarity_threshold
+            ):
+                edges.append(_create_edge(chunk_id, candidate_id, similarity))
+                logger.info(
+                    f"Association created: score={similarity.similarity_score:.2f}, type={similarity.association_type}"
+                )
+
+    logger.info(f"Created {len(edges)} association edges")
+
+    if edges:
+        try:
+            graph_engine = await get_graph_engine()
+            await graph_engine.add_edges(edges)
+            await index_graph_edges(edges)
+            logger.info(f"Successfully persisted {len(edges)} edges to graph database")
+        except Exception as e:
+            logger.error(f"Failed to persist edges to graph database: {e}")
+            raise
+
+    for chunk in chunks:
+        yield chunk

--- a/cognee/tests/test_chunk_associations.py
+++ b/cognee/tests/test_chunk_associations.py
@@ -1,0 +1,262 @@
+import pathlib
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.low_level import setup
+from cognee import memify
+from cognee.modules.pipelines.tasks.task import Task
+from cognee.tasks.memify.extract_subgraph_chunks import extract_subgraph_chunks
+from cognee.tasks.chunks.create_chunk_associations import create_chunk_associations
+from cognee.infrastructure.databases.graph import get_graph_engine
+
+
+@pytest_asyncio.fixture
+async def clean_test_environment():
+    base_dir = pathlib.Path(__file__).parent.parent
+    system_directory_path = str(base_dir / ".cognee_system/test_chunk_associations")
+    data_directory_path = str(base_dir / ".data_storage/test_chunk_associations")
+
+    cognee.config.system_root_directory(system_directory_path)
+    cognee.config.data_root_directory(data_directory_path)
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await setup()
+
+    yield
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+def _get_association_edges(edges):
+    return [edge for edge in edges if edge[2] == "associated_with"]
+
+
+@pytest.mark.asyncio
+async def test_chunk_associations_creates_edges_between_similar_chunks(clean_test_environment):
+    dolphin_text_1 = "River dolphins are freshwater mammals found in South America and Asia."
+    dolphin_text_2 = (
+        "Scientists study dolphin behavior in Amazon rivers to understand their communication."
+    )
+    dolphin_text_3 = "The Amazon river dolphin, also known as boto, is pink in color."
+    unrelated_text = "Python is a high-level programming language widely used for data science."
+
+    await cognee.add(dolphin_text_1)
+    await cognee.add(dolphin_text_2)
+    await cognee.add(dolphin_text_3)
+    await cognee.add(unrelated_text)
+
+    await cognee.cognify()
+
+    extraction_tasks = [Task(extract_subgraph_chunks)]
+    enrichment_tasks = [
+        Task(
+            create_chunk_associations,
+            similarity_threshold=0.7,
+            min_chunk_length=10,
+            top_k_candidates=10,
+            task_config={"batch_size": 10},
+        )
+    ]
+
+    await memify(
+        extraction_tasks=extraction_tasks,
+        enrichment_tasks=enrichment_tasks,
+    )
+
+    graph_engine = await get_graph_engine()
+    nodes, edges = await graph_engine.get_graph_data()
+
+    association_edges = _get_association_edges(edges)
+
+    assert len(association_edges) > 0, "Should have created at least one association edge"
+
+    for edge in association_edges:
+        props = edge[3]
+        weight = props.get("weight")
+        if weight is not None:
+            assert 0.0 <= weight <= 1.0, f"Weight should be between 0 and 1, got {weight}"
+
+
+@pytest.mark.asyncio
+async def test_chunk_associations_respects_similarity_threshold(clean_test_environment):
+    related_text_1 = "Machine learning models require large datasets for training."
+    related_text_2 = "Deep learning is a subset of machine learning that uses neural networks."
+    very_different_text = "The quick brown fox jumps over the lazy dog."
+
+    await cognee.add(related_text_1)
+    await cognee.add(related_text_2)
+    await cognee.add(very_different_text)
+
+    await cognee.cognify()
+
+    extraction_tasks = [Task(extract_subgraph_chunks)]
+    enrichment_tasks = [
+        Task(
+            create_chunk_associations,
+            similarity_threshold=0.9,
+            min_chunk_length=10,
+            task_config={"batch_size": 10},
+        )
+    ]
+
+    await memify(
+        extraction_tasks=extraction_tasks,
+        enrichment_tasks=enrichment_tasks,
+    )
+
+    graph_engine = await get_graph_engine()
+    nodes, edges = await graph_engine.get_graph_data()
+
+    association_edges = _get_association_edges(edges)
+
+    for edge in association_edges:
+        weight = edge[3].get("weight")
+        if weight is not None:
+            assert weight >= 0.9, f"All associations should meet threshold of 0.9, got {weight}"
+
+
+@pytest.mark.asyncio
+async def test_chunk_associations_includes_metadata(clean_test_environment):
+    chunk_1 = "Artificial intelligence is transforming healthcare diagnostics."
+    chunk_2 = "AI systems can now detect diseases from medical images with high accuracy."
+
+    await cognee.add(chunk_1)
+    await cognee.add(chunk_2)
+
+    await cognee.cognify()
+
+    extraction_tasks = [Task(extract_subgraph_chunks)]
+    enrichment_tasks = [
+        Task(
+            create_chunk_associations,
+            similarity_threshold=0.6,
+            task_config={"batch_size": 10},
+        )
+    ]
+
+    await memify(
+        extraction_tasks=extraction_tasks,
+        enrichment_tasks=enrichment_tasks,
+    )
+
+    graph_engine = await get_graph_engine()
+    nodes, edges = await graph_engine.get_graph_data()
+
+    association_edges = _get_association_edges(edges)
+
+    assert len(association_edges) > 0, "Should have created at least one association edge"
+
+    props = association_edges[0][3]
+    assert "relationship_name" in props
+    assert "source_node_id" in props
+    assert "target_node_id" in props
+    assert "ontology_valid" in props
+
+
+@pytest.mark.asyncio
+async def test_chunk_associations_with_cypher_query(clean_test_environment):
+    text_1 = "Climate change is affecting global weather patterns and ecosystems."
+    text_2 = "Rising temperatures contribute to extreme weather events worldwide."
+    text_3 = "Renewable energy sources help reduce carbon emissions."
+
+    await cognee.add(text_1)
+    await cognee.add(text_2)
+    await cognee.add(text_3)
+
+    await cognee.cognify()
+
+    extraction_tasks = [Task(extract_subgraph_chunks)]
+    enrichment_tasks = [
+        Task(
+            create_chunk_associations,
+            similarity_threshold=0.65,
+            task_config={"batch_size": 10},
+        )
+    ]
+
+    await memify(
+        extraction_tasks=extraction_tasks,
+        enrichment_tasks=enrichment_tasks,
+    )
+
+    search_results = await cognee.search(
+        query_text="""
+            MATCH (c1:Node)-[a:EDGE]->(c2:Node)
+            WHERE c1.type = 'DocumentChunk' AND c2.type = 'DocumentChunk' AND a.relationship_name = 'associated_with'
+            RETURN c1.properties, c2.properties, a.properties
+            LIMIT 10
+        """,
+        query_type=cognee.SearchType.CYPHER,
+    )
+
+    assert search_results is not None
+
+
+@pytest.mark.asyncio
+async def test_chunk_associations_handles_single_chunk(clean_test_environment):
+    single_text = "This is a single document chunk with no pairs to compare."
+
+    await cognee.add(single_text)
+    await cognee.cognify()
+
+    extraction_tasks = [Task(extract_subgraph_chunks)]
+    enrichment_tasks = [
+        Task(
+            create_chunk_associations,
+            similarity_threshold=0.7,
+            task_config={"batch_size": 10},
+        )
+    ]
+
+    await memify(
+        extraction_tasks=extraction_tasks,
+        enrichment_tasks=enrichment_tasks,
+    )
+
+    graph_engine = await get_graph_engine()
+    nodes, edges = await graph_engine.get_graph_data()
+
+    association_edges = _get_association_edges(edges)
+
+    assert len(association_edges) == 0, "Should not create associations with only one chunk"
+
+
+@pytest.mark.asyncio
+async def test_chunk_associations_configurable_parameters(clean_test_environment):
+    text_1 = "Short"
+    text_2 = "This is a longer text that should be processed based on min_chunk_length parameter."
+
+    await cognee.add(text_1)
+    await cognee.add(text_2)
+    await cognee.cognify()
+
+    extraction_tasks = [Task(extract_subgraph_chunks)]
+    enrichment_tasks = [
+        Task(
+            create_chunk_associations,
+            similarity_threshold=0.5,
+            min_chunk_length=15,
+            top_k_candidates=5,
+            task_config={"batch_size": 10},
+        )
+    ]
+
+    await memify(
+        extraction_tasks=extraction_tasks,
+        enrichment_tasks=enrichment_tasks,
+    )
+
+    graph_engine = await get_graph_engine()
+    nodes, edges = await graph_engine.get_graph_data()
+
+    association_edges = _get_association_edges(edges)
+
+    assert len(association_edges) == 0, (
+        "Short text below min_chunk_length should not produce associations"
+    )

--- a/examples/python/chunk_associations_example.py
+++ b/examples/python/chunk_associations_example.py
@@ -1,0 +1,113 @@
+import asyncio
+import pathlib
+import os
+
+import cognee
+from cognee import memify
+from cognee.api.v1.visualize.visualize import visualize_graph
+from cognee.shared.logging_utils import setup_logging, ERROR
+from cognee.modules.pipelines.tasks.task import Task
+from cognee.tasks.memify.extract_subgraph_chunks import extract_subgraph_chunks
+from cognee.tasks.chunks.create_chunk_associations import create_chunk_associations
+
+
+async def main():
+    print("Resetting cognee data...")
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    print("Data reset complete.\n")
+
+    text_chunks = [
+        "River dolphins are freshwater mammals found in South America and Asia.",
+        "Scientists study dolphin behavior in Amazon rivers to understand their communication.",
+        "Python is a high-level programming language widely used for data science.",
+        "Dolphins use echolocation to navigate and hunt in murky river waters.",
+        "Machine learning models require large datasets for training.",
+        "The Amazon river dolphin, also known as boto, is pink in color.",
+    ]
+
+    print("Adding text chunks to cognee:\n")
+    for idx, text in enumerate(text_chunks, 1):
+        print(f"{idx}. {text}")
+        await cognee.add(text)
+
+    print("\nText added successfully.\n")
+
+    print("Running cognify to create knowledge graph...")
+    await cognee.cognify()
+    print("Cognify process complete.\n")
+
+    artifacts_dir = os.path.join(pathlib.Path(__file__).parent, ".artifacts")
+    os.makedirs(artifacts_dir, exist_ok=True)
+
+    file_path = os.path.join(artifacts_dir, "graph_visualization_before_associations.html")
+    await visualize_graph(file_path)
+    print(f"Graph visualization before associations: {file_path}\n")
+
+    print("Running memify to create chunk associations...")
+
+    subgraph_extraction_tasks = [Task(extract_subgraph_chunks)]
+
+    chunk_association_tasks = [
+        Task(
+            create_chunk_associations,
+            similarity_threshold=0.7,
+            min_chunk_length=10,
+            top_k_candidates=10,
+            task_config={"batch_size": 10},
+        ),
+    ]
+
+    await memify(
+        extraction_tasks=subgraph_extraction_tasks,
+        enrichment_tasks=chunk_association_tasks,
+    )
+
+    print("\nMemify process complete. Querying for chunk associations...\n")
+
+    search_results = await cognee.search(
+        query_text="""
+            MATCH (c1:Node)-[a:EDGE]->(c2:Node)
+            WHERE c1.type = 'DocumentChunk' AND c2.type = 'DocumentChunk' AND a.relationship_name = 'associated_with'
+            RETURN c1.properties, c2.properties, a.properties
+            LIMIT 20
+        """,
+        query_type=cognee.SearchType.CYPHER,
+    )
+
+    if search_results and len(search_results) > 0:
+        import json
+
+        all_rows = []
+        for result_wrapper in search_results:
+            for dataset_results in result_wrapper.get("search_result", []):
+                for row in dataset_results:
+                    all_rows.append(row)
+
+        print(f"Found {len(all_rows)} chunk associations:\n")
+        for idx, row in enumerate(all_rows, 1):
+            props1 = json.loads(row[0]) if isinstance(row[0], str) else (row[0] or {})
+            props2 = json.loads(row[1]) if isinstance(row[1], str) else (row[1] or {})
+            edge_props = json.loads(row[2]) if isinstance(row[2], str) else (row[2] or {})
+            print(f"{idx}. Similarity: {edge_props.get('weight', 0):.2f}")
+            print(f"   Type: {edge_props.get('association_type', 'N/A')}")
+            print(f"   Chunk 1: {props1.get('text', '')[:80]}")
+            print(f"   Chunk 2: {props2.get('text', '')[:80]}")
+            print(f"   Reasoning: {edge_props.get('reasoning', '')}")
+            print()
+    else:
+        print("No associations found. Possible reasons:")
+        print("- Similarity threshold too high")
+        print("- Chunks not semantically related")
+        print("- LLM API issues")
+
+    file_path = os.path.join(
+        pathlib.Path(__file__).parent, ".artifacts", "graph_visualization_with_associations.html"
+    )
+    await visualize_graph(file_path)
+    print(f"\nGraph visualization with associations: {file_path}")
+
+
+if __name__ == "__main__":
+    setup_logging(log_level=ERROR)
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Fresh branch for CI/CD testing of contributor PR #2113 by @deidaraiorek
- Adds LLM-based chunk association task that creates weighted associated_with edges
- Includes prompt templates, comprehensive tests, and example script

## Original PR
#2113

## Test plan
- [ ] CI/CD passes
- [ ] Chunk association tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic semantic association detection between related text chunks using vector similarity and LLM analysis
  * Configurable parameters for similarity thresholds, minimum chunk length, and candidate limits
  * Association metadata includes type classification (topical, causal, temporal, elaboration, contextual) and reasoning

* **Tests**
  * Added comprehensive test suite covering edge creation, similarity threshold validation, and metadata verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->