### PR TITLE
fix: handle EdgeData 4-tuples and add guards in format_edges

### DIFF
--- a/cognee/memify_pipelines/consolidate_entity_descriptions.py
+++ b/cognee/memify_pipelines/consolidate_entity_descriptions.py
@@ -60,16 +60,24 @@ def get_entity_properties(
 def format_edges(edges: List[Any]) -> Dict[str, str]:
     """Map target node IDs to relationship names.
 
-    Handles both Neo4j and Kuzu edge tuple formats:
+    Handles multiple graph adapter edge tuple formats:
     - Neo4j / Neptune: (source_id, target_id, {"relationship_name": name})
     - Kuzu:            (source_node_dict, relationship_name_str, target_node_dict)
+    - EdgeData:        (source_id, target_id, relationship_name, properties)
     """
     result = {}
     for edge in edges:
+        if not isinstance(edge, (list, tuple)) or len(edge) < 3:
+            continue
+
         if isinstance(edge[2], dict) and "relationship_name" in edge[2]:
             # Neo4j / Neptune format
             target_id = edge[1]
             rel_name = edge[2]["relationship_name"]
+        elif len(edge) >= 4 and isinstance(edge[1], str) and isinstance(edge[2], str):
+            # EdgeData: (source_id, target_id, relationship_name, properties)
+            target_id = edge[1]
+            rel_name = edge[2]
         elif isinstance(edge[1], str) and isinstance(edge[2], dict):
             # Kuzu format: (source_dict, rel_name_str, target_dict)
             target_id = edge[2].get("id", str(edge[2]))
@@ -80,7 +88,7 @@ def format_edges(edges: List[Any]) -> Dict[str, str]:
                 edge[2].get("id", str(edge[2])) if isinstance(edge[2], dict) else str(edge[1])
             )
             rel_name = edge[1] if isinstance(edge[1], str) else str(edge[2])
-        result[target_id] = rel_name
+        result[str(target_id)] = str(rel_name)
     return result
 
 


### PR DESCRIPTION
Follow-up to #2543 addressing CodeRabbit review feedback.

## Changes

1. **EdgeData 4-tuple support** — Explicitly handles `(source_id, target_id, relationship_name, properties)` format which would previously fall through to the fallback branch and misassign `target_id` as the relationship name.

2. **Guard clause** — Skips malformed edges (non-list/tuple or fewer than 3 elements) instead of raising `IndexError`.

3. **Type consistency** — Casts `target_id` and `rel_name` to `str` for consistent dict key types.

## Testing

Verified against Kuzu v0.9+ with Cognee 0.5.5. All three edge formats (Neo4j, Kuzu, EdgeData) now correctly map target IDs to relationship names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data validation and error handling to skip invalid or malformed data structures.

* **Improvements**
  * Enhanced system to support additional data format variants.
  * Normalized output formatting for consistent data type handling across integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->