### PR TITLE
fix: break circular Edge↔Node references in verbose search serialization

### DIFF
--- a/cognee/modules/search/methods/_serialize.py
+++ b/cognee/modules/search/methods/_serialize.py
@@ -1,0 +1,50 @@
+"""Serialize search result objects, breaking circular Edge↔Node references."""
+
+from typing import Any, List, Optional, Union
+
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+
+
+def _serialize_node(node: Node) -> dict:
+    """Convert a Node to a JSON-serializable dict without its skeleton_edges."""
+    return {
+        "id": node.id,
+        "attributes": node.attributes,
+    }
+
+
+def _serialize_edge(edge: Edge) -> dict:
+    """Convert an Edge to a JSON-serializable dict, breaking circular refs."""
+    return {
+        "source_node_id": edge.node1.id,
+        "target_node_id": edge.node2.id,
+        "source_node_attributes": edge.node1.attributes,
+        "target_node_attributes": edge.node2.attributes,
+        "edge_attributes": edge.attributes,
+        "directed": edge.directed,
+    }
+
+
+def serialize_result_objects(
+    objects: Optional[Union[List[Any], Any]],
+) -> Optional[Union[List[Any], Any]]:
+    """Serialize result objects, converting Edge/Node instances to plain dicts.
+
+    This prevents ``jsonable_encoder`` from hitting infinite recursion caused by
+    the circular reference chain: Edge.node1 → Node.skeleton_edges → [Edge, …].
+    """
+    if objects is None:
+        return None
+
+    if isinstance(objects, list):
+        return [_serialize_single(obj) for obj in objects]
+
+    return _serialize_single(objects)
+
+
+def _serialize_single(obj: Any) -> Any:
+    if isinstance(obj, Edge):
+        return _serialize_edge(obj)
+    if isinstance(obj, Node):
+        return _serialize_node(obj)
+    return obj

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -14,6 +14,7 @@ from cognee.context_global_variables import (
 
 from cognee.modules.engine.models.node_set import NodeSet
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
+from cognee.modules.search.methods._serialize import serialize_result_objects
 from cognee.modules.search.types import (
     SearchResult,
     SearchType,
@@ -311,7 +312,7 @@ def _backwards_compatible_search_results(search_results, verbose: bool):
                 # Include all different types of results only in verbose mode
                 search_result_dict["text_result"] = search_result.completion
                 search_result_dict["context_result"] = search_result.context
-                search_result_dict["objects_result"] = search_result.result_object
+                search_result_dict["objects_result"] = serialize_result_objects(search_result.result_object)
             else:
                 # Result attribute handles returning appropriate result based on set flags and outputs
                 search_result_dict["search_result"] = search_result.result
@@ -326,7 +327,7 @@ def _backwards_compatible_search_results(search_results, verbose: bool):
                 search_result_dict = {
                     "text_result": search_result.completion,
                     "context_result": search_result.context,
-                    "objects_result": search_result.result_object,
+                    "objects_result": serialize_result_objects(search_result.result_object),
                 }
                 return_value.append(search_result_dict)
             return return_value

--- a/cognee/tests/unit/modules/search/test_serialize.py
+++ b/cognee/tests/unit/modules/search/test_serialize.py
@@ -1,0 +1,36 @@
+"""Tests for search result serialization (circular reference handling)."""
+
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+from cognee.modules.search.methods._serialize import serialize_result_objects
+
+
+def test_serialize_edge_breaks_circular_ref():
+    """Edge→Node→skeleton_edges→Edge cycle should not cause recursion."""
+    node_a = Node("a", attributes={"name": "Alice"})
+    node_b = Node("b", attributes={"name": "Bob"})
+    edge = Edge(node_a, node_b, attributes={"relation": "knows"})
+    node_a.add_skeleton_edge(edge)
+    node_b.add_skeleton_edge(edge)
+
+    result = serialize_result_objects([edge])
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["source_node_id"] == "a"
+    assert result[0]["target_node_id"] == "b"
+    assert result[0]["edge_attributes"] == {"relation": "knows"}
+
+
+def test_serialize_node():
+    node = Node("x", attributes={"val": 1})
+    result = serialize_result_objects([node])
+    assert result[0]["id"] == "x"
+    assert result[0]["attributes"] == {"val": 1}
+
+
+def test_serialize_none():
+    assert serialize_result_objects(None) is None
+
+
+def test_serialize_non_graph_objects():
+    result = serialize_result_objects(["hello", 42])
+    assert result == ["hello", 42]


### PR DESCRIPTION
## Description

When `verbose=True`, the search API returns raw `Edge` objects that have circular references (`Edge.node1` → `Node.skeleton_edges` → `[Edge, ...]`). This causes `jsonable_encoder` in the search router to raise `RecursionError: maximum recursion depth exceeded`.

This PR adds a `serialize_result_objects()` helper that converts `Edge` and `Node` instances to plain dicts before they reach `jsonable_encoder`, breaking the circular reference chain.

Fixes #2490

## Acceptance Criteria

* `POST /api/v1/search` with `verbose=true` and `search_type=GRAPH_COMPLETION` no longer crashes
* Edge objects are serialized to dicts with `source_node_id`, `target_node_id`, and attributes
* Non-Edge/Node objects pass through unchanged
* Unit tests verify all serialization paths

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
Tests run locally:
```
All tests passed!
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search result serialization to ensure all query results are properly formatted in API responses, enhancing compatibility with various client applications and preventing formatting issues in verbose mode responses.

* **Tests**
  * Added comprehensive unit test coverage for search result serialization, including validation of complex graph structures and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->