### PR TITLE
docs: update supported backends in .env.template for ENABLE_BACKEND_A…

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -256,8 +256,8 @@ REQUIRE_AUTHENTICATION=False
 # Set this variable to True to enforce usage of backend access control for Cognee
 # Note: This is only currently supported by the following databases:
 #       Relational: SQLite, Postgres
-#       Vector: LanceDB
-#       Graph: KuzuDB
+#       Vector: LanceDB, pgvector
+#       Graph: KuzuDB, neo4j_aura_dev
 #
 # It enforces creation of databases per Cognee user + dataset. Does not work with some graph and database providers.
 # Disable mode when using not supported graph/vector databases.


### PR DESCRIPTION
Fixes #2155

The comment above `ENABLE_BACKEND_ACCESS_CONTROL` in `.env.template` 
only listed LanceDB and KuzuDB as supported backends, but pgvector 
and neo4j_aura_dev are also supported, as confirmed in 
`supported_dataset_database_handlers.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend configuration documentation to include additional supported providers for vector and graph backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->