### PR TITLE
fix: serialize Edge/Node objects in verbose search results

### DIFF
--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -293,13 +293,16 @@ async def search_in_datasets_context(
     return await asyncio.gather(*tasks)
 
 
-def _serialize_graph_object(obj):
+def _serialize_graph_object(obj: Any) -> Any:
     """Serialize Edge/Node objects into JSON-safe dicts.
 
     Edge and Node are plain Python classes with circular references
     (Edge.node1 → Node.skeleton_edges → [Edge, ...]) and numpy arrays
     (Node.status). jsonable_encoder() cannot handle these, so we convert
     them into flat dicts before they reach the serialization layer.
+
+    The function recursively normalizes nested structures (dicts, lists,
+    tuples) so that all values under ``attributes`` become JSON-safe.
     """
     import numpy as np
 
@@ -307,21 +310,17 @@ def _serialize_graph_object(obj):
         return {
             "node1": _serialize_graph_object(obj.node1),
             "node2": _serialize_graph_object(obj.node2),
-            "attributes": {
-                k: v.tolist() if isinstance(v, np.ndarray) else v
-                for k, v in obj.attributes.items()
-            },
+            "attributes": _serialize_graph_object(obj.attributes),
             "directed": obj.directed,
         }
     if isinstance(obj, Node):
         return {
             "id": obj.id,
-            "attributes": {
-                k: v.tolist() if isinstance(v, np.ndarray) else v
-                for k, v in obj.attributes.items()
-            },
+            "attributes": _serialize_graph_object(obj.attributes),
         }
-    if isinstance(obj, list):
+    if isinstance(obj, dict):
+        return {k: _serialize_graph_object(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
         return [_serialize_graph_object(item) for item in obj]
     if hasattr(obj, "tolist"):  # numpy arrays
         return obj.tolist()


### PR DESCRIPTION
## Problem

`POST /api/v1/search` with `verbose=true` and `search_type=GRAPH_COMPLETION` fails because `jsonable_encoder()` cannot serialize the `objects_result` field.

GRAPH_COMPLETION returns `List[Edge]` as `result_object`. `Edge` and `Node` are plain Python classes with:
- **Circular references**: `Edge.node1` → `Node.skeleton_edges` → `[Edge, ...]`
- **numpy arrays**: `Node.status` is `np.ndarray` (not JSON-serializable)

`_backwards_compatible_search_results()` passes these directly into the response dict, and `jsonable_encoder()` (line 144 of `get_search_router.py`) fails on them.

## Fix

Add `_serialize_graph_object()` helper that converts `Edge`/`Node` into flat JSON-safe dicts:
- `Edge` → `{node1, node2, attributes, directed}` (nodes serialized without skeleton_edges)
- `Node` → `{id, attributes}` (without skeleton_edges/neighbours)
- numpy arrays → Python lists

Called in `_backwards_compatible_search_results()` to serialize `objects_result` before it reaches `jsonable_encoder`.

## Impact

- Fixes verbose mode for all search types that return `Edge`/`Node` objects (GRAPH_COMPLETION, GRAPH_SUMMARY_COMPLETION, etc.)
- No impact on non-verbose mode (serialization only runs when `verbose=True`)
- No impact on SDK usage (only affects REST API serialization path)

Closes #2498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result formatting so graph objects (nodes/edges) and nested structures are consistently converted to JSON-safe formats, including array-like values. This enhances reliability and consistency of search results across interfaces and prevents serialization errors for complex data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->