### PR TITLE
chore(deps): move pympler and pylance to dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,7 @@ dependencies = [
     "python-multipart>=0.0.22,<1.0.0",
     "fastapi-users[sqlalchemy]>=15.0.2",
     "structlog>=25.2.0,<26",
-    "pympler>=1.1,<2.0.0",
     "onnxruntime<=1.22.1",
-    "pylance>=0.22.0,<=0.36.0",
     "kuzu (==0.11.3)",
     "python-magic-bin<0.5 ; platform_system == 'Windows'", # Only needed for Windows
     "fastembed<=0.6.0",
@@ -155,6 +153,8 @@ dev = [
     "mkdocs-material>=9.5.42,<10",
     "mkdocs-minify-plugin>=0.8.0,<0.9",
     "mkdocstrings[python]>=0.26.2,<0.27",
+    "pympler>=1.1,<2.0.0",
+    "pylance>=0.22.0,<=0.36.0",
 ]
 debug = ["debugpy>=1.8.9,<2.0.0"]
 redis = ["redis>=5.0.3,<6.0.0"]


### PR DESCRIPTION
fix : #2305

### summary

- Move dev-only deps out of core runtime.

### Changes

- Removed pympler and pylance from [project.dependencies].
- Added pympler and pylance to [project.optional-dependencies].dev.
- Kept datamodel-code-generator as a core dependency since it is used at API runtime.

### Testing
uv pip install -e .
uv pip install -e ".[dev]"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency configuration to streamline the runtime environment and optimize installation for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->