### PR TITLE
refactor: remove deprecated backward-compat methods from CacheDBInterface

### DIFF
--- a/cognee/infrastructure/databases/cache/cache_db_interface.py
+++ b/cognee/infrastructure/databases/cache/cache_db_interface.py
@@ -1,4 +1,3 @@
-import uuid
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
@@ -45,24 +44,6 @@ class CacheDBInterface(ABC):
         finally:
             self.release()
 
-    async def add_qa(
-        self,
-        user_id: str,
-        session_id: str,
-        question: str,
-        context: str,
-        answer: str,
-    ):
-        """Backward-compatibility: delegates to create_qa_entry with generated qa_id. :TODO: delete when retrievers are updated"""
-        return await self.create_qa_entry(
-            user_id,
-            session_id,
-            question,
-            context,
-            answer,
-            qa_id=str(uuid.uuid4()),
-        )
-
     @abstractmethod
     async def create_qa_entry(
         self,
@@ -83,20 +64,12 @@ class CacheDBInterface(ABC):
         """
         pass
 
-    async def get_latest_qa(self, user_id: str, session_id: str, last_n: int = 5):
-        """Backward-compat: delegates to get_latest_qa_entries. :TODO: delete when retrievers are updated"""
-        return await self.get_latest_qa_entries(user_id, session_id, last_n)
-
     @abstractmethod
     async def get_latest_qa_entries(self, user_id: str, session_id: str, last_n: int = 5):
         """
         Retrieve the most recent Q/A/context triplets for a session.
         """
         pass
-
-    async def get_all_qas(self, user_id: str, session_id: str):
-        """Backward-compat: delegates to get_all_qa_entries. :TODO: delete when retrievers are updated"""
-        return await self.get_all_qa_entries(user_id, session_id)
 
     @abstractmethod
     async def get_all_qa_entries(self, user_id: str, session_id: str):

--- a/cognee/tests/test_conversation_history.py
+++ b/cognee/tests/test_conversation_history.py
@@ -4,7 +4,7 @@ End-to-end integration test for conversation history feature.
 Covers retrievers that save conversation history (via SessionManager / cache):
   GRAPH_COMPLETION, RAG_COMPLETION, GRAPH_COMPLETION_COT,
   GRAPH_COMPLETION_CONTEXT_EXTENSION, GRAPH_SUMMARY_COMPLETION, TEMPORAL, TRIPLET_COMPLETION.
-Uses cache_engine.get_latest_qa for legacy assertions and cognee.session.get_session for
+Uses cache_engine.get_latest_qa_entries for assertions and cognee.session.get_session for
 session history; e2e for session SDK (get_session, add_feedback, delete_feedback) at end.
 """
 
@@ -95,7 +95,7 @@ async def main():
         session_id=session_id_1,
     )
 
-    history1 = await cache_engine.get_latest_qa(str(user.id), session_id_1, last_n=10)
+    history1 = await cache_engine.get_latest_qa_entries(str(user.id), session_id_1, last_n=10)
     assert len(history1) == 1, f"Expected at least 1 Q&A in history, got {len(history1)}"
     our_qa = [h for h in history1 if h["question"] == "What is TechCorp?"]
     assert len(our_qa) >= 1, "Expected to find 'What is TechCorp?' in history"
@@ -114,7 +114,7 @@ async def main():
         f"Second query should return non-empty list, got: {result2!r}"
     )
 
-    history2 = await cache_engine.get_latest_qa(str(user.id), session_id_1, last_n=10)
+    history2 = await cache_engine.get_latest_qa_entries(str(user.id), session_id_1, last_n=10)
     our_questions = [
         h for h in history2 if h["question"] in ["What is TechCorp?", "Tell me more about it"]
     ]
@@ -134,7 +134,7 @@ async def main():
         f"Different session should return non-empty list, got: {result3!r}"
     )
 
-    history3 = await cache_engine.get_latest_qa(str(user.id), session_id_2, last_n=10)
+    history3 = await cache_engine.get_latest_qa_entries(str(user.id), session_id_2, last_n=10)
     our_qa_session2 = [h for h in history3 if h["question"] == "What is DataCo?"]
     assert len(our_qa_session2) == 1, "Session 2 should have 'What is DataCo?' question"
 
@@ -148,7 +148,7 @@ async def main():
         f"Default session should return non-empty list, got: {result4!r}"
     )
 
