### PR TITLE
fix: Neptune Analytics search fails with GRAPH_COMPLETION

### DIFF
--- a/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
+++ b/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
@@ -26,12 +26,14 @@ class IndexSchema(DataPoint):
     Attributes:
     - id: A string representing the unique identifier for the data point.
     - text: A string representing the content of the data point.
+    - belongs_to_set: A list of node names this data point belongs to, used for filtering.
     - metadata: A dictionary with default index fields for the schema, currently configured
     to include 'text'.
     """
 
     id: str
     text: str
+    belongs_to_set: List[str] = []
     metadata: dict = {"index_fields": ["text"]}
 
 
@@ -237,6 +239,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
         limit: Optional[int] = None,
         with_vector: bool = False,
         include_payload: bool = False,  # TODO: Add support for this parameter
+        node_name: Optional[List[str]] = None,
     ):
         """
         Perform a search in the specified collection using either a text query or a vector
@@ -298,6 +301,15 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
         YIELD node, score
         """
 
+        # Filter by belongs_to_set if node_name is provided
+        if node_name:
+            escaped_names = [name.replace("'", "\\'") for name in node_name]
+            name_list = ", ".join(f"'{name}'" for name in escaped_names)
+            query_string += f"""
+        WITH node, score
+        WHERE any(name IN node.belongs_to_set WHERE name IN [{name_list}])
+        """
+
         if with_vector:
             query_string += """
         WITH node, score, id(node) as node_id
@@ -326,6 +338,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
         limit: int,
         with_vectors: bool = False,
         include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
     ):
         """
         Perform a batch search using multiple text queries against a collection.
@@ -355,6 +368,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                     limit,
                     with_vectors,
                     include_payload=include_payload,
+                    node_name=node_name,
                 )
                 for vector in data_vectors
             ]


### PR DESCRIPTION
## Summary
- Adds missing `node_name` parameter to `NeptuneAnalyticsAdapter.search()` and `batch_search()` methods
- Implements `belongs_to_set` filtering via Cypher `any()` list comprehension, consistent with LanceDB and PGVector adapters
- Adds `belongs_to_set` field to Neptune's `IndexSchema` for data model consistency

## Problem
When using Neptune Analytics with graph search types (`GRAPH_COMPLETION`, `GRAPH_SUMMARY_COMPLETION`), the search pipeline passes `node_name` to `vector_engine.search()`. Neptune's adapter didn't accept this parameter, causing:
```
TypeError: NeptuneAnalyticsAdapter.search() got an unexpected keyword argument 'node_name'
```

Vector-only search types (`RAG_COMPLETION`, `CHUNKS`) and `TRIPLET_COMPLETION` worked because they don't pass `node_name`.

## Test plan
- [ ] Verify `GRAPH_COMPLETION` search works with Neptune Analytics backend
- [ ] Verify `GRAPH_SUMMARY_COMPLETION` search works with Neptune Analytics
- [ ] Verify existing vector-only search types still work (no regression)
- [ ] Verify `node_name` filtering correctly limits results to matching `belongs_to_set` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced optional node-name filtering to search operations. Users can now refine search results by specifying node names to restrict data retrieval to results associated with those nodes. This new filtering capability is available in both single and batch search operations, providing more targeted and precise control over query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->