### PR TITLE
fix(cache): close FsCache adapter before pruning data dir

### DIFF
--- a/cognee/infrastructure/databases/cache/get_cache_engine.py
+++ b/cognee/infrastructure/databases/cache/get_cache_engine.py
@@ -107,3 +107,18 @@ def get_cache_engine(
         tapes_model=config.tapes_model,
         tapes_request_timeout=config.tapes_request_timeout,
     )
+
+
+async def close_and_clear_cache_engine() -> None:
+    """Close the cached cache adapter (if any) and reset the factory cache.
+
+    `create_cache_engine` is wrapped in `lru_cache` keyed on host/port/etc.
+    rather than on `data_root_directory`, so rotating the data root leaves
+    an orphan adapter whose underlying file handle (e.g. diskcache's sqlite
+    on `cache.db`) keeps the previous data dir locked. On Windows that
+    blocks `rmtree`. Closing before `cache_clear()` releases the handle.
+    """
+    engine = get_cache_engine()
+    if engine is not None:
+        await engine.close()
+    create_cache_engine.cache_clear()

--- a/cognee/modules/data/deletion/prune_data.py
+++ b/cognee/modules/data/deletion/prune_data.py
@@ -1,7 +1,15 @@
+from cognee.infrastructure.databases.cache.get_cache_engine import (
+    close_and_clear_cache_engine,
+)
 from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
 
 
 async def prune_data():
+    # Release any open cache adapter handle for the current data_root_directory
+    # before removing the directory; on Windows an open diskcache sqlite handle
+    # would block rmtree of cache.db.
+    await close_and_clear_cache_engine()
+
     storage_config = get_storage_config()
     data_root_directory = storage_config["data_root_directory"]
     await get_file_storage(data_root_directory).remove_all()

--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -14,7 +14,9 @@ from cognee.infrastructure.databases.cache import (
     get_cache_config,
     get_cache_engine,
 )
-from cognee.infrastructure.databases.cache.get_cache_engine import create_cache_engine
+from cognee.infrastructure.databases.cache.get_cache_engine import (
+    close_and_clear_cache_engine,
+)
 from cognee.modules.users.models import DatasetDatabase
 from cognee.shared.logging_utils import get_logger
 
@@ -76,7 +78,7 @@ async def prune_system(graph=True, vector=True, metadata=True, cache=True):
         await delete_cache()
         cache_config = get_cache_config()
         if cache_config.caching or cache_config.usage_logging:
-            create_cache_engine.cache_clear()
+            await close_and_clear_cache_engine()
             cache_engine = get_cache_engine()
             if cache_engine:
                 await cache_engine.prune()


### PR DESCRIPTION
## Summary

`create_cache_engine` is wrapped in `functools.lru_cache` keyed on host/port/etc. but **not** on `data_root_directory`. Rotating the data root (e.g. between tests via `cognee.config.data_root_directory(...)`) leaves an orphan `FSCacheAdapter` whose `diskcache.Cache(directory=…)` keeps a SQLite handle open on the *previous* `…/.cognee_fs_cache/sessions_db/cache.db`.

Linux/macOS: open-file unlink succeeds, rmtree works.
Windows: `rmtree` of the previous data dir hits `WinError 32` (file in use), breaking subsequent tests.

This is the root cause of the long-standing `Unit tests 3.13.x on windows-latest` failure on `dev`. Tail of a recent run:

```
FAILED cognee/tests/unit/modules/pipelines/run_task_from_queue_test.py::test_run_tasks_from_queue
  - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process:
    'D:\\a\\cognee\\cognee\\cognee\\tests\\.data_storage\\test_delete_data_nodes_edges\\.cognee_fs_cache\\sessions_db\\cache.db'
FAILED cognee/tests/unit/modules/pipelines/run_tasks_test.py::test_run_tasks
  - PermissionError: [WinError 32] ...same file...
FAILED cognee/tests/unit/modules/pipelines/run_tasks_with_context_test.py::test_run_tasks
  - PermissionError: [WinError 32] ...same file...
```

The trigger: `test_delete_data_nodes_and_edges_removes_from_all_systems` sets `data_root_directory` to `…/test_delete_data_nodes_edges`, instantiates the FS cache (via `get_session_manager`/`get_cache_engine`), and exits without closing it. The next pipeline test inherits that `data_root_directory`, calls `prune_data()`, and rmtree fails on the locked `cache.db`.

## Fix

`FSCacheAdapter.close()` already exists and is part of `CacheDBInterface` — nothing was calling it.

- Add `close_and_clear_cache_engine()` in `get_cache_engine.py` that closes the cached adapter **before** invalidating the `lru_cache`.
- Call it from `prune_data` (before `rmtree`) and from `prune_system` (replacing the bare `cache_clear()` that was already there but did nothing for the Windows lock).

## Test plan

- [ ] Existing `OS and Python Tests Extended / Unit tests 3.13.x on windows-latest` job goes green
- [ ] No regression on Linux/macOS unit suites
- [ ] `Unit tests 3.10.x` (which has its own pre-existing `test_public_memory_api` mocking issue) is unaffected by this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue preventing data deletion on Windows due to open cache handles blocking file system operations.
  * Enhanced cache engine cleanup during system and data pruning to properly close and reset handles before file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->