### PR TITLE
fix(extract_graph): use issubclass for KnowledgeGraph guard

### DIFF
--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -96,7 +96,7 @@ async def integrate_chunk_graphs(
             type(ontology_resolver).__name__ if ontology_resolver else "None"
         )
 
-    if graph_model is not KnowledgeGraph:
+    if not issubclass(graph_model, KnowledgeGraph):
         for chunk_index, chunk_graph in enumerate(chunk_graphs):
             data_chunks[chunk_index].contains = chunk_graph
 
@@ -178,7 +178,7 @@ async def extract_graph_from_data(
             await callback_result
 
     # Note: Filter edges with missing source or target nodes
-    if graph_model == KnowledgeGraph:
+    if issubclass(graph_model, KnowledgeGraph):
         for graph in chunk_graphs:
             valid_node_ids = {node.id for node in graph.nodes}
             graph.edges = [

--- a/cognee/tests/unit/tasks/graph/test_extract_graph_from_data.py
+++ b/cognee/tests/unit/tasks/graph/test_extract_graph_from_data.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from cognee.shared.data_models import KnowledgeGraph, Node, Edge as KGEdge
-from cognee.tasks.graph.extract_graph_from_data import integrate_chunk_graphs
+from cognee.tasks.graph.extract_graph_from_data import (
+    extract_graph_from_data,
+    integrate_chunk_graphs,
+)
 
 egd_module = importlib.import_module("cognee.tasks.graph.extract_graph_from_data")
 
@@ -103,6 +106,61 @@ async def test_cache_entity_embeddings_hook_called(mock_retrieve):
     hook.assert_called_once()
     entity_nodes_arg = hook.call_args.args[0]
     assert len(entity_nodes_arg) > 0
+
+
+class _KGSubclass(KnowledgeGraph):
+    pass
+
+
+@pytest.mark.asyncio
+@patch.object(egd_module, "retrieve_existing_edges", new_callable=AsyncMock)
+async def test_integrate_chunk_graphs_accepts_knowledge_graph_subclass(mock_retrieve):
+    mock_retrieve.return_value = {}
+    chunk = _make_chunk()
+    graph = _KGSubclass(
+        nodes=[
+            Node(id="n1", name="Alice", type="Person", description="desc"),
+            Node(id="n2", name="Bob", type="Person", description="desc"),
+        ],
+        edges=[KGEdge(source_node_id="n1", target_node_id="n2", relationship_name="knows")],
+    )
+
+    await integrate_chunk_graphs([chunk], [graph], _KGSubclass, _mock_resolver(), {})
+
+    # Subclass should take the integration path, not the contains-passthrough path.
+    assert chunk.contains is not None and len(chunk.contains) > 0
+    _, entity = chunk.contains[0]
+    assert entity.name in ("alice", "bob")
+
+
+@pytest.mark.asyncio
+@patch.object(egd_module, "integrate_chunk_graphs", new_callable=AsyncMock)
+async def test_extract_graph_from_data_filters_edges_for_subclass(mock_integrate):
+    chunk = _make_chunk()
+    graph = _KGSubclass(
+        nodes=[Node(id="n1", name="Alice", type="Person", description="desc")],
+        edges=[
+            KGEdge(source_node_id="n1", target_node_id="n1", relationship_name="self"),
+            KGEdge(source_node_id="n1", target_node_id="missing", relationship_name="dangling"),
+        ],
+    )
+    mock_integrate.side_effect = lambda *a, **kw: a[0]
+
+    async def fake_calc(chunks, graph_model, custom_prompt, **kwargs):
+        return [graph]
+
+    config = {"ontology_config": {"ontology_resolver": _mock_resolver()}}
+
+    await extract_graph_from_data(
+        [chunk],
+        _KGSubclass,
+        config=config,
+        calculate_chunk_graphs=fake_calc,
+    )
+
+    # Edge with missing target should be filtered out for the subclass.
+    assert len(graph.edges) == 1
+    assert graph.edges[0].target_node_id == "n1"
 
 
 @pytest.mark.asyncio

--- a/examples/pocs/disambiguation/extract_graph_from_data_with_entity_disambiguation.py
+++ b/examples/pocs/disambiguation/extract_graph_from_data_with_entity_disambiguation.py
@@ -96,7 +96,7 @@ async def integrate_chunk_graphs(
             type(ontology_resolver).__name__ if ontology_resolver else "None"
         )
 
-    if graph_model is not KnowledgeGraph:
+    if not issubclass(graph_model, KnowledgeGraph):
         for chunk_index, chunk_graph in enumerate(chunk_graphs):
             data_chunks[chunk_index].contains = chunk_graph
 
@@ -170,7 +170,7 @@ async def extract_graph_from_data_with_entity_disambiguation_task(
     )
 
     # Note: Filter edges with missing source or target nodes
-    if graph_model == KnowledgeGraph:
+    if issubclass(graph_model, KnowledgeGraph):
         for graph in chunk_graphs:
             valid_node_ids = {node.id for node in graph.nodes}
             graph.edges = [


### PR DESCRIPTION
## Problem

  `integrate_chunk_graphs` early-returns when `graph_model` is not the
  literal `KnowledgeGraph` class:

  ```python
  if graph_model is not KnowledgeGraph:
      for chunk_index, chunk_graph in enumerate(chunk_graphs):
          data_chunks[chunk_index].contains = chunk_graph
      return data_chunks
```

  This rejects subclasses of KnowledgeGraph even when they have the
  same .nodes / .edges shape. The same issue exists at the edge
  sanity-filter check below (if graph_model == KnowledgeGraph:), which
  also uses identity-style comparison on the class object.

  The downstream expand_with_nodes_and_edges is fully duck-typed (it
  only reads .nodes, .edges, and the standard Node / Edge
  attributes), so any subclass with the same shape is safe to flow
  through. Allowing subclasses unblocks a useful pattern: tightening
  Node.type or Edge.relationship_name to a Literal[...] enum so
  the LLM extraction is grammar-constrained at the JSON-schema level
  while the ontology resolver still runs.

  Fix

  Replace identity / equality checks with issubclass:

  -    if graph_model is not KnowledgeGraph:
  +    if not issubclass(graph_model, KnowledgeGraph):

  -    if graph_model == KnowledgeGraph:
  +    if issubclass(graph_model, KnowledgeGraph):

  Behavior for the default graph_model=KnowledgeGraph is unchanged
  (issubclass(KnowledgeGraph, KnowledgeGraph) is True). Behavior for
  truly non-graph models (e.g. the ScientificPaper(DataPoint) example
  in the cognify docstring) is also unchanged — they still hit the
  early-return, since they're not subclasses of KnowledgeGraph.

  Compatibility

  - No public API change.
  - Default path (graph_model=KnowledgeGraph) takes the same branches
  as before.
  - Subclasses with nodes: List[NodeSubclass] / edges: List[EdgeSubclass]
  now flow through ontology integration as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with custom knowledge-graph subclasses: integration now follows the expanded path for any subclassed graph model.
  * Edge filtering during graph extraction is now applied consistently for subclassed graph models, removing edges that reference missing nodes and ensuring correct node/edge sets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->