### PR TITLE
fix(cognee-mcp): use postgres-binary and flexible cognee version

### DIFF
--- a/cognee-mcp/pyproject.toml
+++ b/cognee-mcp/pyproject.toml
@@ -6,9 +6,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 dependencies = [
-    # For local cognee repo usage remove comment bellow and add absolute path to cognee. Then run `uv sync --reinstall` in the mcp folder on local cognee changes.
-    #"cognee[postgres,docs,neo4j] @ file:/Users/igorilic/Desktop/cognee",
-    "cognee[postgres,docs,neo4j]==1.0.0",
+    # For local cognee repo usage, remove the comment below and add the absolute path to cognee. Then run `uv sync --reinstall` in the mcp folder on local cognee changes.
+    #"cognee[postgres-binary,docs,neo4j] @ file:///absolute/path/to/cognee",
+    "cognee[postgres-binary,docs,neo4j]>=1.0.0,<2.0.0",
     "fastmcp>=3.2.0",
     "mcp>=1.12.0,<2.0.0",
     "uv>=0.6.3,<1.0.0",


### PR DESCRIPTION
## Summary
- Switch `cognee` dependency from `postgres` to `postgres-binary` extra to avoid requiring PostgreSQL dev headers (`pg_config`) for installation
- Relax `cognee` version pin from `==1.0.0` to `>=1.0.0,<2.0.0` so cognee-mcp works with 1.0.2+
- Replace hardcoded developer file path with a generic placeholder
- Fix typo in comment ("bellow" → "below")

## Test plan
- [ ] `uv build` in `cognee-mcp/` produces a valid wheel
- [ ] Install the wheel in a fresh venv (`pip install dist/cognee_mcp-*.whl`) — should not require `pg_config`
- [ ] `cognee-mcp` entry point starts successfully
- [ ] Test with MCP Inspector (`mcp dev src/server.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)