### PR TITLE
fix(ladybug): tolerate unknown version_code on fresh-DB init

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -148,12 +148,20 @@ class LadybugAdapter(GraphDBInterface):
                         max_db_size=4096 * 1024 * 1024,
                     )
                 except RuntimeError:
-                    from .ladybug_migrate import read_ladybug_storage_version
+                    from .ladybug_migrate import try_read_ladybug_storage_version
                     import ladybug
 
-                    ladybug_db_version = read_ladybug_storage_version(self.db_path)
+                    # An unknown version_code (None) means either a fresh path
+                    # or a DB written by a ladybug release newer than
+                    # ladybug_version_mapping knows about. In both cases the
+                    # legacy-Kuzu migration is not applicable — just retry the
+                    # init below. Without this, ladybug>=0.12 fresh DBs raise
+                    # "Could not map version_code to proper Ladybug version"
+                    # because the mapping tops out at 0.11.3.
+                    ladybug_db_version = try_read_ladybug_storage_version(self.db_path)
                     if (
-                        _version_tuple(ladybug_db_version) < (0, 15, 0)
+                        ladybug_db_version is not None
+                        and _version_tuple(ladybug_db_version) < (0, 15, 0)
                         and ladybug_db_version != ladybug.__version__
                     ):
                         # Try to migrate legacy Kuzu database to the current Ladybug version

--- a/cognee/infrastructure/databases/graph/ladybug/ladybug_migrate.py
+++ b/cognee/infrastructure/databases/graph/ladybug/ladybug_migrate.py
@@ -75,6 +75,29 @@ def read_ladybug_storage_version(ladybug_db_path: str) -> str:
         raise ValueError("Could not map version_code to proper Ladybug version.")
 
 
+def try_read_ladybug_storage_version(ladybug_db_path: str):
+    """Best-effort variant of ``read_ladybug_storage_version``.
+
+    Returns the mapped version string if the catalog file exists and its
+    version_code is present in ``ladybug_version_mapping``. Returns ``None``
+    when:
+
+      * the catalog file is missing (truly fresh path), or
+      * the version_code is newer than anything in the mapping (typically
+        a fresh DB written by a ladybug release the mapping table doesn't
+        list yet — at the time of writing the table tops out at 0.11.3,
+        so any code emitted by ladybug >= 0.12 lands here).
+
+    This is the lookup the runtime bootstrap path wants — the legacy
+    migration script keeps using ``read_ladybug_storage_version`` so its
+    CLI surface still raises on bad input.
+    """
+    try:
+        return read_ladybug_storage_version(ladybug_db_path)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
 def _package_for_version(version: str) -> tuple[str, str]:
     version_parts = tuple(int(part) for part in version.split(".")[:3])
     package_name = "ladybug" if version_parts >= (0, 15, 0) else "kuzu"

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_migrate.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_migrate.py
@@ -1,10 +1,69 @@
 """Tests for Ladybug migration helpers."""
 
 import os
+import struct
 import subprocess
 import tempfile
 
