### PR TITLE
feat(permissions): add endpoint to list roles in a tenant. Solves #2035

### DIFF
--- a/cognee/modules/users/permissions/methods/__init__.py
+++ b/cognee/modules/users/permissions/methods/__init__.py
@@ -11,3 +11,4 @@ from .authorized_give_permission_on_datasets import authorized_give_permission_o
 from .give_default_permission_to_tenant import give_default_permission_to_tenant
 from .give_default_permission_to_role import give_default_permission_to_role
 from .give_default_permission_to_user import give_default_permission_to_user
+from .has_user_management_permission import has_user_management_permission  # this was missing

--- a/cognee/modules/users/roles/methods/__init__.py
+++ b/cognee/modules/users/roles/methods/__init__.py
@@ -1,2 +1,3 @@
 from .create_role import create_role
 from .add_user_to_role import add_user_to_role
+from .get_roles_in_tenant import get_roles_in_tenant

--- a/cognee/modules/users/roles/methods/get_roles_in_tenant.py
+++ b/cognee/modules/users/roles/methods/get_roles_in_tenant.py
@@ -1,0 +1,83 @@
+from uuid import UUID
+from typing import List
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.users.models import Role, UserRole
+from cognee.modules.users.exceptions import TenantNotFoundError
+from cognee.modules.users.permissions.methods import get_tenant
+
+
+class RoleInfo:
+    """just a clean way to pass around role data without dealing with ORM objects everywhere."""
+    
+    def __init__(self, role_id: UUID, name: str, description: str = "", user_count: int = 0):
+        self.id = role_id
+        self.name = name
+        self.description = description
+        self.user_count = user_count
+    
+    def dict(self):
+        """converts this to a dict so we can actually send it as JSON."""
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "description": self.description,
+            "user_count": self.user_count,
+        }
+
+
+async def get_roles_in_tenant(tenant_id: UUID) -> List[RoleInfo]:
+    """
+    grabs all the roles in a tenant and counts how many users are in each one.
+    
+    i wrote this because we needed to show role info without exposing the whole 
+    database model to the API. also counting users turned out to be more annoying 
+    than expected with async SQLAlchemy, so here we are.
+    
+    Args:
+        tenant_id: which tenant we're looking at
+    
+    Returns:
+        list of RoleInfo objects with the role details and user counts
+    
+    Raises:
+        TenantNotFoundError: when you pass in a tenant that doesn't exist
+    """
+    # make sure this tenant is actually real before we do anything
+    await get_tenant(tenant_id)
+    
+    db_engine = get_relational_engine()
+    
+    async with db_engine.get_async_session() as session:
+        # grab all roles for this tenant and eagerly load the users relationship
+        # because hitting the DB multiple times for user counts would be stupid
+        query = (
+            select(Role)
+            .where(Role.tenant_id == tenant_id)
+            .options(joinedload(Role.users))
+        )
+        
+        result = await session.execute(query)
+        roles = result.unique().scalars().all()
+        
+        # build our RoleInfo objects with actual user counts
+        role_infos = []
+        for role in roles:
+            # sqlalchemy async relationships are weird, gotta check if we need awaitable_attrs
+            users = await role.awaitable_attrs.users if hasattr(role, 'awaitable_attrs') else role.users
+            user_count = len(users) if users else 0
+            
+            # get description if it exists on the model, otherwise empty string
+            description = getattr(role, 'description', '') or ''
+            
+            role_info = RoleInfo(
+                role_id=role.id,
+                name=role.name,
+                description=description,
+                user_count=user_count
+            )
+            role_infos.append(role_info)
+        
+        return role_infos

