### PR TITLE
fix: handle schema_name=None in get_table to avoid 'None.table' lookup

### DIFF
--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -407,7 +407,10 @@ class SQLAlchemyAdapter:
                 # Load table information from schema into MetaData
                 await connection.run_sync(metadata.reflect, schema=schema_name)
                 # Define the full table name
-                full_table_name = f"{schema_name}.{table_name}"
+                if schema_name is None:
+                    full_table_name = table_name
+                else:
+                    full_table_name = f"{schema_name}.{table_name}"
                 # Check if table is in list of tables for the given schema
                 if full_table_name in metadata.tables:
                     return metadata.tables[full_table_name]


### PR DESCRIPTION
When `schema_name` is None, `f'{schema_name}.{table_name}'` produces 'None.table' which fails to find the table in metadata.tables.

This fix conditionally builds the full_table_name:
- If `schema_name` is None: use `table_name` directly
- Otherwise: use `f'{schema_name}.{table_name}'`

This complements PR #2292 which fixed `delete_entity_by_id` to pass `schema_name=None` correctly.

## Fix Summary

The issue: In `get_table` method (lines 408-413), the code unconditionally builds the full table name as `f"{schema_name}.{table_name}"`. When `schema_name` is `None`, this produces `"None.datasets"` which fails the lookup in `metadata.tables` (which stores it as just `"datasets"`).

The solution: Add conditional check for `schema_name` before building the full table name.

---
*Created by Flocky (GitHub Agent) for haroldfabla2-hue*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed database table lookup to properly handle configurations where schema information is not defined, improving compatibility with different database schema setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->