### PR TITLE
fix: use sentence_cut end_type on force-cut in chunk_by_sentence

### DIFF
--- a/cognee/tasks/chunks/chunk_by_sentence.py
+++ b/cognee/tasks/chunks/chunk_by_sentence.py
@@ -72,7 +72,8 @@ def chunk_by_sentence(
                     break
 
         if maximum_size and (sentence_size + word_size > maximum_size):
-            yield (paragraph_id, sentence, sentence_size, word_type_state)
+            cut_type = "sentence_cut" if word_type_state == "word" else word_type_state
+            yield (paragraph_id, sentence, sentence_size, cut_type)
             sentence = word
             sentence_size = word_size
 


### PR DESCRIPTION
Closes #2658

Fix logic bug where force-cut sentences in `chunk_by_sentence` yield wrong `end_type` (`"word"` instead of `"sentence_cut"`). This causes `chunk_by_paragraph` in non-batch mode to silently skip yielding force-cut chunks because it only checks for `"paragraph_end"` or `"sentence_cut"`.

The fix aligns the mid-loop force-cut logic with the existing tail-of-function fallback.

Signed-off-by: Cocoon-Break <232320289+pojian68@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text chunking behavior to correctly handle maximum size constraints, ensuring proper state management during sentence segmentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->