### PR TITLE
add missing max_completion_tokens and get_tokenizer to OpenAICompatibleEmbeddingEngine

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
@@ -32,6 +32,8 @@ from tenacity import (
 from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import (
     EmbeddingEngine,
 )
+from cognee.infrastructure.llm.tokenizer.HuggingFace import HuggingFaceTokenizer
+from cognee.infrastructure.llm.tokenizer.TikToken import TikTokenTokenizer
 from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
 from cognee.shared.logging_utils import get_logger
 
@@ -69,24 +71,29 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
 
     model: str
     dimensions: int
+    max_completion_tokens: int
     endpoint: str
     api_key: str
     mock: bool
     batch_size: int
+    tokenizer: object
 
     def __init__(
         self,
         model: Optional[str] = "default",
         dimensions: int = 3072,
+        max_completion_tokens: int = 8191,
         endpoint: Optional[str] = "http://localhost:8080",
         api_key: Optional[str] = "no-key-required",
         batch_size: int = 36,
     ):
         self.model = model or "default"
         self.dimensions = dimensions
+        self.max_completion_tokens = max_completion_tokens
         self.endpoint = endpoint or "http://localhost:8080"
         self.api_key = api_key or "no-key-required"
         self.batch_size = batch_size
+        self.tokenizer = self.get_tokenizer()
 
         enable_mocking = os.getenv("MOCK_EMBEDDING", "false").lower()
         self.mock = enable_mocking in ("true", "1", "yes")
@@ -223,3 +230,17 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
             - int: The batch size.
         """
         return self.batch_size
+
+    def get_tokenizer(self):
+        """Load a tokenizer for chunk sizing against OpenAI-compatible embedding servers."""
+        logger.debug("Loading HuggingfaceTokenizer for OpenAICompatibleEmbeddingEngine...")
+        try:
+            tokenizer = HuggingFaceTokenizer(
+                model=self.model,
+                max_completion_tokens=self.max_completion_tokens,
+            )
+        except Exception as error:
+            logger.warning("Could not get tokenizer from HuggingFace due to: %s", error)
+            logger.info("Switching to TikToken default tokenizer.")
+            tokenizer = TikTokenTokenizer(model=None, max_completion_tokens=self.max_completion_tokens)
+        return tokenizer

--- a/cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py
@@ -107,6 +107,7 @@ def create_embedding_engine(
         return OpenAICompatibleEmbeddingEngine(
             model=embedding_model,
             dimensions=embedding_dimensions,
+            max_completion_tokens=embedding_max_completion_tokens,
             endpoint=embedding_endpoint,
             api_key=embedding_api_key or llm_api_key,
             batch_size=embedding_batch_size,

--- a/cognee/tests/unit/infrastructure/test_openai_compatible_embedding_engine.py
+++ b/cognee/tests/unit/infrastructure/test_openai_compatible_embedding_engine.py
@@ -20,6 +20,7 @@ class TestOpenAICompatibleEmbeddingEngine:
         defaults = {
             "model": "test-model",
             "dimensions": 4096,
+            "max_completion_tokens": 8191,
             "endpoint": "http://localhost:8099",
             "api_key": "test-key",
             "batch_size": 36,
@@ -81,6 +82,11 @@ class TestOpenAICompatibleEmbeddingEngine:
         """get_batch_size returns the configured batch size."""
         engine = self._make_engine(batch_size=50)
         assert engine.get_batch_size() == 50
+
+    def test_max_completion_tokens_is_exposed(self):
+        """The engine exposes max_completion_tokens for chunk sizing logic."""
+        engine = self._make_engine(max_completion_tokens=2048)
+        assert engine.max_completion_tokens == 2048
 
     def test_endpoint_normalization(self):
         """Endpoint without /v1 gets /v1 appended for the SDK base_url."""


### PR DESCRIPTION
## Description
This fixes the `openai_compatible` embedding path so it exposes the same chunk-sizing fields as the other embedding engines.
While testing a local OpenAI-compatible embedding server, `cognify` failed because `OpenAICompatibleEmbeddingEngine` did not expose `max_completion_tokens` or a tokenizer. This change adds those fields to the engine, passes `embedding_max_completion_tokens` through from `get_embedding_engine()`, and falls back to a default tokenizer when a Hugging Face tokenizer cannot be loaded for local model names.
## Acceptance Criteria
- `OpenAICompatibleEmbeddingEngine` exposes `max_completion_tokens`
- `OpenAICompatibleEmbeddingEngine` initializes a tokenizer for chunk sizing
- `get_embedding_engine()` passes `embedding_max_completion_tokens` into the `openai_compatible` engine path
- Unit coverage verifies `max_completion_tokens` is available on the engine
- Local `cognify` no longer fails on missing `max_completion_tokens` / `tokenizer` for `openai_compatible` embeddings
## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):
## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI-compatible embedding engines now support configurable maximum completion tokens (default: 8191) for better token limit control.
  * Enhanced tokenizer selection with intelligent fallback mechanism ensures compatibility across different tokenizer implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->