### PR TITLE
fix(deps): allow newer pypika on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,12 @@ groq = ["groq>=0.8.0,<1.0.0"]
 llama-cpp = ["llama-cpp-python[server]>=0.3.0,<1.0.0"]
 chromadb = [
     "chromadb>=0.6,<0.7",
-    "pypika==0.48.9",
+    # pypika 0.48.9's setup.py uses ast.Str, which Python 3.14 removed (it
+    # was deprecated since 3.8). Build fails with "module 'ast' has no
+    # attribute 'Str'". Allow newer pypika on 3.14 — chromadb itself only
+    # requires pypika>=0.48.9, so this is in-range for it.
+    "pypika==0.48.9 ; python_version < '3.14'",
+    "pypika>=0.50.0 ; python_version >= '3.14'",
 ]
 docs = [
     "lxml>=4.9.3,<5 ; python_version < '3.13'",

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,8 @@ dependencies = [
     { name = "overrides" },
     { name = "posthog" },
     { name = "pydantic" },
-    { name = "pypika" },
+    { name = "pypika", version = "0.48.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pypika", version = "0.51.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "tenacity" },
@@ -1255,7 +1256,8 @@ baml = [
 ]
 chromadb = [
     { name = "chromadb" },
-    { name = "pypika" },
+    { name = "pypika", version = "0.48.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pypika", version = "0.51.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 codegraph = [
     { name = "fastembed", marker = "python_full_version < '3.14'" },
@@ -1493,7 +1495,8 @@ requires-dist = [
     { name = "pylance", specifier = ">=0.22.0,<=0.36.0" },
     { name = "pympler", specifier = ">=1.1,<2.0.0" },
     { name = "pypdf", specifier = ">=6.6.2,<7.0.0" },
-    { name = "pypika", marker = "extra == 'chromadb'", specifier = "==0.48.9" },
+    { name = "pypika", marker = "python_full_version >= '3.14' and extra == 'chromadb'", specifier = ">=0.50.0" },
+    { name = "pypika", marker = "python_full_version < '3.14' and extra == 'chromadb'", specifier = "==0.48.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0,<8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.1,<0.22" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1,<7.0.0" },
@@ -8457,7 +8460,32 @@ wheels = [
 name = "pypika"
 version = "0.48.9"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*' and platform_machine != 's390x'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/2c/94ed7b91db81d61d7096ac8f2d325ec562fc75e35f3baea8749c85b28784/PyPika-0.48.9.tar.gz", hash = "sha256:838836a61747e7c8380cd1b7ff638694b7a7335345d0f559b04b2cd832ad5378", size = 67259 }
+
+[[package]]
+name = "pypika"
+version = "0.51.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine != 's390x' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 's390x' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'emscripten')",
+    "(python_full_version >= '3.14' and platform_machine == 's390x' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'emscripten')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/78/cbaebba88e05e2dcda13ca203131b38d3640219f20ebb49676d26714861b/pypika-0.51.1.tar.gz", hash = "sha256:c30c7c1048fbf056fd3920c5a2b88b0c29dd190a9b2bee971fd17e4abe4d0ebe", size = 80919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl", hash = "sha256:77985b4d7ce71b9905255bf12468cf598349e98837c037541cfc240e528aec46", size = 60585 },
+]
 
 [[package]]
 name = "pyproject-hooks"


### PR DESCRIPTION
## Summary

Follow-up to #2759/#2760 — release workflow now trips on pypika after the onnxruntime/spacy fix unblocked it:

\`\`\`
AttributeError: module 'ast' has no attribute 'Str'
help: pypika (v0.48.9) was included because cognee[chromadb]
\`\`\`

\`pypika 0.48.9\`'s setup.py uses \`ast.Str\`, which Python deprecated in 3.8 and removed in 3.14. The build fails even though no platform-specific wheel is needed (pypika is pure Python — the failure is in the build script itself, not at link time).

## Why direct against \`main\`

Same pattern as #2760 (release-line hotfix). The \`cognee[chromadb]\` extra hard-pinned \`pypika==0.48.9\`. chromadb itself only requires \`pypika>=0.48.9\`, so newer versions are in-range. Marker-split so 3.10–3.13 keep the existing 0.48.9 pin (zero behavior change for current users) and 3.14 picks up 0.50.0+ (latest is 0.51.1, also pure-Python).

## Test plan

- [x] \`uv lock\` clean — lock now contains both pypika 0.48.9 and 0.51.1
- [x] \`uv lock --check\` consistent
- [x] \`pip install pypika==0.51.1\` installs cleanly outside the project
- [ ] Release workflow \`uv sync --locked --all-extras\` succeeds on CI's Python 3.14.4

If CI surfaces another 3.14-only resolution gap after this lands, I'll iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized optional dependency specifications to automatically select appropriate package versions based on your Python installation. Ensures users with Python 3.14 and later receive compatible dependency versions while maintaining full backward compatibility with earlier Python releases. Improves overall installation reliability across diverse Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->