### PR TITLE
fix: skip duplicate nodes in CogneeGraph instead of raising error

### DIFF
--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -5,7 +5,6 @@ from typing import List, Dict, Union, Optional, Type, Iterable, Tuple, Callable,
 
 from cognee.modules.graph.exceptions import (
     EntityNotFoundError,
-    EntityAlreadyExistsError,
     InvalidDimensionsError,
 )
 from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface

--- a/cognee/tests/unit/modules/graph/cognee_graph_test.py
+++ b/cognee/tests/unit/modules/graph/cognee_graph_test.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import AsyncMock
 
 from cognee.modules.engine.utils.generate_edge_id import generate_edge_id
-from cognee.modules.graph.exceptions import EntityNotFoundError, EntityAlreadyExistsError
+from cognee.modules.graph.exceptions import EntityNotFoundError
 from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
 
@@ -46,12 +46,14 @@ def test_add_node_success(setup_graph):
 
 
 def test_add_duplicate_node(setup_graph):
-    """Test adding a duplicate node raises an exception."""
+    """Test adding a duplicate node is silently skipped."""
     graph = setup_graph
-    node = Node("node1")
-    graph.add_node(node)
-    with pytest.raises(EntityAlreadyExistsError, match="Node with id node1 already exists."):
-        graph.add_node(node)
+    node1 = Node("node1")
+    graph.add_node(node1)
+    # Adding duplicate should be a no-op (keeps first occurrence)
+    node1_dup = Node("node1")
+    graph.add_node(node1_dup)
+    assert graph.get_node("node1") is node1
 
 
 def test_add_edge_success(setup_graph):


### PR DESCRIPTION
## Problem

When using FalkorDB as graph backend, `get_graph_data()` can return duplicate nodes with the same ID (e.g., nodes that appear under multiple label paths). The current `CogneeGraph.add_node()` raises `EntityAlreadyExistsError` on duplicates, which crashes `GRAPH_COMPLETION` searches:

```python
# CogneeGraph.add_node() raises on duplicate IDs
EntityAlreadyExistsError: Node with id <uuid> already exists.
```

This causes `GRAPH_COMPLETION` to always return empty context on FalkorDB.

## Fix

Change `add_node()` to silently skip duplicate node IDs (keeping the first occurrence) instead of raising an exception. This matches the expected behavior for graph projection where the same node may be encountered multiple times through different query paths.

## Test

- Verified on FalkorDB with `cognee-community-hybrid-adapter-falkor==0.2.4`
- `GRAPH_COMPLETION` searches return correct context after fix
- No impact on other graph backends (Kuzu, Neo4j) as they don't typically return duplicates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate node additions are now treated as a no-op instead of causing an error. The original node instance is preserved and system stability is improved when the same node is added multiple times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->