--- a/cognee/tests/unit/api/test_permissions_endpoint.py
+++ b/cognee/tests/unit/api/test_permissions_endpoint.py
@@ -1,0 +1,187 @@
+import pytest
+import uuid
+from fastapi.testclient import TestClient
+from unittest.mock import Mock, AsyncMock, patch
+from types import SimpleNamespace
+
+from cognee.api.client import app
+from cognee.modules.users.methods import get_authenticated_user
+
+
+@pytest.fixture(scope="session")
+def test_client():
+    """Keep a single TestClient for the whole module."""
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def mock_default_user():
+    """Mock default user for testing."""
+    return SimpleNamespace(
+        id=str(uuid.uuid4()),
+        email="test@example.com",
+        is_active=True,
+        tenant_id=str(uuid.uuid4()),
+    )
+
+
+@pytest.fixture
+def client(test_client, mock_default_user):
+    """Setup test client with mocked authentication."""
+    async def override_get_authenticated_user():
+        return mock_default_user
+
+    app.dependency_overrides[get_authenticated_user] = override_get_authenticated_user
+    yield test_client
+    app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+class TestGetTenantRolesEndpoint:
+    """Tests for the GET /tenants/{tenant_id}/roles endpoint"""
+
+    @patch("cognee.modules.users.permissions.methods.has_user_management_permission", new_callable=AsyncMock)
+    @patch("cognee.modules.users.roles.methods.get_roles_in_tenant", new_callable=AsyncMock)
+    def test_get_tenant_roles_success(
+        self, mock_get_roles, mock_permission_check, client, mock_default_user
+    ):
+        """Test successful retrieval of all roles in a tenant"""
+        tenant_id = str(uuid.uuid4())
+        
+        mock_permission_check.return_value = True
+        
+        mock_role_1 = SimpleNamespace(
+            id=str(uuid.uuid4()),
+            name="Admin",
+            description="Administrator role with full access",
+            user_count=2,
+            dict=lambda: {
+                "id": str(uuid.uuid4()),
+                "name": "Admin",
+                "description": "Administrator role with full access",
+                "user_count": 2,
+            }
+        )
+
+        mock_role_2 = SimpleNamespace(
+            id=str(uuid.uuid4()),
+            name="Viewer",
+            description="Read-only access",
+            user_count=5,
+            dict=lambda: {
+                "id": str(uuid.uuid4()),
+                "name": "Viewer",
+                "description": "Read-only access",
+                "user_count": 5,
+            }
+        )
+        
+        mock_get_roles.return_value = [mock_role_1, mock_role_2]
+        
+        response = client.get(f"/api/v1/permissions/tenants/{tenant_id}/roles")
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "roles" in data
+        assert len(data["roles"]) == 2
+        assert data["roles"][0]["name"] == "Admin"
+        assert data["roles"][0]["description"] == "Administrator role with full access"
+        assert data["roles"][0]["user_count"] == 2
+        assert data["roles"][1]["name"] == "Viewer"
+        assert data["roles"][1]["description"] == "Read-only access"
+        assert data["roles"][1]["user_count"] == 5
+
+    @patch("cognee.modules.users.permissions.methods.has_user_management_permission", new_callable=AsyncMock)
+    def test_get_tenant_roles_permission_denied(
+        self, mock_permission_check, client, mock_default_user
+    ):
+        """Test that non-tenant owners cannot retrieve roles"""
+        from cognee.modules.users.exceptions import PermissionDeniedError
+        
+        tenant_id = str(uuid.uuid4())
+        
+        mock_permission_check.side_effect = PermissionDeniedError(
+            message="User is not authorized to manage users for this tenant"
+        )
+        
+        response = client.get(f"/api/v1/permissions/tenants/{tenant_id}/roles")
+        
+        assert response.status_code == 403
+
+    @patch("cognee.modules.users.permissions.methods.has_user_management_permission", new_callable=AsyncMock)
+    def test_get_tenant_roles_tenant_not_found(
+        self, mock_permission_check, client, mock_default_user
+    ):
+        """Test that request for non-existent tenant returns 404"""
+        from cognee.modules.users.exceptions import TenantNotFoundError
+        
+        tenant_id = str(uuid.uuid4())
+        
+        mock_permission_check.side_effect = TenantNotFoundError(
+            message=f"Could not find tenant: {tenant_id}"
+        )
+        
+        response = client.get(f"/api/v1/permissions/tenants/{tenant_id}/roles")
+        
+        assert response.status_code == 404
+
+    @patch("cognee.modules.users.permissions.methods.has_user_management_permission", new_callable=AsyncMock)
+    @patch("cognee.modules.users.roles.methods.get_roles_in_tenant", new_callable=AsyncMock)
+    def test_get_tenant_roles_empty_list(
+        self, mock_get_roles, mock_permission_check, client, mock_default_user
+    ):
+        """Test retrieval when tenant has no roles"""
+        tenant_id = str(uuid.uuid4())
+        
+        mock_permission_check.return_value = True
+        mock_get_roles.return_value = []
+        
+        response = client.get(f"/api/v1/permissions/tenants/{tenant_id}/roles")
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "roles" in data
+        assert len(data["roles"]) == 0
+
+    @patch("cognee.modules.users.permissions.methods.has_user_management_permission", new_callable=AsyncMock)
+    @patch("cognee.modules.users.roles.methods.get_roles_in_tenant", new_callable=AsyncMock)
+    def test_get_tenant_roles_response_format(
+        self, mock_get_roles, mock_permission_check, client, mock_default_user
+    ):
+        """Test that response includes all required role fields"""
+        tenant_id = str(uuid.uuid4())
+        role_id = str(uuid.uuid4())
+        
+        mock_permission_check.return_value = True
+        
+        mock_role = SimpleNamespace(
+            id=role_id,
+            name="TestRole",
+            description="Test role description",
+            user_count=3,
+            dict=lambda: {
+                "id": role_id,
+                "name": "TestRole",
+                "description": "Test role description",
+                "user_count": 3,
+            }
+        )
+        
+        mock_get_roles.return_value = [mock_role]
+        
+        response = client.get(f"/api/v1/permissions/tenants/{tenant_id}/roles")
+        
+        assert response.status_code == 200
+        data = response.json()
+        role = data["roles"][0]
+        
+        # verify all required fields are present
+        assert "id" in role
+        assert "name" in role
+        assert "description" in role
+        assert "user_count" in role
+        
+        # verify field values
+        assert role["name"] == "TestRole"
+        assert role["description"] == "Test role description"
+        assert role["user_count"] == 3


