### PR TITLE
Allow 'dataset_ids' in 'recall'

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -5,10 +5,10 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict, Unpack
 
-from cognee.infrastructure.databases.cache import SessionAgentTraceEntry, SessionQAEntry
-from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
 from cognee.context_global_variables import set_session_user_context_variable
 from cognee.exceptions import CogneeValidationError
+from cognee.infrastructure.databases.cache import SessionAgentTraceEntry, SessionQAEntry
+from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
 from cognee.memory.entries import normalize_scope
 from cognee.modules.data.exceptions import DatasetNotFoundError
 from cognee.modules.data.methods import get_authorized_existing_datasets
@@ -45,7 +45,6 @@ _MIN_WORD_LEN = 2
 class RecallKwargs(TypedDict, total=False):
     """Power-user overrides for recall(). Most users never need these."""
 
-    dataset_ids: list[UUID]
     system_prompt: str
     system_prompt_path: str
     node_name: list[str]
@@ -317,6 +316,7 @@ async def recall(
     query_type: SearchType | None = None,
     *,
     datasets: list[str] | None = None,
+    dataset_ids: list[UUID] | None = None,
     top_k: int = 10,
     auto_route: bool = True,
     scope: str | list[str] | None = None,
@@ -342,6 +342,7 @@ async def recall(
         query_text: Natural-language query.
         query_type: Search strategy. When provided, the router is bypassed.
         datasets: Dataset names to search within.
+        dataset_ids: Alternative to datasets - use specific UUID identifiers. If set this takes precedence over datasets.
         top_k: Maximum results to return (default *10*).
         auto_route: If True and query_type is None, classify the query
             automatically. If False, fall back to GRAPH_COMPLETION.
@@ -371,7 +372,7 @@ async def recall(
     # Explicit ``scope`` values bypass this entirely.
     resolved_scope = normalize_scope(scope)
     if resolved_scope == ["auto"]:
-        if session_id and not datasets and query_type is None:
+        if session_id and not datasets and not dataset_ids and query_type is None:
             sources = ["session", "graph"]
             auto_fallthrough = True  # session hit short-circuits graph
         elif session_id and query_type is None:
@@ -416,6 +417,7 @@ async def recall(
                 query_text,
                 query_type,
                 datasets=datasets,
+                dataset_ids=dataset_ids,
                 top_k=top_k,
                 scope=scope,
                 **kwargs,
@@ -458,7 +460,7 @@ async def recall(
             return list(await _fetch_graph_context(session_id=session_id, user=user))
 
         async def _run_graph() -> list[RecallResponse]:
-            nonlocal user
+            nonlocal user, dataset_ids
 
             from cognee.modules.recall.methods.normalize_search_payload import (
                 normalize_search_payload,
@@ -501,15 +503,17 @@ async def recall(
                 str(local_query_type.value) if local_query_type else "unknown",
             )
 
-            # Transform string based datasets to UUID - String based datasets can only be found for current user
-            dataset_ids: list[UUID] | None = None
-            if datasets is not None:
-                dataset_ids = [
-                    dataset.id
-                    for dataset in await get_authorized_existing_datasets(datasets, "read", user)
-                ]
-                if not dataset_ids:
-                    raise DatasetNotFoundError(message="No datasets found.")
+            if dataset_ids is None:
+                # Transform string based datasets to UUID - String based datasets can only be found for current user
+                if datasets is not None:
+                    dataset_ids = [
+                        dataset.id
+                        for dataset in await get_authorized_existing_datasets(
+                            datasets, "read", user
+                        )
+                    ]
+                    if not dataset_ids:
+                        raise DatasetNotFoundError(message="No datasets found.")
 
             graph_results = await authorized_search(
                 query_text=query_text,

--- a/cognee/tests/unit/api/v1/recall/test_recall_api.py
+++ b/cognee/tests/unit/api/v1/recall/test_recall_api.py
@@ -1,0 +1,176 @@
+import importlib
+import types
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.search.types import SearchType
+
+
+def _make_user(user_id=None, tenant_id=None):
+    return types.SimpleNamespace(id=user_id or uuid4(), tenant_id=tenant_id)
+
+
+@pytest.fixture
+def api_recall_mod():
+    return importlib.import_module("cognee.api.v1.recall.recall")
+
+
+@pytest.mark.asyncio
+async def test_recall_dataset_ids_takes_precedence_over_datasets(monkeypatch, api_recall_mod):
+    user = _make_user()
+    explicit_id = uuid4()
+
+    captured = {}
+
+    async def dummy_set_session_user_context_variable(_user):
+        return None
+
+    async def dummy_authorized_search(**kwargs):
+        captured["dataset_ids"] = kwargs.get("dataset_ids")
+        return []
+
+    async def dummy_get_authorized_existing_datasets(*args, **kwargs):
+        captured["resolved_from_datasets"] = True
+        return []
+
+    def dummy_get_remote_client():
+        return None
+
+    monkeypatch.setattr(
+        api_recall_mod,
+        "set_session_user_context_variable",
+        dummy_set_session_user_context_variable,
+    )
+    monkeypatch.setattr(
+        api_recall_mod,
+        "get_authorized_existing_datasets",
+        dummy_get_authorized_existing_datasets,
+    )
+
+    serve_state = importlib.import_module("cognee.api.v1.serve.state")
+    search_methods = importlib.import_module("cognee.modules.search.methods.search")
+
+    monkeypatch.setattr(serve_state, "get_remote_client", dummy_get_remote_client)
+    monkeypatch.setattr(search_methods, "authorized_search", dummy_authorized_search)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        datasets=["some_dataset_name"],
+        dataset_ids=[explicit_id],
+        auto_route=False,
+        user=user,
+    )
+
+    assert out == []
+    assert captured["dataset_ids"] == [explicit_id]
+    assert "resolved_from_datasets" not in captured
+
+
+@pytest.mark.asyncio
+async def test_recall_remote_client_forwards_dataset_ids(monkeypatch, api_recall_mod):
+    user = _make_user()
+    explicit_id = uuid4()
+
+    captured = {}
+
+    async def dummy_remote_recall(query_text, query_type, **kwargs):
+        captured["dataset_ids"] = kwargs.get("dataset_ids")
+        return []
+
+    dummy_remote_client = types.SimpleNamespace(recall=dummy_remote_recall)
+
+    def dummy_get_remote_client():
+        return dummy_remote_client
+
+    async def dummy_get_authorized_existing_datasets(*args, **kwargs):
+        captured["resolved_from_datasets"] = True
+        return []
+
+    monkeypatch.setattr(
+        api_recall_mod,
+        "get_authorized_existing_datasets",
+        dummy_get_authorized_existing_datasets,
+    )
+
+    serve_state = importlib.import_module("cognee.api.v1.serve.state")
+    monkeypatch.setattr(serve_state, "get_remote_client", dummy_get_remote_client)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        datasets=["some_dataset_name"],
+        dataset_ids=[explicit_id],
+        auto_route=False,
+        user=user,
+    )
+
+    assert out == []
+    assert captured["dataset_ids"] == [explicit_id]
+    assert "resolved_from_datasets" not in captured
+
+
+@pytest.mark.asyncio
+async def test_recall_session_with_dataset_ids_does_not_short_circuit_graph(
+    monkeypatch, api_recall_mod
+):
+    user = _make_user()
+    explicit_id = uuid4()
+
+    captured = {}
+
+    async def dummy_set_session_user_context_variable(_user):
+        return None
+
+    async def dummy_authorized_search(**kwargs):
+        captured["dataset_ids"] = kwargs.get("dataset_ids")
+        return []
+
+    async def dummy_get_authorized_existing_datasets(*args, **kwargs):
+        captured["resolved_from_datasets"] = True
+        return []
+
+    def dummy_get_remote_client():
+        return None
+
+    async def dummy_search_session(**kwargs):
+        return []
+
+    async def dummy_search_trace(**kwargs):
+        return []
+
+    async def dummy_fetch_graph_context(**kwargs):
+        return []
+
+    monkeypatch.setattr(
+        api_recall_mod,
+        "set_session_user_context_variable",
+        dummy_set_session_user_context_variable,
+    )
+    monkeypatch.setattr(
+        api_recall_mod,
+        "get_authorized_existing_datasets",
+        dummy_get_authorized_existing_datasets,
+    )
+    monkeypatch.setattr(api_recall_mod, "_search_session", dummy_search_session)
+    monkeypatch.setattr(api_recall_mod, "_search_trace", dummy_search_trace)
+    monkeypatch.setattr(api_recall_mod, "_fetch_graph_context", dummy_fetch_graph_context)
+
+    serve_state = importlib.import_module("cognee.api.v1.serve.state")
+    search_methods = importlib.import_module("cognee.modules.search.methods.search")
+
+    monkeypatch.setattr(serve_state, "get_remote_client", dummy_get_remote_client)
+    monkeypatch.setattr(search_methods, "authorized_search", dummy_authorized_search)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        query_type=None,
+        dataset_ids=[explicit_id],
+        session_id="session-1",
+        user=user,
+    )
+
+    assert out == []
+    assert captured["dataset_ids"] == [explicit_id]
+    assert "resolved_from_datasets" not in captured


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
The 'recall' REST API allows both 'datasets' and 'dataset_ids' parameters, but the 'recall' function only supports 'datasets'. In older versions this wasn't an issue, because 'dataset_ids' is forwarded as a kwarg to 'search' which supports it. With the refactoring of 'recall' return types, this is forwarded to a different function which doesn't support this parameter.
To fix this we introduce 'dataset_ids' as a parameter and handle it in the same way as in 'search': If both 'datasets' and 'dataset_ids' are set, 'dataset_ids' takes precendence.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->
`dataset_ids` are supported.
All tests succeed.

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recall search now accepts direct dataset identifiers, which take precedence over dataset-name selection and are honored for remote recall requests.
  * Session-cache-only recall now only applies when no direct dataset identifiers or dataset selections are provided, avoiding unexpected short-circuits.

* **Tests**
  * Added tests covering precedence, forwarding of direct identifiers, and session-vs-remote recall behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->