### PR TITLE
fix(llm): bypass instructor for response_model=str and normalize non-standard litellm kwargs

### DIFF
--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -34,17 +34,28 @@ async def _direct_str_completion(text_input: str, system_prompt: str, **kwargs: 
     """
     llm_config = get_llm_config()
     merged_kwargs = _normalize_llm_kwargs({**(llm_config.llm_args or {}), **kwargs})
-    resp = await litellm.acompletion(
-        model=llm_config.llm_model,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": text_input},
-        ],
-        api_key=llm_config.llm_api_key,
-        api_base=llm_config.llm_endpoint,
-        api_version=llm_config.llm_api_version,
-        **merged_kwargs,
-    )
+
+    model = llm_config.llm_model
+    if model.startswith("hosted_vllm/"):
+        model = "openai/" + model.removeprefix("hosted_vllm/")
+        extra_body = dict(merged_kwargs.get("extra_body", {}) or {})
+        extra_body["strict"] = False
+        merged_kwargs["extra_body"] = extra_body
+
+    from cognee.shared.rate_limiting import llm_rate_limiter_context_manager
+
+    async with llm_rate_limiter_context_manager():
+        resp = await litellm.acompletion(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": text_input},
+            ],
+            api_key=llm_config.llm_api_key,
+            api_base=llm_config.llm_endpoint,
+            api_version=llm_config.llm_api_version,
+            **merged_kwargs,
+        )
     return resp.choices[0].message.content or ""
 
 

--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -1,9 +1,13 @@
 from collections.abc import Coroutine
 from typing import Any, TypeVar
 
+import litellm
 from pydantic import BaseModel
 
 from cognee.infrastructure.llm import get_llm_config
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
+    _normalize_llm_kwargs,
+)
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
 )
@@ -19,6 +23,29 @@ def _inject_agent_memory(text_input: str) -> str:
         return text_input
 
     return f"Additional Memory Context:\n{context.memory_context}\n\nOriginal Input:\n{text_input}"
+
+
+async def _direct_str_completion(text_input: str, system_prompt: str, **kwargs: Any) -> str:
+    """Call litellm directly for plain-text completions, bypassing instructor.
+
+    Instructor wraps the call in JSON/tool-call schemas that local
+    llama.cpp-compatible servers don't honour, causing repeated
+    InstructorRetryException and tenacity retry sleeps.
+    """
+    llm_config = get_llm_config()
+    merged_kwargs = _normalize_llm_kwargs({**(llm_config.llm_args or {}), **kwargs})
+    resp = await litellm.acompletion(
+        model=llm_config.llm_model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": text_input},
+        ],
+        api_key=llm_config.llm_api_key,
+        api_base=llm_config.llm_endpoint,
+        api_version=llm_config.llm_api_version,
+        **merged_kwargs,
+    )
+    return resp.choices[0].message.content or ""
 
 
 async def _record_session_usage_after(
@@ -63,6 +90,16 @@ class LLMGateway:
         **kwargs: Any,
     ) -> Coroutine[Any, Any, T]:
         text_input = _inject_agent_memory(text_input)
+
+        # response_model=str is a plain-text completion — instructor adds
+        # JSON/tool-call schemas that local servers don't honour, causing
+        # repeated InstructorRetryException. Call litellm directly instead.
+        if response_model is str:
+            return _record_session_usage_after(
+                _direct_str_completion(text_input, system_prompt, **kwargs),
+                text_input=text_input,
+            )
+
         llm_config = get_llm_config()
         if llm_config.structured_output_framework.upper() == "BAML":
             from cognee.infrastructure.llm.structured_output_framework.baml.baml_src.extraction import (

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -34,6 +34,29 @@ from cognee.shared.rate_limiting import llm_rate_limiter_context_manager
 logger = get_logger()
 observe = get_observe()
 
+_STANDARD_LITELLM_KEYS = frozenset({
+    "temperature", "top_p", "max_tokens", "max_completion_tokens", "stream",
+    "stop", "presence_penalty", "frequency_penalty", "logit_bias", "user",
+    "seed", "tools", "tool_choice", "response_format", "extra_body",
+    "timeout", "n", "logprobs", "top_logprobs",
+})
+
+
+def _normalize_llm_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Move non-standard litellm keys into extra_body so they reach the server.
+
+    litellm silently drops top-level keys it doesn't recognise (e.g.
+    chat_template_kwargs). Moving them into extra_body ensures they
+    reach the underlying API.
+    """
+    extra_body = dict(kwargs.pop("extra_body", {}) or {})
+    for key in list(kwargs.keys()):
+        if key not in _STANDARD_LITELLM_KEYS:
+            extra_body[key] = kwargs.pop(key)
+    if extra_body:
+        kwargs["extra_body"] = extra_body
+    return kwargs
+
 
 def _enrich_llm_span(model: str, name: str) -> None:
     """Set LLM attributes on the current OTEL span, if tracing is enabled."""
@@ -150,7 +173,7 @@ class GenericAPIAdapter(LLMInterface):
               output from the language model.
         """
 
-        merged_kwargs = {**self.llm_args, **kwargs}
+        merged_kwargs = _normalize_llm_kwargs({**self.llm_args, **kwargs})
         try:
             async with llm_rate_limiter_context_manager():
                 result = await self.aclient.chat.completions.create(
@@ -190,7 +213,7 @@ class GenericAPIAdapter(LLMInterface):
                 ) from error
 
             fallback_model = self.fallback_model
-            fallback_llm_args = {**self._base_llm_args, **kwargs}
+            fallback_llm_args = _normalize_llm_kwargs({**self._base_llm_args, **kwargs})
             if fallback_model and fallback_model.startswith("hosted_vllm/"):
                 fallback_model = fallback_model.replace("hosted_vllm/", "", 1)
                 fallback_model = "openai/" + fallback_model

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -21,6 +21,7 @@ from cognee.infrastructure.llm.exceptions import (
 )
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
     GenericAPIAdapter,
+    _normalize_llm_kwargs,
 )
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
@@ -139,7 +140,7 @@ class OpenAIAdapter(GenericAPIAdapter):
               BaseModel.
         """
 
-        merged_kwargs = {**self.llm_args, **kwargs}
+        merged_kwargs = _normalize_llm_kwargs({**self.llm_args, **kwargs})
         try:
             async with llm_rate_limiter_context_manager():
                 return await self.aclient.chat.completions.create(


### PR DESCRIPTION
## Summary

Three separate bugs combine to cause 10-30x slowdowns when using local llama.cpp-compatible servers (llama-server, LM Studio, etc.) with reasoning/thinking-capable models (Qwen3, DeepSeek-R1, etc.).

### Bug 1 — `chat_template_kwargs` and other non-standard LLM args stripped by litellm

`LLM_ARGS` is merged into kwargs passed to `litellm.acompletion`. litellm only forwards keys it recognises as standard OpenAI parameters. Non-standard keys like `chat_template_kwargs` (required by llama.cpp to disable thinking) are silently dropped.

**Fix**: Added `_normalize_llm_kwargs()` to `GenericAPIAdapter` — moves any key not in `_STANDARD_LITELLM_KEYS` into `extra_body` so they reach the underlying API. Applied in both `GenericAPIAdapter.acreate_structured_output` and `OpenAIAdapter.acreate_structured_output`.

Before: `chat_template_kwargs` at top level → silently stripped → thinking ON → ~1400 reasoning tokens per query → 11x slowdown  
After: `chat_template_kwargs` in `extra_body` → forwarded to server → thinking OFF → 4-13 tokens per query

### Bug 2 — `response_model=str` routed through instructor causes repeated failures on local servers

`generate_completion` in `completion.py` calls `LLMGateway.acreate_structured_output(..., response_model=str)`. This routes through instructor, which adds JSON/tool-call schemas that local llama.cpp servers don't honour. Instructor fails to parse the plain-text response, raises `InstructorRetryException`, and triggers tenacity retry sleeps (8-128s per attempt).

**Fix**: In `LLMGateway.acreate_structured_output`, when `response_model=str`, call `litellm.acompletion` directly via `_direct_str_completion()`, bypassing instructor entirely. The function also normalizes `llm_args` via `_normalize_llm_kwargs`.

### Bug 3 — Silent retry sleeps (already fixed)

The tenacity decorator on `acreate_structured_output` already has `before_sleep=before_sleep_log(logger, logging.WARNING)` in the current code. No change needed.

### Changes

| File | Change |
|------|--------|
| `cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py` | Added `_STANDARD_LITELLM_KEYS` and `_normalize_llm_kwargs()`. Applied in `acreate_structured_output` main and fallback paths. |
| `cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py` | Import and apply `_normalize_llm_kwargs` in `acreate_structured_output`. |
| `cognee/infrastructure/llm/LLMGateway.py` | Added `_direct_str_completion()`. Bypass instructor when `response_model=str`. |

### Performance Impact

Measured on a single-sentence input ("Adel owns webcartel", 19 chars) with Qwen3.6-35B @ ~120 tok/s (from the issue report):

| Operation | Before (bugs present) | After (bugs fixed) | Speedup |
|-----------|----------------------|-------------------|---------|
| cognify — graph extraction | 32s | 2.85s | 11x |
| cognify — summarization | 19s | 1.11s | 17x |
| cognify total | 35s | 6.2s | 5.6x |
| search — LLM completion | 8.5s | 0.70s | 12x |

Fixes: #2840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plain-text LLM responses for better compatibility with some local and remote LLM servers.
  * Fixed parameter forwarding so non-standard LLM API parameters are preserved and transmitted rather than dropped.

* **Improvements**
  * Optimized gateway routing to bypass extra wrapper layers for plain-text completions, yielding more direct and reliable text generation and preserving usage tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->