### PR TITLE
fix: use ORM-based delete in delete_dataset() for non-public schema support

### DIFF
--- a/cognee/modules/data/methods/delete_dataset.py
+++ b/cognee/modules/data/methods/delete_dataset.py
@@ -1,5 +1,5 @@
 from cognee.modules.users.models import DatasetDatabase
-from sqlalchemy import select
+from sqlalchemy import select, delete as sa_delete
 from sqlalchemy.orm.attributes import flag_modified
 
 from cognee.modules.data.models import Dataset, DatasetData, Data
@@ -55,4 +55,12 @@ async def delete_dataset(dataset: Dataset):
 
         await session.commit()
 
-    return await db_engine.delete_entity_by_id(dataset.__tablename__, dataset.id)
+    # Use ORM-based delete instead of raw table reflection with hardcoded
+    # schema.  The previous ``delete_entity_by_id`` call reflected the table
+    # using ``schema_name="public"`` by default, which fails when PostgreSQL
+    # tables live in a non-public schema (e.g. ``cognee``).  ORM queries
+    # resolve the table through SQLAlchemy's ``search_path`` / metadata, so
+    # they work regardless of the configured schema.
+    async with db_engine.get_async_session() as session:
+        await session.execute(sa_delete(Dataset).where(Dataset.id == dataset.id))
+        await session.commit()


### PR DESCRIPTION
## Summary

Fixes #2291

`delete_dataset()` fails with `EntityNotFoundError: Table 'public.datasets' not found` when PostgreSQL tables reside in a non-public schema (e.g. `cognee`).

## Root Cause

The final line of `delete_dataset()` called `db_engine.delete_entity_by_id(dataset.__tablename__, dataset.id)`, which internally uses `get_table(table_name, schema_name='public')` — hardcoding the schema to `public`. When the database uses a different schema in `search_path`, the table reflection fails.

Meanwhile, other dataset operations (`create_dataset`, `list_datasets`, and even the pipeline-status cleanup earlier in the same function) all use ORM model queries that resolve through SQLAlchemy's `search_path`/metadata and work correctly regardless of schema.

## Fix

Replace the raw table reflection approach with an ORM-based `delete()` statement:

```python
# Before (broken for non-public schemas):
return await db_engine.delete_entity_by_id(dataset.__tablename__, dataset.id)

# After (schema-agnostic via ORM):
async with db_engine.get_async_session() as session:
    await session.execute(sa_delete(Dataset).where(Dataset.id == dataset.id))
    await session.commit()
```

This is consistent with how other CRUD operations in the codebase handle datasets, and correctly respects the configured `search_path`.

## Testing

- Works with PostgreSQL tables in `public` schema (default behavior unchanged)
- Works with PostgreSQL tables in custom schema (e.g. `cognee`)
- Works with SQLite (no schema concept, ORM handles it transparently)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dataset deletion process to enhance code maintainability and system architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->