### PR TITLE
fix(llm): honor OpenAI instructor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Cognee is an open-source memory control plane for your Agents that lets you inge
 
 To learn more, [check out this short, end-to-end Colab walkthrough](https://colab.research.google.com/drive/12Vi9zID-M3fpKpKiaqDBvkk98ElkRPWy?usp=sharing) of Cognee's core features.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/12Vi9zID-M3fpKpKiaqDBvkk98ElkRPWy?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1k7UmbTZIdqfO9fb-xy772LfOjujaOsLy?usp=sharing)
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Cognee is an open-source memory control plane for your Agents that lets you inge
 
 ## Basic Usage & Feature Guide
 
-To learn more, [check out this short, end-to-end Colab walkthrough](https://colab.research.google.com/drive/12Vi9zID-M3fpKpKiaqDBvkk98ElkRPWy?usp=sharing) of Cognee's core features.
+To learn more, [check out this short, end-to-end Colab walkthrough](https://colab.research.google.com/drive/1HRrzIvzcbwrESVfX76wJLKmtIg00SUga?usp=sharing) of Cognee's core features.
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1HRrzIvzcbwrESVfX76wJLKmtIg00SUga?usp=sharing)
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Cognee is an open-source memory control plane for your Agents that lets you inge
 
 To learn more, [check out this short, end-to-end Colab walkthrough](https://colab.research.google.com/drive/12Vi9zID-M3fpKpKiaqDBvkk98ElkRPWy?usp=sharing) of Cognee's core features.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1k7UmbTZIdqfO9fb-xy772LfOjujaOsLy?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1HRrzIvzcbwrESVfX76wJLKmtIg00SUga?usp=sharing)
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Cognee is an open-source memory control plane for your Agents that lets you inge
 
 ## Basic Usage & Feature Guide
 
-To learn more, [check out this short, end-to-end Colab walkthrough](https://colab.research.google.com/drive/1HRrzIvzcbwrESVfX76wJLKmtIg00SUga?usp=sharing) of Cognee's core features.
+To learn more, [check out this short, end-to-end Colab walkthrough](https://colab.research.google.com/drive/12Vi9zID-M3fpKpKiaqDBvkk98ElkRPWy?usp=sharing) of Cognee's core features.
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1HRrzIvzcbwrESVfX76wJLKmtIg00SUga?usp=sharing)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/12Vi9zID-M3fpKpKiaqDBvkk98ElkRPWy?usp=sharing)
 
 ## Quickstart
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -89,10 +89,11 @@ class OpenAIAdapter(GenericAPIAdapter):
             llm_args=llm_args,
         )
         self.llm_args: dict[str, Any] = llm_args or {}
+        explicit_instructor_mode = bool(instructor_mode)
         self.instructor_mode = instructor_mode if instructor_mode else self.default_instructor_mode
         # TODO: With gpt5 series models OpenAI expects JSON_SCHEMA as a mode for structured outputs.
         #       Make sure all new gpt models will work with this mode as well.
-        if "gpt-5" in model:
+        if "gpt-5" in model or explicit_instructor_mode:
             self.aclient = instructor.from_litellm(
                 litellm.acompletion, mode=instructor.Mode(self.instructor_mode)
             )

--- a/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
+++ b/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
@@ -4,6 +4,9 @@ import pytest
 
 from cognee.infrastructure.llm.config import LLMConfig
 from cognee.infrastructure.llm.exceptions import LLMAPIKeyNotSetError
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api import (
+    adapter as generic_adapter,
+)
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client import (
     _LLM_CLIENT_CACHE_MAXSIZE,
     LLMProvider,
@@ -12,6 +15,12 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
     _get_llm_client_cached,
     _raise_for_missing_api_key,
     _unfreeze_from_cache,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai import (
+    adapter as openai_adapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai.adapter import (
+    OpenAIAdapter,
 )
 
 
@@ -116,3 +125,40 @@ def test_api_key_validation_still_happens_before_cache_lookup():
         raise_api_key_error=True,
         use_managed_identity=True,
     )
+
+
+def test_openai_adapter_preserves_default_instructor_mode_for_non_gpt5_models(monkeypatch):
+    calls = []
+
+    def fake_from_litellm(completion, **kwargs):
+        calls.append((completion, kwargs))
+        return object()
+
+    monkeypatch.setattr(generic_adapter.instructor, "from_litellm", fake_from_litellm)
+    monkeypatch.setattr(openai_adapter.instructor, "from_litellm", fake_from_litellm)
+
+    OpenAIAdapter(api_key="test-key", model="openai/gpt-4o-mini", max_completion_tokens=1024)
+
+    assert calls[-2][1] == {}
+    assert calls[-1][1] == {}
+
+
+def test_openai_adapter_honors_explicit_instructor_mode_for_non_gpt5_models(monkeypatch):
+    calls = []
+
+    def fake_from_litellm(completion, **kwargs):
+        calls.append((completion, kwargs))
+        return object()
+
+    monkeypatch.setattr(generic_adapter.instructor, "from_litellm", fake_from_litellm)
+    monkeypatch.setattr(openai_adapter.instructor, "from_litellm", fake_from_litellm)
+
+    OpenAIAdapter(
+        api_key="test-key",
+        model="openai/qwen36-35b-a3b-fp8-gpu0",
+        max_completion_tokens=1024,
+        instructor_mode="json_mode",
+    )
+
+    assert calls[-2][1]["mode"].value == "json_mode"
+    assert calls[-1][1]["mode"].value == "json_mode"


### PR DESCRIPTION
## Summary

Honor explicitly configured `LLM_INSTRUCTOR_MODE` in the OpenAI adapter for all model names, not only `gpt-5` models. This preserves the existing default path when no instructor mode is configured.

## Why

OpenAI-compatible local endpoints can require a non-default Instructor mode for structured output. Before this change, the OpenAI adapter accepted `llm_instructor_mode` but ignored it for non-`gpt-5` model names, which could cause Instructor retries and misleading connection-test timeouts.

## Validation

- `uv run pytest cognee/tests/unit/infrastructure/llm/test_get_llm_client.py -v`
- `uv run pytest cognee/tests/unit/infrastructure/llm/ -v`
- `uv run ruff check cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py cognee/tests/unit/infrastructure/llm/test_get_llm_client.py`
- Local OpenAI-compatible vLLM smoke: `test_llm_connection elapsed=0.363s` with `LLM_PROVIDER=openai` and `LLM_INSTRUCTOR_MODE=json_mode`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instructor mode parameter handling in the OpenAI adapter. Now correctly respects explicit configuration settings in addition to model name detection.

* **Tests**
  * Added unit tests verifying instructor mode behavior for default and explicitly configured settings across different model types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->