### PR TITLE
fix: raise ValueError on incomplete Neo4j credentials instead of silent fallback

### DIFF
--- a/cognee/infrastructure/databases/exceptions/__init__.py
+++ b/cognee/infrastructure/databases/exceptions/__init__.py
@@ -14,4 +14,5 @@ from .exceptions import (
     CacheConnectionError,
     SessionQAEntryValidationError,
     SessionParameterValidationError,
+    DatabaseCredentialsError,
 )

--- a/cognee/infrastructure/databases/exceptions/exceptions.py
+++ b/cognee/infrastructure/databases/exceptions/exceptions.py
@@ -198,3 +198,20 @@ class SharedKuzuLockRequiresRedisError(CogneeConfigurationError):
         status_code: int = status.HTTP_400_BAD_REQUEST,
     ):
         super().__init__(message, name, status_code)
+
+
+class DatabaseCredentialsError(CogneeConfigurationError):
+    """
+    Raised when database credentials are incomplete or invalid.
+
+    This error indicates that required authentication parameters (e.g., username
+    or password) are missing or malformed for a database connection.
+    """
+
+    def __init__(
+        self,
+        message: str = "Database credentials are incomplete or invalid. Please check your configuration.",
+        name: str = "DatabaseCredentialsError",
+        status_code: int = status.HTTP_422_UNPROCESSABLE_CONTENT,
+    ):
+        super().__init__(message, name, status_code)

--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -17,7 +17,7 @@ from cognee.shared.logging_utils import get_logger, ERROR
 from cognee.infrastructure.databases.graph.graph_db_interface import (
     GraphDBInterface,
 )
-from cognee.exceptions import CogneeConfigurationError
+from cognee.infrastructure.databases.exceptions import DatabaseCredentialsError
 from cognee.modules.storage.utils import JSONEncoder
 
 from distributed.utils import override_distributed
@@ -62,13 +62,12 @@ class Neo4jAdapter(GraphDBInterface):
         elif graph_database_username or graph_database_password:
             provided = "username" if graph_database_username else "password"
             missing = "password" if graph_database_username else "username"
-            raise CogneeConfigurationError(
+            raise DatabaseCredentialsError(
                 message=(
                     f"Neo4j credentials are incomplete: '{provided}' was provided but "
                     f"'{missing}' is missing. Please provide both "
                     f"GRAPH_DATABASE_USERNAME and GRAPH_DATABASE_PASSWORD, or neither."
                 ),
-                name="IncompleteNeo4jCredentialsError",
             )
         self.graph_database_name = graph_database_name
         self.driver = driver or AsyncGraphDatabase.driver(


### PR DESCRIPTION
## Description

When only one of `GRAPH_DATABASE_USERNAME` or `GRAPH_DATABASE_PASSWORD` is set, the Neo4j adapter silently falls back to an anonymous connection. This masks misconfiguration and can lead to confusing auth failures later. This PR replaces the warning with a clear `ValueError` that tells the user exactly which credential is missing.

## Acceptance Criteria

* `Neo4jAdapter(url, username="neo4j")` raises `ValueError` mentioning missing password
* `Neo4jAdapter(url, password="secret")` raises `ValueError` mentioning missing username
* `Neo4jAdapter(url, username="neo4j", password="secret")` works as before
* `Neo4jAdapter(url)` (no credentials) works as before (anonymous)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Fixes #2307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now enforces complete graph DB credentials: providing only a username or password aborts initialization with a clear configuration error instead of falling back to anonymous access.

* **Chores**
  * Introduced and surfaced a new configuration error type for incomplete database credentials to improve error clarity and handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->