### PR TITLE
fix: accept single string or UUID for datasets/dataset_ids in cognify and search DTOs

### DIFF
--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -1,8 +1,8 @@
 import os
 import asyncio
 from uuid import UUID
-from pydantic import Field
-from typing import List, Optional
+from pydantic import Field, field_validator
+from typing import List, Optional, Union
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from fastapi import APIRouter, WebSocket, Depends, WebSocketDisconnect, status
@@ -39,8 +39,23 @@ logger = get_logger("api.cognify")
 
 
 class CognifyPayloadDTO(InDTO):
-    datasets: Optional[List[str]] = Field(default=None)
-    dataset_ids: Optional[List[UUID]] = Field(default=None, examples=[[]])
+    datasets: Optional[Union[str, List[str]]] = Field(default=None)
+    dataset_ids: Optional[Union[UUID, List[UUID]]] = Field(default=None, examples=[[]])
+
+    @field_validator("datasets", mode="before")
+    @classmethod
+    def coerce_datasets_to_list(cls, v):
+        if isinstance(v, str):
+            return [v]
+        return v
+
+    @field_validator("dataset_ids", mode="before")
+    @classmethod
+    def coerce_dataset_ids_to_list(cls, v):
+        if isinstance(v, (str, UUID)):
+            return [v]
+        return v
+
     run_in_background: Optional[bool] = Field(default=False)
     graph_model: Optional[dict] = Field(default=None, examples=[{}])
     custom_prompt: Optional[str] = Field(

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -2,7 +2,7 @@ import os
 import asyncio
 from uuid import UUID
 from pydantic import Field, field_validator
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from fastapi import APIRouter, WebSocket, Depends, WebSocketDisconnect, status
@@ -44,14 +44,16 @@ class CognifyPayloadDTO(InDTO):
 
     @field_validator("datasets", mode="before")
     @classmethod
-    def coerce_datasets_to_list(cls, v):
+    def coerce_datasets_to_list(cls, v: Any) -> Any:
+        """Coerce a single dataset name string into a one-element list."""
         if isinstance(v, str):
             return [v]
         return v
 
     @field_validator("dataset_ids", mode="before")
     @classmethod
-    def coerce_dataset_ids_to_list(cls, v):
+    def coerce_dataset_ids_to_list(cls, v: Any) -> Any:
+        """Coerce a single dataset UUID (or its string representation) into a one-element list."""
         if isinstance(v, (str, UUID)):
             return [v]
         return v

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 from typing import Optional, Union, List, Any
 from datetime import datetime
-from pydantic import Field
+from pydantic import Field, field_validator
 from fastapi import Depends, APIRouter, status
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -24,8 +24,23 @@ from cognee.api.DTO import ErrorResponse
 #       To search for datasets not owned by the request sender dataset UUID is needed
 class SearchPayloadDTO(InDTO):
     search_type: SearchType = Field(default=SearchType.GRAPH_COMPLETION)
-    datasets: Optional[list[str]] = Field(default=None)
-    dataset_ids: Optional[list[UUID]] = Field(default=None, examples=[[]])
+    datasets: Optional[Union[str, list[str]]] = Field(default=None)
+    dataset_ids: Optional[Union[UUID, list[UUID]]] = Field(default=None, examples=[[]])
+
+    @field_validator("datasets", mode="before")
+    @classmethod
+    def coerce_datasets_to_list(cls, v):
+        if isinstance(v, str):
+            return [v]
+        return v
+
+    @field_validator("dataset_ids", mode="before")
+    @classmethod
+    def coerce_dataset_ids_to_list(cls, v):
+        if isinstance(v, (str, UUID)):
+            return [v]
+        return v
+
     query: str = Field(default="What is in the document?")
     system_prompt: Optional[str] = Field(
         default="Answer the question using the provided context. Be as brief as possible."

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -29,14 +29,16 @@ class SearchPayloadDTO(InDTO):
 
     @field_validator("datasets", mode="before")
     @classmethod
-    def coerce_datasets_to_list(cls, v):
+    def coerce_datasets_to_list(cls, v: Any) -> Any:
+        """Coerce a single dataset name string into a one-element list."""
         if isinstance(v, str):
             return [v]
         return v
 
     @field_validator("dataset_ids", mode="before")
     @classmethod
-    def coerce_dataset_ids_to_list(cls, v):
+    def coerce_dataset_ids_to_list(cls, v: Any) -> Any:
+        """Coerce a single dataset UUID (or its string representation) into a one-element list."""
         if isinstance(v, (str, UUID)):
             return [v]
         return v

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -179,6 +179,33 @@ class TestCognifyEndpoint:
         assert resp.status_code == 500
         assert resp.json()["error"] == "Internal server error"
 
+    def test_cognify_accepts_single_dataset_string(self, client):
+        import cognee.api.v1.cognify as cognify_pkg
+
+        completed = _make_completed()
+        cognify_pkg.cognify = AsyncMock(return_value={str(MOCK_DATASET_ID): completed})
+
+        resp = client.post(
+            "/cognify",
+            json={"datasets": "test_dataset"},
+        )
+        assert resp.status_code == 200
+        call_args = cognify_pkg.cognify.call_args
+        datasets_arg = call_args.args[0] if call_args.args else call_args.kwargs.get("datasets")
+        assert datasets_arg == ["test_dataset"]
+
+    def test_cognify_accepts_single_dataset_id(self, client):
+        import cognee.api.v1.cognify as cognify_pkg
+
+        completed = _make_completed()
+        cognify_pkg.cognify = AsyncMock(return_value={str(MOCK_DATASET_ID): completed})
+
+        resp = client.post(
+            "/cognify",
+            json={"dataset_ids": str(MOCK_DATASET_ID)},
+        )
+        assert resp.status_code == 200
+
 
 # ---------------------------------------------------------------------------
 # Search endpoint
@@ -238,6 +265,32 @@ class TestSearchEndpoint:
         )
         assert resp.status_code == 500
         assert resp.json()["error"] == "Internal server error"
+
+    def test_search_accepts_single_dataset_string(self, client):
+        import cognee.api.v1.search as search_pkg
+
+        search_pkg.search = AsyncMock(return_value=[])
+
+        resp = client.post(
+            "/search",
+            json={"query": "What is Cognee?", "datasets": "test_dataset"},
+        )
+        assert resp.status_code == 200
+        call_kwargs = search_pkg.search.call_args.kwargs
+        assert call_kwargs["datasets"] == ["test_dataset"]
+
+    def test_search_accepts_single_dataset_id(self, client):
+        import cognee.api.v1.search as search_pkg
+
+        search_pkg.search = AsyncMock(return_value=[])
+
+        resp = client.post(
+            "/search",
+            json={"query": "What is Cognee?", "dataset_ids": str(MOCK_DATASET_ID)},
+        )
+        assert resp.status_code == 200
+        call_kwargs = search_pkg.search.call_args.kwargs
+        assert call_kwargs["dataset_ids"] == [MOCK_DATASET_ID]
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -205,6 +205,9 @@ class TestCognifyEndpoint:
             json={"dataset_ids": str(MOCK_DATASET_ID)},
         )
         assert resp.status_code == 200
