### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware alternative

### DIFF
--- a/cognee/eval_framework/modal_run_eval.py
+++ b/cognee/eval_framework/modal_run_eval.py
@@ -60,7 +60,7 @@ async def modal_run_eval(eval_params=None):
 
     version_name = "baseline"
     benchmark_name = os.environ.get("BENCHMARK", eval_params.get("benchmark", "benchmark"))
-    timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
     answers_filename = (
         f"{version_name}_{benchmark_name}_{timestamp}_{eval_params.get('answers_path')}"

--- a/cognee/get_token.py
+++ b/cognee/get_token.py
@@ -10,7 +10,8 @@ def create_jwt(user_id: str, tenant_id: str, roles: list[str]):
         "user_id": user_id,
         "tenant_id": tenant_id,
         "roles": roles,
-        "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),  # 1 hour expiry
+        "exp": datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),  # 1 hour expiry
     }
     return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 

--- a/cognee/get_token.py
+++ b/cognee/get_token.py
@@ -10,7 +10,7 @@ def create_jwt(user_id: str, tenant_id: str, roles: list[str]):
         "user_id": user_id,
         "tenant_id": tenant_id,
         "roles": roles,
-        "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1),  # 1 hour expiry
+        "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),  # 1 hour expiry
     }
     return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 

--- a/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 import diskcache as dc
 
 from pydantic import ValidationError
@@ -48,7 +48,7 @@ class FSCacheAdapter(CacheDBInterface):
         memify_metadata: dict | None = None,
     ) -> dict:
         entry = SessionQAEntry(
-            time=datetime.utcnow().isoformat(),
+            time=datetime.now(timezone.utc).isoformat(),
             question=question,
             context=context,
             answer=answer,

--- a/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
+++ b/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 
 import redis
@@ -98,7 +98,7 @@ class RedisAdapter(CacheDBInterface):
         memify_metadata: dict | None = None,
     ) -> dict:
         entry = SessionQAEntry(
-            time=datetime.utcnow().isoformat(),
+            time=datetime.now(timezone.utc).isoformat(),
             question=question,
             context=context,
             answer=answer,


### PR DESCRIPTION
## Description

Replace remaining `datetime.utcnow()` calls with `datetime.now(timezone.utc)` across 4 files. `datetime.utcnow()` is deprecated since Python 3.12 and returns naive datetimes that can cause subtle timezone bugs.

**Files changed:**
- `cognee/get_token.py` — JWT expiry timestamp
- `cognee/eval_framework/modal_run_eval.py` — eval timestamp
- `cognee/infrastructure/databases/cache/redis/RedisAdapter.py` — cache entry timestamp
- `cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py` — cache entry timestamp

## Acceptance Criteria

* No remaining `utcnow()` calls in the codebase
* All timestamps are now timezone-aware (UTC)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized timestamp handling to use timezone-aware UTC datetimes across the app, affecting filename generation, token expiry timestamps, and cache/redis records.
  * Timestamps now consistently include explicit UTC information while preserving existing timestamp formats and public behaviors. No public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->