### PR TITLE
test(public-memory-api): use patch.object for shadowed serve module

### DIFF
--- a/cognee/tests/unit/api/v1/test_public_memory_api.py
+++ b/cognee/tests/unit/api/v1/test_public_memory_api.py
@@ -4,6 +4,12 @@ from uuid import uuid4
 
 import pytest
 
+# Import the module directly so we can patch attributes via patch.object.
+# Patching by the dotted string "cognee.api.v1.serve.state…" fails on
+# Python 3.10's unittest.mock because `cognee.api.v1.serve` is shadowed by
+# the `serve()` function re-exported in cognee/api/v1/__init__.py — mock's
+# pre-3.11 dotted-path walk hits the function and raises AttributeError.
+from cognee.api.v1.serve import state as serve_state
 from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
 from cognee.modules.search.types import SearchType
 
@@ -32,7 +38,7 @@ async def test_cognee_remember_public_api_completes():
 
     with (
         patch("cognee.shared.utils.send_telemetry"),
-        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(serve_state, "get_remote_client", return_value=None),
         patch("cognee.modules.engine.operations.setup.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=mock_user)),
         patch.object(
@@ -71,7 +77,7 @@ async def test_cognee_recall_public_api_resolves_default_user_for_graph_search()
 
     with (
         patch("cognee.shared.utils.send_telemetry"),
-        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(serve_state, "get_remote_client", return_value=None),
         patch.object(recall_mod, "get_default_user", AsyncMock(return_value=mock_user)),
         patch.object(recall_mod, "set_session_user_context_variable", AsyncMock()),
         patch.object(


### PR DESCRIPTION
## Summary

Unblocks the **\`Unit tests 3.10.x on ubuntu-22.04\`** lane that has been red on \`dev\`. The two failing tests:

\`\`\`
FAILED cognee/tests/unit/api/v1/test_public_memory_api.py::test_cognee_remember_public_api_completes
  - AttributeError: 'function' object has no attribute 'state'
FAILED cognee/tests/unit/api/v1/test_public_memory_api.py::test_cognee_recall_public_api_resolves_default_user_for_graph_search
  - AttributeError: 'function' object has no attribute 'state'
\`\`\`

## Root cause

\`cognee.api.v1.serve\` is a subpackage that contains both a \`serve()\` function (\`serve/serve.py\`) and a \`state\` submodule. \`cognee/api/v1/__init__.py:5\` does \`from .serve import serve, disconnect\`, which writes the **function** into \`cognee.api.v1.__dict__['serve']\` — shadowing the subpackage attribute.

When \`unittest.mock.patch(\"cognee.api.v1.serve.state.get_remote_client\")\` walks the dotted path:

1. \`getattr(cognee.api.v1, 'serve')\` → returns the \*\*function\*\* (because of the shadowing)
2. \`getattr(<function>, 'state')\` → \`AttributeError\`

Python 3.11+ added an \`__import__\` fallback to \`unittest.mock._dot_lookup\` that recovers from this, which is why 3.11/3.12/3.13 lanes pass and only 3.10 fails.

## Fix

Test-only: import \`cognee.api.v1.serve.state\` directly and use \`patch.object(serve_state, \"get_remote_client\", ...)\`. \`patch.object\` patches the attribute on the given object — no dotted walk, no shadowing exposure.

Source-side rename of either the function or the subpackage would also fix it, but both are public API (\`cognee.serve\` and \`cognee.api.v1.serve\`), so a local test fix is the right immediate scope.

## Test plan

- [ ] \`Unit tests 3.10.x on ubuntu-22.04\` goes green
- [ ] No regression on 3.11/3.12/3.13/3.14 lanes (the new \`patch.object\` form is universally compatible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure and mocking patterns for internal API testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->