### PR TITLE
fix: require currency symbol in MONEY regex and uncomment test_extract_money

### DIFF
--- a/cognee/tasks/entity_completion/entity_extractors/regex_entity_config.json
+++ b/cognee/tasks/entity_completion/entity_extractors/regex_entity_config.json
@@ -32,7 +32,7 @@
     {
         "entity_name": "MONEY",
         "entity_description": "Entity type for money entities",
-        "regex": "\\$?\\d{1,3}(,\\d{3})*(\\.[0-9]{2})?|\\€?\\d{1,3}(\\.\\d{3})*(,[0-9]{2})?",
+        "regex": "\\$\\d{1,3}(,\\d{3})*(\\.\\d{2})?|€\\d{1,3}(\\.\\d{3})*(,\\d{2})?",
         "description_template": "Monetary amount: {}"
     },
     {

--- a/cognee/tests/unit/entity_extraction/regex_entity_extraction_test.py
+++ b/cognee/tests/unit/entity_extraction/regex_entity_extraction_test.py
@@ -83,17 +83,15 @@ async def test_extract_times(regex_extractor):
 @pytest.mark.asyncio
 async def test_extract_money(regex_extractor):
     """Test extraction of monetary amounts."""
-    # TODO: Lazar to fix regex for test, it's failing currently
-    pass
-    # text = "The product costs $1,299.99 or €1.045,00 depending on your region."
-    # entities = await regex_extractor.extract_entities(text)
+    text = "The product costs $1,299.99 or €1.045,00 depending on your region."
+    entities = await regex_extractor.extract_entities(text)
 
     # Filter only MONEY entities
-    # money_entities = [e for e in entities if e.is_a.name == "MONEY"]
+    money_entities = [e for e in entities if e.is_a.name == "MONEY"]
 
-    # assert len(money_entities) == 2
-    # assert "$1,299.99" in [e.name for e in money_entities]
-    # assert "€1.045,00" in [e.name for e in money_entities]
+    assert len(money_entities) == 2
+    assert "$1,299.99" in [e.name for e in money_entities]
+    assert "€1.045,00" in [e.name for e in money_entities]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

The MONEY regex in `regex_entity_config.json` had optional currency symbols (`\$?` and `€?`), which caused it to match plain numbers like "42" or "7". This made the `test_extract_money` test fail because the extractor returned false positives alongside the real monetary amounts.

Fixed by making the currency symbol mandatory (`\$` and `€`), so only actual monetary amounts like `$1,299.99` and `€1.045,00` are matched. Uncommented and re-enabled the `test_extract_money` test.

Fixes #2356

## Acceptance Criteria

* MONEY regex no longer matches plain numbers (no false positives)
* `test_extract_money` is uncommented and passes with the expected 2 entities
* `$1,299.99` and `€1.045,00` are correctly extracted

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved currency entity extraction accuracy by requiring explicit currency symbol prefixes ($, €) and enforcing standardized decimal formatting for monetary values.

* **Tests**
  * Enhanced currency extraction tests to validate correct identification of supported money formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->