### PR TITLE
fix: log rotation, safe default dir, and opt-out file logging

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -298,6 +298,18 @@ ENABLE_LAST_ACCESSED="false"
 
 TOKENIZERS_PARALLELISM="false"
 
+# -- Cognee Logging -----------------------------------------------------------
+# Console log level: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: INFO)
+#LOG_LEVEL="INFO"
+# Set to false to disable file logging entirely (console-only)
+#COGNEE_LOG_FILE="true"
+# Override the log directory (default: ~/.cognee/logs)
+#COGNEE_LOGS_DIR="/var/log/cognee"
+# Max size per log file before rotation, in bytes (default: 50 MB)
+#COGNEE_LOG_MAX_BYTES=52428800
+# Number of rotated log files to keep (default: 5 → 300 MB total cap)
+#COGNEE_LOG_BACKUP_COUNT=5
+
 # LITELLM Logging Level. Set to quiet down logging
 LITELLM_LOG="ERROR"
 

--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -12,9 +12,7 @@ class BaseConfig(BaseSettings):
     data_root_directory: str = get_absolute_path(".data_storage")
     system_root_directory: str = get_absolute_path(".cognee_system")
     cache_root_directory: str = get_absolute_path(".cognee_cache")
-    logs_root_directory: str = os.getenv(
-        "COGNEE_LOGS_DIR", str(os.path.join(os.path.dirname(os.path.dirname(__file__)), "logs"))
-    )
+    logs_root_directory: str = os.getenv("COGNEE_LOGS_DIR", str(Path.home() / ".cognee" / "logs"))
     monitoring_tool: object = Observer.NONE
 
     @pydantic.model_validator(mode="after")

--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import logging
+import logging.handlers
 import tempfile
 import structlog
 import traceback
@@ -113,6 +114,10 @@ def resolve_logs_dir():
 # Maximum number of log files to keep
 MAX_LOG_FILES = 10
 
+# Log rotation defaults — override via COGNEE_LOG_MAX_BYTES / COGNEE_LOG_BACKUP_COUNT
+LOG_MAX_BYTES = int(os.getenv("COGNEE_LOG_MAX_BYTES", 50 * 1024 * 1024))  # 50 MB
+LOG_BACKUP_COUNT = int(os.getenv("COGNEE_LOG_BACKUP_COUNT", 5))  # 5 backups → 300 MB cap
+
 # Version information
 PYTHON_VERSION = platform.python_version()
 STRUCTLOG_VERSION = structlog.__version__
@@ -121,8 +126,12 @@ COGNEE_VERSION = cognee_version
 OS_INFO = f"{platform.system()} {platform.release()} ({platform.version()})"
 
 
-class PlainFileHandler(logging.FileHandler):
-    """A custom file handler that writes simpler plain text log entries."""
+class PlainFileHandler(logging.handlers.RotatingFileHandler):
+    """A rotating file handler that writes simpler plain text log entries.
+
+    Inherits from RotatingFileHandler so log files are automatically rotated
+    when they reach maxBytes, keeping at most backupCount old files.
+    """
 
     def emit(self, record):
         try:
@@ -471,29 +480,42 @@ def setup_logging(log_level=None, name=None):
     # can define their own levels.
     root_logger.setLevel(logging.NOTSET)
 
-    # Resolve logs directory with env and safe fallbacks
-    logs_dir = resolve_logs_dir()
+    # --- File logging (opt-out via COGNEE_LOG_FILE=false) ---
+    # Set COGNEE_LOG_FILE=false to disable file logging entirely.
+    log_file_enabled = os.getenv("COGNEE_LOG_FILE", "true").lower() not in ("false", "0", "no")
+    log_file_path = None
 
-    # Check if we already have a log file path from the environment
-    # NOTE: environment variable must be used here as it allows us to
-    # log to a single file with a name based on a timestamp in a multiprocess setting.
-    # Without it, we would have a separate log file for every process.
-    log_file_path = os.environ.get("LOG_FILE_NAME")
-    if not log_file_path and logs_dir is not None:
-        # Create a new log file name with the cognee start time
-        start_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        log_file_path = str((logs_dir / f"{start_time}.log").resolve())
-        os.environ["LOG_FILE_NAME"] = log_file_path
+    if log_file_enabled:
+        # Resolve logs directory with env and safe fallbacks
+        logs_dir = resolve_logs_dir()
 
