### PR TITLE
fix: Docker entrypoint fails on Windows with CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # ignore jupyter notebooks in the language bar on github
 notebooks/** linguist-vendored
+
+# Ensure shell scripts always use LF line endings (fixes Docker on Windows)
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ COPY --from=uv /app /app
 # COPY --from=uv /app/.venv /app/.venv
 # COPY --from=uv /root/.local /root/.local
 
-RUN chmod +x /app/entrypoint.sh
+# Strip Windows carriage returns (fixes "no such file" on Windows Docker)
+RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/cognee-mcp/Dockerfile
+++ b/cognee-mcp/Dockerfile
@@ -41,7 +41,8 @@ WORKDIR /app
 COPY --from=uv /usr/local /usr/local
 COPY --from=uv /app /app
 
-RUN chmod +x /app/entrypoint.sh
+# Strip Windows carriage returns (fixes "no such file" on Windows Docker)
+RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
## Summary
- Add `*.sh text eol=lf` to `.gitattributes` to prevent Git from converting shell scripts to CRLF on Windows checkout
- Add `sed -i 's/\r$//'` in `Dockerfile` and `cognee-mcp/Dockerfile` to strip carriage returns as a safety net for existing clones

Fixes the `exec /app/entrypoint.sh: no such file or directory` error when running `docker-compose up` on Windows, caused by the shebang `#!/bin/bash` becoming `#!/bin/bash\r`.

## Test plan
- [ ] `docker-compose up -d` on Windows with Docker Desktop
- [ ] `docker-compose up -d` on Linux/macOS (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows Docker compatibility where shell scripts with CRLF endings could fail to run.
  * Ensured shell scripts are normalized to Unix line endings before being made executable.
  * Added repository configuration to enforce LF line endings for shell scripts, reducing Windows-related runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->