### PR TITLE
fix: keep belongs_to_set consistent across dataset cognify and deletion

### DIFF
--- a/cognee/infrastructure/databases/graph/graph_db_interface.py
+++ b/cognee/infrastructure/databases/graph/graph_db_interface.py
@@ -109,6 +109,16 @@ class GraphDBInterface(ABC):
         """
         raise NotImplementedError
 
+    async def remove_belongs_to_set_tags(self, tags: List[str]) -> None:
+        """
+        Remove the given tag names from every node's `belongs_to_set` property
+        array. Keeps the property consistent with the additive
+        `belongs_to_set` edges after a NodeSet or its containing dataset is
+        deleted. Default no-op; adapters that store a list property (Neo4j,
+        Neptune) override this.
+        """
+        return None
+
     @abstractmethod
     async def get_node(self, node_id: str) -> Optional[NodeData]:
         """

--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -200,10 +200,18 @@ class Neo4jAdapter(GraphDBInterface):
         """
         serialized_properties = self.serialize_properties(node.model_dump())
 
+        # Capture the existing belongs_to_set before `+=` overwrites it, then
+        # write back the union so a DataPoint cognified into multiple datasets
+        # retains every dataset tag on its node property (edges are already
+        # additive; this keeps the property consistent with them).
         query = dedent(
             f"""MERGE (node: `{BASE_LABEL}`{{id: $node_id}})
-                ON CREATE SET node += $properties, node.updated_at = timestamp()
-                ON MATCH SET node += $properties, node.updated_at = timestamp()
+                WITH node, apoc.coll.toSet(
+                    coalesce(node.belongs_to_set, [])
+                    + coalesce($properties.belongs_to_set, [])
+                ) AS merged_belongs_to_set
+                SET node += $properties, node.updated_at = timestamp()
+                SET node.belongs_to_set = merged_belongs_to_set
                 WITH node, $node_label AS label
                 CALL apoc.create.addLabels(node, [label]) YIELD node AS labeledNode
                 RETURN ID(labeledNode) AS internal_id, labeledNode.id AS nodeId"""
@@ -233,11 +241,19 @@ class Neo4jAdapter(GraphDBInterface):
 
             - None: None
         """
+        # Capture the existing belongs_to_set before `+=` overwrites it, then
+        # write back the union so the property on a shared DataPoint reflects
+        # every dataset that cognified it (consistent with the additive
+        # belongs_to_set edges). See add_node for the single-node variant.
         query = f"""
         UNWIND $nodes AS node
         MERGE (n: `{BASE_LABEL}`{{id: node.node_id}})
-        ON CREATE SET n += node.properties, n.updated_at = timestamp()
-        ON MATCH SET n += node.properties, n.updated_at = timestamp()
+        WITH n, node, apoc.coll.toSet(
+            coalesce(n.belongs_to_set, [])
+            + coalesce(node.properties.belongs_to_set, [])
+        ) AS merged_belongs_to_set
+        SET n += node.properties, n.updated_at = timestamp()
+        SET n.belongs_to_set = merged_belongs_to_set
         WITH n, node.label AS label
         CALL apoc.create.addLabels(n, [label]) YIELD node AS labeledNode
         RETURN ID(labeledNode) AS internal_id, labeledNode.id AS nodeId

--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -259,17 +259,53 @@ class Neo4jAdapter(GraphDBInterface):
         RETURN ID(labeledNode) AS internal_id, labeledNode.id AS nodeId
         """
 
-        nodes = [
-            {
-                "node_id": str(node.id),
-                "label": type(node).__name__,
-                "properties": self.serialize_properties(dict(node)),
-            }
-            for node in nodes
-        ]
+        # Dedup by node_id within the batch — UNWIND on a list with
+        # duplicates yields the same `n` twice, and each pass recomputes
+        # merged_belongs_to_set from the pre-SET state. The second SET then
+        # overwrites the first, losing any tag only seen on the first
+        # duplicate. Collapsing duplicates here (union of tags kept) avoids
+        # the race and matches the batch-dedup already done in PGVector.
+        deduped: Dict[str, Dict[str, Any]] = {}
+        for node in nodes:
+            key = str(node.id)
+            props = self.serialize_properties(dict(node))
+            existing_entry = deduped.get(key)
+            if existing_entry:
+                existing_tags = existing_entry["properties"].get("belongs_to_set") or []
+                incoming_tags = props.get("belongs_to_set") or []
+                if existing_tags or incoming_tags:
+                    merged = list(dict.fromkeys(list(existing_tags) + list(incoming_tags)))
+                    props["belongs_to_set"] = merged
+                existing_entry["properties"] = props
+                existing_entry["label"] = type(node).__name__
+            else:
+                deduped[key] = {
+                    "node_id": key,
+                    "label": type(node).__name__,
+                    "properties": props,
+                }
 
