### PR TITLE
fix(cognee-mcp): route remember(session_id=...) to JSON /entry endpoint to avoid silent no-op

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -464,6 +464,14 @@ class CogneeClient:
         """
         if self.use_api:
             if session_id:
+                if custom_prompt:
+                    logger.warning(
+                        "remember: custom_prompt is not supported with session_id in API mode "
+                        "(the /remember/entry endpoint does not forward custom_prompt)"
+                    )
+                    raise ValueError(
+                        "custom_prompt is not supported when session_id is provided in API mode"
+                    )
                 # Session mode: POST a JSON QAEntry so the backend receives
                 # real text, not a multipart-file placeholder that triggers
                 # the _SESSION_PLACEHOLDER_PREFIXES skip in _add_to_session.

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -463,11 +463,32 @@ class CogneeClient:
         Without session_id: full add + cognify pipeline (permanent).
         """
         if self.use_api:
+            if session_id:
+                # Session mode: POST a JSON QAEntry so the backend receives
+                # real text, not a multipart-file placeholder that triggers
+                # the _SESSION_PLACEHOLDER_PREFIXES skip in _add_to_session.
+                endpoint = f"{self.api_url}/api/v1/remember/entry"
+                payload = {
+                    "entry": {
+                        "type": "qa",
+                        "question": "",
+                        "answer": str(data),
+                        "context": "",
+                    },
+                    "dataset_name": dataset_name,
+                    "session_id": session_id,
+                }
+                response = await self.client.post(
+                    endpoint,
+                    json=payload,
+                    headers=self._get_headers(),
+                )
+                response.raise_for_status()
+                return response.json()
+
             endpoint = f"{self.api_url}/api/v1/remember"
             files = self._text_upload(data)
             form_data = {"datasetName": dataset_name}
-            if session_id:
-                form_data["session_id"] = session_id
             if custom_prompt:
                 form_data["custom_prompt"] = custom_prompt
             response = await self.client.post(


### PR DESCRIPTION
## Summary

When `session_id` is set, `remember()` via the HTTP/MCP path silently no-ops — the backend returns `status=session_stored` but writes nothing to the session cache. The `cognee-mcp` client always wraps `data` as a multipart file upload, and the backend's `_add_to_session` explicitly skips file-shaped data (placeholder strings like `[UploadFile]`).

### Root Cause

`cognee-mcp/src/cognee_client.py` sends `data` as a multipart file upload to `POST /api/v1/remember`. When `session_id` is set, the backend calls `_add_to_session`, which converts the `UploadFile` object to the placeholder string `[UploadFile]` via `_data_to_text()`, then skips the write because the string matches `_SESSION_PLACEHOLDER_PREFIXES`. The `RememberResult` is already constructed as `status=session_stored` before this check, so the caller sees success.

### Fix

**Approach #1 from the issue** (client-side). When `session_id` is set in API mode, the client now POSTs a JSON `QAEntry` body to `POST /api/v1/remember/entry` (the typed-entry endpoint that already exists) instead of a multipart file to `/api/v1/remember`. This completely bypasses the file-upload shape that triggers the placeholder filter, and reaches `_dispatch_session_entry` -> `SessionManager.add_qa` correctly.

Additionally, since `/api/v1/remember/entry` does not support `custom_prompt`, passing it alongside `session_id` now raises a clear `ValueError` (with a warning log) rather than silently ignoring the parameter.

When `session_id` is absent, the existing multipart-file behavior for the add+cognify pipeline is preserved unchanged.

### Changes

| File | Change |
|------|--------|
| `cognee-mcp/src/cognee_client.py` | When `session_id` is set in API mode, POST JSON to `/api/v1/remember/entry` with a `QAEntry` instead of multipart to `/api/v1/remember`. Raise `ValueError` if `custom_prompt` is passed with `session_id`. |

### Testing

- `remember(data, session_id="test")` in API mode: session entry is now written to Redis/fs cache, `session_records` row is created, and `recall(session_id="test")` finds the entry.
- `remember(data)` without session_id: permanent add+cognify pipeline unaffected.
- `remember(data, session_id="test", custom_prompt="...")` in API mode: raises `ValueError` with clear message.
- Direct Python `cognee.remember(session_id=...)` was already working and is untouched.

Fixes: #2888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved remember behavior: when a session is provided, requests now use a JSON-based session flow and return structured JSON responses.
  * Non-session uploads continue to use the existing multipart/text upload flow.
  * Validation updated: supplying a custom prompt together with a session now raises an error to prevent mixed modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->