### PR TITLE
feat: expose chunk size in API

### DIFF
--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -201,7 +201,13 @@ async def cognify(
 
     client = get_remote_client()
     if client is not None:
-        return await client.cognify(datasets)
+        return await client.cognify(
+            datasets,
+            chunk_size=chunk_size,
+            chunks_per_batch=chunks_per_batch,
+            custom_prompt=custom_prompt,
+            run_in_background=run_in_background,
+        )
 
     with new_span("cognee.api.cognify") as span:
         span.set_attribute(COGNEE_PIPELINE_NAME, "cognify")

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -46,6 +46,11 @@ class CognifyPayloadDTO(InDTO):
     custom_prompt: Optional[str] = Field(
         default="", description="Custom prompt for entity extraction and graph generation"
     )
+    chunk_size: Optional[int] = Field(
+        default=None,
+        description="Maximum tokens per chunk. Defaults to automatic model-based sizing.",
+        examples=[512, 1024, 2048],
+    )
     ontology_key: Optional[List[str]] = Field(
         default=None,
         examples=[[]],
@@ -93,6 +98,8 @@ def get_cognify_router() -> APIRouter:
         - **dataset_ids** (Optional[List[UUID]]): List of existing dataset UUIDs to process. UUIDs allow processing of datasets not owned by the user (if permitted).
         - **run_in_background** (Optional[bool]): Whether to execute processing asynchronously. Defaults to False (blocking).
         - **custom_prompt** (Optional[str]): Custom prompt for entity extraction and graph generation. If provided, this prompt will be used instead of the default prompts for knowledge graph extraction.
+        - **chunk_size** (Optional[int]): Maximum tokens per chunk. If omitted, Cognee chooses
+          a size from the configured LLM and embedding limits.
         - **ontology_key** (Optional[List[str]]): Reference to one or more previously uploaded ontology files to use for knowledge graph construction.
 
         ## Response
@@ -209,6 +216,7 @@ def get_cognify_router() -> APIRouter:
                 config=config_to_use,
                 run_in_background=payload.run_in_background,
                 custom_prompt=custom_prompt,
+                chunk_size=payload.chunk_size,
                 chunks_per_batch=payload.chunks_per_batch,
             )
 

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -670,7 +670,15 @@ async def _remember_inner(
     client = get_remote_client()
     if client is not None:
         span.set_attribute(COGNEE_OPERATION_MODE, "cloud")
-        return await client.remember(data, dataset_name, session_id=session_id, **kwargs)
+        return await client.remember(
+            data,
+            dataset_name,
+            session_id=session_id,
+            chunk_size=chunk_size,
+            custom_prompt=custom_prompt,
+            run_in_background=run_in_background,
+            **kwargs,
+        )
 
     from cognee.api.v1.add import add
     from cognee.api.v1.cognify import cognify

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -35,6 +35,7 @@ def get_remember_router() -> APIRouter:
         node_set: Optional[List[str]] = Form(default=[""], example=[""]),
         run_in_background: Optional[bool] = Form(default=False),
         custom_prompt: Optional[str] = Form(default=""),
+        chunk_size: Optional[int] = Form(default=None),
         chunks_per_batch: Optional[int] = Form(default=10),
         user: User = Depends(get_authenticated_user),
     ):
@@ -51,6 +52,8 @@ def get_remember_router() -> APIRouter:
         - **node_set** (Optional[List[str]]): Node identifiers for graph organisation.
         - **run_in_background** (Optional[bool]): Run the cognify step asynchronously (default: False).
         - **custom_prompt** (Optional[str]): Custom prompt for entity extraction.
+        - **chunk_size** (Optional[int]): Maximum tokens per chunk. Defaults to automatic
+          model-based sizing.
         - **chunks_per_batch** (Optional[int]): Chunks per cognify batch.
 
         Either datasetName or datasetId must be provided.
@@ -87,6 +90,7 @@ def get_remember_router() -> APIRouter:
                 node_set=node_set if node_set != [""] else None,
                 run_in_background=run_in_background or False,
                 custom_prompt=custom_prompt or None,
+                chunk_size=chunk_size,
                 chunks_per_batch=chunks_per_batch,
             )
 

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -59,6 +59,10 @@ class CloudClient:
             form.add_field("run_in_background", "true")
         if kwargs.get("custom_prompt"):
             form.add_field("custom_prompt", kwargs["custom_prompt"])
+        if kwargs.get("chunk_size") is not None:
+            form.add_field("chunk_size", str(kwargs["chunk_size"]))
+        if kwargs.get("chunks_per_batch") is not None:
+            form.add_field("chunks_per_batch", str(kwargs["chunks_per_batch"]))
 
         # Handle data — string or file-like objects
         if isinstance(data, str):
@@ -220,6 +224,14 @@ class CloudClient:
             payload["datasets"] = (
                 [str(d) for d in datasets] if isinstance(datasets, list) else [str(datasets)]
             )
