### PR TITLE
fix: auto-share agent-created datasets with parent user

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -15,15 +15,13 @@ from cognee import datasets
 from cognee.api.DTO import InDTO, OutDTO
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.data.methods import get_authorized_existing_datasets
-from cognee.modules.data.methods import create_dataset, get_datasets_by_name
+from cognee.modules.data.methods import get_datasets_by_name
+from cognee.modules.data.methods.create_authorized_dataset import create_authorized_dataset
 from cognee.shared.logging_utils import get_logger
 from cognee.api.v1.exceptions import DataNotFoundError
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
-from cognee.modules.users.permissions.methods import (
-    get_all_user_permission_datasets,
-    give_permission_on_dataset,
-)
+from cognee.modules.users.permissions.methods import get_all_user_permission_datasets
 from cognee.modules.graph.methods import get_formatted_graph_data
 from cognee.modules.pipelines.models import PipelineRunStatus
 from cognee.shared.utils import send_telemetry
@@ -168,18 +166,9 @@ def get_datasets_router() -> APIRouter:
             if datasets:
                 return datasets[0]
 
-            db_engine = get_relational_engine()
-            async with db_engine.get_async_session() as session:
-                dataset = await create_dataset(
-                    dataset_name=dataset_data.name, user=user, session=session
-                )
+            dataset = await create_authorized_dataset(dataset_data.name, user)
 
-                await give_permission_on_dataset(user, dataset.id, "read")
-                await give_permission_on_dataset(user, dataset.id, "write")
-                await give_permission_on_dataset(user, dataset.id, "share")
-                await give_permission_on_dataset(user, dataset.id, "delete")
-
-                return dataset
+            return dataset
         except Exception as error:
             logger.error(f"Error creating dataset: {str(error)}")
             raise HTTPException(


### PR DESCRIPTION
## Summary
- When an agent creates a dataset via `POST /api/v1/datasets`, the parent user (tenant owner) was **not** granted permissions on the new dataset
- The endpoint manually called `create_dataset()` + `give_permission_on_dataset()` only for the calling agent, bypassing the `parent_user_id` auto-share logic that exists in `create_authorized_dataset()`
- Replaced with `create_authorized_dataset()` which already handles granting permissions to both the agent and its parent user

## Root cause
Two different dataset creation paths existed:
1. `POST /api/v1/datasets/` → `create_dataset()` (no parent auto-share)
2. `add()` / `remember()` → `load_or_create_datasets()` → `create_authorized_dataset()` (has parent auto-share)

## Test plan
- [ ] Create an agent under a parent user
- [ ] Have the agent call `POST /api/v1/datasets/` to create a new dataset
- [ ] Verify the parent user can see the dataset in their dataset list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal dataset creation workflow for better code maintainability with no changes to user-facing functionality or API behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2816)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->