### PR TITLE
fix(skills): record SkillRuns only for skills opened via load_skill 

### DIFF
--- a/cognee/modules/retrieval/agentic_retriever.py
+++ b/cognee/modules/retrieval/agentic_retriever.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 from cognee.modules.engine.models import Skill, Tool
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.completion import generate_completion
-from cognee.modules.tools.context import active_skills_var
+from cognee.modules.tools.context import active_skills_var, opened_skills_var
 from cognee.modules.tools.errors import (
     ToolInvocationError,
     ToolPermissionError,
@@ -197,6 +197,8 @@ class AgenticRetriever(GraphCompletionRetriever):
         tool_names = [t.name for t in tools]
 
         started_at_ms = int(time.time() * 1000)
+        opened_skills: set[str] = set()
+        opened_token = opened_skills_var.set(opened_skills)
         token = active_skills_var.set({s.name: s for s in skills})
         try:
             try:
@@ -207,9 +209,10 @@ class AgenticRetriever(GraphCompletionRetriever):
                 )
             except Exception as exc:
                 latency_ms = int(time.time() * 1000) - started_at_ms
-                if skills:
+                skills_to_record = [s for s in skills if s.name in opened_skills]
+                if skills_to_record:
                     await self._record_skill_runs(
-                        skills,
+                        skills_to_record,
                         query or "",
                         "",
                         started_at_ms=started_at_ms,
@@ -221,16 +224,19 @@ class AgenticRetriever(GraphCompletionRetriever):
                 raise
         finally:
             active_skills_var.reset(token)
+            opened_skills_var.reset(opened_token)
 
         latency_ms = int(time.time() * 1000) - started_at_ms
 
-        # Record a SkillRun for each skill that was routed to on this
-        # call. ``improve_failing_skills`` consumes only low-scored
-        # runs, so ungraded agentic executions use the neutral default
-        # score until explicit feedback or an evaluator supplies one.
-        if skills:
+        # Record a SkillRun only for skills the agent actually opened via
+        # load_skill — not for every skill in the prefilter catalog.
+        # ``improve_failing_skills`` consumes only low-scored runs, so
+        # ungraded agentic executions use the neutral default score until
+        # explicit feedback or an evaluator supplies one.
+        skills_to_record = [s for s in skills if s.name in opened_skills]
+        if skills_to_record:
             await self._record_skill_runs(
-                skills,
+                skills_to_record,
                 query or "",
                 final,
                 started_at_ms=started_at_ms,

--- a/cognee/modules/tools/builtin/load_skill.py
+++ b/cognee/modules/tools/builtin/load_skill.py
@@ -9,7 +9,7 @@ the handler does not need another graph round-trip.
 from typing import Any, Dict
 
 from cognee.modules.engine.models import Tool
-from cognee.modules.tools.context import active_skills_var
+from cognee.modules.tools.context import active_skills_var, opened_skills_var
 from cognee.modules.tools.errors import ToolInvocationError
 from cognee.modules.tools.registry import register_builtin_tool
 
@@ -43,6 +43,10 @@ async def handler(args: Dict[str, Any], **_) -> str:
         raise ToolInvocationError(
             f"Skill {name!r} is not in the active skill set. Available: {available}"
         )
+
+    opened = opened_skills_var.get()
+    if opened is not None:
+        opened.add(skill.name)
 
     body = skill.procedure or "(this skill has no procedure body)"
     return f"# Skill: {skill.name}\n{body}"

--- a/cognee/modules/tools/context.py
+++ b/cognee/modules/tools/context.py
@@ -3,12 +3,19 @@
 AgenticRetriever sets `active_skills_var` to the set of resolved Skill objects
 before each turn so the `load_skill` tool can return their procedure bodies
 without another round-trip to the graph.
+
+`opened_skills_var` accumulates the names of skills the LLM actually opens
+via `load_skill` during one agentic loop. Used at SkillRun-write time to
+attribute runs only to skills the agent consulted, not to every skill in
+the prefilter catalog.
 """
 
 from contextvars import ContextVar
-from typing import Dict
+from typing import Dict, Optional, Set
 
 from cognee.modules.engine.models import Skill
 
 
 active_skills_var: ContextVar[Dict[str, Skill]] = ContextVar("cognee_active_skills", default={})
+
+opened_skills_var: ContextVar[Optional[Set[str]]] = ContextVar("cognee_opened_skills", default=None)

--- a/cognee/tests/unit/modules/tools/test_skill_ingest.py
+++ b/cognee/tests/unit/modules/tools/test_skill_ingest.py
@@ -323,6 +323,53 @@ class TestSkillIngest(unittest.TestCase):
 
         assert run.success_score == UNSCORED_SKILL_RUN_SCORE
 
+    def test_load_skill_records_open_in_opened_skills_var(self):
+        from cognee.modules.engine.models import Skill
+        from cognee.modules.tools.builtin.load_skill import handler
+        from cognee.modules.tools.context import active_skills_var, opened_skills_var
+
+        skill = Skill(
+            name="summarize",
+            description="Summarize text.",
+            procedure="step 1",
+        )
+
+        async def _run():
+            active_token = active_skills_var.set({skill.name: skill})
+            opened: set[str] = set()
+            opened_token = opened_skills_var.set(opened)
+            try:
+                body = await handler({"name": "summarize"})
+            finally:
+                active_skills_var.reset(active_token)
+                opened_skills_var.reset(opened_token)
+            return body, opened
+
+        body, opened = self._run(_run())
+        assert "summarize" in opened
+        assert "step 1" in body
+
+    def test_load_skill_works_when_opened_skills_var_unset(self):
+        from cognee.modules.engine.models import Skill
+        from cognee.modules.tools.builtin.load_skill import handler
+        from cognee.modules.tools.context import active_skills_var
+
+        skill = Skill(
+            name="summarize",
+            description="Summarize text.",
+            procedure="step 1",
+        )
+
+        async def _run():
+            active_token = active_skills_var.set({skill.name: skill})
+            try:
+                return await handler({"name": "summarize"})
+            finally:
+                active_skills_var.reset(active_token)
+
+        body = self._run(_run())
+        assert "step 1" in body
+
     def test_skill_run_entry_validates_score_ranges(self):
         from pydantic import ValidationError
 


### PR DESCRIPTION
  ## Description                                                                                                                                                                                                  
                                                                                                                                                                                                                  
  `AgenticRetriever._record_skill_runs` writes one `SkillRun` per skill in the                                                                                                                                    
  prefilter catalog, regardless of whether the agent actually opened that skill                                                                                                                                   
  via `load_skill`. So if `resolve_skills` returns top-3 skills and the agent                                                                                                                                     
  only opens one, the graph still gets three SkillRuns — two of which blame                                                                                                                                       
  skills the agent never consulted.                                                                                                                                                                               
                                                                                                                                                                                                                  
  `improve_failing_skills` reads those rows. With misattributed runs, the                                                                                                                                         
  critic in `inspect_skill` ends up reasoning about skills that had nothing to
  do with the call, and proposed amendments target the wrong skills.                                                                                                                                              
                                                                                                                                                                                                                  
  Fix: track the names of opened skills in a new `opened_skills_var`                                                                                                                                              
  ContextVar declared next to the existing `active_skills_var`. `load_skill`                                                                                                                                      
  adds to it on a successful open. The retriever filters the catalog by it                                                                                                                                        
  before persisting on both the success and error paths. If the loop opened                                                                                                                                       
  zero skills, zero runs are recorded — no skill is responsible for an
  unconsulted call.                                                                                                                                                                                               
                  
  ## Acceptance Criteria                                                                                                                                                                                          
                  
  - [x] `_record_skill_runs` is called only with skills that were opened via `load_skill`                                                                                                                         
  - [x] When the agent opens zero skills, zero SkillRuns are written
  - [x] `_record_skill_runs`'s signature is unchanged — filtering happens in the caller                                                                                                                           
  - [x] The existing `test_agentic_skill_runs_use_neutral_success_score` continues to pass byte-for-byte                                                                                                          
  - [x] `load_skill` stays safe if invoked outside the agentic loop (the new ContextVar defaults to `None`; the handler is guarded)                                                                               
                                                                                                                                                                                                                  
  ## Type of Change                                                                                                                                                                                               
                                                                                                                                                                                                                  
  - [x] Bug fix (non-breaking change that fixes an issue)                                                                                                                                                         
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Code refactoring
  - [ ] Other (please specify):                                                                                                                                                                                   
   
  ## Screenshots                                                                                                                                                                                                  
                  
  19/19 tests in `cognee/tests/unit/modules/tools/test_skill_ingest.py` pass.                                                                                                                                     
   
  ## Pre-submission Checklist                                                                                                                                                                                     
                  
  - [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)                                                                                                                 
  - [x] **This PR contains minimal changes necessary to address the issue/feature**
  - [x] My code follows the project's coding standards and style guidelines                                                                                                                                       
  - [x] I have added tests that prove my fix is effective or that my feature works                                                                                                                                
  - [ ] I have added necessary documentation (if applicable)
  - [x] All new and existing tests pass                                                                                                                                                                           
  - [x] I have searched existing PRs to ensure this change hasn't been submitted already
  - [x] I have linked any relevant issues in the description                                                                                                                                                      
  - [x] My commits have clear and descriptive messages                                                                                                                                                            
   
  ## DCO Affirmation                                                                                                                                                                                              
                  
  I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.                                                                           
 