### PR TITLE
fix: reset pipeline status on data deletion to allow re-ingestion

### DIFF
--- a/cognee/api/v1/datasets/datasets.py
+++ b/cognee/api/v1/datasets/datasets.py
@@ -129,6 +129,9 @@ class datasets:
         delete_dataset_if_empty: bool = False,  # if this flag is True, delete the whole dataset if it is left empty after data deletion
     ):
         from cognee.modules.data.methods import delete_data, get_data, delete_dataset
+        from cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status import (
+            reset_dataset_pipeline_run_status,
+        )
 
         if not user:
             user = await get_default_user()
@@ -150,6 +153,8 @@ class datasets:
             await set_database_global_context_variables(dataset_id, dataset.owner_id)
             await delete_data_nodes_and_edges(dataset_id, data_id, user.id)
 
+            await reset_dataset_pipeline_run_status(dataset_id, user)
+
             dataset_data = await get_dataset_data(dataset.id)
             if not dataset_data and delete_dataset_if_empty:
                 await delete_dataset(dataset)
@@ -167,6 +172,10 @@ class datasets:
             await delete_data_nodes_and_edges(dataset_id, data_id, user.id)
 
         await delete_data(data, dataset_id)
+
+        # Reset pipeline run status so that re-adding and re-cognifying the
+        # same data will not be skipped as "already completed".
+        await reset_dataset_pipeline_run_status(dataset_id, user)
 
         dataset_data = await get_dataset_data(dataset.id)
         if not dataset_data and delete_dataset_if_empty:

--- a/cognee/tasks/ingestion/ingest_data.py
+++ b/cognee/tasks/ingestion/ingest_data.py
@@ -174,6 +174,13 @@ async def ingest_data(
                 if str(data_point.id) in dataset_data_map:
                     existing_data_points.append(data_point)
                 else:
+                    # Data exists but is being (re-)added to this dataset
+                    # (e.g. after deletion). Clear per-dataset pipeline status
+                    # so that pipelines like cognify will re-process it.
+                    for pname in list(data_point.pipeline_status.keys()):
+                        statuses = data_point.pipeline_status[pname]
+                        if isinstance(statuses, dict):
+                            statuses.pop(str(dataset.id), None)
                     dataset_new_data_points.append(data_point)
                     dataset_data_map[str(data_point.id)] = True
             else:


### PR DESCRIPTION
## Summary
- After deleting a file and re-adding it to the same dataset, `cognify` would skip processing because stale pipeline state marked it as `PipelineRunAlreadyCompleted`
- `datasets.delete_data()` now calls `reset_dataset_pipeline_run_status()` after deletion, clearing the dataset-level pipeline run status so `check_pipeline_run_qualification` no longer short-circuits the next cognify
- `ingest_data()` now clears per-dataset `pipeline_status` entries when a `Data` record is re-added to a dataset it was removed from, so the data-item-level incremental check no longer skips it

## Root Cause
Two layers of pipeline state were not being cleaned up on deletion:
1. **Dataset-level** (`pipeline_runs` table): remained `DATASET_PROCESSING_COMPLETED` after data deletion
2. **Data-item-level** (`Data.pipeline_status` JSON column): when a `Data` record survived deletion (e.g. shared across datasets), its per-dataset completion status persisted, and `ingest_data` did not clear it on re-add because `content_changed` was `False`

## Test plan
- [ ] Deploy via Docker API
- [ ] Add a `.txt` file to dataset `test` via `POST /api/v1/add`
- [ ] Call `POST /api/v1/cognify` — file is ingested successfully
- [ ] Call `DELETE /api/v1/delete` to delete the file
- [ ] Re-add the same file via `POST /api/v1/add`
- [ ] Call `POST /api/v1/cognify` — verify the file is re-ingested and knowledge graph is rebuilt
- [ ] Verify that adding the same file *without* deleting first still correctly skips re-processing (incremental loading preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Fixed pipeline processing state to be properly reset when deleting data from datasets across all deletion paths, preventing stale or incorrect status from interfering with future dataset operations.
- Fixed pipeline state management when re-adding existing data records to datasets, ensuring accurate per-dataset processing status is properly maintained and tracked throughout all data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->