### PR TITLE
fix: dynamic parameter forwarding and collision-resistant naming in Neo4jAuraDevDatasetDatabaseHandler

### DIFF
--- a/cognee/infrastructure/databases/dataset_database_handler/dataset_database_handler_interface.py
+++ b/cognee/infrastructure/databases/dataset_database_handler/dataset_database_handler_interface.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 from abc import ABC, abstractmethod
 
@@ -9,7 +9,9 @@ from cognee.modules.users.models.DatasetDatabase import DatasetDatabase
 class DatasetDatabaseHandlerInterface(ABC):
     @classmethod
     @abstractmethod
-    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+    async def create_dataset(
+        cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs: Any
+    ) -> dict:
         """
         Return a dictionary with database connection/resolution info for a graph or vector database for the given dataset.
         Function can auto handle deploying of the actual database if needed, but is not necessary.
@@ -28,6 +30,9 @@ class DatasetDatabaseHandlerInterface(ABC):
         Args:
             dataset_id: UUID of the dataset if needed by the database creation logic
             user: User object if needed by the database creation logic
+            **kwargs: Implementation-specific overrides for the database creation request.
+                Concrete handlers should document and validate the keys they accept and
+                raise ``ValueError`` for unknown keys.
         Returns:
             dict: Connection info for the created graph or vector database instance.
         """

--- a/cognee/infrastructure/databases/graph/kuzu/KuzuDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/kuzu/KuzuDatasetDatabaseHandler.py
@@ -1,6 +1,6 @@
 import os
 from uuid import UUID
-from typing import Optional
+from typing import Any, Optional
 
 from cognee.infrastructure.databases.graph.get_graph_engine import create_graph_engine
 from cognee.base_config import get_base_config
@@ -15,18 +15,29 @@ class KuzuDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
     """
 
     @classmethod
-    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+    async def create_dataset(
+        cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs: Any
+    ) -> dict:
         """
         Create a new Kuzu instance for the dataset. Return connection info that will be mapped to the dataset.
 
         Args:
             dataset_id: Dataset UUID
             user: User object who owns the dataset and is making the request
+            **kwargs: Reserved for future overrides; the Kuzu handler currently
+                accepts no implementation-specific options and raises
+                ``ValueError`` if any are supplied.
 
         Returns:
             dict: Connection details for the created Kuzu instance
 
         """
+        if kwargs:
+            raise ValueError(
+                "KuzuDatasetDatabaseHandler.create_dataset does not accept overrides; "
+                f"got unsupported keys: {sorted(kwargs)}"
+            )
+
         from cognee.infrastructure.databases.graph.config import get_graph_config
 
         graph_config = get_graph_config()

--- a/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jAuraDevDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jAuraDevDatasetDatabaseHandler.py
@@ -4,7 +4,7 @@ import asyncio
 import base64
 import hashlib
 from uuid import UUID
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import urlparse
 from cryptography.fernet import Fernet
 from aiohttp import BasicAuth
@@ -12,6 +12,13 @@ from aiohttp import BasicAuth
 from cognee.infrastructure.databases.graph import get_graph_config
 from cognee.modules.users.models import User, DatasetDatabase
 from cognee.infrastructure.databases.dataset_database_handler import DatasetDatabaseHandlerInterface
+
+
+# Allowed keys for Aura instance payload overrides supplied via ``create_dataset(**kwargs)``.
+# Keep in sync with the docstring on ``create_dataset`` below.
+_ALLOWED_AURA_OVERRIDE_KEYS: frozenset[str] = frozenset(
+    {"version", "region", "memory", "type", "cloud_provider"}
+)
 
 
 class Neo4jAuraDevDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
@@ -29,15 +36,18 @@ class Neo4jAuraDevDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
 
     @classmethod
     async def create_dataset(
-        cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs
+        cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs: Any
     ) -> dict:
         """
         Create a new Neo4j Aura instance for the dataset. Return connection info that will be mapped to the dataset.
 
         Args:
-            dataset_id: Dataset UUID
+            dataset_id: Dataset UUID. Required for collision-resistant instance naming;
+                a ``ValueError`` is raised when ``None``.
             user: User object who owns the dataset and is making the request
