### PR TITLE
fix(neo4j): raise ValueError on incomplete credentials instead of silent fallback

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -63,13 +63,19 @@ class Neo4jAdapter(GraphDBInterface):
         graph_database_name: Optional[str] = None,
         driver: Optional[Any] = None,
     ):
-        # Only use auth if both username and password are provided
+        # Only use auth if both username and password are provided.
+        # Partial credentials are an error — fail fast with a clear message.
         auth = None
         if graph_database_username and graph_database_password:
             auth = (graph_database_username, graph_database_password)
         elif graph_database_username or graph_database_password:
-            logger = get_logger(__name__)
-            logger.warning("Neo4j credentials incomplete – falling back to anonymous connection.")
+            missing = "GRAPH_DATABASE_PASSWORD" if graph_database_username else "GRAPH_DATABASE_USERNAME"
+            raise ValueError(
+                f"Neo4j credentials incomplete: {missing} is not set. "
+                "Provide both GRAPH_DATABASE_USERNAME and GRAPH_DATABASE_PASSWORD in your "
+                ".env file, or configure them programmatically. "
+                "If anonymous authentication is intentional, leave both values empty."
+            )
         self.graph_database_name = graph_database_name
         self.driver = driver or AsyncGraphDatabase.driver(
             graph_database_url,


### PR DESCRIPTION
## Description

Fixes #2307.

The Neo4j adapter was silently falling back to anonymous auth when only one of `username`/`password` was set, logging a warning but continuing. This causes confusing permission errors at runtime instead of a clear startup failure.

Replaced the silent fallback with an explicit `ValueError` that identifies the missing credential and tells the user exactly what to fix. Anonymous auth (both values empty) remains fully supported.

## Acceptance Criteria

* Incomplete credentials raise a clear `ValueError` ✅
* Error message identifies the specific missing env var ✅
* Anonymous auth (both empty) still works ✅
* Valid credentials behavior unchanged ✅

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

No UI changes.

## Pre-submission Checklist

Please make sure all the checkboxes are checked:
- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have added end-to-end and unit tests (if applicable).
- [x] I have updated the documentation and README.md file (if necessary).
- [x] I have removed unnecessary code and debug statements.
- [x] PR title is clear and follows the convention.
- [ ] I have tagged reviewers or team members for feedback.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
