### PR TITLE
chore: release v1.0.5

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -6,6 +6,9 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypedDict, Unpack
 
 from cognee.infrastructure.databases.cache import SessionAgentTraceEntry, SessionQAEntry
+from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
+from cognee.context_global_variables import set_session_user_context_variable
+from cognee.exceptions import CogneeValidationError
 from cognee.memory.entries import normalize_scope
 from cognee.modules.data.exceptions import DatasetNotFoundError
 from cognee.modules.data.methods import get_authorized_existing_datasets
@@ -29,6 +32,8 @@ from cognee.modules.recall.types.RecallResponse import (
 from cognee.modules.recall.types.SearchResultItem import SearchResultItem
 from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
 from cognee.modules.search.types import SearchResult, SearchType
+from cognee.modules.users.exceptions.exceptions import UserNotFoundError
+from cognee.modules.users.methods import get_default_user
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("recall")
@@ -62,11 +67,27 @@ def _tokenize(text: str) -> set[str]:
 
 async def _resolve_user_id(user: str | None) -> str | None:
     """Return the user id as a string, resolving default if needed."""
-    from cognee.modules.users.methods import get_default_user
-
     if user is None:
         user = await get_default_user()
     return str(user.id) if hasattr(user, "id") else None
+
+
+async def _resolve_graph_user(user):
+    if user is None:
+        try:
+            user = await get_default_user()
+        except (DatabaseNotCreatedError, UserNotFoundError) as error:
+            raise CogneeValidationError(
+                message=(
+                    "Recall prerequisites not met: no database/default user found. "
+                    "Initialize Cognee before recalling by:\n"
+                    "- running `await cognee.add(...)` followed by `await cognee.cognify()`."
+                ),
+                name="RecallPreconditionError",
+            ) from error
+
+    await set_session_user_context_variable(user)
+    return user
 
 
 async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | None) -> str | None:
