### PR TITLE
feat: replace coding rules with triplet embedding in default memify pipeline

### DIFF
--- a/cognee/memify_pipelines/memify_default_tasks.py
+++ b/cognee/memify_pipelines/memify_default_tasks.py
@@ -1,19 +1,21 @@
 from cognee.modules.pipelines.tasks.task import Task
-from cognee.tasks.memify.extract_subgraph_chunks import extract_subgraph_chunks
-from cognee.tasks.codingagents.coding_rule_associations import (
-    add_rule_associations,
-)
+from cognee.tasks.memify.get_triplet_datapoints import get_triplet_datapoints
+from cognee.tasks.memify.extract_user_sessions import extract_user_sessions
+from cognee.tasks.memify.cognify_session import cognify_session
+from cognee.tasks.storage.index_data_points import index_data_points
 
 
 def get_default_memify_extraction_tasks():
-    return [Task(extract_subgraph_chunks)]
+    return [Task(get_triplet_datapoints, triplets_batch_size=100)]
 
 
 def get_default_memify_enrichment_tasks():
-    return [
-        Task(
-            add_rule_associations,
-            rules_nodeset_name="coding_agent_rules",
-            task_config={"batch_size": 1},
-        )
-    ]
+    return [Task(index_data_points, task_config={"batch_size": 100})]
+
+
+def get_session_memify_tasks():
+    """Return (extraction_tasks, enrichment_tasks) for session cognification."""
+    return (
+        [Task(extract_user_sessions)],
+        [Task(cognify_session)],
+    )

--- a/cognee/modules/memify/memify.py
+++ b/cognee/modules/memify/memify.py
@@ -62,7 +62,7 @@ async def memify(
                           Use pipeline_run_id from return value to monitor progress.
     """
 
-    # Use default coding rules tasks if no tasks were provided
+    # Use default triplet embedding tasks if no tasks were provided
     if not extraction_tasks:
         extraction_tasks = get_default_memify_extraction_tasks()
     if not enrichment_tasks:


### PR DESCRIPTION
## Summary
- Replace default memify extraction task (`extract_subgraph_chunks`) with `get_triplet_datapoints` for triplet embedding
- Replace default memify enrichment task (`add_rule_associations` / coding rules) with `index_data_points` for vector indexing
- Add `get_session_memify_tasks()` helper that returns session extraction + cognification tasks for explicit use

## Test plan
- [ ] Verify imports: `from cognee.memify_pipelines.memify_default_tasks import get_default_memify_extraction_tasks, get_default_memify_enrichment_tasks, get_session_memify_tasks`
- [ ] Run `ruff check` on changed files
- [ ] Verify `add_rule_associations` still works independently (not removed, just decoupled from defaults)
- [ ] Run memify pipeline end-to-end with new defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced session-oriented memify tasks that enable new session-based cognification workflows and enhanced data processing capabilities.

* **Refactor**
  * Updated default extraction and enrichment task mechanisms with improved batch processing configuration for better overall system performance.
  * Restructured the task pipeline architecture to provide more efficient, streamlined, and optimized operation across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->