### PR TITLE
feat(session): add tapes cache backend that mirrors QAs to tapes ingest

### DIFF
--- a/cognee/infrastructure/databases/cache/config.py
+++ b/cognee/infrastructure/databases/cache/config.py
@@ -34,7 +34,7 @@ class CacheConfig(BaseSettings):
     max_session_context_chars: Optional[int] = None
     usage_logging: bool = False
     usage_logging_ttl: int = 604800
-    tapes_ingest_url: str = "http://localhost:8081"
+    tapes_ingest_url: str = "http://localhost:8082"
     tapes_provider: Literal["openai", "anthropic", "ollama"] = "openai"
     tapes_agent_name: str = "cognee"
     tapes_model: str = "cognee-session"

--- a/cognee/infrastructure/databases/cache/config.py
+++ b/cognee/infrastructure/databases/cache/config.py
@@ -20,7 +20,7 @@ class CacheConfig(BaseSettings):
     - auto_feedback: When caching is True, run automatic feedback detection on each query (default False).
     """
 
-    cache_backend: Literal["redis", "fs"] = "fs"
+    cache_backend: Literal["redis", "fs", "tapes"] = "fs"
     caching: bool = True
     auto_feedback: bool = False
     shared_kuzu_lock: bool = False
@@ -34,6 +34,11 @@ class CacheConfig(BaseSettings):
     max_session_context_chars: Optional[int] = None
     usage_logging: bool = False
     usage_logging_ttl: int = 604800
+    tapes_ingest_url: str = "http://localhost:8081"
+    tapes_provider: Literal["openai", "anthropic", "ollama"] = "openai"
+    tapes_agent_name: str = "cognee"
+    tapes_model: str = "cognee-session"
+    tapes_request_timeout: float = 5.0
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
@@ -53,6 +58,11 @@ class CacheConfig(BaseSettings):
             "max_session_context_chars": self.max_session_context_chars,
             "usage_logging": self.usage_logging,
             "usage_logging_ttl": self.usage_logging_ttl,
+            "tapes_ingest_url": self.tapes_ingest_url,
+            "tapes_provider": self.tapes_provider,
+            "tapes_agent_name": self.tapes_agent_name,
+            "tapes_model": self.tapes_model,
+            "tapes_request_timeout": self.tapes_request_timeout,
         }
 
 

--- a/cognee/infrastructure/databases/cache/get_cache_engine.py
+++ b/cognee/infrastructure/databases/cache/get_cache_engine.py
@@ -18,7 +18,7 @@ def create_cache_engine(
     agentic_lock_expire: int = 240,
     agentic_lock_timeout: int = 300,
     session_ttl_seconds: int | None = 604800,
-    tapes_ingest_url: str = "http://localhost:8081",
+    tapes_ingest_url: str = "http://localhost:8082",
     tapes_provider: str = "openai",
     tapes_agent_name: str = "cognee",
     tapes_model: str = "cognee-session",

--- a/cognee/infrastructure/databases/cache/get_cache_engine.py
+++ b/cognee/infrastructure/databases/cache/get_cache_engine.py
@@ -18,6 +18,11 @@ def create_cache_engine(
     agentic_lock_expire: int = 240,
     agentic_lock_timeout: int = 300,
     session_ttl_seconds: int | None = 604800,
+    tapes_ingest_url: str = "http://localhost:8081",
+    tapes_provider: str = "openai",
+    tapes_agent_name: str = "cognee",
+    tapes_model: str = "cognee-session",
+    tapes_request_timeout: float = 5.0,
 ):
     """
     Factory function to instantiate a cache coordination backend (currently Redis).
@@ -55,10 +60,23 @@ def create_cache_engine(
             )
         elif config.cache_backend == "fs":
             return FSCacheAdapter(session_ttl_seconds=session_ttl_seconds)
+        elif config.cache_backend == "tapes":
+            from cognee.infrastructure.databases.cache.tapes.TapesCacheAdapter import (
+                TapesCacheAdapter,
+            )
+
+            return TapesCacheAdapter(
+                session_ttl_seconds=session_ttl_seconds,
+                tapes_ingest_url=tapes_ingest_url,
+                tapes_provider=tapes_provider,
+                tapes_agent_name=tapes_agent_name,
+                tapes_model=tapes_model,
+                tapes_request_timeout=tapes_request_timeout,
+            )
         else:
             raise ValueError(
                 f"Unsupported cache backend: '{config.cache_backend}'. "
-                f"Supported backends are: 'redis', 'fs'"
+                f"Supported backends are: 'redis', 'fs', 'tapes'"
             )
     else:
         return None
