### PR TITLE
feat: auto-verify @cognee.agent users on registration

### DIFF
--- a/cognee/modules/users/get_user_manager.py
+++ b/cognee/modules/users/get_user_manager.py
@@ -33,6 +33,15 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_register(self, user: User, request: Optional[Request] = None):
         logger.info("User %s has registered.", user.id)
 
+        # Auto-verify and promote agent users (@cognee.agent emails).
+        # Agents register programmatically and don't go through email
+        # verification. They need verified+superuser status to access
+        # protected endpoints (remember, cognify, etc.).
+        if user.email and user.email.endswith("@cognee.agent"):
+            user_update = {"is_verified": True, "is_superuser": True}
+            await self.update(user_update, user)
+            logger.info("Agent %s auto-verified and promoted.", user.email)
+
     async def on_after_forgot_password(
         self, user: User, token: str, request: Optional[Request] = None
     ):


### PR DESCRIPTION
## Summary
- Auto-verify and promote agent users (`@cognee.agent` emails) in `UserManager.on_after_register()`
- Sets `is_verified=true` and `is_superuser=true` immediately after registration
- Agents register programmatically and don't go through email verification, but need full access to protected endpoints

This enables agent plugins (Claude Code, Hermes, MCP) to self-register via `POST /api/v1/auth/register` and immediately use all API endpoints without manual admin intervention.

## Test plan
- [ ] Register a new agent: `POST /api/v1/auth/register` with email `test-agent@cognee.agent`
- [ ] Verify the response shows `is_verified: true, is_superuser: true`
- [ ] Verify the agent can call `/api/v2/remember` with its own API key
- [ ] Verify non-agent registrations (`@example.com`) remain `is_verified: false`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User registration process now automatically verifies and grants elevated access permissions for accounts registered with specific email domain addresses, streamlining onboarding workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->