### PR TITLE
fix: handle Kuzu edge tuple format in entity consolidation

### DIFF
--- a/cognee/memify_pipelines/consolidate_entity_descriptions.py
+++ b/cognee/memify_pipelines/consolidate_entity_descriptions.py
@@ -58,8 +58,28 @@ def get_entity_properties(
 
 
 def format_edges(edges: List[Any]) -> Dict[str, str]:
-    """Map target node IDs to relationship names."""
-    return {edge[1]: edge[2]["relationship_name"] for edge in edges}
+    """Map target node IDs to relationship names.
+
+    Handles both Neo4j and Kuzu edge tuple formats:
+    - Neo4j / Neptune: (source_id, target_id, {"relationship_name": name})
+    - Kuzu:            (source_node_dict, relationship_name_str, target_node_dict)
+    """
+    result = {}
+    for edge in edges:
+        if isinstance(edge[2], dict) and "relationship_name" in edge[2]:
+            # Neo4j / Neptune format
+            target_id = edge[1]
+            rel_name = edge[2]["relationship_name"]
+        elif isinstance(edge[1], str) and isinstance(edge[2], dict):
+            # Kuzu format: (source_dict, rel_name_str, target_dict)
+            target_id = edge[2].get("id", str(edge[2]))
+            rel_name = edge[1]
+        else:
+            # Fallback: best-effort extraction
+            target_id = edge[2].get("id", str(edge[2])) if isinstance(edge[2], dict) else str(edge[1])
+            rel_name = edge[1] if isinstance(edge[1], str) else str(edge[2])
+        result[target_id] = rel_name
+    return result
 
 
 def format_neighbors(


### PR DESCRIPTION
## Problem

`format_edges()` in `consolidate_entity_descriptions.py` assumes Neo4j's edge tuple format:

```python
(source_id, target_id, {"relationship_name": name})
```

However, the Kuzu adapter's `get_edges()` returns:

```python
(source_node_dict, relationship_name_str, target_node_dict)
```

This causes a `KeyError` on `'relationship_name'` when running entity consolidation (`memify`) with the Kuzu graph backend.

## Fix

Detect the edge tuple format at runtime:
- If `edge[2]` is a dict containing `'relationship_name'` → Neo4j/Neptune format
- If `edge[1]` is a string and `edge[2]` is a dict → Kuzu format
- Fallback with best-effort extraction for any other adapter

No changes to any adapter code. The fix is purely in the consumer (`format_edges`).

## Testing

Verified against Kuzu v0.9+ with Cognee 0.5.5. Entity consolidation pipeline now completes successfully with ~13k nodes and ~17k edges.

## Related

Affects any user running Cognee with the Kuzu graph backend and calling `consolidate_entity_descriptions_pipeline()` via `memify`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with multiple graph database formats (Neo4j, Neptune, Kuzu) for edge data processing. The system now correctly handles different edge tuple structures, ensuring consistent relationship mapping across supported database backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->