### PR TITLE
fix: implement include_payload and node_name filter in ChromaDBAdapter

### DIFF
--- a/cognee/infrastructure/databases/vector/chromadb/ChromaDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/chromadb/ChromaDBAdapter.py
@@ -1,7 +1,7 @@
 import json
 import asyncio
 from uuid import UUID
-from typing import List, Optional
+from typing import List, Literal, Optional
 from chromadb import AsyncHttpClient, Settings
 from pydantic import BaseModel
 
@@ -352,6 +352,35 @@ class ChromaDBAdapter(VectorDBInterface):
             for id, metadata in zip(results["ids"], results["metadatas"])
         ]
 
+    @staticmethod
+    def _build_where_filter(
+        node_name: Optional[List[str]],
+        node_name_filter_operator: "Literal['OR', 'AND']",
+    ) -> Optional[dict]:
+        """Build a ChromaDB ``where`` filter dict from node_name constraints."""
+        if node_name_filter_operator not in ("OR", "AND"):
+            raise ValueError(
+                f"Unsupported node_name_filter_operator: {node_name_filter_operator!r}. "
+                "Expected 'OR' or 'AND'."
+            )
+        if not node_name:
+            return None
+        if len(node_name) == 1:
+            return {"belongs_to_set": {"$eq": node_name[0]}}
+        if node_name_filter_operator == "AND":
+            return {"$and": [{"belongs_to_set": {"$eq": name}} for name in node_name]}
+        return {"$or": [{"belongs_to_set": {"$eq": name}} for name in node_name]}
+
+    @staticmethod
+    def _build_include_list(include_payload: bool, with_vector: bool) -> List[str]:
+        """Build the ChromaDB ``include`` list based on caller requirements."""
+        include = ["distances"]
+        if include_payload:
+            include.append("metadatas")
+        if with_vector:
+            include.append("embeddings")
+        return include
+
     async def search(
         self,
         collection_name: str,
@@ -359,9 +388,9 @@ class ChromaDBAdapter(VectorDBInterface):
         query_vector: List[float] = None,
         limit: Optional[int] = 15,
         with_vector: bool = False,
-        include_payload: bool = False,  # TODO: Add support for this parameter when set to False
-        node_name: Optional[List[str]] = None,  # TODO: Add support/functionality for this parameter
-        node_name_filter_operator: str = "OR",  # TODO: Add support/functionality for this parameter
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: Literal["OR", "AND"] = "OR",
     ):
         """
         Search for items in a collection using either a text or a vector query.
@@ -376,6 +405,16 @@ class ChromaDBAdapter(VectorDBInterface):
               query_text is provided. (default None)
             - limit (int): The maximum number of results to return; defaults to 15. (default 15)
             - with_vector (bool): Whether to include vectors in the results. (default False)
+            - include_payload (bool): When True, fetches metadatas from ChromaDB and populates
+              ``ScoredResult.payload``. When False (default), metadatas are omitted from the
+              query to reduce memory and network overhead; ``payload`` will be None.
+            - node_name (Optional[List[str]]): Filter results to nodes whose
+              ``belongs_to_set`` field matches one of the provided names.
+              No filter is applied when None. (default None)
+            - node_name_filter_operator (Literal["OR", "AND"]): Logical operator applied to
+              ``node_name`` entries. ``"OR"`` (default) accepts nodes matching any name;
+              ``"AND"`` requires all names to be present in ``belongs_to_set``.
+
         Returns:
         --------
 
@@ -397,21 +436,27 @@ class ChromaDBAdapter(VectorDBInterface):
             if limit <= 0:
                 return []
 
-            results = await collection.query(
-                query_embeddings=[query_vector],
-                include=["metadatas", "distances", "embeddings"]
-                if with_vector
-                else ["metadatas", "distances"],
-                n_results=limit,
-            )
+            where_filter = self._build_where_filter(node_name, node_name_filter_operator)
+            include_list = self._build_include_list(include_payload, with_vector)
+
+            query_kwargs = {
+                "query_embeddings": [query_vector],
+                "include": include_list,
+                "n_results": limit,
+            }
+            if where_filter is not None:
+                query_kwargs["where"] = where_filter
+
+            results = await collection.query(**query_kwargs)
 
             vector_list = []
-            for i, (id, metadata, distance) in enumerate(
-                zip(results["ids"][0], results["metadatas"][0], results["distances"][0])
-            ):
+            metadatas = results.get("metadatas")
+            for i, (id, distance) in enumerate(zip(results["ids"][0], results["distances"][0])):
                 item = {
                     "id": parse_id(id),
-                    "payload": restore_data_from_chroma(metadata),
+                    "payload": restore_data_from_chroma(metadatas[0][i])
+                    if include_payload
+                    else None,
                     "_distance": distance,
                 }
 
@@ -445,6 +490,8 @@ class ChromaDBAdapter(VectorDBInterface):
         limit: int = 5,
         with_vectors: bool = False,
         include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: Literal["OR", "AND"] = "OR",
     ):
         """
         Perform multiple searches in a single request for efficiency, returning results for each
