### PR TITLE
Downgrade actions/checkout from v6 to v4

### DIFF
--- a/.github/workflows/dockerhub-mcp.yml
+++ b/.github/workflows/dockerhub-mcp.yml
@@ -24,7 +24,7 @@ jobs:
           df -h
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Description
This PR downgrades the `actions/checkout` action from v6 to v4 in the DockerHub MCP workflow. This change reverts to an earlier version of the checkout action that may have better compatibility with the current CI/CD pipeline or address specific issues encountered with v6.

## Type of Change
- [x] Other (dependency version adjustment)

## Pre-submission Checklist
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] All new and existing tests pass (CI workflow will validate)

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

https://claude.ai/code/session_01EEfxj4EHfMjjrN17Lmz8hG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->