@@ -83,4 +101,9 @@ def get_cache_engine(
         agentic_lock_expire=config.agentic_lock_expire,
         agentic_lock_timeout=config.agentic_lock_timeout,
         session_ttl_seconds=config.session_ttl_seconds,
+        tapes_ingest_url=config.tapes_ingest_url,
+        tapes_provider=config.tapes_provider,
+        tapes_agent_name=config.tapes_agent_name,
+        tapes_model=config.tapes_model,
+        tapes_request_timeout=config.tapes_request_timeout,
     )

--- a/cognee/infrastructure/databases/cache/tapes/TapesCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/tapes/TapesCacheAdapter.py
@@ -27,7 +27,7 @@ class TapesCacheAdapter(FSCacheAdapter):
         self,
         session_ttl_seconds: int | None = 604800,
         *,
-        tapes_ingest_url: str = "http://localhost:8081",
+        tapes_ingest_url: str = "http://localhost:8082",
         tapes_provider: str = "openai",
         tapes_agent_name: str = "cognee",
         tapes_model: str = "cognee-session",

--- a/cognee/infrastructure/databases/cache/tapes/TapesCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/tapes/TapesCacheAdapter.py
@@ -1,0 +1,173 @@
+"""Filesystem-backed cache adapter that mirrors QA writes to a running tapes
+ingest server (https://github.com/papercomputeco/tapes).
+
+The FS adapter remains the source of truth for session state. Every new QA
+entry is additionally POSTed to `{tapes_ingest_url}/v1/ingest` as a provider-
+shaped request/response turn, so the conversation becomes queryable through
+tapes' Merkle DAG and semantic search surfaces. Tapes is append-only; QA
+updates, deletes, agent-trace steps, and usage logs are not mirrored.
+"""
+
+import json
+import time
+import uuid
+
+import httpx
+
+from cognee.infrastructure.databases.cache.fscache.FsCacheAdapter import FSCacheAdapter
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("TapesCacheAdapter")
+
+
+class TapesCacheAdapter(FSCacheAdapter):
+    """FS adapter that also mirrors each new QA to tapes /v1/ingest."""
+
+    def __init__(
+        self,
+        session_ttl_seconds: int | None = 604800,
+        *,
+        tapes_ingest_url: str = "http://localhost:8081",
+        tapes_provider: str = "openai",
+        tapes_agent_name: str = "cognee",
+        tapes_model: str = "cognee-session",
+        tapes_request_timeout: float = 5.0,
+    ):
+        super().__init__(session_ttl_seconds=session_ttl_seconds)
+        self.tapes_ingest_url = tapes_ingest_url.rstrip("/")
+        self.tapes_provider = tapes_provider
+        self.tapes_agent_name = tapes_agent_name
+        self.tapes_model = tapes_model
+        self.tapes_request_timeout = tapes_request_timeout
+        self._tapes_client: httpx.AsyncClient | None = None
+
+    def _get_tapes_client(self) -> httpx.AsyncClient:
+        if self._tapes_client is None:
+            self._tapes_client = httpx.AsyncClient(timeout=self.tapes_request_timeout)
+        return self._tapes_client
+
+    def _build_openai_turn(self, *, question: str, context: str, answer: str) -> tuple[dict, dict]:
+        messages: list[dict] = []
+        if context:
+            messages.append({"role": "system", "content": context})
+        messages.append({"role": "user", "content": question})
+
+        request_body = {"model": self.tapes_model, "messages": messages}
+        response_body = {
+            "id": f"cognee-{uuid.uuid4()}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": self.tapes_model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": answer},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        return request_body, response_body
+
+    def _build_anthropic_turn(
+        self, *, question: str, context: str, answer: str
+    ) -> tuple[dict, dict]:
+        request_body: dict = {
+            "model": self.tapes_model,
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": question}],
+        }
+        if context:
+            request_body["system"] = context
+        response_body = {
+            "id": f"msg_cognee_{uuid.uuid4()}",
+            "type": "message",
+            "role": "assistant",
+            "model": self.tapes_model,
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": answer}],
+        }
+        return request_body, response_body
+
+    def _build_ollama_turn(self, *, question: str, context: str, answer: str) -> tuple[dict, dict]:
+        messages: list[dict] = []
+        if context:
+            messages.append({"role": "system", "content": context})
+        messages.append({"role": "user", "content": question})
+        request_body = {"model": self.tapes_model, "messages": messages, "stream": False}
+        response_body = {
+            "model": self.tapes_model,
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "message": {"role": "assistant", "content": answer},
+            "done": True,
+            "done_reason": "stop",
+        }
+        return request_body, response_body
+
+    def _build_provider_turn(
+        self, *, question: str, context: str, answer: str
+    ) -> tuple[dict, dict]:
+        builders = {
+            "openai": self._build_openai_turn,
+            "anthropic": self._build_anthropic_turn,
+            "ollama": self._build_ollama_turn,
+        }
+        builder = builders.get(self.tapes_provider, self._build_openai_turn)
+        return builder(question=question, context=context, answer=answer)
+
+    async def _mirror_to_tapes(self, *, question: str, context: str, answer: str) -> None:
+        request_body, response_body = self._build_provider_turn(
+            question=question, context=context, answer=answer
+        )
+        payload = {
+            "provider": self.tapes_provider,
+            "agent_name": self.tapes_agent_name,
+            "request": json.loads(json.dumps(request_body)),
+            "response": json.loads(json.dumps(response_body)),
+        }
+        try:
+            client = self._get_tapes_client()
+            resp = await client.post(f"{self.tapes_ingest_url}/v1/ingest", json=payload)
+            if resp.status_code >= 400:
+                logger.warning(
+                    "Tapes ingest rejected turn: status=%s body=%s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+        except Exception as e:
+            logger.warning("Tapes mirror failed, continuing with FS cache only: %s", e)
+
+    async def create_qa_entry(
+        self,
+        user_id: str,
+        session_id: str,
+        question: str,
+        context: str,
+        answer: str,
+        qa_id: str | None = None,
+        feedback_text: str | None = None,
+        feedback_score: int | None = None,
+        used_graph_element_ids: dict | None = None,
+        memify_metadata: dict | None = None,
+    ):
+        await super().create_qa_entry(
+            user_id,
+            session_id,
+            question,
+            context,
+            answer,
+            qa_id,
+            feedback_text,
+            feedback_score,
+            used_graph_element_ids=used_graph_element_ids,
+            memify_metadata=memify_metadata,
+        )
+        await self._mirror_to_tapes(question=question, context=context, answer=answer)
+
+    async def close(self):
+        if self._tapes_client is not None:
+            try:
+                await self._tapes_client.aclose()
+            except Exception as e:
+                logger.debug("Error closing tapes HTTP client: %s", e)
+            self._tapes_client = None
+        await super().close()

--- a/cognee/infrastructure/databases/cache/tapes/__init__.py
+++ b/cognee/infrastructure/databases/cache/tapes/__init__.py
@@ -1,0 +1,3 @@
+from .TapesCacheAdapter import TapesCacheAdapter
+
+__all__ = ["TapesCacheAdapter"]

--- a/cognee/tests/integration/infrastructure/session/test_tapes_cache_adapter.py
+++ b/cognee/tests/integration/infrastructure/session/test_tapes_cache_adapter.py
@@ -1,0 +1,135 @@
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def tapes_adapter():
+    """TapesCacheAdapter rooted in a temp cache directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch(
+            "cognee.infrastructure.databases.cache.fscache.FsCacheAdapter.get_storage_config",
+            return_value={"data_root_directory": tmpdir},
+        ):
+            from cognee.infrastructure.databases.cache.tapes.TapesCacheAdapter import (
+                TapesCacheAdapter,
+            )
+
+            inst = TapesCacheAdapter(
+                tapes_ingest_url="http://tapes.test:8081",
+                tapes_agent_name="cognee-unit",
+                tapes_model="unit-model",
+            )
+            yield inst
+            inst.cache.close()
+
+
+def _patched_post_returning(status_code: int = 202):
+    """Build a mock httpx.AsyncClient.post returning a response with given status."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = ""
+    return AsyncMock(return_value=response)
+
+
+@pytest.mark.asyncio
+async def test_create_qa_entry_writes_fs_and_mirrors_to_tapes(tapes_adapter):
+    mock_post = _patched_post_returning(202)
+    with patch("httpx.AsyncClient.post", mock_post):
+        await tapes_adapter.create_qa_entry(
+            user_id="u1",
+            session_id="s1",
+            question="What is cognee?",
+            context="Background context here.",
+            answer="An AI memory platform.",
+            qa_id="qa-1",
+        )
+
+    entries = await tapes_adapter.get_all_qa_entries("u1", "s1")
+    assert len(entries) == 1
+    assert entries[0]["qa_id"] == "qa-1"
+    assert entries[0]["answer"] == "An AI memory platform."
+
+    assert mock_post.await_count == 1
+    call = mock_post.await_args
+    assert call.args[0] == "http://tapes.test:8081/v1/ingest"
+    payload = call.kwargs["json"]
+    assert payload["provider"] == "openai"
+    assert payload["agent_name"] == "cognee-unit"
+    assert payload["request"]["model"] == "unit-model"
+    assert payload["request"]["messages"] == [
+        {"role": "system", "content": "Background context here."},
+        {"role": "user", "content": "What is cognee?"},
+    ]
+    assert payload["response"]["model"] == "unit-model"
+    assert payload["response"]["choices"][0]["message"]["content"] == "An AI memory platform."
+
+
+@pytest.mark.asyncio
+async def test_ingest_failure_does_not_break_fs_write(tapes_adapter):
+    mock_post = AsyncMock(side_effect=RuntimeError("tapes unreachable"))
+    with patch("httpx.AsyncClient.post", mock_post):
+        await tapes_adapter.create_qa_entry(
+            user_id="u1",
+            session_id="s1",
+            question="Q?",
+            context="",
+            answer="A.",
+            qa_id="qa-2",
+        )
+
+    entries = await tapes_adapter.get_all_qa_entries("u1", "s1")
+    assert len(entries) == 1
+    assert entries[0]["qa_id"] == "qa-2"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_provider_shape(tapes_adapter):
+    tapes_adapter.tapes_provider = "anthropic"
+    mock_post = _patched_post_returning(202)
+    with patch("httpx.AsyncClient.post", mock_post):
+        await tapes_adapter.create_qa_entry(
+            user_id="u1",
+            session_id="s1",
+            question="Hi?",
+            context="sys",
+            answer="Hello.",
+            qa_id="qa-3",
+        )
+
+    payload = mock_post.await_args.kwargs["json"]
+    assert payload["provider"] == "anthropic"
+    assert payload["request"]["system"] == "sys"
+    assert payload["request"]["messages"] == [{"role": "user", "content": "Hi?"}]
+    assert payload["response"]["content"] == [{"type": "text", "text": "Hello."}]
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_are_not_mirrored(tapes_adapter):
+    """Updates and deletes stay local: tapes is append-only."""
+    mock_post = _patched_post_returning(202)
+    with patch("httpx.AsyncClient.post", mock_post):
+        await tapes_adapter.create_qa_entry(
+            user_id="u1",
+            session_id="s1",
+            question="Q?",
+            context="",
+            answer="A.",
+            qa_id="qa-4",
+        )
+        assert mock_post.await_count == 1
+
+        updated = await tapes_adapter.update_qa_entry(
+            user_id="u1",
+            session_id="s1",
+            qa_id="qa-4",
+            feedback_score=5,
+        )
+        assert updated is True
+
+        deleted = await tapes_adapter.delete_qa_entry("u1", "s1", "qa-4")
+        assert deleted is True
+
+    # Only the initial create_qa_entry should have reached tapes.
+    assert mock_post.await_count == 1

--- a/cognee/tests/unit/infrastructure/databases/cache/test_cache_config.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_cache_config.py
@@ -88,6 +88,11 @@ def test_cache_config_to_dict():
         "max_session_context_chars": None,
         "usage_logging": False,
         "usage_logging_ttl": 604800,
+        "tapes_ingest_url": "http://localhost:8082",
+        "tapes_provider": "openai",
+        "tapes_agent_name": "cognee",
+        "tapes_model": "cognee-session",
+        "tapes_request_timeout": 5.0,
     }
 
 


### PR DESCRIPTION
## Summary
- Adds a third `cache_backend` option, `"tapes"`, next to `"redis"` and `"fs"`.
- `TapesCacheAdapter` subclasses `FSCacheAdapter` — the filesystem cache stays the source of truth. Each new QA entry is additionally mirrored to `{tapes_ingest_url}/v1/ingest` as an OpenAI / Anthropic / Ollama-shaped turn so the conversation becomes queryable through tapes' Merkle DAG and semantic search.
- Ingest failures (tapes down, HTTP error) are logged at warning and swallowed; the FS write is never blocked. Updates, deletes, agent-trace steps, and usage logs stay local because tapes is append-only.
- Configurable via `CACHE_BACKEND=tapes` and `TAPES_INGEST_URL` / `TAPES_PROVIDER` / `TAPES_AGENT_NAME` / `TAPES_MODEL` / `TAPES_REQUEST_TIMEOUT` env vars.

## Test plan
- [x] `uv run pytest cognee/tests/integration/infrastructure/session/test_tapes_cache_adapter.py` — 4 new tests pass (FS + mirror write, ingest-failure tolerance, Anthropic-shape payload, updates/deletes not mirrored).
- [x] `uv run pytest cognee/tests/integration/infrastructure/session/test_session_manager_fs.py` — pre-existing 14 FS tests still pass.
- [ ] Manual end-to-end against a running `tapes serve`: verify turns show up in `GET /v1/sessions` and `GET /v1/search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "tapes" cache backend that mirrors Q&A entries to an external Tapes ingest service
  * Support for multiple ingestion providers: OpenAI, Anthropic, Ollama

* **Chores**
  * Added configurable Tapes parameters (ingest URL, provider, agent name, model, request timeout)
  * Cache configuration now exposes those fields

* **Tests**
  * Added integration tests for persistence, mirroring, failure handling, and provider payload shapes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->