### PR TITLE
chore: add CODEOWNERS to route PR reviews automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,71 @@
+# Code owners for the cognee repository.
+#
+# GitHub auto-requests reviews from these owners when a PR touches their paths.
+# Order matters: the LAST matching pattern wins. Keep most-specific rules at the
+# bottom.
+#
+# To update this file, please confirm the change with the affected owners
+# before merging. Tracking ticket: COG-4900.
+
+# -----------------------------------------------------------------------------
+# Default fallback — picked when no other rule matches.
+# -----------------------------------------------------------------------------
+*                                                  @Vasilije1990
+
+# -----------------------------------------------------------------------------
+# Public API surface (V1 + V2)
+# -----------------------------------------------------------------------------
+/cognee/api/v1/                                    @dexters1 @Vasilije1990
+/cognee/api/v1/cognify/                            @dexters1
+/cognee/api/v1/remember/                           @dexters1 @Vasilije1990
+/cognee/api/v1/recall/                             @dexters1 @Vasilije1990
+
+# -----------------------------------------------------------------------------
+# Retrieval / memory tasks (V2 memory + agentic retrievers)
+# -----------------------------------------------------------------------------
+/cognee/modules/retrieval/                         @hajdul88 @lazarobradovic
+/cognee/tasks/memify/                              @lazarobradovic @hajdul88
+/cognee/tasks/temporal_awareness/                  @lazarobradovic @hajdul88
+/cognee/tasks/temporal_graph/                      @lazarobradovic @hajdul88
+
+# -----------------------------------------------------------------------------
+# Pipelines & tasks (the cognify ECL pipeline + composable tasks)
+# -----------------------------------------------------------------------------
+/cognee/pipelines/                                 @Vasilije1990
+/cognee/tasks/                                     @Vasilije1990 @siillee
+
+# -----------------------------------------------------------------------------
+# Infrastructure adapters
+# -----------------------------------------------------------------------------
+/cognee/infrastructure/databases/vector/           @siillee @dexters1
+/cognee/infrastructure/databases/graph/            @siillee
+/cognee/infrastructure/databases/graph/ladybug/    @siillee @hajdul88
+/cognee/infrastructure/databases/cache/            @Vasilije1990
+
+# -----------------------------------------------------------------------------
+# MCP server
+# -----------------------------------------------------------------------------
+/cognee-mcp/                                       @Vasilije1990 @dexters1
+
+# -----------------------------------------------------------------------------
+# Frontend (Next.js UI)
+# -----------------------------------------------------------------------------
+/cognee-frontend/                                  @LStromann
+
+# -----------------------------------------------------------------------------
+# Build, packaging, CI
+# -----------------------------------------------------------------------------
+/Dockerfile                                        @Vasilije1990
+/distributed/Dockerfile                            @Vasilije1990
+/.github/workflows/                                @dexters1 @siillee
+/.github/actions/                                  @dexters1
+/pyproject.toml                                    @Vasilije1990 @dexters1
+/uv.lock                                           @Vasilije1990 @dexters1
+
+# -----------------------------------------------------------------------------
+# Contributor experience (this file, CONTRIBUTING.md, AGENTS.md, CLAUDE.md)
+# -----------------------------------------------------------------------------
+/.github/CODEOWNERS                                @Vasilije1990
+/CONTRIBUTING.md                                   @Vasilije1990
+/AGENTS.md                                         @Vasilije1990
+/CLAUDE.md                                         @Vasilije1990

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,10 @@ git push origin feature/your-feature-name
    - Fill in the PR template with details about your changes
    - You MUST provide screenshots of unit and integration tests passing on your machine. We can't merge PRs otherwise
 
+> **Reviewers are auto-routed.** Cognee uses a [`CODEOWNERS`](.github/CODEOWNERS)
+> file to request reviews automatically based on the directories your PR touches.
+> No manual ping required — the right person will get notified when you open the PR.
+
 ## 5. 📜 Developer Certificate of Origin (DCO)
 
 All contributions must be signed-off to indicate agreement with our DCO:


### PR DESCRIPTION
Closes COG-4900.

## Summary

Adds \`.github/CODEOWNERS\` so GitHub auto-requests review from the right person based on the directory the PR touches. Removes the \"who do I ping?\" friction every external contributor hits.

Also adds a single-paragraph callout in \`CONTRIBUTING.md\` so contributors know reviews are auto-routed.

## How owners were chosen

Commit-authorship counts over the last 90 days, by directory:

| Directory | Top contributors (90d) |
|---|---|
| \`cognee/api/v1/\` | Igor (61), vasilije (46), Andrej (38) |
| \`cognee/modules/retrieval/\` | hajdul88 (34), Andrej (16), vasilije (14) |
| \`cognee/infrastructure/databases/vector/\` | Andrej (31), Igor (19), vasilije (16) |
| \`cognee/infrastructure/databases/graph/\` | Dan (27), vasilije (15), Andrej (8) |
| \`cognee-mcp/\` | vasilije (28), Igor (13) |
| \`cognee/api/v1/cognify/\` | vasilije (14), Andrej (5), Igor (4) |
| \`cognee/api/v1/recall/\` | vasilije (7), Jan Schlicht (1), Igor (1) |

Lazar Obradovic is added to retrieval/memify rows because he's owning the new Q2 memory tickets ([COG-4896](https://linear.app/cognee/issue/COG-4896), [COG-4897](https://linear.app/cognee/issue/COG-4897), [COG-4898](https://linear.app/cognee/issue/COG-4898)).

## Confirmed handles

| Linear / commit name | GitHub | Verified via |
|---|---|---|
| Vasilije Markovic | @Vasilije1990 | recent PRs (#2754–#2776) |
| Igor Ilic | @dexters1 | PR #2771 author payload |
| Andrej Milicevic | @siillee | PR #2742, #2766 author payload |
| László Hajdu | @hajdul88 | \`gh api users/hajdul88\` returns \"László Hajdu\" |
| Lazar Obradovic | @lazarobradovic | \`gh api users/lazarobradovic\` exists |
| Luca Stromann | @LStromann | \`gh api users/LStromann\` returns \"Luca Stromann\" |

## Notes

- **Order matters in CODEOWNERS** — last matching rule wins. File is structured so general rules come first, specific subdirectories last.
- **Pavel Zorin not yet added.** Couldn't confirm GitHub handle (3 candidates: \`pzorin\`, \`pazone\`, \`PavelZorin158\`; none clearly the cognee team member). Not strictly needed for v1 since vasilije fallback covers his areas. Add in a follow-up once handle is confirmed.
- **No branch-protection change in this PR.** That's a separate decision: should requiring CODEOWNERS approval be a merge gate? Filed mentally for a follow-up; out of scope here.

## Test plan

- [ ] Open a draft PR touching \`cognee/api/v1/cognify/cognify.py\` and confirm @dexters1 is auto-requested.
- [ ] Open a draft PR touching \`cognee/modules/retrieval/\` and confirm @hajdul88 + @lazarobradovic are auto-requested.
- [ ] Confirm CONTRIBUTING.md renders correctly with the new note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to clarify the PR review routing process.

* **Chores**
  * Configured repository code ownership structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->