### PR TITLE
fix(api): forward session_id through cloud client to remember endpoint

### DIFF
--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -464,7 +464,7 @@ async def _remember_inner(
     client = get_remote_client()
     if client is not None:
         span.set_attribute(COGNEE_OPERATION_MODE, "cloud")
-        return await client.remember(data, dataset_name, **kwargs)
+        return await client.remember(data, dataset_name, session_id=session_id, **kwargs)
 
     # Run vector migrations lazily on the first local SDK call.
     # This ensures stale LanceDB schemas are migrated before any

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -30,6 +30,7 @@ def get_remember_router() -> APIRouter:
         data: List[UploadFile] = File(default=None),
         datasetName: Optional[str] = Form(default=None),
         datasetId: Union[UUID, Literal[""], None] = Form(default=None, examples=[""]),
+        session_id: Optional[str] = Form(default=None),
         node_set: Optional[List[str]] = Form(default=[""], example=[""]),
         run_in_background: Optional[bool] = Form(default=False),
         custom_prompt: Optional[str] = Form(default=""),
@@ -79,6 +80,7 @@ def get_remember_router() -> APIRouter:
             result = await cognee_remember(
                 data,
                 dataset_name=datasetName,
+                session_id=session_id,
                 user=user,
                 dataset_id=datasetId if datasetId else None,
                 node_set=node_set if node_set != [""] else None,

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -53,6 +53,8 @@ class CloudClient:
         form = aiohttp.FormData()
         form.add_field("datasetName", dataset_name)
 
+        if kwargs.get("session_id"):
+            form.add_field("session_id", kwargs["session_id"])
         if kwargs.get("run_in_background"):
             form.add_field("run_in_background", "true")
         if kwargs.get("custom_prompt"):


### PR DESCRIPTION
## Summary
- The `CloudClient.remember()` method did not forward `session_id` to the server, so all remote `remember()` calls ran the full add+cognify pipeline (~30s with LLM) instead of the fast session-cache path (instant)
- `_remember_inner` now explicitly passes `session_id` to the cloud client
- The remember router now accepts `session_id` as an optional Form parameter and forwards it to the SDK

## Context
Discovered while debugging the Claude Code Cognee plugin — hook scripts calling `cognee.remember(data, session_id=...)` in cloud mode were timing out because the server never received `session_id` and treated every call as permanent memory ingestion.

## Test plan
- [ ] `cognee.remember("test", session_id="s1")` via cloud client returns instantly (session cache path)
- [ ] `cognee.remember("test")` without session_id still runs full pipeline
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `session_id` parameter handling to ensure proper forwarding through remote/cloud execution calls and API endpoints.

* **New Features**
  * Added optional `session_id` parameter support to the remember endpoint for better session tracking across distributed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->