### PR TITLE
fix(llm/anthropic): inject max_tokens into Anthropic adapter (1.0.6)

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
@@ -50,6 +50,10 @@ class AnthropicAdapter(GenericAPIAdapter):
             llm_args=llm_args,
         )
         self.llm_args: dict[str, Any] = llm_args or {}
+        # Anthropic's messages.create requires max_tokens. Unlike the litellm path used by
+        # GenericAPIAdapter, instructor.patch around the raw Anthropic SDK does not auto-inject
+        # it, so we surface max_completion_tokens here.
+        self.llm_args.setdefault("max_tokens", max_completion_tokens)
         self.instructor_mode = instructor_mode if instructor_mode else self.default_instructor_mode
 
         self.aclient: AsyncInstructorChatCompletionCreate = instructor.patch(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.0.5"
+version = "1.0.6"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1194,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Anthropic adapter (`cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py`) wraps `anthropic.AsyncAnthropic().messages.create` via `instructor.patch`, bypassing litellm. Neither layer auto-injects `max_tokens`, which the Anthropic SDK requires — every `cognify`/`search` call with `LLM_PROVIDER=anthropic` failed with a misleading `InstructorRetryException: Missing required arguments...`.
- Fix: `self.llm_args.setdefault("max_tokens", max_completion_tokens)` in `AnthropicAdapter.__init__`, so the value flows through `merged_kwargs` at the call site and explicit user overrides are preserved.
- Version bump 1.0.5 → 1.0.6 (`pyproject.toml` + `uv.lock`).

## Note on branching
Repo convention is to branch from `dev`. This PR targets `main` per the request to ship a hotfix release. A follow-up cherry-pick / merge into `dev` is needed so the fix is not lost on the next dev → main merge.

## Test plan
- [x] Local repro via direct adapter instantiation: `llm_args["max_tokens"]` is populated from `max_completion_tokens` when not provided
- [x] User-supplied `llm_args={"max_tokens": 4096}` is honored (setdefault, not overwrite)
- [x] `ruff check` + `ruff format --check` pass on the changed file
- [ ] CI on PR: full unit + integration suite
- [ ] End-to-end smoke: `cognee.add` → `cognee.cognify` → `cognee.search` with `LLM_PROVIDER=anthropic`, `LLM_MODEL=claude-haiku-4-5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Anthropic API integration to properly handle parameter requirements for structured output functionality.

* **Chores**
  * Version updated to 1.0.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->