### PR TITLE
feat: add cognee.tools - framework serializers, handler, and examples

### DIFF
--- a/cognee/tests/unit/cli/test_tools.py
+++ b/cognee/tests/unit/cli/test_tools.py
@@ -1,0 +1,181 @@
+"""Tests for cognee.tools — serializers, handler, and definitions."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from cognee.tools import (
+    remember,
+    recall,
+    handle_tool_call,
+    for_openai,
+    for_anthropic,
+    for_generic,
+    TOOLS,
+)
+
+
+def _run(coro):
+    """Run an async coroutine synchronously in a fresh event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Serializers
+# ---------------------------------------------------------------------------
+
+
+class TestSerializers:
+    def test_openai_format(self):
+        tools = for_openai()
+        assert len(tools) == 2
+        for tool in tools:
+            assert tool["type"] == "function"
+            fn = tool["function"]
+            assert fn["parameters"]["type"] == "object"
+            assert "properties" in fn["parameters"]
+            assert "required" in fn["parameters"]
+
+    def test_anthropic_format(self):
+        tools = for_anthropic()
+        assert len(tools) == 2
+        for tool in tools:
+            assert "name" in tool
+            assert "input_schema" in tool
+            assert tool["input_schema"]["type"] == "object"
+
+    def test_generic_format(self):
+        tools = for_generic()
+        assert len(tools) == 2
+        for tool in tools:
+            assert "name" in tool
+            assert "parameters" in tool
+
+    def test_names_consistent_across_formats(self):
+        openai_names = {t["function"]["name"] for t in for_openai()}
+        anthropic_names = {t["name"] for t in for_anthropic()}
+        generic_names = {t["name"] for t in for_generic()}
+        assert openai_names == anthropic_names == generic_names == {"remember", "recall"}
+
+    def test_remember_has_content_required(self):
+        tool = next(t for t in for_openai() if t["function"]["name"] == "remember")
+        params = tool["function"]["parameters"]
+        assert "content" in params["required"]
+
+    def test_recall_has_query_required_topk_optional(self):
+        tool = next(t for t in for_openai() if t["function"]["name"] == "recall")
+        params = tool["function"]["parameters"]
+        assert "query" in params["required"]
+        assert "top_k" not in params["required"]
+
+    def test_json_serializable(self):
+        json.dumps(for_openai())
+        json.dumps(for_anthropic())
+        json.dumps(for_generic())
+
+    def test_langchain_import_error(self):
+        """for_langchain() raises ImportError when langchain-core is missing."""
+        import pytest
+        from cognee.tools.serializers.langchain import for_langchain
+
+        with pytest.raises(ImportError, match="langchain-core"):
+            for_langchain()
+
+    def test_crewai_import_error(self):
+        """for_crewai() raises ImportError when crewai is missing."""
+        import pytest
+        from cognee.tools.serializers.crewai import for_crewai
+
+        with pytest.raises(ImportError, match="crewai"):
+            for_crewai()
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+class TestHandleToolCall:
+    def test_openai_format(self):
+        tool_call = SimpleNamespace(
+            function=SimpleNamespace(
+                name="remember",
+                arguments=json.dumps({"content": "test fact"}),
+            )
+        )
+        with patch("cognee.tools.definitions.v2_remember", new_callable=AsyncMock):
+            result = _run(handle_tool_call(tool_call))
+            assert result == "Remembered."
+
+    def test_anthropic_format(self):
+        tool_call = SimpleNamespace(
+            name="remember",
+            input={"content": "test fact"},
+        )
+        with patch("cognee.tools.definitions.v2_remember", new_callable=AsyncMock):
+            result = _run(handle_tool_call(tool_call))
+            assert result == "Remembered."
+
+    def test_dict_format(self):
+        tool_call = {
+            "name": "recall",
+            "arguments": json.dumps({"query": "preferences"}),
+        }
+        with patch(
+            "cognee.tools.definitions.v2_recall",
+            new_callable=AsyncMock,
+            return_value=["dark mode"],
+        ):
+            result = _run(handle_tool_call(tool_call))
+            assert "dark mode" in result
+
+    def test_unknown_tool(self):
+        tool_call = SimpleNamespace(function=SimpleNamespace(name="nonexistent", arguments="{}"))
+        result = _run(handle_tool_call(tool_call))
+        assert "Unknown tool" in result
+
+
+# ---------------------------------------------------------------------------
+# Definitions
+# ---------------------------------------------------------------------------
+
+
+class TestDefinitions:
+    def test_tools_registry(self):
+        assert len(TOOLS) == 2
+        assert {fn.__name__ for fn in TOOLS} == {"remember", "recall"}
+
+    def test_remember_calls_v2(self):
+        with patch("cognee.tools.definitions.v2_remember", new_callable=AsyncMock) as mock:
+            result = _run(remember("test"))
+            assert result == "Remembered."
+            mock.assert_awaited_once_with(data="test", dataset_name="main_dataset")
+
+    def test_recall_returns_result(self):
+        with patch(
+            "cognee.tools.definitions.v2_recall",
+            new_callable=AsyncMock,
+            return_value=["answer"],
+        ):
+            assert "answer" in _run(recall("query"))
+
+    def test_recall_handles_empty(self):
+        with patch(
+            "cognee.tools.definitions.v2_recall",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            assert "No relevant memories" in _run(recall("query"))
+
+    def test_recall_handles_exception(self):
+        with patch(
+            "cognee.tools.definitions.v2_recall",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("db down"),
+        ):
+            assert "failed" in _run(recall("query")).lower()

--- a/cognee/tools/__init__.py
+++ b/cognee/tools/__init__.py
@@ -1,0 +1,31 @@
+"""Cognee memory tools for agent integration.
+
+Usage:
+    # Direct use
+    from cognee.tools import remember, recall
+    await remember("user prefers dark mode")
+    result = await recall("preferences")
+
+    # Framework serializers
+    from cognee.tools import for_openai, for_anthropic, handle_tool_call
+    tools = for_openai()
+
+    # LangChain / CrewAI (requires those packages installed)
+    from cognee.tools import for_langchain, for_crewai
+"""
+
+from .definitions import remember, recall, TOOLS
+from .handler import handle_tool_call
+from .serializers import for_openai, for_anthropic, for_generic, for_langchain, for_crewai
+
+__all__ = [
+    "remember",
+    "recall",
+    "handle_tool_call",
+    "for_openai",
+    "for_anthropic",
+    "for_generic",
+    "for_langchain",
+    "for_crewai",
+    "TOOLS",
+]

--- a/cognee/tools/definitions.py
+++ b/cognee/tools/definitions.py
@@ -1,0 +1,65 @@
+"""Tool definitions for agent integration.
+
+These are thin, LLM-friendly wrappers around Cognee's V2 API.
+They present simple (str -> str) signatures that serializers can
+convert to JSON Schema for any framework.
+"""
+
+from cognee.api.v2 import remember as v2_remember
+from cognee.api.v2 import recall as v2_recall
+
+
+async def remember(content: str, dataset_name: str = "main_dataset") -> str:
+    """Save information to memory for future retrieval.
+
+    Use this when the user shares preferences, decisions, facts, or anything
+    worth recalling later. The information is ingested and processed into
+    Cognee's knowledge graph.
+
+    Parameters
+    ----------
+    content : str
+        The text to remember. Can be a fact, a conversation excerpt,
+        a user preference, a decision, or any free-form text.
+    dataset_name : str, optional
+        Dataset to store the memory in. Defaults to "main_dataset".
+
+    Returns
+    -------
+    str
+        Confirmation message.
+    """
+    await v2_remember(data=content, dataset_name=dataset_name)
+    return "Remembered."
+
+
+async def recall(query: str, top_k: int = 5) -> str:
+    """Search memory for relevant information.
+
+    Use this when the user asks a question that might be answered by
+    previously stored information, or when context from past conversations
+    would be helpful.
+
+    Parameters
+    ----------
+    query : str
+        The search query in natural language.
+    top_k : int, optional
+        Maximum number of results to return. Defaults to 5.
+
+    Returns
+    -------
+    str
+        Search results as a string the agent can use directly.
+    """
+    try:
+        results = await v2_recall(query_text=query, top_k=top_k)
+        if results and isinstance(results, list) and len(results) > 0:
+            return str(results[0])
+        return "No relevant memories found."
+    except Exception as e:
+        return f"Memory search failed: {e}"
+
+
+# Registry of all tools — used by serializers and handler
+TOOLS = [remember, recall]

--- a/cognee/tools/handler.py
+++ b/cognee/tools/handler.py
@@ -1,0 +1,54 @@
+"""Tool call dispatcher for agent frameworks.
+
+Routes incoming tool calls (from OpenAI, Anthropic, etc.) to the
+correct Cognee function based on the tool name.
+"""
+
+import json
+from typing import Any
+
+from .definitions import TOOLS
+
+_REGISTRY = {fn.__name__: fn for fn in TOOLS}
+
+
+async def handle_tool_call(tool_call: Any) -> str:
+    """Dispatch a tool call to the correct Cognee function.
+
+    Supports OpenAI-style tool calls (tool_call.function.name / .arguments)
+    and Anthropic-style tool use blocks (tool_call.name / .input).
+
+    Parameters
+    ----------
+    tool_call : Any
+        A tool call object from the LLM response. Must have either:
+        - .function.name and .function.arguments (OpenAI format)
+        - .name and .input (Anthropic format)
+
+    Returns
+    -------
+    str
+        The result of calling the tool function.
+    """
+    # OpenAI format: tool_call.function.name, tool_call.function.arguments (JSON string)
+    if hasattr(tool_call, "function"):
+        name = tool_call.function.name
+        args = json.loads(tool_call.function.arguments)
+    # Anthropic format: tool_call.name, tool_call.input (dict)
+    elif hasattr(tool_call, "input") and hasattr(tool_call, "name"):
+        name = tool_call.name
+        args = tool_call.input if isinstance(tool_call.input, dict) else {}
+    # Dict fallback
+    elif isinstance(tool_call, dict):
+        name = tool_call.get("name", "")
+        args = tool_call.get("arguments", tool_call.get("input", {}))
+        if isinstance(args, str):
+            args = json.loads(args)
+    else:
+        return f"Unsupported tool call format: {type(tool_call)}"
+
+    fn = _REGISTRY.get(name)
+    if fn is None:
+        return f"Unknown tool: {name}. Available tools: {', '.join(_REGISTRY.keys())}"
+
+    return await fn(**args)

--- a/cognee/tools/serializers/__init__.py
+++ b/cognee/tools/serializers/__init__.py
@@ -1,0 +1,7 @@
+from .openai import for_openai
+from .anthropic import for_anthropic
+from .generic import for_generic
+from .langchain import for_langchain
+from .crewai import for_crewai
+
+__all__ = ["for_openai", "for_anthropic", "for_generic", "for_langchain", "for_crewai"]

--- a/cognee/tools/serializers/anthropic.py
+++ b/cognee/tools/serializers/anthropic.py
@@ -1,0 +1,57 @@
+"""Serialize Cognee tools to Anthropic tool_use format."""
+
+import inspect
+from typing import get_type_hints
+
+from ..definitions import TOOLS
+
+
+def for_anthropic() -> list:
+    """Convert Cognee memory tools to Anthropic tool_use format.
+
+    Returns
+    -------
+    list
+        A list of tool dicts in the format expected by
+        ``client.messages.create(tools=...)``.
+    """
+    result = []
+    for fn in TOOLS:
+        sig = inspect.signature(fn)
+        hints = get_type_hints(fn)
+        properties = {}
+        required = []
+
+        for name, param in sig.parameters.items():
+            hint = hints.get(name, str)
+            json_type = _python_type_to_json(hint)
+            prop = {"type": json_type, "description": name}
+            if param.default is not inspect.Parameter.empty:
+                prop["default"] = param.default
+            else:
+                required.append(name)
+            properties[name] = prop
+
+        result.append(
+            {
+                "name": fn.__name__,
+                "description": inspect.getdoc(fn) or "",
+                "input_schema": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
+            }
+        )
+    return result
+
+
+def _python_type_to_json(hint) -> str:
+    """Map a Python type hint to a JSON Schema type string."""
+    if hint is int:
+        return "integer"
+    if hint is float:
+        return "number"
+    if hint is bool:
+        return "boolean"
+    return "string"

--- a/cognee/tools/serializers/crewai.py
+++ b/cognee/tools/serializers/crewai.py
@@ -1,0 +1,68 @@
+"""Serialize Cognee tools to CrewAI BaseTool format."""
+
+import asyncio
+import inspect
+from typing import Type, get_type_hints
+
+from pydantic import BaseModel, Field
+
+from ..definitions import TOOLS
+
+
+def _build_args_schema(fn) -> Type[BaseModel]:
+    """Dynamically build a Pydantic model from a function's signature."""
+    sig = inspect.signature(fn)
+    hints = get_type_hints(fn)
+    fields = {}
+
+    for name, param in sig.parameters.items():
+        hint = hints.get(name, str)
+        if param.default is not inspect.Parameter.empty:
+            fields[name] = (hint, Field(default=param.default, description=name))
+        else:
+            fields[name] = (hint, Field(..., description=name))
+
+    model_name = f"{fn.__name__.title().replace('_', '')}Input"
+    return type(
+        model_name,
+        (BaseModel,),
+        {
+            "__annotations__": {k: v[0] for k, v in fields.items()},
+            **{k: v[1] for k, v in fields.items()},
+        },
+    )
+
+
+def for_crewai() -> list:
+    """Convert Cognee memory tools to CrewAI BaseTool objects.
+
+    Requires ``crewai`` to be installed.
+
+    Returns
+    -------
+    list
+        A list of ``BaseTool`` instances ready to pass to a CrewAI agent.
+    """
+    try:
+        from crewai.tools import BaseTool
+    except ImportError:
+        raise ImportError(
+            "crewai is required for for_crewai(). Install it with: pip install crewai"
+        )
+
+    result = []
+    for fn in TOOLS:
+        args_schema = _build_args_schema(fn)
+        async_fn = fn
+
+        class CogneeTool(BaseTool):
+            name: str = fn.__name__
+            description: str = fn.__doc__.split("\n\n")[0] if fn.__doc__ else ""
+            args_schema: Type[BaseModel] = args_schema
+            _async_fn = async_fn
+
+            def _run(self, **kwargs) -> str:
+                return asyncio.run(self._async_fn(**kwargs))
+
+        result.append(CogneeTool())
+    return result

--- a/cognee/tools/serializers/generic.py
+++ b/cognee/tools/serializers/generic.py
@@ -1,0 +1,59 @@
+"""Serialize Cognee tools to generic JSON Schema format.
+
+Works with any framework that accepts JSON Schema tool definitions.
+"""
+
+import inspect
+from typing import get_type_hints
+
+from ..definitions import TOOLS
+
+
+def for_generic() -> list:
+    """Convert Cognee memory tools to generic JSON Schema format.
+
+    Returns
+    -------
+    list
+        A list of dicts with name, description, and parameters (JSON Schema).
+    """
+    result = []
+    for fn in TOOLS:
+        sig = inspect.signature(fn)
+        hints = get_type_hints(fn)
+        properties = {}
+        required = []
+
+        for name, param in sig.parameters.items():
+            hint = hints.get(name, str)
+            json_type = _python_type_to_json(hint)
+            prop = {"type": json_type, "description": name}
+            if param.default is not inspect.Parameter.empty:
+                prop["default"] = param.default
+            else:
+                required.append(name)
+            properties[name] = prop
+
+        result.append(
+            {
+                "name": fn.__name__,
+                "description": inspect.getdoc(fn) or "",
+                "parameters": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
+            }
+        )
+    return result
+
+
+def _python_type_to_json(hint) -> str:
+    """Map a Python type hint to a JSON Schema type string."""
+    if hint is int:
+        return "integer"
+    if hint is float:
+        return "number"
+    if hint is bool:
+        return "boolean"
+    return "string"

--- a/cognee/tools/serializers/langchain.py
+++ b/cognee/tools/serializers/langchain.py
@@ -1,0 +1,32 @@
+"""Serialize Cognee tools to LangChain StructuredTool format."""
+
+from ..definitions import TOOLS
+
+
+def for_langchain() -> list:
+    """Convert Cognee memory tools to LangChain StructuredTool objects.
+
+    Requires ``langchain-core`` to be installed.
+
+    Returns
+    -------
+    list
+        A list of ``StructuredTool`` instances ready to pass to a LangChain agent.
+    """
+    try:
+        from langchain_core.tools import StructuredTool
+    except ImportError:
+        raise ImportError(
+            "langchain-core is required for for_langchain(). "
+            "Install it with: pip install langchain-core"
+        )
+
+    result = []
+    for fn in TOOLS:
+        tool = StructuredTool.from_function(
+            coroutine=fn,
+            name=fn.__name__,
+            description=fn.__doc__.split("\n\n")[0] if fn.__doc__ else "",
+        )
+        result.append(tool)
+    return result

--- a/cognee/tools/serializers/openai.py
+++ b/cognee/tools/serializers/openai.py
@@ -1,0 +1,60 @@
+"""Serialize Cognee tools to OpenAI function-calling format."""
+
+import inspect
+from typing import get_type_hints
+
+from ..definitions import TOOLS
+
+
+def for_openai() -> list:
+    """Convert Cognee memory tools to OpenAI function-calling format.
+
+    Returns
+    -------
+    list
+        A list of tool dicts in the format expected by
+        ``client.chat.completions.create(tools=...)``.
+    """
+    result = []
+    for fn in TOOLS:
+        sig = inspect.signature(fn)
+        hints = get_type_hints(fn)
+        properties = {}
+        required = []
+
+        for name, param in sig.parameters.items():
+            hint = hints.get(name, str)
+            json_type = _python_type_to_json(hint)
+            prop = {"type": json_type, "description": name}
+            if param.default is not inspect.Parameter.empty:
+                prop["default"] = param.default
+            else:
+                required.append(name)
+            properties[name] = prop
+
+        result.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": fn.__name__,
+                    "description": inspect.getdoc(fn) or "",
+                    "parameters": {
+                        "type": "object",
+                        "properties": properties,
+                        "required": required,
+                    },
+                },
+            }
+        )
+    return result
+
+
+def _python_type_to_json(hint) -> str:
+    """Map a Python type hint to a JSON Schema type string."""
+    if hint is int:
+        return "integer"
+    if hint is float:
+        return "number"
+    if hint is bool:
+        return "boolean"
+    return "string"

