### PR TITLE
feat: add graph_only option to forget endpoint

### DIFF
--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 from typing import Optional, Union
 
+from cognee.context_global_variables import set_database_global_context_variables
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.observability import (
     new_span,
@@ -114,28 +115,29 @@ async def forget(
         if user is None:
             user = await get_default_user()
 
-        if everything:
-            result = await _forget_everything(user)
-            span.set_attribute(COGNEE_RESULT_COUNT, result.get("datasets_removed", 0))
-            return result
+        async with set_database_global_context_variables(dataset, user.id):
+            if everything:
+                result = await _forget_everything(user)
+                span.set_attribute(COGNEE_RESULT_COUNT, result.get("datasets_removed", 0))
+                return result
 
-        if memory_only:
-            if dataset is None:
-                raise ValueError("memory_only requires dataset to be specified.")
+            if memory_only:
+                if dataset is None:
+                    raise ValueError("memory_only requires dataset to be specified.")
+                if data_id is not None:
+                    return await _forget_data_memory(data_id, dataset, user)
+                return await _forget_dataset_memory(dataset, user)
+
+            if dataset is not None and data_id is not None:
+                return await _forget_data_item(data_id, dataset, user)
+
+            if dataset is not None:
+                return await _forget_dataset(dataset, user)
+
             if data_id is not None:
-                return await _forget_data_memory(data_id, dataset, user)
-            return await _forget_dataset_memory(dataset, user)
+                raise ValueError("data_id requires dataset to be specified.")
 
-        if dataset is not None and data_id is not None:
-            return await _forget_data_item(data_id, dataset, user)
-
-        if dataset is not None:
-            return await _forget_dataset(dataset, user)
-
-        if data_id is not None:
-            raise ValueError("data_id requires dataset to be specified.")
-
-        raise ValueError("Specify dataset, data_id+dataset, or everything=True.")
+            raise ValueError("Specify dataset, data_id+dataset, or everything=True.")
 
 
 async def _forget_everything(user) -> dict:
@@ -236,6 +238,9 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user) -> dict:
     from cognee.modules.graph.methods.delete_dataset_nodes_and_edges import (
         delete_dataset_nodes_and_edges,
     )
+    from cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status import (
+        reset_dataset_pipeline_run_status,
+    )
 
     dataset_id = await _resolve_dataset_id(dataset_ref, user)
 
@@ -264,6 +269,13 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user) -> dict:
 
         await session.commit()
 
