### PR TITLE
fix(llm): tune default rate limit for GPT-5.5

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -62,8 +62,8 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 #LLM_ARGS='{}'
 
 # LLM rate limiting
-#LLM_RATE_LIMIT_ENABLED=true
-#LLM_RATE_LIMIT_REQUESTS=60
+LLM_RATE_LIMIT_ENABLED=true
+LLM_RATE_LIMIT_REQUESTS=450
 #LLM_RATE_LIMIT_INTERVAL=60
 
 ################################################################################

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -193,8 +193,8 @@ async def cognify(
 
         Optional (same as add function):
         - LLM_PROVIDER, LLM_MODEL, VECTOR_DB_PROVIDER, GRAPH_DATABASE_PROVIDER
-        - LLM_RATE_LIMIT_ENABLED: Enable rate limiting (default: False)
-        - LLM_RATE_LIMIT_REQUESTS: Max requests per interval (default: 60)
+        - LLM_RATE_LIMIT_ENABLED: Enable rate limiting (default: True)
+        - LLM_RATE_LIMIT_REQUESTS: Max requests per interval (default: 450)
     """
     # Route to remote instance if connected via serve()
     from cognee.api.v1.serve.state import get_remote_client

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -61,9 +61,9 @@ class LLMConfig(BaseSettings):
     graph_prompt_path: str = "generate_graph_prompt.txt"
     temporal_graph_prompt_path: str = "generate_event_graph_prompt.txt"
     event_entity_prompt_path: str = "generate_event_entity_prompt.txt"
-    llm_rate_limit_enabled: bool = False
-    llm_rate_limit_requests: int = 60
-    llm_rate_limit_interval: int = 60  # in seconds (default is 60 requests per minute)
+    llm_rate_limit_enabled: bool = True
+    llm_rate_limit_requests: int = 450
+    llm_rate_limit_interval: int = 60  # in seconds (default is 450 requests per minute)
     llm_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
     embedding_rate_limit_enabled: bool = False
     embedding_rate_limit_requests: int = 60

--- a/cognee/shared/rate_limiting.py
+++ b/cognee/shared/rate_limiting.py
@@ -7,7 +7,7 @@ from cognee.infrastructure.llm.config import get_llm_config
 llm_config = get_llm_config()
 
 llm_rate_limiter = AsyncLimiter(
-    llm_config.llm_rate_limit_requests, llm_config.embedding_rate_limit_interval
+    llm_config.llm_rate_limit_requests, llm_config.llm_rate_limit_interval
 )
 embedding_rate_limiter = AsyncLimiter(
     llm_config.embedding_rate_limit_requests, llm_config.embedding_rate_limit_interval

--- a/cognee/tests/unit/infrastructure/test_shared_rate_limiting.py
+++ b/cognee/tests/unit/infrastructure/test_shared_rate_limiting.py
@@ -1,0 +1,33 @@
+import importlib
+
+from cognee.infrastructure.llm.config import get_llm_config
+
+
+def test_default_llm_rate_limit_is_below_gpt_5_5_tier_1():
+    get_llm_config.cache_clear()
+
+    config = get_llm_config()
+
+    assert config.llm_rate_limit_enabled is True
+    assert config.llm_rate_limit_requests == 450
+    assert config.llm_rate_limit_interval == 60
+
+
+def test_shared_llm_limiter_uses_llm_interval(monkeypatch):
+    import cognee.shared.rate_limiting as rate_limiting
+
+    with monkeypatch.context() as patched_env:
+        patched_env.setenv("LLM_RATE_LIMIT_ENABLED", "true")
+        patched_env.setenv("LLM_RATE_LIMIT_REQUESTS", "7")
+        patched_env.setenv("LLM_RATE_LIMIT_INTERVAL", "11")
+        patched_env.setenv("EMBEDDING_RATE_LIMIT_INTERVAL", "29")
+        get_llm_config.cache_clear()
+
+        rate_limiting = importlib.reload(rate_limiting)
+
+        assert rate_limiting.llm_rate_limiter.max_rate == 7
+        assert rate_limiting.llm_rate_limiter.time_period == 11
+        assert rate_limiting.embedding_rate_limiter.time_period == 29
+
+    get_llm_config.cache_clear()
+    importlib.reload(rate_limiting)


### PR DESCRIPTION
## Summary
- enable LLM rate limiting by default at 450 requests per 60 seconds
- update .env.template and cognify docs to match the new defaults
- fix the shared LLM limiter to use LLM_RATE_LIMIT_INTERVAL instead of EMBEDDING_RATE_LIMIT_INTERVAL
- add unit coverage for the default and limiter interval wiring

## Current settings before this PR
- LLM_RATE_LIMIT_ENABLED=false
- LLM_RATE_LIMIT_REQUESTS=60
- LLM_RATE_LIMIT_INTERVAL=60
- EMBEDDING_RATE_LIMIT_ENABLED=false
- EMBEDDING_RATE_LIMIT_REQUESTS=60
- EMBEDDING_RATE_LIMIT_INTERVAL=60

## New settings in this PR
- LLM_RATE_LIMIT_ENABLED=true
- LLM_RATE_LIMIT_REQUESTS=450
- LLM_RATE_LIMIT_INTERVAL=60
- embedding rate limit defaults are unchanged

## Tests
- uv run pytest cognee/tests/unit/infrastructure/test_shared_rate_limiting.py -q
- uv run ruff check cognee/infrastructure/llm/config.py cognee/shared/rate_limiting.py cognee/api/v1/cognify/cognify.py cognee/tests/unit/infrastructure/test_shared_rate_limiting.py
- uv run ruff format --check cognee/infrastructure/llm/config.py cognee/shared/rate_limiting.py cognee/api/v1/cognify/cognify.py cognee/tests/unit/infrastructure/test_shared_rate_limiting.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM rate limiting is now enabled by default with increased request limits (450 requests per minute, up from 60)

* **Tests**
  * Added unit tests to verify rate limiting configuration and environment variable overrides

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2839)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->