### PR TITLE
fix: await storage function while visualization

### DIFF
--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -105,7 +105,7 @@ async def cognee_network_visualization(
     file_path = os.path.basename(destination_file_path)
 
     file_storage = LocalFileStorage(dir_path)
-    file_storage.store(file_path, html_content, overwrite=True)
+    await file_storage.store(file_path, html_content, overwrite=True)
 
     logger.info(f"Graph visualization saved as {destination_file_path}")
 

--- a/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
@@ -299,7 +299,9 @@ async def test_rag_completion_context_complex(setup_test_environment_with_chunks
 
 
 @pytest.mark.asyncio
-async def test_rag_completion_context_top_k_limits_results(setup_test_environment_with_chunks_complex):
+async def test_rag_completion_context_top_k_limits_results(
+    setup_test_environment_with_chunks_complex,
+):
     """Integration test: verify top_k parameter limits the number of retrieved chunks."""
     top_k = 2
     retriever = CompletionRetriever(top_k=top_k)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
This PR awaits an async store function, which was sending warnings during visualization.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network visualization file saving reliability to ensure generated graphs are properly persisted to disk before the operation completes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2827)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->