### PR TITLE
fix: remove deprecated backward-compat methods from CacheDBInterface

### DIFF
--- a/cognee/infrastructure/databases/cache/cache_db_interface.py
+++ b/cognee/infrastructure/databases/cache/cache_db_interface.py
@@ -1,4 +1,3 @@
-import uuid
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
@@ -45,24 +44,6 @@ class CacheDBInterface(ABC):
         finally:
             self.release()
 
-    async def add_qa(
-        self,
-        user_id: str,
-        session_id: str,
-        question: str,
-        context: str,
-        answer: str,
-    ):
-        """Backward-compatibility: delegates to create_qa_entry with generated qa_id. :TODO: delete when retrievers are updated"""
-        return await self.create_qa_entry(
-            user_id,
-            session_id,
-            question,
-            context,
-            answer,
-            qa_id=str(uuid.uuid4()),
-        )
-
     @abstractmethod
     async def create_qa_entry(
         self,
@@ -85,20 +66,12 @@ class CacheDBInterface(ABC):
         """
         pass
 
-    async def get_latest_qa(self, user_id: str, session_id: str, last_n: int = 5):
-        """Backward-compat: delegates to get_latest_qa_entries. :TODO: delete when retrievers are updated"""
-        return await self.get_latest_qa_entries(user_id, session_id, last_n)
-
     @abstractmethod
     async def get_latest_qa_entries(self, user_id: str, session_id: str, last_n: int = 5):
         """
         Retrieve the most recent Q/A/context triplets for a session.
         """
         pass
-
-    async def get_all_qas(self, user_id: str, session_id: str):
-        """Backward-compat: delegates to get_all_qa_entries. :TODO: delete when retrievers are updated"""
-        return await self.get_all_qa_entries(user_id, session_id)
 
     @abstractmethod
     async def get_all_qa_entries(self, user_id: str, session_id: str):


### PR DESCRIPTION
Closes #2306

Removes the three deprecated backward-compatibility methods (`add_qa`, `get_latest_qa`, `get_all_qas`) from `CacheDBInterface`. Confirmed no callers remain in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Removed legacy backward-compatibility methods for Q&A caching operations. Underlying functionality remains available through updated interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->