### PR TITLE
feat: support external metadata in add REST API

### DIFF
--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -1,11 +1,13 @@
+import json
 from uuid import UUID
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from fastapi import Form, File, UploadFile as UF, Depends, status
-from typing import List, Optional, Union, Literal, Annotated
+from typing import Any, List, Optional, Union, Literal, Annotated
 from pydantic import WithJsonSchema
 
+from cognee.tasks.ingestion.data_item import DataItem
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.shared.utils import send_telemetry
@@ -20,6 +22,51 @@ logger = get_logger()
 # NOTE: Needed because of: https://github.com/fastapi/fastapi/discussions/14975
 #       Once issue is resolved on Swagger side it can be removed.
 UploadFile = Annotated[UF, WithJsonSchema({"type": "string", "format": "binary"})]
+
+
+def _parse_external_metadata(
+    external_metadata: Optional[str],
+    data: Optional[List[UploadFile]],
+) -> Optional[Union[dict[str, Any], list[dict[str, Any]]]]:
+    if external_metadata is None:
+        return None
+
+    try:
+        parsed_metadata = json.loads(external_metadata)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"external_metadata must be valid JSON: {error.msg}") from error
+
+    if isinstance(parsed_metadata, dict):
+        return parsed_metadata
+
+    if isinstance(parsed_metadata, list):
+        if not all(isinstance(item, dict) for item in parsed_metadata):
+            raise ValueError("external_metadata array items must be JSON objects.")
+
+        if data is not None and len(parsed_metadata) != len(data):
+            raise ValueError(
+                "external_metadata array length must match the number of uploaded files."
+            )
+
+        return parsed_metadata
+
+    raise ValueError("external_metadata must be a JSON object or an array of JSON objects.")
+
+
+def _wrap_data_with_external_metadata(
+    data: Optional[List[UploadFile]],
+    external_metadata: Union[dict[str, Any], list[dict[str, Any]]],
+) -> Optional[List[DataItem]]:
+    if data is None:
+        return data
+
+    if isinstance(external_metadata, dict):
+        return [DataItem(data=data_item, external_metadata=external_metadata) for data_item in data]
+
+    return [
+        DataItem(data=data_item, external_metadata=item_external_metadata)
+        for data_item, item_external_metadata in zip(data, external_metadata)
+    ]
 
 
 def get_add_router() -> APIRouter:
@@ -42,6 +89,7 @@ def get_add_router() -> APIRouter:
         # Note: Literal is needed for Swagger use
         datasetId: Union[UUID, Literal[""], None] = Form(default=None, examples=[""]),
         node_set: Optional[List[str]] = Form(default=[""], example=[""]),
+        external_metadata: Optional[str] = Form(default=None),
         run_in_background: Optional[bool] = Form(default=False),
         user: User = Depends(get_authenticated_user),
     ):
@@ -61,6 +109,8 @@ def get_add_router() -> APIRouter:
         - **datasetId** (Optional[UUID]): UUID of an already existing dataset
         - **node_set** Optional[list[str]]: List of node identifiers for graph organization and access control.
                  Used for grouping related data points in the knowledge graph.
+        - **external_metadata** (Optional[str]): JSON object to attach to each uploaded item,
+          or a JSON array of objects matching the uploaded files order.
         - **run_in_background** (Optional[bool]): Run add pipeline asynchronously (default: False).
 
         Either datasetName or datasetId must be provided.
@@ -99,6 +149,20 @@ def get_add_router() -> APIRouter:
                     error="Either datasetId or datasetName must be provided.",
                 ).model_dump(),
             )