-        results = await self.query(query, dict(nodes=nodes))
+        results = await self.query(query, dict(nodes=list(deduped.values())))
         return results
+
+    async def remove_belongs_to_set_tags(self, tags: List[str]) -> None:
+        """
+        Strip the given tag names from every node's `belongs_to_set`
+        property array. Used to reconcile surviving shared nodes after a
+        dataset or its NodeSet is deleted — the NodeSet node itself and
+        its edges are already removed elsewhere; this brings the stored
+        property in line with the surviving edges.
+        """
+        if not tags:
+            return None
+
+        query = f"""
+        MATCH (n: `{BASE_LABEL}`)
+        WHERE any(tag IN $tags WHERE tag IN coalesce(n.belongs_to_set, []))
+        SET n.belongs_to_set = [x IN n.belongs_to_set WHERE NOT x IN $tags]
+        """
+        await self.query(query, {"tags": list(tags)})
+        return None
 
     async def extract_node(self, node_id: str):
         """

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -729,6 +729,103 @@ class LanceDBAdapter(VectorDBInterface):
         for data_point_id in data_point_ids:
             await collection.delete(f"id = '{data_point_id}'")
 
+    async def remove_belongs_to_set_tags(self, tags: List[str]) -> None:
+        """
+        Strip the given tag names from `belongs_to_set` arrays in every
+        table and delete rows whose array becomes empty. Used to reconcile
+        surviving shared rows after a dataset/NodeSet is deleted.
+
+        LanceDB doesn't support in-place array mutation, so the update path
+        reads rows that reference any target tag, rewrites the payload with
+        the tag removed, and either re-inserts them (merge_insert) or
+        deletes them when the array is empty.
+        """
+        if not tags:
+            return None
+
+        tag_set = set(tags)
+        connection = await self.get_connection()
+        collection_names = await connection.table_names()
+
+        for collection_name in collection_names:
+            try:
+                collection = await connection.open_table(collection_name)
+            except (ValueError, OSError, RuntimeError) as e:
+                logger.debug(
+                    "remove_belongs_to_set_tags: could not open '%s': %s",
+                    collection_name,
+                    e,
+                )
+                continue
+
+            try:
+                arrow_schema = (await collection.to_arrow()).schema
+            except Exception as e:
+                logger.debug(
+                    "remove_belongs_to_set_tags: schema read failed for '%s': %s",
+                    collection_name,
+                    e,
+                )
+                continue
+
+            payload_idx = arrow_schema.get_field_index("payload")
+            if payload_idx < 0:
+                continue
+
+            payload_type = arrow_schema.field(payload_idx).type
+            if not hasattr(payload_type, "num_fields"):
+                continue
+
+            payload_fields = {payload_type.field(i).name for i in range(payload_type.num_fields)}
+            if "belongs_to_set" not in payload_fields:
+                continue
+
+            async with self.VECTOR_DB_LOCK:
+                try:
+                    rows = await collection.query().to_list()
+                except Exception as e:
+                    logger.debug(
+                        "remove_belongs_to_set_tags: row scan failed for '%s': %s",
+                        collection_name,
+                        e,
+                    )
+                    continue
+
+                rows_to_delete: list[str] = []
+                rows_to_update = []
+                for row in rows:
+                    payload = row.get("payload") or {}
+                    current = payload.get("belongs_to_set") or []
+                    if not any(tag in tag_set for tag in current):
+                        continue
+                    remaining = [tag for tag in current if tag not in tag_set]
+                    if remaining:
+                        payload["belongs_to_set"] = remaining
+                        rows_to_update.append(row)
+                    else:
+                        rows_to_delete.append(row["id"])
+
+                for row_id in rows_to_delete:
+                    await collection.delete(f"id = '{row_id}'")
+
+                # LanceDB merge_insert silently no-ops when given dicts whose
+                # nested payload shape doesn't match the struct schema, so
+                # delete + re-add is the reliable path to persist the
+                # rewritten belongs_to_set.
+                for row in rows_to_update:
+                    await collection.delete(f"id = '{row['id']}'")
+                if rows_to_update:
+                    try:
+                        await collection.add(rows_to_update)
+                    except Exception as e:
+                        logger.debug(
+                            "remove_belongs_to_set_tags: re-add failed for '%s': %s",
+                            collection_name,
+                            e,
+                        )
+
+        return None
+
     async def create_vector_index(self, index_name: str, index_property_name: str):
         await self.create_collection(
             f"{index_name}_{index_property_name}", payload_schema=IndexSchema

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -173,6 +173,34 @@ class LanceDBAdapter(VectorDBInterface):
             [DataPoint.get_embeddable_data(data_point) for data_point in data_points]
         )
 
+        # Fetch existing `belongs_to_set` values for rows we are about to
+        # upsert so the same DataPoint cognified into multiple datasets
+        # accumulates every dataset tag. Without this, merge_insert's
+        # when_matched_update_all overwrites the prior dataset's tags.
+        existing_belongs_to_set: dict[str, list] = {}
+        incoming_ids = [str(dp.id) for dp in data_points]
+        if incoming_ids:
+            try:
+                if len(incoming_ids) == 1:
+                    where_clause = f"id = '{incoming_ids[0]}'"
+                else:
+                    where_clause = f"id IN {tuple(incoming_ids)}"
+                existing_rows = await collection.query().where(where_clause).to_list()
+                for row in existing_rows:
+                    row_payload = row.get("payload") or {}
+                    prior = row_payload.get("belongs_to_set") or []
+                    if prior:
+                        existing_belongs_to_set[row["id"]] = list(prior)
+            except Exception as e:
+                # Best-effort: if the lookup fails (e.g. empty table, schema
+                # mismatch that the migration path will handle), fall through
+                # to the standard upsert.
+                logger.debug(
+                    "belongs_to_set merge lookup failed for '%s': %s",
+                    collection_name,
+                    e,
+                )
+
         IdType = TypeVar("IdType")
         PayloadSchema = TypeVar("PayloadSchema")
         vector_size = self.embedding_engine.get_vector_size()
@@ -195,6 +223,11 @@ class LanceDBAdapter(VectorDBInterface):
             properties = payload_model.model_validate(
                 serialize_data(data_point.model_dump())
             ).model_dump()
+
+            prior = existing_belongs_to_set.get(str(data_point.id))
+            if prior:
+                incoming = properties.get("belongs_to_set") or []
+                properties["belongs_to_set"] = list(dict.fromkeys(list(prior) + list(incoming)))
 
             return LanceDataPoint[str, self.get_data_point_schema(type(data_point))](
                 id=str(data_point.id),

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy import JSON, Column, Table, select, delete, MetaData, func
+from sqlalchemy import JSON, Column, Table, select, delete, MetaData, func, text
 from sqlalchemy import exc
 from sqlalchemy.exc import ProgrammingError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -266,11 +266,45 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
                     for column in inspect(obj).mapper.column_attrs
                 }
 
+            # Dedup by id within the batch — with ON CONFLICT DO UPDATE,
+            # Postgres raises "cannot affect row a second time" if the same
+            # id appears twice in one INSERT. The prior ON CONFLICT DO NOTHING
+            # path silently tolerated duplicates, so entity extraction may
+            # still emit same-UUID5 rows in one batch.
+            pgvector_data_points = list(
+                {data_point.id: data_point for data_point in pgvector_data_points}.values()
+            )
+
             # session.add_all(pgvector_data_points)
             insert_statement = insert(PGVectorDataPoint).values(
                 [to_dict(data_point) for data_point in pgvector_data_points]
             )
-            insert_statement = insert_statement.on_conflict_do_nothing(index_elements=["id"])
+            # On conflict, merge the `belongs_to_set` arrays so a DataPoint
+            # cognified into multiple datasets keeps every dataset tag. Take
+            # the incoming payload as the base (refreshing any other fields)
+            # and rewrite only `belongs_to_set` with the union of existing
+            # and incoming values. `collection_name` is cognee-controlled,
+            # not user input, so interpolation is safe.
+            quoted_table = f'"{collection_name}"'
+            merged_payload_expr = text(
+                f"""
+                jsonb_set(
+                    EXCLUDED.payload::jsonb,
+                    '{{belongs_to_set}}',
+                    (
+                        SELECT COALESCE(jsonb_agg(DISTINCT val), '[]'::jsonb)
+                        FROM jsonb_array_elements_text(
+                            COALESCE({quoted_table}.payload::jsonb->'belongs_to_set', '[]'::jsonb)
+                            || COALESCE(EXCLUDED.payload::jsonb->'belongs_to_set', '[]'::jsonb)
+                        ) AS val
+                    )
+                )::json
+                """
+            )
+            insert_statement = insert_statement.on_conflict_do_update(
+                index_elements=["id"],
+                set_={"payload": merged_payload_expr},
+            )
             await session.execute(insert_statement)
             await session.commit()
 

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -513,6 +513,73 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
             await session.commit()
             return results
 
+    async def remove_belongs_to_set_tags(self, tags: List[str]) -> None:
+        """
+        Strip the given tag names from `belongs_to_set` arrays in every
+        vector collection and delete rows whose array is now empty. Used to
+        reconcile surviving shared rows when a dataset/NodeSet is deleted.
+
+        Cognee vector collections follow the `{PascalCaseType}_{field}`
+        naming convention (e.g. `Entity_name`, `DocumentChunk_text`) and
+        coexist in the same schema as lowercase relational tables — filter
+        to collections by requiring an uppercase first character.
+        """
+        if not tags:
+            return None
+
+        candidate_tables = [
+            name for name in await self.get_table_names() if name and name[0].isupper()
+        ]
+
+        async with self.get_async_session() as session:
+            for table_name in candidate_tables:
+                quoted_table = f'"{table_name}"'
+                update_sql = text(
+                    f"""
+                    UPDATE {quoted_table}
+                    SET payload = jsonb_set(
+                        payload::jsonb,
+                        '{{belongs_to_set}}',
+                        (
+                            SELECT COALESCE(jsonb_agg(val), '[]'::jsonb)
+                            FROM jsonb_array_elements_text(
+                                COALESCE(payload::jsonb->'belongs_to_set', '[]'::jsonb)
+                            ) AS val
+                            WHERE val <> ALL(:tags)
+                        )
+                    )::json
+                    WHERE payload::jsonb ? 'belongs_to_set'
+                      AND EXISTS (
+                          SELECT 1
+                          FROM jsonb_array_elements_text(payload::jsonb->'belongs_to_set') v
+                          WHERE v = ANY(:tags)
+                      )
+                    """
+                )
+                delete_sql = text(
+                    f"""
+                    DELETE FROM {quoted_table}
+                    WHERE payload::jsonb->'belongs_to_set' = '[]'::jsonb
+                    """
+                )
+                try:
+                    await session.execute(update_sql, {"tags": list(tags)})
+                    await session.execute(delete_sql)
+                except exc.SQLAlchemyError as e:
+                    # Not every upper-case table is guaranteed to have a
+                    # jsonb `payload` column — skip any table that rejects
+                    # the payload-shaped statements rather than aborting
+                    # the whole detag pass.
+                    logger.debug(
+                        "remove_belongs_to_set_tags skipped '%s': %s",
+                        table_name,
+                        e,
+                    )
+                    await session.rollback()
+            await session.commit()
+
+        return None
+
     async def prune(self):
         self._metadata.clear()
         await self.delete_database()

--- a/cognee/infrastructure/databases/vector/vector_db_interface.py
+++ b/cognee/infrastructure/databases/vector/vector_db_interface.py
@@ -155,6 +155,18 @@ class VectorDBInterface(Protocol):
         """
         raise NotImplementedError
 
