### PR TITLE
fix: read graph dataset handler env var

### DIFF
--- a/cognee/infrastructure/databases/graph/config.py
+++ b/cognee/infrastructure/databases/graph/config.py
@@ -47,7 +47,9 @@ class GraphConfig(BaseSettings):
     graph_filename: str = ""
     graph_model: object = KnowledgeGraph
     graph_topology: object = KnowledgeGraph
-    graph_dataset_database_handler: str = "kuzu"
+    graph_dataset_database_handler: str = Field(
+        "kuzu", env="GRAPH_DATASET_TO_DATABASE_HANDLER"
+    )
     model_config = SettingsConfigDict(env_file=".env", extra="allow", populate_by_name=True)
 
     # Model validator updates graph_filename and path dynamically after class creation based on current database provider


### PR DESCRIPTION
## Description
Fixes #2697 by wiring `graph_dataset_database_handler` to the existing `GRAPH_DATASET_TO_DATABASE_HANDLER` environment variable.

Without this mapping, the field always stayed on its default value (`"kuzu"`), even when the env var was set to a different handler. That made backend access-control startup validation fail for valid Neo4j configurations.

## Acceptance Criteria
- `GraphConfig.graph_dataset_database_handler` now reads from `GRAPH_DATASET_TO_DATABASE_HANDLER`
- existing default behavior still stays `"kuzu"` when the env var is unset
- the change is limited to the config field mapping described in the issue

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
N/A, config-only change.

Validation run locally:
```bash
python3 -m py_compile cognee/infrastructure/databases/graph/config.py
```

## Pre-submission Checklist
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Made the graph database handler configurable via the `GRAPH_DATASET_TO_DATABASE_HANDLER` environment variable, allowing customization while maintaining the default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->