### PR TITLE
fix: use timezone-aware UTC datetime in temporal awareness

### DIFF
--- a/cognee/tasks/temporal_awareness/build_graph_with_temporal_awareness.py
+++ b/cognee/tasks/temporal_awareness/build_graph_with_temporal_awareness.py
@@ -1,6 +1,6 @@
 import os
 from typing import List
-from datetime import datetime
+from datetime import datetime, timezone
 
 from graphiti_core import Graphiti
 from graphiti_core.nodes import EpisodeType
@@ -32,7 +32,7 @@ async def build_graph_with_temporal_awareness(data: List[Data]):
             episode_body=text,
             source=EpisodeType.text,
             source_description="input",
-            reference_time=datetime.now(),
+            reference_time=datetime.now(timezone.utc),
         )
         print(f"Added text: {text[:35]}...")
 


### PR DESCRIPTION
## Description

Replace naive `datetime.now()` with `datetime.now(timezone.utc)` in `build_graph_with_temporal_awareness.py`.

The naive call produces timestamps without timezone info, which causes inconsistent behavior across different deployment environments and can lead to drift when other components expect UTC or timezone-aware datetimes.

## Acceptance Criteria

* `reference_time` passed to `graphiti.add_episode()` is timezone-aware (UTC)
* No change in behavior for single-timezone deployments
* Consistent timestamps across different deployment regions

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Fixes #2428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the temporal awareness system by correcting how timestamps are processed and managed. The system now consistently uses UTC timezone instead of local time, ensuring accurate and reliable handling of time-dependent features across all different geographical regions and various system environments, preventing potential time-related issues and improving overall reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->