### PR TITLE
feat: add HelixDB as hybrid provider in UnifiedStoreEngine

### DIFF
--- a/cognee/infrastructure/databases/unified/get_unified_engine.py
+++ b/cognee/infrastructure/databases/unified/get_unified_engine.py
@@ -6,7 +6,7 @@ from cognee.infrastructure.databases.vector import get_vector_engine
 from .capabilities import EngineCapability
 from .unified_store_engine import UnifiedStoreEngine
 
-HYBRID_PROVIDERS = {"neptune_analytics"}
+HYBRID_PROVIDERS = {"neptune_analytics", "helixdb"}
 
 
 def _is_hybrid_provider(graph_config: dict, vector_config: dict) -> bool:
@@ -42,6 +42,27 @@ def _create_hybrid_adapter(graph_config: dict, vector_config: dict):
         return NeptuneAnalyticsAdapter(
             graph_id=graph_identifier,
             embedding_engine=embedding_engine,
+        )
+
+    elif provider == "helixdb":
+        from cognee.infrastructure.databases.graph.get_graph_engine import (
+            supported_databases as graph_dbs,
+        )
+        from cognee.infrastructure.databases.vector.embeddings import get_embedding_engine
+
+        adapter_cls = graph_dbs.get("helixdb")
+        if adapter_cls is None:
+            raise EnvironmentError(
+                "HelixDB adapter not registered. "
+                "Install cognee-community-hybrid-adapter-helixdb"
+            )
+
+        embedding_engine = get_embedding_engine()
+        return adapter_cls(
+            graph_database_url=graph_config.get("graph_database_url", ""),
+            graph_database_port=graph_config.get("graph_database_port", 6969),
+            embedding_engine=embedding_engine,
+            database_name=graph_config.get("graph_database_name", "cognee_graph"),
         )
 
     raise EnvironmentError(f"Unsupported hybrid provider: {provider}")


### PR DESCRIPTION
## Summary
- Adds `"helixdb"` to `HYBRID_PROVIDERS` set in `get_unified_engine.py`
- Adds creation case in `_create_hybrid_adapter()` that looks up the community-registered HelixDB adapter class and instantiates it with graph config

## Details

This enables the `UnifiedStoreEngine` to recognise HelixDB as a hybrid backend (like Neptune Analytics) where a single adapter instance serves as both graph and vector engine.

The actual adapter implementation lives in the cognee-community repo as `cognee-community-hybrid-adapter-helixdb`. When installed, it registers itself via `use_graph_adapter("helixdb", HelixDBAdapter)` and this code discovers it through `supported_databases.get("helixdb")`.

**Companion PR:** topoteretes/cognee-community (adds the full HelixDB hybrid adapter package)

## Test plan
- [ ] Install `cognee-community-hybrid-adapter-helixdb` package
- [ ] Configure `GRAPH_DATABASE_PROVIDER=helixdb` and `VECTOR_DB_PROVIDER=helixdb`
- [ ] Verify `get_unified_engine()` returns a `UnifiedStoreEngine` with `HYBRID_*` capabilities
- [ ] Run add -> cognify -> search cycle with HelixDB backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HelixDB is now available as a hybrid database backend option, enabling configuration and usage alongside existing providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->