### PR TITLE
fix: auto-migrate LanceDB on 'contained null values' schema drift (#2702)

### DIFF
--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -218,7 +218,17 @@ class LanceDBAdapter(VectorDBInterface):
                     .execute(lance_data_points)
                 )
         except (ValueError, OSError, RuntimeError) as e:
-            if "not found in target schema" not in str(e):
+            # Two LanceDB schema-drift failure modes are recoverable by rebuilding
+            # the table via Pydantic validation (which fills defaults from the
+            # current DataPoint subclass):
+            #   1) "not found in target schema" — incoming payload has a field the
+            #      old table schema does not know about.
+            #   2) "contained null values" — old rows lack a field that the current
+            #      schema now requires to be non-null. Raised from the Rust side
+            #      (lance-file writer) when an old-schema row is upserted against
+            #      a newer schema with a non-null field and no default in storage.
+            err = str(e)
+            if "not found in target schema" not in err and "contained null values" not in err:
                 raise
             logger.warning(
                 "Schema mismatch detected for collection '%s', migrating table: %s",

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_schema_migration.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_schema_migration.py
@@ -175,6 +175,65 @@ async def test_non_schema_errors_propagate(tmp_path):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_null_in_non_null_field_triggers_migration(tmp_path):
+    # Regression for #2702: the lance-file writer raises
+    # "contained null values even though the field is marked non-null" when an
+    # old-schema row is upserted against a newer schema that requires a field
+    # to be non-null. The message does not match "not found in target schema",
+    # so the auto-migration path was bypassed and the RuntimeError escaped.
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"), api_key=None, embedding_engine=_FakeEmbeddingEngine()
+    )
+    col = "Test_text"
+    await _seed(adapter, col, [_make_point(str(uuid4()), "seed")])
+
+    # Wrap get_collection so we see every collection instance the adapter
+    # opens — the one used inside create_data_points is fetched after our
+    # hook runs, so we patch merge_insert on each one we hand back.
+    original_get_collection = adapter.get_collection
+    called = {"count": 0}
+
+    async def wrapped_get_collection(name):
+        collection = await original_get_collection(name)
+        original_merge_insert = collection.merge_insert
+
+        def patched_merge_insert(key):
+            builder = original_merge_insert(key)
+            original_execute = builder.execute
+
+            async def fail_once(data):
+                called["count"] += 1
+                if called["count"] == 1:
+                    raise RuntimeError(
+                        "lance error: Invalid user input: The field `feedback_weight` "
+                        "contained null values even though the field is marked non-null "
+                        "in the schema"
+                    )
+                return await original_execute(data)
+
+            builder.execute = fail_once
+            return builder
+
+        collection.merge_insert = patched_merge_insert
+        return collection
+
+    adapter.get_collection = wrapped_get_collection
+
+    new_id = str(uuid4())
+    await adapter.create_data_points(col, [_make_point(new_id, "after-drift")])
+
+    # Migration path ran (rebuilt the table via drop/create), so restore the
+    # real get_collection before reading back.
+    adapter.get_collection = original_get_collection
+
+    results = await adapter.retrieve(col, [new_id])
+    assert len(results) == 1
+    assert results[0].payload["text"] == "after-drift"
+    assert called["count"] >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
 async def test_payload_preserves_inherited_datapoint_fields(tmp_path):
     adapter = LanceDBAdapter(
         url=str(tmp_path / "db"), api_key=None, embedding_engine=_FakeEmbeddingEngine()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.0.1"
+version = "1.0.2"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1054,7 +1054,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes #2702. `LanceDBAdapter.create_data_points` only treated `"not found in target schema"` as a recoverable schema drift. The inverse case — old rows lacking a field the current schema now requires to be non-null — raises `"contained null values even though the field is marked non-null"` from the Rust `lance-file` writer and was not matched, so the `RuntimeError` escaped and killed the uvicorn worker mid-batch.

- `cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py` — extend the message match so both patterns route to the existing `_migrate_collection_schema` path (which rebuilds via Pydantic validation and fills defaults like `feedback_weight=0.5`).
- `cognee/tests/unit/infrastructure/databases/vector/test_lancedb_schema_migration.py` — adds `test_null_in_non_null_field_triggers_migration` (patches `merge_insert` to raise the Rust-side message once; verifies the row lands after migration).
- `pyproject.toml` / `uv.lock` — bump `1.0.1` → `1.0.2`.

## Test plan
- [x] `pytest cognee/tests/unit/infrastructure/databases/vector/test_lancedb_schema_migration.py -v` → 7 passed (6 prior + 1 new)
- [x] New test fails on main without the one-line match extension (verified locally by stashing the fix and re-running)
- [x] `ruff check` / `ruff format` clean on changed files

Fixes #2702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced vector database adapter error handling to recover from additional schema-drift failure scenarios during data operations, improving overall system reliability.

* **Tests**
  * Added regression test to validate vector database schema migration and error recovery behavior.

* **Chores**
  * Version bumped to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->