### PR TITLE
feat: color ontology nodes in graph visualization

### DIFF
--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -41,6 +41,8 @@ async def cognee_network_visualization(graph_data, destination_file_path: str = 
         node_info = node_info.copy()
         node_info["id"] = str(node_id)
         node_info["color"] = color_map.get(node_info.get("type", "default"), "#DBD8D8")
+        if node_info.get("ontology_valid") is True:
+            node_info["color"] = "#D8D8D8"
         node_info["name"] = node_info.get("name", str(node_id))
         node_info.pop("updated_at", None)
         node_info.pop("created_at", None)
@@ -444,6 +446,10 @@ nodes.forEach(function(n){
     }
   }
   n._rgb=typeRgbCache[n.type];
+  if(n.ontology_valid===true){
+    n.color="#D8D8D8";
+    n._rgb=[216,216,216];
+  }
 });
 
 // ── Color-by mode ──
@@ -462,12 +468,17 @@ function recolorNodes(){
     }else if(colorByMode==="user"){
       n.color=userColors[n.source_user||"Unknown"]||"#DBD8D8";
     }
-    // Recache RGB
-    if(n.color.indexOf("hsl")===0){
-      var m=n.color.match(/[\d.]+/g);
-      n._rgb=hslToRgb(+m[0],+m[1],+m[2]);
+    if(colorByMode==="type"&&n.ontology_valid===true){
+      n.color="#D8D8D8";
+      n._rgb=[216,216,216];
     }else{
-      n._rgb=hexToRgb(n.color);
+      // Recache RGB
+      if(n.color.indexOf("hsl")===0){
+        var m=n.color.match(/[\d.]+/g);
+        n._rgb=hslToRgb(+m[0],+m[1],+m[2]);
+      }else{
+        n._rgb=hexToRgb(n.color);
+      }
     }
   });
 }
@@ -798,6 +809,7 @@ function showNodeInfo(n){
   if(n.source_pipeline)html+='<div class="panel-row"><span class="k">Source Pipeline</span><span class="v">'+esc(n.source_pipeline)+"</span></div>";
   if(n.source_node_set)html+='<div class="panel-row"><span class="k">Source Node Set</span><span class="v">'+esc(n.source_node_set)+"</span></div>";
   if(n.source_user)html+='<div class="panel-row"><span class="k">Source User</span><span class="v">'+esc(n.source_user)+"</span></div>";
+  if(n.ontology_valid!==undefined&&n.ontology_valid!==null){var ovStyle=n.ontology_valid===true?'color:#D8D8D8;font-weight:600':'color:var(--text2)';html+='<div class="panel-row"><span class="k">Ontology Valid</span><span class="v" style="'+ovStyle+'">'+esc(String(n.ontology_valid))+"</span></div>";}
 
   if(n.properties){
     Object.keys(n.properties).slice(0,10).forEach(function(key){


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Color ontology-validated nodes differently in the graph visualization to visually distinguish them from standard type-colored nodes. This change is only visible in the Type color tab. 

Nodes with ontology_valid === true are rendered in a neutral gray (#D8D8D8). The ontology validity status is also displayed in the node info panel.

## Acceptance Criteria

- Nodes with ontology_valid: true appear in gray (#D8D8D8) when color-by mode is "type"
- The node info panel shows the "Ontology Valid" field when the property is present
- Existing color-by modes (type, user) continue to work correctly

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<img width="1130" height="1171" alt="image" src="https://github.com/user-attachments/assets/784f9b82-fbbc-4009-ab8a-ac746f06900b" />

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network visualization nodes now display in neutral gray when ontology validity is confirmed, providing consistent visual feedback and overriding previous type-based coloring.
  * Added ontology validity status information to the node details panel with enhanced visual styling, enabling users to quickly verify the compliance and validity state of individual network nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->