### PR TITLE
COG-4294:  Add data points breaks when ingesting custom pipelines

### DIFF
--- a/examples/custom_pipelines/organizational_hierarchy/organizational_hierarchy_pipeline_example.py
+++ b/examples/custom_pipelines/organizational_hierarchy/organizational_hierarchy_pipeline_example.py
@@ -42,7 +42,9 @@ class Company(DataPoint):
     metadata: dict = {"index_fields": ["name"]}
 
 
-class LightWeightData(BaseModel):
+class LightweightData(DataPoint):
+    """Lightweight DataPoint model for data ingestion only."""
+
     id: UUID
     companies: List[Dict[str, Any]]
     people: List[Dict[str, Any]]
@@ -50,7 +52,7 @@ class LightWeightData(BaseModel):
 
 def build_lightweight_data_object(data_list):
     return [
-        LightWeightData(
+        LightweightData(
             id=uuid5(NAMESPACE_OID, str(data)), companies=data["companies"], people=data["people"]
         )
         for data in data_list

--- a/examples/guides/custom_tasks_and_pipelines.py
+++ b/examples/guides/custom_tasks_and_pipelines.py
@@ -34,7 +34,9 @@ class Person(DataPoint):
     metadata: Dict[str, Any] = {"index_fields": ["name"]}
 
 
-class LightweightData(BaseModel):
+class LightweightData(DataPoint):
+    """Lightweight DataPoint model for data ingestion only."""
+
     id: UUID
     text: str
 


### PR DESCRIPTION
## Description
add_data_points breaks when ingesting plain text in custom pipelines. It tries to access data.id field from shared context. In case of ingesting plain text, that is str.id, which doesn't exist. By wrapping the text in LightweightData object that contains id+text fields, this issue is mitigated. It is not a big bug fix, so the code can still be used for short guides.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an organizational-hierarchy example demonstrating ingestion of people, departments, and companies, a runnable pipeline with deterministic IDs, and graph visualization.
  * Added a guide showing LLM-driven extraction of people/relationships from text, a lightweight two-step pipeline for extraction and persistence, and visualization of results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->