### PR TITLE
fix(mcp): enable stateless http for reliable proxy support

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -41,7 +41,9 @@ except ModuleNotFoundError:
     )
 
 
-mcp = FastMCP("Cognee")
+import os
+_stateless = os.environ.get("MCP_STATELESS_HTTP", "false").lower() == "true"
+mcp = FastMCP("Cognee", stateless_http=_stateless)
 
 logger = get_logger()
 


### PR DESCRIPTION
## Description
Enables `stateless_http=True` on the FastMCP initialization. 

The standard SSE transport requires strict session affinity which often drops behind proxies or in K8s/LXC environments without sticky sessions, resulting in 'Missing session ID' errors on POST requests to `/messages`. 

Stateless HTTP ensures modern clients can reliably communicate with the MCP server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized HTTP server configuration to improve session management and concurrent request handling for enhanced performance and scalability across deployments.
  * Made stateless HTTP mode configurable via an environment setting to provide deployment flexibility and easier operational control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->