### PR TITLE
fix(tests): remove stale TODO and add top_k limit assertions in CompletionRetriever tests

### DIFF
--- a/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
@@ -285,7 +285,6 @@ async def test_rag_completion_context_multiple_chunks(setup_test_environment_wit
 @pytest.mark.asyncio
 async def test_rag_completion_context_complex(setup_test_environment_with_chunks_complex):
     """Integration test: verify CompletionRetriever can retrieve context (complex)."""
-    # TODO: top_k doesn't affect the output, it should be fixed.
     retriever = CompletionRetriever(top_k=20)
     query = "Christina"
 
@@ -295,7 +294,22 @@ async def test_rag_completion_context_complex(setup_test_environment_with_chunks
         query=query, retrieved_objects=retrieved_objects
     )
 
+    assert len(retrieved_objects) <= 20, "Retrieved objects should be limited by top_k"
     assert context[0:15] == "Christina Mayer", "Failed to get Christina Mayer"
+
+
+@pytest.mark.asyncio
+async def test_rag_completion_context_top_k_limits_results(setup_test_environment_with_chunks_complex):
+    """Integration test: verify top_k parameter limits the number of retrieved chunks."""
+    top_k = 2
+    retriever = CompletionRetriever(top_k=top_k)
+    query = "Christina"
+
+    retrieved_objects = await retriever.get_retrieved_objects(query)
+
+    assert len(retrieved_objects) <= top_k, (
+        f"Retrieved {len(retrieved_objects)} objects but top_k={top_k} should limit results"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The `top_k` parameter in `CompletionRetriever` is correctly passed as `limit` to `vector_engine.search()` (verified by unit tests in `rag_completion_retriever_test.py`). However, the integration test `test_rag_completion_context_complex` had a stale TODO comment claiming `top_k` didn't affect output, and no test actually asserted that the limit was enforced end-to-end.

- Remove the stale `# TODO: top_k doesn't affect the output, it should be fixed.` comment from `test_rag_completion_context_complex`
- Add `assert len(retrieved_objects) <= 20` to the existing test to make the top_k bound explicit
- Add new integration test `test_rag_completion_context_top_k_limits_results` that uses `top_k=2` against a 6-chunk dataset and asserts `len(retrieved_objects) <= 2`, exercising the limit end-to-end

## Test plan

- [x] `pytest cognee/tests/unit/modules/retrieval/rag_completion_retriever_test.py` — 13 passed (existing unit tests unaffected)
- [ ] `pytest cognee/tests/integration/retrieval/test_rag_completion_retriever.py` — requires a configured LLM/vector backend (integration environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened integration tests for the retrieval system to ensure the result-limit parameter correctly constrains the number of returned items.
  * Added a new test verifying smaller limit values produce appropriately fewer results and tightened an existing test to enforce the limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->