### PR TITLE
feat(config): add embedding configuration methods to public API

### DIFF
--- a/cognee/api/v1/config/config.py
+++ b/cognee/api/v1/config/config.py
@@ -255,7 +255,8 @@
       def set_embedding_dimensions(embedding_dimensions: int):
           """Set the embedding vector dimensions.
 
-          Coerces string inputs to int for CLI compatibility.
+          Coerces string inputs to int for CLI compatibility and validates
+          the value is a positive integer.
 
           Parameters
           ----------
@@ -266,10 +267,15 @@
           Raises
           ------
           ValueError
-              If the value cannot be converted to an integer.
+              If the value cannot be converted to an integer or is not positive.
           """
           if isinstance(embedding_dimensions, str):
-              embedding_dimensions = int(embedding_dimensions)
+              try:
+                  embedding_dimensions = int(embedding_dimensions)
+              except ValueError as exc:
+                  raise ValueError("embedding_dimensions must be a positive integer.") from exc
+          if embedding_dimensions <= 0:
+              raise ValueError("embedding_dimensions must be a positive integer.")
           embedding_config = get_embedding_config()
           embedding_config.embedding_dimensions = embedding_dimensions
 
@@ -301,6 +307,9 @@
       def set_embedding_config(config_dict: dict):
           """Update the embedding config with values from a dictionary.
 
+          Routes embedding_dimensions through set_embedding_dimensions to ensure
+          type coercion and positive-value validation are applied.
+
           Parameters
           ----------
           config_dict : dict
@@ -320,7 +329,10 @@
               })
               ```
           """
-          config._update_config(get_embedding_config(), config_dict)
+          normalized_config = dict(config_dict)
+          if "embedding_dimensions" in normalized_config:
+              config.set_embedding_dimensions(normalized_config.pop("embedding_dimensions"))
+          config._update_config(get_embedding_config(), normalized_config)
 
       @staticmethod
       def set_chunk_strategy(chunk_strategy: object):
@@ -494,6 +506,10 @@
           Generic setter that maps configuration keys to their specific setter methods.
           This enables CLI commands like 'cognee config set llm_api_key <value>'.
 
+          For embedding keys not explicitly listed in the mapping but present on
+          EmbeddingConfig, the value is routed through set_embedding_config as a
+          fallback so that all valid embedding attributes are accessible via CLI.
+
           Parameters
           ----------
           key : str
@@ -532,10 +548,16 @@
               "data_root_directory": "data_root_directory",
           }
 
-          if key not in setter_mapping:
-              raise InvalidConfigAttributeError(attribute=key)
+          if key in setter_mapping:
+              method_name = setter_mapping[key]
+              method = getattr(config, method_name)
+              method(value)
+              return
 
-          method_name = setter_mapping[key]
-          method = getattr(config, method_name)
-          method(value)
+          embedding_config = get_embedding_config()
+          if hasattr(embedding_config, key):
+              config.set_embedding_config({key: value})
+              return
+
+          raise InvalidConfigAttributeError(attribute=key)
   


### PR DESCRIPTION
## Summary

  Add embedding configuration methods to the public `cognee.config` API, filling a gap where embedding settings were the only major configuration subsystem without public setters.

  ## Problem

  The `cognee.config` class provides convenient runtime configuration for:
  - **LLM**: `set_llm_provider`, `set_llm_model`, `set_llm_endpoint`, `set_llm_api_key`, `set_llm_config`
  - **Vector DB**: `set_vector_db_provider`, `set_vector_db_url`, `set_vector_db_key`, `set_vector_db_config`
  - **Graph DB**: `set_graph_database_provider`, `set_graph_db_config`
  - **Chunking**: `set_chunk_strategy`, `set_chunk_size`, `set_chunk_overlap`, `set_chunk_engine`
  - **Translation**: `set_translation_provider`, `set_translation_target_language`, `set_translation_config`

  However, **embedding configuration has no public setters at all**. Users who want to switch embedding providers (e.g. to `fastembed` for local embeddings, or to a custom endpoint) must import internal modules directly:

  ```python
  # Current workaround — requires knowledge of internal module paths
  from cognee.infrastructure.databases.vector.embeddings.config import get_embedding_config
  ecfg = get_embedding_config()
  ecfg.embedding_provider = 'fastembed'
  ecfg.embedding_model = 'BAAI/bge-small-en-v1.5'
  ecfg.embedding_dimensions = 384
  ```

  This is a common need — many users run Cognee in environments where they can't use the default OpenAI embeddings (air-gapped systems, cost constraints, latency requirements, custom proxy endpoints).

  ## Solution

  Add six new methods to `cognee.config` that follow the exact same patterns as the existing LLM and translation setters:

  | Method | Purpose |
  |--------|---------|
  | `set_embedding_provider(provider)` | Set provider (e.g. `"openai"`, `"fastembed"`, `"azure"`, `"litellm"`) |
  | `set_embedding_model(model)` | Set model name |
  | `set_embedding_dimensions(dims)` | Set vector dimensions (with string-to-int coercion for CLI compatibility) |
  | `set_embedding_endpoint(url)` | Set custom API endpoint |
  | `set_embedding_api_key(key)` | Set API key |
  | `set_embedding_config(dict)` | Bulk update via dict (matches `set_llm_config` pattern) |

  Also registers all five embedding keys in the generic `set()` method's mapping for CLI support.

  ### After this change:

  ```python
  import cognee

  # Individual setters
  cognee.config.set_embedding_provider("fastembed")
  cognee.config.set_embedding_model("BAAI/bge-small-en-v1.5")
  cognee.config.set_embedding_dimensions(384)

  # Or bulk update
  cognee.config.set_embedding_config({
      "embedding_provider": "fastembed",
      "embedding_model": "BAAI/bge-small-en-v1.5",
      "embedding_dimensions": 384,
  })

  # Or via CLI
  # cognee config set embedding_provider fastembed
  ```

  ## Context

  This gap was discovered while integrating Cognee into a Replit Agent environment where we needed `fastembed` for local embeddings (to avoid external API dependencies) and a custom LLM proxy endpoint. The LLM configuration was straightforward via `cognee.config`, but embedding configuration required digging into internal module paths — an unnecessary friction point for what should be a first-class configuration surface.

  ## Changes

  - **`cognee/api/v1/config/config.py`**: 
    - Added import of `get_embedding_config`
    - Added 6 new static methods for embedding configuration
    - Added 5 embedding keys to the `set()` method's `setter_mapping`
    - Updated class docstring to show embedding configuration example
    - Added NumPy-style docstrings to all methods (new and existing) to meet docstring coverage threshold
    - `set_embedding_dimensions` includes string-to-int coercion for CLI compatibility

  ## Breaking Changes

  None. This is purely additive — no existing behavior is modified.

  ## Pre-submission Checklist

  - [x] I have tested these changes locally.
  - [x] I have reviewed the code changes.
  - [ ] I have added end-to-end and unit tests (if applicable).
  - [x] I have updated the documentation and README.md file (if necessary).
  - [x] I have removed unnecessary code and debug statements.
  - [x] PR title is clear and follows the convention.
  - [x] I have tagged reviewers or team members for feedback.
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added embedding configuration to the public config API: set provider, model, dimensions, endpoint, and API key via individual setters or a bulk configure method.
  * Accepts numeric dimensions provided as strings (coerced to integers) with validation for positive values.
  * Documentation and examples updated to illustrate embedding configuration; existing validation for unknown keys retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->