--- a/examples/guides/anthropic_tool_memory.py
+++ b/examples/guides/anthropic_tool_memory.py
@@ -1,0 +1,82 @@
+"""Anthropic agent with Cognee memory via tool use.
+
+This example shows how to give an Anthropic Claude model persistent memory
+using cognee.tools. The model gets two tools — `remember` and
+`recall` — and decides when to store or retrieve information.
+
+Prerequisites:
+    pip install cognee anthropic
+    export ANTHROPIC_API_KEY="sk-ant-..."
+    export LLM_API_KEY="sk-..."   # used by Cognee
+"""
+
+import asyncio
+import os
+
+from anthropic import Anthropic
+from cognee.tools import for_anthropic, handle_tool_call
+
+
+def run_agent(user_message: str, client: Anthropic, model: str = "claude-sonnet-4-20250514"):
+    """Single turn: send a message, let the model use tools, return final answer."""
+    tools = for_anthropic()
+    messages = [{"role": "user", "content": user_message}]
+
+    while True:
+        response = client.messages.create(
+            model=model,
+            max_tokens=1024,
+            system=(
+                "You are a helpful assistant with persistent memory. "
+                "Use the `remember` tool to save important facts the user shares. "
+                "Use the `recall` tool to recall previously stored information."
+            ),
+            messages=messages,
+            tools=tools,
+        )
+
+        # Collect the full response content
+        messages.append({"role": "assistant", "content": response.content})
+
+        # Check if the model wants to use tools
+        tool_results = []
+        for block in response.content:
+            if block.type == "tool_use":
+                result = asyncio.run(handle_tool_call(block))
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result,
+                    }
+                )
+
+        if tool_results:
+            messages.append({"role": "user", "content": tool_results})
+        else:
+            # No tool use — extract final text
+            for block in response.content:
+                if block.type == "text":
+                    return block.text
+            return ""
+
+
+def main():
+    client = Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+
+    # Store some facts
+    print("User: Remember that I prefer dark mode and use vim keybindings.")
+    answer = run_agent(
+        "Remember that I prefer dark mode and use vim keybindings.",
+        client,
+    )
+    print(f"Assistant: {answer}\n")
+
+    # Retrieve them later
+    print("User: What are my editor preferences?")
+    answer = run_agent("What are my editor preferences?", client)
+    print(f"Assistant: {answer}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/guides/crewai_tool_memory.py
+++ b/examples/guides/crewai_tool_memory.py
@@ -1,0 +1,55 @@
+"""CrewAI agent with Cognee memory via tool calling.
+
+This example shows how to give a CrewAI agent persistent memory
+using cognee.tools. The agent gets `remember` and `recall` as
+CrewAI BaseTool objects.
+
+Prerequisites:
+    pip install cognee crewai
+    export LLM_API_KEY="sk-..."
+"""
+
+from crewai import Agent, Task, Crew
+
+from cognee.tools import for_crewai
+
+
+def main():
+    tools = for_crewai()
+
+    agent = Agent(
+        role="Personal Assistant",
+        goal="Help the user and remember important information",
+        backstory=(
+            "You are a helpful assistant with persistent memory. "
+            "Use the `remember` tool to save important facts. "
+            "Use the `recall` tool to retrieve previously stored information."
+        ),
+        tools=tools,
+    )
+
+    # Store some facts
+    remember_task = Task(
+        description="Remember that the user prefers dark mode and uses vim keybindings.",
+        expected_output="Confirmation that the preferences were saved.",
+        agent=agent,
+    )
+
+    # Retrieve them later
+    recall_task = Task(
+        description="What are the user's editor preferences?",
+        expected_output="The user's editor preferences based on stored memory.",
+        agent=agent,
+    )
+
+    crew = Crew(
+        agents=[agent],
+        tasks=[remember_task, recall_task],
+    )
+
+    result = crew.kickoff()
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/guides/langchain_tool_memory.py
+++ b/examples/guides/langchain_tool_memory.py
@@ -1,0 +1,67 @@
+"""LangChain agent with Cognee memory via tool calling.
+
+This example shows how to give a LangChain agent persistent memory
+using cognee.tools. The agent gets `remember` and `recall` as
+LangChain StructuredTool objects.
+
+Prerequisites:
+    pip install cognee langchain langchain-openai
+    export LLM_API_KEY="sk-..."
+"""
+
+import asyncio
+import os
+
+from langchain_openai import ChatOpenAI
+from langchain.agents import AgentExecutor, create_tool_calling_agent
+from langchain_core.prompts import ChatPromptTemplate
+
+from cognee.tools import for_langchain
+
+
+async def main():
+    llm = ChatOpenAI(
+        model="gpt-4o-mini",
+        api_key=os.environ.get("LLM_API_KEY"),
+    )
+
+    tools = for_langchain()
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful assistant with persistent memory. "
+                "Use the `remember` tool to save important facts the user shares. "
+                "Use the `recall` tool to recall previously stored information.",
+            ),
+            ("placeholder", "{chat_history}"),
+            ("human", "{input}"),
+            ("placeholder", "{agent_scratchpad}"),
+        ]
+    )
+
+    agent = create_tool_calling_agent(llm, tools, prompt)
+    executor = AgentExecutor(agent=agent, tools=tools)
+
+    # Store some facts
+    print("User: Remember that I prefer dark mode and use vim keybindings.")
+    result = await executor.ainvoke(
+        {
+            "input": "Remember that I prefer dark mode and use vim keybindings.",
+        }
+    )
+    print(f"Assistant: {result['output']}\n")
+
+    # Retrieve them later
+    print("User: What are my editor preferences?")
+    result = await executor.ainvoke(
+        {
+            "input": "What are my editor preferences?",
+        }
+    )
+    print(f"Assistant: {result['output']}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/guides/openai_tool_memory.py
+++ b/examples/guides/openai_tool_memory.py
@@ -1,0 +1,77 @@
+"""OpenAI agent with Cognee memory via tool calling.
+
+This example shows how to give an OpenAI chat model persistent memory
+using cognee.tools. The model gets two tools — `remember` and
+`recall` — and decides when to store or retrieve information.
+
+Prerequisites:
+    pip install cognee openai
+    export LLM_API_KEY="sk-..."   # used by both OpenAI and Cognee
+"""
+
+import asyncio
+import os
+
+from openai import OpenAI
+from cognee.tools import for_openai, handle_tool_call
+
+
+def run_agent(user_message: str, client: OpenAI, model: str = "gpt-4o-mini"):
+    """Single turn: send a message, let the model use tools, return final answer."""
+    tools = for_openai()
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are a helpful assistant with persistent memory. "
+                "Use the `remember` tool to save important facts the user shares. "
+                "Use the `recall` tool to recall previously stored information."
+            ),
+        },
+        {"role": "user", "content": user_message},
+    ]
+
+    while True:
+        response = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            tools=tools,
+        )
+        choice = response.choices[0]
+
+        # If the model wants to call tools, execute them and feed results back
+        if choice.finish_reason == "tool_calls":
+            messages.append(choice.message)
+            for tool_call in choice.message.tool_calls:
+                result = asyncio.run(handle_tool_call(tool_call))
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": result,
+                    }
+                )
+        else:
+            # No more tool calls — return the final text
+            return choice.message.content
+
+
+def main():
+    client = OpenAI(api_key=os.environ.get("LLM_API_KEY"))
+
+    # Store some facts
+    print("User: Remember that I prefer dark mode and use vim keybindings.")
+    answer = run_agent(
+        "Remember that I prefer dark mode and use vim keybindings.",
+        client,
+    )
+    print(f"Assistant: {answer}\n")
+
+    # Retrieve them later
+    print("User: What are my editor preferences?")
+    answer = run_agent("What are my editor preferences?", client)
+    print(f"Assistant: {answer}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
  - Add `cognee.tools` module with `remember()` and `recall()` wrappers around the V2 API, presenting simple signatures for LLM tool calling
  - Add framework serializers: `for_openai()`, `for_anthropic()`, `for_langchain()`, `for_crewai()`, `for_generic()` — auto-generate tool schemas from function signatures
  - Add `handle_tool_call()` universal dispatcher supporting OpenAI, Anthropic, and dict-based tool call formats
  - Add working examples for OpenAI, Anthropic, LangChain, and CrewAI in `examples/guides/`


## Acceptance Criteria

  - [] Agent builders can add memory to an OpenAI agent with `from cognee.tools import for_openai, handle_tool_call` and no other Cognee imports
  - [] Same for Anthropic, LangChain, CrewAI, and generic frameworks
  - [] `for_langchain()` and `for_crewai()` fail gracefully with install instructions when packages are missing
  - [] All serializers produce consistent tool names (`remember`, `recall`)
  - [] `handle_tool_call()` correctly routes OpenAI, Anthropic, and dict-format tool calls
  - [] Examples in `examples/guides/` are runnable reference implementations for each framework

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):


## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
