### PR TITLE
fix(pghybrid): respect embedding_engine.get_batch_size() in add_nodes_with_vectors and add_edges_with_vectors

### DIFF
--- a/cognee/infrastructure/databases/hybrid/postgres/adapter.py
+++ b/cognee/infrastructure/databases/hybrid/postgres/adapter.py
@@ -284,7 +284,7 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
             if not valid_items:
                 continue
             texts = [t for _, t in valid_items]
-            batch_size = self._vector.embedding_engine.get_batch_size()
+            batch_size = self._vector.embedding_engine.get_batch_size() or len(texts)
             vectors = []
             for i in range(0, len(texts), batch_size):
                 vectors.extend(await self._vector.embed_data(texts[i : i + batch_size]))
@@ -393,7 +393,7 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
         # Embed unique edge types
         unique_texts = list(edge_type_counts.keys())
         if unique_texts:
-            batch_size = self._vector.embedding_engine.get_batch_size()
+            batch_size = self._vector.embedding_engine.get_batch_size() or len(unique_texts)
             unique_vectors = []
             for i in range(0, len(unique_texts), batch_size):
                 unique_vectors.extend(

--- a/cognee/infrastructure/databases/hybrid/postgres/adapter.py
+++ b/cognee/infrastructure/databases/hybrid/postgres/adapter.py
@@ -284,7 +284,10 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
             if not valid_items:
                 continue
             texts = [t for _, t in valid_items]
-            vectors = await self._vector.embed_data(texts)
+            batch_size = self._vector.embedding_engine.get_batch_size()
+            vectors = []
+            for i in range(0, len(texts), batch_size):
+                vectors.extend(await self._vector.embed_data(texts[i : i + batch_size]))
             embeddings_by_collection[collection] = [
                 (dp, vec, t) for (dp, t), vec in zip(valid_items, vectors)
             ]
@@ -390,7 +393,12 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
         # Embed unique edge types
         unique_texts = list(edge_type_counts.keys())
         if unique_texts:
-            unique_vectors = await self._vector.embed_data(unique_texts)
+            batch_size = self._vector.embedding_engine.get_batch_size()
+            unique_vectors = []
+            for i in range(0, len(unique_texts), batch_size):
+                unique_vectors.extend(
+                    await self._vector.embed_data(unique_texts[i : i + batch_size])
+                )
             text_to_vector = dict(zip(unique_texts, unique_vectors))
         else:
             text_to_vector = {}

--- a/cognee/infrastructure/databases/hybrid/postgres/adapter.py
+++ b/cognee/infrastructure/databases/hybrid/postgres/adapter.py
@@ -249,6 +249,19 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
     # Hybrid: combined graph+vector writes
     # ------------------------------------------------------------------
 
+    def _resolve_batch_size(self, items: List) -> int:
+        """Positive batch size for chunking ``items`` through ``embed_data``.
+
+        Falls back to ``len(items)`` (single-batch call) when
+        ``get_batch_size()`` returns None, 0, or a negative int — those
+        values would otherwise either crash ``range()`` or silently drop
+        embeddings by causing it to skip all iterations.
+        """
+        raw = self._vector.embedding_engine.get_batch_size()
+        if isinstance(raw, int) and raw > 0:
+            return raw
+        return len(items)
+
     async def add_nodes_with_vectors(self, data_points: List[DataPoint]) -> None:
         """Insert nodes into graph and their embeddings into vector tables
         in a single database transaction.
@@ -284,7 +297,7 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
             if not valid_items:
                 continue
             texts = [t for _, t in valid_items]
-            batch_size = self._vector.embedding_engine.get_batch_size() or len(texts)
+            batch_size = self._resolve_batch_size(texts)
             vectors = []
             for i in range(0, len(texts), batch_size):
                 vectors.extend(await self._vector.embed_data(texts[i : i + batch_size]))
@@ -393,7 +406,7 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
         # Embed unique edge types
         unique_texts = list(edge_type_counts.keys())
         if unique_texts:
-            batch_size = self._vector.embedding_engine.get_batch_size() or len(unique_texts)
+            batch_size = self._resolve_batch_size(unique_texts)
             unique_vectors = []
             for i in range(0, len(unique_texts), batch_size):
                 unique_vectors.extend(

--- a/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
+++ b/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
@@ -74,10 +74,11 @@ async def test_add_nodes_with_vectors_chunks_by_batch_size():
 
     calls = adapter._vector.embed_data.await_args_list
     assert len(calls) == 3, f"expected 3 chunked calls, got {len(calls)}"
+    all_texts = []
     for call in calls:
         (texts,) = call.args
         assert len(texts) <= 2, f"chunk size {len(texts)} exceeds batch_size 2"
-    all_texts = [t for call in calls for t in call.args[0]]
+        all_texts.extend(texts)
     assert sorted(all_texts) == sorted(f"n{i}" for i in range(5))
 
 
@@ -91,11 +92,12 @@ async def test_add_edges_with_vectors_chunks_by_batch_size():
 
     calls = adapter._vector.embed_data.await_args_list
     assert len(calls) == 3, f"expected 3 chunked calls, got {len(calls)}"
+    all_texts = []
     for call in calls:
         (texts,) = call.args
         assert len(texts) <= 2, f"chunk size {len(texts)} exceeds batch_size 2"
-    all_texts = sorted(t for call in calls for t in call.args[0])
-    assert all_texts == sorted(f"rel_{i}" for i in range(5))
+        all_texts.extend(texts)
+    assert sorted(all_texts) == sorted(f"rel_{i}" for i in range(5))
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
+++ b/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
@@ -46,7 +46,9 @@ def _make_fake_hybrid(batch_size: int):
     fake._graph._session = MagicMock(return_value=session_cm)
 
     async def embed_data(texts):
-        if len(texts) > batch_size:
+        # batch_size <= 0 means "no per-call cap" — the production code is expected
+        # to fall back to a single all-in-one call, so don't enforce here.
+        if batch_size > 0 and len(texts) > batch_size:
             raise ValueError(
                 f"embed_data called with {len(texts)} texts, exceeds batch_size={batch_size}"
             )
@@ -94,3 +96,35 @@ async def test_add_edges_with_vectors_chunks_by_batch_size():
         assert len(texts) <= 2, f"chunk size {len(texts)} exceeds batch_size 2"
     all_texts = sorted(t for call in calls for t in call.args[0])
     assert all_texts == sorted(f"rel_{i}" for i in range(5))
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_with_vectors_batch_size_zero_falls_back_to_single_call():
+    """get_batch_size()==0 must not crash on `range() arg 3 must not be zero`.
+
+    The adapter falls back to len(texts) so the loop runs exactly once and
+    embed_data is called with all inputs at once (matches pre-batching behavior).
+    """
+    adapter = _make_fake_hybrid(batch_size=0)
+    nodes = [_Node(id=uuid4(), name=f"n{i}") for i in range(5)]
+
+    await adapter.add_nodes_with_vectors(nodes)
+
+    calls = adapter._vector.embed_data.await_args_list
+    assert len(calls) == 1, f"expected 1 fallback call, got {len(calls)}"
+    (texts,) = calls[0].args
+    assert sorted(texts) == sorted(f"n{i}" for i in range(5))
+
+
+@pytest.mark.asyncio
+async def test_add_edges_with_vectors_batch_size_zero_falls_back_to_single_call():
+    """Same fallback for edges: get_batch_size()==0 → one all-inputs call."""
+    adapter = _make_fake_hybrid(batch_size=0)
+    edges = [(str(uuid4()), str(uuid4()), f"rel_{i}", {"edge_text": f"rel_{i}"}) for i in range(5)]
+
+    await adapter.add_edges_with_vectors(edges)
+
+    calls = adapter._vector.embed_data.await_args_list
+    assert len(calls) == 1, f"expected 1 fallback call, got {len(calls)}"
+    (texts,) = calls[0].args
+    assert sorted(texts) == sorted(f"rel_{i}" for i in range(5))

--- a/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
+++ b/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
@@ -1,0 +1,96 @@
+"""Regression tests: PostgresHybridAdapter must respect embedding batch size.
+
+The pghybrid adapter delegates embeddings to its underlying vector adapter.
+Some embedding providers (e.g. gemini-embedding-001, batch limit 100) reject
+calls with too many inputs in a single request. Both add_nodes_with_vectors
+and add_edges_with_vectors must chunk by embedding_engine.get_batch_size()
+before calling embed_data, mirroring index_data_points.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("asyncpg", reason="PostgresHybridAdapter requires the postgres extra")
+pytest.importorskip("pgvector", reason="PostgresHybridAdapter requires the postgres extra")
+
+from cognee.infrastructure.engine import DataPoint  # noqa: E402
+from cognee.infrastructure.databases.hybrid.postgres.adapter import (  # noqa: E402
+    PostgresHybridAdapter,
+)
+
+
+class _Node(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"]}
+
+
+def _make_fake_hybrid(batch_size: int):
+    """Build a PostgresHybridAdapter with stubbed graph/vector adapters.
+
+    embed_data raises if called with more inputs than batch_size, so any
+    failure to chunk surfaces as a ValueError from the test.
+    """
+    fake = PostgresHybridAdapter.__new__(PostgresHybridAdapter)
+
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=None)
+
+    fake._graph = MagicMock()
+    fake._graph.initialize = AsyncMock()
+    fake._graph._session = MagicMock(return_value=session_cm)
+
+    async def embed_data(texts):
+        if len(texts) > batch_size:
+            raise ValueError(
+                f"embed_data called with {len(texts)} texts, exceeds batch_size={batch_size}"
+            )
+        return [[0.1, 0.2] for _ in texts]
+
+    fake._vector = MagicMock()
+    fake._vector.embed_data = AsyncMock(side_effect=embed_data)
+    fake._vector.create_vector_index = AsyncMock()
+    fake._vector.embedding_engine = MagicMock()
+    fake._vector.embedding_engine.get_batch_size = MagicMock(return_value=batch_size)
+    fake.embedding_engine = fake._vector.embedding_engine
+
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_with_vectors_chunks_by_batch_size():
+    """5 nodes + batch_size=2 → embed_data must be called 3 times in chunks of ≤2."""
+    adapter = _make_fake_hybrid(batch_size=2)
+    nodes = [_Node(id=uuid4(), name=f"n{i}") for i in range(5)]
+
+    await adapter.add_nodes_with_vectors(nodes)
+
+    calls = adapter._vector.embed_data.await_args_list
+    assert len(calls) == 3, f"expected 3 chunked calls, got {len(calls)}"
+    for call in calls:
+        (texts,) = call.args
+        assert len(texts) <= 2, f"chunk size {len(texts)} exceeds batch_size 2"
+    all_texts = [t for call in calls for t in call.args[0]]
+    assert sorted(all_texts) == sorted(f"n{i}" for i in range(5))
+
+
+@pytest.mark.asyncio
+async def test_add_edges_with_vectors_chunks_by_batch_size():
+    """5 unique edge types + batch_size=2 → embed_data must be called 3 times."""
+    adapter = _make_fake_hybrid(batch_size=2)
+    edges = [(str(uuid4()), str(uuid4()), f"rel_{i}", {"edge_text": f"rel_{i}"}) for i in range(5)]
+
+    await adapter.add_edges_with_vectors(edges)
+
+    calls = adapter._vector.embed_data.await_args_list
+    assert len(calls) == 3, f"expected 3 chunked calls, got {len(calls)}"
+    for call in calls:
+        (texts,) = call.args
+        assert len(texts) <= 2, f"chunk size {len(texts)} exceeds batch_size 2"
+    all_texts = sorted(t for call in calls for t in call.args[0])
+    assert all_texts == sorted(f"rel_{i}" for i in range(5))

--- a/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
+++ b/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
@@ -130,3 +130,36 @@ async def test_add_edges_with_vectors_batch_size_zero_falls_back_to_single_call(
     assert len(calls) == 1, f"expected 1 fallback call, got {len(calls)}"
     (texts,) = calls[0].args
     assert sorted(texts) == sorted(f"rel_{i}" for i in range(5))
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_with_vectors_negative_batch_size_falls_back_to_single_call():
+    """Negative get_batch_size() must not silently drop embeddings.
+
+    range(0, n, -1) yields no iterations, so without the guard the loop would
+    skip every input and `vectors` would stay empty — silent data loss. The
+    fallback to len(items) makes the loop run once with all inputs.
+    """
+    adapter = _make_fake_hybrid(batch_size=-1)
+    nodes = [_Node(id=uuid4(), name=f"n{i}") for i in range(5)]
+
+    await adapter.add_nodes_with_vectors(nodes)
+
+    calls = adapter._vector.embed_data.await_args_list
+    assert len(calls) == 1, f"expected 1 fallback call, got {len(calls)}"
+    (texts,) = calls[0].args
+    assert sorted(texts) == sorted(f"n{i}" for i in range(5))
+
+
+@pytest.mark.asyncio
+async def test_add_edges_with_vectors_negative_batch_size_falls_back_to_single_call():
+    """Same fallback for edges: negative get_batch_size() → one all-inputs call."""
+    adapter = _make_fake_hybrid(batch_size=-1)
+    edges = [(str(uuid4()), str(uuid4()), f"rel_{i}", {"edge_text": f"rel_{i}"}) for i in range(5)]
+
+    await adapter.add_edges_with_vectors(edges)
+
+    calls = adapter._vector.embed_data.await_args_list
+    assert len(calls) == 1, f"expected 1 fallback call, got {len(calls)}"
+    (texts,) = calls[0].args
+    assert sorted(texts) == sorted(f"rel_{i}" for i in range(5))


### PR DESCRIPTION
## Problem

`PostgresHybridAdapter.add_nodes_with_vectors` and `add_edges_with_vectors` send their full text list to `self._vector.embed_data()` in a single call, ignoring `embedding_engine.get_batch_size()`. Embedding providers with a per-call batch limit reject any document large enough to exceed it:

- `gemini/gemini-embedding-001` — 100 inputs/call max
- some self-hosted/compatible endpoints — smaller still

Reproducer: configure cognee with `EMBEDDING_PROVIDER=gemini`, `EMBEDDING_MODEL=gemini/gemini-embedding-001`, `USE_UNIFIED_PROVIDER=pghybrid`. POST a ~30 KB markdown doc (or any doc that yields >100 unique entity texts or >100 unique edge-type names) to `/api/v1/remember`. Logs show:

```
EmbeddingException ... (Status code: 422)
"Number of input texts cannot exceed 100"
PipelineRunFailedError: Pipeline run failed.
```

## Fix

Mirror the precedent in [`cognee/tasks/storage/index_data_points.py:56-63`](https://github.com/topoteretes/cognee/blob/dev/cognee/tasks/storage/index_data_points.py#L56-L63): chunk by `embedding_engine.get_batch_size()` before each `embed_data` call.

Two hunks, 8 net lines added in [`cognee/infrastructure/databases/hybrid/postgres/adapter.py`](cognee/infrastructure/databases/hybrid/postgres/adapter.py).

## Tests

New regression file [`cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py`](cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py) with two unit tests (one per fixed method). The fakes install an `embed_data` that **raises if called with more inputs than `batch_size`**, so any failure-to-chunk surfaces as `ValueError` and any drop/dup of inputs is caught by the union-of-chunks assertion. Tests use `pytest.importorskip("asyncpg")` / `pytest.importorskip("pgvector")`, mirroring the optional-dep guard in `test_neptune_analytics_hybrid.py`.

Confirmed the tests fail on the unpatched adapter and pass on the patched one.

## Duplicate search performed

Before drafting, queried `topoteretes/cognee` via `gh`:

- `gh pr list --search "pghybrid"` — closest hits #2587 / #2502 / #2755 (all introduced/refactored pghybrid; none address batch size)
- `gh pr list --search "get_batch_size"` — no hits to the same files
- `gh pr list --search "embedding batch"` — closest is #2616 (Ollama/Fastembed context-window handling — different concern: token limits per call, not input-count limits)
- `gh pr list --search "add_nodes_with_vectors"` — only #2710 (added the methods to `NeptuneAnalyticsAdapter`; see follow-up note below)
- `gh issue list --search "pghybrid"` — no hits
- `gh issue list --search "Number of input texts cannot exceed"` — no hits

No duplicate, no related open PR.

## Verification

Run on `dev` (baseline) vs this branch, after `uv sync --extra api --extra docs --extra evals --extra codegraph --extra ollama --extra dev --extra neo4j --extra redis --extra tracing --extra scraping --extra postgres` (mirrors `cognee_setup` action + per-job extras), against local pgvector/redis containers configured to match CI:

| Tree | dev | this branch |
|---|---|---|
| `pytest cognee/tests/unit/` | 1505 passed, 9 skipped | **1508 passed, 8 skipped** (+2 new regression tests; +1 previously-skipped now collected via postgres extra) |
| `pytest cognee/tests/integration/` (3 known-broken-on-dev files deselected, see below) | 11 failed, 113 passed | **11 failed, 113 passed (identical failure list)** |
| `pytest cognee/tests/e2e/` | 41 passed | **41 passed** |
| `python cognee/tests/e2e/postgres/test_pghybrid.py` | passed | **passed** |

Ran with `--timeout=120 --timeout-method=signal` per-test.

`diff` of the integration failure list between `dev` and this branch is empty — this PR introduces zero new failures.

### Pre-existing dev test failures and hangs (filed separately)

While baselining I observed several pre-existing failures and hangs on `dev` HEAD. None are caused by this PR; all reproduce on `dev` and (where applicable) in upstream CI. Three integration files were deselected from the comparison runs above:

- `cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py` — hangs indefinitely in the full-suite run. Same hang in CI's `Run Integration Tests / Integration - Web & Infrastructure` job (run [25354640017](https://github.com/topoteretes/cognee/actions/runs/25354640017), the test step ran 6h until GH Actions cancelled it). Each individual test passes in isolation, so it's a test-isolation/state-pollution issue.
- `cognee/tests/integration/infrastructure/session/test_session_manager_redis.py` — multiple failures in CI's same job (`..FFFF.FFFF.FFF` cluster).
- `cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py` — same shape as the persistence file.

Happy to file these as standalone issues if maintainers prefer.

## What this PR deliberately does NOT do

- **No change to `NeptuneAnalyticsAdapter`.** PR #2710 added `add_nodes_with_vectors` / `add_edges_with_vectors` to that adapter using a similar shape; from the file alone it's plausible the same batch-size omission exists there. I did not extend the fix because (a) Neptune is a different code path with its own integration tests, and (b) keeping the PR scope minimal made sense. Flagging it for maintainer judgment — happy to extend in this PR or follow up separately.
- **No change to behavior for providers with large limits** — when `batch_size` ≥ `len(texts)` the loop runs once and is functionally equivalent to the old single call.

## DCO

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Embedding generation for node and edge data now processes inputs in configurable batches and safely falls back to a single-call embedding when the configured batch size is unset or non-positive.

* **Tests**
  * Added regression tests confirming correct batched embedding behavior and verifying the safe fallback for non-positive batch size values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->