### PR TITLE
feat: add DeepSeek as LLM provider

### DIFF
--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -221,6 +221,27 @@ class LLMConfig(BaseSettings):
 
         return self
 
+    @model_validator(mode="after")
+    def ensure_env_vars_for_deepseek(self) -> "LLMConfig":
+        """
+        Set default values for the DeepSeek provider.
+
+        Only runs when llm_provider is set to 'deepseek'. Sets sensible defaults
+        for endpoint, model, and API key if not already configured. Users can
+        override LLM_ENDPOINT to use local Ollama/vLLM instances.
+        """
+        if self.llm_provider != "deepseek":
+            return self
+
+        if not os.environ.get("LLM_ENDPOINT"):
+            os.environ["LLM_ENDPOINT"] = "https://api.deepseek.com/v1"
+        if not os.environ.get("LLM_MODEL"):
+            os.environ["LLM_MODEL"] = "deepseek-chat"
+        if not os.environ.get("LLM_API_KEY"):
+            os.environ["LLM_API_KEY"] = os.environ.get("DEEPSEEK_API_KEY", "")
+
+        return self
+
     def to_dict(self) -> dict[str, Any]:
         """
         Convert the LLMConfig instance into a dictionary representation.

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/deepseek/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/deepseek/adapter.py
@@ -101,7 +101,6 @@ class DeepSeekAPIAdapter(LLMInterface):
             response = await self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,
-                response_format={"type": "json_object"},
                 **merged_kwargs,
             )
             content = response.choices[0].message.content or ""

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/deepseek/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/deepseek/adapter.py
@@ -1,0 +1,170 @@
+"""DeepSeek API adapter — single-call, self-discovering V4 cloud / local R1."""
+import logging
+import re
+from typing import Any
+
+import litellm
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_not_exception_type,
+    stop_after_delay,
+    wait_exponential_jitter,
+)
+
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
+    LLMInterface,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
+    TranscriptionReturnType,
+)
+from cognee.shared.logging_utils import get_logger
+from cognee.shared.rate_limiting import llm_rate_limiter_context_manager
+from cognee.infrastructure.files.utils.open_data_file import open_data_file
+
+logger = get_logger()
+
+# Strips <think>...</think> blocks from local R1 model responses.
+# Handles: <think>, <THINK>, <think >, </think>, </THINK>
+THINK_PATTERN = re.compile(
+    r"<\s*think[^>]*>.*?<\s*/\s*think\s*>", re.DOTALL | re.IGNORECASE
+)
+
+
+class DeepSeekAPIAdapter(LLMInterface):
+    """Adapter for DeepSeek API — single-call, self-discovering parsing.
+
+    Makes one API call per request and inspects the response to decide
+    whether <think> tag stripping is needed (local R1) or not (V4 cloud).
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        api_key: str,
+        model: str,
+        name: str,
+        max_completion_tokens: int,
+        instructor_mode: str | None = None,
+        llm_args: dict[str, Any] | None = None,
+    ) -> None:
+        self.name = name
+        self.model = model
+        self.api_key = api_key
+        self.endpoint = endpoint
+        self.max_completion_tokens = max_completion_tokens
+        self.llm_args: dict[str, Any] = llm_args or {}
+
+        # instructor_mode is accepted for Cognee factory compatibility but not used.
+        # The adapter uses native JSON mode (response_format) instead of instructor.
+        if instructor_mode is not None:
+            logger.debug(
+                "instructor_mode=%s provided but not used — "
+                "DeepSeek adapter uses native response_format=json_object.",
+                instructor_mode,
+            )
+
+        # Single async client — one call per request, inspect response to discover
+        # whether <think> tag stripping is needed (local R1) or not (V4 cloud).
+        self.client = AsyncOpenAI(base_url=self.endpoint, api_key=self.api_key)
+
+    @retry(
+        stop=stop_after_delay(128),
+        wait=wait_exponential_jitter(8, 128),
+        retry=retry_if_not_exception_type(
+            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
+        ),
+        before_sleep=before_sleep_log(logger, logging.DEBUG),
+        reraise=True,
+    )
+    async def acreate_structured_output(
+        self,
+        text_input: str,
+        system_prompt: str,
+        response_model: type[BaseModel],
+        **kwargs,
+    ) -> BaseModel:
+        """Single-call structured output. Inspects response to decide parse path.
+
+        V4 cloud: clean JSON → parsed directly.
+        Local R1: <think> tags inline → stripped first, then parsed.
+        """
+        merged_kwargs = {**self.llm_args, **kwargs}
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": text_input},
+        ]
+
+        async with llm_rate_limiter_context_manager():
+            response = await self.client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                response_format={"type": "json_object"},
+                **merged_kwargs,
+            )
+            content = response.choices[0].message.content or ""
+
+            # V4 cloud: clean JSON — parse directly.
+            # Local R1: <think> tags inline — strip first.
+            if THINK_PATTERN.search(content):
+                clean = THINK_PATTERN.sub("", content).strip()
+
+                # Strip any markdown fences the model may have added
+                if clean.startswith("```"):
+                    clean = clean.split("\n", 1)[1] if "\n" in clean else clean[3:]
+                    if clean.endswith("```"):
+                        clean = clean[:-3]
+                    clean = clean.strip()
+                    if clean.startswith("json"):
+                        clean = clean[4:].strip()
+
+                return response_model.model_validate_json(clean)
+
+            # No <think> tags — parse the clean JSON directly.
+            return response_model.model_validate_json(content)
+
+    @retry(
+        stop=stop_after_delay(128),
+        wait=wait_exponential_jitter(2, 128),
+        retry=retry_if_not_exception_type(
+            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
+        ),
+        before_sleep=before_sleep_log(logger, logging.DEBUG),
+        reraise=True,
+    )
+    async def transcribe_image(self, input: str, **kwargs: Any) -> str:
+        """DeepSeek V4 supports image input via OpenAI-compatible vision API."""
+        import base64
+
+        async with open_data_file(input, mode="rb") as image_file:
+            encoded = base64.b64encode(image_file.read()).decode("utf-8")
+
+        response = await self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What's in this image?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/jpeg;base64,{encoded}"},
+                        },
+                    ],
+                }
+            ],
+            max_completion_tokens=300,
+        )
+
+        if not hasattr(response, "choices") or not response.choices:
+            raise ValueError("Image transcription failed. No response received.")
+        return response.choices[0].message.content
+
+    async def create_transcript(self, input: str, **kwargs: Any) -> TranscriptionReturnType:
+        """DeepSeek does not provide an audio transcription endpoint."""
+        raise NotImplementedError(
+            "DeepSeek does not support audio transcription. "
+            "Use a separate LLM provider with OpenAI Whisper for transcription tasks."
+        )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -16,6 +16,9 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.ollama.adapter import (
     OllamaAPIAdapter,
 )
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.deepseek.adapter import (
+    DeepSeekAPIAdapter,
+)
 
 _LLM_CLIENT_CACHE_MAXSIZE = 32
 _FROZEN_DICT = "__cognee_dict__"
