### PR TITLE
fix: disable hybrid capabilities of neptune adapter for now

### DIFF
--- a/cognee/infrastructure/databases/unified/get_unified_engine.py
+++ b/cognee/infrastructure/databases/unified/get_unified_engine.py
@@ -6,7 +6,7 @@ from cognee.infrastructure.databases.vector import get_vector_engine
 from .capabilities import EngineCapability
 from .unified_store_engine import UnifiedStoreEngine
 
-HYBRID_PROVIDERS = {"neptune_analytics"}
+HYBRID_PROVIDERS = {}
 UNIFIED_PROVIDERS = {"pghybrid"}
 
 

--- a/cognee/tests/unit/infrastructure/databases/test_get_unified_engine.py
+++ b/cognee/tests/unit/infrastructure/databases/test_get_unified_engine.py
@@ -10,10 +10,11 @@ from cognee.infrastructure.databases.unified.get_unified_engine import (
 
 
 class TestIsHybridProvider:
-    def test_both_neptune_analytics_is_hybrid(self):
-        g = {"graph_database_provider": "neptune_analytics"}
-        v = {"vector_db_provider": "neptune_analytics"}
-        assert _is_hybrid_provider(g, v) is True
+    # NOTE: This test is disabled temporarily, until we implement Neptune hybrid capabilities
+    # def test_both_neptune_analytics_is_hybrid(self):
+    #     g = {"graph_database_provider": "neptune_analytics"}
+    #     v = {"vector_db_provider": "neptune_analytics"}
+    #     assert _is_hybrid_provider(g, v) is True
 
     def test_kuzu_lancedb_is_not_hybrid(self):
         g = {"graph_database_provider": "kuzu"}
@@ -33,8 +34,9 @@ class TestIsHybridProvider:
     def test_empty_configs(self):
         assert _is_hybrid_provider({}, {}) is False
 
-    def test_hybrid_providers_registry(self):
-        assert "neptune_analytics" in HYBRID_PROVIDERS
+    # NOTE: This test is disabled temporarily, until we implement Neptune hybrid capabilities
+    # def test_hybrid_providers_registry(self):
+    #     assert "neptune_analytics" in HYBRID_PROVIDERS
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
This PR removes the Neptune adapter from hybrid adapters, until we create an instance of Neptune which we can use to test it, and until we implement the hybrid capabilities for it.
This PR also disables a couple of unit tests related to Neptune, so they don't fail.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed neptune_analytics from registered hybrid providers, affecting hybrid provider detection. The system now only recognizes pghybrid through unified provider configuration.

* **Tests**
  * Disabled unit tests verifying neptune_analytics hybrid provider detection and registry membership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->