@@ -460,6 +507,12 @@ class ChromaDBAdapter(VectorDBInterface):
               5. (default 5)
             - with_vectors (bool): Whether to include vectors in the results for each query.
               (default False)
+            - include_payload (bool): Whether to include payload metadata in results.
+              (default False)
+            - node_name (Optional[List[str]]): Filter results to nodes matching these names.
+              (default None)
+            - node_name_filter_operator (Literal["OR", "AND"]): Logical operator for
+              node_name filter, ``"OR"`` or ``"AND"``. (default "OR")
 
         Returns:
         --------
@@ -470,24 +523,30 @@ class ChromaDBAdapter(VectorDBInterface):
 
         collection = await self.get_collection(collection_name)
 
-        results = await collection.query(
-            query_embeddings=query_vectors,
-            include=["metadatas", "distances", "embeddings"]
-            if with_vectors
-            else ["metadatas", "distances"],
-            n_results=limit,
-        )
+        where_filter = self._build_where_filter(node_name, node_name_filter_operator)
+        include_list = self._build_include_list(include_payload, with_vectors)
+
+        query_kwargs = {
+            "query_embeddings": query_vectors,
+            "include": include_list,
+            "n_results": limit,
+        }
+        if where_filter is not None:
+            query_kwargs["where"] = where_filter
+
+        results = await collection.query(**query_kwargs)
 
         all_results = []
+        metadatas = results.get("metadatas")
         for i in range(len(query_texts)):
             vector_list = []
 
-            for j, (id, metadata, distance) in enumerate(
-                zip(results["ids"][i], results["metadatas"][i], results["distances"][i])
-            ):
+            for j, (id, distance) in enumerate(zip(results["ids"][i], results["distances"][i])):
                 item = {
                     "id": parse_id(id),
-                    "payload": restore_data_from_chroma(metadata),
+                    "payload": restore_data_from_chroma(metadatas[i][j])
+                    if include_payload
+                    else None,
                     "_distance": distance,
                 }
 

