### PR TITLE
feat(skills): capture tool_trace on every SkillRun

### DIFF
--- a/cognee/modules/retrieval/agentic_retriever.py
+++ b/cognee/modules/retrieval/agentic_retriever.py
@@ -18,6 +18,7 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, Field
 
 from cognee.modules.engine.models import Skill, Tool
+from cognee.modules.engine.models.SkillRun import ToolCall as SkillRunToolCall
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.modules.tools.context import active_skills_var
@@ -197,6 +198,7 @@ class AgenticRetriever(GraphCompletionRetriever):
         tool_names = [t.name for t in tools]
 
         started_at_ms = int(time.time() * 1000)
+        tool_trace: List[SkillRunToolCall] = []
         token = active_skills_var.set({s.name: s for s in skills})
         try:
             try:
@@ -204,6 +206,7 @@ class AgenticRetriever(GraphCompletionRetriever):
                     query=query,
                     initial_context=context if isinstance(context, str) else "",
                     tool_names=tool_names,
+                    tool_trace=tool_trace,
                 )
             except Exception as exc:
                 latency_ms = int(time.time() * 1000) - started_at_ms
@@ -217,6 +220,7 @@ class AgenticRetriever(GraphCompletionRetriever):
                         success_score=0.0,
                         error_type=type(exc).__name__,
                         error_message=str(exc),
+                        tool_trace=tool_trace,
                     )
                 raise
         finally:
@@ -235,6 +239,7 @@ class AgenticRetriever(GraphCompletionRetriever):
                 final,
                 started_at_ms=started_at_ms,
                 latency_ms=latency_ms,
+                tool_trace=tool_trace,
             )
 
         await self._store_session_qa(
@@ -257,12 +262,14 @@ class AgenticRetriever(GraphCompletionRetriever):
         success_score: Optional[float] = None,
         error_type: str = "",
         error_message: str = "",
+        tool_trace: Optional[List[SkillRunToolCall]] = None,
     ) -> None:
         """Persist one SkillRun node per active skill after a retrieval call."""
         from cognee.modules.engine.models.SkillRun import SkillRun, UNSCORED_SKILL_RUN_SCORE
         from cognee.tasks.storage.add_data_points import add_data_points
 
         resolved_score = UNSCORED_SKILL_RUN_SCORE if success_score is None else success_score
+        resolved_trace = list(tool_trace) if tool_trace else []
         runs = [
             SkillRun(
                 run_id=f"agentic:{s.name}:{uuid4()}",
@@ -275,6 +282,7 @@ class AgenticRetriever(GraphCompletionRetriever):
                 error_message=error_message,
                 started_at_ms=started_at_ms,
                 latency_ms=latency_ms,
+                tool_trace=list(resolved_trace),
             )
             for s in skills
         ]
@@ -349,6 +357,7 @@ class AgenticRetriever(GraphCompletionRetriever):
         query: Optional[str],
         initial_context: str,
         tool_names: List[str],
+        tool_trace: Optional[List[SkillRunToolCall]] = None,
     ) -> str:
         loop_context = initial_context
         conversation_history = await self._get_session_history()
@@ -373,7 +382,19 @@ class AgenticRetriever(GraphCompletionRetriever):
                 )
                 break
 
+            t0 = time.perf_counter()
             tool_result = await self._run_tool_safely(step.tool_call, tool_names)
