### PR TITLE
fix: fix mocking in run_migrations test

### DIFF
--- a/cognee/tests/unit/test_run_migrations.py
+++ b/cognee/tests/unit/test_run_migrations.py
@@ -2,16 +2,14 @@
 
 import sys
 import unittest
+import importlib
 from unittest.mock import patch, MagicMock
 
 
 class TestRunMigrations(unittest.TestCase):
     """Verify run_migrations() invokes alembic via sys.executable, not bare 'python'."""
 
-    @patch("cognee.run_migrations.subprocess.run")
-    @patch("cognee.run_migrations.os.path.exists", return_value=True)
-    @patch("cognee.run_migrations.pkg_resources.files", return_value="/fake/package")
-    def test_uses_sys_executable(self, mock_files, mock_exists, mock_run):
+    def test_uses_sys_executable(self):
         """subprocess.run must be called with sys.executable, not 'python'.
 
         On Windows with uv-managed Python, bare 'python' can resolve to a
@@ -19,11 +17,16 @@ class TestRunMigrations(unittest.TestCase):
         (see GitHub issue #2466).
         """
         import asyncio
-        from cognee.run_migrations import run_migrations
 
-        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        module = importlib.import_module("cognee.run_migrations")
 
-        asyncio.run(run_migrations())
+        with (
+            patch.object(module.pkg_resources, "files", return_value="/fake/package"),
+            patch.object(module.os.path, "exists", return_value=True),
+            patch.object(module.subprocess, "run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+            asyncio.run(module.run_migrations())
 
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
Fixes the way resources are patched in the run_migrations test. The old way was failing on Python 3.10 tests.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored migration test to improve test isolation and mocking strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->