+    async def remove_belongs_to_set_tags(self, tags: List[str]) -> None:
+        """
+        Remove the given tag names from every `belongs_to_set` array in the
+        adapter's vector collections and delete rows whose `belongs_to_set`
+        becomes empty as a result. Keeps the stored tags consistent with
+        the graph after a dataset or NodeSet is removed.
+
+        Default no-op; adapters that need to clean up stale NodeSet tags
+        on dataset deletion override this.
+        """
+        return None
+
     @abstractmethod
     async def prune(self):
         """

--- a/cognee/modules/graph/methods/delete_from_graph_and_vector.py
+++ b/cognee/modules/graph/methods/delete_from_graph_and_vector.py
@@ -40,6 +40,17 @@ async def delete_from_graph_and_vector(
             seen_node_slugs.add(node.slug)
             unique_nodes.append(node)
 
+    # Capture NodeSet names before their ledger/graph rows are deleted so
+    # we can strip these tags from any surviving shared DataPoint afterwards.
+    # When a dataset is deleted in single-tenant mode its uniquely-owned
+    # NodeSet nodes are in `unique_nodes`; shared entities tagged with
+    # those names are not. The detag pass in `remove_belongs_to_set_tags`
+    # keeps the stored `belongs_to_set` arrays consistent with the graph
+    # after the hard delete.
+    removed_nodeset_tags = {
+        node.label for node in unique_nodes if node.type == "NodeSet" and node.label
+    }
+
     graph_engine = None
 
     # Delete from graph DB
@@ -117,6 +128,24 @@ async def delete_from_graph_and_vector(
                 )
         except Exception as e:
             logger.warning("EdgeType cleanup failed (non-fatal): %s", e)
+
+    # Strip now-orphaned NodeSet tags from surviving rows/nodes so shared
+    # entities stop advertising membership in a dataset that no longer
+    # exists. Runs after the hard-delete pass so freshly-deleted rows
+    # aren't touched redundantly.
+    if removed_nodeset_tags:
+        tags_to_remove = sorted(removed_nodeset_tags)
+        try:
+            if not graph_engine:
+                graph_engine = await get_graph_engine()
+            await graph_engine.remove_belongs_to_set_tags(tags_to_remove)
+        except Exception as e:
+            logger.warning("Graph NodeSet tag cleanup failed (non-fatal): %s", e)
+
+        try:
+            await vector_engine.remove_belongs_to_set_tags(tags_to_remove)
+        except Exception as e:
+            logger.warning("Vector NodeSet tag cleanup failed (non-fatal): %s", e)
 
     # Mark ledger entries as deleted
     await mark_ledger_nodes_as_deleted([node.slug for node in non_legacy_nodes])

--- a/cognee/tests/unit/infrastructure/databases/vector/test_belongs_to_set_merge.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_belongs_to_set_merge.py
@@ -1,0 +1,102 @@
+"""Upserting the same DataPoint with different `belongs_to_set` values must
+accumulate the set names, not overwrite them. This guards against losing
+dataset tags when the same content is cognified into multiple datasets.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.engine import DataPoint
+
+try:
+    from cognee.infrastructure.databases.vector.lancedb.LanceDBAdapter import (
+        IndexSchema,
+        LanceDBAdapter,
+    )
+
+    HAS_LANCEDB = True
+except ModuleNotFoundError:
+    HAS_LANCEDB = False
+
+
+class _FakeEmbeddingEngine:
+    def get_vector_size(self):
+        return 3
+
+    def get_batch_size(self):
+        return 100
+
+    async def embed_text(self, texts):
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+
+class _TaggedPoint(DataPoint):
+    text: str
+    metadata: dict = {"index_fields": ["text"]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_belongs_to_set_merges_across_upserts(tmp_path):
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+    collection = "Tagged_text"
+    point_id = str(uuid4())
+
+    first = _TaggedPoint(id=point_id, text="shared", belongs_to_set=["DatasetA"])
+    await adapter.create_collection(collection, type(first))
+    await adapter.create_data_points(collection, [first])
+
+    second = _TaggedPoint(id=point_id, text="shared", belongs_to_set=["DatasetB"])
+    await adapter.create_data_points(collection, [second])
+
+    results = await adapter.retrieve(collection, [point_id])
+    assert len(results) == 1
+    assert sorted(results[0].payload["belongs_to_set"]) == ["DatasetA", "DatasetB"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_belongs_to_set_dedupes_on_repeat_upsert(tmp_path):
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+    collection = "Tagged_text"
+    point_id = str(uuid4())
+
+    point = _TaggedPoint(id=point_id, text="shared", belongs_to_set=["DatasetA"])
+    await adapter.create_collection(collection, type(point))
+    await adapter.create_data_points(collection, [point])
+    await adapter.create_data_points(collection, [point])
+
+    results = await adapter.retrieve(collection, [point_id])
+    assert results[0].payload["belongs_to_set"] == ["DatasetA"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_belongs_to_set_first_insert_has_no_prior_tags(tmp_path):
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+    collection = "Index_text"
+    point_id = str(uuid4())
+
+    await adapter.create_collection(collection, IndexSchema)
+    await adapter.create_data_points(
+        collection,
+        [IndexSchema(id=point_id, text="fresh", belongs_to_set=["OnlyDataset"])],
+    )
+
+    results = await adapter.retrieve(collection, [point_id])
+    assert results[0].payload["belongs_to_set"] == ["OnlyDataset"]

--- a/cognee/tests/unit/infrastructure/databases/vector/test_belongs_to_set_merge.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_belongs_to_set_merge.py
@@ -100,3 +100,55 @@ async def test_belongs_to_set_first_insert_has_no_prior_tags(tmp_path):
 
     results = await adapter.retrieve(collection, [point_id])
     assert results[0].payload["belongs_to_set"] == ["OnlyDataset"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_remove_belongs_to_set_tags_strips_and_deletes(tmp_path):
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+    collection = "Tagged_text"
+
+    shared_id = str(uuid4())
+    orphaned_id = str(uuid4())
+    untouched_id = str(uuid4())
+
+    shared = _TaggedPoint(id=shared_id, text="shared", belongs_to_set=["Dev", "DevMirror"])
+    orphaned = _TaggedPoint(id=orphaned_id, text="orphaned", belongs_to_set=["Dev"])
+    untouched = _TaggedPoint(id=untouched_id, text="untouched", belongs_to_set=["Production"])
+
+    await adapter.create_collection(collection, type(shared))
+    await adapter.create_data_points(collection, [shared, orphaned, untouched])
+
+    await adapter.remove_belongs_to_set_tags(["Dev"])
+
+    surviving = await adapter.retrieve(collection, [shared_id, untouched_id])
+    surviving_by_id = {str(r.id): r for r in surviving}
+
+    assert sorted(surviving_by_id[shared_id].payload["belongs_to_set"]) == ["DevMirror"]
+    assert surviving_by_id[untouched_id].payload["belongs_to_set"] == ["Production"]
+    assert await adapter.retrieve(collection, [orphaned_id]) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_remove_belongs_to_set_tags_noop_for_empty_input(tmp_path):
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+    collection = "Tagged_text"
+    point_id = str(uuid4())
+
+    point = _TaggedPoint(id=point_id, text="shared", belongs_to_set=["Dev"])
+    await adapter.create_collection(collection, type(point))
+    await adapter.create_data_points(collection, [point])
+
+    await adapter.remove_belongs_to_set_tags([])
+
+    result = (await adapter.retrieve(collection, [point_id]))[0]
+    assert result.payload["belongs_to_set"] == ["Dev"]

--- a/cognee/tests/unit/modules/graph/test_delete_detag_nodeset.py
+++ b/cognee/tests/unit/modules/graph/test_delete_detag_nodeset.py
@@ -1,0 +1,101 @@
+"""When delete_from_graph_and_vector processes a dataset whose uniquely-owned
+NodeSet nodes are in the hard-delete set, it must also detag the deleted
+NodeSet's name from every surviving row/node. This test exercises the
+orchestration wiring without needing a live Neo4j or Postgres.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.graph.methods.delete_from_graph_and_vector import (
+    delete_from_graph_and_vector,
+)
+
+
+def _node(node_type: str, label: str | None = None):
+    return SimpleNamespace(
+        slug=uuid4(),
+        type=node_type,
+        label=label,
+        indexed_fields=["name"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_detag_called_with_removed_nodeset_names():
+    nodeset_node = _node("NodeSet", label="Dev")
+    entity_node = _node("Entity", label="Alice")
+    nodes = [nodeset_node, entity_node]
+
+    graph_engine = AsyncMock()
+    vector_engine = AsyncMock()
+
+    with (
+        patch(
+            "cognee.modules.graph.methods.delete_from_graph_and_vector.get_graph_engine",
+            AsyncMock(return_value=graph_engine),
+        ),
+        patch(
+            "cognee.modules.graph.methods.delete_from_graph_and_vector.get_vector_engine",
+            lambda: vector_engine,
+        ),
+        patch(
+            "cognee.modules.graph.methods.delete_from_graph_and_vector.mark_ledger_nodes_as_deleted",
+            AsyncMock(),
+        ),
+        patch(
+            "cognee.modules.graph.methods.delete_from_graph_and_vector.mark_ledger_edges_as_deleted",
+            AsyncMock(),
+        ),
+    ):
+        await delete_from_graph_and_vector(
+            affected_nodes=nodes,
+            affected_edges=[],
+            is_legacy_node=[False, False],
+            is_legacy_edge=[],
+        )
+
+    graph_engine.remove_belongs_to_set_tags.assert_awaited_once_with(["Dev"])
+    vector_engine.remove_belongs_to_set_tags.assert_awaited_once_with(["Dev"])
+
+
+@pytest.mark.asyncio
+async def test_detag_skipped_when_no_nodeset_in_batch():
+    entity_node = _node("Entity", label="Alice")
+    nodes = [entity_node]
+
+    graph_engine = AsyncMock()
+    vector_engine = AsyncMock()
+
+    with (
+        patch(
+            "cognee.modules.graph.methods.delete_from_graph_and_vector.get_graph_engine",
+            AsyncMock(return_value=graph_engine),
+        ),
+        patch(
+            "cognee.modules.graph.methods.delete_from_graph_and_vector.get_vector_engine",
+            lambda: vector_engine,
+        ),
+        patch(
+            "cognee.modules.graph.methods.delete_from_graph_and_vector.mark_ledger_nodes_as_deleted",
+            AsyncMock(),
+        ),
+        patch(
+            "cognee.modules.graph.methods.delete_from_graph_and_vector.mark_ledger_edges_as_deleted",
+            AsyncMock(),
+        ),
+    ):
+        await delete_from_graph_and_vector(
+            affected_nodes=nodes,
+            affected_edges=[],
+            is_legacy_node=[False],
+            is_legacy_edge=[],
+        )
+
+    graph_engine.remove_belongs_to_set_tags.assert_not_awaited()
+    vector_engine.remove_belongs_to_set_tags.assert_not_awaited()


### PR DESCRIPTION
## Summary

Shared DataPoints (deterministic UUID5 ids) are meant to stay consistent across datasets when users re-cognify the same content or delete one of the datasets. Two symmetric bugs broke that consistency:

**Upsert side — tags were dropped or overwritten:**

- **PGVector** (`PGVectorAdapter.create_data_points`) used `ON CONFLICT (id) DO NOTHING`. The second dataset's rows were silently discarded and its `belongs_to_set` tag was never stored.
- **LanceDB** (`create_data_points`) used `merge_insert("id").when_matched_update_all()`, which replaces the whole row, overwriting `belongs_to_set`.
- **Neo4j** (`add_node` / `add_nodes`) used `SET n += properties`, which overwrites `belongs_to_set` with the incoming list (last-writer-wins). The `belongs_to_set` edges to NodeSet nodes are already additive, so this was "cosmetic" but left the node property inconsistent with the edges.

**Delete side — orphaned tags were never cleaned up:**

When a dataset is deleted, `delete_from_graph_and_vector` hard-deletes uniquely-owned nodes (including the dataset's NodeSet node), but leaves `belongs_to_set` on shared rows pointing at a NodeSet that no longer exists. Search-time NodeSet filtering then still matches a dataset that's been removed.

## What this PR does

1. **PGVector merge on conflict** — `ON CONFLICT (id) DO UPDATE` with a `jsonb_set` expression that unions `{existing, incoming}` belongs_to_set arrays via `jsonb_agg(DISTINCT ...)`. Dedupes `pgvector_data_points` by id in Python before the INSERT to avoid the "cannot affect row a second time" Postgres error that `DO NOTHING` used to silently swallow.
2. **LanceDB merge on conflict** — before constructing the `LanceDataPoint` batch, query the table for existing rows with matching ids, capture their `belongs_to_set`, and union those prior tags into each incoming payload so `merge_insert().when_matched_update_all()` writes the merged list.
3. **Neo4j merge on merge** — in both `add_node` and `add_nodes`, capture the existing `belongs_to_set` via `apoc.coll.toSet(...)` before the `SET n += properties` overwrite, then re-apply the union. Nodes in the same batch with the same id are deduped in Python first (same reason as PGVector — UNWIND over a duplicated id recomputes the union twice and drops a tag from the first pass).
4. **New primitive `remove_belongs_to_set_tags(tags)`** on all three adapters (default no-op on `VectorDBInterface` / `GraphDBInterface` so Kuzu, Chroma, Qdrant, Weaviate, Milvus, Neptune, Falkor are unchanged):
   - **PGVector** enumerates its vector collections (tables whose name is PascalCase, which disambiguates them from lowercase relational tables that share the schema), issues a `jsonb_agg` UPDATE that strips the tags from each row's `belongs_to_set`, then `DELETE`s rows whose `belongs_to_set` is now empty.
   - **LanceDB** iterates `list_tables`, skips tables whose payload struct doesn't have a `belongs_to_set` field, then per matched row either rewrites (delete + re-add; `merge_insert` silently no-ops for dicts with nested payload structs) or deletes outright if the array empties.
   - **Neo4j** runs one Cypher `SET n.belongs_to_set = [x IN n.belongs_to_set WHERE NOT x IN $tags]` over every matching `__Node__`.
5. **Automatic detag on dataset deletion** — `delete_from_graph_and_vector` now inspects `unique_nodes` (the rows about to be hard-deleted) for NodeSet-typed entries, captures their labels, and after the hard-delete pass calls `graph_engine.remove_belongs_to_set_tags(...)` + `vector_engine.remove_belongs_to_set_tags(...)`. This is gated on the NodeSet actually being exclusive to the deleted dataset (i.e., in `unique_nodes`): if another dataset still references it, we leave the tag alone so that other dataset's filtering keeps working.

## Scope note

Scope intentionally covers the three adapters affected by the user-reported bug. Kuzu / Chroma / Qdrant / Weaviate / Milvus / Neptune / Falkor inherit the no-op default — they're not regressed, but they also don't get detag semantics in this PR. Happy to extend if maintainers want.

## Test plan

- [x] `uv run pytest cognee/tests/unit/infrastructure/databases/vector/test_belongs_to_set_merge.py` — 5 cases: merge across upserts, dedup, first-insert, detag strips+deletes, detag is no-op for empty input.
- [x] `uv run pytest cognee/tests/unit/modules/graph/test_delete_detag_nodeset.py` — orchestration test using mocked graph/vector engines verifies that `delete_from_graph_and_vector` calls the detag primitives with the right tag list when a NodeSet is in the hard-delete set, and skips them otherwise.
- [x] `uv run pytest cognee/tests/unit/infrastructure/databases/` — 117 pass / 2 skipped (pgvector + chromadb adapters skip without their extras installed locally).
- [x] `uv run ruff check` / `ruff format` / pre-commit hooks green.
- [ ] Integration: `cognee/tests/test_pgvector.py` and `cognee/tests/test_neo4j.py` with `docker compose --profile postgres --profile neo4j up -d`. The existing pgvector test exercises multi-dataset cognify with shared files, which is exactly the setup the fixes target — pending a run with live containers.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Upsert behavior now merges and deduplicates dataset membership tags ("belongs_to_set") instead of overwriting them across vector and graph backends.
* **New Features**
  * Added a global detagging operation to remove specified "belongs_to_set" tags across graph and vector stores; delete workflow now invokes detagging when relevant.
* **Tests**
  * Added unit tests covering tag accumulation, deduplication, and detagging orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->