### PR TITLE
fix: MCP cognify silent failure on file paths in Docker

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1,9 +1,11 @@
 import json
 import os
+import re
 import sys
 import argparse
 import asyncio
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from cognee.modules.data.methods.get_datasets_by_name import get_datasets_by_name
@@ -44,6 +46,50 @@ mcp = FastMCP("Cognee")
 logger = get_logger()
 
 cognee_client: Optional[CogneeClient] = None
+
+# Stores background task errors so cognify_status can report them
+_task_errors: dict[str, str] = {}
+
+
+def _is_running_in_docker() -> bool:
+    """Check if the process is running inside a Docker container."""
+    return os.path.exists("/.dockerenv") or os.path.isdir("/app")
+
+
+def _looks_like_file_path(data: str) -> bool:
+    """Check if the data string looks like a local file path."""
+    data = data.strip()
+    # Unix absolute path, Windows drive letter path, or file:// URI
+    if data.startswith("/") or re.match(r"^[A-Za-z]:\\", data) or data.startswith("file://"):
+        return True
+    return False
+
+
+def _validate_file_path(data: str) -> Optional[str]:
+    """
+    If data looks like a file path, validate it exists.
+    Returns an error message string if invalid, or None if OK.
+    """
+    if not _looks_like_file_path(data):
+        return None
+
+    path = data.strip()
+    if path.startswith("file://"):
+        path = path[7:]
+
+    if not os.path.exists(path):
+        msg = f"File not found: {path}"
+        if _is_running_in_docker():
+            msg += (
+                "\n\nIt looks like you're running inside Docker. Host file paths are not "
+                "accessible inside the container. To ingest local files, mount a volume in "
+                "docker-compose.yml:\n"
+                "  volumes:\n"
+                "    - /path/to/your/data:/data\n"
+                "Then reference the file as /data/<filename> instead."
+            )
+        return msg
+    return None
 
 
 async def run_sse_with_cors():
@@ -204,6 +250,16 @@ async def cognify(
 
     """
 
+    # Validate file paths before launching background task
+    file_error = _validate_file_path(data)
+    if file_error:
+        return [
+            types.TextContent(
+                type="text",
+                text=f"Error: {file_error}",
+            )
+        ]
+
     async def cognify_task(
         data: str,
         graph_model_file: str = None,
@@ -234,8 +290,17 @@ async def cognify(
                 logger.error("Cognify process failed.")
                 raise ValueError(f"Failed to cognify: {str(e)}")
 
+    async def cognify_task_wrapper(**kwargs):
+        """Wrapper that captures errors from the background task."""
+        try:
+            await cognify_task(**kwargs)
+        except Exception as e:
+            timestamp = datetime.now(timezone.utc).isoformat()
+            _task_errors[timestamp] = str(e)
+            logger.error(f"Background cognify task failed: {e}")
+
     asyncio.create_task(
-        cognify_task(
+        cognify_task_wrapper(
             data=data,
             graph_model_file=graph_model_file,
             graph_model_name=graph_model_name,
@@ -793,13 +858,28 @@ async def cognify_status():
             status = await cognee_client.get_pipeline_status(
                 [await get_unique_dataset_id("main_dataset", user)], "cognify_pipeline"
             )
-            return [types.TextContent(type="text", text=str(status))]
+
+            # Append any background task errors
+            status_text = str(status)
+            if _task_errors:
+                error_lines = ["\n\nBackground task errors:"]
+                for ts, err in sorted(_task_errors.items(), reverse=True):
+                    error_lines.append(f"  [{ts}] {err}")
+                status_text += "\n".join(error_lines)
+
+            return [types.TextContent(type="text", text=status_text)]
         except NotImplementedError:
             error_msg = "❌ Pipeline status is not available in API mode"
             logger.error(error_msg)
             return [types.TextContent(type="text", text=error_msg)]
         except Exception as e:
             error_msg = f"❌ Failed to get cognify status: {str(e)}"
+            # Still report background errors even if pipeline status fails
+            if _task_errors:
+                error_lines = ["\n\nBackground task errors:"]
+                for ts, err in sorted(_task_errors.items(), reverse=True):
+                    error_lines.append(f"  [{ts}] {err}")
+                error_msg += "\n".join(error_lines)
             logger.error(error_msg)
             return [types.TextContent(type="text", text=error_msg)]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     volumes:
       - ./cognee:/app/cognee
       - .env:/app/.env
+      # Uncomment to allow ingestion of local files from host:
+      # - /path/to/your/data:/data
     environment:
       - DEBUG=false # Change to true if debugging
       - HOST=0.0.0.0
@@ -43,6 +45,8 @@ services:
     volumes:
       - .env:/app/.env
       - ./cognee:/app/cognee
+      # Uncomment to allow ingestion of local files from host:
+      # - /path/to/your/data:/data
     environment:
       - DEBUG=false # Change to true if debugging
       - ENVIRONMENT=local


### PR DESCRIPTION
## Summary
- Validates file paths before launching background cognify task — returns an immediate error if the file doesn't exist, with Docker volume mount hints when running in a container
- Captures background task errors in a module-level dict so `cognify_status` can report them even when the pipeline never starts
- Adds commented-out volume mount documentation to `docker-compose.yml` for both `cognee` and `cognee-mcp` services

## Test plan
- [ ] Pass a nonexistent file path to the MCP cognify tool → should get immediate clear error
- [ ] Pass a valid text string → should still work as before (no regression)
- [ ] `cognify_status` after a failed background task → should show the error
- [ ] Docker compose still starts cleanly with default config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved diagnostics and observability for background task processing, exposing recent background errors in status outputs

* **Bug Fixes**
  * Stronger pre-flight file path validation with clearer user-facing errors
  * More reliable capture and reporting of background task failures for easier troubleshooting
  * Enhanced visibility of background errors via status endpoints

* **Documentation**
  * Added commented example for optional data volume binding in configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->