### PR TITLE
fix(recall): remove unused debugpy import

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -2,7 +2,6 @@ import re
 from typing import Annotated, Literal
 from uuid import UUID
 
-from debugpy.adapter.sessions import Session
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict, Unpack
 


### PR DESCRIPTION
## Summary

- `cognee/api/v1/recall/recall.py:5` had a stray `from debugpy.adapter.sessions import Session` introduced by 17c26ff4dd (feat: clear return types for 'recall'). `Session` is never referenced in the module — only mentioned in a docstring at line 76. Looks like an IDE auto-import slip.
- `debugpy` is a dev-only dependency (declared under `[dependency-groups].dev` in `cognee-mcp/pyproject.toml`, not in the runtime deps), so this raises `ModuleNotFoundError` on any environment that installs `cognee` without dev extras.
- The blast radius is wide: `cognee/api/v1/__init__.py` imports `from .recall import recall`, so this `ImportError`s any `import cognee` in a clean venv. Surfaced while pulling `dev` into another feature branch (`feat/mcp-server-hardening`) — moved unit tests there fail at collection.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('cognee/api/v1/recall/recall.py').read())"` — parses
- [ ] `pytest cognee/tests/unit/` passes in cognee's main venv (no `debugpy` available)
- [ ] `pytest cognee-mcp/tests/` passes after this PR + the hardening PR are both merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal code cleanup and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->