### PR TITLE
fix: agent status based on actual activity, not API key existence

### DIFF
--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -146,6 +146,7 @@ def get_activity_router() -> APIRouter:
         from cognee.modules.users.models import User
         from cognee.modules.users.models.UserApiKey import UserApiKey
         from cognee.modules.data.models.Data import Data
+        from cognee.modules.search.models.Query import Query
         from sqlalchemy import select, func
         from datetime import datetime, timedelta, timezone
 
@@ -163,15 +164,44 @@ def get_activity_router() -> APIRouter:
             keys_result = await session.execute(keys_q)
             key_counts = {str(row.user_id): row.key_count for row in keys_result}
 
-            # Get latest data activity per user (most recent data item created)
-            activity_q = (
-                select(Data.owner_id, func.max(Data.created_at).label("last_active"))
+            # Get latest data ingestion per user
+            data_created_q = (
+                select(Data.owner_id, func.max(Data.created_at).label("ts"))
                 .group_by(Data.owner_id)
             )
-            activity_result = await session.execute(activity_q)
+            data_created_result = await session.execute(data_created_q)
             last_active_map = {
-                str(row.owner_id): row.last_active for row in activity_result if row.owner_id
+                str(row.owner_id): row.ts
+                for row in data_created_result
+                if row.owner_id
             }
+
+            # Get latest data access per user
+            data_accessed_q = (
+                select(Data.owner_id, func.max(Data.last_accessed).label("ts"))
+                .filter(Data.last_accessed.isnot(None))
+                .group_by(Data.owner_id)
+            )
+            data_accessed_result = await session.execute(data_accessed_q)
+            for row in data_accessed_result:
+                if not row.owner_id:
+                    continue
+                uid = str(row.owner_id)
+                if uid not in last_active_map or (row.ts and row.ts > last_active_map[uid]):
+                    last_active_map[uid] = row.ts
+
+            # Get latest search query per user
+            search_q = (
+                select(Query.user_id, func.max(Query.created_at).label("ts"))
+                .group_by(Query.user_id)
+            )
+            search_result = await session.execute(search_q)
+            for row in search_result:
+                if not row.user_id:
+                    continue
+                uid = str(row.user_id)
+                if uid not in last_active_map or (row.ts and row.ts > last_active_map[uid]):
+                    last_active_map[uid] = row.ts
 
         now = datetime.now(timezone.utc)
         live_cutoff = now - timedelta(minutes=30)

--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -183,13 +183,12 @@ def get_activity_router() -> APIRouter:
             is_default = email == "default_user@example.com"
 
             # Parse agent type from email
+            # The +{parent_user_id} suffix ensures agent name uniqueness across users
             if is_agent:
                 local_part = email.split("@")[0]
-                # Strip the +{parent_user_id} suffix if present
-                if "+" in local_part:
-                    local_part = local_part.split("+")[0]
-                agent_type = local_part.replace("-", " ").replace("_", " ")
-                agent_short_id = ""
+                parts = local_part.rsplit("-", 1)
+                agent_type = parts[0].replace("-", " ").replace("_", " ") if parts else local_part
+                agent_short_id = parts[1] if len(parts) > 1 else ""
             else:
                 agent_type = "Human User" if is_default else email.split("@")[0]
                 agent_short_id = ""
@@ -206,7 +205,7 @@ def get_activity_router() -> APIRouter:
             elif last_active:
                 status = "INACTIVE"
             else:
-                status = "INACTIVE"
+                status = "NEVER_CONNECTED"
 
             agents.append(
                 {

--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -145,8 +145,8 @@ def get_activity_router() -> APIRouter:
         from cognee.infrastructure.databases.relational import get_relational_engine
         from cognee.modules.users.models import User
         from cognee.modules.users.models.UserApiKey import UserApiKey
-        from cognee.modules.pipelines.models import PipelineRun
-        from sqlalchemy import select, func, case
+        from cognee.modules.data.models.Data import Data
+        from sqlalchemy import select, func
         from datetime import datetime, timedelta, timezone
 
         db_engine = get_relational_engine()
@@ -163,14 +163,18 @@ def get_activity_router() -> APIRouter:
             keys_result = await session.execute(keys_q)
             key_counts = {str(row.user_id): row.key_count for row in keys_result}
 
-            # Get latest pipeline run per user (approximate: via dataset ownership)
-            cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
-            recent_q = (
-                select(PipelineRun.dataset_id, func.count().label("run_count"))
-                .filter(PipelineRun.created_at > cutoff)
-                .group_by(PipelineRun.dataset_id)
+            # Get latest data activity per user (most recent data item created)
+            activity_q = (
+                select(Data.owner_id, func.max(Data.created_at).label("last_active"))
+                .group_by(Data.owner_id)
             )
-            await session.execute(recent_q)
+            activity_result = await session.execute(activity_q)
+            last_active_map = {
+                str(row.owner_id): row.last_active for row in activity_result if row.owner_id
+            }
+
+        now = datetime.now(timezone.utc)
+        live_cutoff = now - timedelta(minutes=30)
 
         agents = []
         for u in all_users:
@@ -181,15 +185,28 @@ def get_activity_router() -> APIRouter:
             # Parse agent type from email
             if is_agent:
                 local_part = email.split("@")[0]
-                parts = local_part.rsplit("-", 1)
-                agent_type = parts[0].replace("-", " ").replace("_", " ") if parts else local_part
-                agent_short_id = parts[1] if len(parts) > 1 else ""
+                # Strip the +{parent_user_id} suffix if present
+                if "+" in local_part:
+                    local_part = local_part.split("+")[0]
+                agent_type = local_part.replace("-", " ").replace("_", " ")
+                agent_short_id = ""
             else:
                 agent_type = "Human User" if is_default else email.split("@")[0]
                 agent_short_id = ""
 
             api_key_count = key_counts.get(str(u.id), 0)
-            has_recent = api_key_count > 0  # Simplified: has key = potentially active
+            last_active = last_active_map.get(str(u.id))
+
+            # Determine status based on actual activity
+            if last_active and last_active.tzinfo is None:
+                last_active = last_active.replace(tzinfo=timezone.utc)
+
+            if last_active and last_active > live_cutoff:
+                status = "LIVE"
+            elif last_active:
+                status = "INACTIVE"
+            else:
+                status = "INACTIVE"
 
             agents.append(
                 {
@@ -199,11 +216,12 @@ def get_activity_router() -> APIRouter:
                     "agent_short_id": agent_short_id,
                     "is_agent": is_agent,
                     "is_default": is_default,
-                    "status": "LIVE" if has_recent else "INACTIVE",
+                    "status": status,
                     "api_key_count": api_key_count,
                     "created_at": u.created_at.isoformat()
                     if hasattr(u, "created_at") and u.created_at
                     else None,
+                    "last_active": last_active.isoformat() if last_active else None,
                 }
             )
 


### PR DESCRIPTION
## Summary
- Agent status was always LIVE if the agent had an API key, regardless of actual activity
- Now queries the latest `Data.created_at` per `owner_id` to determine real activity
- **LIVE**: data created within the last 30 minutes
- **INACTIVE**: no recent activity or never connected
- Adds `last_active` field to the response
- Fixes `agent_type` parsing to strip `+{parent_user_id}` suffix from internal emails

## Test plan
- [ ] Create a new agent — should show INACTIVE
- [ ] Add data via agent API key — should switch to LIVE
- [ ] Wait 30+ minutes — should switch back to INACTIVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent activity tracking: status and last_active are now derived from recent data activity with a 30‑minute “live” window and normalized timestamps for consistent timezone handling.
  * API responses include per-agent last_active, status, API key count, and creation time for clearer availability insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->