### PR TITLE
feat(cognee-mcp): support batch file-path ingestion in cognify tool

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -347,7 +347,18 @@ async def cognify(
 
                     graph_model = load_class(graph_model_file, graph_model_name)
 
-            await cognee_client.add(data, dataset_name=dataset_name)
+            # Support JSON array of items (file paths, text, URLs) for batch add
+            items = [data]
+            try:
+                parsed = json.loads(data)
+                if isinstance(parsed, list):
+                    items = parsed
+                    logger.info(f"Batch mode: adding {len(items)} items to '{dataset_name}'")
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+            for item in items:
+                await cognee_client.add(item, dataset_name=dataset_name)
 
             try:
                 await cognee_client.cognify(

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -352,12 +352,17 @@ async def cognify(
             try:
                 parsed = json.loads(data)
                 if isinstance(parsed, list):
+                    if not parsed:
+                        raise ValueError("Batch input cannot be an empty JSON array.")
                     items = parsed
                     logger.info(f"Batch mode: adding {len(items)} items to '{dataset_name}'")
-            except (json.JSONDecodeError, TypeError):
+            except json.JSONDecodeError:
+                # Plain text / non-JSON input: keep backward-compatible single-item flow
                 pass
 
             for item in items:
+                if not isinstance(item, str) or not item.strip():
+                    raise ValueError(f"Invalid batch item (must be a non-empty string): {item!r}")
                 await cognee_client.add(item, dataset_name=dataset_name)
 
             try:


### PR DESCRIPTION
## Summary

- The `cognify` MCP tool now detects JSON-encoded arrays in the `data` parameter
- Calls `cognee_client.add()` for each item before running a single `cognify()` pipeline pass
- Enables efficient multi-file ingestion (file paths, text, URLs) into a dataset with one pipeline run instead of N separate runs
- Plain string inputs are unchanged — fully backwards-compatible

Fixes #2624

## Problem

The `cognify` tool bundles `add()` + `cognify()` in a single call. When indexing N files into the same dataset, each call re-runs the full pipeline on the growing dataset — O(n²) work. There's no way to batch multiple `add()` calls before a single `cognify()` through the MCP interface.

Meanwhile, `cognee.add()` natively supports file paths and lists, but the MCP tool doesn't leverage this.

## Solution

Before the `add()` call in `cognify_task()`, try to parse `data` as a JSON array. If it is one, iterate and call `add()` per item. Otherwise, pass the string as-is (backwards-compatible).

Input validation:
- Empty arrays are rejected with `ValueError`
- Each item must be a non-empty string
- Only `json.JSONDecodeError` is caught (not `TypeError`)

## Test plan

- [x] Single file path (`/path/to/file.py`) — cognee reads the file natively via its file loader
- [x] JSON array of file paths — each file added separately, pipeline runs once
- [x] Plain text string — unchanged behavior (backwards-compatible)
- [x] Empty array `[]` — raises ValueError, does not run pipeline
- [x] 12 datasets (71 files total) reindexed successfully using batch file-path mode
- [x] Search quality verified on reindexed data (CHUNKS + GRAPH_COMPLETION)

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch processing: system now auto-detects list-formatted submissions, processes each item individually, logs item count, and preserves backward compatibility with single-item submissions.

* **Bug Fixes**
  * Added input validation to reject empty/whitespace items and fallback to single-item handling when input isn't valid JSON or not a list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->