-from cognee.infrastructure.databases.graph.ladybug.ladybug_migrate import run_migration_step
+import pytest
+
+from cognee.infrastructure.databases.graph.ladybug.ladybug_migrate import (
+    ladybug_version_mapping,
+    read_ladybug_storage_version,
+    run_migration_step,
+    try_read_ladybug_storage_version,
+)
+
+
+def _write_catalog_kz(dir_path: str, version_code: int) -> str:
+    """Write a fake catalog.kz with the given storage version_code.
+
+    Format mirrors what read_ladybug_storage_version expects:
+      3-byte magic 'KUZ' + 1 byte padding + 8 bytes little-endian uint64.
+    """
+    os.makedirs(dir_path, exist_ok=True)
+    catalog = os.path.join(dir_path, "catalog.kz")
+    with open(catalog, "wb") as f:
+        f.write(b"KUZ\x00")
+        f.write(struct.pack("<Q", version_code))
+    return catalog
+
+
+def test_read_ladybug_storage_version_known_code(tmp_path):
+    # Pick any code that's actually in the mapping.
+    code, expected = next(iter(ladybug_version_mapping.items()))
+    _write_catalog_kz(str(tmp_path), code)
+    assert read_ladybug_storage_version(str(tmp_path)) == expected
+
+
+def test_read_ladybug_storage_version_unknown_code_raises(tmp_path):
+    # Anything outside the known table — e.g., a code emitted by a newer
+    # ladybug release that hasn't been added yet.
+    unknown = max(ladybug_version_mapping.keys()) + 100
+    _write_catalog_kz(str(tmp_path), unknown)
+    with pytest.raises(ValueError, match="Could not map version_code"):
+        read_ladybug_storage_version(str(tmp_path))
+
+
+def test_try_read_storage_version_unknown_code_returns_none(tmp_path):
+    """Regression: ladybug 0.16.0 fresh DB writes a code that's not in the
+    mapping (which currently tops out at 0.11.3). The runtime bootstrap
+    must not crash — try_read_* returns None so the caller can skip the
+    legacy migration path."""
+    unknown = max(ladybug_version_mapping.keys()) + 100
+    _write_catalog_kz(str(tmp_path), unknown)
+    assert try_read_ladybug_storage_version(str(tmp_path)) is None
+
+
+def test_try_read_storage_version_missing_catalog_returns_none(tmp_path):
+    # Truly fresh path — no catalog.kz yet.
+    assert try_read_ladybug_storage_version(str(tmp_path)) is None
+
+
+def test_try_read_storage_version_known_code(tmp_path):
+    code, expected = next(iter(ladybug_version_mapping.items()))
+    _write_catalog_kz(str(tmp_path), code)
+    assert try_read_ladybug_storage_version(str(tmp_path)) == expected
 
 
 def test_run_migration_step_isolates_legacy_import_path(monkeypatch):


### PR DESCRIPTION
## Reproduction

cognee 1.0.4 / 1.0.5, ladybug==0.16.0, fresh tenant dir:

\`\`\`python
cognee.config.system_root_directory("/tmp/fresh-tenant")
asyncio.run(cognee.add("hello"))
asyncio.run(cognee.cognify())
\`\`\`

\`\`\`
ValueError: Could not map version_code to proper Ladybug version.
  File ".../cognee/infrastructure/databases/graph/ladybug/ladybug_migrate.py", line 75, in read_ladybug_storage_version
  File ".../cognee/infrastructure/databases/graph/ladybug/adapter.py", line 154, in _initialize_connection
\`\`\`

## Root cause

\`LadybugAdapter._initialize_connection\` wraps the first \`Database()\` call in \`except RuntimeError\`. ladybug 0.16.0 raises RuntimeError on first init (after writing a \`catalog.kz\` with its current storage version_code). The except branch then calls \`read_ladybug_storage_version\` to decide whether legacy-Kuzu migration is needed. That function fails because \`ladybug_version_mapping\` only goes up to code \`39 → 0.11.3\` — anything written by ladybug ≥ 0.12 hits the bare ValueError, which masks the original RuntimeError and never reaches the retry.

## Fix

1. New helper \`try_read_ladybug_storage_version(path) → str | None\` — returns None for unknown version_codes and missing catalog files. The CLI migration script keeps using the strict \`read_ladybug_storage_version\`.
2. \`adapter.py\` uses the lenient helper. \`None\` means either a fresh path or a ladybug release newer than the mapping — neither case calls for legacy-Kuzu migration. We just retry \`Database()\`, which succeeds.

## Why this approach over expanding the mapping

The user's bug report suggested two fixes:
- (a) add ladybug 0.15+ entries to \`ladybug_version_mapping\`
- (b) skip the version-check on fresh DBs

(a) only delays the next recurrence — every ladybug bump would require a mapping update or this exact bug returns. (b) makes the runtime path forward-compatible by default. The legacy migration script still uses the strict mapping where the version_code → version mapping actually matters (for invoking the right legacy kuzu binary).

## Tests

\`cognee/tests/unit/infrastructure/databases/graph/test_ladybug_migrate.py\`:

- [x] \`read_ladybug_storage_version\` still raises ValueError on unknown code (CLI behavior unchanged)
- [x] \`try_read_*\` returns mapped string for a known code
- [x] \`try_read_*\` returns None for unknown code (the regression case)
- [x] \`try_read_*\` returns None for missing catalog (truly fresh path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Ladybug database initialization to gracefully handle cases where storage version cannot be determined, preventing failures during startup on fresh installations or with incompatible database versions.

* **Tests**
  * Added comprehensive test coverage for storage version detection and migration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->