### PR TITLE
fix(temporal): extend TemporalRetriever to filter all ontology types, not just Events

### DIFF
--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -187,32 +187,46 @@ class TemporalRetriever(GraphCompletionRetriever):
                 has_relevant_events = any(event_groups)
 
         vector_search_results = retrieved_objects.get("vector_search_results")
-        if has_relevant_events and vector_search_results:
-            top_k_events = await self.filter_top_k_events(relevant_events, vector_search_results)
-            return self.descriptions_to_string(top_k_events)
-
-        if retrieved_objects.get("graph_nodes", None):
-            nodes, edges = retrieved_objects.get("graph_nodes")
-            nodes_by_id = {
-                str(node_id): Node(str(node_id), properties) for node_id, properties in nodes
-            }
-            graph_edges = []
-            for source_id, target_id, relationship_type, properties in edges:
-                source_node = nodes_by_id.get(str(source_id))
-                target_node = nodes_by_id.get(str(target_id))
-                if source_node and target_node:
-                    edge_attributes = dict(properties or {})
-                    edge_attributes["relationship_type"] = relationship_type
-                    graph_edges.append(Edge(source_node, target_node, attributes=edge_attributes))
-
-            if not graph_edges and nodes_by_id:
-                return self.descriptions_to_string(
-                    [node.properties for node in nodes_by_id.values()]
+        if has_relevant_events:
+            if vector_search_results:
+                top_k_events = await self.filter_top_k_events(
+                    relevant_events, vector_search_results
                 )
+                return self.descriptions_to_string(top_k_events)
 
-            return await self.resolve_edges_to_text(graph_edges)
-        else:
-            # In case no events were found, fall back to triplet context
-            triplets = retrieved_objects.get("triplets", [])
-            context_text = await self.resolve_edges_to_text(triplets)
-            return context_text
+            fallback_events = [
+                event
+                for event_group in relevant_events
+                if isinstance(event_group, dict)
+                for event in event_group.get("events", [])
+            ]
+            if fallback_events:
+                return self.descriptions_to_string(fallback_events[: self.top_k])
+
+        graph_nodes = retrieved_objects.get("graph_nodes")
+        if graph_nodes:
+            nodes, edges = graph_nodes
+            if nodes or edges:
+                nodes_by_id = {
+                    str(node_id): Node(str(node_id), properties) for node_id, properties in nodes
+                }
+                graph_edges = []
+                for source_id, target_id, relationship_type, properties in edges:
+                    source_node = nodes_by_id.get(str(source_id))
+                    target_node = nodes_by_id.get(str(target_id))
+                    if source_node and target_node:
+                        edge_attributes = dict(properties or {})
+                        edge_attributes["relationship_type"] = relationship_type
+                        graph_edges.append(Edge(source_node, target_node, attributes=edge_attributes))
+
+                if not graph_edges and nodes_by_id:
+                    return self.descriptions_to_string(
+                        [node.attributes for node in nodes_by_id.values()]
+                    )
+
+                return await self.resolve_edges_to_text(graph_edges)
+
+        # In case no events were found, fall back to triplet context
+        triplets = retrieved_objects.get("triplets", [])
+        context_text = await self.resolve_edges_to_text(triplets)
+        return context_text

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -7,6 +7,7 @@ from operator import itemgetter
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.llm.prompts import render_prompt
 from cognee.infrastructure.llm import LLMGateway
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.used_graph_elements import extract_from_temporal_dict
 from cognee.shared.logging_utils import get_logger
@@ -137,6 +138,9 @@ class TemporalRetriever(GraphCompletionRetriever):
 
         if ids:
             relevant_events = await graph_engine.collect_events(ids=ids)
+            ids_list = [i.strip().strip("'") for i in ids.split(",") if i.strip()]
+            graph_data = await graph_engine.get_id_filtered_graph_data(ids_list)
+            graph_nodes = graph_data if isinstance(graph_data, tuple) else ([], [])
         else:
             logger.info(
                 "No events identified based on timestamp filtering, performing retrieval using triplet search on events and entities."
@@ -151,18 +155,46 @@ class TemporalRetriever(GraphCompletionRetriever):
             collection_name="Event_name", query_vector=query_vector, limit=self.top_k
         )
 
-        return {"relevant_events": relevant_events, "vector_search_results": vector_search_results}
+        return {
+            "relevant_events": relevant_events,
+            "graph_nodes": graph_nodes,
+            "vector_search_results": vector_search_results,
+        }
 
     async def get_context_from_objects(self, query: str, retrieved_objects: Any) -> Any:
         """Retrieves context based on the query."""
-        if retrieved_objects.get("relevant_events", None) and retrieved_objects.get(
-            "vector_search_results", None
-        ):
+        relevant_events = retrieved_objects.get("relevant_events", None)
+        has_relevant_events = bool(relevant_events)
+        if has_relevant_events and isinstance(relevant_events, list):
+            event_groups = [
+                event_group.get("events")
+                for event_group in relevant_events
+                if isinstance(event_group, dict) and "events" in event_group
+            ]
+            if event_groups:
+                has_relevant_events = any(event_groups)
+
+        if has_relevant_events and retrieved_objects.get("vector_search_results", None):
             top_k_events = await self.filter_top_k_events(
                 retrieved_objects.get("relevant_events"),
                 retrieved_objects.get("vector_search_results", None),
             )
             return self.descriptions_to_string(top_k_events)
+        elif not has_relevant_events and retrieved_objects.get("graph_nodes", None):
+            nodes, edges = retrieved_objects.get("graph_nodes")
+            nodes_by_id = {
+                str(node_id): Node(str(node_id), properties) for node_id, properties in nodes
+            }
+            graph_edges = []
+            for source_id, target_id, relationship_type, properties in edges:
+                source_node = nodes_by_id.get(str(source_id))
+                target_node = nodes_by_id.get(str(target_id))
+                if source_node and target_node:
+                    edge_attributes = dict(properties or {})
+                    edge_attributes["relationship_type"] = relationship_type
+                    graph_edges.append(Edge(source_node, target_node, attributes=edge_attributes))
+
+            return await self.resolve_edges_to_text(graph_edges)
         else:
             # In case no events were found, fall back to triplet context
             triplets = retrieved_objects.get("triplets", [])

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -150,13 +150,21 @@ class TemporalRetriever(GraphCompletionRetriever):
 
         vector_search_results = []
         if relevant_events and any(event_group.get("events") for event_group in relevant_events):
+            collection_name = "Event_name"
             try:
                 vector_engine = unified.vector
                 query_vector = (await vector_engine.embedding_engine.embed_text([query]))[0]
                 vector_search_results = await vector_engine.search(
-                    collection_name="Event_name", query_vector=query_vector, limit=self.top_k
+                    collection_name=collection_name, query_vector=query_vector, limit=self.top_k
                 )
-            except Exception:
+            except Exception as e:
+                logger.error(
+                    "Temporal retriever vector search failed for query=%r collection_name=%r: %s",
+                    query,
+                    collection_name,
+                    e,
+                    exc_info=True,
+                )
                 vector_search_results = []
 
         return {
@@ -178,13 +186,12 @@ class TemporalRetriever(GraphCompletionRetriever):
             if event_groups:
                 has_relevant_events = any(event_groups)
 
-        if has_relevant_events and retrieved_objects.get("vector_search_results", None):
-            top_k_events = await self.filter_top_k_events(
-                retrieved_objects.get("relevant_events"),
-                retrieved_objects.get("vector_search_results", None),
-            )
+        vector_search_results = retrieved_objects.get("vector_search_results")
+        if has_relevant_events and vector_search_results:
+            top_k_events = await self.filter_top_k_events(relevant_events, vector_search_results)
             return self.descriptions_to_string(top_k_events)
-        elif not has_relevant_events and retrieved_objects.get("graph_nodes", None):
+
+        if retrieved_objects.get("graph_nodes", None):
             nodes, edges = retrieved_objects.get("graph_nodes")
             nodes_by_id = {
                 str(node_id): Node(str(node_id), properties) for node_id, properties in nodes

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -148,12 +148,16 @@ class TemporalRetriever(GraphCompletionRetriever):
             triplets = await self.get_triplets(query)
             return {"triplets": triplets}
 
-        vector_engine = unified.vector
-        query_vector = (await vector_engine.embedding_engine.embed_text([query]))[0]
-
-        vector_search_results = await vector_engine.search(
-            collection_name="Event_name", query_vector=query_vector, limit=self.top_k
-        )
+        vector_search_results = []
+        if relevant_events and any(event_group.get("events") for event_group in relevant_events):
+            try:
+                vector_engine = unified.vector
+                query_vector = (await vector_engine.embedding_engine.embed_text([query]))[0]
+                vector_search_results = await vector_engine.search(
+                    collection_name="Event_name", query_vector=query_vector, limit=self.top_k
+                )
+            except Exception:
+                vector_search_results = []
 
         return {
             "relevant_events": relevant_events,
@@ -193,6 +197,11 @@ class TemporalRetriever(GraphCompletionRetriever):
                     edge_attributes = dict(properties or {})
                     edge_attributes["relationship_type"] = relationship_type
                     graph_edges.append(Edge(source_node, target_node, attributes=edge_attributes))
+
+            if not graph_edges and nodes_by_id:
+                return self.descriptions_to_string(
+                    [node.properties for node in nodes_by_id.values()]
+                )
 
             return await self.resolve_edges_to_text(graph_edges)
         else:

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -109,13 +109,32 @@ class TemporalRetriever(GraphCompletionRetriever):
         score_lookup = {res.id: res.score for res in scored_results}
 
         events_with_scores = []
-        for event in relevant_events[0]["events"]:
-            score = score_lookup.get(event["id"], float("inf"))
-            events_with_scores.append({**event, "score": score})
+        for event_group in relevant_events:
+            if not isinstance(event_group, dict):
+                raise TypeError("Event group must be a dictionary")
+            if "events" not in event_group:
+                raise KeyError("events")
+
+            for event in event_group["events"]:
+                score = score_lookup.get(event["id"], float("inf"))
+                events_with_scores.append({**event, "score": score})
 
         events_with_scores.sort(key=itemgetter("score"))
 
         return events_with_scores[: self.top_k]
+
+    def node_attributes_to_description(self, attributes):
+        description = (
+            attributes.get("description") or attributes.get("text") or attributes.get("name")
+        )
+        if description:
+            return {"description": str(description)}
+
+        return {
+            "description": ", ".join(
+                f"{key}: {value}" for key, value in attributes.items() if value is not None
+            )
+        }
 
     async def get_retrieved_objects(self, query: str) -> dict:
         time_from, time_to = await self.extract_time_from_query(query)
@@ -221,7 +240,10 @@ class TemporalRetriever(GraphCompletionRetriever):
 
                 if not graph_edges and nodes_by_id:
                     return self.descriptions_to_string(
-                        [node.attributes for node in nodes_by_id.values()]
+                        [
+                            self.node_attributes_to_description(node.attributes)
+                            for node in nodes_by_id.values()
+                        ]
                     )
 
                 return await self.resolve_edges_to_text(graph_edges)


### PR DESCRIPTION
Fixes #2429

  ## Problem

  `TemporalRetriever` extracted time windows correctly via `extract_time_from_query()`,
  but then only retrieved `Event`-type nodes via `collect_events()`. Ontology nodes
  such as `Person`, `Organization`, or `Concept` connected to matching timestamps
  were invisible to temporal retrieval.

  ## Solution

  After `collect_time_ids()` returns timestamp-bounded IDs, `TemporalRetriever` now
  also calls `get_id_filtered_graph_data()` to retrieve all ontology node types
  connected to those timestamps.

  `collect_time_ids()` returns a Cypher-formatted string like `'id1', 'id2'`, while
  `get_id_filtered_graph_data()` expects a Python list. The IDs are now parsed into
  a list before calling the generic graph retrieval path.

  Retrieval/context priority:
  1. Event path, preserved as the primary path
  2. Generic ontology nodes via `get_id_filtered_graph_data()` when no Events are found
  3. Existing triplet fallback when no timestamp IDs are found

  ## Changes

  Only `cognee/modules/retrieval/temporal_retriever.py` was modified.

  ## Testing

  - `uv run ruff check cognee/modules/retrieval/temporal_retriever.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vector search now runs only when event groups with events exist; search failures are caught and return empty results instead of errors.
  * Temporal retrieval includes time-filtered graph data and consistently returns graph-derived nodes alongside vector results.
  * Event-group inputs are validated to prevent malformed data from breaking retrieval.

* **Refactor**
  * Context assembly and temporal query flow simplified to prefer available vector results, then graph-derived node/edge descriptions, with clear fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->