### PR TITLE
fix: memify example TypeError on search result iteration

### DIFF
--- a/examples/custom_pipelines/memify_coding_agent_rule_extraction_example.py
+++ b/examples/custom_pipelines/memify_coding_agent_rule_extraction_example.py
@@ -89,8 +89,9 @@ async def main():
     )
 
     print("Coding rules created by memify:")
-    for coding_rule in coding_rules:
-        print("- " + coding_rule)
+    for result in coding_rules:
+        for rule in result["search_result"]:
+            print("- " + str(rule))
 
     # Visualize new graph with added memify context
     file_path = os.path.join(


### PR DESCRIPTION
## Summary
- Fix `TypeError: can only concatenate str (not "dict") to str` in memify coding rules example
- `cognee.search()` returns a list of dicts with `dataset_id`, `dataset_name`, `dataset_tenant_id`, and `search_result` keys — the example was iterating the list directly and trying to concatenate dicts to strings
- Properly iterate `result["search_result"]` to access the rule strings

Reverts the regression introduced in a9604f74 which undid the earlier fix from 6e65fc5e.

## Test plan
- [ ] CI memify example test passes
- [ ] `memify_coding_agent_rule_extraction_example.py` runs without TypeError

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the coding agent example to handle revised rule output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->