-    history_default = await cache_engine.get_latest_qa(str(user.id), "default_session", last_n=10)
+    history_default = await cache_engine.get_latest_qa_entries(str(user.id), "default_session", last_n=10)
     our_qa_default = [h for h in history_default if h["question"] == "Test default session"]
     assert len(our_qa_default) == 1, "Should find 'Test default session' in default_session"
 
@@ -164,7 +164,7 @@ async def main():
         f"RAG_COMPLETION should return non-empty list, got: {result_rag!r}"
     )
 
-    history_rag = await cache_engine.get_latest_qa(str(user.id), session_id_rag, last_n=10)
+    history_rag = await cache_engine.get_latest_qa_entries(str(user.id), session_id_rag, last_n=10)
     our_qa_rag = [h for h in history_rag if h["question"] == "What companies are mentioned?"]
     assert len(our_qa_rag) == 1, "Should find RAG question in history"
     _assert_used_graph_element_ids_shape(our_qa_rag[0])
@@ -181,7 +181,7 @@ async def main():
         f"GRAPH_COMPLETION_COT should return non-empty list, got: {result_cot!r}"
     )
 
-    history_cot = await cache_engine.get_latest_qa(str(user.id), session_id_cot, last_n=10)
+    history_cot = await cache_engine.get_latest_qa_entries(str(user.id), session_id_cot, last_n=10)
     our_qa_cot = [h for h in history_cot if h["question"] == "What do you know about TechCorp?"]
     assert len(our_qa_cot) == 1, "Should find CoT question in history"
     _assert_used_graph_element_ids_shape(our_qa_cot[0])
@@ -198,7 +198,7 @@ async def main():
         f"GRAPH_COMPLETION_CONTEXT_EXTENSION should return non-empty list, got: {result_ext!r}"
     )
 
-    history_ext = await cache_engine.get_latest_qa(str(user.id), session_id_ext, last_n=10)
+    history_ext = await cache_engine.get_latest_qa_entries(str(user.id), session_id_ext, last_n=10)
     our_qa_ext = [h for h in history_ext if h["question"] == "Tell me about DataCo"]
     assert len(our_qa_ext) == 1, "Should find Context Extension question in history"
     _assert_used_graph_element_ids_shape(our_qa_ext[0])
@@ -215,7 +215,7 @@ async def main():
         f"GRAPH_SUMMARY_COMPLETION should return non-empty list, got: {result_summary!r}"
     )
 
-    history_summary = await cache_engine.get_latest_qa(str(user.id), session_id_summary, last_n=10)
+    history_summary = await cache_engine.get_latest_qa_entries(str(user.id), session_id_summary, last_n=10)
     our_qa_summary = [
         h for h in history_summary if h["question"] == "What are the key points about TechCorp?"
     ]
@@ -234,7 +234,7 @@ async def main():
         f"TEMPORAL should return non-empty list, got: {result_temporal!r}"
     )
 