-    try:
-        # Create a file handler that uses our custom PlainFileHandler
-        file_handler = PlainFileHandler(log_file_path, encoding="utf-8")
-        file_handler.setLevel(DEBUG)
-        root_logger.addHandler(file_handler)
-    except Exception as e:
-        # Note: Exceptions happen in case of read only file systems or log file path poiting to location where it does
-        # not have write permission. Logging to file is not mandatory so we just log a warning to console.
-        root_logger.warning(f"Warning: Could not create log file handler at {log_file_path}: {e}")
+        # Check if we already have a log file path from the environment
+        # NOTE: environment variable must be used here as it allows us to
+        # log to a single file with a name based on a timestamp in a multiprocess setting.
+        # Without it, we would have a separate log file for every process.
+        log_file_path = os.environ.get("LOG_FILE_NAME")
+        if not log_file_path and logs_dir is not None:
+            # Create a new log file name with the cognee start time
+            start_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            log_file_path = str((logs_dir / f"{start_time}.log").resolve())
+            os.environ["LOG_FILE_NAME"] = log_file_path
+
+        try:
+            # Rotating file handler: caps each file at LOG_MAX_BYTES,
+            # keeps LOG_BACKUP_COUNT old files (default 50 MB × 5 = 250 MB total).
+            file_handler = PlainFileHandler(
+                log_file_path,
+                maxBytes=LOG_MAX_BYTES,
+                backupCount=LOG_BACKUP_COUNT,
+                encoding="utf-8",
+            )
+            file_handler.setLevel(log_level)
+            root_logger.addHandler(file_handler)
+        except Exception as e:
+            # Logging to file is not mandatory — warn on console and continue.
+            root_logger.warning(
+                f"Warning: Could not create log file handler at {log_file_path}: {e}"
+            )
 
     if log_level > logging.DEBUG:
         import warnings
@@ -508,7 +530,7 @@ def setup_logging(log_level=None, name=None):
         )
 
     # Clean up old log files, keeping only the most recent ones
-    if logs_dir is not None:
+    if log_file_enabled and logs_dir is not None:
         cleanup_old_logs(logs_dir, MAX_LOG_FILES)
 
     # Mark logging as configured
@@ -538,7 +560,7 @@ def setup_logging(log_level=None, name=None):
         "From version 0.5.0 onwards, Cognee will run with multi-user access control mode set to on by default. Data isolation between different users and datasets will be enforced and data created before multi-user access control mode was turned on won't be accessible by default. To disable multi-user access control mode and regain access to old data set the environment variable ENABLE_BACKEND_ACCESS_CONTROL to false before starting Cognee. For more information, please refer to the Cognee documentation."
     )
 
-    if logs_dir is not None:
+    if log_file_path is not None:
         logger.info(f"Log file created at: {log_file_path}", log_file=log_file_path)
 
     # Detailed initialization for regular usage


### PR DESCRIPTION
## Summary
- **Default log dir** changed from `site-packages/logs/` to `~/.cognee/logs` — logs no longer written inside the installed package directory
- **Log rotation** via `RotatingFileHandler`: 50MB max per file, 5 backups (300MB total cap). Prevents unbounded growth that caused 22GB+ log files and disk exhaustion in production.
- **`COGNEE_LOG_FILE=false`** disables file logging entirely (console-only mode)
- **File handler respects `LOG_LEVEL`** instead of being hardcoded to `DEBUG`
- New env vars documented in `.env.template`: `COGNEE_LOG_FILE`, `COGNEE_LOGS_DIR`, `COGNEE_LOG_MAX_BYTES`, `COGNEE_LOG_BACKUP_COUNT`

Fixes reported production issue where a single log file grew to 22GB over 3 days, filling the disk and causing cascading failures in FalkorDB and SQLite.

## Test plan
- [ ] Verify logs are created in `~/.cognee/logs` by default (not site-packages)
- [ ] Verify `COGNEE_LOGS_DIR=/tmp/test_logs` overrides the log directory
- [ ] Verify log files rotate at 50MB (or custom `COGNEE_LOG_MAX_BYTES`)
- [ ] Verify `COGNEE_LOG_FILE=false` produces no log files
- [ ] Verify `LOG_LEVEL=WARNING` suppresses INFO in both console and file output
- [ ] Verify existing `LOG_FILE_NAME` env var still works for multiprocess setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable logging through environment variables: log level, file logging toggle, rotation limits, and custom log directory.
  * Enabled automatic log file rotation to prevent excessive disk space usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->