--- a/cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py
@@ -1,0 +1,231 @@
+"""Unit tests for ChromaDBAdapter.search() and batch_search().
+
+Covers the include_payload flag (omit metadatas when False) and the
+node_name filtering support added in issue #2353.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+chromadb = pytest.importorskip("chromadb", reason="ChromaDB tests require chromadb")
+
+from cognee.infrastructure.databases.vector.chromadb.ChromaDBAdapter import (  # noqa: E402
+    ChromaDBAdapter,
+)
+
+
+def _make_chroma_result(ids, distances, metadatas=None, embeddings=None):
+    """Build a ChromaDB-style query result dict."""
+    result = {
+        "ids": [ids],
+        "distances": [distances],
+    }
+    if metadatas is not None:
+        result["metadatas"] = [metadatas]
+    if embeddings is not None:
+        result["embeddings"] = [embeddings]
+    return result
+
+
+def _make_adapter():
+    """Return a ChromaDBAdapter with mocked internals."""
+    adapter = ChromaDBAdapter.__new__(ChromaDBAdapter)
+    adapter.embedding_engine = AsyncMock()
+    adapter.embedding_engine.embed_text = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    mock_collection = AsyncMock()
+    mock_collection.count = AsyncMock(return_value=10)
+
+    adapter.get_collection = AsyncMock(return_value=mock_collection)
+    adapter.embed_data = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    return adapter, mock_collection
+
+
+@pytest.mark.asyncio
+async def test_search_include_payload_false_omits_metadatas():
+    """include_payload=False must not request metadatas from ChromaDB."""
+    adapter, collection = _make_adapter()
+    node_id = str(uuid4())
+
+    collection.query = AsyncMock(
+        return_value=_make_chroma_result(
+            ids=[node_id],
+            distances=[0.2],
+        )
+    )
+
+    results = await adapter.search(
+        collection_name="test_col",
+        query_text="hello",
+        limit=5,
+        include_payload=False,
+    )
+
+    assert len(results) == 1
+    assert results[0].payload is None
+
+    call_kwargs = collection.query.call_args[1]
+    assert "metadatas" not in call_kwargs["include"]
+
+
+@pytest.mark.asyncio
+async def test_search_include_payload_true_fetches_metadatas():
+    """include_payload=True must request metadatas and populate payload."""
+    adapter, collection = _make_adapter()
+    node_id = str(uuid4())
+
+    collection.query = AsyncMock(
+        return_value=_make_chroma_result(
+            ids=[node_id],
+            distances=[0.2],
+            metadatas=[{"text": "Alice", "id": node_id}],
+        )
+    )
+
+    results = await adapter.search(
+        collection_name="test_col",
+        query_text="hello",
+        limit=5,
+        include_payload=True,
+    )
+
+    assert len(results) == 1
+    assert results[0].payload is not None
+
+    call_kwargs = collection.query.call_args[1]
+    assert "metadatas" in call_kwargs["include"]
+
+
+@pytest.mark.asyncio
+async def test_search_node_name_single_applies_eq_filter():
+    """A single node_name entry uses a simple equality where filter."""
+    adapter, collection = _make_adapter()
+
+    collection.query = AsyncMock(return_value=_make_chroma_result(ids=[], distances=[]))
+
+    await adapter.search(
+        collection_name="test_col",
+        query_text="hello",
+        limit=5,
+        include_payload=False,
+        node_name=["Alice"],
+    )
+
+    call_kwargs = collection.query.call_args[1]
+    assert "where" in call_kwargs
+    assert call_kwargs["where"] == {"belongs_to_set": {"$eq": "Alice"}}
+
+
+@pytest.mark.asyncio
+async def test_search_node_name_or_operator_uses_dollar_or():
+    """Multiple node_names with OR operator uses $or filter."""
+    adapter, collection = _make_adapter()
+
+    collection.query = AsyncMock(return_value=_make_chroma_result(ids=[], distances=[]))
+
+    await adapter.search(
+        collection_name="test_col",
+        query_text="hello",
+        limit=5,
+        include_payload=False,
+        node_name=["Alice", "Bob"],
+        node_name_filter_operator="OR",
+    )
+
+    call_kwargs = collection.query.call_args[1]
+    assert "where" in call_kwargs
+    where = call_kwargs["where"]
+    assert "$or" in where
+    names = {clause["belongs_to_set"]["$eq"] for clause in where["$or"]}
+    assert names == {"Alice", "Bob"}
+
+
+@pytest.mark.asyncio
+async def test_search_node_name_and_operator_uses_dollar_and():
+    """Multiple node_names with AND operator uses $and filter."""
+    adapter, collection = _make_adapter()
+
+    collection.query = AsyncMock(return_value=_make_chroma_result(ids=[], distances=[]))
+
+    await adapter.search(
+        collection_name="test_col",
+        query_text="hello",
+        limit=5,
+        include_payload=False,
+        node_name=["Alice", "Bob"],
+        node_name_filter_operator="AND",
+    )
+
+    call_kwargs = collection.query.call_args[1]
+    assert "where" in call_kwargs
+    where = call_kwargs["where"]
+    assert "$and" in where
+    names = {clause["belongs_to_set"]["$eq"] for clause in where["$and"]}
+    assert names == {"Alice", "Bob"}
+
+
+@pytest.mark.asyncio
+async def test_search_no_node_name_omits_where():
+    """When node_name is None, no where clause is added to the query."""
+    adapter, collection = _make_adapter()
+
+    collection.query = AsyncMock(return_value=_make_chroma_result(ids=[], distances=[]))
+
+    await adapter.search(
+        collection_name="test_col",
+        query_text="hello",
+        limit=5,
+        include_payload=False,
+    )
+
+    call_kwargs = collection.query.call_args[1]
+    assert "where" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_batch_search_include_payload_false_omits_metadatas():
+    """batch_search with include_payload=False must not request metadatas."""
+    adapter, collection = _make_adapter()
+    node_id = str(uuid4())
+
+    collection.query = AsyncMock(
+        return_value={
+            "ids": [[node_id]],
+            "distances": [[0.3]],
+        }
+    )
+
+    results = await adapter.batch_search(
+        collection_name="test_col",
+        query_texts=["hello"],
+        limit=5,
+        include_payload=False,
+    )
+
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert results[0][0].payload is None
+
+    call_kwargs = collection.query.call_args[1]
+    assert "metadatas" not in call_kwargs["include"]
+
+
+@pytest.mark.asyncio
+async def test_batch_search_node_name_filter_is_forwarded():
+    """batch_search forwards node_name filter to the ChromaDB query."""
+    adapter, collection = _make_adapter()
+
+    collection.query = AsyncMock(return_value={"ids": [[]], "distances": [[]]})
+
+    await adapter.batch_search(
+        collection_name="test_col",
+        query_texts=["hello"],
+        limit=5,
+        include_payload=False,
+        node_name=["Alice"],
+    )
+
+    call_kwargs = collection.query.call_args[1]
+    assert "where" in call_kwargs
+    assert call_kwargs["where"] == {"belongs_to_set": {"$eq": "Alice"}}


### PR DESCRIPTION
## Description

Fixes #2353 — two TODO items in `ChromaDBAdapter.search()` and `batch_search()` that were left unimplemented.

**1. `include_payload` flag**
Previously the `metadatas` field was always requested from ChromaDB regardless of `include_payload`. Now when `include_payload=False`, `metadatas` is omitted from the `collection.query()` include list. This reduces memory and network overhead when callers only need IDs and scores. `ScoredResult.payload` is set to `None` in this case.

**2. `node_name` / `node_name_filter_operator` filter**
The `node_name` parameter was accepted but never used. It is now translated into a ChromaDB `where` filter clause:
- Single name → simple equality: `{"belongs_to_set": {"$eq": name}}`
- Multiple names with `OR` (default) → `{"$or": [...]}`
- Multiple names with `AND` → `{"$and": [...]}`

Both `search()` and `batch_search()` are updated consistently.

## Acceptance Criteria

- `include_payload=False` omits `metadatas` from the ChromaDB query include list; `ScoredResult.payload` is `None`.
- `include_payload=True` includes `metadatas`; `ScoredResult.payload` is populated.
- `node_name` list is translated to a `where` clause respecting `node_name_filter_operator`.
- No `where` key is added when `node_name` is `None`.
- 8 unit tests added; all pass.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

```
cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py::test_search_include_payload_false_omits_metadatas PASSED
cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py::test_search_include_payload_true_fetches_metadatas PASSED
cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py::test_search_node_name_single_applies_eq_filter PASSED
cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py::test_search_node_name_or_operator_uses_dollar_or PASSED
cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py::test_search_node_name_and_operator_uses_dollar_and PASSED
cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py::test_search_no_node_name_omits_where PASSED
cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py::test_batch_search_include_payload_false_omits_metadatas PASSED
cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py::test_batch_search_node_name_filter_is_forwarded PASSED

================== 8 passed in 123.24s ========================
```

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional node-name filtering for search and batch search with OR/AND operator.

* **Improvements**
  * Batch search now respects OR/AND semantics across providers.
  * Payload/metadata returned only when requested, reducing data transfer.
  * Invalid operator values now raise a clear error.
  * Safer result handling to avoid missing-data issues.

* **Documentation**
  * Interface docs updated to describe node-name filtering semantics.

* **Tests**
  * Added tests for payload inclusion and node-name filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->