### PR TITLE
fix: add EdgeType nodes to graph DB for GRAPH_COMPLETION search

### DIFF
--- a/cognee/tasks/storage/index_graph_edges.py
+++ b/cognee/tasks/storage/index_graph_edges.py
@@ -53,7 +53,8 @@ async def index_graph_edges(
     Steps:
     1. Initialize the graph engine if needed and retrieve edge data.
     2. Transform edge data into EdgeType datapoints.
-    3. Index the EdgeType datapoints using the standard indexing function.
+    3. Persist EdgeType nodes in the graph database for triplet search.
+    4. Index the EdgeType datapoints using the standard indexing function.
 
     Raises:
         RuntimeError: If initialization of the graph engine fails.
@@ -61,6 +62,7 @@ async def index_graph_edges(
     Returns:
         None
     """
+    graph_engine = None
     try:
         if edges_data is None:
             graph_engine = await get_graph_engine()
@@ -68,20 +70,21 @@ async def index_graph_edges(
             logger.warning(
                 "Your graph edge embedding is deprecated, please pass edges to the index_graph_edges directly."
             )
+
+        edge_type_datapoints = create_edge_type_datapoints(edges_data)
+
+        # Persist EdgeType nodes in the graph database so they are available for
+        # GRAPH_COMPLETION triplet search.  Without this, adapters that don't
+        # store nodes via index_data_points (e.g. FalkorDB) will have EdgeType
+        # entries without vector embeddings, causing triplet search to fail.
+        if edge_type_datapoints:
+            if graph_engine is None:
+                graph_engine = await get_graph_engine()
+            await graph_engine.add_nodes(edge_type_datapoints)
+
+        await index_data_points(edge_type_datapoints, vector_engine=vector_engine)
     except Exception as e:
-        logger.error("Failed to initialize engines: %s", e)
-        raise RuntimeError("Initialization error") from e
-
-    edge_type_datapoints = create_edge_type_datapoints(edges_data)
-
-    # Persist EdgeType nodes in the graph database so they are available for
-    # GRAPH_COMPLETION triplet search.  Without this, adapters that don't
-    # store nodes via index_data_points (e.g. FalkorDB) will have EdgeType
-    # entries without vector embeddings, causing triplet search to fail.
-    if edge_type_datapoints:
-        graph_engine = await get_graph_engine()
-        await graph_engine.add_nodes(edge_type_datapoints)
-
-    await index_data_points(edge_type_datapoints, vector_engine=vector_engine)
+        logger.error("Failed to index graph edges: %s", e)
+        raise RuntimeError("Graph edge indexing error") from e
 
     return None


### PR DESCRIPTION
## Problem

`index_graph_edges()` creates `EdgeType` datapoints and calls `index_data_points()`, but some graph adapters (specifically FalkorDB via `cognee-community-hybrid-adapter-falkor`) don't persist nodes through `index_data_points()`. This results in EdgeType entries existing without vector embeddings in the graph database.

The consequence is that `GRAPH_COMPLETION` triplet search fails silently because it cannot find EdgeType vectors to match against query embeddings.

## Fix

Add an explicit `graph_engine.add_nodes(edge_type_datapoints)` call before `index_data_points()` in `index_graph_edges()`. This ensures EdgeType nodes are persisted with their vector embeddings in the graph database regardless of the adapter's `index_data_points` implementation.

## Impact

- Fixes `GRAPH_COMPLETION` search returning empty results on FalkorDB
- No impact on adapters where `index_data_points` already persists nodes (e.g. Kuzu, LanceDB) — the `add_nodes` call is idempotent
- The additional `add_nodes` call only runs when there are edge type datapoints to persist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence of edge-type data to the graph database for more reliable storage and access across different adapters.
  * Ensured indexing proceeds only after edge data is persisted, reducing data loss or inconsistency.
  * Unified and clearer error reporting for failures during edge retrieval/transform/persist/index operations, aiding troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->