### PR TITLE
fix: skip oversized/failed chunk summaries in cognify

### DIFF
--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Type
 from uuid import uuid5
 from pydantic import BaseModel
@@ -8,6 +9,15 @@ from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.infrastructure.llm.extraction import extract_summary
 from cognee.modules.cognify.config import get_cognify_config
 from cognee.tasks.summarization.models import TextSummary
+
+
+logger = logging.getLogger(__name__)
+
+
+class _FallbackSummary:
+    def __init__(self, summary: str = "", description: str = ""):
+        self.summary = summary
+        self.description = description
 
 
 async def summarize_text(
@@ -49,9 +59,23 @@ async def summarize_text(
         cognee_config = get_cognify_config()
         summarization_model = cognee_config.summarization_model
 
-    chunk_summaries = await asyncio.gather(
-        *[extract_summary(chunk.text, summarization_model) for chunk in data_chunks]
+    raw_chunk_summaries = await asyncio.gather(
+        *[extract_summary(chunk.text, summarization_model) for chunk in data_chunks],
+        return_exceptions=True,
     )
+
+    chunk_summaries = []
+    for chunk_index, summary_result in enumerate(raw_chunk_summaries):
+        if isinstance(summary_result, Exception):
+            logger.warning(
+                "Skipping chunk summary at index %s due to extraction error: %s",
+                chunk_index,
+                summary_result,
+            )
+            chunk_summaries.append(_FallbackSummary())
+            continue
+
+        chunk_summaries.append(summary_result)
 
     summaries = [
         TextSummary(


### PR DESCRIPTION
## Summary
- prevent a single chunk summary failure from aborting the entire `summarize_text` batch
- use `asyncio.gather(..., return_exceptions=True)` and handle per-chunk exceptions
- log failed chunk summary extraction and continue with an empty fallback summary so long unattended runs can proceed

## Why
Local/self-hosted LLM backends may return transient 500s for oversized prompts or malformed structured output for specific chunks. Today that raises and stops cognify. This change degrades gracefully by skipping only the failed chunk summary.

## Validation
- `python -m py_compile cognee/tasks/summarization/summarize_text.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text summarization robustness to gracefully handle individual chunk processing failures, ensuring the operation continues without complete failure when encountering errors on specific chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->