### PR TITLE
fix(docker): copy kuzu compatibility shim into image

### DIFF
--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -169,7 +169,7 @@ jobs:
     if: ${{ !cancelled() && needs.basic-tests.result == 'success' }}
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
-      python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x"]'
+      python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"]'
       os: '["ubuntu-22.04"]'
     secrets: inherit
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Installing separately from its dependencies allows optimal layer caching
 COPY ./cognee /app/cognee
 COPY ./distributed /app/distributed
+# Compatibility shim that re-exports ladybug under the legacy `kuzu`
+# module name. Listed in [tool.hatch.build.targets.wheel] packages, and
+# imported at module load by alembic/versions/b9274c27a25a_kuzu_11_migration.py.
+COPY ./kuzu /app/kuzu
 RUN --mount=type=cache,target=/root/.cache/uv \
 uv sync --extra debug --extra api --extra postgres --extra neo4j --extra llama-index --extra ollama --extra mistral --extra groq --extra anthropic --extra chromadb --frozen --no-dev --no-editable
 

--- a/cognee/tests/test_library.py
+++ b/cognee/tests/test_library.py
@@ -78,6 +78,30 @@ async def main():
 
     assert len(history) == 6, "Search history is not correct."
 
+    memory_text = (
+        "Grace Hopper designed one of the first compilers and popularized the term "
+        "debugging in computing."
+    )
+    remember_result = await cognee.remember(
+        memory_text,
+        dataset_name=dataset_name,
+        self_improvement=False,
+    )
+    assert remember_result.status == "completed", "Remember did not complete successfully."
+    assert remember_result.dataset_name == dataset_name, "Remember used the wrong dataset."
+
+    recall_results = await cognee.recall(
+        query_text="Grace Hopper compiler debugging",
+        query_type=SearchType.CHUNKS,
+        datasets=[dataset_name],
+        top_k=5,
+        auto_route=False,
+    )
+    assert len(recall_results) != 0, "Recall results list is empty."
+    recall_text = "\n".join(result.text for result in recall_results).lower()
+    assert "grace hopper" in recall_text, "Recall did not return remembered content."
+    assert "compiler" in recall_text, "Recall result is missing the remembered compiler detail."
+
     # Test updating of documents
     # Get Pipeline Run object
     pipeline_run_obj = list(cognify_run_info.values())[0]

--- a/cognee/tests/unit/api/v1/test_public_memory_api.py
+++ b/cognee/tests/unit/api/v1/test_public_memory_api.py
@@ -4,6 +4,12 @@ from uuid import uuid4
 
 import pytest
 
+# Import the module directly so we can patch attributes via patch.object.
+# Patching by the dotted string "cognee.api.v1.serve.state…" fails on
+# Python 3.10's unittest.mock because `cognee.api.v1.serve` is shadowed by
+# the `serve()` function re-exported in cognee/api/v1/__init__.py — mock's
+# pre-3.11 dotted-path walk hits the function and raises AttributeError.
+from cognee.api.v1.serve import state as serve_state
 from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
 from cognee.modules.search.types import SearchType
 
@@ -32,7 +38,7 @@ async def test_cognee_remember_public_api_completes():
 
     with (
         patch("cognee.shared.utils.send_telemetry"),
-        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(serve_state, "get_remote_client", return_value=None),
         patch("cognee.modules.engine.operations.setup.setup", AsyncMock()),
         patch("cognee.modules.users.methods.get_default_user", AsyncMock(return_value=mock_user)),
         patch.object(
@@ -71,7 +77,7 @@ async def test_cognee_recall_public_api_resolves_default_user_for_graph_search()
 
     with (
         patch("cognee.shared.utils.send_telemetry"),
-        patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
+        patch.object(serve_state, "get_remote_client", return_value=None),
         patch.object(recall_mod, "get_default_user", AsyncMock(return_value=mock_user)),
         patch.object(recall_mod, "set_session_user_context_variable", AsyncMock()),
         patch.object(

--- a/distributed/Dockerfile
+++ b/distributed/Dockerfile
@@ -24,6 +24,7 @@ RUN uv sync --frozen --no-dev --extra neo4j --extra postgres --extra aws --extra
 
 COPY cognee/ /app/cognee
 COPY distributed/ /app/distributed
+COPY kuzu/ /app/kuzu
 
 # Modal's post-build steps require pip available on the default Python
 RUN uv pip install pip wheel


### PR DESCRIPTION
Closes #2775

## Summary

Cognee 1.0.4 replaced the real \`kuzu\` PyPI package with [ladybug](https://github.com/topoteretes/ladybug) and added a tiny compatibility shim at repo-root \`kuzu/\` that re-exports ladybug under the legacy \`kuzu\` module name. The shim is listed in \`pyproject.toml\` under \`[tool.hatch.build.targets.wheel] packages = [\"cognee\", \"distributed\", \"kuzu\"]\`.

The Dockerfile only COPYs \`./cognee\` and \`./distributed\`, so when \`uv sync --no-editable\` builds the cognee wheel inside the image, hatchling silently produces a wheel **without** the kuzu shim. The runtime then crashes the first time alembic runs:

\`\`\`
File \"/app/cognee/alembic/versions/b9274c27a25a_kuzu_11_migration.py\", line 16, in <module>
    import kuzu
ModuleNotFoundError: No module named 'kuzu'
\`\`\`

## Fix

Add \`COPY ./kuzu /app/kuzu\` to the root \`Dockerfile\` and \`distributed/Dockerfile\` so hatchling sees the shim at wheel-build time and bundles it into the installed cognee package.

## Verification

Built the image locally with the patch applied. Inside the container:

\`\`\`
\$ ls /app/.venv/lib/python3.12/site-packages/ | grep -E \"kuzu|ladybug\"
kuzu                       # ← previously missing
ladybug
ladybug-0.16.0.dist-info

\$ python -c \"import kuzu; print(kuzu.__file__, kuzu.__version__)\"
/app/.venv/lib/python3.12/site-packages/kuzu/__init__.py 0.16.0

\$ python -c \"from cognee.alembic.versions import b9274c27a25a_kuzu_11_migration as m; print(m.revision)\"
b9274c27a25a
\`\`\`

The previously-crashing migration imports cleanly, and the shim resolves to the **installed wheel** copy under site-packages (not the source-tree copy at \`/app/kuzu\`).

## Out of scope

\`cognee/eval_framework/Dockerfile\` and \`deployment/helm/Dockerfile\` also lack the \`COPY ./kuzu\` line, but they predate the ladybug migration entirely (still use \`poetry.lock\`) and would need a much broader update to be runnable. Left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configurations to ensure compatibility with legacy module imports and migrations at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->