-    history_temporal = await cache_engine.get_latest_qa(
+    history_temporal = await cache_engine.get_latest_qa_entries(
         str(user.id), session_id_temporal, last_n=10
     )
     our_qa_temporal = [
@@ -255,7 +255,7 @@ async def main():
         f"TRIPLET_COMPLETION should return non-empty list, got: {result_triplet!r}"
     )
 
-    history_triplet = await cache_engine.get_latest_qa(str(user.id), session_id_triplet, last_n=10)
+    history_triplet = await cache_engine.get_latest_qa_entries(str(user.id), session_id_triplet, last_n=10)
     our_qa_triplet = [
         h for h in history_triplet if h["question"] == "What companies are mentioned?"
     ]

--- a/cognee/tests/unit/infrastructure/databases/cache/test_fs_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_fs_adapter_crud.py
@@ -116,36 +116,3 @@ async def test_prune(adapter):
     await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
     await adapter.prune()
     assert await adapter.get_all_qa_entries("u1", "s1") == []
-
-
-@pytest.mark.asyncio
-async def test_add_qa_backward_compat(adapter):
-    """Legacy add_qa stores entry with auto-generated qa_id."""
-    await adapter.add_qa("u1", "s1", "Q", "C", "A")
-    entries = await adapter.get_all_qa_entries("u1", "s1")
-    assert len(entries) == 1
-    assert "qa_id" in entries[0]
-    assert entries[0]["question"] == "Q" and entries[0]["answer"] == "A"
-
-
-@pytest.mark.asyncio
-async def test_get_all_qas_backward_compat(adapter):
-    """Legacy get_all_qas returns same as get_all_qa_entries."""
-    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
-    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
-    via_legacy = await adapter.get_all_qas("u1", "s1")
-    via_new = await adapter.get_all_qa_entries("u1", "s1")
-    assert via_legacy == via_new
-    assert len(via_legacy) == 2
-
-
-@pytest.mark.asyncio
-async def test_get_latest_qa_backward_compat(adapter):
-    """Legacy get_latest_qa returns same as get_latest_qa_entries."""
-    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
-    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
-    await adapter.create_qa_entry("u1", "s1", "Q3", "C3", "A3", qa_id="id3")
-    via_legacy = await adapter.get_latest_qa("u1", "s1", last_n=2)
-    via_new = await adapter.get_latest_qa_entries("u1", "s1", last_n=2)
-    assert via_legacy == via_new
-    assert len(via_legacy) == 2

--- a/cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py
@@ -148,37 +148,3 @@ async def test_prune(adapter):
     await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
     await adapter.prune()
     assert await adapter.get_all_qa_entries("u1", "s1") == []
-
-
-# Backward-compatibility tests (add_qa, get_latest_qa, get_all_qas) :TODO: Can be deleted after session manager integration into retrievers
-@pytest.mark.asyncio
-async def test_add_qa_backward_compat(adapter):
-    """Legacy add_qa stores entry with auto-generated qa_id."""
-    await adapter.add_qa("u1", "s1", "Q", "C", "A")
-    entries = await adapter.get_all_qa_entries("u1", "s1")
-    assert len(entries) == 1
-    assert "qa_id" in entries[0]
-    assert entries[0]["question"] == "Q" and entries[0]["answer"] == "A"
-
-
-@pytest.mark.asyncio
-async def test_get_all_qas_backward_compat(adapter):
-    """Legacy get_all_qas returns same as get_all_qa_entries."""
-    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
-    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
-    via_legacy = await adapter.get_all_qas("u1", "s1")
-    via_new = await adapter.get_all_qa_entries("u1", "s1")
-    assert via_legacy == via_new
-    assert len(via_legacy) == 2
-
-
-@pytest.mark.asyncio
-async def test_get_latest_qa_backward_compat(adapter):
-    """Legacy get_latest_qa returns same as get_latest_qa_entries."""
-    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
-    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
-    await adapter.create_qa_entry("u1", "s1", "Q3", "C3", "A3", qa_id="id3")
-    via_legacy = await adapter.get_latest_qa("u1", "s1", last_n=2)
-    via_new = await adapter.get_latest_qa_entries("u1", "s1", last_n=2)
-    assert via_legacy == via_new
-    assert len(via_legacy) == 2


### PR DESCRIPTION
## Summary

Closes #2306

Removes the three `CacheDBInterface` methods that were marked `:TODO: delete when retrievers are updated`:

| Removed | Replacement |
|---------|------------|
| `add_qa(user_id, session_id, question, context, answer)` | `create_qa_entry(…, qa_id=…)` |
| `get_latest_qa(user_id, session_id, last_n)` | `get_latest_qa_entries(…)` |
| `get_all_qas(user_id, session_id)` | `get_all_qa_entries(…)` |

Also removes the now-unused `import uuid` from the interface file.

## Files changed

- `cognee/infrastructure/databases/cache/cache_db_interface.py` — remove 3 deprecated methods + `import uuid`
- `cognee/tests/test_conversation_history.py` — replace 10× `cache_engine.get_latest_qa(` with `cache_engine.get_latest_qa_entries(`; update docstring
- `cognee/tests/unit/infrastructure/databases/cache/test_fs_adapter_crud.py` — delete 3 `*_backward_compat` test functions
- `cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py` — delete 3 `*_backward_compat` test functions + the section comment

## Notes

`SessionManager.add_qa()` is a separate method on the session manager (not the cache interface shim) and was **not** changed — it already calls `create_qa_entry` directly.

The integration test files (`test_session_manager_fs.py`, `test_session_manager_redis.py`, etc.) call `session_manager.add_qa()`, not `cache_engine.add_qa()`, so they also required no changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed legacy conversation history retrieval methods from the cache interface; updated to use current API methods for improved consistency.
  
* **Tests**
  * Removed backward-compatibility test coverage for deprecated conversation history functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->