### PR TITLE
fix: handle markdown-wrapped JSON in infer-schema endpoint

### DIFF
--- a/cognee/api/v1/llm/routers/get_llm_router.py
+++ b/cognee/api/v1/llm/routers/get_llm_router.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Annotated
 from fastapi import APIRouter, Depends, File, UploadFile as UF, Form
 from fastapi.responses import JSONResponse
 from pydantic import Field
+from pydantic import ConfigDict, ValidationError
 
 from cognee import __version__ as cognee_version
 from cognee.api.DTO import InDTO, OutDTO
@@ -28,35 +29,6 @@ logger = get_logger("api.llm")
 UploadFile = Annotated[UF, WithJsonSchema({"type": "string", "format": "binary"})]
 
 _ALLOWED_LLM_PARAMS = {"temperature", "max_tokens", "top_p", "seed"}
-
-import re
-
-def _extract_json(raw: str) -> dict:
-    """Extract a JSON object from LLM output that may contain markdown fences or surrounding text."""
-    if not raw or not raw.strip():
-        raise json.JSONDecodeError("LLM returned empty output", raw or "", 0)
-
-    text = raw.strip()
-
-    # Strip markdown code fences (```json ... ``` or ``` ... ```)
-    fence_match = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
-    if fence_match:
-        text = fence_match.group(1).strip()
-
-    # Try parsing directly
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        pass
-
-    # Last resort: find the first { ... } block
-    brace_match = re.search(r"\{.*\}", text, re.DOTALL)
-    if brace_match:
-        return json.loads(brace_match.group(0))
-
-    raise json.JSONDecodeError(
-        "Could not extract valid JSON from LLM output", raw, 0
-    )
 
 
 def _safe_params(params: dict) -> dict:
@@ -102,6 +74,16 @@ class CustomPromptGenerationResponseDTO(OutDTO):
 
 class InferSchemaResponseDTO(OutDTO):
     graph_schema: Dict[str, Any]
+
+
+class InferredGraphSchemaDTO(OutDTO):
+    title: str
+    type: str
+    properties: Dict[str, Any]
+    required: List[str] = Field(default_factory=list)
+    defs: Dict[str, Any] = Field(default_factory=dict, alias="$defs")
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 
 def get_llm_router() -> APIRouter:
@@ -222,15 +204,11 @@ def get_llm_router() -> APIRouter:
             llm_output = await LLMGateway.acreate_structured_output(
                 text_input=user_prompt,
                 system_prompt=system_prompt,
-                response_model=str,  # type: ignore[arg-type]
+                response_model=InferredGraphSchemaDTO,
                 **_safe_params(parameters_dict),
             )
 
-            # Parse the LLM output as JSON.
-            # The LLM may wrap the JSON in markdown fences or add surrounding
-            # text even though the system prompt asks for raw JSON only.
-            # Strip common wrappers before parsing.
-            schema_dict = _extract_json(llm_output)
+            schema_dict = llm_output.model_dump(by_alias=True, exclude_none=True)
 
             # Validate by attempting conversion — raises if schema is invalid
             from cognee.shared.graph_model_utils import graph_schema_to_graph_model
@@ -241,7 +219,12 @@ def get_llm_router() -> APIRouter:
         except json.JSONDecodeError as error:
             return JSONResponse(
                 status_code=422,
-                content={"error": f"LLM output is not valid JSON: {error}"},
+                content={"error": f"Invalid JSON in request parameters: {error}"},
+            )
+        except ValidationError as error:
+            return JSONResponse(
+                status_code=422,
+                content={"error": f"LLM output did not match expected schema: {error}"},
             )
         except Exception as error:
             logger.error("LLM schema inference failed: %s", error)

