### PR TITLE
fix(llm): respect user's LLM_MAX_COMPLETION_TOKENS setting

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -64,11 +64,12 @@ def get_llm_client(raise_api_key_error: bool = True):
     )  # imported here to avoid circular imports
 
     model_max_completion_tokens = get_model_max_completion_tokens(llm_config.llm_model)
-    max_completion_tokens = (
-        model_max_completion_tokens
-        if model_max_completion_tokens
-        else llm_config.llm_max_completion_tokens
-    )
+    user_max = llm_config.llm_max_completion_tokens
+    if model_max_completion_tokens is not None:
+        # Use the lower of the model's hard limit and the user's configured ceiling
+        max_completion_tokens = min(model_max_completion_tokens, user_max)
+    else:
+        max_completion_tokens = user_max
 
     llm_args = llm_config.llm_args
 


### PR DESCRIPTION
## Summary
- Uses `min(model_max, user_max)` instead of unconditionally preferring litellm's `model_cost["max_tokens"]`
- User's `LLM_MAX_COMPLETION_TOKENS` now acts as a ceiling; litellm's value only guards against exceeding the model's hard limit
- Fixes silent config override that caused Anthropic SDK to raise `ValueError("Streaming is required for operations that may take longer than 10 minutes")`

## Root cause
For `claude-haiku-4-5-20251001`, litellm's `model_cost` reports `max_tokens = 64000`. The previous logic used this unconditionally, ignoring the user's `.env` setting (e.g., `LLM_MAX_COMPLETION_TOKENS=4096`). The Anthropic SDK then computed a 1800-second timeout from the inflated token count, triggering its streaming-required safety check.

## Test plan
- [ ] Set `LLM_MAX_COMPLETION_TOKENS=4096` in `.env` with Anthropic provider
- [ ] Run `cognee.cognify()` and `cognee.search()` — should succeed without streaming error
- [ ] Verify that without the env setting, litellm's model max is still used as the default
- [ ] Verify that setting a value higher than the model max gets capped to the model max

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token limit computation to consistently respect user-configured maximum completion token settings as the primary ceiling, with model-specific limits applied as additional constraints when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->