-            **kwargs: Optional overrides for the Aura instance payload fields:
+            **kwargs: Optional overrides for the Aura instance payload fields. Unknown keys
+                or ``None`` values raise ``ValueError`` rather than silently falling back to
+                defaults — callers must use one of the supported keys below:
                 version (str): Neo4j version, default "5"
                 region (str): Cloud region, default "europe-west1"
                 memory (str): Instance memory, default "1GB"
@@ -53,6 +63,31 @@ class Neo4jAuraDevDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         if graph_config.graph_database_provider != "neo4j":
             raise ValueError(
                 "Neo4jAuraDevDatasetDatabaseHandler can only be used with Neo4j graph database provider."
+            )
+
+        # Hashing ``None`` produces a stable digest, which would silently collapse every
+        # ``None``-id dataset onto the same Aura instance name. Fail loudly instead so the
+        # caller can supply a real dataset id rather than minting a shared bucket.
+        if dataset_id is None:
+            raise ValueError(
+                "Neo4jAuraDevDatasetDatabaseHandler.create_dataset requires a non-None dataset_id "
+                "for collision-resistant Aura instance naming."
+            )
+
+        # Reject unknown override keys up front so typos like ``regoin`` surface immediately
+        # instead of silently falling back to the default region.
+        unknown_keys = set(kwargs).difference(_ALLOWED_AURA_OVERRIDE_KEYS)
+        if unknown_keys:
+            raise ValueError(
+                "Unknown override keys passed to Neo4jAuraDevDatasetDatabaseHandler.create_dataset: "
+                f"{sorted(unknown_keys)}. Allowed keys: {sorted(_ALLOWED_AURA_OVERRIDE_KEYS)}."
+            )
+        none_valued_keys = [key for key, value in kwargs.items() if value is None]
+        if none_valued_keys:
+            raise ValueError(
+                "Override keys with None values are not permitted in "
+                f"Neo4jAuraDevDatasetDatabaseHandler.create_dataset: {sorted(none_valued_keys)}. "
+                "Omit the key to use the default instead of passing None."
             )
 
         # Use SHA-256 hash of the dataset ID for a compact, collision-resistant name

--- a/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jAuraDevDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jAuraDevDatasetDatabaseHandler.py
@@ -28,13 +28,21 @@ class Neo4jAuraDevDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
     """
 
     @classmethod
-    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+    async def create_dataset(
+        cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs
+    ) -> dict:
         """
         Create a new Neo4j Aura instance for the dataset. Return connection info that will be mapped to the dataset.
 
         Args:
             dataset_id: Dataset UUID
             user: User object who owns the dataset and is making the request
+            **kwargs: Optional overrides for the Aura instance payload fields:
+                version (str): Neo4j version, default "5"
+                region (str): Cloud region, default "europe-west1"
+                memory (str): Instance memory, default "1GB"
+                type (str): Instance type, default "professional-db"
+                cloud_provider (str): Cloud provider, default "gcp"
 
         Returns:
             dict: Connection details for the created Neo4j instance
@@ -47,7 +55,9 @@ class Neo4jAuraDevDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
                 "Neo4jAuraDevDatasetDatabaseHandler can only be used with Neo4j graph database provider."
             )
 
-        graph_db_name = f"{dataset_id}"
+        # Use SHA-256 hash of the dataset ID for a compact, collision-resistant name
+        # that fits within Neo4j Aura's 30-character limit without hyphens
+        graph_db_name = hashlib.sha256(str(dataset_id).encode()).hexdigest()[:29]
 
         # Client credentials and encryption
         # Note: Should not be used as class variables so that they are not persisted in memory longer than needed
@@ -75,18 +85,14 @@ class Neo4jAuraDevDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
             "Content-Type": "application/json",
         }
 
