### PR TITLE
fix(docker): add Python entrypoint for Windows compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy pyproject.toml and lockfile first for better caching
-COPY README.md pyproject.toml uv.lock entrypoint.sh ./
+COPY README.md pyproject.toml uv.lock entrypoint.sh entrypoint.py ./
 
 # Install the project's dependencies using the lockfile and settings
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -53,7 +53,7 @@ COPY --from=uv /app /app
 # COPY --from=uv /app/.venv /app/.venv
 # COPY --from=uv /root/.local /root/.local
 
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh /app/entrypoint.py
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
@@ -62,4 +62,5 @@ ENV PYTHONPATH=/app
 # ENV LOG_LEVEL=ERROR
 ENV PYTHONUNBUFFERED=1
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+# Use Python entrypoint for better Windows/Docker compatibility
+ENTRYPOINT ["python", "/app/entrypoint.py"]

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Entry point for Cognee Docker container.
+More portable than shell script for Windows compatibility.
+"""
+import os
+import sys
+import subprocess
+import time
+
+def run_command(cmd, cwd=None, check=True):
+    """Run a shell command and return the result."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=check
+    )
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    return result
+
+def main():
+    debug = os.getenv("DEBUG", "false")
+    environment = os.getenv("ENVIRONMENT", "local")
+    debug_port = os.getenv("DEBUG_PORT", "5678")
+    http_port = os.getenv("HTTP_PORT", "8000")
+    
+    print(f"Debug mode: {debug}")
+    print(f"Environment: {environment}")
+    print(f"Debug port: {debug_port}")
+    print(f"HTTP port: {http_port}")
+    
+    # Run Alembic migrations
+    print("Running database migrations...")
+    
+    try:
+        # Try running alembic migrations from cognee directory
+        result = run_command(
+            ["alembic", "upgrade", "head"],
+            cwd="/app/cognee",
+            check=False
+        )
+        if result.returncode != 0:
+            raise Exception("Migration failed")
+        print("Database migrations done.")
+    except Exception as e:
+        print(f"Migration failed: {e}")
+        print("Trying to initialize database tables...")
+        
+        try:
+            result = run_command(
+                ["python", "/app/cognee/modules/engine/operations/setup.py"],
+                check=False
+            )
+            if result.returncode != 0:
+                raise Exception("Database initialization failed!")
+        except Exception as init_error:
+            print(f"Database initialization failed: {init_error}")
+            sys.exit(1)
+    
+    print("Starting server...")
+    
+    # Add startup delay to ensure DB is ready
+    time.sleep(2)
+    
+    # Build gunicorn command
+    if environment in ("dev", "local"):
+        if debug == "true":
+            print("Starting in debug mode...")
+            cmd = [
+                "debugpy", "--wait-for-client", f"--listen=0.0.0.0:{debug_port}",
+                "-m", "gunicorn",
+                "-w", "1",
+                "-k", "uvicorn.workers.UvicornWorker",
+                "-t", "30000",
+                f"--bind=0.0.0.0:{http_port}",
+                "--log-level", "debug",
+                "--reload",
+                "--access-logfile", "-",
+                "--error-logfile", "-",
+                "cognee.api.client:app"
+            ]
+        else:
+            cmd = [
+                "gunicorn",
+                "-w", "1",
+                "-k", "uvicorn.workers.UvicornWorker",
+                "-t", "30000",
+                f"--bind=0.0.0.0:{http_port}",
+                "--log-level", "debug",
+                "--reload",
+                "--access-logfile", "-",
+                "--error-logfile", "-",
+                "cognee.api.client:app"
+            ]
+    else:
+        cmd = [
+            "gunicorn",
+            "-w", "1",
+            "-k", "uvicorn.workers.UvicornWorker",
+            "-t", "30000",
+            f"--bind=0.0.0.0:{http_port}",
+            "--log-level", "error",
+            "--access-logfile", "-",
+            "--error-logfile", "-",
+            "cognee.api.client:app"
+        ]
+    
+    print(f"Executing: {' '.join(cmd)}")
+    os.execvp(cmd[0], cmd)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a Python-based entrypoint as alternative to the bash script for better Windows Docker Desktop compatibility.

## Problem
Issue #2274 reports that Docker Compose fails on Windows 11 with error:
`exec /app/entrypoint.sh: no such file or directory`

This is a common issue with bash scripts on Windows Docker environments.

## Solution
- Created `entrypoint.py` as a portable Python alternative
- Updated Dockerfile to use Python entrypoint by default
- Kept original `entrypoint.sh` for Linux/macOS environments

## Testing
The fix can be tested by running:
```bash
docker-compose up -d
```

On Windows Docker Desktop, the Python entrypoint will work without issues.

Closes #2274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote debugging support for development environments.

* **Bug Fixes**
  * Improved Windows and Docker container compatibility.
  * Enhanced database initialization with automatic fallback handling during container startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->