### PR TITLE
feat: add env var to allow specifying max number of dbs to be cached

### DIFF
--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -1,6 +1,7 @@
 """Factory function to get the appropriate graph client based on the graph type."""
 
 from functools import lru_cache
+from cognee.shared.lru_cache import DATABASE_MAX_LRU_CACHE_SIZE
 
 from .config import get_graph_context_config
 from .graph_db_interface import GraphDBInterface
@@ -66,7 +67,7 @@ def create_graph_engine(
     )
 
 
-@lru_cache
+@lru_cache(maxsize=DATABASE_MAX_LRU_CACHE_SIZE)
 def _create_graph_engine(
     graph_database_provider,
     graph_file_path,

--- a/cognee/infrastructure/databases/relational/create_relational_engine.py
+++ b/cognee/infrastructure/databases/relational/create_relational_engine.py
@@ -1,9 +1,10 @@
 from sqlalchemy import URL
 from .sqlalchemy.SqlAlchemyAdapter import SQLAlchemyAdapter
 from functools import lru_cache
+from cognee.shared.lru_cache import DATABASE_MAX_LRU_CACHE_SIZE
 
 
-@lru_cache
+@lru_cache(maxsize=DATABASE_MAX_LRU_CACHE_SIZE)
 def create_relational_engine(
     db_path: str,
     db_name: str,

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -5,6 +5,7 @@ from .embeddings import get_embedding_engine
 from cognee.infrastructure.databases.graph.config import get_graph_context_config
 
 from functools import lru_cache
+from cognee.shared.lru_cache import DATABASE_MAX_LRU_CACHE_SIZE
 
 
 def create_vector_engine(
@@ -58,7 +59,7 @@ def create_vector_engine(
     )
 
 
-@lru_cache
+@lru_cache(maxsize=DATABASE_MAX_LRU_CACHE_SIZE)
 def _create_vector_engine(
     vector_db_provider: str,
     vector_db_url: str,

--- a/cognee/shared/lru_cache.py
+++ b/cognee/shared/lru_cache.py
@@ -1,0 +1,10 @@
+"""
+Shared cache size setting for Cognee database adapters.
+
+Set DATABASE_MAX_LRU_CACHE_SIZE in the environment to control the maxsize of the
+lru_cache used by the graph, vector, and relational DB engine factories (default: 128).
+"""
+
+import os
+
+DATABASE_MAX_LRU_CACHE_SIZE: int = int(os.getenv("DATABASE_MAX_LRU_CACHE_SIZE", "128"))


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Add ability to define DB lru cache size 

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable cache size limit for database engine instances via `DATABASE_MAX_LRU_CACHE_SIZE` environment variable (defaults to 128).

* **Improvements**
  * Applied bounded caching to database engine factories, preventing unbounded memory growth during engine instance reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->