-        # TODO: Maybe we can allow **kwargs parameter forwarding for cases like these
-        #       Too allow different configurations between datasets
         payload = {
-            "version": "5",
-            "region": "europe-west1",
-            "memory": "1GB",
-            "name": graph_db_name[
-                0:29
-            ],  # TODO: Find better name to name Neo4j instance within 30 character limit
-            "type": "professional-db",
+            "version": kwargs.get("version", "5"),
+            "region": kwargs.get("region", "europe-west1"),
+            "memory": kwargs.get("memory", "1GB"),
+            "name": graph_db_name,
+            "type": kwargs.get("type", "professional-db"),
             "tenant_id": tenant_id,
-            "cloud_provider": "gcp",
+            "cloud_provider": kwargs.get("cloud_provider", "gcp"),
         }
 
         async def _create_database_instance_request():

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py
@@ -1,6 +1,6 @@
 import os
 from uuid import UUID
-from typing import Optional
+from typing import Any, Optional
 
 from cognee.infrastructure.databases.vector.create_vector_engine import create_vector_engine
 from cognee.modules.users.models import User
@@ -16,7 +16,15 @@ class LanceDBDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
     """
 
     @classmethod
-    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+    async def create_dataset(
+        cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs: Any
+    ) -> dict:
+        if kwargs:
+            raise ValueError(
+                "LanceDBDatasetDatabaseHandler.create_dataset does not accept overrides; "
+                f"got unsupported keys: {sorted(kwargs)}"
+            )
+
         vector_config = get_vectordb_config()
         base_config = get_base_config()
 

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py
@@ -19,6 +19,19 @@ class LanceDBDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
     async def create_dataset(
         cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs: Any
     ) -> dict:
+        """
+        Create a new LanceDB instance for the dataset. Return connection info that will be mapped to the dataset.
+
+        Args:
+            dataset_id: Dataset UUID
+            user: User object who owns the dataset and is making the request
+            **kwargs: Reserved for future overrides; the LanceDB handler currently
+                accepts no implementation-specific options and raises
+                ``ValueError`` if any are supplied.
+
+        Returns:
+            dict: Connection details for the created LanceDB instance
+        """
         if kwargs:
             raise ValueError(
                 "LanceDBDatasetDatabaseHandler.create_dataset does not accept overrides; "

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorDatasetDatabaseHandler.py
@@ -21,6 +21,19 @@ class PGVectorDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
     async def create_dataset(
         cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs: Any
     ) -> dict:
+        """
+        Create a new PGVector instance for the dataset. Return connection info that will be mapped to the dataset.
+
+        Args:
+            dataset_id: Dataset UUID
+            user: User object who owns the dataset and is making the request
+            **kwargs: Reserved for future overrides; the PGVector handler currently
+                accepts no implementation-specific options and raises
+                ``ValueError`` if any are supplied.
+
+        Returns:
+            dict: Connection details for the created PGVector instance
+        """
         if kwargs:
             raise ValueError(
                 "PGVectorDatasetDatabaseHandler.create_dataset does not accept overrides; "

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorDatasetDatabaseHandler.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import Optional
+from typing import Any, Optional
 from sqlalchemy import MetaData
 
 from cognee.infrastructure.databases.vector.pgvector.create_db_and_tables import delete_pg_database
@@ -18,7 +18,15 @@ class PGVectorDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
     """
 
     @classmethod
-    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+    async def create_dataset(
+        cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs: Any
+    ) -> dict:
+        if kwargs:
+            raise ValueError(
+                "PGVectorDatasetDatabaseHandler.create_dataset does not accept overrides; "
+                f"got unsupported keys: {sorted(kwargs)}"
+            )
+
         vector_config = get_vectordb_config()
 
         if vector_config.vector_db_provider != "pgvector":

--- a/cognee/infrastructure/databases/vector/vector_db_interface.py
+++ b/cognee/infrastructure/databases/vector/vector_db_interface.py
@@ -259,6 +259,7 @@ class VectorDBInterface(Protocol):
             **kwargs: Implementation-specific overrides for the database creation
                 request. Concrete handlers should document and validate the keys
                 they accept and raise ``ValueError`` for unknown keys.
