### PR TITLE
fix: add asyncio.wait_for timeout to test_llm_connection()

### DIFF
--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -78,10 +78,13 @@ async def test_llm_connection():
     """
     try:
         logger.info("Testing connection to LLM endpoint...")
-        await LLMGateway.acreate_structured_output(
-            text_input="test",
-            system_prompt='Respond to me with the following string: "test"',
-            response_model=str,
+        await asyncio.wait_for(
+            LLMGateway.acreate_structured_output(
+                text_input="test",
+                system_prompt='Respond to me with the following string: "test"',
+                response_model=str,
+            ),
+            timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
         msg = (


### PR DESCRIPTION
## Description
Wrap the LLM call in `test_llm_connection()` with `asyncio.wait_for(timeout=CONNECTION_TEST_TIMEOUT_SECONDS)`, matching the existing pattern in `test_embedding_connection()`.

Without this, the connection test hangs indefinitely if the LLM endpoint is unreachable.

Fixes #2362

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] New and existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced LLM connectivity test with improved timeout handling. The connection diagnostic now enforces a maximum timeout duration, preventing indefinite hangs and ensuring faster detection of connection issues for improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->