### PR TITLE
fix: docker mcp build, dockerfile updated

### DIFF
--- a/cognee-mcp/Dockerfile
+++ b/cognee-mcp/Dockerfile
@@ -16,6 +16,13 @@ ARG DEBUG
 # Set environment variable based on the build argument
 ENV DEBUG=${DEBUG}
 
+# Needed when psycopg2 is built from source via cognee[postgres] in linux images.
+# libpq-dev provides pg_config; gcc is required for compilation.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy pyproject.toml and lockfile first for better caching
 COPY ./cognee-mcp/pyproject.toml ./cognee-mcp/uv.lock ./cognee-mcp/entrypoint.sh ./
 
@@ -31,7 +38,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM python:3.12-slim-bookworm
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/cognee-mcp/Dockerfile
+++ b/cognee-mcp/Dockerfile
@@ -17,9 +17,9 @@ ARG DEBUG
 ENV DEBUG=${DEBUG}
 
 # Needed when psycopg2 is built from source via cognee[postgres] in linux images.
-# libpq-dev provides pg_config; gcc is required for compilation.
+# libpq-dev provides pg_config; build-essential provides libc headers and toolchain.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
+    build-essential \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
After bumping cognee[postgres] dependency in mcp, the docker image build failed.
It tried to install psycopg from source, and was missing gcc and some packages.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build steps to tighten package installation and cleanup, improving build efficiency and producing a leaner runtime image for more consistent deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->