### PR TITLE
feat: add weekly dev-canary release pipeline

### DIFF
--- a/.github/workflows/dev_canary_release.yml
+++ b/.github/workflows/dev_canary_release.yml
@@ -1,0 +1,123 @@
+name: Dev Canary Release
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: dev-canary-release
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # ── Gate: run core test suites before publishing ────────────────────
+  test-gate:
+    name: Canary Test Gate
+    uses: ./.github/workflows/basic_tests.yml
+    with:
+      ci-image: ""
+    secrets: inherit
+
+  # ── Compute canary version ──────────────────────────────────────────
+  prepare:
+    name: Prepare Canary Version
+    runs-on: ubuntu-latest
+    needs: test-gate
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      canary_version: ${{ steps.version.outputs.canary_version }}
+    steps:
+      - name: Check out dev
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install
+
+      - name: Compute canary version
+        id: version
+        run: |
+          BASE_VERSION="$(uv version --short)"
+          # Strip any existing .devN suffix to get the base
+          CLEAN_VERSION="${BASE_VERSION%%\.dev*}"
+          # PEP 440 dev release: 0.5.4.dev20260309
+          CANARY_VERSION="${CLEAN_VERSION}.dev$(date -u +%Y%m%d)"
+          echo "version=${CLEAN_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "canary_version=${CANARY_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Canary version: ${CANARY_VERSION}"
+
+  # ── Publish to PyPI ─────────────────────────────────────────────────
+  release-pypi:
+    name: Publish Dev Canary to PyPI
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out dev
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install
+
+      - name: Set canary version in pyproject.toml
+        run: uv version "${{ needs.prepare.outputs.canary_version }}"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish
+
+  # ── Publish Docker image ────────────────────────────────────────────
+  release-docker:
+    name: Publish Dev Canary Docker Image
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out dev
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            cognee/cognee:dev-canary
+            cognee/cognee:${{ needs.prepare.outputs.canary_version }}
+          labels: |
+            version=${{ needs.prepare.outputs.canary_version }}
+            flavour=dev-canary
+          cache-from: type=registry,ref=cognee/cognee:buildcache
+          cache-to: type=registry,ref=cognee/cognee:buildcache,mode=max

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -3,6 +3,7 @@ name: Release Test Workflow
 
 permissions:
   contents: read
+  packages: write
 
 on:
   workflow_dispatch:
@@ -14,4 +15,11 @@ jobs:
   load-tests:
     name: Load Tests
     uses: ./.github/workflows/load_tests.yml
+    secrets: inherit
+
+  dev-canary-release:
+    name: Dev Canary Release
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: load-tests
+    uses: ./.github/workflows/dev_canary_release.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `dev_canary_release.yml` workflow that publishes canary releases from the `dev` branch
- Runs automatically **every Monday at 06:00 UTC** and supports **manual dispatch** on demand
- Integrates into `release_test.yml` so canary can also be triggered after load tests pass

## How it works
1. **Test gate** — runs basic test suite before any publishing
2. **Version computation** — strips `.devN` suffix from `pyproject.toml`, appends `.dev{YYYYMMDD}` (PEP 440 compliant)
3. **PyPI publish** — publishes as a pre-release (`pip install cognee --pre` or `pip install cognee==0.5.4.dev20260309`)
4. **Docker publish** — pushes `cognee/cognee:dev-canary` (rolling) + `cognee/cognee:0.5.4.dev20260309` (pinned)

## Usage
- **Install canary from PyPI**: `pip install cognee --pre`
- **Pull canary Docker image**: `docker pull cognee/cognee:dev-canary`
- **Trigger manually**: Actions → Dev Canary Release → Run workflow
- **From release pipeline**: Actions → Release Test Workflow → Run workflow (runs load tests first, then canary)

## Test plan
- [ ] Trigger workflow manually via Actions tab and verify PyPI + Docker publish
- [ ] Verify PEP 440 version format is correct (e.g. `0.5.4.dev20260309`)
- [ ] Verify `pip install cognee --pre` picks up the canary release
- [ ] Verify `docker pull cognee/cognee:dev-canary` works after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Introduced automated canary release workflow triggering weekly and on-demand.
  * Canary package versions are now published to PyPI with date suffixes.
  * Docker images are now built and published for both AMD64 and ARM64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->