### PR TITLE
refactor: replace wildcard import in cognee/pipelines.py with explicit imports

### DIFF
--- a/cognee/pipelines.py
+++ b/cognee/pipelines.py
@@ -2,4 +2,6 @@
 # of enabling imports from `cognee.pipelines` module.
 # `from cognee.pipelines import Task` for example.
 
-from .modules.pipelines import *
+from .modules.pipelines import Task, run_tasks, run_tasks_parallel, run_pipeline
+
+__all__ = ["Task", "run_tasks", "run_tasks_parallel", "run_pipeline"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,6 @@ exclude = [
     "migrations/",  # Ignore migrations directory
     "notebooks/",       # Ignore notebook files
     "build/",           # Ignore build directory
-    "cognee/pipelines.py",
     "cognee/modules/users/models/Group.py",
     "cognee/modules/users/models/ACL.py",
     "cognee/modules/pipelines/models/Task.py",


### PR DESCRIPTION
## Summary

This PR replaces the wildcard import in `cognee/pipelines.py` with explicit imports, following PEP8 best practices.

## Changes

- Replace `from .modules.pipelines import *` with explicit imports: `Task, run_tasks, run_tasks_parallel, run_pipeline`
- Add `__all__` list to make the public API explicit
- Remove `cognee/pipelines.py` from ruff exclude list in `pyproject.toml`

## Benefits

- Improves code clarity and maintainability
- Makes static analysis easier
- Avoids potential name collisions
- Explicitly defines the public API

## Testing

All existing imports from `cognee.pipelines` continue to work:
- `from cognee.pipelines import Task` ✅
- `from cognee.pipelines import run_tasks` ✅

Closes #2303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by explicitly defining public module exports.

* **Chores**
  * Enhanced code quality tooling configuration to enable linting on additional modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->