### PR TITLE
fix: pipeline dataset passthrough, race condition, and provenance perf

### DIFF
--- a/cognee/modules/pipelines/models/PipelineContext.py
+++ b/cognee/modules/pipelines/models/PipelineContext.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 
 @dataclass
@@ -15,7 +15,7 @@ class PipelineContext:
                 custom_val = ctx.extras.get("my_key")
 
     The pipeline machinery passes ``ctx`` to any task whose signature
-    includes a parameter named ``ctx`` with type ``PipelineContext``.
+    includes a parameter named ``ctx`` (matched by name, not by type annotation).
 
     Custom pipelines can store additional state in ``extras``.
     """
@@ -25,3 +25,7 @@ class PipelineContext:
     dataset: Any = None
     pipeline_name: Optional[str] = None
     extras: Dict[str, Any] = field(default_factory=dict)
+
+    # Internal: persisted across tasks so _stamp_provenance skips
+    # DataPoints that were already walked in earlier pipeline stages.
+    _provenance_visited: Set[int] = field(default_factory=set, repr=False)

--- a/cognee/modules/pipelines/operations/run_pipeline.py
+++ b/cognee/modules/pipelines/operations/run_pipeline.py
@@ -86,6 +86,7 @@ async def run_pipeline(
     # Build typed context — pass caller-supplied context dict as extras
     ctx = PipelineContext(
         user=user,
+        dataset=dataset,
         pipeline_name=pipeline_name,
         extras=context if isinstance(context, dict) else {},
     )

--- a/cognee/modules/pipelines/operations/run_tasks_base.py
+++ b/cognee/modules/pipelines/operations/run_tasks_base.py
@@ -33,7 +33,12 @@ def _build_result_summary(executable, task_name: str, count: int) -> str:
 def _stamp_provenance(
     data, pipeline_name, task_name, visited=None, node_set=None, user_label=None, content_hash=None
 ):
-    """Recursively stamp DataPoints with provenance. Only sets if currently None."""
+    """Recursively stamp DataPoints with provenance. Only sets if currently None.
+
+    The ``visited`` set should be persisted across task calls (via
+    PipelineContext._provenance_visited) so that DataPoints stamped in
+    earlier stages are skipped in later ones.
+    """
     if visited is None:
         visited = set()
 
@@ -88,6 +93,8 @@ def _stamp_provenance(
 def _extract_node_set(args):
     """Extract source_node_set from input args to propagate across task boundaries."""
     for arg in args:
+        if isinstance(arg, DataPoint) and arg.source_node_set is not None:
+            return arg.source_node_set
         if isinstance(arg, (list, tuple)):
             for item in arg:
                 if isinstance(item, DataPoint) and item.source_node_set is not None:
@@ -102,6 +109,8 @@ def _extract_content_hash(args):
     for arg in args:
         if isinstance(arg, Data) and arg.content_hash is not None:
             return arg.content_hash
+        if isinstance(arg, DataPoint) and arg.source_content_hash is not None:
+            return arg.source_content_hash
         if isinstance(arg, (list, tuple)):
             for item in arg:
                 if isinstance(item, Data) and item.content_hash is not None:
@@ -150,6 +159,9 @@ async def handle_task(
             input_node_set = _extract_node_set(args)
             input_content_hash = _extract_content_hash(args)
             user_label = getattr(user, "email", None) or (str(user.id) if user else None)
+            # Reuse the visited set across tasks so already-stamped
+            # DataPoints are skipped in subsequent pipeline stages.
+            provenance_visited = ctx._provenance_visited if ctx else None
 
             async for result_data in running_task.execute(args, kwargs, next_task_batch_size):
                 if isinstance(result_data, list):
@@ -161,6 +173,7 @@ async def handle_task(
                     result_data,
                     pipe_name,
                     task_name,
+                    visited=provenance_visited,
                     node_set=input_node_set,
                     user_label=user_label,
                     content_hash=input_content_hash,

--- a/cognee/modules/pipelines/tasks/task.py
+++ b/cognee/modules/pipelines/tasks/task.py
@@ -183,7 +183,6 @@ class Task:
     task_type: str = None
     enriches: bool = False
     _execute_method: Callable = None
-    _next_batch_size: int = 1
 
     def __init__(
         self, executable, *args, task_config=None, batch_size=None, enriches=False, **kwargs
@@ -249,7 +248,7 @@ class Task:
 
         return self.executable(*combined_args, **combined_kwargs)
 
-    async def execute_async_generator(self, args, kwargs):
+    async def execute_async_generator(self, args, kwargs, batch_size):
         """Execute async generator task and collect results in batches."""
         results = []
         async_iterator = self.run(*args, **kwargs)
@@ -259,14 +258,14 @@ class Task:
                 continue
             results.append(partial_result)
 
-            if len(results) == self._next_batch_size:
+            if len(results) == batch_size:
                 yield results
                 results = []
 
         if results:
             yield results
 
-    async def execute_generator(self, args, kwargs):
+    async def execute_generator(self, args, kwargs, batch_size):
         """Execute generator task and collect results in batches."""
         results = []
 
@@ -275,14 +274,14 @@ class Task:
                 continue
             results.append(partial_result)
 
-            if len(results) == self._next_batch_size:
+            if len(results) == batch_size:
                 yield results
                 results = []
 
         if results:
             yield results
 
-    async def execute_coroutine(self, args, kwargs):
+    async def execute_coroutine(self, args, kwargs, batch_size):
         """Execute coroutine task and yield the result."""
         task_result = await self.run(*args, **kwargs)
         if isinstance(task_result, _Drop):
@@ -292,7 +291,7 @@ class Task:
             return
         yield task_result
 
-    async def execute_function(self, args, kwargs):
+    async def execute_function(self, args, kwargs, batch_size):
         """Execute function task and yield the result."""
         task_result = self.run(*args, **kwargs)
         if isinstance(task_result, _Drop):
@@ -304,8 +303,7 @@ class Task:
 
     async def execute(self, args, kwargs, next_batch_size=None):
         """Execute the task based on its type and yield results with the next task's batch size."""
