### PR TITLE
feat(users): parent_user_id so agent-created datasets auto-share with owner

### DIFF
--- a/cognee/modules/data/methods/create_authorized_dataset.py
+++ b/cognee/modules/data/methods/create_authorized_dataset.py
@@ -1,13 +1,25 @@
+import logging
+
 from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.databases.exceptions import EntityNotFoundError
 from cognee.modules.users.models import User
 from cognee.modules.data.models import Dataset
+from cognee.modules.users.methods import get_user
 from cognee.modules.users.permissions.methods import give_permission_on_dataset
 from .create_dataset import create_dataset
+
+logger = logging.getLogger(__name__)
+
+_DATASET_PERMISSIONS = ("read", "write", "delete", "share")
 
 
 async def create_authorized_dataset(dataset_name: str, user: User) -> Dataset:
     """
         Create a new dataset and give all permissions on this dataset to the given user.
+
+        If ``user.parent_user_id`` is set (i.e. the user is an agent/service
+        identity with a human owner), the parent user also receives full
+        permissions so the dataset is visible to them.
     Args:
         dataset_name: Name of the dataset.
         user: The user object.
@@ -20,9 +32,23 @@ async def create_authorized_dataset(dataset_name: str, user: User) -> Dataset:
     async with db_engine.get_async_session() as session:
         new_dataset = await create_dataset(dataset_name, user, session)
 
-    await give_permission_on_dataset(user, new_dataset.id, "read")
-    await give_permission_on_dataset(user, new_dataset.id, "write")
-    await give_permission_on_dataset(user, new_dataset.id, "delete")
-    await give_permission_on_dataset(user, new_dataset.id, "share")
+    for permission in _DATASET_PERMISSIONS:
+        await give_permission_on_dataset(user, new_dataset.id, permission)
+
+    parent_user_id = getattr(user, "parent_user_id", None)
+    if parent_user_id is not None and parent_user_id != user.id:
+        try:
+            parent = await get_user(parent_user_id)
+        except EntityNotFoundError:
+            logger.warning(
+                "parent_user_id %s on user %s does not resolve to a user; "
+                "skipping auto-share of dataset %s",
+                parent_user_id,
+                user.id,
+                new_dataset.id,
+            )
+        else:
+            for permission in _DATASET_PERMISSIONS:
+                await give_permission_on_dataset(parent, new_dataset.id, permission)
 
     return new_dataset

--- a/cognee/modules/users/methods/create_user.py
+++ b/cognee/modules/users/methods/create_user.py
@@ -1,3 +1,6 @@
+from typing import Optional
+from uuid import UUID
+
 from fastapi_users.exceptions import UserAlreadyExists
 
 from cognee.infrastructure.databases.relational import get_relational_engine
@@ -13,6 +16,7 @@ async def create_user(
     is_active: bool = True,
     is_verified: bool = False,
     auto_login: bool = False,
+    parent_user_id: Optional[UUID] = None,
 ):
     try:
         relational_engine = get_relational_engine()
@@ -27,6 +31,7 @@ async def create_user(
                             is_superuser=is_superuser,
                             is_active=is_active,
                             is_verified=is_verified,
+                            parent_user_id=parent_user_id,
                         )
                     )
 

--- a/cognee/modules/users/models/User.py
+++ b/cognee/modules/users/models/User.py
@@ -20,6 +20,10 @@ class User(SQLAlchemyBaseUserTableUUID, Principal):
     # Foreign key to current Tenant (Many-to-One relationship)
     tenant_id = Column(UUID, ForeignKey("tenants.id"))
 
+    # Parent user — when an agent/service user creates datasets, the parent
+    # inherits full permissions automatically. Null for regular human users.
+    parent_user_id = Column(UUID, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+
     # Many-to-Many Relationship with Roles
     roles: Mapped[list["Role"]] = relationship(
         "Role",
@@ -45,10 +49,12 @@ class User(SQLAlchemyBaseUserTableUUID, Principal):
 # Keep these schemas in sync with User model
 class UserRead(schemas.BaseUser[uuid_UUID]):
     tenant_id: Optional[uuid_UUID] = None
+    parent_user_id: Optional[uuid_UUID] = None
 
 
 class UserCreate(schemas.BaseUserCreate):
     is_verified: bool = True
+    parent_user_id: Optional[uuid_UUID] = None
 
 
 class UserUpdate(schemas.BaseUserUpdate):

--- a/cognee/tests/unit/modules/data/test_create_authorized_dataset_parent_share.py
+++ b/cognee/tests/unit/modules/data/test_create_authorized_dataset_parent_share.py
@@ -1,0 +1,123 @@
+"""Tests for ``create_authorized_dataset`` parent-user auto-share.
+
+When a user has ``parent_user_id`` set (typical for agent/service
+identities owned by a human), the parent should receive full permissions
+on any dataset the agent creates.
+"""
+
+import importlib
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.databases.exceptions import EntityNotFoundError
+from cognee.modules.data.methods import create_authorized_dataset
+
+module_under_test = importlib.import_module(create_authorized_dataset.__module__)
+
+PERMS = ("read", "write", "delete", "share")
+
+
+def _install_fakes(monkeypatch, recorded_calls, parent_resolver):
+    async def fake_create_dataset(_name, _user, _session):
+        return SimpleNamespace(id=uuid4())
+
+    async def fake_give_permission(principal, dataset_id, permission_name):
+        recorded_calls.append((principal.id, dataset_id, permission_name))
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+    class _FakeEngine:
+        def get_async_session(self):
+            return _FakeSession()
+
+    def fake_get_engine():
+        return _FakeEngine()
+
+    monkeypatch.setattr(module_under_test, "create_dataset", fake_create_dataset)
+    monkeypatch.setattr(module_under_test, "give_permission_on_dataset", fake_give_permission)
+    monkeypatch.setattr(module_under_test, "get_relational_engine", fake_get_engine)
+    monkeypatch.setattr(module_under_test, "get_user", parent_resolver)
+
+
+@pytest.mark.asyncio
+async def test_parent_user_receives_full_permissions(monkeypatch):
+    parent_id = uuid4()
+    agent_id = uuid4()
+    recorded = []
+
+    async def fake_get_user(user_id):
+        assert user_id == parent_id
+        return SimpleNamespace(id=parent_id)
+
+    _install_fakes(monkeypatch, recorded, fake_get_user)
+
+    agent = SimpleNamespace(id=agent_id, parent_user_id=parent_id)
+    await module_under_test.create_authorized_dataset("demo", agent)
+
+    agent_perms = sorted({perm for (pid, _, perm) in recorded if pid == agent_id})
+    parent_perms = sorted({perm for (pid, _, perm) in recorded if pid == parent_id})
+
+    assert agent_perms == sorted(PERMS)
+    assert parent_perms == sorted(PERMS)
+
+
+@pytest.mark.asyncio
+async def test_no_parent_skips_extra_grants(monkeypatch):
+    agent_id = uuid4()
+    recorded = []
+
+    async def fake_get_user(_user_id):  # should never be called
+        raise AssertionError("get_user must not run when parent_user_id is None")
+
+    _install_fakes(monkeypatch, recorded, fake_get_user)
+
+    agent = SimpleNamespace(id=agent_id, parent_user_id=None)
+    await module_under_test.create_authorized_dataset("demo", agent)
+
+    principals = {pid for (pid, _, _) in recorded}
+    assert principals == {agent_id}
+
+
+@pytest.mark.asyncio
+async def test_self_parent_is_ignored(monkeypatch):
+    """A user that points parent_user_id at itself should not be double-granted."""
+    user_id = uuid4()
+    recorded = []
+
+    async def fake_get_user(_user_id):
+        raise AssertionError("get_user must not run when parent equals user")
+
+    _install_fakes(monkeypatch, recorded, fake_get_user)
+
+    user = SimpleNamespace(id=user_id, parent_user_id=user_id)
+    await module_under_test.create_authorized_dataset("demo", user)
+
+    perms = [perm for (pid, _, perm) in recorded if pid == user_id]
+    assert sorted(perms) == sorted(PERMS)  # exactly one grant per permission
+
+
+@pytest.mark.asyncio
+async def test_missing_parent_does_not_block_creation(monkeypatch):
+    """If parent_user_id points to a deleted user, dataset creation still succeeds."""
+    parent_id = uuid4()
+    agent_id = uuid4()
+    recorded = []
+
+    async def fake_get_user(_user_id):
+        raise EntityNotFoundError(message="nope")
+
+    _install_fakes(monkeypatch, recorded, fake_get_user)
+
+    agent = SimpleNamespace(id=agent_id, parent_user_id=parent_id)
+    dataset = await module_under_test.create_authorized_dataset("demo", agent)
+
+    assert dataset is not None
+    parent_perms = [perm for (pid, _, perm) in recorded if pid == parent_id]
+    assert parent_perms == []


### PR DESCRIPTION
## Summary

- Adds a nullable `parent_user_id` FK on `users` so an agent/service user can declare a human owner.
- `create_authorized_dataset` now also grants the parent full `read/write/delete/share` on datasets created by the agent — the human admin sees them in the UI without manual ACL work.
- `create_user()` + `UserCreate` / `UserRead` schemas take an optional `parent_user_id` so agent-registration flows can thread the owner through at creation time.

## Why

Every agent integration so far (Claude Code plugin, MCP, Hermes) registers under its own identity, and any dataset the agent creates becomes invisible to the human admin's UI login — the agent is the owner, and the admin has no ACL rows. We were fixing this manually by inserting ACL rows. This PR makes that auto-grant flow a first-class part of the user model, so every future agent integration inherits the behavior for free.

## Notes

- DB migration is intentionally **not** included in this PR — it'll land in a follow-up as discussed.
- Self-referential `parent_user_id` (user points at itself) is ignored.
- If the parent user has been deleted, dataset creation logs a warning and still succeeds (no double-failure path).
- No changes to the FastAPI register endpoint are needed — the extended `UserCreate` schema is picked up by fastapi-users automatically.

## Test plan

- [x] New unit tests in `cognee/tests/unit/modules/data/test_create_authorized_dataset_parent_share.py` — all 4 pass:
  - parent receives full permissions when `parent_user_id` is set
  - no extra grants when `parent_user_id` is `None`
  - self-parent is ignored (no duplicate grants)
  - missing parent does not block dataset creation
- [ ] Follow-up PR: alembic migration adding the column + (optionally) UI filter that surfaces datasets owned by child agents of the logged-in user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Users can now designate a parent user during account creation.
  - Parent users automatically receive the same permissions (read, write, delete, share) on datasets created by their child users.
  - Parent-child user relationships with automatic permission inheritance are now supported in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->