### PR TITLE
fix: add missing frontend dependencies to package.json

### DIFF
--- a/cognee-frontend/package.json
+++ b/cognee-frontend/package.json
@@ -14,9 +14,12 @@
     "culori": "^4.0.1",
     "d3-force-3d": "^3.0.6",
     "next": "^16.1.5",
+    "ngraph.forcelayout": "^3.3.1",
+    "ngraph.graph": "^20.0.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-force-graph-2d": "^1.27.1",
+    "react-markdown": "^9.0.3",
     "three": "^0.175.0",
     "troika-three-text": "^0.52.4",
     "uuid": "^9.0.1"


### PR DESCRIPTION
Add react-markdown, ngraph.graph, and ngraph.forcelayout to cognee-frontend/package.json. These are imported in source files but not declared as dependencies, causing Next.js compilation failures.

Fixes #2413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for graph visualization and enhanced markdown content rendering capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->