+        if kwargs.get("run_in_background"):
+            payload["run_in_background"] = True
+        if kwargs.get("custom_prompt"):
+            payload["custom_prompt"] = kwargs["custom_prompt"]
+        if kwargs.get("chunk_size") is not None:
+            payload["chunk_size"] = kwargs["chunk_size"]
+        if kwargs.get("chunks_per_batch") is not None:
+            payload["chunks_per_batch"] = kwargs["chunks_per_batch"]
 
         async with session.post(
             f"{self.service_url}/api/v1/cognify",

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -6,10 +6,12 @@ Tests cover:
 - Basic endpoint functionality (happy path with mocked backends)
 """
 
-import pytest
+import importlib
 from types import SimpleNamespace
 from uuid import uuid4
 from unittest.mock import AsyncMock
+
+import pytest
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -20,6 +22,7 @@ from cognee.modules.users.exceptions.exceptions import PermissionDeniedError
 from cognee.api.v1.add.routers.get_add_router import get_add_router
 from cognee.api.v1.cognify.routers.get_cognify_router import get_cognify_router
 from cognee.api.v1.memify.routers.get_memify_router import get_memify_router
+from cognee.api.v1.remember.routers.get_remember_router import get_remember_router
 from cognee.api.v1.search.routers.get_search_router import get_search_router
 from cognee.api.v1.update.routers.get_update_router import get_update_router
 
@@ -58,6 +61,7 @@ def app():
     app.include_router(get_add_router(), prefix="/add")
     app.include_router(get_cognify_router(), prefix="/cognify")
     app.include_router(get_memify_router(), prefix="/memify")
+    app.include_router(get_remember_router(), prefix="/remember")
     app.include_router(get_search_router(), prefix="/search")
     app.include_router(get_update_router(), prefix="/update")
 
@@ -133,6 +137,33 @@ class TestAddEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# Remember endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRememberEndpoint:
+    def test_remember_passes_chunk_size(self, client, monkeypatch):
+        remember_pkg = importlib.import_module("cognee.api.v1.remember")
+
+        class RememberResultStub:
+            def to_dict(self):
+                return {"status": "completed", "dataset_name": "test_dataset"}
+
+        remember = AsyncMock(return_value=RememberResultStub())
+        monkeypatch.setattr(remember_pkg, "remember", remember)
+
+        resp = client.post(
+            "/remember",
+            data={"datasetName": "test_dataset", "chunk_size": "42"},
+            files={"data": ("test.txt", b"Cognee is an AI memory platform.", "text/plain")},
+        )
+
+        assert resp.status_code == 200
+        remember.assert_awaited_once()
+        assert remember.await_args.kwargs["chunk_size"] == 42
+
+
+# ---------------------------------------------------------------------------
 # Cognify endpoint
 # ---------------------------------------------------------------------------
 
@@ -166,6 +197,22 @@ class TestCognifyEndpoint:
             json={"datasets": ["test_dataset"], "run_in_background": False},
         )
         assert resp.status_code == 200
+
+    def test_cognify_passes_chunk_size(self, client, monkeypatch):
+        import cognee.api.v1.cognify as cognify_pkg
+
+        completed = _make_completed()
+        cognify = AsyncMock(return_value={str(MOCK_DATASET_ID): completed})
+        monkeypatch.setattr(cognify_pkg, "cognify", cognify)
+
+        resp = client.post(
+            "/cognify",
+            json={"datasets": ["test_dataset"], "chunk_size": 42},
+        )
+
+        assert resp.status_code == 200
+        cognify.assert_awaited_once()
+        assert cognify.await_args.kwargs["chunk_size"] == 42
 
     def test_cognify_internal_error_returns_500(self, client):
         import cognee.api.v1.cognify as cognify_pkg


### PR DESCRIPTION
Exposes chunk_size through the HTTP API and remote client paths.\n\nChanges:\n- Add chunk_size form support to /api/v1/remember and pass it into cognee.remember.\n- Add chunk_size JSON support to /api/v1/cognify and pass it into cognee.cognify.\n- Forward chunk_size and related processing options through CloudClient for remember/cognify.\n- Preserve chunk_size when SDK calls route through a remote Cognee client.\n- Add unit coverage for remember and cognify route forwarding.\n\nValidation:\n- uv run pytest cognee/tests/unit/api/test_api_error_responses.py -q\n- uv run ruff check cognee/api/v1/cognify/cognify.py cognee/api/v1/cognify/routers/get_cognify_router.py cognee/api/v1/remember/remember.py cognee/api/v1/remember/routers/get_remember_router.py cognee/api/v1/serve/cloud_client.py cognee/tests/unit/api/test_api_error_responses.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `chunk_size` parameter to cognify and remember API endpoints, allowing users to control the maximum tokens per chunk during data processing.
  * Extended support for forwarding processing parameters to remote client calls, enabling consistent behavior across distributed deployments.

* **Tests**
  * Added comprehensive tests to verify that the chunk_size parameter is correctly parsed and forwarded throughout the API call chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->