### PR TITLE
fix: use argument lists instead of shell=True to prevent command injection

### DIFF
--- a/evals/src/modal_apps/modal_qa_benchmark_graphiti.py
+++ b/evals/src/modal_apps/modal_qa_benchmark_graphiti.py
@@ -73,11 +73,9 @@ async def launch_neo4j_and_run_benchmark(config_params: dict, dir_suffix: str):
     """Launches Neo4j and then triggers the Graphiti benchmark."""
     print("Starting Neo4j server process...")
     password = neo4j_env_dict["NEO4J_AUTH"].split("/")[1]
-    set_password_command = f"neo4j-admin dbms set-initial-password {password}"
     try:
         subprocess.run(
-            f"su-exec neo4j:neo4j {set_password_command}",
-            shell=True,
+            ["su-exec", "neo4j:neo4j", "neo4j-admin", "dbms", "set-initial-password", password],
             check=True,
             capture_output=True,
             text=True,
@@ -92,8 +90,7 @@ async def launch_neo4j_and_run_benchmark(config_params: dict, dir_suffix: str):
             raise
 
     neo4j_process = subprocess.Popen(
-        "su-exec neo4j:neo4j neo4j console",
-        shell=True,
+        ["su-exec", "neo4j:neo4j", "neo4j", "console"],
     )
 
     print("Waiting for Neo4j server to become available on port 7474...")

--- a/evals/src/modal_apps/test_neo4j_server.py
+++ b/evals/src/modal_apps/test_neo4j_server.py
@@ -25,11 +25,9 @@ async def start_neo4j_server():
 
     # Set initial password
     password = neo4j_env_dict["NEO4J_AUTH"].split("/")[1]
-    set_password_command = f"neo4j-admin dbms set-initial-password {password}"
     try:
         subprocess.run(
-            f"su-exec neo4j:neo4j {set_password_command}",
-            shell=True,
+            ["su-exec", "neo4j:neo4j", "neo4j-admin", "dbms", "set-initial-password", password],
             check=True,
             capture_output=True,
             text=True,
@@ -45,8 +43,7 @@ async def start_neo4j_server():
 
     # Start Neo4j server
     neo4j_process = subprocess.Popen(
-        "su-exec neo4j:neo4j neo4j console",
-        shell=True,
+        ["su-exec", "neo4j:neo4j", "neo4j", "console"],
     )
 
     print("Waiting for Neo4j server to become available on port 7474...")


### PR DESCRIPTION
## Summary

- Replace `shell=True` with explicit argument lists in Neo4j setup scripts
- Remove unused f-string variable `set_password_command`

Fixes #2422

## Problem

The Neo4j setup code in two eval scripts interpolates a password from `NEO4J_AUTH` into shell command strings using f-strings + `shell=True`. If the password contains shell metacharacters, this becomes a command injection vector (CWE-78).

## Solution

Use `subprocess.run()` / `subprocess.Popen()` with argument lists instead of shell strings. This avoids shell interpretation entirely while preserving the same functionality.

## Changes

| File | Change |
|------|--------|
| `evals/src/modal_apps/test_neo4j_server.py` | `shell=True` + f-string → argument list (2 calls) |
| `evals/src/modal_apps/modal_qa_benchmark_graphiti.py` | Same pattern, same fix (2 calls) |

## Testing

- Argument lists are a drop-in replacement — same commands, same arguments
- No behavioral change for normal passwords
- Passwords with special characters are now correctly passed as-is

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal process execution reliability for Neo4j operations by modernizing system-level command invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*