### PR TITLE
fix: improve infer-schema prompt for comprehensive output

### DIFF
--- a/cognee/infrastructure/llm/prompts/infer_schema_system.txt
+++ b/cognee/infrastructure/llm/prompts/infer_schema_system.txt
@@ -19,7 +19,7 @@ Requirements for the generated schema:
    - Object reference: {"$ref": "#/$defs/TypeName"} for one-to-one
    - Array of references: {"type": "array", "items": {"$ref": "#/$defs/TypeName"}} for one-to-many
 5. Use snake_case for property/relationship names.
-6. Keep the schema minimal — only include types and relationships clearly supported by the text.
+6. Be thorough — include all distinct entity types and relationships clearly supported by the text. Aim for comprehensive coverage of the domain rather than a minimal schema.
 7. Do not include infrastructure fields (id, created_at, version, etc.) — only domain fields.
 8. Prefer clear, descriptive type names that reflect the domain.
 


### PR DESCRIPTION
## Summary
- Changes the `infer_schema_system.txt` prompt from "Keep the schema minimal" to "Be thorough — include all distinct entity types and relationships"
- The previous "minimal" instruction caused the LLM to return only 3-4 entity types even for complex documents (e.g. Alice in Wonderland full text)

## Context
This was identified and first fixed on the cloud side (inline prompt override). Now upstreaming to OSS so cloud can use the OSS endpoint directly.

Note: The OSS `dev` branch already fixed the JSON parsing reliability issue by switching from `response_model=str` + `json.loads()` to a proper `InferredGraphSchemaDTO` Pydantic model — so the `_extract_json` helper from cloud is not needed here.

## Test plan
- [ ] Upload a large text file and infer schema — should return more than 4 entity types
- [ ] Verify small text inference still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced schema generation to identify more comprehensive entity types and relationships, providing better coverage of domain information during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->