### PR TITLE
feat: adds migration for parent_user_id

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -39,6 +39,7 @@ class CogneeClient:
         self.tenant_id: Optional[str] = None
         if self.api_url:
             import re
+
             match = re.search(r"tenant-([0-9a-f-]{36})", self.api_url)
             if match:
                 self.tenant_id = match.group(1)
@@ -376,7 +377,10 @@ class CogneeClient:
             if custom_prompt:
                 form_data["custom_prompt"] = custom_prompt
             response = await self.client.post(
-                endpoint, files=files, data=form_data, headers=self._get_headers(include_content_type=False)
+                endpoint,
+                files=files,
+                data=form_data,
+                headers=self._get_headers(include_content_type=False),
             )
             response.raise_for_status()
             return response.json()

--- a/cognee/alembic/versions/7c5d4e2f8a91_add_parent_user_id_to_users.py
+++ b/cognee/alembic/versions/7c5d4e2f8a91_add_parent_user_id_to_users.py
@@ -1,0 +1,75 @@
+"""Add parent_user_id to users
+
+Revision ID: 7c5d4e2f8a91
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-23 21:35:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7c5d4e2f8a91"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE_NAME = "users"
+COLUMN_NAME = "parent_user_id"
+FK_NAME = "fk_users_parent_user_id_users"
+
+
+def _has_column(inspector: sa.Inspector, table_name: str, column_name: str) -> bool:
+    return any(column["name"] == column_name for column in inspector.get_columns(table_name))
+
+
+def _has_foreign_key(inspector: sa.Inspector, table_name: str, fk_name: str) -> bool:
+    return any(foreign_key.get("name") == fk_name for foreign_key in inspector.get_foreign_keys(table_name))
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    if not _has_column(inspector, TABLE_NAME, COLUMN_NAME):
+        if op.get_context().dialect.name == "sqlite":
+            with op.batch_alter_table(TABLE_NAME) as batch_op:
+                batch_op.add_column(sa.Column(COLUMN_NAME, sa.UUID(), nullable=True))
+        else:
+            op.add_column(TABLE_NAME, sa.Column(COLUMN_NAME, sa.UUID(), nullable=True))
+
+    if op.get_context().dialect.name != "sqlite":
+        inspector = sa.inspect(connection)
+        if not _has_foreign_key(inspector, TABLE_NAME, FK_NAME):
+            op.create_foreign_key(
+                FK_NAME,
+                TABLE_NAME,
+                TABLE_NAME,
+                [COLUMN_NAME],
+                ["id"],
+                ondelete="SET NULL",
+            )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if TABLE_NAME not in inspector.get_table_names() or not _has_column(inspector, TABLE_NAME, COLUMN_NAME):
+        return
+
+    if op.get_context().dialect.name != "sqlite" and _has_foreign_key(inspector, TABLE_NAME, FK_NAME):
+        op.drop_constraint(FK_NAME, TABLE_NAME, type_="foreignkey")
+
+    if op.get_context().dialect.name == "sqlite":
+        with op.batch_alter_table(TABLE_NAME) as batch_op:
+            batch_op.drop_column(COLUMN_NAME)
+    else:
+        op.drop_column(TABLE_NAME, COLUMN_NAME)

--- a/cognee/alembic/versions/7c5d4e2f8a91_add_parent_user_id_to_users.py
+++ b/cognee/alembic/versions/7c5d4e2f8a91_add_parent_user_id_to_users.py
@@ -28,7 +28,9 @@ def _has_column(inspector: sa.Inspector, table_name: str, column_name: str) -> b
 
 
 def _has_foreign_key(inspector: sa.Inspector, table_name: str, fk_name: str) -> bool:
-    return any(foreign_key.get("name") == fk_name for foreign_key in inspector.get_foreign_keys(table_name))
+    return any(
+        foreign_key.get("name") == fk_name for foreign_key in inspector.get_foreign_keys(table_name)
+    )
 
 
 def upgrade() -> None:
@@ -62,10 +64,14 @@ def downgrade() -> None:
     connection = op.get_bind()
     inspector = sa.inspect(connection)
 
-    if TABLE_NAME not in inspector.get_table_names() or not _has_column(inspector, TABLE_NAME, COLUMN_NAME):
+    if TABLE_NAME not in inspector.get_table_names() or not _has_column(
+        inspector, TABLE_NAME, COLUMN_NAME
+    ):
         return
 
-    if op.get_context().dialect.name != "sqlite" and _has_foreign_key(inspector, TABLE_NAME, FK_NAME):
+    if op.get_context().dialect.name != "sqlite" and _has_foreign_key(
+        inspector, TABLE_NAME, FK_NAME
+    ):
         op.drop_constraint(FK_NAME, TABLE_NAME, type_="foreignkey")
 
     if op.get_context().dialect.name == "sqlite":

--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -73,22 +73,10 @@ async def prune_system(graph=True, vector=True, metadata=True, cache=True):
         await db_engine.delete_database()
 
     if cache:
+        await delete_cache()
         cache_config = get_cache_config()
         if cache_config.caching or cache_config.usage_logging:
-            cache_engine = get_cache_engine()
-            if cache_engine:
-                await cache_engine.close()
-
             create_cache_engine.cache_clear()
-
-            await delete_cache()
-
             cache_engine = get_cache_engine()
             if cache_engine:
-                try:
-                    await cache_engine.prune()
-                finally:
-                    await cache_engine.close()
-                    create_cache_engine.cache_clear()
-        else:
-            await delete_cache()
+                await cache_engine.prune()

--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -73,10 +73,22 @@ async def prune_system(graph=True, vector=True, metadata=True, cache=True):
         await db_engine.delete_database()
 
     if cache:
-        await delete_cache()
         cache_config = get_cache_config()
         if cache_config.caching or cache_config.usage_logging:
-            create_cache_engine.cache_clear()
             cache_engine = get_cache_engine()
             if cache_engine:
-                await cache_engine.prune()
+                await cache_engine.close()
+
+            create_cache_engine.cache_clear()
+
+            await delete_cache()
+
+            cache_engine = get_cache_engine()
+            if cache_engine:
+                try:
+                    await cache_engine.prune()
+                finally:
+                    await cache_engine.close()
+                    create_cache_engine.cache_clear()
+        else:
+            await delete_cache()

--- a/cognee/tests/unit/modules/retrieval/graph_completion_retriever_cot_test.py
+++ b/cognee/tests/unit/modules/retrieval/graph_completion_retriever_cot_test.py
@@ -592,7 +592,14 @@ async def test_get_completion_batch_queries(mock_edge):
             "cognee.modules.retrieval.utils.completion.generate_completion",
             return_value="Generated answer",
         ),
+        patch(
+            "cognee.modules.retrieval.graph_completion_retriever.CacheConfig"
+        ) as mock_cache_config,
     ):
+        mock_config = MagicMock()
+        mock_config.caching = False
+        mock_cache_config.return_value = mock_config
+
         objects = await retriever.get_retrieved_objects(
             query_batch=["test query 1", "test query 2"]
         )
@@ -695,7 +702,14 @@ async def test_get_completion_batch_queries_duplicate_queries(mock_edge):
             "cognee.modules.retrieval.utils.completion.generate_completion",
             return_value="Generated answer",
         ),
+        patch(
+            "cognee.modules.retrieval.graph_completion_retriever.CacheConfig"
+        ) as mock_cache_config,
     ):
+        mock_config = MagicMock()
+        mock_config.caching = False
+        mock_cache_config.return_value = mock_config
+
         objects = await retriever.get_retrieved_objects(
             query_batch=["test query 1", "test query 1"]
         )

--- a/cognee/tests/unit/test_add_parent_user_id_migration.py
+++ b/cognee/tests/unit/test_add_parent_user_id_migration.py
@@ -1,0 +1,72 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "7c5d4e2f8a91_add_parent_user_id_to_users.py"
+)
+_SPEC = importlib.util.spec_from_file_location("parent_user_id_migration", _MIGRATION_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+migration = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(migration)
+
+
+def _make_inspector(*, columns=None, foreign_keys=None, tables=None):
+    inspector = MagicMock()
+    inspector.get_table_names.return_value = tables or [migration.TABLE_NAME]
+    inspector.get_columns.return_value = columns or [{"name": "id"}]
+    inspector.get_foreign_keys.return_value = foreign_keys or []
+    return inspector
+
+
+def _make_context(dialect_name: str):
+    return SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
+
+
+def test_upgrade_adds_parent_user_id_column_and_fk(monkeypatch):
+    inspector = _make_inspector()
+    monkeypatch.setattr(migration.sa, "inspect", lambda _: inspector)
+
+    add_column = MagicMock()
+    create_foreign_key = MagicMock()
+    monkeypatch.setattr(migration.op, "get_bind", lambda: object())
+    monkeypatch.setattr(migration.op, "get_context", lambda: _make_context("postgresql"))
+    monkeypatch.setattr(migration.op, "add_column", add_column)
+    monkeypatch.setattr(migration.op, "create_foreign_key", create_foreign_key)
+
+    migration.upgrade()
+
+    add_column.assert_called_once()
+    create_foreign_key.assert_called_once_with(
+        migration.FK_NAME,
+        migration.TABLE_NAME,
+        migration.TABLE_NAME,
+        [migration.COLUMN_NAME],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def test_upgrade_skips_when_parent_user_id_column_exists(monkeypatch):
+    inspector = _make_inspector(
+        columns=[{"name": "id"}, {"name": migration.COLUMN_NAME}],
+        foreign_keys=[{"name": migration.FK_NAME}],
+    )
+    monkeypatch.setattr(migration.sa, "inspect", lambda _: inspector)
+
+    add_column = MagicMock()
+    create_foreign_key = MagicMock()
+    monkeypatch.setattr(migration.op, "get_bind", lambda: object())
+    monkeypatch.setattr(migration.op, "get_context", lambda: _make_context("postgresql"))
+    monkeypatch.setattr(migration.op, "add_column", add_column)
+    monkeypatch.setattr(migration.op, "create_foreign_key", create_foreign_key)
+
+    migration.upgrade()
+
+    add_column.assert_not_called()
+    create_foreign_key.assert_not_called()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
This PR adds the missing Alembic migration for users.parent_user_id, which is now part of the User ORM model but was not present in legacy relational schemas. As a result, backwards-compatibility runs against older PostgreSQL databases failed during default user lookup before search execution began.

The migration:

adds a nullable parent_user_id column to users
adds a self-referencing foreign key to users.id for non-SQLite databases
keeps the upgrade idempotent by checking whether the column and FK already exist
supports SQLite with batch_alter_table
This PR also adds unit tests covering the migration behavior for both:

schemas missing parent_user_id
schemas where parent_user_id already exists
Related: backwards-compatibility failure in PostgreSQL + PGVector + Kuzu during Phase 2 verification.
Issue: COG-4822



## Acceptance Criteria
Legacy databases without users.parent_user_id can be upgraded successfully through startup migrations
get_default_user() no longer fails against upgraded legacy schemas due to a missing parent_user_id column
Migration remains safe to run on already-upgraded schemas
Migration behavior is covered by unit tests

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional parent-user support to allow hierarchical user relationships.

* **Bug Fixes / Improvements**
  * Safer and more selective cache pruning and deletion to avoid unintended cache shutdowns.

* **Tests**
  * Added tests validating the user-hierarchy migration across databases.
  * Adjusted retrieval/completion tests to disable caching for deterministic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->