### PR TITLE
fix: handle standalone newlines as paragraph boundaries in chunk_by_word

### DIFF
--- a/cognee/tasks/chunks/chunk_by_word.py
+++ b/cognee/tasks/chunks/chunk_by_word.py
@@ -71,6 +71,18 @@ def chunk_by_word(data: str) -> Iterator[Tuple[str, str]]:
             i += 1
             continue
 
+        if re.match(PARAGRAPH_ENDINGS, character):
+            # Standalone newline without preceding sentence ending — treat as paragraph boundary
+            next_i = i + 1
+            while next_i < len(data) and re.match(PARAGRAPH_ENDINGS, data[next_i]):
+                current_chunk += data[next_i]
+                next_i += 1
+
+            yield (current_chunk, "paragraph_end")
+            current_chunk = ""
+            i = next_i
+            continue
+
         if re.match(SENTENCE_ENDINGS, character):
             # Look ahead for whitespace
             next_i = i + 1


### PR DESCRIPTION
## Summary
- Fixes `chunk_by_word` to correctly detect paragraph boundaries when newlines appear without preceding sentence-ending punctuation
- Previously, text like titles, list items, and markdown headings separated by bare newlines (`\n`) were treated as continuous words instead of paragraph boundaries

## Problem
The `chunk_by_word` function only detected `paragraph_end` when newlines followed sentence-ending punctuation (`.;!?…`). This meant text like:

```
Title
First paragraph text
```

Would not split at the newline after "Title" because there's no preceding `.` or `!`.

The `is_real_paragraph_end` helper function was written to address this but was never integrated into `chunk_by_word` (dead code).

## Fix
Added newline/carriage-return detection **before** the sentence-ending check in `chunk_by_word`, so standalone newlines are correctly yielded as `paragraph_end` events. This preserves the isomorphism property (joining all chunks recreates the original text).

## Test Plan
- [ ] Verify `chunk_by_word("Title\nParagraph")` yields `paragraph_end` after "Title\n"
- [ ] Verify existing sentence-ending paragraph detection still works
- [ ] Verify joining chunked output recreates the original input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text chunking to properly handle standalone paragraph-ending characters (newlines/carriage returns), ensuring more accurate paragraph boundary detection during document processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->