### PR TITLE
Fix queue subprocess orchestration

### DIFF
--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -232,15 +232,23 @@ class DatabaseContextManager:
         if not backend_access_control_enabled():
             return None
 
-        # Evict this dataset's engine entries from the LRU caches before
-        # releasing the queue slot. This guarantees the freed slot and the
-        # freed cache entry are the same dataset, so the LRU never evicts
-        # a still-active dataset's adapter to make room for a new one.
-        from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
-        from cognee.infrastructure.databases.vector.create_vector_engine import evict_vector_engine
+        # In subprocess mode each adapter's child process holds an
+        # exclusive flock() on the DB file. Proactively evict this
+        # dataset's adapters so the LRU never evicts a still-active
+        # dataset's adapter whose subprocess still holds the lock.
+        g_cfg = get_graph_context_config()
+        if g_cfg.get("graph_database_subprocess_enabled"):
+            from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
 
-        evict_graph_engine(**get_graph_context_config())
-        evict_vector_engine(**get_vectordb_context_config())
+            evict_graph_engine(**g_cfg)
+
+        v_cfg = get_vectordb_context_config()
+        if v_cfg.get("vector_db_subprocess_enabled"):
+            from cognee.infrastructure.databases.vector.create_vector_engine import (
+                evict_vector_engine,
+            )
+
+            evict_vector_engine(**v_cfg)
 
         from cognee.infrastructure.databases.dataset_queue import dataset_queue
 

--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -233,22 +233,30 @@ class DatabaseContextManager:
             return None
 
         # In subprocess mode each adapter's child process holds an
-        # exclusive flock() on the DB file. Proactively evict this
-        # dataset's adapters so the LRU never evicts a still-active
-        # dataset's adapter whose subprocess still holds the lock.
+        # exclusive flock() on the DB file. Evict and **await** close so
+        # the subprocess fully releases the lock before the next caller
+        # tries to open the same database file.
         g_cfg = get_graph_context_config()
         if g_cfg.get("graph_database_subprocess_enabled"):
-            from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
+            from cognee.infrastructure.databases.graph.get_graph_engine import (
+                create_graph_engine,
+                evict_graph_engine,
+            )
 
+            engine = create_graph_engine(**g_cfg)
             evict_graph_engine(**g_cfg)
+            await engine.close()
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
             from cognee.infrastructure.databases.vector.create_vector_engine import (
+                create_vector_engine,
                 evict_vector_engine,
             )
 
+            engine = create_vector_engine(**v_cfg)
             evict_vector_engine(**v_cfg)
+            await engine.close()
 
         from cognee.infrastructure.databases.dataset_queue import dataset_queue
 

--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -229,13 +229,22 @@ class DatabaseContextManager:
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        # Lazily import to avoid circular imports at module load.
+        if not backend_access_control_enabled():
+            return None
+
+        # Evict this dataset's engine entries from the LRU caches before
+        # releasing the queue slot. This guarantees the freed slot and the
+        # freed cache entry are the same dataset, so the LRU never evicts
+        # a still-active dataset's adapter to make room for a new one.
+        from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
+        from cognee.infrastructure.databases.vector.create_vector_engine import evict_vector_engine
+
+        evict_graph_engine(**get_graph_context_config())
+        evict_vector_engine(**get_vectordb_context_config())
+
         from cognee.infrastructure.databases.dataset_queue import dataset_queue
 