@@ -352,7 +373,8 @@ async def recall(
     from cognee.shared.utils import send_telemetry
 
     session_id = kwargs.get("session_id")
-    user = kwargs.get("user")
+    user = kwargs.pop("user", None)
+    telemetry_user = getattr(user, "id", user) or "sdk"
 
     # Resolve scope → concrete source list. "auto" (the default) picks
     # sources based on what the caller supplied:
@@ -384,7 +406,7 @@ async def recall(
 
     send_telemetry(
         "cognee.recall",
-        kwargs.get("user", "sdk"),
+        telemetry_user,
         additional_properties={
             "query_length": len(query_text),
             "scope": span_scope,
@@ -419,6 +441,9 @@ async def recall(
             span.set_attribute(COGNEE_RECALL_SOURCE, "cloud")
             span.set_attribute(COGNEE_RESULT_COUNT, len(results) if results else 0)
             return results
+
+        if "graph" in sources:
+            user = await _resolve_graph_user(user)
 
         merged: list[RecallResponse] = []
 

--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -72,24 +72,6 @@ async def _resolve_user_id(user: str | None) -> str | None:
     return str(user.id) if hasattr(user, "id") else None
 
 
-async def _resolve_graph_user(user):
-    if user is None:
-        try:
-            user = await get_default_user()
-        except (DatabaseNotCreatedError, UserNotFoundError) as error:
-            raise CogneeValidationError(
-                message=(
-                    "Recall prerequisites not met: no database/default user found. "
-                    "Initialize Cognee before recalling by:\n"
-                    "- running `await cognee.add(...)` followed by `await cognee.cognify()`."
-                ),
-                name="RecallPreconditionError",
-            ) from error
-
-    await set_session_user_context_variable(user)
-    return user
-
-
 async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | None) -> str | None:
     """Resolve the user_id to use when querying the session cache.
 
@@ -373,7 +355,7 @@ async def recall(
     from cognee.shared.utils import send_telemetry
 
     session_id = kwargs.get("session_id")
-    user = kwargs.pop("user", None)
+    user = kwargs.get("user")
     telemetry_user = getattr(user, "id", user) or "sdk"
 
     # Resolve scope → concrete source list. "auto" (the default) picks
@@ -442,8 +424,7 @@ async def recall(
             span.set_attribute(COGNEE_RESULT_COUNT, len(results) if results else 0)
             return results
 
-        if "graph" in sources:
-            user = await _resolve_graph_user(user)
+        user = kwargs.pop("user", None)
 
         merged: list[RecallResponse] = []
 
@@ -477,10 +458,27 @@ async def recall(
             return list(await _fetch_graph_context(session_id=session_id, user=user))
 
         async def _run_graph() -> list[RecallResponse]:
+            nonlocal user
+
             from cognee.modules.recall.methods.normalize_search_payload import (
                 normalize_search_payload,
             )
             from cognee.modules.search.methods.search import authorized_search
+
+            if user is None:
+                try:
+                    user = await get_default_user()
+                except (DatabaseNotCreatedError, UserNotFoundError) as error:
+                    raise CogneeValidationError(
+                        message=(
+                            "Recall prerequisites not met: no database/default user found. "
+                            "Initialize Cognee before recalling by:\n"
+                            "- running `await cognee.add(...)` followed by `await cognee.cognify()`."
+                        ),
+                        name="RecallPreconditionError",
+                    ) from error
+
+            await set_session_user_context_variable(user)
 
             local_query_type = query_type
             if local_query_type is not None:

--- a/cognee/tests/unit/api/v1/test_public_memory_api.py
+++ b/cognee/tests/unit/api/v1/test_public_memory_api.py
@@ -1,0 +1,93 @@
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
+from cognee.modules.search.types import SearchType
+
+
+def _remember_module():
+    return importlib.import_module("cognee.api.v1.remember.remember")
+
+
+def _recall_module():
+    return importlib.import_module("cognee.api.v1.recall.recall")
+
+
+def _search_methods_module():
+    return importlib.import_module("cognee.modules.search.methods.search")
+
+
+@pytest.mark.asyncio
+async def test_cognee_remember_public_api_completes():
+    import cognee
+
+    remember_mod = _remember_module()
+    mock_user = MagicMock()
+    mock_user.id = uuid4()
+    mock_dataset = MagicMock()
+    mock_dataset.id = uuid4()
+
+    with (
+        patch("cognee.shared.utils.send_telemetry"),
+        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch("cognee.modules.engine.operations.setup.setup", AsyncMock()),
+        patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=mock_user)),
+        patch.object(
+            remember_mod,
+            "resolve_authorized_user_datasets",
+            AsyncMock(return_value=(mock_user, [mock_dataset])),
+        ),
+        patch("cognee.api.v1.add.add", AsyncMock()) as add,
+        patch("cognee.api.v1.cognify.cognify", AsyncMock(return_value={})) as cognify,
+    ):
+        result = await cognee.remember(
+            "public memory smoke",
+            dataset_name="public_api",
+            self_improvement=False,
+        )
+
+    add.assert_awaited_once()
+    cognify.assert_awaited_once()
+    assert isinstance(result, cognee.RememberResult)
+    assert result.status == "completed"
+    assert result.dataset_name == "public_api"
+
+
+@pytest.mark.asyncio
+async def test_cognee_recall_public_api_resolves_default_user_for_graph_search():
+    import cognee
+
+    recall_mod = _recall_module()
+    search_methods = _search_methods_module()
+    mock_user = MagicMock()
+    mock_user.id = uuid4()
+    mock_payload = SearchResultPayload(
+        result_object="graph result",
+        search_type=SearchType.GRAPH_COMPLETION,
+    )
+
+    with (
+        patch("cognee.shared.utils.send_telemetry"),
+        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(recall_mod, "get_default_user", AsyncMock(return_value=mock_user)),
+        patch.object(recall_mod, "set_session_user_context_variable", AsyncMock()),
+        patch.object(
+            search_methods,
+            "authorized_search",
+            AsyncMock(return_value=[mock_payload]),
+        ) as authorized_search,
+    ):
+        results = await cognee.recall(
+            "public recall smoke",
+            query_type=SearchType.GRAPH_COMPLETION,
+            auto_route=False,
+        )
+
+    authorized_search.assert_awaited_once()
+    assert authorized_search.await_args.kwargs["user"] is mock_user
+    assert len(results) == 1
+    assert results[0].source == "graph"
+    assert results[0].text == "graph result"

--- a/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
@@ -1025,6 +1025,8 @@ class TestRecallSessionMode:
         """When session search returns nothing, falls through to graph."""
         recall_mod = _get_recall_module()
 
+        mock_user = MagicMock()
+        mock_user.id = uuid4()
         mock_payload = SearchResultPayload(
             result_object="graph result", search_type=SearchType.GRAPH_COMPLETION
         )
@@ -1046,7 +1048,7 @@ class TestRecallSessionMode:
                 return_value=MagicMock(search_type=MagicMock()),
             ),
         ):
-            results = await recall_mod.recall("test", session_id="s1")
+            results = await recall_mod.recall("test", session_id="s1", user=mock_user)
 
         # Should get graph results since session was empty
         assert len(results) == 1
@@ -1059,6 +1061,8 @@ class TestRecallSessionMode:
         mock_payload = SearchResultPayload(
             result_object="graph result", search_type=SearchType.GRAPH_COMPLETION
         )
+        mock_user = MagicMock()
+        mock_user.id = uuid4()
 
         recall_mod = _get_recall_module()
 
@@ -1073,6 +1077,7 @@ class TestRecallSessionMode:
                 "test",
                 query_type=SearchType.GRAPH_COMPLETION,
                 session_id="s1",
+                user=mock_user,
             )
 
         assert len(results) == 1

--- a/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
@@ -1078,3 +1078,39 @@ class TestRecallSessionMode:
         assert len(results) == 1
         assert results[0].source == "graph"
         assert results[0].text == "graph result"
+
+    @pytest.mark.asyncio
+    async def test_graph_recall_resolves_default_user(self):
+        """Graph recall without an explicit user should use the default user."""
+        mock_user = MagicMock()
+        mock_user.id = uuid4()
+        mock_payload = SearchResultPayload(
+            result_object="graph result", search_type=SearchType.GRAPH_COMPLETION
+        )
+
+        recall_mod = _get_recall_module()
+
+        with (
+            patch.object(recall_mod, "get_default_user", AsyncMock(return_value=mock_user)),
+            patch.object(
+                recall_mod,
+                "set_session_user_context_variable",
+                AsyncMock(),
+            ) as set_user_context,
+            patch.object(
+                _mod_search_methods,
+                "authorized_search",
+                AsyncMock(return_value=[mock_payload]),
+            ) as authorized_search,
+        ):
+            results = await recall_mod.recall(
+                "test",
+                query_type=SearchType.GRAPH_COMPLETION,
+            )
+
+        authorized_search.assert_awaited_once()
+        assert authorized_search.await_args.kwargs["user"] is mock_user
+        set_user_context.assert_awaited_once_with(mock_user)
+        assert len(results) == 1
+        assert results[0].source == "graph"
+        assert results[0].text == "graph result"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.0.4"
+version = "1.0.5"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1192,7 +1192,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Bump cognee to 1.0.5 and refresh uv.lock
- Restore default-user resolution for cognee.recall graph searches
- Add public cognee.remember/cognee.recall API regression tests

## Tests
- uv run ruff check cognee/api/v1/recall/recall.py cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py cognee/tests/unit/api/v1/test_public_memory_api.py
- uv run ruff format --check cognee/api/v1/recall/recall.py cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py cognee/tests/unit/api/v1/test_public_memory_api.py
- uv run --extra dev python -m pytest cognee/tests/unit/api/v1/test_public_memory_api.py cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolve and enforce a default user for graph recall paths, improve session user context handling, and surface clearer validation errors
  * Improve telemetry user tracking for recall operations

* **Tests**
  * Added unit tests covering public memory APIs and graph recall default-user behavior

* **Chores**
  * Updated package version to 1.0.5
<!-- end of auto-generated comment: release notes by coderabbit.ai -->