### PR TITLE
fix(graph): align cascade ontology resolver parameter naming

### DIFF
--- a/cognee/eval_framework/corpus_builder/task_getters/get_default_tasks_by_indices.py
+++ b/cognee/eval_framework/corpus_builder/task_getters/get_default_tasks_by_indices.py
@@ -39,9 +39,7 @@ async def get_no_summary_tasks(
     }
     if ontology_file_path is not None:
         ontology_resolver = RDFLibOntologyResolver(ontology_file=ontology_file_path)
-        graph_task_kwargs["config"] = {
-            "ontology_config": {"ontology_resolver": ontology_resolver}
-        }
+        graph_task_kwargs["config"] = {"ontology_config": {"ontology_resolver": ontology_resolver}}
 
     graph_task = Task(extract_graph_from_data, **graph_task_kwargs)
 

--- a/cognee/eval_framework/corpus_builder/task_getters/get_default_tasks_by_indices.py
+++ b/cognee/eval_framework/corpus_builder/task_getters/get_default_tasks_by_indices.py
@@ -33,12 +33,12 @@ async def get_no_summary_tasks(
     # Get base tasks (0=classify, 1=extract_chunks)
     base_tasks = await get_default_tasks_by_indices([0, 1], chunk_size, chunker)
 
-    ontology_adapter = RDFLibOntologyResolver(ontology_file=ontology_file_path)
+    ontology_resolver = RDFLibOntologyResolver(ontology_file=ontology_file_path)
 
     graph_task = Task(
         extract_graph_from_data,
         graph_model=graph_model,
-        ontology_adapter=ontology_adapter,
+        config={"ontology_config": {"ontology_resolver": ontology_resolver}},
         task_config={"batch_size": 10},
     )
 

--- a/cognee/eval_framework/corpus_builder/task_getters/get_default_tasks_by_indices.py
+++ b/cognee/eval_framework/corpus_builder/task_getters/get_default_tasks_by_indices.py
@@ -33,14 +33,17 @@ async def get_no_summary_tasks(
     # Get base tasks (0=classify, 1=extract_chunks)
     base_tasks = await get_default_tasks_by_indices([0, 1], chunk_size, chunker)
 
-    ontology_resolver = RDFLibOntologyResolver(ontology_file=ontology_file_path)
+    graph_task_kwargs = {
+        "graph_model": graph_model,
+        "task_config": {"batch_size": 10},
+    }
+    if ontology_file_path is not None:
+        ontology_resolver = RDFLibOntologyResolver(ontology_file=ontology_file_path)
+        graph_task_kwargs["config"] = {
+            "ontology_config": {"ontology_resolver": ontology_resolver}
+        }
 
-    graph_task = Task(
-        extract_graph_from_data,
-        graph_model=graph_model,
-        config={"ontology_config": {"ontology_resolver": ontology_resolver}},
-        task_config={"batch_size": 10},
-    )
+    graph_task = Task(extract_graph_from_data, **graph_task_kwargs)
 
     add_data_points_task = Task(add_data_points, task_config={"batch_size": 10})
 

--- a/cognee/tasks/graph/extract_graph_from_data_v2.py
+++ b/cognee/tasks/graph/extract_graph_from_data_v2.py
@@ -21,7 +21,7 @@ from cognee.modules.pipelines.tasks.task import task_summary
 async def extract_graph_from_data(
     data_chunks: List[DocumentChunk],
     n_rounds: int = 2,
-    ontology_adapter: BaseOntologyResolver = None,
+    ontology_resolver: BaseOntologyResolver = None,
 ) -> List[DocumentChunk]:
     """Extract and update graph data from document chunks using cascade extraction.
 
@@ -31,7 +31,7 @@ async def extract_graph_from_data(
     Args:
         data_chunks: List of document chunks to process
         n_rounds: Number of extraction rounds to perform (default: 2)
-        ontology_adapter: Resolver for validating entities against ontology
+        ontology_resolver: Resolver for validating entities against ontology
 
     Returns:
         List of updated DocumentChunk objects with extracted graph data
@@ -60,5 +60,5 @@ async def extract_graph_from_data(
         data_chunks=data_chunks,
         chunk_graphs=chunk_graphs,
         graph_model=KnowledgeGraph,
-        ontology_adapter=ontology_adapter,
+        ontology_resolver=ontology_resolver,
     )

--- a/cognee/tests/unit/eval_framework/test_get_default_tasks_by_indices.py
+++ b/cognee/tests/unit/eval_framework/test_get_default_tasks_by_indices.py
@@ -34,3 +34,22 @@ async def test_get_no_summary_tasks_passes_ontology_resolver_via_config(
         "ontology_config": {"ontology_resolver": ontology_resolver}
     }
     assert "ontology_adapter" not in graph_task.default_params["kwargs"]
+
+
+@pytest.mark.asyncio
+@patch.object(task_getter_module, "get_default_tasks", new_callable=AsyncMock)
+async def test_get_no_summary_tasks_omits_config_when_no_ontology_file(
+    mock_get_default_tasks,
+):
+    mock_get_default_tasks.return_value = [
+        Task(lambda: None),
+        Task(lambda: None),
+        Task(lambda: None),
+    ]
+
+    tasks = await task_getter_module.get_no_summary_tasks()
+
+    graph_task = tasks[2]
+
+    assert graph_task.executable is task_getter_module.extract_graph_from_data
+    assert "config" not in graph_task.default_params["kwargs"]

--- a/cognee/tests/unit/eval_framework/test_get_default_tasks_by_indices.py
+++ b/cognee/tests/unit/eval_framework/test_get_default_tasks_by_indices.py
@@ -1,0 +1,36 @@
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognee.modules.pipelines.tasks.task import Task
+
+task_getter_module = importlib.import_module(
+    "cognee.eval_framework.corpus_builder.task_getters.get_default_tasks_by_indices"
+)
+
+
+@pytest.mark.asyncio
+@patch.object(task_getter_module, "RDFLibOntologyResolver")
+@patch.object(task_getter_module, "get_default_tasks", new_callable=AsyncMock)
+async def test_get_no_summary_tasks_passes_ontology_resolver_via_config(
+    mock_get_default_tasks,
+    mock_ontology_resolver_class,
+):
+    mock_get_default_tasks.return_value = [
+        Task(lambda: None),
+        Task(lambda: None),
+        Task(lambda: None),
+    ]
+    ontology_resolver = MagicMock()
+    mock_ontology_resolver_class.return_value = ontology_resolver
+
+    tasks = await task_getter_module.get_no_summary_tasks(ontology_file_path="ontology.rdf")
+
+    graph_task = tasks[2]
+
+    assert graph_task.executable is task_getter_module.extract_graph_from_data
+    assert graph_task.default_params["kwargs"]["config"] == {
+        "ontology_config": {"ontology_resolver": ontology_resolver}
+    }
+    assert "ontology_adapter" not in graph_task.default_params["kwargs"]

--- a/cognee/tests/unit/tasks/graph/test_extract_graph_from_data_v2.py
+++ b/cognee/tests/unit/tasks/graph/test_extract_graph_from_data_v2.py
@@ -1,0 +1,47 @@
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognee.shared.data_models import KnowledgeGraph
+
+cascade_module = importlib.import_module("cognee.tasks.graph.extract_graph_from_data_v2")
+
+
+@pytest.mark.asyncio
+@patch.object(cascade_module, "integrate_chunk_graphs", new_callable=AsyncMock)
+@patch.object(cascade_module, "extract_edge_triplets", new_callable=AsyncMock)
+@patch.object(
+    cascade_module,
+    "extract_content_nodes_and_relationship_names",
+    new_callable=AsyncMock,
+)
+@patch.object(cascade_module, "extract_nodes", new_callable=AsyncMock)
+async def test_extract_graph_from_data_passes_ontology_resolver(
+    mock_extract_nodes,
+    mock_extract_content_nodes_and_relationship_names,
+    mock_extract_edge_triplets,
+    mock_integrate_chunk_graphs,
+):
+    chunk = MagicMock(text="chunk text")
+    ontology_resolver = MagicMock()
+
+    mock_extract_nodes.return_value = ["node"]
+    mock_extract_content_nodes_and_relationship_names.return_value = (
+        ["node"],
+        ["relationship"],
+    )
+    mock_extract_edge_triplets.return_value = MagicMock(name="chunk_graph")
+    mock_integrate_chunk_graphs.return_value = [chunk]
+
+    result = await cascade_module.extract_graph_from_data(
+        [chunk], ontology_resolver=ontology_resolver
+    )
+
+    assert result == [chunk]
+    mock_integrate_chunk_graphs.assert_awaited_once_with(
+        data_chunks=[chunk],
+        chunk_graphs=[mock_extract_edge_triplets.return_value],
+        graph_model=KnowledgeGraph,
+        ontology_resolver=ontology_resolver,
+    )


### PR DESCRIPTION
Fixes #2556

## Description

While going through the cascade graph extraction path (`extract_graph_from_data_v2.py`), I noticed the function passes `ontology_adapter=` as a keyword argument to `integrate_chunk_graphs()`. 
However, that function's signature expects `ontology_resolver=`. Because `integrate_chunk_graphs` accepts `**kwargs`, the wrong keyword gets silently swallowed, and `ontology_resolver` ends up as a missing required positional argument.
That causes a TypeError at runtime.

Additionally, the same naming inconsistency existed in `get_default_tasks_by_indices.py`, where `ontology_adapter` was being passed as a task kwarg instead of going through the expected `config["ontology_config"]["ontology_resolver"]` path.

### Changes:
- Renamed `ontology_adapter` → `ontology_resolver` in `extract_graph_from_data_v2.py` (function parameter + call site)
- Updated `get_no_summary_tasks()` in `get_default_tasks_by_indices.py` to pass the resolver via the `config` dict, consistent with how the v1 extraction path does it
- Added two unit tests verifying the parameter is correctly forwarded

## Acceptance Criteria

- `extract_graph_from_data_v2.extract_graph_from_data()` correctly passes `ontology_resolver=` to `integrate_chunk_graphs()`
- `get_no_summary_tasks()` passes the resolver through the config dict, matching the v1 path convention
- New tests verify both call sites

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<img width="2560" height="941" alt="image" src="https://github.com/user-attachments/assets/5a1515d7-5152-410e-a113-32a12a467f9b" />


## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Graph extraction tasks now treat ontology integration as optional and configuration-driven; parameter name updated for clarity.
* **Bug Fixes**
  * Ensured ontology is only instantiated when provided and not passed inadvertently.
* **Tests**
  * Added unit tests verifying optional ontology handling and correct forwarding of parameters in graph extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->