### PR TITLE
fix: place system message before user message in LLM adapters

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -203,12 +203,12 @@ class AzureOpenAIAdapter(OpenAIAdapter):
                     model=self._extract_deployment(self.model),
                     messages=[
                         {
-                            "role": "user",
-                            "content": f"""{text_input}""",
-                        },
-                        {
                             "role": "system",
                             "content": system_prompt,
+                        },
+                        {
+                            "role": "user",
+                            "content": f"""{text_input}""",
                         },
                     ],
                     response_model=response_model,
@@ -230,12 +230,12 @@ class AzureOpenAIAdapter(OpenAIAdapter):
                         model=self.fallback_model,
                         messages=[
                             {
-                                "role": "user",
-                                "content": f"""{text_input}""",
-                            },
-                            {
                                 "role": "system",
                                 "content": system_prompt,
+                            },
+                            {
+                                "role": "user",
+                                "content": f"""{text_input}""",
                             },
                         ],
                         api_key=self.fallback_api_key,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
@@ -72,8 +72,8 @@ class BedrockAdapter(LLMInterface):
             "custom_llm_provider": "bedrock",
             "drop_params": True,
             "messages": [
-                {"role": "user", "content": text_input},
                 {"role": "system", "content": system_prompt},
+                {"role": "user", "content": text_input},
             ],
             "response_model": response_model,
             "max_retries": self.MAX_RETRIES,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
@@ -123,12 +123,12 @@ class GeminiAdapter(GenericAPIAdapter):
                     model=self.model,
                     messages=[
                         {
-                            "role": "user",
-                            "content": f"""{text_input}""",
-                        },
-                        {
                             "role": "system",
                             "content": system_prompt,
+                        },
+                        {
+                            "role": "user",
+                            "content": f"""{text_input}""",
                         },
                     ],
                     api_key=self.api_key,
@@ -160,12 +160,12 @@ class GeminiAdapter(GenericAPIAdapter):
                         model=self.fallback_model,
                         messages=[
                             {
-                                "role": "user",
-                                "content": f"""{text_input}""",
-                            },
-                            {
                                 "role": "system",
                                 "content": system_prompt,
+                            },
+                            {
+                                "role": "user",
+                                "content": f"""{text_input}""",
                             },
                         ],
                         max_retries=2,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -148,12 +148,12 @@ class GenericAPIAdapter(LLMInterface):
                     model=self.model,
                     messages=[
                         {
-                            "role": "user",
-                            "content": f"""{text_input}""",
-                        },
-                        {
                             "role": "system",
                             "content": system_prompt,
+                        },
+                        {
+                            "role": "user",
+                            "content": f"""{text_input}""",
                         },
                     ],
                     max_retries=2,
@@ -186,12 +186,12 @@ class GenericAPIAdapter(LLMInterface):
                         model=self.fallback_model,
                         messages=[
                             {
-                                "role": "user",
-                                "content": f"""{text_input}""",
-                            },
-                            {
                                 "role": "system",
                                 "content": system_prompt,
+                            },
+                            {
+                                "role": "user",
+                                "content": f"""{text_input}""",
                             },
                         ],
                         max_retries=2,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -106,12 +106,12 @@ class OllamaAPIAdapter(LLMInterface):
                 model=self.model,
                 messages=[
                     {
-                        "role": "user",
-                        "content": f"{text_input}",
-                    },
-                    {
                         "role": "system",
                         "content": system_prompt,
+                    },
+                    {
+                        "role": "user",
+                        "content": f"{text_input}",
                     },
                 ],
                 max_retries=2,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -146,12 +146,12 @@ class OpenAIAdapter(GenericAPIAdapter):
                     model=self.model,
                     messages=[
                         {
-                            "role": "user",
-                            "content": f"""{text_input}""",
-                        },
-                        {
                             "role": "system",
                             "content": system_prompt,
+                        },
+                        {
+                            "role": "user",
+                            "content": f"""{text_input}""",
                         },
                     ],
                     api_key=self.api_key,
@@ -174,12 +174,12 @@ class OpenAIAdapter(GenericAPIAdapter):
                         model=self.fallback_model,
                         messages=[
                             {
-                                "role": "user",
-                                "content": f"""{text_input}""",
-                            },
-                            {
                                 "role": "system",
                                 "content": system_prompt,
+                            },
+                            {
+                                "role": "user",
+                                "content": f"""{text_input}""",
                             },
                         ],
                         api_key=self.fallback_api_key,


### PR DESCRIPTION
## Description

Six LLM adapters (generic_llm_api, openai, azure_openai, gemini, bedrock, ollama) placed the system message *after* the user message in the `messages` array sent to chat completions. This causes 400 errors with vLLM and other providers that enforce strict chat template ordering where system messages must come first.

Swapped the message order so system messages precede user messages in both primary and fallback request blocks across all affected adapters. The anthropic, mistral, and llama_cpp adapters already had the correct order and were left unchanged.

## Acceptance Criteria

* System messages are placed before user messages in all LLM adapter `messages` arrays
* No functional change to message content — only ordering is affected

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Fixes #2537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized message ordering across multiple LLM provider adapters to ensure consistent message sequencing. System messages now consistently precede user messages in request structures. This change maintains all existing functionality while improving internal consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->