--- a/cognee/api/v1/llm/routers/get_llm_router.py
+++ b/cognee/api/v1/llm/routers/get_llm_router.py
@@ -29,6 +29,35 @@ UploadFile = Annotated[UF, WithJsonSchema({"type": "string", "format": "binary"}
 
 _ALLOWED_LLM_PARAMS = {"temperature", "max_tokens", "top_p", "seed"}
 
+import re
+
+def _extract_json(raw: str) -> dict:
+    """Extract a JSON object from LLM output that may contain markdown fences or surrounding text."""
+    if not raw or not raw.strip():
+        raise json.JSONDecodeError("LLM returned empty output", raw or "", 0)
+
+    text = raw.strip()
+
+    # Strip markdown code fences (```json ... ``` or ``` ... ```)
+    fence_match = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
+    if fence_match:
+        text = fence_match.group(1).strip()
+
+    # Try parsing directly
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Last resort: find the first { ... } block
+    brace_match = re.search(r"\{.*\}", text, re.DOTALL)
+    if brace_match:
+        return json.loads(brace_match.group(0))
+
+    raise json.JSONDecodeError(
+        "Could not extract valid JSON from LLM output", raw, 0
+    )
+
 
 def _safe_params(params: dict) -> dict:
     return {k: v for k, v in params.items() if k in _ALLOWED_LLM_PARAMS}
@@ -196,8 +225,11 @@ def get_llm_router() -> APIRouter:
                 **_safe_params(parameters),
             )
 
-            # Parse the LLM output as JSON
-            schema_dict = json.loads(llm_output)
+            # Parse the LLM output as JSON.
+            # The LLM may wrap the JSON in markdown fences or add surrounding
+            # text even though the system prompt asks for raw JSON only.
+            # Strip common wrappers before parsing.
+            schema_dict = _extract_json(llm_output)
 
             # Validate by attempting conversion — raises if schema is invalid
             from cognee.shared.graph_model_utils import graph_schema_to_graph_model

--- a/cognee/tests/unit/api/v1/test_dataset_schema_endpoints.py
+++ b/cognee/tests/unit/api/v1/test_dataset_schema_endpoints.py
@@ -1,6 +1,5 @@
 """Tests for dataset schema endpoints and related utilities."""
 
-import json
 import pytest
 from uuid import uuid4
 
@@ -102,70 +101,37 @@ def test_dataset_schema_payload_dto_validation():
     assert dto_empty.custom_prompt is None
 
 
-# ── _extract_json tests ──────────────────────────────────────────────────
+def test_inferred_graph_schema_dto_accepts_json_schema_shape():
+    """Verify InferredGraphSchemaDTO accepts required fields and $defs alias."""
+    from cognee.api.v1.llm.routers.get_llm_router import InferredGraphSchemaDTO
 
-
-_SAMPLE_SCHEMA = {
-    "title": "CompanyGraph",
-    "type": "object",
-    "properties": {"name": {"type": "string"}},
-    "required": ["name"],
-    "$defs": {
-        "Person": {
-            "title": "Person",
+    dto = InferredGraphSchemaDTO.model_validate(
+        {
+            "title": "CompanyGraph",
             "type": "object",
             "properties": {"name": {"type": "string"}},
             "required": ["name"],
+            "$defs": {
+                "Person": {
+                    "title": "Person",
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                }
+            },
+            "additional_json_schema_keyword": True,
         }
-    },
-}
+    )
 
-_SAMPLE_JSON = json.dumps(_SAMPLE_SCHEMA)
+    dumped = dto.model_dump(by_alias=True)
+    assert dumped["$defs"]["Person"]["title"] == "Person"
+    assert dumped["additional_json_schema_keyword"] is True
 
 
-class TestExtractJson:
-    """Verify _extract_json handles the various formats LLMs return."""
+def test_inferred_graph_schema_dto_requires_core_fields():
+    """Verify InferredGraphSchemaDTO enforces title/type/properties fields."""
+    from pydantic import ValidationError
+    from cognee.api.v1.llm.routers.get_llm_router import InferredGraphSchemaDTO
 
-    @staticmethod
-    def _extract(raw: str) -> dict:
-        from cognee.api.v1.llm.routers.get_llm_router import _extract_json
-        return _extract_json(raw)
-
-    def test_clean_json(self):
-        """Parse clean JSON directly."""
-        assert self._extract(_SAMPLE_JSON) == _SAMPLE_SCHEMA
-
-    def test_whitespace_padding(self):
-        """Parse JSON with leading/trailing whitespace and newlines."""
-        assert self._extract(f"  \n\n  {_SAMPLE_JSON}  \n  ") == _SAMPLE_SCHEMA
-
-    def test_markdown_fences_with_lang(self):
-        """Strip ```json ... ``` markdown fences."""
-        wrapped = f"```json\n{_SAMPLE_JSON}\n```"
-        assert self._extract(wrapped) == _SAMPLE_SCHEMA
-
-    def test_markdown_fences_without_lang(self):
-        """Strip ``` ... ``` fences without language tag."""
-        wrapped = f"```\n{_SAMPLE_JSON}\n```"
-        assert self._extract(wrapped) == _SAMPLE_SCHEMA
-
-    def test_surrounding_text(self):
-        """Extract JSON when LLM adds explanation around it."""
-        wrapped = f"Here is the schema:\n\n{_SAMPLE_JSON}\n\nThis covers all entities."
-        assert self._extract(wrapped) == _SAMPLE_SCHEMA
-
-    def test_markdown_fences_with_surrounding_text(self):
-        """Handle fences plus explanation text."""
-        wrapped = f"Sure! Here is the schema:\n\n```json\n{_SAMPLE_JSON}\n```\n\nLet me know if you need changes."
-        assert self._extract(wrapped) == _SAMPLE_SCHEMA
-
-    @pytest.mark.parametrize("raw", ["", "   \n\n  ", None])
-    def test_empty_input_raises(self, raw):
-        """Raise JSONDecodeError on empty / whitespace-only / None input."""
-        with pytest.raises(json.JSONDecodeError, match="empty output"):
-            self._extract(raw)
-
-    def test_no_json_raises(self):
-        """Raise JSONDecodeError when there is no JSON at all."""
-        with pytest.raises(json.JSONDecodeError, match="Could not extract"):
-            self._extract("I could not generate a schema for this input.")
+    with pytest.raises(ValidationError):
+        InferredGraphSchemaDTO.model_validate({"type": "object", "properties": {}})

--- a/cognee/tests/unit/api/v1/test_dataset_schema_endpoints.py
+++ b/cognee/tests/unit/api/v1/test_dataset_schema_endpoints.py
@@ -1,5 +1,6 @@
 """Tests for dataset schema endpoints and related utilities."""
 
+import json
 import pytest
 from uuid import uuid4
 
@@ -99,3 +100,72 @@ def test_dataset_schema_payload_dto_validation():
     dto_empty = DatasetSchemaPayloadDTO()
     assert dto_empty.graph_schema is None
     assert dto_empty.custom_prompt is None
+
+
+# ── _extract_json tests ──────────────────────────────────────────────────
+
+
+_SAMPLE_SCHEMA = {
+    "title": "CompanyGraph",
+    "type": "object",
+    "properties": {"name": {"type": "string"}},
+    "required": ["name"],
+    "$defs": {
+        "Person": {
+            "title": "Person",
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+    },
+}
+
+_SAMPLE_JSON = json.dumps(_SAMPLE_SCHEMA)
+
+
+class TestExtractJson:
+    """Verify _extract_json handles the various formats LLMs return."""
+
+    @staticmethod
+    def _extract(raw: str) -> dict:
+        from cognee.api.v1.llm.routers.get_llm_router import _extract_json
+        return _extract_json(raw)
+
+    def test_clean_json(self):
+        """Parse clean JSON directly."""
+        assert self._extract(_SAMPLE_JSON) == _SAMPLE_SCHEMA
+
+    def test_whitespace_padding(self):
+        """Parse JSON with leading/trailing whitespace and newlines."""
+        assert self._extract(f"  \n\n  {_SAMPLE_JSON}  \n  ") == _SAMPLE_SCHEMA
+
+    def test_markdown_fences_with_lang(self):
+        """Strip ```json ... ``` markdown fences."""
+        wrapped = f"```json\n{_SAMPLE_JSON}\n```"
+        assert self._extract(wrapped) == _SAMPLE_SCHEMA
+
+    def test_markdown_fences_without_lang(self):
+        """Strip ``` ... ``` fences without language tag."""
+        wrapped = f"```\n{_SAMPLE_JSON}\n```"
+        assert self._extract(wrapped) == _SAMPLE_SCHEMA
+
+    def test_surrounding_text(self):
+        """Extract JSON when LLM adds explanation around it."""
+        wrapped = f"Here is the schema:\n\n{_SAMPLE_JSON}\n\nThis covers all entities."
+        assert self._extract(wrapped) == _SAMPLE_SCHEMA
+
+    def test_markdown_fences_with_surrounding_text(self):
+        """Handle fences plus explanation text."""
+        wrapped = f"Sure! Here is the schema:\n\n```json\n{_SAMPLE_JSON}\n```\n\nLet me know if you need changes."
+        assert self._extract(wrapped) == _SAMPLE_SCHEMA
+
+    @pytest.mark.parametrize("raw", ["", "   \n\n  ", None])
+    def test_empty_input_raises(self, raw):
+        """Raise JSONDecodeError on empty / whitespace-only / None input."""
+        with pytest.raises(json.JSONDecodeError, match="empty output"):
+            self._extract(raw)
+
+    def test_no_json_raises(self):
+        """Raise JSONDecodeError when there is no JSON at all."""
+        with pytest.raises(json.JSONDecodeError, match="Could not extract"):
+            self._extract("I could not generate a schema for this input.")


### PR DESCRIPTION
## Summary
- The `/v1/llm/infer-schema` endpoint uses `response_model=str` with `LLMGateway.acreate_structured_output`, so the LLM output is not structurally constrained to raw JSON
- LLMs frequently wrap JSON output in markdown code fences (` ```json ... ``` `) or add surrounding text, causing `json.loads()` to fail with a 422 error
- Add `_extract_json()` helper that strips markdown fences and extracts the JSON object before parsing

## Root cause
```python
llm_output = await LLMGateway.acreate_structured_output(
    ...,
    response_model=str,  # Not a Pydantic model → no structured JSON enforcement
)
schema_dict = json.loads(llm_output)  # Fails on markdown-wrapped output
```

## Fix
`_extract_json()` handles three cases:
1. Clean JSON → parse directly
2. Markdown-fenced JSON (` ```json { ... } ``` `) → strip fences, then parse
3. JSON embedded in text → extract first `{ ... }` block

## Test plan
- [ ] Call `/v1/llm/infer-schema` with a text sample → should return valid schema
- [ ] Call with uploaded files → should return valid schema
- [ ] Verify markdown-wrapped LLM responses are handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema inference endpoint now returns a structured schema object (preserving $defs) instead of raw text.

* **Bug Fixes**
  * Improved handling and clearer 422 responses when inference output is invalid or unparsable.
  * Extraction remains resilient to JSON in various formats (e.g., fenced blocks, embedded text).

* **Tests**
  * Added unit tests validating structured schema parsing, $defs preservation, and validation error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->