### PR TITLE
fix(recall): pass Pydantic models with kwargs and required source literal

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -277,7 +277,7 @@ async def _search_trace(
 
     results: list[ResponseAgentTraceEntry] = []
     for _, entry in scored[:top_k]:
-        results.append(ResponseAgentTraceEntry(entry))
+        results.append(ResponseAgentTraceEntry(**entry.model_dump(), source="trace"))
 
     return results
 
@@ -309,7 +309,7 @@ async def _fetch_graph_context(
     if not snapshot:
         return []
 
-    return [ResponseGraphContextEntry(content=snapshot)]
+    return [ResponseGraphContextEntry(content=snapshot, source="graph_context")]
 
 
 async def recall(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.0.7"
+version = "1.0.8"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1194,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Two bugs in \`cognee/api/v1/recall/recall.py\` made every \`POST /api/v1/recall\` call return **HTTP 409** whenever the request scope included \`trace\` or \`graph_context\`. The recall endpoint catches \`Exception\` broadly and returns \`409: An error occurred during recall.\`, so the actual root cause was silent in client logs.

### Bug 1 — \`_search_trace\` passes a Pydantic model positionally (line 280)

\`\`\`python
results.append(ResponseAgentTraceEntry(entry))   # entry is a SessionAgentTraceEntry
\`\`\`

Pydantic v2 \`BaseModel.__init__\` rejects positional args:

\`\`\`
TypeError: BaseModel.__init__() takes 1 positional argument but 2 were given
\`\`\`

Fix mirrors the working pattern from \`_search_session\` (line 209):

\`\`\`python
results.append(ResponseAgentTraceEntry(**entry.model_dump(), source="trace"))
\`\`\`

### Bug 2 — \`_fetch_graph_context\` omits the required \`source\` literal (line 312)

\`\`\`python
return [ResponseGraphContextEntry(content=snapshot)]
\`\`\`

\`ResponseGraphContextEntry\` declares \`source: Literal[\"graph_context\"]\` as a required field. Once Bug 1 is fixed and execution reaches this runner, this would be the next 409.

## Reproduction

\`\`\`python
import requests
requests.post(\"http://localhost:8000/api/v1/recall\", json={
    \"query\": \"anything\",
    \"session_id\": \"<any active session>\",
    \"scope\": [\"session\", \"trace\", \"graph_context\"],
}).status_code
# 409 before, 200 after
\`\`\`

## End-user symptom

The Claude Code memory plugin hits this endpoint on every \`UserPromptSubmit\`. With these two bugs, the \`🔍 cognee recall\` status header always reported \`0 / 0 / 0\` regardless of what was in session memory — recall was effectively dead for that integration.

## Test plan

- [x] Verified locally against \`cognee.serve()\` on a session with stored QA + trace entries: \`scope=[\"session\",\"trace\",\"graph_context\"]\` returns 200 with content from all three buckets.
- [x] Verified \`scope=[\"graph\"]\` (existing path) still returns 200 with \`GRAPH_COMPLETION\` results.
- [ ] Add unit coverage for \`_search_trace\` and \`_fetch_graph_context\` constructing valid \`ResponseAgentTraceEntry\` / \`ResponseGraphContextEntry\` from realistic inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recall and search results now include a visible "source" field indicating whether data comes from trace entries or graph context.

* **Chores**
  * Project version updated to 1.0.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->