+        body = resp.json()
+        assert str(MOCK_DATASET_ID) in body
+        assert body[str(MOCK_DATASET_ID)]["status"] == "completed"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The `CognifyPayloadDTO` and `SearchPayloadDTO` had a type mismatch with the underlying core functions they call. The DTOs required `List[str]` / `List[UUID]` for `datasets` and `dataset_ids`, but the core `cognify()` and `search()` functions both accept single `str` or `UUID` values. This meant REST API callers always had to wrap single dataset names in a list, while the Python SDK users could pass a bare string.

This PR adds Pydantic `field_validator` coercions on both DTOs so a single string or UUID is automatically normalized to a single-element list before being forwarded to the core functions. Existing list inputs and `None` are passed through unchanged.

Scope is intentionally limited to the `datasets` / `dataset_ids` fields on cognify and search — the `add` / `update` file-upload endpoints involve more complex multipart handling and are tracked separately.

## Acceptance Criteria

* `POST /v1/cognify` with `{"datasets": "my_dataset"}` (bare string) is accepted and treated identically to `{"datasets": ["my_dataset"]}`
* `POST /v1/cognify` with `{"dataset_ids": "<uuid>"}` (bare UUID string) is accepted and treated identically to `{"dataset_ids": ["<uuid>"]}`
* Same coercions apply to `POST /v1/search`
* All existing list-based calls continue to work unchanged
* Unit tests covering each new input shape pass

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

```
=============================== 22 passed, 53 warnings in 2.61s ========================
```
All 22 tests pass (18 existing + 4 new).

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Closes #2049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The /cognify and /search endpoints now accept dataset parameters as either a single value or a list (for both dataset names and dataset IDs), improving request flexibility and usability.

* **Tests**
  * Added unit tests confirming single-value dataset and dataset ID inputs are accepted and normalized for both /cognify and /search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->