### PR TITLE
feat(users): add endpoint to remove user from role within tenant

### DIFF
--- a/cognee/modules/users/roles/methods/remove_user_from_role.py
+++ b/cognee/modules/users/roles/methods/remove_user_from_role.py
@@ -1,0 +1,104 @@
+from uuid import UUID
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.databases.exceptions import EntityNotFoundError
+from cognee.modules.users.permissions.methods.has_user_management_permission import (
+    has_user_management_permission,
+)
+from cognee.modules.users.exceptions import (
+    UserNotFoundError,
+    RoleNotFoundError,
+    TenantNotFoundError,
+    PermissionDeniedError,
+)
+from cognee.modules.users.models import User, Role, Tenant, UserRole
+
+
+async def remove_user_from_role(
+    tenant_id: UUID,
+    user_id: UUID,
+    role_id: UUID,
+    requester_id: UUID,
+) -> None:
+    """
+    Remove a role assignment from a user within a specific tenant.
+
+    This function ensures:
+        - The tenant exists.
+        - The requester has permission to manage users in the tenant.
+        - The user exists and belongs to the tenant.
+        - The role exists and belongs to the tenant.
+        - The user-role association exists before attempting deletion.
+
+    Args:
+        tenant_id: UUID of the tenant where the operation is performed.
+        user_id: UUID of the user to remove from the role.
+        role_id: UUID of the role to be removed.
+        requester_id: UUID of the user performing the action (must be tenant owner).
+
+    Raises:
+        TenantNotFoundError: If the tenant does not exist.
+        PermissionDeniedError: If the requester is not authorized.
+        UserNotFoundError: If the user does not exist or is not part of the tenant.
+        RoleNotFoundError: If the role does not exist in the tenant.
+        EntityNotFoundError: If the user is not assigned to the specified role.
+
+    Returns:
+        None. The operation completes silently on success.
+    """
+
+    db_engine = get_relational_engine()
+
+    async with db_engine.get_async_session() as session:  # type: AsyncSession
+
+        tenant = (
+            await session.execute(
+                select(Tenant).where(Tenant.id == tenant_id)
+            )
+        ).scalars().first()
+
+        if not tenant:
+            raise TenantNotFoundError
+
+        await has_user_management_permission(requester_id, tenant_id)
+
+        user = (
+            await session.execute(
+                select(User).where(User.id == user_id)
+            )
+        ).scalars().first()
+
+        if not user:
+            raise UserNotFoundError
+
+        user_tenants = await user.awaitable_attrs.tenants
+        if tenant_id not in [t.id for t in user_tenants]:
+            raise UserNotFoundError
+
+        role = (
+            await session.execute(
+                select(Role).where(
+                    Role.id == role_id,
+                    Role.tenant_id == tenant_id,
+                )
+            )
+        ).scalars().first()
+
+        if not role:
+            raise RoleNotFoundError
+
+        result = await session.execute(
+            delete(UserRole).where(
+                UserRole.user_id == user_id,
+                UserRole.role_id == role_id,
+            )
+        )
+
+        if result.rowcount == 0:
+            raise EntityNotFoundError(
+                message="User is not assigned to this role."
+            )
+
+        await session.commit()


### PR DESCRIPTION
## Problem

Tenant owners cannot remove users from roles via API.

## Solution

- Added new DELETE endpoint:
  DELETE /api/v1/tenants/{tenant_id}/users/{user_id}/roles/{role_id}

- Uses centralized permission check function
- Validates tenant existence
- Validates user belongs to tenant
- Validates role belongs to tenant
- Removes user-role association
- Returns appropriate HTTP status codes

## Behavior

- 204 on successful removal
- 404 if tenant, user, role, or association not found
- 403 if requester lacks permission

## Tests

- Success case (owner removes role)
- 403 unauthorized requester
- 404 missing tenant
- 404 missing user
- 404 missing role
- 404 association not found

## Related

Issue: #2032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to remove user role assignments within a tenant with proper authorization checks and validation of tenant, user, and role existence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->