### PR TITLE
fix: serialize Edge objects in verbose search to prevent RecursionError

### DIFF
--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -301,7 +301,20 @@ def _serialize_result_objects(objects: Any) -> Any:
     ``jsonable_encoder`` to raise ``RecursionError``.  This helper breaks
     the cycle by extracting only the essential fields.
     """
-    if not objects or not isinstance(objects, list):
+    if not objects:
+        return objects
+
+    # Handle a single Edge object (result_object is typed as Any)
+    if isinstance(objects, Edge):
+        return {
+            "source_node_id": objects.node1.id,
+            "target_node_id": objects.node2.id,
+            "source_node_attributes": objects.node1.attributes,
+            "target_node_attributes": objects.node2.attributes,
+            "edge_attributes": objects.attributes,
+        }
+
+    if not isinstance(objects, list):
         return objects
 
     serialized = []


### PR DESCRIPTION
## Problem

When calling the search API with `verbose=true`, `jsonable_encoder` raises:

```
RecursionError: maximum recursion depth exceeded
```

This is caused by circular references between `Edge` and `Node` objects in `CogneeGraphElements`:
- `Edge.node1` → `Node`
- `Node.skeleton_edges` → `[Edge, ...]`
- → infinite recursion when serializing

The `verbose=true` mode is needed to access `objects_result` for source provenance tracing (Entity → DocumentChunk → TextDocument), making this a blocker for source attribution in the REST API.

## Fix

Add `_serialize_result_objects()` helper in `search.py` that converts `Edge` objects to JSON-serializable dicts before they reach `jsonable_encoder`. The helper extracts:
- `source_node_id` / `target_node_id`
- `source_node_attributes` / `target_node_attributes`
- `edge_attributes`

Applied at both verbose result paths in `_backwards_compatible_search_results()` (lines 314 and 329).

## Impact

- Fixes `verbose=true` search for all search types (GRAPH_COMPLETION, RAG_COMPLETION, etc.)
- No impact on `verbose=false` (default) — that path is unchanged
- No impact on SDK direct calls — they bypass the REST API serialization

Fixes #2490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization of search results containing relationship/edge data so responses are JSON-safe; verbose search responses now include properly serialized result objects instead of raw edge instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->