+    # 3. Reset dataset-level pipeline run status so cached cognify runs can execute again.
+    await reset_dataset_pipeline_run_status(
+        dataset_id=dataset_id,
+        user=user,
+        pipeline_names=["cognify_pipeline"],
+    )
+
     logger.info(
         "forget: cleared memory for dataset=%s, user=%s (%d data records reset)",
         dataset_id,
@@ -286,7 +298,7 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
     Cleanup scope:
     - Graph DB (nodes, edges for this data item): yes
     - Vector DB (embeddings for this data item): yes
-    - Pipeline status (for this data item): reset
+    - Pipeline status (for this data item): reset for cognify only
     - Relational DB (data record): preserved
     - Raw file: preserved
     """
@@ -314,10 +326,14 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
         if data_record and data_record.pipeline_status:
             dataset_id_str = str(dataset_id)
             updated = False
-            for pipeline_name in list(data_record.pipeline_status.keys()):
-                if dataset_id_str in data_record.pipeline_status[pipeline_name]:
-                    del data_record.pipeline_status[pipeline_name][dataset_id_str]
-                    updated = True
+            # Memory-only forget removes cognify artifacts (graph/vector), so only
+            # cognify_pipeline status should be reset. Keep add status intact.
+            if (
+                "cognify_pipeline" in data_record.pipeline_status
+                and dataset_id_str in data_record.pipeline_status["cognify_pipeline"]
+            ):
+                del data_record.pipeline_status["cognify_pipeline"][dataset_id_str]
+                updated = True
             if updated:
                 orm_attributes.flag_modified(data_record, "pipeline_status")
             await session.commit()

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -17,7 +17,7 @@ async def forget(
     data_id: Optional[UUID] = None,
     dataset: Optional[Union[str, UUID]] = None,
     everything: bool = False,
-    graph_only: bool = False,
+    memory_only: bool = False,
     user=None,
 ) -> dict:
     """Remove data from the knowledge graph.
@@ -36,8 +36,8 @@ async def forget(
         # Forget everything the current user owns
         await cognee.forget(everything=True)
 
-        # Forget only graph/vector data for a dataset (keep raw files)
-        await cognee.forget(dataset="scientists", graph_only=True)
+        # Forget only memory (graph + vector) for a dataset (keep raw files)
+        await cognee.forget(dataset="scientists", memory_only=True)
 
     Args:
         data_id: UUID of a specific data item to remove.
@@ -47,8 +47,8 @@ async def forget(
             item from this dataset.
         everything: If True, delete all datasets and data the user owns.
             Ignores ``data_id`` and ``dataset``.
-        graph_only: If True (requires ``dataset``), delete only graph
-            nodes/edges and vector embeddings, and reset pipeline status.
+        memory_only: If True (requires ``dataset``), delete only memory
+            (graph nodes/edges and vector embeddings) and reset pipeline status.
             Raw files and data records are preserved so the dataset can
             be re-cognified with different settings.
         user: User context. Resolved to default user when None.
@@ -61,8 +61,8 @@ async def forget(
 
     if everything:
         target = "everything"
-    elif graph_only and dataset:
-        target = "dataset_graph_only"
+    elif memory_only and dataset:
+        target = "dataset_memory_only"
     elif data_id:
         target = "data_item"
     elif dataset:
@@ -90,7 +90,7 @@ async def forget(
 
         client = get_remote_client()
         if client is not None:
-            result = await client.forget(data_id=data_id, dataset=dataset, everything=everything, graph_only=graph_only)
+            result = await client.forget(data_id=data_id, dataset=dataset, everything=everything, memory_only=memory_only)
             span.set_attribute(
                 COGNEE_RESULT_COUNT,
                 result.get("datasets_removed", 0) if isinstance(result, dict) else 0,
@@ -112,12 +112,12 @@ async def forget(
             span.set_attribute(COGNEE_RESULT_COUNT, result.get("datasets_removed", 0))
             return result
 
-        if graph_only:
+        if memory_only:
             if dataset is None:
-                raise ValueError("graph_only requires dataset to be specified.")
+                raise ValueError("memory_only requires dataset to be specified.")
             if data_id is not None:
-                raise ValueError("graph_only cannot be combined with data_id.")
-            return await _forget_dataset_graph(dataset, user)
+                raise ValueError("memory_only cannot be combined with data_id.")
+            return await _forget_dataset_memory(dataset, user)
 
         if dataset is not None and data_id is not None:
             return await _forget_data_item(data_id, dataset, user)
@@ -207,8 +207,8 @@ async def _forget_data_item(data_id: UUID, dataset_ref: Union[str, UUID], user) 
     return {"data_id": str(data_id), "dataset_id": str(dataset_id), "status": "success"}
 
 
-async def _forget_dataset_graph(dataset_ref: Union[str, UUID], user) -> dict:
-    """Delete only graph/vector data for a dataset, preserving raw files.
+async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user) -> dict:
+    """Delete only memory (graph + vector) for a dataset, preserving raw files.
 
     This allows re-cognifying the dataset with different settings
     (e.g. a new custom prompt or graph model).
@@ -260,7 +260,7 @@ async def _forget_dataset_graph(dataset_ref: Union[str, UUID], user) -> dict:
         await session.commit()
 
     logger.info(
-        "forget: cleared graph data for dataset=%s, user=%s (%d data records reset)",
+        "forget: cleared memory for dataset=%s, user=%s (%d data records reset)",
         dataset_id, user.id, len(data_records),
     )
     return {

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -17,6 +17,7 @@ async def forget(
     data_id: Optional[UUID] = None,
     dataset: Optional[Union[str, UUID]] = None,
     everything: bool = False,
+    graph_only: bool = False,
     user=None,
 ) -> dict:
     """Remove data from the knowledge graph.
@@ -35,6 +36,9 @@ async def forget(
         # Forget everything the current user owns
         await cognee.forget(everything=True)
 
+        # Forget only graph/vector data for a dataset (keep raw files)
+        await cognee.forget(dataset="scientists", graph_only=True)
+
     Args:
         data_id: UUID of a specific data item to remove.
             Requires ``dataset`` to also be set.
@@ -43,6 +47,10 @@ async def forget(
             item from this dataset.
         everything: If True, delete all datasets and data the user owns.
             Ignores ``data_id`` and ``dataset``.
+        graph_only: If True (requires ``dataset``), delete only graph
+            nodes/edges and vector embeddings, and reset pipeline status.
+            Raw files and data records are preserved so the dataset can
+            be re-cognified with different settings.
         user: User context. Resolved to default user when None.
 
     Returns:
@@ -51,11 +59,16 @@ async def forget(
     from cognee.shared.utils import send_telemetry
     from cognee import __version__ as cognee_version
 
-    target = (
-        "everything"
-        if everything
-        else ("data_item" if data_id else ("dataset" if dataset else "unknown"))
-    )
+    if everything:
+        target = "everything"
+    elif graph_only and dataset:
+        target = "dataset_graph_only"
+    elif data_id:
+        target = "data_item"
+    elif dataset:
+        target = "dataset"
+    else:
+        target = "unknown"
 
     send_telemetry(
         "cognee.forget",
@@ -77,7 +90,7 @@ async def forget(
 
         client = get_remote_client()
         if client is not None:
-            result = await client.forget(data_id=data_id, dataset=dataset, everything=everything)
+            result = await client.forget(data_id=data_id, dataset=dataset, everything=everything, graph_only=graph_only)
             span.set_attribute(
                 COGNEE_RESULT_COUNT,
                 result.get("datasets_removed", 0) if isinstance(result, dict) else 0,
@@ -98,6 +111,9 @@ async def forget(
             result = await _forget_everything(user)
             span.set_attribute(COGNEE_RESULT_COUNT, result.get("datasets_removed", 0))
             return result
+
+        if graph_only and dataset is not None:
+            return await _forget_dataset_graph(dataset, user)
 
         if dataset is not None and data_id is not None:
             return await _forget_data_item(data_id, dataset, user)
@@ -185,6 +201,69 @@ async def _forget_data_item(data_id: UUID, dataset_ref: Union[str, UUID], user) 
         user.id,
     )
     return {"data_id": str(data_id), "dataset_id": str(dataset_id), "status": "success"}
+
+
+async def _forget_dataset_graph(dataset_ref: Union[str, UUID], user) -> dict:
+    """Delete only graph/vector data for a dataset, preserving raw files.
+
+    This allows re-cognifying the dataset with different settings
+    (e.g. a new custom prompt or graph model).
+
+    Cleanup scope:
+    - Graph DB (nodes, edges): yes
+    - Vector DB (embeddings): yes
+    - Pipeline status: reset (so cognify re-processes all data)
+    - Relational DB (dataset, data records): preserved
+    - Raw files: preserved
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import attributes as orm_attributes
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.data.models import Data
+    from cognee.modules.data.models.DatasetData import DatasetData
+    from cognee.modules.graph.methods.delete_dataset_nodes_and_edges import (
+        delete_dataset_nodes_and_edges,
+    )
+
+    dataset_id = await _resolve_dataset_id(dataset_ref, user)
+
+    # 1. Delete graph nodes/edges and vector embeddings
+    await delete_dataset_nodes_and_edges(dataset_id, user.id)
+
+    # 2. Reset pipeline_status on all data records in this dataset
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        data_ids_query = select(DatasetData.data_id).where(
+            DatasetData.dataset_id == dataset_id
+        )
+        data_records = (
+            await session.execute(select(Data).where(Data.id.in_(data_ids_query)))
+        ).scalars().all()
+
+        dataset_id_str = str(dataset_id)
+        for data_record in data_records:
+            if not data_record.pipeline_status:
+                continue
+            updated = False
+            for pipeline_name in list(data_record.pipeline_status.keys()):
+                if dataset_id_str in data_record.pipeline_status[pipeline_name]:
+                    del data_record.pipeline_status[pipeline_name][dataset_id_str]
+                    updated = True
+            if updated:
+                orm_attributes.flag_modified(data_record, "pipeline_status")
+
+        await session.commit()
+
+    logger.info(
+        "forget: cleared graph data for dataset=%s, user=%s (%d data records reset)",
+        dataset_id, user.id, len(data_records),
+    )
+    return {
+        "dataset_id": str(dataset_id),
+        "data_records_reset": len(data_records),
+        "status": "success",
+    }
 
 
 async def _resolve_dataset_id(dataset_ref: Union[str, UUID], user) -> UUID:

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -95,7 +95,9 @@ async def forget(
 
         client = get_remote_client()
         if client is not None:
-            result = await client.forget(data_id=data_id, dataset=dataset, everything=everything, memory_only=memory_only)
+            result = await client.forget(
+                data_id=data_id, dataset=dataset, everything=everything, memory_only=memory_only
+            )
             span.set_attribute(
                 COGNEE_RESULT_COUNT,
                 result.get("datasets_removed", 0) if isinstance(result, dict) else 0,
@@ -243,12 +245,10 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user) -> dict:
     # 2. Reset pipeline_status on all data records in this dataset
     db_engine = get_relational_engine()
     async with db_engine.get_async_session() as session:
-        data_ids_query = select(DatasetData.data_id).where(
-            DatasetData.dataset_id == dataset_id
-        )
+        data_ids_query = select(DatasetData.data_id).where(DatasetData.dataset_id == dataset_id)
         data_records = (
-            await session.execute(select(Data).where(Data.id.in_(data_ids_query)))
-        ).scalars().all()
+            (await session.execute(select(Data).where(Data.id.in_(data_ids_query)))).scalars().all()
+        )
 
         dataset_id_str = str(dataset_id)
         for data_record in data_records:
@@ -266,7 +266,9 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user) -> dict:
 
     logger.info(
         "forget: cleared memory for dataset=%s, user=%s (%d data records reset)",
-        dataset_id, user.id, len(data_records),
+        dataset_id,
+        user.id,
+        len(data_records),
     )
     return {
         "dataset_id": str(dataset_id),
@@ -306,8 +308,8 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
     db_engine = get_relational_engine()
     async with db_engine.get_async_session() as session:
         data_record = (
-            await session.execute(select(Data).where(Data.id == data_id))
-        ).scalars().first()
+            (await session.execute(select(Data).where(Data.id == data_id))).scalars().first()
+        )
 
         if data_record and data_record.pipeline_status:
             dataset_id_str = str(dataset_id)
@@ -322,7 +324,9 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
 
     logger.info(
         "forget: cleared memory for data_id=%s in dataset=%s, user=%s",
-        data_id, dataset_id, user.id,
+        data_id,
+        dataset_id,
+        user.id,
     )
     return {
         "data_id": str(data_id),

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -112,7 +112,11 @@ async def forget(
             span.set_attribute(COGNEE_RESULT_COUNT, result.get("datasets_removed", 0))
             return result
 
-        if graph_only and dataset is not None:
+        if graph_only:
+            if dataset is None:
+                raise ValueError("graph_only requires dataset to be specified.")
+            if data_id is not None:
+                raise ValueError("graph_only cannot be combined with data_id.")
             return await _forget_dataset_graph(dataset, user)
 
         if dataset is not None and data_id is not None:

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -39,6 +39,9 @@ async def forget(
         # Forget only memory (graph + vector) for a dataset (keep raw files)
         await cognee.forget(dataset="scientists", memory_only=True)
 
+        # Forget only memory for a single file in a dataset
+        await cognee.forget(dataset="scientists", data_id=data_id, memory_only=True)
+
     Args:
         data_id: UUID of a specific data item to remove.
             Requires ``dataset`` to also be set.
@@ -61,6 +64,8 @@ async def forget(
 
     if everything:
         target = "everything"
+    elif memory_only and data_id:
+        target = "data_item_memory_only"
     elif memory_only and dataset:
         target = "dataset_memory_only"
     elif data_id:
@@ -116,7 +121,7 @@ async def forget(
             if dataset is None:
                 raise ValueError("memory_only requires dataset to be specified.")
             if data_id is not None:
-                raise ValueError("memory_only cannot be combined with data_id.")
+                return await _forget_data_memory(data_id, dataset, user)
             return await _forget_dataset_memory(dataset, user)
 
         if dataset is not None and data_id is not None:
@@ -266,6 +271,62 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user) -> dict:
     return {
         "dataset_id": str(dataset_id),
         "data_records_reset": len(data_records),
+        "status": "success",
+    }
+
+
+async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user) -> dict:
+    """Delete only memory (graph + vector) for a single data item, preserving the raw file.
+
+    This allows re-cognifying a specific file with different settings
+    without affecting the rest of the dataset.
+
+    Cleanup scope:
+    - Graph DB (nodes, edges for this data item): yes
+    - Vector DB (embeddings for this data item): yes
+    - Pipeline status (for this data item): reset
+    - Relational DB (data record): preserved
+    - Raw file: preserved
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import attributes as orm_attributes
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.data.models import Data
+    from cognee.modules.graph.methods.delete_data_nodes_and_edges import (
+        delete_data_nodes_and_edges,
+    )
+
+    dataset_id = await _resolve_dataset_id(dataset_ref, user)
+
+    # 1. Delete graph nodes/edges and vector embeddings for this data item
+    await delete_data_nodes_and_edges(dataset_id, data_id, user.id)
+
+    # 2. Reset pipeline_status for this data record
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        data_record = (
+            await session.execute(select(Data).where(Data.id == data_id))
+        ).scalars().first()
+
+        if data_record and data_record.pipeline_status:
+            dataset_id_str = str(dataset_id)
+            updated = False
+            for pipeline_name in list(data_record.pipeline_status.keys()):
+                if dataset_id_str in data_record.pipeline_status[pipeline_name]:
+                    del data_record.pipeline_status[pipeline_name][dataset_id_str]
+                    updated = True
+            if updated:
+                orm_attributes.flag_modified(data_record, "pipeline_status")
+            await session.commit()
+
+    logger.info(
+        "forget: cleared memory for data_id=%s in dataset=%s, user=%s",
+        data_id, dataset_id, user.id,
+    )
+    return {
+        "data_id": str(data_id),
+        "dataset_id": str(dataset_id),
         "status": "success",
     }
 

--- a/cognee/api/v1/forget/routers/get_forget_router.py
+++ b/cognee/api/v1/forget/routers/get_forget_router.py
@@ -38,8 +38,10 @@ def get_forget_router() -> APIRouter:
         - Set `everything: true` to delete all user data.
         - Set `dataset` alone to delete an entire dataset.
         - Set `dataset` + `data_id` to delete a single item.
-        - Set `dataset` + `memory_only: true` to clear only graph/vector
-          data, preserving raw files so the dataset can be re-cognified.
+        - Set `dataset` + `memory_only: true` to clear memory
+          (graph + vector), preserving raw files so the dataset can be re-cognified.
+        - Set `dataset` + `data_id` + `memory_only: true` to clear memory
+          for a single file only.
         """
         send_telemetry(
             "Forget API Endpoint Invoked",

--- a/cognee/api/v1/forget/routers/get_forget_router.py
+++ b/cognee/api/v1/forget/routers/get_forget_router.py
@@ -17,9 +17,9 @@ class ForgetPayloadDTO(InDTO):
     data_id: Optional[UUID] = Field(default=None)
     dataset: Optional[Union[str, UUID]] = Field(default=None)
     everything: bool = Field(default=False)
-    graph_only: bool = Field(
+    memory_only: bool = Field(
         default=False,
-        description="When True with a dataset, delete only graph/vector data "
+        description="When True with a dataset, delete only memory (graph nodes/edges and vector embeddings) "
         "and reset pipeline status — raw files and data records are preserved. "
         "This allows re-cognifying the dataset from scratch.",
     )
@@ -38,7 +38,7 @@ def get_forget_router() -> APIRouter:
         - Set `everything: true` to delete all user data.
         - Set `dataset` alone to delete an entire dataset.
         - Set `dataset` + `data_id` to delete a single item.
-        - Set `dataset` + `graph_only: true` to clear only graph/vector
+        - Set `dataset` + `memory_only: true` to clear only graph/vector
           data, preserving raw files so the dataset can be re-cognified.
         """
         send_telemetry(
@@ -57,7 +57,7 @@ def get_forget_router() -> APIRouter:
                 data_id=payload.data_id,
                 dataset=payload.dataset,
                 everything=payload.everything,
-                graph_only=payload.graph_only,
+                memory_only=payload.memory_only,
                 user=user,
             )
             return result

--- a/cognee/api/v1/forget/routers/get_forget_router.py
+++ b/cognee/api/v1/forget/routers/get_forget_router.py
@@ -17,6 +17,12 @@ class ForgetPayloadDTO(InDTO):
     data_id: Optional[UUID] = Field(default=None)
     dataset: Optional[Union[str, UUID]] = Field(default=None)
     everything: bool = Field(default=False)
+    graph_only: bool = Field(
+        default=False,
+        description="When True with a dataset, delete only graph/vector data "
+        "and reset pipeline status — raw files and data records are preserved. "
+        "This allows re-cognifying the dataset from scratch.",
+    )
 
 
 def get_forget_router() -> APIRouter:
@@ -32,6 +38,8 @@ def get_forget_router() -> APIRouter:
         - Set `everything: true` to delete all user data.
         - Set `dataset` alone to delete an entire dataset.
         - Set `dataset` + `data_id` to delete a single item.
+        - Set `dataset` + `graph_only: true` to clear only graph/vector
+          data, preserving raw files so the dataset can be re-cognified.
         """
         send_telemetry(
             "Forget API Endpoint Invoked",
@@ -49,6 +57,7 @@ def get_forget_router() -> APIRouter:
                 data_id=payload.data_id,
                 dataset=payload.dataset,
                 everything=payload.everything,
+                graph_only=payload.graph_only,
                 user=user,
             )
             return result

--- a/cognee/api/v1/ontologies/ontologies.py
+++ b/cognee/api/v1/ontologies/ontologies.py
@@ -163,8 +163,14 @@ class OntologyService:
         if ontology_key not in metadata:
             raise ValueError(f"Ontology key '{ontology_key}' not found")
 
-        file_path = user_dir / f"{ontology_key}.owl"
-        if file_path.exists():
+        base_dir = user_dir.resolve()
+        file_path = (user_dir / f"{ontology_key}.owl").resolve()
+
+        # Prevent path traversal from deleting files outside the user's ontology directory.
+        if file_path.parent != base_dir:
+            raise ValueError("Invalid ontology key")
+
+        if file_path.is_file():
             file_path.unlink()
 
         del metadata[ontology_key]

--- a/cognee/api/v1/ontologies/ontologies.py
+++ b/cognee/api/v1/ontologies/ontologies.py
@@ -156,6 +156,20 @@ class OntologyService:
                 contents.append(f.read())
         return contents
 
+    def delete_ontology(self, ontology_key: str, user) -> None:
+        user_dir = self._get_user_dir(str(user.id))
+        metadata = self._load_metadata(user_dir)
+
+        if ontology_key not in metadata:
+            raise ValueError(f"Ontology key '{ontology_key}' not found")
+
+        file_path = user_dir / f"{ontology_key}.owl"
+        if file_path.exists():
+            file_path.unlink()
+
+        del metadata[ontology_key]
+        self._save_metadata(user_dir, metadata)
+
     def list_ontologies(self, user) -> dict:
         user_dir = self._get_user_dir(str(user.id))
         return self._load_metadata(user_dir)

--- a/cognee/api/v1/ontologies/routers/get_ontology_router.py
+++ b/cognee/api/v1/ontologies/routers/get_ontology_router.py
@@ -80,6 +80,38 @@ def get_ontology_router() -> APIRouter:
         except Exception as e:
             return JSONResponse(status_code=500, content={"error": str(e)})
 
+    @router.delete("/{ontology_key}", response_model=dict)
+    async def delete_ontology(
+        ontology_key: str,
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        Delete an uploaded ontology by key.
+
+        ## Path Parameters
+        - **ontology_key** (str): The key of the ontology to delete.
+
+        ## Error Codes
+        - **400 Bad Request**: Ontology key not found
+        - **500 Internal Server Error**: File system errors
+        """
+        send_telemetry(
+            "Ontology Delete API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "DELETE /api/v1/ontologies/{ontology_key}",
+                "cognee_version": cognee_version,
+            },
+        )
+
+        try:
+            ontology_service.delete_ontology(ontology_key=ontology_key, user=user)
+            return {"status": "success", "ontology_key": ontology_key}
+        except ValueError as e:
+            return JSONResponse(status_code=400, content={"error": str(e)})
+        except Exception as e:
+            return JSONResponse(status_code=500, content={"error": str(e)})
+
     @router.get("", response_model=dict)
     async def list_ontologies(user: User = Depends(get_authenticated_user)):
         """

--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -92,7 +92,7 @@ def backend_access_control_enabled():
     return False
 
 
-VECTOR_DBS_WITH_MULTI_USER_SUPPORT = ["lancedb", "falkor"]
+VECTOR_DBS_WITH_MULTI_USER_SUPPORT = ["lancedb", "pgvector", "falkor"]
 GRAPH_DBS_WITH_MULTI_USER_SUPPORT = ["kuzu", "falkor"]
 
 

--- a/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
@@ -19,7 +19,6 @@ from cognee.modules.users.methods.get_user import get_user
 
 
 async def delete_data_nodes_and_edges(dataset_id: UUID, data_id: UUID, user_id: UUID) -> None:
-
     user = await get_user(user_id)
 
     # Check if user has delete permissions for the dataset before proceeding with deletion of related graph/vector nodes and edges.

--- a/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
@@ -14,9 +14,18 @@ from cognee.modules.graph.methods import (
 from cognee.modules.graph.methods.delete_from_graph_and_vector import (
     delete_from_graph_and_vector,
 )
+from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+from cognee.modules.users.methods.get_user import get_user
 
 
 async def delete_data_nodes_and_edges(dataset_id: UUID, data_id: UUID, user_id: UUID) -> None:
+
+    user = await get_user(user_id)
+
+    # Check if user has delete permissions for the dataset before proceeding with deletion of related graph/vector nodes and edges.
+    dataset = await get_authorized_dataset(user, dataset_id, "delete")
+    dataset_id = dataset.id
+
     if is_multi_user_support_possible():
         affected_nodes = await get_data_related_nodes(dataset_id, data_id)
         affected_edges = await get_data_related_edges(dataset_id, data_id) if affected_nodes else []

--- a/cognee/modules/graph/methods/delete_dataset_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_dataset_nodes_and_edges.py
@@ -14,9 +14,16 @@ from cognee.modules.graph.methods import (
 from cognee.modules.graph.methods.delete_from_graph_and_vector import (
     delete_from_graph_and_vector,
 )
+from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+from cognee.modules.users.methods.get_user import get_user
 
 
 async def delete_dataset_nodes_and_edges(dataset_id: UUID, user_id: UUID) -> None:
+    user = await get_user(user_id)
+    # Check if user has delete permission for the dataset before proceeding with deletion of related graph/vector nodes and edges.
+    dataset = await get_authorized_dataset(user, dataset_id, "delete")
+    dataset_id = dataset.id
+
     if is_multi_user_support_possible():
         affected_nodes = await get_dataset_related_nodes(dataset_id)
         affected_edges = await get_dataset_related_edges(dataset_id) if affected_nodes else []

--- a/cognee/tests/unit/api/test_delete_ontology.py
+++ b/cognee/tests/unit/api/test_delete_ontology.py
@@ -142,6 +142,24 @@ class TestOntologyServiceDelete:
         assert "delete_this" not in updated_metadata
         assert (user_dir / "keep_this.owl").exists()
 
+    def test_delete_ontology_rejects_path_traversal_key(self, ontology_service, tmp_path):
+        """delete_ontology rejects keys that resolve outside the user directory."""
+        user = SimpleNamespace(id="user-1")
+        user_dir = tmp_path / "user-1"
+        user_dir.mkdir()
+
+        metadata = {
+            "../escape": {
+                "filename": "escape.owl",
+                "size_bytes": 10,
+                "uploaded_at": "2024-01-01",
+            }
+        }
+        (user_dir / "metadata.json").write_text(json.dumps(metadata))
+
+        with pytest.raises(ValueError, match="Invalid ontology key"):
+            ontology_service.delete_ontology("../escape", user)
+
 
 # ---------------------------------------------------------------------------
 # API endpoint tests for DELETE /api/v1/ontologies/{key}

--- a/cognee/tests/unit/api/test_delete_ontology.py
+++ b/cognee/tests/unit/api/test_delete_ontology.py
@@ -1,0 +1,210 @@
+"""Tests for the delete ontology feature.
+
+Covers:
+- OntologyService.delete_ontology: removes file and metadata
+- OntologyService.delete_ontology: raises ValueError for unknown key
+- OntologyService.delete_ontology: handles missing .owl file gracefully
+- DELETE /api/v1/ontologies/{key} endpoint: success, 400, upload-then-delete workflow
+"""
+
+import json
+import uuid
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from cognee.api.v1.ontologies.ontologies import OntologyService
+from cognee.api.client import app
+from cognee.modules.users.methods import get_authenticated_user
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def test_client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def mock_default_user():
+    return SimpleNamespace(
+        id=str(uuid.uuid4()),
+        email="test@example.com",
+        is_active=True,
+        tenant_id=str(uuid.uuid4()),
+    )
+
+
+@pytest.fixture
+def client(test_client, mock_default_user):
+    async def override_get_authenticated_user():
+        return mock_default_user
+
+    app.dependency_overrides[get_authenticated_user] = override_get_authenticated_user
+    yield test_client
+    app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+@pytest.fixture
+def ontology_service(tmp_path):
+    """OntologyService with base_dir pointed at tmp_path."""
+    fake_config = SimpleNamespace(data_root_directory=tmp_path)
+    with patch("cognee.api.v1.ontologies.ontologies.get_base_config", return_value=fake_config):
+        yield OntologyService()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for OntologyService.delete_ontology
+# ---------------------------------------------------------------------------
+
+
+class TestOntologyServiceDelete:
+    def test_delete_ontology_removes_file_and_metadata(self, ontology_service, tmp_path):
+        """delete_ontology removes the .owl file and metadata entry."""
+        user = SimpleNamespace(id="user-1")
+
+        user_dir = tmp_path / "user-1"
+        user_dir.mkdir()
+        owl_file = user_dir / "my_ontology.owl"
+        owl_file.write_text("<rdf>test</rdf>")
+
+        metadata = {
+            "my_ontology": {
+                "filename": "test.owl",
+                "size_bytes": 14,
+                "uploaded_at": "2024-01-01T00:00:00",
+            }
+        }
+        (user_dir / "metadata.json").write_text(json.dumps(metadata))
+
+        ontology_service.delete_ontology("my_ontology", user)
+
+        assert not owl_file.exists()
+        updated_metadata = json.loads((user_dir / "metadata.json").read_text())
+        assert "my_ontology" not in updated_metadata
+
+    def test_delete_ontology_raises_for_unknown_key(self, ontology_service, tmp_path):
+        """delete_ontology raises ValueError if ontology_key not in metadata."""
+        user = SimpleNamespace(id="user-1")
+
+        user_dir = tmp_path / "user-1"
+        user_dir.mkdir()
+        (user_dir / "metadata.json").write_text(json.dumps({}))
+
+        with pytest.raises(ValueError, match="not found"):
+            ontology_service.delete_ontology("nonexistent", user)
+
+    def test_delete_ontology_handles_missing_owl_file(self, ontology_service, tmp_path):
+        """delete_ontology succeeds even if .owl file is already missing."""
+        user = SimpleNamespace(id="user-1")
+
+        user_dir = tmp_path / "user-1"
+        user_dir.mkdir()
+
+        metadata = {
+            "orphan_key": {
+                "filename": "gone.owl",
+                "size_bytes": 0,
+                "uploaded_at": "2024-01-01T00:00:00",
+            }
+        }
+        (user_dir / "metadata.json").write_text(json.dumps(metadata))
+
+        ontology_service.delete_ontology("orphan_key", user)
+
+        updated_metadata = json.loads((user_dir / "metadata.json").read_text())
+        assert "orphan_key" not in updated_metadata
+
+    def test_delete_ontology_preserves_other_entries(self, ontology_service, tmp_path):
+        """Deleting one ontology preserves other ontology entries."""
+        user = SimpleNamespace(id="user-1")
+
+        user_dir = tmp_path / "user-1"
+        user_dir.mkdir()
+
+        metadata = {
+            "keep_this": {"filename": "keep.owl", "size_bytes": 10, "uploaded_at": "2024-01-01"},
+            "delete_this": {"filename": "del.owl", "size_bytes": 10, "uploaded_at": "2024-01-01"},
+        }
+        (user_dir / "metadata.json").write_text(json.dumps(metadata))
+        (user_dir / "delete_this.owl").write_text("<rdf/>")
+        (user_dir / "keep_this.owl").write_text("<rdf/>")
+
+        ontology_service.delete_ontology("delete_this", user)
+
+        updated_metadata = json.loads((user_dir / "metadata.json").read_text())
+        assert "keep_this" in updated_metadata
+        assert "delete_this" not in updated_metadata
+        assert (user_dir / "keep_this.owl").exists()
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests for DELETE /api/v1/ontologies/{key}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_ontology_endpoint_not_found(client):
+    """DELETE with unknown key returns 400."""
+    response = client.delete("/api/v1/ontologies/nonexistent_key")
+    assert response.status_code == 400
+    assert "not found" in response.json()["error"]
+
+
+def test_upload_then_delete_ontology_endpoint(client):
+    """Upload an ontology, verify it's listed, delete it, verify it's gone."""
+    ontology_content = (
+        b"<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'></rdf:RDF>"
+    )
+    unique_key = f"test_del_{uuid.uuid4().hex[:8]}"
+
+    # Upload
+    upload_resp = client.post(
+        "/api/v1/ontologies",
+        files=[("ontology_file", ("test.owl", ontology_content, "application/xml"))],
+        data={"ontology_key": unique_key},
+    )
+    assert upload_resp.status_code == 200
+
+    # Verify listed
+    list_resp = client.get("/api/v1/ontologies")
+    assert list_resp.status_code == 200
+    assert unique_key in list_resp.json()
+
+    # Delete
+    delete_resp = client.delete(f"/api/v1/ontologies/{unique_key}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["status"] == "success"
+    assert delete_resp.json()["ontology_key"] == unique_key
+
+    # Verify gone
+    list_resp2 = client.get("/api/v1/ontologies")
+    assert unique_key not in list_resp2.json()
+
+
+def test_delete_ontology_twice_returns_400(client):
+    """Deleting the same ontology twice should return 400 on second attempt."""
+    ontology_content = (
+        b"<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'></rdf:RDF>"
+    )
+    unique_key = f"test_double_del_{uuid.uuid4().hex[:8]}"
+
+    # Upload
+    client.post(
+        "/api/v1/ontologies",
+        files=[("ontology_file", ("test.owl", ontology_content, "application/xml"))],
+        data={"ontology_key": unique_key},
+    )
+
+    # First delete succeeds
+    resp1 = client.delete(f"/api/v1/ontologies/{unique_key}")
+    assert resp1.status_code == 200
+
+    # Second delete fails
+    resp2 = client.delete(f"/api/v1/ontologies/{unique_key}")
+    assert resp2.status_code == 400
+    assert "not found" in resp2.json()["error"]

--- a/cognee/tests/unit/api/v1/forget/test_forget_endpoint.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_endpoint.py
@@ -6,6 +6,7 @@ Covers:
 """
 
 import uuid
+import importlib
 import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -13,6 +14,8 @@ from fastapi.testclient import TestClient
 
 from cognee.api.client import app
 from cognee.modules.users.methods import get_authenticated_user
+
+forget_pkg = importlib.import_module("cognee.api.v1.forget")
 
 
 @pytest.fixture(scope="session")
@@ -50,7 +53,7 @@ def test_forget_endpoint_passes_memory_only_flag(client, mock_default_user):
         "status": "success",
     }
 
-    with patch("cognee.api.v1.forget.forget", new_callable=AsyncMock) as mock_forget:
+    with patch.object(forget_pkg, "forget", new_callable=AsyncMock) as mock_forget:
         mock_forget.return_value = expected_result
 
         response = client.post(
@@ -69,7 +72,7 @@ def test_forget_endpoint_passes_memory_only_flag(client, mock_default_user):
 
 def test_forget_endpoint_memory_only_defaults_to_false(client):
     """POST /v1/forget without memory_only should default to False."""
-    with patch("cognee.api.v1.forget.forget", new_callable=AsyncMock) as mock_forget:
+    with patch.object(forget_pkg, "forget", new_callable=AsyncMock) as mock_forget:
         mock_forget.return_value = {"status": "success", "datasets_removed": 0}
 
         response = client.post(
@@ -87,7 +90,7 @@ def test_forget_endpoint_memory_only_with_data_id(client):
     dataset_id = str(uuid.uuid4())
     data_id = str(uuid.uuid4())
 
-    with patch("cognee.api.v1.forget.forget", new_callable=AsyncMock) as mock_forget:
+    with patch.object(forget_pkg, "forget", new_callable=AsyncMock) as mock_forget:
         mock_forget.return_value = {
             "data_id": data_id,
             "dataset_id": dataset_id,

--- a/cognee/tests/unit/api/v1/forget/test_forget_endpoint.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_endpoint.py
@@ -50,9 +50,7 @@ def test_forget_endpoint_passes_memory_only_flag(client, mock_default_user):
         "status": "success",
     }
 
-    with patch(
-        "cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock
-    ) as mock_forget:
+    with patch("cognee.api.v1.forget.forget", new_callable=AsyncMock) as mock_forget:
         mock_forget.return_value = expected_result
 
         response = client.post(
@@ -71,9 +69,7 @@ def test_forget_endpoint_passes_memory_only_flag(client, mock_default_user):
 
 def test_forget_endpoint_memory_only_defaults_to_false(client):
     """POST /v1/forget without memory_only should default to False."""
-    with patch(
-        "cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock
-    ) as mock_forget:
+    with patch("cognee.api.v1.forget.forget", new_callable=AsyncMock) as mock_forget:
         mock_forget.return_value = {"status": "success", "datasets_removed": 0}
 
         response = client.post(
@@ -91,9 +87,7 @@ def test_forget_endpoint_memory_only_with_data_id(client):
     dataset_id = str(uuid.uuid4())
     data_id = str(uuid.uuid4())
 
-    with patch(
-        "cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock
-    ) as mock_forget:
+    with patch("cognee.api.v1.forget.forget", new_callable=AsyncMock) as mock_forget:
         mock_forget.return_value = {
             "data_id": data_id,
             "dataset_id": dataset_id,

--- a/cognee/tests/unit/api/v1/forget/test_forget_endpoint.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_endpoint.py
@@ -50,7 +50,9 @@ def test_forget_endpoint_passes_memory_only_flag(client, mock_default_user):
         "status": "success",
     }
 
-    with patch("cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock) as mock_forget:
+    with patch(
+        "cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock
+    ) as mock_forget:
         mock_forget.return_value = expected_result
 
         response = client.post(
@@ -69,7 +71,9 @@ def test_forget_endpoint_passes_memory_only_flag(client, mock_default_user):
 
 def test_forget_endpoint_memory_only_defaults_to_false(client):
     """POST /v1/forget without memory_only should default to False."""
-    with patch("cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock) as mock_forget:
+    with patch(
+        "cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock
+    ) as mock_forget:
         mock_forget.return_value = {"status": "success", "datasets_removed": 0}
 
         response = client.post(
@@ -87,7 +91,9 @@ def test_forget_endpoint_memory_only_with_data_id(client):
     dataset_id = str(uuid.uuid4())
     data_id = str(uuid.uuid4())
 
-    with patch("cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock) as mock_forget:
+    with patch(
+        "cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock
+    ) as mock_forget:
         mock_forget.return_value = {
             "data_id": data_id,
             "dataset_id": dataset_id,

--- a/cognee/tests/unit/api/v1/forget/test_forget_endpoint.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_endpoint.py
@@ -1,0 +1,106 @@
+"""Tests for the POST /v1/forget endpoint with memory_only flag.
+
+Covers:
+- memory_only is passed through to the forget() function
+- Validation error when memory_only=True without dataset
+"""
+
+import uuid
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+from cognee.api.client import app
+from cognee.modules.users.methods import get_authenticated_user
+
+
+@pytest.fixture(scope="session")
+def test_client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def mock_default_user():
+    return SimpleNamespace(
+        id=str(uuid.uuid4()),
+        email="test@example.com",
+        is_active=True,
+        tenant_id=str(uuid.uuid4()),
+    )
+
+
+@pytest.fixture
+def client(test_client, mock_default_user):
+    async def override_get_authenticated_user():
+        return mock_default_user
+
+    app.dependency_overrides[get_authenticated_user] = override_get_authenticated_user
+    yield test_client
+    app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+def test_forget_endpoint_passes_memory_only_flag(client, mock_default_user):
+    """POST /v1/forget with memory_only=True passes the flag to forget()."""
+    dataset_id = str(uuid.uuid4())
+    expected_result = {
+        "dataset_id": dataset_id,
+        "data_records_reset": 3,
+        "status": "success",
+    }
+
+    with patch("cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock) as mock_forget:
+        mock_forget.return_value = expected_result
+
+        response = client.post(
+            "/api/v1/forget",
+            json={"dataset": dataset_id, "memory_only": True},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == expected_result
+
+        mock_forget.assert_awaited_once()
+        call_kwargs = mock_forget.call_args.kwargs
+        assert call_kwargs["memory_only"] is True
+        assert call_kwargs["dataset"] == dataset_id
+
+
+def test_forget_endpoint_memory_only_defaults_to_false(client):
+    """POST /v1/forget without memory_only should default to False."""
+    with patch("cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock) as mock_forget:
+        mock_forget.return_value = {"status": "success", "datasets_removed": 0}
+
+        response = client.post(
+            "/api/v1/forget",
+            json={"everything": True},
+        )
+
+        assert response.status_code == 200
+        call_kwargs = mock_forget.call_args.kwargs
+        assert call_kwargs["memory_only"] is False
+
+
+def test_forget_endpoint_memory_only_with_data_id(client):
+    """POST /v1/forget with memory_only + dataset + data_id passes all params."""
+    dataset_id = str(uuid.uuid4())
+    data_id = str(uuid.uuid4())
+
+    with patch("cognee.api.v1.forget.routers.get_forget_router.forget", new_callable=AsyncMock) as mock_forget:
+        mock_forget.return_value = {
+            "data_id": data_id,
+            "dataset_id": dataset_id,
+            "status": "success",
+        }
+
+        response = client.post(
+            "/api/v1/forget",
+            json={"dataset": dataset_id, "data_id": data_id, "memory_only": True},
+        )
+
+        assert response.status_code == 200
+        call_kwargs = mock_forget.call_args.kwargs
+        assert call_kwargs["memory_only"] is True
+        assert call_kwargs["data_id"] == uuid.UUID(data_id)
+        assert call_kwargs["dataset"] == dataset_id

--- a/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
@@ -16,6 +16,16 @@ from unittest.mock import AsyncMock, patch
 
 # Import the actual module (not the function) to access private helpers
 forget_module = importlib.import_module("cognee.api.v1.forget.forget")
+serve_state_module = importlib.import_module("cognee.api.v1.serve.state")
+delete_dataset_nodes_and_edges_module = importlib.import_module(
+    "cognee.modules.graph.methods.delete_dataset_nodes_and_edges"
+)
+delete_data_nodes_and_edges_module = importlib.import_module(
+    "cognee.modules.graph.methods.delete_data_nodes_and_edges"
+)
+reset_dataset_pipeline_run_status_module = importlib.import_module(
+    "cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status"
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -115,16 +125,18 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
     )
 
     with (
-        patch(
-            "cognee.modules.graph.methods.delete_dataset_nodes_and_edges.delete_dataset_nodes_and_edges",
+        patch.object(
+            delete_dataset_nodes_and_edges_module,
+            "delete_dataset_nodes_and_edges",
             mock_delete,
         ),
         patch(
             "cognee.infrastructure.databases.relational.get_relational_engine",
             return_value=engine,
         ),
-        patch(
-            "cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status.reset_dataset_pipeline_run_status",
+        patch.object(
+            reset_dataset_pipeline_run_status_module,
+            "reset_dataset_pipeline_run_status",
             mock_reset_status,
         ),
         patch("sqlalchemy.orm.attributes.flag_modified"),
@@ -169,16 +181,18 @@ async def test_forget_dataset_memory_skips_records_without_pipeline_status(monke
     mock_reset_status = AsyncMock()
 
     with (
-        patch(
-            "cognee.modules.graph.methods.delete_dataset_nodes_and_edges.delete_dataset_nodes_and_edges",
+        patch.object(
+            delete_dataset_nodes_and_edges_module,
+            "delete_dataset_nodes_and_edges",
             AsyncMock(),
         ),
         patch(
             "cognee.infrastructure.databases.relational.get_relational_engine",
             return_value=engine,
         ),
-        patch(
-            "cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status.reset_dataset_pipeline_run_status",
+        patch.object(
+            reset_dataset_pipeline_run_status_module,
+            "reset_dataset_pipeline_run_status",
             mock_reset_status,
         ),
     ):
@@ -215,8 +229,9 @@ async def test_forget_data_memory_clears_graph_and_resets_pipeline(monkeypatch):
     )
 
     with (
-        patch(
-            "cognee.modules.graph.methods.delete_data_nodes_and_edges.delete_data_nodes_and_edges",
+        patch.object(
+            delete_data_nodes_and_edges_module,
+            "delete_data_nodes_and_edges",
             mock_delete,
         ),
         patch(
@@ -255,8 +270,9 @@ async def test_forget_data_memory_no_record_found(monkeypatch):
     )
 
     with (
-        patch(
-            "cognee.modules.graph.methods.delete_data_nodes_and_edges.delete_data_nodes_and_edges",
+        patch.object(
+            delete_data_nodes_and_edges_module,
+            "delete_data_nodes_and_edges",
             AsyncMock(),
         ),
         patch(
@@ -285,12 +301,11 @@ async def test_forget_memory_only_without_dataset_raises(monkeypatch):
 
     with (
         patch("cognee.shared.utils.send_telemetry", lambda *a, **kw: None),
-        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(serve_state_module, "get_remote_client", return_value=None),
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
-        patch(
-            "cognee.api.v1.forget.forget.set_database_global_context_variables",
-            return_value=_NoOpAsyncContext(),
+        patch.object(
+            forget_module, "set_database_global_context_variables", return_value=_NoOpAsyncContext()
         ),
     ):
         with pytest.raises(ValueError, match="memory_only requires dataset"):
@@ -311,12 +326,11 @@ async def test_forget_routes_to_dataset_memory(monkeypatch):
 
     with (
         patch("cognee.shared.utils.send_telemetry", lambda *a, **kw: None),
-        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(serve_state_module, "get_remote_client", return_value=None),
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
-        patch(
-            "cognee.api.v1.forget.forget.set_database_global_context_variables",
-            return_value=_NoOpAsyncContext(),
+        patch.object(
+            forget_module, "set_database_global_context_variables", return_value=_NoOpAsyncContext()
         ),
     ):
         result = await forget_module.forget(dataset="my-dataset", memory_only=True)
@@ -339,12 +353,11 @@ async def test_forget_routes_to_data_memory(monkeypatch):
 
     with (
         patch("cognee.shared.utils.send_telemetry", lambda *a, **kw: None),
-        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(serve_state_module, "get_remote_client", return_value=None),
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
-        patch(
-            "cognee.api.v1.forget.forget.set_database_global_context_variables",
-            return_value=_NoOpAsyncContext(),
+        patch.object(
+            forget_module, "set_database_global_context_variables", return_value=_NoOpAsyncContext()
         ),
     ):
         result = await forget_module.forget(
@@ -382,12 +395,11 @@ async def test_forget_telemetry_target_labels(monkeypatch):
 
     with (
         patch("cognee.shared.utils.send_telemetry", fake_telemetry),
-        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(serve_state_module, "get_remote_client", return_value=None),
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
-        patch(
-            "cognee.api.v1.forget.forget.set_database_global_context_variables",
-            return_value=_NoOpAsyncContext(),
+        patch.object(
+            forget_module, "set_database_global_context_variables", return_value=_NoOpAsyncContext()
         ),
     ):
         await forget_module.forget(dataset="ds", memory_only=True)

--- a/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
@@ -99,6 +99,7 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
     engine = _FakeEngine(session)
 
     mock_delete = AsyncMock()
+    mock_reset_status = AsyncMock()
     monkeypatch.setattr(
         forget_module,
         "_resolve_dataset_id",
@@ -114,6 +115,10 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
             "cognee.infrastructure.databases.relational.get_relational_engine",
             return_value=engine,
         ),
+        patch(
+            "cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status.reset_dataset_pipeline_run_status",
+            mock_reset_status,
+        ),
         patch("sqlalchemy.orm.attributes.flag_modified"),
     ):
         result = await forget_module._forget_dataset_memory(str(DATASET_ID), USER)
@@ -123,6 +128,11 @@ async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatc
     assert result["data_records_reset"] == 2
 
     mock_delete.assert_awaited_once_with(DATASET_ID, USER.id)
+    mock_reset_status.assert_awaited_once_with(
+        dataset_id=DATASET_ID,
+        user=USER,
+        pipeline_names=["cognify_pipeline"],
+    )
 
     # pipeline_status should have dataset entry removed
     assert str(DATASET_ID) not in data_a.pipeline_status["cognify"]
@@ -148,6 +158,7 @@ async def test_forget_dataset_memory_skips_records_without_pipeline_status(monke
         "_resolve_dataset_id",
         AsyncMock(return_value=DATASET_ID),
     )
+    mock_reset_status = AsyncMock()
 
     with (
         patch(
@@ -158,11 +169,16 @@ async def test_forget_dataset_memory_skips_records_without_pipeline_status(monke
             "cognee.infrastructure.databases.relational.get_relational_engine",
             return_value=engine,
         ),
+        patch(
+            "cognee.modules.pipelines.layers.reset_dataset_pipeline_run_status.reset_dataset_pipeline_run_status",
+            mock_reset_status,
+        ),
     ):
         result = await forget_module._forget_dataset_memory(str(DATASET_ID), USER)
 
     assert result["status"] == "success"
     assert result["data_records_reset"] == 2
+    mock_reset_status.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -173,8 +189,10 @@ async def test_forget_dataset_memory_skips_records_without_pipeline_status(monke
 @pytest.mark.asyncio
 async def test_forget_data_memory_clears_graph_and_resets_pipeline(monkeypatch):
     """memory_only=True with dataset+data_id clears graph/vector for the item."""
+    other_dataset_id = str(uuid4())
     pipeline_status = {
-        "cognify": {str(DATASET_ID): "COMPLETE"},
+        "add_pipeline": {str(DATASET_ID): "COMPLETE"},
+        "cognify_pipeline": {str(DATASET_ID): "COMPLETE", other_dataset_id: "COMPLETE"},
     }
     data_record = _make_data_record(DATA_ID_A, pipeline_status)
 
@@ -207,8 +225,12 @@ async def test_forget_data_memory_clears_graph_and_resets_pipeline(monkeypatch):
 
     mock_delete.assert_awaited_once_with(DATASET_ID, DATA_ID_A, USER.id)
 
-    # pipeline_status should have dataset entry removed
-    assert str(DATASET_ID) not in data_record.pipeline_status["cognify"]
+    # only cognify status should be reset for this dataset
+    assert str(DATASET_ID) not in data_record.pipeline_status["cognify_pipeline"]
+    # other cognify dataset entries should remain
+    assert other_dataset_id in data_record.pipeline_status["cognify_pipeline"]
+    # add pipeline status should remain untouched
+    assert str(DATASET_ID) in data_record.pipeline_status["add_pipeline"]
     assert session.committed
 
 

--- a/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
@@ -77,6 +77,14 @@ class _FakeEngine:
         return self._session
 
 
+class _NoOpAsyncContext:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Tests for _forget_dataset_memory
 # ---------------------------------------------------------------------------
@@ -280,6 +288,10 @@ async def test_forget_memory_only_without_dataset_raises(monkeypatch):
         patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
+        patch(
+            "cognee.api.v1.forget.forget.set_database_global_context_variables",
+            return_value=_NoOpAsyncContext(),
+        ),
     ):
         with pytest.raises(ValueError, match="memory_only requires dataset"):
             await forget_module.forget(memory_only=True)
@@ -302,6 +314,10 @@ async def test_forget_routes_to_dataset_memory(monkeypatch):
         patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
+        patch(
+            "cognee.api.v1.forget.forget.set_database_global_context_variables",
+            return_value=_NoOpAsyncContext(),
+        ),
     ):
         result = await forget_module.forget(dataset="my-dataset", memory_only=True)
 
@@ -326,6 +342,10 @@ async def test_forget_routes_to_data_memory(monkeypatch):
         patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
+        patch(
+            "cognee.api.v1.forget.forget.set_database_global_context_variables",
+            return_value=_NoOpAsyncContext(),
+        ),
     ):
         result = await forget_module.forget(
             dataset="my-dataset", data_id=DATA_ID_A, memory_only=True
@@ -365,6 +385,10 @@ async def test_forget_telemetry_target_labels(monkeypatch):
         patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
+        patch(
+            "cognee.api.v1.forget.forget.set_database_global_context_variables",
+            return_value=_NoOpAsyncContext(),
+        ),
     ):
         await forget_module.forget(dataset="ds", memory_only=True)
         await forget_module.forget(dataset="ds", data_id=DATA_ID_A, memory_only=True)

--- a/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
@@ -305,7 +305,9 @@ async def test_forget_routes_to_data_memory(monkeypatch):
         patch("cognee.low_level.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
     ):
-        result = await forget_module.forget(dataset="my-dataset", data_id=DATA_ID_A, memory_only=True)
+        result = await forget_module.forget(
+            dataset="my-dataset", data_id=DATA_ID_A, memory_only=True
+        )
 
     assert result["status"] == "success"
     mock_forget_data_memory.assert_awaited_once_with(DATA_ID_A, "my-dataset", USER)

--- a/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
@@ -1,0 +1,348 @@
+"""Tests for the memory_only option in cognee.forget().
+
+Covers:
+- _forget_dataset_memory: clears graph+vector, resets pipeline_status, preserves data
+- _forget_data_memory: clears graph+vector for a single item, resets its pipeline_status
+- Validation: memory_only without dataset raises ValueError
+- Routing: memory_only with dataset vs memory_only with dataset+data_id
+- Telemetry target labels for memory_only combinations
+"""
+
+import importlib
+import pytest
+from types import SimpleNamespace
+from uuid import uuid4
+from unittest.mock import AsyncMock, patch
+
+# Import the actual module (not the function) to access private helpers
+forget_module = importlib.import_module("cognee.api.v1.forget.forget")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DATASET_ID = uuid4()
+DATA_ID_A = uuid4()
+DATA_ID_B = uuid4()
+USER = SimpleNamespace(id=uuid4())
+
+
+def _make_data_record(data_id, pipeline_status=None):
+    """Create a fake Data record with mutable pipeline_status."""
+    return SimpleNamespace(id=data_id, pipeline_status=pipeline_status)
+
+
+class _FakeScalarsResult:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+    def first(self):
+        return self._items[0] if self._items else None
+
+
+class _FakeExecuteResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return _FakeScalarsResult(self._items)
+
+
+class _FakeSession:
+    def __init__(self, data_records):
+        self._data_records = data_records
+        self.committed = False
+
+    async def execute(self, _query):
+        return _FakeExecuteResult(self._data_records)
+
+    async def commit(self):
+        self.committed = True
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self, session):
+        self._session = session
+
+    def get_async_session(self):
+        return self._session
+
+
+# ---------------------------------------------------------------------------
+# Tests for _forget_dataset_memory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forget_dataset_memory_clears_graph_and_resets_pipeline(monkeypatch):
+    """memory_only=True with dataset clears graph/vector and resets pipeline_status."""
+    other_dataset_id = str(uuid4())
+    pipeline_status_a = {
+        "cognify": {str(DATASET_ID): "COMPLETE", other_dataset_id: "COMPLETE"},
+    }
+    pipeline_status_b = {
+        "cognify": {str(DATASET_ID): "COMPLETE"},
+    }
+    data_a = _make_data_record(DATA_ID_A, pipeline_status_a)
+    data_b = _make_data_record(DATA_ID_B, pipeline_status_b)
+
+    session = _FakeSession([data_a, data_b])
+    engine = _FakeEngine(session)
+
+    mock_delete = AsyncMock()
+    monkeypatch.setattr(
+        forget_module,
+        "_resolve_dataset_id",
+        AsyncMock(return_value=DATASET_ID),
+    )
+
+    with (
+        patch(
+            "cognee.modules.graph.methods.delete_dataset_nodes_and_edges.delete_dataset_nodes_and_edges",
+            mock_delete,
+        ),
+        patch(
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            return_value=engine,
+        ),
+        patch("sqlalchemy.orm.attributes.flag_modified"),
+    ):
+        result = await forget_module._forget_dataset_memory(str(DATASET_ID), USER)
+
+    assert result["status"] == "success"
+    assert result["dataset_id"] == str(DATASET_ID)
+    assert result["data_records_reset"] == 2
+
+    mock_delete.assert_awaited_once_with(DATASET_ID, USER.id)
+
+    # pipeline_status should have dataset entry removed
+    assert str(DATASET_ID) not in data_a.pipeline_status["cognify"]
+    assert str(DATASET_ID) not in data_b.pipeline_status["cognify"]
+
+    # Other dataset entries should be preserved
+    assert len(data_a.pipeline_status["cognify"]) == 1
+
+    assert session.committed
+
+
+@pytest.mark.asyncio
+async def test_forget_dataset_memory_skips_records_without_pipeline_status(monkeypatch):
+    """Records with no pipeline_status should not cause errors."""
+    data_no_status = _make_data_record(DATA_ID_A, None)
+    data_empty_status = _make_data_record(DATA_ID_B, {})
+
+    session = _FakeSession([data_no_status, data_empty_status])
+    engine = _FakeEngine(session)
+
+    monkeypatch.setattr(
+        forget_module,
+        "_resolve_dataset_id",
+        AsyncMock(return_value=DATASET_ID),
+    )
+
+    with (
+        patch(
+            "cognee.modules.graph.methods.delete_dataset_nodes_and_edges.delete_dataset_nodes_and_edges",
+            AsyncMock(),
+        ),
+        patch(
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            return_value=engine,
+        ),
+    ):
+        result = await forget_module._forget_dataset_memory(str(DATASET_ID), USER)
+
+    assert result["status"] == "success"
+    assert result["data_records_reset"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests for _forget_data_memory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forget_data_memory_clears_graph_and_resets_pipeline(monkeypatch):
+    """memory_only=True with dataset+data_id clears graph/vector for the item."""
+    pipeline_status = {
+        "cognify": {str(DATASET_ID): "COMPLETE"},
+    }
+    data_record = _make_data_record(DATA_ID_A, pipeline_status)
+
+    session = _FakeSession([data_record])
+    engine = _FakeEngine(session)
+
+    mock_delete = AsyncMock()
+    monkeypatch.setattr(
+        forget_module,
+        "_resolve_dataset_id",
+        AsyncMock(return_value=DATASET_ID),
+    )
+
+    with (
+        patch(
+            "cognee.modules.graph.methods.delete_data_nodes_and_edges.delete_data_nodes_and_edges",
+            mock_delete,
+        ),
+        patch(
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            return_value=engine,
+        ),
+        patch("sqlalchemy.orm.attributes.flag_modified"),
+    ):
+        result = await forget_module._forget_data_memory(DATA_ID_A, str(DATASET_ID), USER)
+
+    assert result["status"] == "success"
+    assert result["data_id"] == str(DATA_ID_A)
+    assert result["dataset_id"] == str(DATASET_ID)
+
+    mock_delete.assert_awaited_once_with(DATASET_ID, DATA_ID_A, USER.id)
+
+    # pipeline_status should have dataset entry removed
+    assert str(DATASET_ID) not in data_record.pipeline_status["cognify"]
+    assert session.committed
+
+
+@pytest.mark.asyncio
+async def test_forget_data_memory_no_record_found(monkeypatch):
+    """When data record is not found, should still succeed (graph cleanup done)."""
+    session = _FakeSession([])  # No data records
+    engine = _FakeEngine(session)
+
+    monkeypatch.setattr(
+        forget_module,
+        "_resolve_dataset_id",
+        AsyncMock(return_value=DATASET_ID),
+    )
+
+    with (
+        patch(
+            "cognee.modules.graph.methods.delete_data_nodes_and_edges.delete_data_nodes_and_edges",
+            AsyncMock(),
+        ),
+        patch(
+            "cognee.infrastructure.databases.relational.get_relational_engine",
+            return_value=engine,
+        ),
+    ):
+        result = await forget_module._forget_data_memory(DATA_ID_A, str(DATASET_ID), USER)
+
+    assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Tests for forget() routing with memory_only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forget_memory_only_without_dataset_raises(monkeypatch):
+    """memory_only=True without dataset should raise ValueError."""
+    monkeypatch.setattr(
+        forget_module,
+        "_forget_dataset_memory",
+        AsyncMock(),
+    )
+
+    with (
+        patch("cognee.shared.utils.send_telemetry", lambda *a, **kw: None),
+        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch("cognee.low_level.setup", AsyncMock()),
+        patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
+    ):
+        with pytest.raises(ValueError, match="memory_only requires dataset"):
+            await forget_module.forget(memory_only=True)
+
+
+@pytest.mark.asyncio
+async def test_forget_routes_to_dataset_memory(monkeypatch):
+    """memory_only=True with dataset routes to _forget_dataset_memory."""
+    mock_forget_dataset_memory = AsyncMock(
+        return_value={"status": "success", "dataset_id": str(DATASET_ID), "data_records_reset": 1}
+    )
+    monkeypatch.setattr(
+        forget_module,
+        "_forget_dataset_memory",
+        mock_forget_dataset_memory,
+    )
+
+    with (
+        patch("cognee.shared.utils.send_telemetry", lambda *a, **kw: None),
+        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch("cognee.low_level.setup", AsyncMock()),
+        patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
+    ):
+        result = await forget_module.forget(dataset="my-dataset", memory_only=True)
+
+    assert result["status"] == "success"
+    mock_forget_dataset_memory.assert_awaited_once_with("my-dataset", USER)
+
+
+@pytest.mark.asyncio
+async def test_forget_routes_to_data_memory(monkeypatch):
+    """memory_only=True with dataset+data_id routes to _forget_data_memory."""
+    mock_forget_data_memory = AsyncMock(
+        return_value={"status": "success", "data_id": str(DATA_ID_A), "dataset_id": str(DATASET_ID)}
+    )
+    monkeypatch.setattr(
+        forget_module,
+        "_forget_data_memory",
+        mock_forget_data_memory,
+    )
+
+    with (
+        patch("cognee.shared.utils.send_telemetry", lambda *a, **kw: None),
+        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch("cognee.low_level.setup", AsyncMock()),
+        patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
+    ):
+        result = await forget_module.forget(dataset="my-dataset", data_id=DATA_ID_A, memory_only=True)
+
+    assert result["status"] == "success"
+    mock_forget_data_memory.assert_awaited_once_with(DATA_ID_A, "my-dataset", USER)
+
+
+# ---------------------------------------------------------------------------
+# Tests for telemetry target labels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forget_telemetry_target_labels(monkeypatch):
+    """Verify correct telemetry target strings for memory_only combinations."""
+    captured_targets = []
+
+    def fake_telemetry(_event, _user, additional_properties=None):
+        if additional_properties:
+            captured_targets.append(additional_properties.get("target"))
+
+    monkeypatch.setattr(
+        forget_module,
+        "_forget_dataset_memory",
+        AsyncMock(return_value={"status": "success", "dataset_id": "x", "data_records_reset": 0}),
+    )
+    monkeypatch.setattr(
+        forget_module,
+        "_forget_data_memory",
+        AsyncMock(return_value={"status": "success", "data_id": "x", "dataset_id": "x"}),
+    )
+
+    with (
+        patch("cognee.shared.utils.send_telemetry", fake_telemetry),
+        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch("cognee.low_level.setup", AsyncMock()),
+        patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=USER)),
+    ):
+        await forget_module.forget(dataset="ds", memory_only=True)
+        await forget_module.forget(dataset="ds", data_id=DATA_ID_A, memory_only=True)
+
+    assert captured_targets == ["dataset_memory_only", "data_item_memory_only"]

--- a/cognee/tests/unit/modules/graph/test_graph_methods.py
+++ b/cognee/tests/unit/modules/graph/test_graph_methods.py
@@ -17,8 +17,7 @@ import cognee
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
-from cognee.modules.data.methods import create_dataset, get_dataset_data
+from cognee.modules.data.methods import create_dataset, create_authorized_dataset
 from cognee.modules.engine.operations.setup import setup
 from cognee.modules.graph.methods import delete_data_nodes_and_edges, get_data_related_nodes
 from cognee.modules.graph.models import Node, Edge
@@ -201,7 +200,7 @@ async def test_delete_data_nodes_and_edges_removes_from_all_systems():
     user = await get_default_user()
 
     # Create dataset
-    dataset = await create_dataset("test_delete_complete", user=user)
+    dataset = await create_authorized_dataset("test_delete_complete", user=user)
     dataset_id = dataset.id
 
     await set_database_global_context_variables(dataset_id, user.id)


### PR DESCRIPTION
## Summary
- Adds `graph_only` flag to `POST /v1/forget` and `cognee.forget()` SDK
- When `graph_only=True` with a `dataset`, clears graph nodes/edges and vector embeddings while preserving raw files and data records
- Resets `pipeline_status` so the dataset can be re-cognified with different settings (e.g. new custom prompt or graph model)
- Rejects invalid combinations: `graph_only` without `dataset`, or `graph_only` with `data_id`

## Usage
```json
POST /v1/forget
{"dataset": "my-dataset-id", "graph_only": true}
```

```python
await cognee.forget(dataset="my-dataset", graph_only=True)
```

## Motivation
When a user changes their custom prompt or graph model, they need to re-cognify a dataset from scratch. Currently the only way is to delete the entire dataset (including raw files) and re-upload. This flag allows clearing just the graph output while keeping everything else intact.

## Test plan
- [ ] `forget(dataset="x", graph_only=True)` clears graph/vector data and resets pipeline status
- [ ] `forget(dataset="x", graph_only=True)` followed by `cognify(dataset="x")` re-processes all data
- [ ] `forget(graph_only=True)` without dataset returns 422
- [ ] `forget(dataset="x", data_id=uuid, graph_only=True)` returns 422
- [ ] Existing forget patterns (everything, dataset, data_id) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a memory-only option for the forget operation to selectively remove in-memory artifacts (graph structures and vector embeddings) while preserving raw files and stored records; supports dataset-level or single-item cleanup and resets pipeline status.
  * The forget API accepts a memory-only flag.
  * New endpoint to delete user-uploaded ontologies, removing stored ontology files and metadata with error handling.

* **Bug Fixes / Security**
  * Deletion operations now enforce dataset-level authorization.

* **Tests**
  * Added unit tests covering memory-only behavior and ontology deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->