### PR TITLE
fix(recall): handle dataset_ids explicitly

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
-from typing_extensions import TypedDict, Unpack
+from typing_extensions import TypedDict
 
 from cognee.infrastructure.databases.cache import SessionAgentTraceEntry, SessionQAEntry
 from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
@@ -43,7 +43,7 @@ _MIN_WORD_LEN = 2
 
 
 class RecallKwargs(TypedDict, total=False):
-    """Power-user overrides for recall(). Most users never need these."""
+    """Backward-compatible export for callers that import RecallKwargs."""
 
     dataset_ids: list[UUID]
     system_prompt: str
@@ -317,10 +317,24 @@ async def recall(
     query_type: SearchType | None = None,
     *,
     datasets: list[str] | None = None,
+    dataset_ids: list[UUID] | None = None,
     top_k: int = 10,
     auto_route: bool = True,
     scope: str | list[str] | None = None,
-    **kwargs: Unpack[RecallKwargs],
+    system_prompt: str | None = None,
+    system_prompt_path: str = "answer_simple_question.txt",
+    node_name: list[str] | None = None,
+    node_name_filter_operator: str = "OR",
+    only_context: bool = False,
+    session_id: str | None = None,
+    wide_search_top_k: int | None = 100,
+    triplet_distance_penalty: float | None = 6.5,
+    feedback_influence: float = 0.0,
+    verbose: bool = False,
+    retriever_specific_config: dict | None = None,
+    neighborhood_depth: int | None = None,
+    neighborhood_seed_top_k: int | None = None,
+    user: object | None = None,
 ) -> list[RecallResponse]:
     """Search the knowledge graph for relevant information.
 
@@ -342,10 +356,10 @@ async def recall(
         query_text: Natural-language query.
         query_type: Search strategy. When provided, the router is bypassed.
         datasets: Dataset names to search within.
+        dataset_ids: Dataset UUIDs to search within. Takes precedence over datasets.
         top_k: Maximum results to return (default *10*).
         auto_route: If True and query_type is None, classify the query
             automatically. If False, fall back to GRAPH_COMPLETION.
-        **kwargs: Additional options -- see ``RecallKwargs``.
 
     Returns:
         Search results. When searching session-only, returns a list of
@@ -354,8 +368,6 @@ async def recall(
     from cognee import __version__ as cognee_version
     from cognee.shared.utils import send_telemetry
 
-    session_id = kwargs.get("session_id")
-    user = kwargs.get("user")
     telemetry_user = getattr(user, "id", user) or "sdk"
 
     # Resolve scope → concrete source list. "auto" (the default) picks
@@ -371,7 +383,8 @@ async def recall(
     # Explicit ``scope`` values bypass this entirely.
     resolved_scope = normalize_scope(scope)
     if resolved_scope == ["auto"]:
-        if session_id and not datasets and query_type is None:
+        has_dataset_scope = bool(dataset_ids) or bool(datasets)
+        if session_id and not has_dataset_scope and query_type is None:
             sources = ["session", "graph"]
             auto_fallthrough = True  # session hit short-circuits graph
         elif session_id and query_type is None:
@@ -397,6 +410,7 @@ async def recall(
             "search_type": str(query_type.value) if query_type else "auto",
             "session_id": session_id or "",
             "datasets": ",".join(datasets) if datasets else "",
+            "dataset_ids": ",".join(str(dataset_id) for dataset_id in dataset_ids or []),
             "cognee_version": cognee_version,
         },
     )
@@ -416,15 +430,18 @@ async def recall(
                 query_text,
                 query_type,
                 datasets=datasets,
+                dataset_ids=dataset_ids,
                 top_k=top_k,
                 scope=scope,
-                **kwargs,
+                system_prompt=system_prompt,
+                node_name=node_name,
+                only_context=only_context,
+                session_id=session_id,
+                verbose=verbose,
             )
             span.set_attribute(COGNEE_RECALL_SOURCE, "cloud")
             span.set_attribute(COGNEE_RESULT_COUNT, len(results) if results else 0)
             return results
-
-        user = kwargs.pop("user", None)
 
         merged: list[RecallResponse] = []
 
@@ -501,23 +518,35 @@ async def recall(
                 str(local_query_type.value) if local_query_type else "unknown",
             )
 
-            # Transform string based datasets to UUID - String based datasets can only be found for current user
-            dataset_ids: list[UUID] | None = None
-            if datasets is not None:
-                dataset_ids = [
+            # Dataset UUIDs take precedence over names, matching /api/v1/search.
+            # String dataset names can only resolve for the current user.
+            search_dataset_ids = dataset_ids or None
+            if search_dataset_ids is None and datasets is not None:
+                search_dataset_ids = [
                     dataset.id
                     for dataset in await get_authorized_existing_datasets(datasets, "read", user)
                 ]
-                if not dataset_ids:
+                if not search_dataset_ids:
                     raise DatasetNotFoundError(message="No datasets found.")
 
             graph_results = await authorized_search(
                 query_text=query_text,
                 query_type=local_query_type,
                 user=user,
-                dataset_ids=dataset_ids,
+                dataset_ids=search_dataset_ids,
+                system_prompt_path=system_prompt_path,
+                system_prompt=system_prompt,
                 top_k=top_k,
-                **kwargs,
+                node_name=node_name,
+                node_name_filter_operator=node_name_filter_operator,
+                only_context=only_context,
+                session_id=session_id,
+                wide_search_top_k=wide_search_top_k,
+                triplet_distance_penalty=triplet_distance_penalty,
+                feedback_influence=feedback_influence,
+                retriever_specific_config=retriever_specific_config,
+                neighborhood_depth=neighborhood_depth,
+                neighborhood_seed_top_k=neighborhood_seed_top_k,
             )
 
             tagged = []

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -130,12 +130,20 @@ class CloudClient:
         payload: dict = {"query": query_text}
         if query_type:
             payload["search_type"] = query_type if isinstance(query_type, str) else query_type.value
-        if kwargs.get("datasets"):
+        if kwargs.get("dataset_ids"):
+            payload["dataset_ids"] = [str(dataset_id) for dataset_id in kwargs["dataset_ids"]]
+        elif kwargs.get("datasets"):
             payload["datasets"] = kwargs["datasets"]
         if kwargs.get("top_k"):
             payload["top_k"] = kwargs["top_k"]
         if kwargs.get("system_prompt"):
             payload["system_prompt"] = kwargs["system_prompt"]
+        if kwargs.get("node_name"):
+            payload["node_name"] = kwargs["node_name"]
+        if kwargs.get("only_context"):
+            payload["only_context"] = kwargs["only_context"]
+        if kwargs.get("verbose"):
+            payload["verbose"] = kwargs["verbose"]
         if kwargs.get("session_id"):
             payload["session_id"] = kwargs["session_id"]
         if kwargs.get("scope") is not None:

--- a/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py
@@ -995,6 +995,10 @@ def _get_recall_module():
 
 
 class TestRecallSessionMode:
+    @pytest.fixture(autouse=True)
+    def _disable_telemetry(self, monkeypatch):
+        monkeypatch.setattr("cognee.shared.utils.send_telemetry", lambda *args, **kwargs: None)
+
     @pytest.mark.asyncio
     async def test_session_only_when_no_datasets_no_type(self):
         """recall(session_id=X) without datasets/type searches session."""
@@ -1119,3 +1123,96 @@ class TestRecallSessionMode:
         assert len(results) == 1
         assert results[0].source == "graph"
         assert results[0].text == "graph result"
+
+    @pytest.mark.asyncio
+    async def test_api_style_recall_kwargs_forward_search_options_once(self):
+        """API recall kwargs should not duplicate or leak into authorized_search."""
+        recall_mod = _get_recall_module()
+        user = MagicMock()
+        user.id = uuid4()
+        dataset_id = uuid4()
+        captured_kwargs = {}
+        mock_payload = SearchResultPayload(
+            result_object="graph result", search_type=SearchType.GRAPH_COMPLETION
+        )
+
+        async def dummy_authorized_search(**kwargs):
+            captured_kwargs.update(kwargs)
+            return [mock_payload]
+
+        with patch.object(
+            _mod_search_methods,
+            "authorized_search",
+            dummy_authorized_search,
+        ):
+            results = await recall_mod.recall(
+                "test",
+                query_type=SearchType.GRAPH_COMPLETION,
+                user=user,
+                datasets=["ignored-when-ids-exist"],
+                dataset_ids=[dataset_id],
+                system_prompt="Use concise answers.",
+                node_name=["ImportantNode"],
+                top_k=4,
+                verbose=True,
+                only_context=True,
+                session_id="s1",
+            )
+
+        assert len(results) == 1
+        assert captured_kwargs["user"] is user
+        assert captured_kwargs["dataset_ids"] == [dataset_id]
+        assert captured_kwargs["system_prompt"] == "Use concise answers."
+        assert captured_kwargs["node_name"] == ["ImportantNode"]
+        assert captured_kwargs["top_k"] == 4
+        assert captured_kwargs["only_context"] is True
+        assert captured_kwargs["session_id"] == "s1"
+        assert "verbose" not in captured_kwargs
+
+    @pytest.mark.asyncio
+    async def test_session_with_dataset_ids_also_runs_graph_search(self):
+        """dataset_ids should count as graph scope, same as datasets by name."""
+        recall_mod = _get_recall_module()
+        user = MagicMock()
+        user.id = uuid4()
+        dataset_id = uuid4()
+
+        session_entries = [
+            ResponseQAEntry(
+                time=datetime.utcnow().isoformat(),
+                question="test",
+                context="",
+                answer="session result",
+                source="session",
+            )
+        ]
+        mock_payload = SearchResultPayload(
+            result_object="graph result", search_type=SearchType.GRAPH_COMPLETION
+        )
+
+        with (
+            patch.object(
+                recall_mod,
+                "_search_session",
+                AsyncMock(return_value=session_entries),
+            ),
+            patch.object(
+                _mod_search_methods,
+                "authorized_search",
+                AsyncMock(return_value=[mock_payload]),
+            ) as authorized_search_mock,
+            patch.object(
+                _mod_query_router,
+                "route_query",
+                return_value=MagicMock(search_type=SearchType.GRAPH_COMPLETION),
+            ),
+        ):
+            results = await recall_mod.recall(
+                "test",
+                session_id="s1",
+                dataset_ids=[dataset_id],
+                user=user,
+            )
+
+        assert [result.source for result in results] == ["session", "graph"]
+        assert authorized_search_mock.await_args.kwargs["dataset_ids"] == [dataset_id]


### PR DESCRIPTION
## Summary

- Make `recall()` accept API/MCP-facing options explicitly instead of forwarding loose `**kwargs` into `authorized_search`.
- Treat `dataset_ids` as first-class dataset scope and let it take precedence over dataset names, matching `/api/v1/search`.
- Forward `dataset_ids`, `node_name`, `only_context`, and `verbose` through the remote client payload.
- Add regression coverage for API-style recall calls and `session_id` plus `dataset_ids` graph search.

## Root Cause

In v1.0.5, the recall route can pass values such as `dataset_ids` and `user` explicitly while also leaving them in `**kwargs`, which can duplicate arguments or leak unsupported options like `verbose` into `authorized_search`. This shows up when MCP/API callers use the latest recall path with dataset IDs.

## Validation

- `uv run --extra dev python -m pytest cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py::TestRecallSessionMode -q`
- `uv run --extra dev ruff check cognee/api/v1/recall/recall.py cognee/api/v1/serve/cloud_client.py cognee/tests/unit/modules/memify_tasks/test_sync_graph_to_session.py`
- `git diff --check HEAD~1..HEAD`

Related to #2747, but this PR addresses a separate latest-release recall/API mismatch rather than the MCP text-upload filename collision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined the recall API with more explicit parameter handling for clearer and more predictable behavior.
  * Enhanced dataset-related operations with improved ID and parameter forwarding mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->