### PR TITLE
fix: coerce empty port string to None in create_graph_engine

### DIFF
--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -39,6 +39,13 @@ def create_graph_engine(
     Wrapper function to call create graph engine with caching.
     For a detailed description, see _create_graph_engine.
     """
+    # Normalize empty/None port before the lru_cache boundary to avoid
+    # duplicate cache entries for "" vs None.
+    normalized_port = (
+        None
+        if graph_database_port in ("", None)
+        else graph_database_port
+    )
     return _create_graph_engine(
         graph_database_provider,
         graph_file_path,
@@ -46,7 +53,7 @@ def create_graph_engine(
         graph_database_name,
         graph_database_username,
         graph_database_password,
-        graph_database_port,
+        normalized_port,
         graph_database_key,
         graph_dataset_database_handler,
     )
@@ -95,14 +102,11 @@ def _create_graph_engine(
     if graph_database_provider in supported_databases:
         adapter = supported_databases[graph_database_provider]
 
-        # Coerce empty/None port to None so adapters can apply their own defaults
-        port = graph_database_port if graph_database_port not in ("", None) else None
-
         return adapter(
             graph_database_url=graph_database_url,
             graph_database_username=graph_database_username,
             graph_database_password=graph_database_password,
-            graph_database_port=port,
+            graph_database_port=graph_database_port,
             graph_database_key=graph_database_key,
             database_name=graph_database_name,
         )

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -95,11 +95,14 @@ def _create_graph_engine(
     if graph_database_provider in supported_databases:
         adapter = supported_databases[graph_database_provider]
 
+        # Coerce empty/None port to None so adapters can apply their own defaults
+        port = graph_database_port if graph_database_port not in ("", None) else None
+
         return adapter(
             graph_database_url=graph_database_url,
             graph_database_username=graph_database_username,
             graph_database_password=graph_database_password,
-            graph_database_port=graph_database_port,
+            graph_database_port=port,
             graph_database_key=graph_database_key,
             database_name=graph_database_name,
         )


### PR DESCRIPTION
## Problem

When `GRAPH_DATABASE_PORT` is unset or empty, `get_graph_context_config()` returns `graph_database_port=""` (empty string). This value is passed directly to community adapters (via `supported_databases` dict), which may call `int(port)`, causing:

```
ValueError: invalid literal for int() with base 10: ''
```

This affects FalkorDB and potentially other community adapters that expect a numeric port.

## Fix

Coerce empty string and `None` to `None` before passing to adapters in `_create_graph_engine()`. This lets each adapter apply its own default port value (e.g. FalkorDB defaults to 6379).

## Impact

- Only affects the `supported_databases` code path (community adapters)
- Built-in adapters (Neo4j, Kuzu, Neptune) are unaffected as they don't use the port parameter directly
- No breaking changes — adapters already need to handle `None` port gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized empty or missing graph database port values so they’re treated consistently, preventing redundant cache entries and improving connection reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->