### PR TITLE
fix: wrap UUID in list to fix memify 409 when runInBackground=true

### DIFF
--- a/cognee/modules/memify/memify.py
+++ b/cognee/modules/memify/memify.py
@@ -121,7 +121,7 @@ async def memify(
         tasks=memify_tasks,
         user=user,
         data=data,
-        datasets=authorized_dataset.id,
+        datasets=[authorized_dataset.id],
         vector_db_config=vector_db_config,
         graph_db_config=graph_db_config,
         use_pipeline_cache=False,


### PR DESCRIPTION
## Summary

`POST /api/v1/memify` with `runInBackground: true` returns 409 with `'UUID' object is not iterable`.

## Root Cause

`memify.py` passes `authorized_dataset.id` (a bare `uuid.UUID`) as the `datasets` param to the pipeline executor:

```python
# cognee/modules/memify/memify.py line 124 (before fix)
datasets=authorized_dataset.id,
```

When `runInBackground=True`, `run_pipeline_as_background_process` in `pipeline_execution_mode.py` normalizes only `str` to a list:

```python
if isinstance(datasets, str):   # does NOT handle uuid.UUID
    datasets = [datasets]

for dataset in datasets:        # TypeError: 'UUID' object is not iterable
```

The blocking path (`runInBackground=False`) uses a different code path and is not affected.

## Fix

Wrap the UUID in a list at the call site:

```python
# cognee/modules/memify/memify.py line 124 (after fix)
datasets=[authorized_dataset.id],
```

One character change. Verified working against v0.5.5 with a 3063-node knowledge graph.

## Test Plan

- [ ] `POST /api/v1/memify` with `runInBackground: true` returns `PipelineRunStarted` instead of 409
- [ ] `POST /api/v1/memify` with `runInBackground: false` still works (unaffected path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset handling in the memify pipeline to properly support processing multiple datasets in a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->