+            duration_ms = int((time.perf_counter() - t0) * 1000)
+            if tool_trace is not None:
+                tool_trace.append(
+                    SkillRunToolCall(
+                        tool_name=step.tool_call.tool_name,
+                        tool_input=step.tool_call.arguments,
+                        tool_output=tool_result[:1000],
+                        success=not tool_result.startswith("ERROR:"),
+                        duration_ms=duration_ms,
+                    )
+                )
             loop_context += (
                 f"\n\n# Tool call {iteration + 1}: {step.tool_call.tool_name}\n"
                 f"Args: {step.tool_call.arguments}\nResult:\n{tool_result}"

--- a/cognee/tests/unit/modules/tools/test_skill_ingest.py
+++ b/cognee/tests/unit/modules/tools/test_skill_ingest.py
@@ -323,6 +323,61 @@ class TestSkillIngest(unittest.TestCase):
 
         assert run.success_score == UNSCORED_SKILL_RUN_SCORE
 
+    def test_record_skill_runs_persists_tool_trace(self):
+        from cognee.modules.engine.models import Skill
+        from cognee.modules.engine.models.SkillRun import ToolCall as SkillRunToolCall
+        from cognee.modules.retrieval.agentic_retriever import AgenticRetriever
+
+        skill = Skill(name="summarize", description="Summarize text.")
+        trace = [
+            SkillRunToolCall(
+                tool_name="memory_search",
+                tool_input={"query": "x"},
+                tool_output="ok",
+                success=True,
+                duration_ms=42,
+            ),
+            SkillRunToolCall(
+                tool_name="load_skill",
+                tool_input={"name": "summarize"},
+                tool_output="# Skill: summarize\n...",
+                success=True,
+                duration_ms=7,
+            ),
+        ]
+
+        async def _run():
+            with patch(
+                "cognee.tasks.storage.add_data_points.add_data_points",
+                new_callable=AsyncMock,
+            ) as mock_add:
+                await AgenticRetriever._record_skill_runs([skill], "task", "done", tool_trace=trace)
+                return mock_add.await_args.args[0][0]
+
+        run = self._run(_run())
+        assert len(run.tool_trace) == 2
+        assert run.tool_trace[0].tool_name == "memory_search"
+        assert run.tool_trace[0].success is True
+        assert run.tool_trace[0].duration_ms == 42
+        assert run.tool_trace[1].tool_name == "load_skill"
+
+    def test_record_skill_runs_defaults_tool_trace_empty(self):
+        from cognee.modules.engine.models import Skill
+        from cognee.modules.retrieval.agentic_retriever import AgenticRetriever
+
+        skill = Skill(name="summarize", description="Summarize text.")
+
+        async def _run():
+            with patch(
+                "cognee.tasks.storage.add_data_points.add_data_points",
+                new_callable=AsyncMock,
+            ) as mock_add:
+                await AgenticRetriever._record_skill_runs([skill], "task", "done")
+                return mock_add.await_args.args[0][0]
+
+        run = self._run(_run())
+        assert run.tool_trace == []
+
     def test_skill_run_entry_validates_score_ranges(self):
         from pydantic import ValidationError
 


### PR DESCRIPTION
## Description                                                                                                                                                                                                  
                                                                                                                                                                                                                  
  `AgenticRetriever`'s `_run_tool_loop` calls tools each iteration and folds                                                                                                                                      
  the result into the loop context as a string — then discards it.                                                                                                                                                
  `inspect_skill`'s prompt already reads `SkillRun.tool_trace` and renders                                                                                                                                        
  it as part of the failure analysis the LLM critic produces, but no                                                                                                                                              
  producer was filling that field. So on a crash the critic sees the                                                                                                                                              
  exception type and message and nothing else: it has no visibility into                                                                                                                                          
  what tools were called, with what args, or what came back, in the steps                                                                                                                                         
  leading up to the failure.                                                                                                                                                                                      
                                                                                                                                                                                                                  
  That makes it hard for the critic to distinguish "the skill instructions                                                                                                                                        
  were broken" from "the skill was fine but a downstream tool returned bad                                                                                                                                      
  data" — exactly the kind of attribution the improvement loop needs.                                                                                                                                             
                                                                                                                                                                                                                  
  Fix: accumulate one `SkillRunToolCall` (the `ToolCall` DataPoint on                                                                                                                                             
  `SkillRun`, aliased to avoid the name clash with the local AgentStep                                                                                                                                            
  `ToolCall`) per `execute_tool` invocation: `tool_name`, `tool_input`,                                                                                                                                           
  `tool_output` (truncated to 1000 chars to bound graph storage), a                                                                                                                                             
  `success` bool inferred from the `"ERROR:"` prefix the loop already                                                                                                                                             
  emits on tool failures, and `duration_ms` measured with                                                                                                                                                         
  `time.perf_counter`. The list is built in `get_completion_from_context`                                                                                                                                         
  and passed into the loop as a kwarg; the loop mutates it in place; the                                                                                                                                          
  caller then forwards it to `_record_skill_runs` on both the success and                                                                                                                                         
  error paths.                                                                                                                                                                                                    
                                                                                                                                                                                                                  
  ## Acceptance Criteria                                                                                                                                                                                          
                  
  - [x] Every persisted `SkillRun` includes the per-iteration `tool_trace` for the call                                                                                                                           
  - [x] `tool_trace` is populated on the success path and on the exception path
  - [x] No schema change (`tool_trace` field already exists on `SkillRun`)                                                                                                                                        
  - [x] No public API change (`_record_skill_runs`'s new arg is keyword-only with a default)                                                                                                                      
  - [x] Existing `test_agentic_skill_runs_use_neutral_success_score` continues to pass byte-for-byte                                                                                                              
  - [x] Tool output is truncated to bound storage size                                                                                                                                                            
  - [x] `success` is inferred from the loop's existing `"ERROR:"` convention                                                                                                                                      
                                                                                                                                                                                                                  
  ## Type of Change                                                                                                                                                                                               
                                                                                                                                                                                                                  
  - [ ] Bug fix (non-breaking change that fixes an issue)                                                                                                                                                         
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Code refactoring                                                                                                                                                                                          
  - [ ] Other (please specify):                                  

19/19 tests in `cognee/tests/unit/modules/tools/test_skill_ingest.py` pass.

  ## Pre-submission Checklist

  - [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
  - [x] **This PR contains minimal changes necessary to address the issue/feature**
  - [x] My code follows the project's coding standards and style guidelines
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have added necessary documentation (if applicable)
  - [x] All new and existing tests pass
  - [x] I have searched existing PRs to ensure this change hasn't been submitted already
  - [x] I have linked any relevant issues in the description                                                                                                                                                      
  - [x] My commits have clear and descriptive messages                                                                                                                                                            
                                                                                                                                                                                                                  
  ## DCO Affirmation                                                                                                                                                                                              
                                                                                                                                                                                                                  
  I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.    