### PR DESCRIPTION
- Add GET /api/v1/permissions/tenants/{tenant_id}/roles endpoint (acknowledged recommendation by @Vasilije1990)
- Add get_roles_in_tenant method with RoleInfo class
- Add has_user_management_permission check
- Add unit tests for the new endpoint
- Returns all roles in a tenant with id, name, description, user_count

Solves #2035

<!-- .github/pull_request_template.md -->

### Description
Added a new endpoint that lets you fetch all roles within a tenant along with user counts for each role.

I built this to tackle the issue where there was no way to get role information for a specific tenant through the API. The frontend needed this to display available roles in the tenant management view, and without it there was no clean way to show admins what roles exist and how many users are assigned to each one.

The endpoint uses the existing has_user_management_permission check to make sure only tenant owners can access it. I also added a RoleInfo class to keep the response clean because I didn't want to expose raw ORM objects to the API layer.

The 403 and 404 responses are handled at runtime via exception handlers.

### Acceptance Criteria

| Criteria | Status | Evidence |
| :--- | :---: | :--- |
| Endpoint created and properly routed | ✅ | `GET /api/v1/permissions/tenants/{tenant_id}/roles` |
| Uses centralized permission check function | ✅ | Calls `has_user_management_permission(user.id, tenant_id)` |
| Only tenant owner can access endpoint | ✅ | Returns 403 if not owner (see unit test) |
| Returns list of all roles in tenant | ✅ | Returns `{"roles": [...]}` array |
| Includes role details (id, name, description) | ✅ | All fields included in response |
| Includes count of users in each role | ✅ | `user_count` field in each role object |
| Returns 403 if requester lacks permission | ✅ | `test_get_tenant_roles_permission_denied` passes |
| API documentation updated | ✅ | Docstring with full details added |
| Tests cover success and error cases | ✅ | 5 unit tests covering all scenarios |

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
### Unit Tests Passing
<img width="1105" height="291" alt="unit tests passing" src="https://github.com/user-attachments/assets/a0a3119f-81e9-4ec3-8fac-d6bbcba0b980" />

### Swagger Documentation
<img width="1448" height="680" alt="swagger doc 1" src="https://github.com/user-attachments/assets/7686bf80-6c5c-4ea2-ae30-fa0bfa60175d" />

<img width="1439" height="342" alt="swagger doc 2" src="https://github.com/user-attachments/assets/362a0716-dafa-4b0b-94eb-8fb8689ecfef" />


## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve all roles within a tenant, displaying role names, descriptions, and associated user counts.
  * Implemented authorization controls to restrict access to users with management permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->