-        # Release the slot for this dataset when exiting the context.
-        if backend_access_control_enabled():
-            dataset_queue().release_slot_for(self._dataset)
-        return None
+        dataset_queue().release_slot_for(self._dataset)
 
 
 def set_database_global_context_variables(

--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -233,30 +233,39 @@ class DatabaseContextManager:
             return None
 
         # In subprocess mode each adapter's child process holds an
-        # exclusive flock() on the DB file. Evict and **await** close so
+        # exclusive flock() on the DB file. Evict and await close() so
         # the subprocess fully releases the lock before the next caller
         # tries to open the same database file.
+        #
+        # Check the cache *before* calling create — if the entry was
+        # already removed (e.g. by delete_dataset), calling create
+        # would manufacture a new adapter that re-creates the deleted
+        # database on disk.
         g_cfg = get_graph_context_config()
         if g_cfg.get("graph_database_subprocess_enabled"):
             from cognee.infrastructure.databases.graph.get_graph_engine import (
                 create_graph_engine,
                 evict_graph_engine,
+                is_graph_engine_cached,
             )
 
-            engine = create_graph_engine(**g_cfg)
-            evict_graph_engine(**g_cfg)
-            await engine.close()
+            if is_graph_engine_cached(**g_cfg):
+                engine = create_graph_engine(**g_cfg)
+                evict_graph_engine(**g_cfg)
+                await engine.close()
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
             from cognee.infrastructure.databases.vector.create_vector_engine import (
                 create_vector_engine,
                 evict_vector_engine,
+                is_vector_engine_cached,
             )
 
-            engine = create_vector_engine(**v_cfg)
-            evict_vector_engine(**v_cfg)
-            await engine.close()
+            if is_vector_engine_cached(**v_cfg):
+                engine = create_vector_engine(**v_cfg)
+                evict_vector_engine(**v_cfg)
+                await engine.close()
 
         from cognee.infrastructure.databases.dataset_queue import dataset_queue
 

--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -252,7 +252,8 @@ class DatabaseContextManager:
             if is_graph_engine_cached(**g_cfg):
                 engine = create_graph_engine(**g_cfg)
                 evict_graph_engine(**g_cfg)
-                await engine.close()
+                if hasattr(engine, "close"):
+                    await engine.close()
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
@@ -265,7 +266,8 @@ class DatabaseContextManager:
             if is_vector_engine_cached(**v_cfg):
                 engine = create_vector_engine(**v_cfg)
                 evict_vector_engine(**v_cfg)
-                await engine.close()
+                if hasattr(engine, "close"):
+                    await engine.close()
 
         from cognee.infrastructure.databases.dataset_queue import dataset_queue
 

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -53,21 +53,48 @@ def _normalize_optional_create_graph_engine_params(params: dict) -> dict:
     return normalized
 
 
+class _GraphEngineHandle:
+    """Auto-refreshing handle that re-resolves through the cache on every access.
+
+    If the cached engine was closed (e.g. by ``__aexit__``, ``prune_system``,
+    or ``cache_clear``), the next attribute access transparently gets a fresh
+    one from the cache.  Callers can hold a reference across eviction
+    boundaries without hitting "adapter is closed" errors.
+
+    For adapters that expose ``initialize()`` (Postgres, Neo4j), the handle
+    tracks which proxy was last initialized and re-initializes when the
+    underlying engine changes.
+    """
+
+    __slots__ = ("_config", "_last_initialized_id")
+
+    def __init__(self, config: dict):
+        object.__setattr__(self, "_config", config)
+        object.__setattr__(self, "_last_initialized_id", None)
+
+    def _engine(self):
+        return create_graph_engine(**self._config)
+
+    async def _ensure_initialized(self):
+        engine = self._engine()
+        engine_id = id(engine)
+        if engine_id != self._last_initialized_id and hasattr(engine, "initialize"):
+            await engine.initialize()
+        object.__setattr__(self, "_last_initialized_id", engine_id)
+
+    def __getattr__(self, name):
+        return getattr(self._engine(), name)
+
+    def __repr__(self):
+        return f"<GraphEngineHandle config={self._config!r}>"
+
+
 async def get_graph_engine() -> GraphDBInterface:
     """Factory function to get the appropriate graph client based on the graph type."""
-    # Get appropriate graph configuration based on current async context
     config = get_graph_context_config()
-
-    graph_client = create_graph_engine(**config)
-
-    # Async functions can't be cached. After creating and caching the graph engine
-    # handle all necessary async operations for different graph types bellow.
-
-    # Run any adapter‐specific async initialization
-    if hasattr(graph_client, "initialize"):
-        await graph_client.initialize()
-
-    return graph_client
+    handle = _GraphEngineHandle(config)
+    await handle._ensure_initialized()
+    return handle
 
 
 def create_graph_engine(

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -93,6 +93,10 @@ class _GraphEngineHandle:
             await engine.initialize()
         object.__setattr__(self, "_last_initialized_id", engine_id)
 
+    @property
+    def __class__(self):
+        return self._engine().__class__
+
     def __getattr__(self, name):
         return getattr(self._engine(), name)
 

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -173,6 +173,29 @@ def evict_graph_engine(**kwargs) -> bool:
     )
 
 
+def is_graph_engine_cached(**kwargs) -> bool:
+    """Check whether a graph engine entry exists in the cache without creating."""
+    normalized = _normalize_optional_create_graph_engine_params(kwargs)
+    provider = _normalize_graph_database_provider(kwargs.get("graph_database_provider"))
+    return _create_graph_engine.cache_contains(
+        provider,
+        kwargs.get("graph_file_path"),
+        normalized["graph_database_url"],
+        normalized["graph_database_name"],
+        normalized["graph_database_username"],
+        normalized["graph_database_password"],
+        normalized["graph_database_host"],
+        normalized["graph_database_allow_anonymous"],
+        normalized["graph_database_port"],
+        normalized["graph_database_key"],
+        normalized["graph_dataset_database_handler"],
+        normalized["graph_database_subprocess_enabled"],
+        normalized["kuzu_num_threads"],
+        normalized["kuzu_buffer_pool_size"],
+        normalized["kuzu_max_db_size"],
+    )
+
+
 @closing_lru_cache(maxsize=DATABASE_MAX_LRU_CACHE_SIZE)
 def _create_graph_engine(
     graph_database_provider,

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -54,16 +54,27 @@ def _normalize_optional_create_graph_engine_params(params: dict) -> dict:
 
 
 class _GraphEngineHandle:
-    """Auto-refreshing handle that re-resolves through the cache on every access.
+    """Stable reference to the current graph engine that survives cache invalidation.
 
-    If the cached engine was closed (e.g. by ``__aexit__``, ``prune_system``,
-    or ``cache_clear``), the next attribute access transparently gets a fresh
-    one from the cache.  Callers can hold a reference across eviction
-    boundaries without hitting "adapter is closed" errors.
+    Database engine instances are cached via ``closing_lru_cache``.  Several
+    operations invalidate that cache — ``prune_system`` calls ``cache_clear()``,
+    ``delete_dataset`` evicts individual entries, and the ``__aexit__`` of
+    ``set_database_global_context_variables`` evicts subprocess-mode engines to
+    release file locks.  When an entry is evicted the underlying adapter is
+    closed, so any direct proxy reference becomes a dead object that raises
+    "adapter is closed" on use.
+
+    This handle solves the problem by deferring resolution: every attribute
+    access calls ``create_graph_engine(**config)`` which either returns the
+    existing cached proxy (fast path) or transparently creates a fresh adapter
+    if the old one was evicted (recovery path).  Code that stores the return
+    value of ``get_graph_engine()`` — even across ``cognify``, ``search``,
+    ``prune``, or ``delete`` calls — always reaches a live adapter without
+    needing to re-call ``get_graph_engine()``.
 
     For adapters that expose ``initialize()`` (Postgres, Neo4j), the handle
-    tracks which proxy was last initialized and re-initializes when the
-    underlying engine changes.
+    tracks which engine proxy was last initialized and re-runs the idempotent
+    schema setup when the underlying engine changes.
     """
 
     __slots__ = ("_config", "_last_initialized_id")

--- a/cognee/infrastructure/databases/graph/ladybug/LadybugDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/ladybug/LadybugDatasetDatabaseHandler.py
@@ -88,9 +88,5 @@ class LadybugDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         )
         graph_engine = create_graph_engine(**engine_kwargs)
         await graph_engine.delete_graph()
-        # Drop the cache entry so the leased adapter's ``close()`` runs:
-        # in subprocess mode that shuts down the worker process. Leaving
-        # the entry behind would let an LRU hit return an adapter
-        # pointing at a now-deleted on-disk store, and would keep the
-        # worker process alive until LRU eviction.
         evict_graph_engine(**engine_kwargs)
+        await graph_engine.close()

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -314,6 +314,11 @@ class ClosingLRUCache:
         self._detach_entry(entry)
         return True
 
+    def contains(self, key) -> bool:
+        """Check whether *key* is currently in the cache without creating."""
+        with self._lock:
+            return key in self._cache
+
     def cache_info(self):
         """Return current size and max size."""
         with self._lock:
@@ -356,8 +361,13 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True):
             """
             return cache.evict(_key(args, kwargs))
 
+        def cache_contains(*args, **kwargs) -> bool:
+            """Return True if the key is cached, without creating."""
+            return cache.contains(_key(args, kwargs))
+
         wrapper.cache_clear = cache.cache_clear
         wrapper.cache_evict = cache_evict
+        wrapper.cache_contains = cache_contains
         wrapper.cache_info = cache.cache_info
         wrapper.__wrapped__ = fn
         return wrapper

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -130,6 +130,23 @@ def evict_vector_engine(**kwargs) -> bool:
     )
 
 
+def is_vector_engine_cached(**kwargs) -> bool:
+    """Check whether a vector engine entry exists in the cache without creating."""
+    normalized = _normalize_optional_create_vector_engine_params(kwargs)
+    return _create_vector_engine.cache_contains(
+        kwargs.get("vector_db_provider", ""),
+        kwargs.get("vector_db_url", ""),
+        kwargs.get("vector_db_name", ""),
+        normalized["vector_db_port"],
+        normalized["vector_db_key"],
+        normalized["vector_dataset_database_handler"],
+        normalized["vector_db_username"],
+        normalized["vector_db_password"],
+        normalized["vector_db_host"],
+        normalized["vector_db_subprocess_enabled"],
+    )
+
+
 @closing_lru_cache(maxsize=DATABASE_MAX_LRU_CACHE_SIZE)
 def _create_vector_engine(
     vector_db_provider: str,

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -109,6 +109,27 @@ def create_vector_engine(
     )
 
 
+def evict_vector_engine(**kwargs) -> bool:
+    """Evict a cached vector engine entry created via ``create_vector_engine``.
+
+    Mirrors ``create_vector_engine``'s normalization so the cache key
+    matches. Returns True if the entry existed.
+    """
+    normalized = _normalize_optional_create_vector_engine_params(kwargs)
+    return _create_vector_engine.cache_evict(
+        kwargs.get("vector_db_provider", ""),
+        kwargs.get("vector_db_url", ""),
+        kwargs.get("vector_db_name", ""),
+        normalized["vector_db_port"],
+        normalized["vector_db_key"],
+        normalized["vector_dataset_database_handler"],
+        normalized["vector_db_username"],
+        normalized["vector_db_password"],
+        normalized["vector_db_host"],
+        normalized["vector_db_subprocess_enabled"],
+    )
+
+
 @closing_lru_cache(maxsize=DATABASE_MAX_LRU_CACHE_SIZE)
 def _create_vector_engine(
     vector_db_provider: str,

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -3,12 +3,23 @@ from .create_vector_engine import create_vector_engine
 
 
 class _VectorEngineHandle:
-    """Auto-refreshing handle that re-resolves through the cache on every access.
+    """Stable reference to the current vector engine that survives cache invalidation.
 
-    If the cached engine was closed (e.g. by ``prune_system`` or
-    ``cache_clear``), the next attribute access transparently gets a
-    fresh one from the cache.  Callers can hold a reference across
-    prune boundaries without hitting "adapter is closed" errors.
+    Database engine instances are cached via ``closing_lru_cache``.  Several
+    operations invalidate that cache — ``prune_system`` calls ``cache_clear()``,
+    ``delete_dataset`` evicts individual entries, and the ``__aexit__`` of
+    ``set_database_global_context_variables`` evicts subprocess-mode engines to
+    release file locks.  When an entry is evicted the underlying adapter is
+    closed, so any direct proxy reference becomes a dead object that raises
+    "adapter is closed" on use.
+
+    This handle solves the problem by deferring resolution: every attribute
+    access calls ``create_vector_engine(**config)`` which either returns the
+    existing cached proxy (fast path) or transparently creates a fresh adapter
+    if the old one was evicted (recovery path).  Code that stores the return
+    value of ``get_vector_engine()`` — even across ``cognify``, ``search``,
+    ``prune``, or ``delete`` calls — always reaches a live adapter without
+    needing to re-call ``get_vector_engine()``.
     """
 
     __slots__ = ("_config",)

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -2,6 +2,29 @@ from .config import get_vectordb_context_config
 from .create_vector_engine import create_vector_engine
 
 
+class _VectorEngineHandle:
+    """Auto-refreshing handle that re-resolves through the cache on every access.
+
+    If the cached engine was closed (e.g. by ``prune_system`` or
+    ``cache_clear``), the next attribute access transparently gets a
+    fresh one from the cache.  Callers can hold a reference across
+    prune boundaries without hitting "adapter is closed" errors.
+    """
+
+    __slots__ = ("_config",)
+
+    def __init__(self, config: dict):
+        object.__setattr__(self, "_config", config)
+
+    def _engine(self):
+        return create_vector_engine(**self._config)
+
+    def __getattr__(self, name):
+        return getattr(self._engine(), name)
+
+    def __repr__(self):
+        return f"<VectorEngineHandle config={self._config!r}>"
+
+
 def get_vector_engine():
-    # Get appropriate vector db configuration based on current async context
-    return create_vector_engine(**get_vectordb_context_config())
+    return _VectorEngineHandle(get_vectordb_context_config())

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -30,6 +30,10 @@ class _VectorEngineHandle:
     def _engine(self):
         return create_vector_engine(**self._config)
 
+    @property
+    def __class__(self):
+        return self._engine().__class__
+
     def __getattr__(self, name):
         return getattr(self._engine(), name)
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved resource cleanup to evict and close subprocess-held engines and release dataset slots, reducing leaks.
  * Added cache membership checks to allow querying whether engines are cached without creating them.

* **New Features**
  * Vector engine access now uses a lazy handle that transparently re-creates engines on use for greater resilience.

* **Bug Fixes**
  * Context exit now respects access-control settings and avoids holding dataset queue slots when disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->