### PR TITLE
fix(neo4j): raise ValueError on incomplete credentials instead of silent fallback

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -63,13 +63,19 @@ class Neo4jAdapter(GraphDBInterface):
         graph_database_name: Optional[str] = None,
         driver: Optional[Any] = None,
     ):
-        # Only use auth if both username and password are provided
+        # Only use auth if both username and password are provided.
+        # Partial credentials are an error — fail fast with a clear message.
         auth = None
         if graph_database_username and graph_database_password:
             auth = (graph_database_username, graph_database_password)
         elif graph_database_username or graph_database_password:
-            logger = get_logger(__name__)
-            logger.warning("Neo4j credentials incomplete – falling back to anonymous connection.")
+            missing = "GRAPH_DATABASE_PASSWORD" if graph_database_username else "GRAPH_DATABASE_USERNAME"
+            raise ValueError(
+                f"Neo4j credentials incomplete: {missing} is not set. "
+                "Provide both GRAPH_DATABASE_USERNAME and GRAPH_DATABASE_PASSWORD in your "
+                ".env file, or configure them programmatically. "
+                "If anonymous authentication is intentional, leave both values empty."
+            )
         self.graph_database_name = graph_database_name
         self.driver = driver or AsyncGraphDatabase.driver(
             graph_database_url,


### PR DESCRIPTION
## Summary

Fixes #2307.

The Neo4j adapter was silently falling back to anonymous auth when only one of username/password was provided, logging a warning but continuing. This leads to confusing permission errors at runtime rather than a clear startup failure.

## Changes

Replaced the silent fallback with an explicit `ValueError` that identifies the missing credential and tells the user exactly how to fix it:

```python
raise ValueError(
    f"Neo4j credentials incomplete: {missing} is not set. "
    "Provide both GRAPH_DATABASE_USERNAME and GRAPH_DATABASE_PASSWORD in your "
    ".env file, or configure them programmatically. "
    "If anonymous authentication is intentional, leave both values empty."
)
```

Anonymous auth (both values empty) is still fully supported — only partial credentials are rejected.

## Checklist
- [x] Incomplete credentials raise a clear, actionable `ValueError`
- [x] Error message identifies the specific missing variable
- [x] Anonymous auth (both empty) still works
- [x] Existing behavior for valid credentials unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Neo4j authentication now enforces a strict requirement: both username and password must be provided together, or neither. Partial credentials will raise an error with a clear message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->