+
         Returns:
             dict: Connection info for the created vector database instance.
         """

--- a/cognee/infrastructure/databases/vector/vector_db_interface.py
+++ b/cognee/infrastructure/databases/vector/vector_db_interface.py
@@ -239,7 +239,9 @@ class VectorDBInterface(Protocol):
         return model_type
 
     @classmethod
-    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+    async def create_dataset(
+        cls, dataset_id: Optional[UUID], user: Optional[User], **kwargs: Any
+    ) -> dict:
         """
         Return a dictionary with connection info for a vector database for the given dataset.
         Function can auto handle deploying of the actual database if needed, but is not necessary.
@@ -254,6 +256,9 @@ class VectorDBInterface(Protocol):
         Args:
             dataset_id: UUID of the dataset if needed by the database creation logic
             user: User object if needed by the database creation logic
+            **kwargs: Implementation-specific overrides for the database creation
+                request. Concrete handlers should document and validate the keys
+                they accept and raise ``ValueError`` for unknown keys.
         Returns:
             dict: Connection info for the created vector database instance.
         """

--- a/cognee/tests/test_dataset_database_handler.py
+++ b/cognee/tests/test_dataset_database_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from typing import Any
 
 # Set custom dataset database handler environment variable
 os.environ["VECTOR_DATASET_DATABASE_HANDLER"] = "custom_lancedb_handler"
@@ -14,7 +15,12 @@ from cognee.api.v1.search import SearchType
 
 class LanceDBTestDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
     @classmethod
-    async def create_dataset(cls, dataset_id, user):
+    async def create_dataset(cls, dataset_id, user, **kwargs: Any):
+        if kwargs:
+            raise ValueError(
+                "LanceDBTestDatasetDatabaseHandler.create_dataset does not accept overrides; "
+                f"got unsupported keys: {sorted(kwargs)}"
+            )
         import pathlib
 
         cognee_directory_path = str(
@@ -39,7 +45,12 @@ class LanceDBTestDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
 
 class KuzuTestDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
     @classmethod
-    async def create_dataset(cls, dataset_id, user):
+    async def create_dataset(cls, dataset_id, user, **kwargs: Any):
+        if kwargs:
+            raise ValueError(
+                "KuzuTestDatasetDatabaseHandler.create_dataset does not accept overrides; "
+                f"got unsupported keys: {sorted(kwargs)}"
+            )
         databases_directory_path = os.path.join("databases", str(user.id))
         os.makedirs(databases_directory_path, exist_ok=True)
 


### PR DESCRIPTION
## Summary

Addresses the two TODOs left in `Neo4jAuraDevDatasetDatabaseHandler.create_dataset()` noted in issue #2354:

- **Dynamic parameter forwarding**: Add `**kwargs` to `create_dataset()` so callers can override any Neo4j Aura instance configuration field (`version`, `region`, `memory`, `type`, `cloud_provider`) without subclassing. Previously all fields were hardcoded with no override path.

- **Collision-resistant instance naming**: Replace the raw UUID slice `f"{dataset_id}"[:29]` with a SHA-256 hash truncated to 29 hex characters. The original approach risked name collisions for deterministic UUIDs sharing long common prefixes, and also allowed hyphens which Neo4j Aura may reject. The SHA-256 approach provides 116 bits of effective uniqueness from a 29-character hex string.

- **Updated docstring**: Documents all supported `**kwargs` keys and their defaults.

## Test plan

- [ ] Existing callers of `create_dataset(dataset_id, user)` continue to work unchanged (backward-compatible `**kwargs` addition)
- [ ] Callers can override any payload field: `create_dataset(dataset_id, user, region="us-east-1", memory="2GB")`
- [ ] Generated instance name is always 29 hex characters (no hyphens, fits within Neo4j Aura's 30-char limit)
- [ ] Same `dataset_id` always produces the same name (deterministic hash)

Fixes #2354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataset creation handlers now accept optional override parameters for instance settings.

* **Improvements**
  * Aura instance names are generated deterministically to meet naming constraints.
  * Interfaces/docstrings clarify that handlers may accept and validate implementation-specific overrides.

* **Bug Fixes**
  * Validation added: dataset ID required; unknown or explicitly null overrides are rejected.

* **Tests**
  * Test handlers updated to accept and validate the new override parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->