-        if next_batch_size is not None:
-            self._next_batch_size = next_batch_size
+        batch_size = next_batch_size if next_batch_size is not None else 1
 
-        async for result in self._execute_method(args, kwargs):
+        async for result in self._execute_method(args, kwargs, batch_size):
             yield result

--- a/cognee/pipelines/__init__.py
+++ b/cognee/pipelines/__init__.py
@@ -24,7 +24,7 @@ _LEGACY_IMPORTS = {
     "task": "cognee.modules.pipelines.tasks.task",
     "run_tasks": "cognee.modules.pipelines.operations.run_tasks",
     "run_tasks_parallel": "cognee.modules.pipelines.operations.run_parallel",
-    "run_pipeline": "cognee.modules.pipelines.operations.pipeline",
+    "run_pipeline": "cognee.modules.pipelines.operations.run_pipeline",
 }
 
 

--- a/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
@@ -684,7 +684,8 @@ class TestRememberResult:
                 AsyncMock(return_value=mock_user),
             ),
             patch.object(
-                _mod_sm, "get_session_manager",
+                _mod_sm,
+                "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -787,7 +788,8 @@ class TestSearchSession:
 
         with (
             patch.object(
-                _mod_sm, "get_session_manager",
+                _mod_sm,
+                "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -819,7 +821,8 @@ class TestSearchSession:
 
         with (
             patch.object(
-                _mod_sm, "get_session_manager",
+                _mod_sm,
+                "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -847,7 +850,8 @@ class TestSearchSession:
 
         with (
             patch.object(
-                _mod_sm, "get_session_manager",
+                _mod_sm,
+                "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -869,7 +873,8 @@ class TestSearchSession:
 
         with (
             patch.object(
-                _mod_sm, "get_session_manager",
+                _mod_sm,
+                "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -895,7 +900,8 @@ class TestSearchSession:
 
         with (
             patch.object(
-                _mod_sm, "get_session_manager",
+                _mod_sm,
+                "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -959,7 +965,8 @@ class TestRecallSessionMode:
                 AsyncMock(return_value=mock_graph_results),
             ),
             patch.object(
-                _mod_query_router, "route_query",
+                _mod_query_router,
+                "route_query",
                 return_value=MagicMock(search_type=MagicMock()),
             ),
         ):

--- a/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import sys
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,9 +15,16 @@ from cognee.tasks.memify.sync_graph_to_session import (
 
 sync_module = sys.modules["cognee.tasks.memify.sync_graph_to_session"]
 
-# Patch paths for lazy imports inside sync_graph_to_session()
-_PATCH_GET_CACHE = "cognee.infrastructure.databases.cache.get_cache_engine.get_cache_engine"
-_PATCH_GET_SM = "cognee.infrastructure.session.get_session_manager.get_session_manager"
+# Import actual modules via importlib to avoid __init__.py name shadowing.
+# Several __init__.py files re-export functions with the same name as their
+# module (e.g., `from .get_session_manager import get_session_manager`),
+# which causes mock.patch()'s getattr-based resolution to find the function
+# instead of the submodule on Python ≤3.12.
+_mod_sm = importlib.import_module("cognee.infrastructure.session.get_session_manager")
+_mod_cache = importlib.import_module("cognee.infrastructure.databases.cache.get_cache_engine")
+_pkg_improve = importlib.import_module("cognee.api.v2.improve")
+_mod_query_router = importlib.import_module("cognee.api.v2.recall.query_router")
+
 _PATCH_GET_REL = "cognee.tasks.memify.sync_graph_to_session.get_relational_engine"
 
 
@@ -154,8 +162,8 @@ async def test_sync_no_new_edges():
     db_engine = _mock_db_engine_empty()
 
     with (
-        patch(_PATCH_GET_SM, return_value=sm),
-        patch(_PATCH_GET_CACHE, return_value=cache_engine),
+        patch.object(_mod_sm, "get_session_manager", return_value=sm),
+        patch.object(_mod_cache, "get_cache_engine", return_value=cache_engine),
         patch(_PATCH_GET_REL, return_value=db_engine),
     ):
         result = await sync_graph_to_session(
@@ -179,8 +187,8 @@ async def test_sync_cache_unavailable():
     sm.is_available = False
 
     with (
-        patch(_PATCH_GET_SM, return_value=sm),
-        patch(_PATCH_GET_CACHE, return_value=None),
+        patch.object(_mod_sm, "get_session_manager", return_value=sm),
+        patch.object(_mod_cache, "get_cache_engine", return_value=None),
     ):
         result = await sync_graph_to_session(
             user_id="u1",
@@ -212,8 +220,8 @@ async def test_sync_merges_with_existing():
     db_engine = _mock_db_engine_returning([edge], [n1, n2])
 
     with (
-        patch(_PATCH_GET_SM, return_value=sm),
-        patch(_PATCH_GET_CACHE, return_value=cache_engine),
+        patch.object(_mod_sm, "get_session_manager", return_value=sm),
+        patch.object(_mod_cache, "get_cache_engine", return_value=cache_engine),
         patch(_PATCH_GET_REL, return_value=db_engine),
     ):
         result = await sync_graph_to_session(
@@ -254,8 +262,8 @@ async def test_sync_caps_at_max_lines():
     db_engine = _mock_db_engine_returning(edges, list(nodes.values()))
 
     with (
-        patch(_PATCH_GET_SM, return_value=sm),
-        patch(_PATCH_GET_CACHE, return_value=cache_engine),
+        patch.object(_mod_sm, "get_session_manager", return_value=sm),
+        patch.object(_mod_cache, "get_cache_engine", return_value=cache_engine),
         patch(_PATCH_GET_REL, return_value=db_engine),
     ):
         result = await sync_graph_to_session(
@@ -426,7 +434,7 @@ async def test_remember_passes_session_ids_to_improve():
     with (
         patch("cognee.api.v1.add.add", AsyncMock()),
         patch("cognee.api.v1.cognify.cognify", AsyncMock(return_value={"status": "ok"})),
-        patch("cognee.api.v2.improve.improve", mock_improve),
+        patch.object(_pkg_improve, "improve", mock_improve),
         patch(
             "cognee.modules.users.methods.get_default_user",
             AsyncMock(return_value=mock_user),
@@ -460,7 +468,7 @@ async def test_remember_no_session_ids_skips_in_improve():
     with (
         patch("cognee.api.v1.add.add", AsyncMock()),
         patch("cognee.api.v1.cognify.cognify", AsyncMock(return_value={"status": "ok"})),
-        patch("cognee.api.v2.improve.improve", mock_improve),
+        patch.object(_pkg_improve, "improve", mock_improve),
         patch(
             "cognee.modules.users.methods.get_default_user",
             AsyncMock(return_value=mock_user),
@@ -644,7 +652,7 @@ class TestRememberResult:
                 "cognee.api.v1.cognify.cognify",
                 AsyncMock(return_value={}),
             ),
-            patch("cognee.api.v2.improve.improve", AsyncMock()),
+            patch.object(_pkg_improve, "improve", AsyncMock()),
             patch(
                 "cognee.modules.users.methods.get_default_user",
                 AsyncMock(return_value=mock_user),
@@ -675,8 +683,8 @@ class TestRememberResult:
                 "cognee.modules.users.methods.get_default_user",
                 AsyncMock(return_value=mock_user),
             ),
-            patch(
-                "cognee.infrastructure.session.get_session_manager.get_session_manager",
+            patch.object(
+                _mod_sm, "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -740,7 +748,7 @@ class TestRememberResultSessions:
         with (
             patch("cognee.api.v1.add.add", AsyncMock()),
             patch("cognee.api.v1.cognify.cognify", AsyncMock(return_value={})),
-            patch("cognee.api.v2.improve.improve", AsyncMock()),
+            patch.object(_pkg_improve, "improve", AsyncMock()),
             patch(
                 "cognee.modules.users.methods.get_default_user",
                 AsyncMock(return_value=mock_user),
@@ -778,8 +786,8 @@ class TestSearchSession:
         mock_sm.get_session = AsyncMock(return_value=entries)
 
         with (
-            patch(
-                "cognee.infrastructure.session.get_session_manager.get_session_manager",
+            patch.object(
+                _mod_sm, "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -810,8 +818,8 @@ class TestSearchSession:
         mock_sm.get_session = AsyncMock(return_value=entries)
 
         with (
-            patch(
-                "cognee.infrastructure.session.get_session_manager.get_session_manager",
+            patch.object(
+                _mod_sm, "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -838,8 +846,8 @@ class TestSearchSession:
         mock_sm.get_session = AsyncMock(return_value=entries)
 
         with (
-            patch(
-                "cognee.infrastructure.session.get_session_manager.get_session_manager",
+            patch.object(
+                _mod_sm, "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -860,8 +868,8 @@ class TestSearchSession:
         mock_sm.get_session = AsyncMock(return_value=[])
 
         with (
-            patch(
-                "cognee.infrastructure.session.get_session_manager.get_session_manager",
+            patch.object(
+                _mod_sm, "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -886,8 +894,8 @@ class TestSearchSession:
         mock_sm.get_session = AsyncMock(return_value=entries)
 
         with (
-            patch(
-                "cognee.infrastructure.session.get_session_manager.get_session_manager",
+            patch.object(
+                _mod_sm, "get_session_manager",
                 return_value=mock_sm,
             ),
         ):
@@ -950,8 +958,8 @@ class TestRecallSessionMode:
                 "cognee.api.v1.search.search",
                 AsyncMock(return_value=mock_graph_results),
             ),
-            patch(
-                "cognee.api.v2.recall.query_router.route_query",
+            patch.object(
+                _mod_query_router, "route_query",
                 return_value=MagicMock(search_type=MagicMock()),
             ),
         ):


### PR DESCRIPTION
## Summary

- **`run_pipeline` ignores `dataset`**: The `dataset` parameter was accepted but never passed to `PipelineContext`, so tasks like `add_data_points` that gate ownership upserts on `ctx.dataset` never took that path.
- **`cognee.pipelines.run_pipeline` resolves to old runner**: The lazy import mapped to the old dataset-backed `pipeline.py` module, not the new BoundTask-based `run_pipeline.py`. Callers following the module docstring would get a runtime error.
- **`PipelineContext` docstring claims type-based ctx injection**: The runtime check is name-only (`"ctx" in signature`), not type-based. Fixed the docstring.
- **`_extract_node_set` / `_extract_content_hash` miss scalar DataPoints**: Both only searched inside lists. A task returning a scalar DataPoint wouldn't propagate provenance forward.
- **`Task._next_batch_size` race condition**: `TaskSpec` reuses the same `Task` instance across calls with no config overrides. `_next_batch_size` was mutated during `execute()`, creating a race if concurrent pipelines share a `TaskSpec`. Fixed by passing `batch_size` as a parameter through the execute chain.
- **`_stamp_provenance` re-walks entire graph per task**: The `visited` set was created fresh each call. Now persisted on `PipelineContext._provenance_visited` so DataPoints stamped by earlier tasks are skipped in later stages.

## Test plan

- [x] All 42 existing pipeline unit tests pass (`cognee/tests/unit/pipelines/`)
- [ ] Verify `add_data_points` ownership upserts fire when `dataset` is passed to `run_pipeline`
- [ ] Verify enrichment pipelines with large graphs see reduced overhead from provenance stamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure dataset is included in pipeline context during execution
  * Prevent duplicate processing of DataPoints across pipeline stages by persisting provenance tracking

* **Refactor**
  * Simplified and clarified batch-size handling in task execution

* **Documentation**
  * Clarified how task context values are matched by parameter name

* **Tests**
  * Updated unit tests to use pre-imports and more robust mocking approaches

* **Chores**
  * Updated legacy re-export for pipeline entrypoint import mapping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->