### PR TITLE
docs: align handler list in context_global_variables.py docstring

### DIFF
--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -91,8 +91,8 @@ async def set_database_global_context_variables(dataset: Union[str, UUID], user_
 
     Note: This is only currently supported by the following databases:
           Relational: SQLite, Postgres
-          Vector: LanceDB
-          Graph: KuzuDB
+          Vector: LanceDB, pgvector
+          Graph: KuzuDB, neo4j_aura_dev
 
     Args:
         dataset: Cognee dataset name or id


### PR DESCRIPTION
Updates the docstring in **context_global_variables.py** to reflect the currently supported dataset database handlers when **ENABLE_BACKEND_ACCESS_CONTROL** is enabled.

Added **pgvector** and **neo4j_aura_dev** to the existing list.
**No behavior or logic is changed.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect expanded database provider support. New vector database options (LanceDB, pgvector) and graph database options (KuzuDB, neo4j_aura_dev) are now officially documented as supported. This enhancement provides users with greater flexibility and choice when selecting and configuring database providers for their system deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->