### PR TITLE
fix: increment chunk_index after yielding oversized single-paragraph chunk

### DIFF
--- a/cognee/modules/chunking/TextChunker.py
+++ b/cognee/modules/chunking/TextChunker.py
@@ -37,6 +37,7 @@ class TextChunker(Chunker):
                         )
                         paragraph_chunks = []
                         self.chunk_size = 0
+                        self.chunk_index += 1
                     else:
                         chunk_text = " ".join(chunk["text"] for chunk in paragraph_chunks)
                         try:


### PR DESCRIPTION
## Fix: chunk_index not incremented for oversized single-paragraph chunks

**Issue:** #2656

In `TextChunker.py`, when a paragraph exceeds `max_chunk_size` and there are no buffered chunks, the chunk is yielded directly but `self.chunk_index` is never incremented. This causes duplicate `chunk_index` values and potential UUID5 collisions.

**Fix:** Added `self.chunk_index += 1` after resetting state in the oversized single-paragraph branch, matching the behavior in the buffered-chunk branch.

Closes #2656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document chunk indexing to ensure proper sequencing of chunks during document processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->