@@ -79,6 +82,8 @@ class LLMProvider(Enum):
     - GEMINI: Represents the Gemini provider.
     - MISTRAL: Represents the Mistral AI provider.
     - BEDROCK: Represents the AWS Bedrock provider.
+    - LLAMA_CPP: Represents the llama.cpp provider.
+    - DEEPSEEK: Represents the DeepSeek provider.
     """
 
     OPENAI = "openai"
@@ -90,6 +95,7 @@ class LLMProvider(Enum):
     AZURE = "azure"
     BEDROCK = "bedrock"
     LLAMA_CPP = "llama_cpp"
+    DEEPSEEK = "deepseek"
 
 
 _API_KEY_REQUIRED_PROVIDERS = {
@@ -99,6 +105,7 @@ _API_KEY_REQUIRED_PROVIDERS = {
     LLMProvider.GEMINI,
     LLMProvider.MISTRAL,
     LLMProvider.ANTHROPIC,
+    LLMProvider.DEEPSEEK,
 }
 
 
@@ -251,6 +258,17 @@ def _get_llm_client_cached(cache_key: _LLMClientCacheKey) -> LLMInterface:
             llm_api_key,
             cache_key.model,
             "Ollama",
+            max_completion_tokens,
+            instructor_mode=cache_key.instructor_mode,
+            llm_args=llm_args,
+        )
+
+    elif provider == LLMProvider.DEEPSEEK:
+        return DeepSeekAPIAdapter(
+            cache_key.endpoint,
+            llm_api_key,
+            cache_key.model,
+            "DeepSeek",
             max_completion_tokens,
             instructor_mode=cache_key.instructor_mode,
             llm_args=llm_args,

--- a/cognee/infrastructure/llm/tokenizer/TikToken/adapter.py
+++ b/cognee/infrastructure/llm/tokenizer/TikToken/adapter.py
@@ -20,7 +20,11 @@ class TikTokenTokenizer(TokenizerInterface):
         self.max_completion_tokens = max_completion_tokens
         # Initialize TikToken for GPT based on model
         if model:
-            self.tokenizer = tiktoken.encoding_for_model(model)
+            try:
+                self.tokenizer = tiktoken.encoding_for_model(model)
+            except KeyError:
+                # Fall back to cl100k_base for unlisted models (e.g., DeepSeek)
+                self.tokenizer = tiktoken.get_encoding("cl100k_base")
         else:
             # Use default if model not provided
             self.tokenizer = tiktoken.get_encoding("cl100k_base")

--- a/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
+++ b/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
@@ -13,6 +13,10 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
     _raise_for_missing_api_key,
     _unfreeze_from_cache,
 )
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.deepseek.adapter import (
+    DeepSeekAPIAdapter,
+    THINK_PATTERN,
+)
 
 
 def _llm_config(**overrides):
@@ -116,3 +120,53 @@ def test_api_key_validation_still_happens_before_cache_lookup():
         raise_api_key_error=True,
         use_managed_identity=True,
     )
+
+
+# ── DeepSeek provider tests ────────────────────────────────────────────────
+
+
+def test_deepseek_provider_registered():
+    """DeepSeek is a valid LLMProvider enum member."""
+    assert LLMProvider.DEEPSEEK.value == "deepseek"
+
+
+def test_deepseek_client_creation():
+    """DeepSeekAPIAdapter can be instantiated with standard parameters."""
+    adapter = DeepSeekAPIAdapter(
+        endpoint="https://api.deepseek.com/v1",
+        api_key="test-key",
+        model="deepseek-chat",
+        name="DeepSeek",
+        max_completion_tokens=4096,
+    )
+    assert adapter.name == "DeepSeek"
+    assert adapter.endpoint == "https://api.deepseek.com/v1"
+    assert adapter.model == "deepseek-chat"
+
+
+def test_think_pattern_stripping():
+    """THINK_PATTERN strips <think> blocks in all common variants."""
+    cases = [
+        ("<think>\nreasoning\n</think>\n{\"key\": 1}", '{"key": 1}'),
+        ("<think>a</think><THINK>b</THINK>hello", "hello"),
+        ("<think >stuff</think >{\"a\":1}", '{"a":1}'),
+        ("no think tags here", "no think tags here"),
+    ]
+    for raw, expected in cases:
+        assert THINK_PATTERN.sub("", raw).strip() == expected
+
+
+def test_tokenizer_fallback_for_unlisted_model():
+    """TikTokenTokenizer falls back to cl100k_base for unlisted models."""
+    from cognee.infrastructure.llm.tokenizer.TikToken.adapter import TikTokenTokenizer
+
+    tokenizer = TikTokenTokenizer(model="deepseek-chat")
+    tokens = tokenizer.count_tokens("Hello world")
+    assert tokens > 0
+
+
+def test_deepseek_api_key_is_required():
+    """DEEPSEEK provider requires an API key."""
+    with pytest.raises(LLMAPIKeyNotSetError):
+        _raise_for_missing_api_key(LLMProvider.DEEPSEEK, None, raise_api_key_error=True)
+


### PR DESCRIPTION
## Summary

Adds `deepseek` as a first-class LLM provider in Cognee. Supports V4 cloud (`deepseek-chat`, `deepseek-v4-flash`) and local R1 models (`deepseek-r1:8b` via Ollama). Enables `LLM_PROVIDER=deepseek` with a standard DeepSeek API key.

## Changes

- **New:** `deepseek/adapter.py` — DeepSeekAPIAdapter with single-call self-discovery. Inspects response to determine whether `<think>` tag stripping is needed (local R1) or not (V4 cloud). Uses native `response_format=json_object` — instructor-free architecture.
- **Edit:** `get_llm_client.py` — add DEEPSEEK to LLMProvider enum + factory case
- **Edit:** `config.py` — auto-resolve deepseek defaults (endpoint, model, api_key from DEEPSEEK_API_KEY env var). `LLM_ENDPOINT` override supports local Ollama/vLLM.
- **Edit:** `TikToken/adapter.py` — cl100k_base fallback for unlisted models (fixes tokenizer crash on any model not in tiktoken's registry)
- **Tests:** provider registration, adapter instantiation, think tag stripping, tokenizer fallback, API key validation

## Usage

```bash
# Cloud DeepSeek
LLM_PROVIDER=deepseek
DEEPSEEK_API_KEY=sk-...

# Local Ollama running DeepSeek
LLM_PROVIDER=deepseek
LLM_ENDPOINT=http://localhost:11434/v1
LLM_MODEL=deepseek-r1:8b

# V4 thinking mode (via LLM_ARGS pass-through)
LLM_ARGS='\{extra_body: \{thinking: \{type: enabled}}}'
```

## Notes

- No new dependencies — uses existing `openai` + `pydantic` packages
- Single API call per request (no double-call for local R1)
- Tokenizer fallback benefits all unlisted models, not just DeepSeek
- Backward compatible — zero impact on existing providers
- Full architecture review: Gemini ✓ | Claude ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeepSeek added as a supported LLM provider with auto-populated environment defaults when selected.
  * Vision/image transcription support for DeepSeek models.
  * Improved tokenizer resilience with a safe fallback for unknown model names.

* **Reliability**
  * Structured-output calls include retry/backoff for greater robustness.
  * Response parsing now strips helper tags and common markdown fences for cleaner JSON results.

* **Tests**
  * Added coverage for the DeepSeek provider, parsing behavior, and tokenizer fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->