+
+        try:
+            parsed_external_metadata = _parse_external_metadata(external_metadata, data)
+        except ValueError as error:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content=ErrorResponse(
+                    error="Invalid external_metadata.",
+                    detail=str(error),
+                ).model_dump(),
+            )
+
+        if parsed_external_metadata is not None:
+            data = _wrap_data_with_external_metadata(data, parsed_external_metadata)
 
         try:
             add_run = await cognee_add(

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -7,6 +7,7 @@ Tests cover:
 """
 
 import importlib
+import json
 from types import SimpleNamespace
 from uuid import uuid4
 from unittest.mock import AsyncMock
@@ -17,6 +18,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from cognee.modules.users.methods import get_authenticated_user
+from cognee.tasks.ingestion.data_item import DataItem
 from cognee.modules.pipelines.models import PipelineRunErrored, PipelineRunCompleted
 from cognee.modules.users.exceptions.exceptions import PermissionDeniedError
 from cognee.api.v1.add.routers.get_add_router import get_add_router
@@ -121,6 +123,85 @@ class TestAddEndpoint:
         body = resp.json()
         assert body["status"] == "completed"
         assert body["dataset_name"] == "test_dataset"
+
+    def test_add_passes_external_metadata_object(self, client):
+        import cognee.api.v1.add as add_pkg
+
+        completed = _make_completed()
+        add_pkg.add = AsyncMock(return_value=completed)
+        metadata = {"source": "crm", "author": "Ada"}
+
+        resp = client.post(
+            "/add",
+            data={"datasetName": "test_dataset", "external_metadata": json.dumps(metadata)},
+            files={"data": ("test.txt", b"Cognee is an AI memory platform.", "text/plain")},
+        )
+
+        assert resp.status_code == 200
+        add_pkg.add.assert_awaited_once()
+        data_arg = add_pkg.add.await_args.args[0]
+        assert len(data_arg) == 1
+        assert isinstance(data_arg[0], DataItem)
+        assert data_arg[0].external_metadata == metadata
+        assert data_arg[0].data.filename == "test.txt"
+
+    def test_add_passes_external_metadata_array_by_file(self, client):
+        import cognee.api.v1.add as add_pkg
+
+        completed = _make_completed()
+        add_pkg.add = AsyncMock(return_value=completed)
+        metadata = [{"source": "crm"}, {"source": "support"}]
+
+        resp = client.post(
+            "/add",
+            data={"datasetName": "test_dataset", "external_metadata": json.dumps(metadata)},
+            files=[
+                ("data", ("first.txt", b"first", "text/plain")),
+                ("data", ("second.txt", b"second", "text/plain")),
+            ],
+        )
+
+        assert resp.status_code == 200
+        add_pkg.add.assert_awaited_once()
+        data_arg = add_pkg.add.await_args.args[0]
+        assert [item.external_metadata for item in data_arg] == metadata
+        assert [item.data.filename for item in data_arg] == ["first.txt", "second.txt"]
+
+    def test_add_rejects_invalid_external_metadata_json(self, client):
+        import cognee.api.v1.add as add_pkg
+
+        add_pkg.add = AsyncMock(return_value=_make_completed())
+
+        resp = client.post(
+            "/add",
+            data={"datasetName": "test_dataset", "external_metadata": "{"},
+            files={"data": ("test.txt", b"hello", "text/plain")},
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "Invalid external_metadata."
+        add_pkg.add.assert_not_awaited()
+
+    def test_add_rejects_external_metadata_array_length_mismatch(self, client):
+        import cognee.api.v1.add as add_pkg
+
+        add_pkg.add = AsyncMock(return_value=_make_completed())
+
+        resp = client.post(
+            "/add",
+            data={
+                "datasetName": "test_dataset",
+                "external_metadata": json.dumps([{"source": "crm"}]),
+            },
+            files=[
+                ("data", ("first.txt", b"first", "text/plain")),
+                ("data", ("second.txt", b"second", "text/plain")),
+            ],
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "Invalid external_metadata."
+        add_pkg.add.assert_not_awaited()
 
     def test_add_internal_error_returns_500(self, client):
         import cognee.api.v1.add as add_pkg


### PR DESCRIPTION
## Description

Expose the existing `DataItem.external_metadata` ingestion path through the REST `POST /api/v1/add` endpoint.

The endpoint now accepts an optional `external_metadata` multipart form field as JSON:

- a JSON object applies the same metadata to every uploaded file
- a JSON array of objects applies metadata per file, matching upload order
- invalid JSON, non-object values, or array length mismatches return `400 Bad Request`

This keeps the lower ingestion pipeline unchanged and wraps uploaded files in `DataItem` only when metadata is provided.

## Acceptance Criteria

- REST add accepts `external_metadata={...}` and forwards uploaded files as `DataItem` instances
- REST add accepts `external_metadata=[...]` for per-file metadata
- invalid metadata input fails before calling the add pipeline
- existing add behavior remains unchanged when `external_metadata` is omitted

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test plan

- [x] `uv run ruff check cognee/api/v1/add/routers/get_add_router.py cognee/tests/unit/api/test_api_error_responses.py`
- [x] `uv run pytest cognee/tests/unit/api/test_api_error_responses.py -q`

## Duplicate check

I searched existing open and closed PRs/issues for `external_metadata`, `external_metadata REST add`, `metadata add api`, and `DataItem external_metadata`. I found related historical work around metadata storage and `DataItem`, but no open PR exposing external metadata through the REST add endpoint.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.