### PR TITLE
fix: preserve DataPoint.id in copy_model to prevent duplicate nodes

### DIFF
--- a/cognee/modules/graph/utils/get_graph_from_model.py
+++ b/cognee/modules/graph/utils/get_graph_from_model.py
@@ -183,7 +183,7 @@ async def get_graph_from_model(
         },
     )
 
-    data_point_properties = {"type": type(data_point).__name__}
+    data_point_properties = {"id": data_point.id, "type": type(data_point).__name__}
     excluded_properties = set()
     properties_to_visit = set()
 


### PR DESCRIPTION
## Fix: DataPoint.id Lost During copy_model (#2633)

**Issue:** When using custom deterministic `id` values on DataPoint instances, `get_graph_from_model` creates duplicate nodes in the graph database.

**Root cause:** `copy_model` creates a new `SimpleDataPointModel` instance without explicitly passing the `id` field. Since the base `DataPoint` class uses `default_factory=uuid4` for `id`, a new random UUID is generated, overwriting the user-defined deterministic ID.

**Fix:** Explicitly include `"id": data_point.id` in `data_point_properties` before calling `copy_model`. This ensures the original deterministic ID is preserved through the graph building process.

Closes #2633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph node initialization to ensure nodes are created with complete identifier and type information, enhancing data structure integrity and consistency across all node models in the graph system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->