### PR TITLE
docs: add deployment options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Use [Cognee Cloud](https://www.cognee.ai) for a fully managed experience, or sel
 | **Render** | Simple PaaS with managed Postgres | Deploy to Render button |
 | **Daytona** | Cloud sandboxes (SDK or CLI) | See `distributed/deploy/daytona_sandbox.py` |
 
+See the [`distributed/`](distributed/) folder for deploy scripts, worker configurations, and additional details.
+
 ## Latest News
 
 [![Watch Demo](https://img.youtube.com/vi/8hmqS2Y5RVQ/maxresdefault.jpg)](https://www.youtube.com/watch?v=8hmqS2Y5RVQ&t=13s)


### PR DESCRIPTION
## Summary
- Adds a "Deploy Cognee" section to README with 1-click deployment configurations
- Covers Modal, Railway, Fly.io, Render, and Daytona platforms

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment options guide to the README, including Cognee Cloud sign-up link and self-hosting instructions for multiple platforms (Modal, Railway, Fly.io, Render, Daytona). References deployment scripts and configurations for further details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->