### PR TITLE
docs: explain quickstart memory output

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ if __name__ == '__main__':
 
 ```
 
+### Understanding the Output
+
+After running the pipeline above, here's what happens:
+
+- **`remember`** takes your text, splits it into chunks, generates embeddings, and stores them in both a vector index (for semantic search) and a knowledge graph (for relationship-aware queries). The call is non-blocking — processing happens in the background.
+
+- **`recall`** returns a list of relevant text chunks ordered by relevance score. Each result is a piece of the original text with context attached — not raw data, but meaningfully retrieved fragments ready for an agent to use.
+
+- **Session memory** (`session_id` variant) lives in a fast cache and is ideal for short-lived context like ongoing conversations. It automatically falls through to the permanent graph when a session expires.
+
+**What to put in memory:** Plain text works, but cognee handles richer sources — support tickets, meeting notes, Slack threads, PDF documents, database records. The more structured your data, the more useful the graph relationships become. Start with whatever data is most relevant to your agent's goals.
+
 ### Use the Cognee CLI
 
 ```bash


### PR DESCRIPTION
## What problem does this solve?
The Quickstart section shows a code example with `remember` and `recall` calls but provides no explanation of what those calls actually do, what data gets stored, or what the output means. Beginners run the example and get results they can't interpret. Closes #2879.

## What was changed and why?
Added a new section **"### Understanding the Output"** immediately after the pipeline code block:
- Explains what `remember` does — chunking, embeddings, vector index + knowledge graph
- Explains what `recall` returns — relevant text chunks ordered by relevance score
- Describes session memory and when to use it
- Points beginners toward richer data sources (documents, support tickets, meeting notes)

## How was this tested?
- Reviewed the README insertion point and Markdown structure locally
- Confirmed the new section renders correctly after the code block
- Verified the diff shows only the new section (+12 lines, no deletions)

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] My changes match the project's code style
- [x] I have added/updated tests where appropriate (not applicable — documentation-only)
- [x] All existing tests pass locally

---
*This contribution was created with AI assistance following structured guidelines, with human review and approval at each step.*