### PR TITLE
fix: include node category in UUID generation to prevent Entity/Entit…

### DIFF
--- a/cognee/modules/graph/utils/expand_with_nodes_and_edges.py
+++ b/cognee/modules/graph/utils/expand_with_nodes_and_edges.py
@@ -36,7 +36,7 @@ def _process_ontology_nodes(
 ) -> None:
     """Process and store ontology nodes"""
     for ontology_node in ontology_nodes:
-        ont_node_id = generate_node_id(ontology_node.name)
+        ont_node_id = generate_node_id(f"type:{ontology_node.name}") if ontology_node.category == "classes" else generate_node_id(f"entity:{ontology_node.name}")
         ont_node_name = generate_node_name(ontology_node.name)
 
         if ontology_node.category == "classes":
@@ -102,7 +102,7 @@ def _create_type_node(
     ontology_relationships: list,
 ) -> EntityType:
     """Create or retrieve a type node with ontology validation"""
-    node_id = generate_node_id(node_type)
+    node_id = generate_node_id(f"type:{node_type}")
     node_name = generate_node_name(node_type)
     type_node_key = _create_node_key(node_id, "type")
 
@@ -120,7 +120,7 @@ def _create_type_node(
 
     if ontology_validated:
         old_key = type_node_key
-        node_id = generate_node_id(closest_class.name)
+        node_id = generate_node_id(f"type:{closest_class.name}")
         type_node_key = _create_node_key(node_id, "type")
         new_node_name = generate_node_name(closest_class.name)
 
@@ -161,7 +161,7 @@ def _create_entity_node(
     ontology_relationships: list,
 ) -> Entity:
     """Create or retrieve an entity node with ontology validation"""
-    generated_node_id = generate_node_id(node_id)
+    generated_node_id = generate_node_id(f"entity:{node_id}")
     generated_node_name = generate_node_name(node_name)
     entity_node_key = _create_node_key(generated_node_id, "entity")
 
@@ -179,7 +179,7 @@ def _create_entity_node(
 
     if ontology_validated:
         old_key = entity_node_key
-        generated_node_id = generate_node_id(start_ent_ont.name)
+        generated_node_id = generate_node_id(f"entity:{start_ent_ont.name}")
         entity_node_key = _create_node_key(generated_node_id, "entity")
         new_node_name = generate_node_name(start_ent_ont.name)
 
@@ -280,8 +280,8 @@ def _process_graph_edges(
         source_id = name_mapping.get(generate_node_name(edge.source_node_id), edge.source_node_id)
         target_id = name_mapping.get(generate_node_name(edge.target_node_id), edge.target_node_id)
 
-        source_node_id = generate_node_id(source_id)
-        target_node_id = generate_node_id(target_id)
+        source_node_id = generate_node_id(f"entity:{source_id}")
+        target_node_id = generate_node_id(f"entity:{target_id}")
         relationship_name = generate_edge_name(edge.relationship_name)
         edge_key = _create_edge_key(source_node_id, target_node_id, relationship_name)
 

--- a/cognee/modules/graph/utils/expand_with_nodes_and_edges.py
+++ b/cognee/modules/graph/utils/expand_with_nodes_and_edges.py
@@ -64,12 +64,15 @@ def _process_ontology_nodes(
 
 
 def _process_ontology_edges(
-    ontology_edges: list, existing_edges_map: dict, ontology_relationships: list
+    ontology_nodes: list, ontology_edges: list, existing_edges_map: dict, ontology_relationships: list
 ) -> None:
     """Process ontology edges and add them if new"""
+    node_category = {node.name: node.category for node in ontology_nodes}
     for source, relation, target in ontology_edges:
-        source_node_id = generate_node_id(source)
-        target_node_id = generate_node_id(target)
+        source_prefix = "type" if node_category.get(source) == "classes" else "entity"
+        target_prefix = "type" if node_category.get(target) == "classes" else "entity"
+        source_node_id = generate_node_id(f"{source_prefix}:{source}")
+        target_node_id = generate_node_id(f"{target_prefix}:{target}")
         relationship_name = generate_edge_name(relation)
         edge_key = _create_edge_key(source_node_id, target_node_id, relationship_name)
 
@@ -141,7 +144,7 @@ def _create_type_node(
 
     # Process ontology nodes and edges
     _process_ontology_nodes(ontology_nodes, data_chunk, added_nodes_map, added_ontology_nodes_map)
-    _process_ontology_edges(ontology_edges, existing_edges_map, ontology_relationships)
+    _process_ontology_edges(ontology_nodes, ontology_edges, existing_edges_map, ontology_relationships)
 
     return type_node
 
@@ -202,7 +205,7 @@ def _create_entity_node(
 
     # Process ontology nodes and edges
     _process_ontology_nodes(ontology_nodes, data_chunk, added_nodes_map, added_ontology_nodes_map)
-    _process_ontology_edges(ontology_edges, existing_edges_map, ontology_relationships)
+    _process_ontology_edges(ontology_nodes, ontology_edges, existing_edges_map, ontology_relationships)
 
     return entity_node
 

--- a/cognee/modules/graph/utils/retrieve_existing_edges.py
+++ b/cognee/modules/graph/utils/retrieve_existing_edges.py
@@ -40,7 +40,7 @@ async def retrieve_existing_edges(
         - Prevents processing the same node multiple times using a processed_nodes tracker
         - The returned mapping can be used with expand_with_nodes_and_edges() to avoid duplicates
     """
-    processed_nodes = {}
+    processed_edges = set()
     type_node_edges = []
     entity_node_edges = []
     type_entity_edges = []
@@ -51,17 +51,23 @@ async def retrieve_existing_edges(
         graph = chunk_graphs[index]
 
         for node in graph.nodes:
-            type_node_id = generate_node_id(node.type)
-            entity_node_id = generate_node_id(node.id)
+            type_node_id = generate_node_id(f"type:{node.type}")
+            entity_node_id = generate_node_id(f"entity:{node.id}")
 
-            if str(type_node_id) not in processed_nodes:
-                type_node_edges.append((data_chunk.id, type_node_id, "exists_in"))
-                processed_nodes[str(type_node_id)] = True
+            type_edge = (data_chunk.id, type_node_id, "exists_in")
+            if type_edge not in processed_edges:
+                type_node_edges.append(type_edge)
+                processed_edges.add(type_edge)
 
-            if str(entity_node_id) not in processed_nodes:
-                entity_node_edges.append((data_chunk.id, entity_node_id, "mentioned_in"))
-                type_entity_edges.append((entity_node_id, type_node_id, "is_a"))
-                processed_nodes[str(entity_node_id)] = True
+            entity_edge = (data_chunk.id, entity_node_id, "mentioned_in")
+            if entity_edge not in processed_edges:
+                entity_node_edges.append(entity_edge)
+                processed_edges.add(entity_edge)
+
+            type_entity_edge = (entity_node_id, type_node_id, "is_a")
+            if type_entity_edge not in processed_edges:
+                type_entity_edges.append(type_entity_edge)
+                processed_edges.add(type_entity_edge)
 
         graph_node_edges.extend(
             (

--- a/cognee/modules/graph/utils/retrieve_existing_edges.py
+++ b/cognee/modules/graph/utils/retrieve_existing_edges.py
@@ -71,8 +71,8 @@ async def retrieve_existing_edges(
 
         graph_node_edges.extend(
             (
-                generate_node_id(edge.source_node_id),
-                generate_node_id(edge.target_node_id),
+                generate_node_id(f"entity:{edge.source_node_id}"),
+                generate_node_id(f"entity:{edge.target_node_id}"),
                 generate_edge_name(edge.relationship_name),
             )
             for edge in graph.edges

--- a/cognee/tests/unit/modules/graph/test_retrieve_existing_edges.py
+++ b/cognee/tests/unit/modules/graph/test_retrieve_existing_edges.py
@@ -49,13 +49,13 @@ async def test_retrieve_existing_edges_queries_graph_edges_from_all_chunks(mock_
     queried_edges = graph_engine.has_edges.await_args.args[0]
 
     assert (
-        generate_node_id("Source 1"),
-        generate_node_id("Target 1"),
+        generate_node_id("entity:Source 1"),
+        generate_node_id("entity:Target 1"),
         generate_edge_name("Knows"),
     ) in queried_edges
     assert (
-        generate_node_id("Source 2"),
-        generate_node_id("Target 2"),
+        generate_node_id("entity:Source 2"),
+        generate_node_id("entity:Target 2"),
         generate_edge_name("Works With"),
     ) in queried_edges
 

--- a/cognee/tests/utils/extract_entities.py
+++ b/cognee/tests/utils/extract_entities.py
@@ -10,7 +10,7 @@ def extract_entities(graph: KnowledgeGraph, cache: dict | None = None):
     entity_types = []
 
     for node in graph.nodes:
-        node_id = generate_node_id(node.id)
+        node_id = generate_node_id(f"entity:{node.id}")
 
         if node_id not in cache:
             entity = Entity(
@@ -27,7 +27,7 @@ def extract_entities(graph: KnowledgeGraph, cache: dict | None = None):
         entities.append(entity)
 
         node_type = node.type
-        type_node_id = generate_node_id(node_type)
+        type_node_id = generate_node_id(f"type:{node_type}")
         if type_node_id not in cache:
             type_node_name = generate_node_name(node_type)
 

--- a/cognee/tests/utils/extract_relationships.py
+++ b/cognee/tests/utils/extract_relationships.py
@@ -26,8 +26,8 @@ def extract_relationships(
         relationships.append(relationship)
 
     for node in graph.nodes:
-        node_id = generate_node_id(node.id)
-        type_node_id = generate_node_id(node.type)
+        node_id = generate_node_id(f"entity:{node.id}")
+        type_node_id = generate_node_id(f"type:{node.type}")
         type_edge_id = f"{str(node_id)}_is_a_{str(type_node_id)}"
 
         if type_edge_id not in cache:


### PR DESCRIPTION


## Description
Fixes #2510.

`_create_type_node` and `_create_entity_node` in `expand_with_nodes_and_edges.py` both call `generate_node_id` with the node name only, so `Entity("institution")` and `EntityType("institution")` produce the same UUID. Within a single run this is fine because deduplication uses keys like `uuid_type` vs `uuid_entity`, but across runs only the UUID is persisted to PostgreSQL, causing an `EntityAlreadyExistsError` (409) on the second `cognify`, which breaks graph projection and returns empty search results.

The fix includes the node category in the hash:
```python
# _create_type_node
node_id = generate_node_id(f"type:{node_type}")

# _create_entity_node
generated_node_id = generate_node_id(f"entity:{node_id}")
```

## Acceptance Criteria
* `Entity("institution")` and `EntityType("institution")` now produce different UUIDs
* Running `cognify` twice on the same data no longer raises `EntityAlreadyExistsError`
* Minimal repro confirming the collision and the fix:
```python
from uuid import NAMESPACE_OID, uuid5

def generate_node_id(node_id):
    return uuid5(NAMESPACE_OID, node_id.lower().replace(" ", "_").replace("'", ""))

# Before fix → same UUID
assert generate_node_id("institution") == generate_node_id("institution")  # True (collision)

# After fix → different UUIDs
assert generate_node_id("type:institution") != generate_node_id("entity:institution")  # True
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass (except an error in `test_neptune_analytics_graph.py` which is unrelated)
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Node identifiers now use explicit type and entity namespaces for consistent naming across the knowledge graph.
  * Edge de-duplication has been standardized to operate at the relationship level, improving duplicate detection.
  * These updates make graph keys more consistent and reduce accidental ID collisions, improving reliability of graph merging and mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->