### PR TITLE
fix(llm): preflight uses litellm ping instead of structured-output (1.0.7)

### DIFF
--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -105,7 +105,9 @@ async def test_llm_connection() -> None:
                 api_base=llm_config.llm_endpoint or None,
                 api_version=llm_config.llm_api_version or None,
                 messages=[{"role": "user", "content": "hi"}],
-                max_tokens=1,
+                # Reasoning models (o1/o3/gpt-5) consume the budget on hidden reasoning
+                # before emitting output and 400 if the cap is too small, so leave headroom.
+                max_tokens=256,
                 num_retries=0,
             ),
             timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
@@ -124,6 +126,16 @@ async def test_llm_connection() -> None:
             "Set COGNEE_SKIP_CONNECTION_TEST=true to bypass this check."
         )
         logger.error(msg)
+        raise e
+    except litellm.exceptions.BadRequestError as e:
+        # A "max_tokens / output limit reached" 400 still proves the endpoint is reachable
+        # and the credentials are accepted — treat it as a passing preflight rather than
+        # failing the whole pipeline on an artifact of our tiny ping.
+        if "max_tokens" in str(e).lower() or "output limit" in str(e).lower():
+            logger.debug("LLM preflight hit token-limit response; treating as reachable.")
+            return
+        logger.error(e)
+        logger.error("Connection to LLM could not be established.")
         raise e
     except Exception as e:
         logger.error(e)

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -2,7 +2,7 @@ import asyncio
 
 import litellm
 
-from cognee.infrastructure.llm.LLMGateway import LLMGateway
+from cognee.infrastructure.llm.config import get_llm_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client import (
     get_llm_client,
 )
@@ -79,15 +79,34 @@ def get_model_max_completion_tokens(model_name: str) -> int | None:
 
 async def test_llm_connection() -> None:
     """
-    Test connectivity to the LLM endpoint using a simple completion call.
+    Test connectivity to the LLM endpoint using a minimal completion call.
+
+    Uses litellm.acompletion with a single-token ping rather than the structured-output
+    path, so the preflight stays uniform across providers and isn't subject to the
+    instructor + tenacity retry stack inside the provider adapters (which can mask a
+    fast failure behind exponential backoff and trigger spurious timeouts).
     """
+    llm_config = get_llm_config()
+    model = llm_config.llm_model
+    provider = llm_config.llm_provider
+    # Some configs duplicate the provider in the model id (e.g. provider="anthropic",
+    # model="anthropic/claude-..."); pass an unprefixed model and let
+    # custom_llm_provider drive routing.
+    if provider and model.startswith(f"{provider}/"):
+        model = model[len(provider) + 1 :]
+
     try:
         logger.info("Testing connection to LLM endpoint...")
         await asyncio.wait_for(
-            LLMGateway.acreate_structured_output(
-                text_input="test",
-                system_prompt='Respond to me with the following string: "test"',
-                response_model=str,
+            litellm.acompletion(
+                model=model,
+                custom_llm_provider=provider or None,
+                api_key=llm_config.llm_api_key,
+                api_base=llm_config.llm_endpoint or None,
+                api_version=llm_config.llm_api_version or None,
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=1,
+                num_retries=0,
             ),
             timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.0.6"
+version = "1.0.7"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1194,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
The startup connection check in `cognee/infrastructure/llm/utils.py::test_llm_connection` ran a full structured-output call (`LLMGateway.acreate_structured_output(..., response_model=str)`) for what is supposed to be a lightweight ping. For non-OpenAI providers this routes through the provider-specific adapter, whose tenacity retry decorator (`stop_after_delay(128)` with `wait_exponential_jitter(8, 128)`) can mask a fast underlying failure behind exponential backoff, tripping the 30 s `asyncio.wait_for` and surfacing a misleading "endpoint unreachable" message even when the endpoint is healthy (verified with the same key/model via raw `curl` in <1 s in the original report).

This PR replaces the preflight with a uniform `litellm.acompletion` ping (`max_tokens=1`, `num_retries=0`, no structured-output wrapper). Authentication or routing errors now surface immediately instead of being eaten by the inner retry stack. Provider routing is made explicit via `custom_llm_provider` so it's correct regardless of whether `LLM_MODEL` is written as `claude-haiku-4-5` or `anthropic/claude-haiku-4-5`.

## Stacking
This PR is **stacked on top of #2783** (the `max_tokens` Anthropic fix, base `main`). The two are related: the original 30 s timeout on `LLM_PROVIDER=anthropic` was triggered by the missing `max_tokens` causing the adapter retry loop to spin. The first PR fixes the symptom; this PR fixes the preflight design so future provider-specific bugs don't get masked the same way. Merge #2783 first, then this. Otherwise expect a `pyproject.toml` / `uv.lock` version conflict on 1.0.6.

## Test plan
- [x] `LLM_PROVIDER=anthropic`, bad key: now raises `AuthenticationError` in ~0.2 s instead of `TimeoutError` in 30 s
- [x] `LLM_PROVIDER=openai`, valid key: preflight returns successfully
- [x] `ruff check` + `ruff format --check` clean on changed file
- [x] `LLM_MODEL` containing duplicated provider prefix (e.g., `anthropic/claude-haiku-4-5`) routes correctly
- [ ] CI on PR: full unit + integration suite
- [ ] Cross-provider sanity: gemini, ollama, custom (OpenAI-compatible) endpoints

## Note on branching
Repo convention is to branch from `dev`. Targeting `main` per the request to ship as a hotfix release alongside #2783. A follow-up cherry-pick / merge into `dev` is needed for both PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable LLM connectivity check: uses a lightweight ping, better provider/model routing, treats token/output-limit responses as successful health checks, and improves error handling.

* **Chores**
  * Package version bumped to 1.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->