### PR TITLE
feat(core): add ingest/query event hooks for external subscribers

### DIFF
--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -58,3 +58,14 @@ from cognee.modules.observability.trace_context import (
 
 # Agent memory
 from cognee.modules.agent_memory import agent_memory
+
+# Event hooks for external subscribers (audit sinks, metrics, loggers, etc.)
+from cognee.events import (
+    CogneeEvent,
+    subscribe,
+    emit,
+    INGEST_BEFORE,
+    INGEST_AFTER,
+    QUERY_BEFORE,
+    QUERY_AFTER,
+)

--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 from typing import Union, BinaryIO, List, Optional, Any
 
+from cognee.events import emit as emit_event, INGEST_AFTER, INGEST_BEFORE
 from cognee.modules.users.models import User
 from cognee.modules.pipelines import Task, run_pipeline
 from cognee.modules.pipelines.layers.resolve_authorized_user_dataset import (
@@ -214,6 +215,14 @@ async def add(
         ),
     ]
 
+    await emit_event(
+        INGEST_BEFORE,
+        dataset_name=dataset_name,
+        dataset_id=dataset_id,
+        node_set=node_set,
+        run_in_background=run_in_background,
+    )
+
     await setup()
 
     user, authorized_dataset = await resolve_authorized_user_dataset(
@@ -252,6 +261,13 @@ async def add(
     # run_pipeline_blocking returns {dataset_id: PipelineRunInfo} but callers
     # expect a single PipelineRunInfo (add always processes one dataset).
     if isinstance(result, dict) and len(result) == 1:
-        return next(iter(result.values()))
+        result = next(iter(result.values()))
+
+    await emit_event(
+        INGEST_AFTER,
+        dataset_name=dataset_name,
+        dataset_id=getattr(authorized_dataset, "id", dataset_id),
+        run_in_background=run_in_background,
+    )
 
     return result

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -32,6 +32,7 @@ from cognee.tasks.temporal_graph.extract_knowledge_graph_from_events import (
     extract_knowledge_graph_from_events,
 )
 from cognee.modules.observability import new_span, COGNEE_PIPELINE_NAME, COGNEE_RESULT_SUMMARY
+from cognee.events import emit as emit_event, INGEST_AFTER, INGEST_BEFORE
 
 
 logger = get_logger("cognify")
@@ -208,6 +209,14 @@ async def cognify(
         if datasets is not None:
             span.set_attribute("cognee.cognify.datasets", str(datasets))
 
+        await emit_event(
+            INGEST_BEFORE,
+            stage="cognify",
+            datasets=str(datasets) if datasets is not None else None,
+            temporal_cognify=temporal_cognify,
+            run_in_background=run_in_background,
+        )
+
         if config is None:
             ontology_config = get_ontology_env_config()
             if (
@@ -267,6 +276,14 @@ async def cognify(
         span.set_attribute(
             COGNEE_RESULT_SUMMARY,
             f"Cognify completed for {dataset_desc}",
+        )
+
+        await emit_event(
+            INGEST_AFTER,
+            stage="cognify",
+            datasets=str(datasets) if datasets is not None else None,
+            temporal_cognify=temporal_cognify,
+            run_in_background=run_in_background,
         )
 
         return result

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -20,6 +20,7 @@ from cognee.modules.observability import (
     COGNEE_RESULT_SUMMARY,
     COGNEE_RESULT_COUNT,
 )
+from cognee.events import emit as emit_event, QUERY_AFTER, QUERY_BEFORE
 
 logger = get_logger()
 
@@ -214,6 +215,14 @@ async def search(
         span.set_attribute(COGNEE_SEARCH_TYPE, str(query_type.value))
         span.set_attribute("cognee.search.top_k", top_k)
 
+        await emit_event(
+            QUERY_BEFORE,
+            query_text=query_text,
+            query_type=str(query_type.value),
+            top_k=top_k,
+            session_id=session_id,
+        )
+
         # We use lists from now on for datasets
         if isinstance(datasets, UUID) or isinstance(datasets, str):
             datasets = [datasets]
@@ -276,6 +285,15 @@ async def search(
         span.set_attribute(
             COGNEE_RESULT_SUMMARY,
             f"Found {n} result(s) via {query_type.value}",
+        )
+
+        await emit_event(
+            QUERY_AFTER,
+            query_text=query_text,
+            query_type=str(query_type.value),
+            top_k=top_k,
+            session_id=session_id,
+            result_count=n,
         )
 
         return filtered_search_results

--- a/cognee/events/__init__.py
+++ b/cognee/events/__init__.py
@@ -1,0 +1,100 @@
+"""Event hooks for cognee core operations.
+
+A tiny in-process pub/sub so external observers (audit trails, metrics, custom
+loggers) can react to ingest and query lifecycle events without being pinned
+as a core dependency. Zero external deps.
+
+Public surface:
+    - CogneeEvent: dataclass carrying event_type, timestamp, payload
+    - subscribe(listener): register a listener, returns an unsubscribe callable
+    - emit(event_type, **payload): fire an event to all listeners
+
+Listeners can be sync or async. Exceptions raised by a listener are logged
+and swallowed so a bad listener cannot take down the core operation.
+"""
+
+import inspect
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Union
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("cognee.events")
+
+
+# Known event types emitted by cognee core. Listeners may filter on these.
+INGEST_BEFORE = "ingest.before"
+INGEST_AFTER = "ingest.after"
+QUERY_BEFORE = "query.before"
+QUERY_AFTER = "query.after"
+
+
+Listener = Callable[["CogneeEvent"], Union[None, Awaitable[None]]]
+
+
+@dataclass
+class CogneeEvent:
+    """A single event fired from a cognee core operation."""
+
+    event_type: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+_listeners: list[Listener] = []
+
+
+def subscribe(listener: Listener) -> Callable[[], None]:
+    """Register a listener. Returns an unsubscribe function."""
+    _listeners.append(listener)
+
+    def unsubscribe() -> None:
+        if listener in _listeners:
+            _listeners.remove(listener)
+
+    return unsubscribe
+
+
+def clear_listeners() -> None:
+    """Remove all registered listeners. Primarily useful for tests."""
+    _listeners.clear()
+
+
+async def emit(event_type: str, **payload: Any) -> None:
+    """Fire an event to all registered listeners.
+
+    If no listeners are registered this is a near-noop (single list check).
+    Sync listeners are called directly; async listeners are awaited.
+    Listener exceptions are logged and suppressed.
+    """
+    if not _listeners:
+        return
+
+    event = CogneeEvent(event_type=event_type, payload=dict(payload))
+    # Snapshot the listener list so a listener that unsubscribes during
+    # iteration does not skip siblings.
+    for fn in list(_listeners):
+        try:
+            result = fn(event)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            logger.warning(
+                "Cognee event listener raised an exception for %s: %s",
+                event_type,
+                exc,
+            )
+
+
+__all__ = [
+    "CogneeEvent",
+    "Listener",
+    "subscribe",
+    "clear_listeners",
+    "emit",
+    "INGEST_BEFORE",
+    "INGEST_AFTER",
+    "QUERY_BEFORE",
+    "QUERY_AFTER",
+]

--- a/cognee/tests/unit/events/test_events.py
+++ b/cognee/tests/unit/events/test_events.py
@@ -1,0 +1,116 @@
+"""Unit tests for the cognee.events pub/sub module."""
+
+import pytest
+
+from cognee.events import (
+    CogneeEvent,
+    INGEST_AFTER,
+    INGEST_BEFORE,
+    QUERY_AFTER,
+    QUERY_BEFORE,
+    clear_listeners,
+    emit,
+    subscribe,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_listeners():
+    """Ensure each test starts and ends with no registered listeners."""
+    clear_listeners()
+    yield
+    clear_listeners()
+
+
+@pytest.mark.asyncio
+async def test_emit_with_no_listeners_is_noop():
+    # Should not raise even with zero subscribers.
+    await emit(INGEST_BEFORE, dataset_name="main_dataset")
+
+
+@pytest.mark.asyncio
+async def test_sync_listener_is_invoked():
+    received: list[CogneeEvent] = []
+
+    def listener(event: CogneeEvent) -> None:
+        received.append(event)
+
+    subscribe(listener)
+    await emit(INGEST_BEFORE, dataset_name="main_dataset")
+
+    assert len(received) == 1
+    assert received[0].event_type == INGEST_BEFORE
+    assert received[0].payload == {"dataset_name": "main_dataset"}
+    assert received[0].timestamp is not None
+
+
+@pytest.mark.asyncio
+async def test_async_listener_is_awaited():
+    received: list[CogneeEvent] = []
+
+    async def listener(event: CogneeEvent) -> None:
+        received.append(event)
+
+    subscribe(listener)
+    await emit(QUERY_AFTER, query_text="hello", result_count=3)
+
+    assert len(received) == 1
+    assert received[0].event_type == QUERY_AFTER
+    assert received[0].payload["result_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_stops_future_events():
+    received: list[CogneeEvent] = []
+
+    def listener(event: CogneeEvent) -> None:
+        received.append(event)
+
+    unsubscribe = subscribe(listener)
+    await emit(INGEST_AFTER)
+    unsubscribe()
+    await emit(INGEST_AFTER)
+
+    assert len(received) == 1
+
+
+@pytest.mark.asyncio
+async def test_listener_exception_does_not_break_others():
+    received: list[CogneeEvent] = []
+
+    def bad_listener(event: CogneeEvent) -> None:
+        raise RuntimeError("boom")
+
+    def good_listener(event: CogneeEvent) -> None:
+        received.append(event)
+
+    subscribe(bad_listener)
+    subscribe(good_listener)
+
+    # Should not raise, and good_listener must still observe the event.
+    await emit(QUERY_BEFORE, query_text="x")
+
+    assert len(received) == 1
+    assert received[0].event_type == QUERY_BEFORE
+
+
+@pytest.mark.asyncio
+async def test_multiple_listeners_each_receive_events():
+    calls_a = 0
+    calls_b = 0
+
+    def listener_a(event: CogneeEvent) -> None:
+        nonlocal calls_a
+        calls_a += 1
+
+    async def listener_b(event: CogneeEvent) -> None:
+        nonlocal calls_b
+        calls_b += 1
+
+    subscribe(listener_a)
+    subscribe(listener_b)
+    await emit(INGEST_BEFORE)
+    await emit(INGEST_AFTER)
+
+    assert calls_a == 2
+    assert calls_b == 2

--- a/examples/guides/event_hooks.py
+++ b/examples/guides/event_hooks.py
@@ -1,0 +1,52 @@
+"""Event hooks example: subscribe to cognee ingest/query events.
+
+This demonstrates how an external observer (audit trail, metrics, custom
+logger) can react to cognee lifecycle events without being a cognee core
+dependency. Listeners can be plain functions or coroutines.
+
+Prerequisites:
+    1. Copy `.env.template` to `.env`.
+    2. Set LLM_API_KEY in `.env`.
+"""
+
+import asyncio
+
+import cognee
+from cognee.api.v1.search import SearchType
+
+
+def log_event(event: cognee.CogneeEvent) -> None:
+    """Sync listener: print each event we observe."""
+    print(f"[{event.timestamp.isoformat()}] {event.event_type} {event.payload}")
+
+
+async def audit_listener(event: cognee.CogneeEvent) -> None:
+    """Async listener: demonstrate that coroutine listeners are awaited."""
+    if event.event_type == cognee.QUERY_AFTER:
+        print(f"  -> query returned {event.payload.get('result_count', 0)} result(s)")
+
+
+async def main() -> None:
+    unsub_sync = cognee.subscribe(log_event)
+    unsub_async = cognee.subscribe(audit_listener)
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+
+        await cognee.add("Natural language processing is a field of artificial intelligence.")
+        await cognee.cognify()
+
+        results = await cognee.search(
+            query_type=SearchType.GRAPH_COMPLETION,
+            query_text="What is NLP?",
+        )
+        for item in results:
+            print(item)
+    finally:
+        unsub_sync()
+        unsub_async()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

Part of #2562. Follows up on the discussion with @Vasilije1990: rather than pinning a vendor SDK as a core dep, this adds a tiny in-process pub/sub so any external observer (audit trail, metrics collector, custom logger) can subscribe to ingest and query lifecycle events.

New module: `cognee.events`. Four event types fire today:
- `ingest.before` / `ingest.after` around `cognee.add` and `cognee.cognify`
- `query.before` / `query.after` around `cognee.search`

Listeners can be sync or async. If a listener raises, we log a warning and keep going so a misbehaving listener cannot break the core operation. With no listeners registered, `emit` is a single list check and returns immediately, so the backward-compatible path is essentially free.

A follow-up `cognee[asqav]` extra (outside this PR) will ship a signed-audit subscriber using this exact hook. Keeping core vendor-neutral is the point.

## Acceptance Criteria

- `cognee.events` exposes `CogneeEvent`, `subscribe`, `emit`, and four event-type constants.
- `CogneeEvent`, `subscribe`, `emit`, `INGEST_BEFORE`, `INGEST_AFTER`, `QUERY_BEFORE`, `QUERY_AFTER` are re-exported from the top-level `cognee` package.
- Listeners fire before and after `cognee.add`, `cognee.cognify`, and `cognee.search`.
- Listeners may be sync or async; exceptions are logged, not raised.
- No new runtime dependencies.
- Unit tests under `cognee/tests/unit/events/test_events.py` cover: no-listener noop, sync listener, async listener, unsubscribe, exception isolation, multi-listener fan-out.
- Example at `examples/guides/event_hooks.py` shows vendor-neutral subscriber usage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

I could not run the full test suite locally: `uv sync --frozen` fails on my macOS x86_64 because the pinned `lancedb==0.29.2` has no wheel for that platform. I ran the new events module's test cases via a standalone harness (stubbing `cognee.shared.logging_utils.get_logger` to avoid pulling the full cognee import chain). All six cases pass:

```
PASS: emit_no_listeners
PASS: sync_listener
PASS: async_listener
PASS: unsubscribe_stops_events
PASS: bad_listener_isolated
PASS: multi_listeners

6 tests passed
```

I also ran `ruff check` and `ruff format` across the modified files, and `pre-commit run` on all changed files (all hooks passed: trailing whitespace, end-of-file, check-yaml, check-added-large-files, ruff, ruff-format). Happy to re-run the pytest suite in CI or on a Linux host if that is preferred.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (see Screenshots note)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (docstrings + example)
- [x] All new and existing tests pass (events tests pass; full suite not runnable locally because of the lancedb wheel issue above)
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an event hook system allowing users to subscribe to pipeline lifecycle events (ingest before/after, query before/after) and execute custom sync or async listeners in response.
  * Event listeners receive detailed context including query parameters, dataset information, and operation results.

* **Tests**
  * Added comprehensive unit tests for event subscription and emission.

* **Documentation**
  * Added example guide demonstrating event hook subscription and listener implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->