### PR TITLE
fix: add missing npm dependencies for frontend

### DIFF
--- a/cognee-frontend/package.json
+++ b/cognee-frontend/package.json
@@ -19,7 +19,10 @@
     "react-force-graph-2d": "^1.27.1",
     "three": "^0.175.0",
     "troika-three-text": "^0.52.4",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "react-markdown": "^9.0.0",
+    "ngraph.graph": "^20.0.0",
+    "ngraph.forcelayout": "^3.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
Fixes #2413 - Frontend fails to compile due to missing npm dependencies.

## Problem
Running `cognee-cli -ui` results in 500 error because Next.js dev server cannot find these packages:

| Package | Imported in |
|---------|------------|
| `react-markdown` | `src/ui/elements/Notebook/MarkdownPreview.tsx` |
| `ngraph.graph` | `src/ui/rendering/animate.ts`, `src/ui/rendering/graph/createGraph.ts` |
| `ngraph.forcelayout` | `src/ui/rendering/animate.ts` |

## Solution
Add missing dependencies to `cognee-frontend/package.json`:
- `react-markdown`: `^9.0.0`
- `ngraph.graph`: `^20.0.0`
- `ngraph.forcelayout`: `^3.0.0`

## Testing
1. Run `cognee-cli -ui`
2. Verify frontend compiles without errors
3. Verify no 500 errors on page load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to support markdown content rendering and graph visualization capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->