### PR TITLE
Fix custom LLM provider not forwarding endpoint to LiteLLM

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -138,6 +138,7 @@ def get_llm_client(raise_api_key_error: bool = True):
             llm_config.llm_model,
             max_completion_tokens,
             "Custom",
+            endpoint=llm_config.llm_endpoint,
             instructor_mode=llm_config.llm_instructor_mode.lower(),
             fallback_api_key=llm_config.fallback_api_key,
             fallback_endpoint=llm_config.fallback_endpoint,


### PR DESCRIPTION
## Summary

- Pass `endpoint=llm_config.llm_endpoint` to `GenericAPIAdapter` in the `LLM_PROVIDER=custom` code path, matching how other providers (OpenAI, Gemini, Mistral, etc.) already forward this value

## Problem

When using `LLM_PROVIDER=custom` with a local OpenAI-compatible server (e.g. vLLM), the configured `LLM_ENDPOINT` is never passed to `GenericAPIAdapter`. This means `api_base` is `None` in the LiteLLM completion call, so LiteLLM routes based on the model prefix (e.g. `hosted_vllm/`) instead of the user's local endpoint.

This causes requests to hit remote hosted infrastructure instead of the local server, producing errors like:
```
litellm.APIError: Hosted_vllmException - {"error":{"code":"unsupported_country_region_territory",...}}
```

## Root Cause

In `get_llm_client.py`, the `CUSTOM` provider case was missing the `endpoint` parameter:

```python
# Before (broken) — endpoint not passed
return GenericAPIAdapter(
    llm_config.llm_api_key,
    llm_config.llm_model,
    max_completion_tokens,
    "Custom",
    instructor_mode=...,
    ...
)
```

`GenericAPIAdapter.__init__` already accepts an `endpoint` parameter (used as `api_base` in LiteLLM calls), but the CUSTOM code path simply wasn't providing it. Every other provider that uses endpoints (OpenAI, Gemini, Mistral, LlamaCpp) correctly passes this value.

## Fix

One line: add `endpoint=llm_config.llm_endpoint` to the `GenericAPIAdapter` constructor call for the custom provider.

Fixes #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom endpoint URLs for custom LLM providers, enabling more flexible integration with third-party API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->