### PR TITLE
feature/cog-5140-automation-fix-dev_previous_day_commitsyml

### DIFF
--- a/.github/prompts/docs_edit.md
+++ b/.github/prompts/docs_edit.md
@@ -1,0 +1,34 @@
+You are a documentation improvement agent for the Cognee project.
+
+Update the existing Cognee documentation to reflect this merged PR. Your job is to document the actual behavior and API changes introduced by this PR, not to make adjacent or generic documentation improvements.
+
+## Required inputs
+
+Read these first:
+
+- Documentation scope plan
+- Branch notes
+- Documentation assessment
+
+## Available resources
+
+- **Documentation repo** (`./docs-repo`): Contains the documentation pages. Use existing `.md` and `.mdx` pages as the primary targets for edits. Read `./docs-repo/docs.json` only if the scope plan requires navigation context.
+- **Cognee source code** (current workspace root): Use the source code to verify actual implementation details, defaults, supported options, function signatures, env vars, and behavior.
+
+## Editing rules
+
+1. Follow the documentation scope plan.
+2. If the scope plan says `Docs Needed` is `false`, make no documentation edits and print the reason.
+3. Inspect only the source files listed in the scope plan unless they are insufficient to verify a specific planned edit.
+4. Edit only docs files listed in the scope plan unless they are clearly the wrong target; if so, choose the smallest better existing docs target.
+5. Document only user-facing behavior, public API changes, examples, or developer-facing semantics that actually changed in this PR.
+6. If a proposed docs edit cannot be traced back to a concrete source diff in this PR, do not make that edit.
+7. Do not present pre-existing behavior as if this PR introduced it.
+8. Do not make unrelated cleanup edits, style edits, or generic improvements.
+9. Edit at most 3 documentation files unless the scope plan explicitly justifies more.
+10. Prefer updating existing pages over creating new ones.
+11. Do not edit `docs.json` unless the scope plan says a new docs page is strictly required.
+12. Only edit documentation files inside `./docs-repo`. Do NOT modify the source repository files, workflow files, or non-documentation assets.
+13. Do NOT create git commits.
+
+When done, print a short summary of what you changed and which existing documentation pages you updated.

--- a/.github/prompts/docs_scope_plan.md
+++ b/.github/prompts/docs_scope_plan.md
@@ -1,0 +1,53 @@
+You are a documentation scope planner for the Cognee project.
+
+Analyze this merged PR and produce a small documentation edit plan. Do not edit documentation files.
+
+## Available resources
+
+- **Documentation repo** (`./docs-repo`): Contains the documentation pages. Use existing `.md` and `.mdx` pages as the primary targets for edits. Read `./docs-repo/docs.json` if it exists to understand the documentation structure.
+- **Cognee source code** (current workspace root): Use the source code to verify actual implementation details, defaults, supported options, function signatures, env vars, and behavior.
+- **Branch notes**: Summary of the merged branch.
+- **Documentation assessment**: Candidate docs areas and rationale for the update.
+
+## Planning task
+
+1. Read the branch notes and documentation assessment.
+2. Use the branch notes, documentation assessment, changed source file list, and likely documentation targets as your primary evidence.
+3. Read at most 8 source files and at most 5 documentation files. Prefer files that are clearly public API, CLI, configuration, examples, or user-facing docs targets.
+4. Do not run shell commands or inspect the full diff. If the inputs are too broad, produce a conservative small plan instead of exploring further.
+5. Ignore tests, generated assets, lockfiles, and unrelated implementation-only changes unless they reveal public behavior.
+6. For each changed source file you consider, classify whether it changes:
+   - public behavior
+   - public API / imports / entrypoints
+   - documented configuration or defaults
+   - developer-facing extension semantics
+   - examples or usage patterns
+   - or only internal implementation details
+7. Identify the smallest docs edit surface that could cover the public-facing changes.
+
+Write the final plan to the scope plan output path provided by the workflow prompt.
+
+The plan must be Markdown with these exact sections:
+
+# Documentation Scope Plan
+
+## Docs Needed
+`true` or `false`
+
+## Reason
+One concise paragraph.
+
+## Documentation-Worthy Changes
+Bullets. Each bullet must name the change, the source files proving it, and the recommended docs page type.
+
+## Files To Edit
+Bullets of existing docs files to edit. Use paths relative to `docs-repo`. Leave empty if none.
+
+## Source Files To Inspect During Editing
+Bullets of source files the editing step should inspect. Keep this list short and exclude tests/assets/lockfiles.
+
+## Out Of Scope
+Bullets for changes intentionally skipped.
+
+Do not edit files inside `./docs-repo`.
+Do not create commits.

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,6 +1,7 @@
-name: automation | Draft Docs PRs For Current Day Dev Merges
+name: automation | Draft Docs PRs For Previous Day Dev PRs
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       lookback_days:
@@ -16,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
@@ -40,11 +42,12 @@ jobs:
       - name: Fetch latest dev branch
         run: git fetch origin dev:refs/remotes/origin/dev --no-tags
 
-      - name: Prepare current day merged branches
+      - name: Prepare merged PRs
         id: prepare
         shell: bash
         env:
           INPUT_ANCHOR_DATE: ${{ github.event.inputs.anchor_date || '' }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -113,12 +116,20 @@ jobs:
           LLM_MODEL: ${{ vars.LLM_MODEL || secrets.LLM_MODEL || 'openai/gpt-4o-mini' }}
           NOTES_JSON: ${{ steps.branch_paths.outputs.notes_json }}
           NOTES_MARKDOWN: ${{ steps.branch_paths.outputs.notes_markdown }}
+          PR_NUMBER: ${{ matrix.pr_number }}
+          PR_TITLE: ${{ matrix.pr_title }}
+          PR_BODY_B64: ${{ matrix.pr_body_b64 }}
+          PR_URL: ${{ matrix.pr_url }}
         run: |
           uv run python tools/generate_branch_notes.py \
             --branch-name "${{ matrix.branch_name }}" \
             --merge-sha "${{ matrix.merge_sha }}" \
             --first-parent "${{ matrix.first_parent }}" \
             --second-parent "${{ matrix.second_parent }}" \
+            --pr-number "${PR_NUMBER}" \
+            --pr-title "${PR_TITLE}" \
+            --pr-body-base64 "${PR_BODY_B64}" \
+            --pr-url "${PR_URL}" \
             --json-output "${NOTES_JSON}" \
             --markdown-output "${NOTES_MARKDOWN}"
 
@@ -152,8 +163,9 @@ jobs:
           needs_update = bool(assessment.get("needs_documentation_update"))
           branch_slug = os.environ["BRANCH_SLUG"]
           short_sha = os.environ["SHORT_SHA"]
-          docs_branch = f"automation/docs-{branch_slug}-{short_sha}"
-          pr_title = f"docs: draft updates for {os.environ['BRANCH_NAME']}"
+          pr_number = "${{ matrix.pr_number }}"
+          docs_branch = f"automation/docs-pr-{pr_number}-{branch_slug}-{short_sha}"
+          pr_title = f"docs: draft updates for PR #{pr_number}"
 
           output_path = Path(os.environ["GITHUB_OUTPUT"])
           with output_path.open("a", encoding="utf-8") as fh:
@@ -272,6 +284,7 @@ jobs:
             Your job is to document the actual behavior and API changes introduced by this branch, not to make adjacent or generic documentation improvements.
 
             - Branch: `${{ matrix.branch_name }}`
+            - PR: `#${{ matrix.pr_number }} ${{ matrix.pr_title }}`
             - Merge SHA: `${{ matrix.merge_sha }}`
             - Short SHA: `${{ matrix.short_sha }}`
             - First parent: `${{ matrix.first_parent }}`
@@ -481,7 +494,7 @@ jobs:
         run: |
           EXISTING_PR_NUMBER="$(gh pr list \
             --repo "${TARGET_REPO}" \
-            --head "topoteretes:${HEAD_BRANCH}" \
+            --head "${HEAD_BRANCH}" \
             --base main \
             --state open \
             --json number \
@@ -523,8 +536,9 @@ jobs:
           CHANGED_FILES: ${{ steps.pr_content.outputs.changed_files }}
         run: |
           {
-            echo "## Branch docs review: ${{ matrix.branch_name }}"
+            echo "## PR docs review: #${{ matrix.pr_number }} ${{ matrix.pr_title }}"
             echo
+            echo "- Branch: \`${{ matrix.branch_name }}\`"
             echo "- Merge commit: \`${{ matrix.merge_sha }}\`"
             echo "- Needs documentation update: \`${{ steps.assessment.outputs.needs_update }}\`"
             if [ "${{ steps.assessment.outputs.needs_update }}" = "true" ]; then

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,6 +1,7 @@
 name: automation | Draft Docs PRs For Previous Day Dev PRs
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       lookback_days:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -7,7 +7,7 @@ on:
       lookback_days:
         description: Number of UTC calendar days to look back when scanning merged PRs
         required: false
-        default: "1"
+        default: "3"
       anchor_date:
         description: Optional UTC date to scan, in YYYY-MM-DD format
         required: false

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -574,7 +574,13 @@ jobs:
               pr = github_request(
                   "POST",
                   "/pulls",
-                  {"base": "main", "head": head_branch, "title": pr_title, "body": pr_body},
+                  {
+                      "base": "main",
+                      "head": head_branch,
+                      "title": pr_title,
+                      "body": pr_body,
+                      "draft": True,
+                  },
               )
           else:
               print(

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -7,7 +7,7 @@ on:
       lookback_days:
         description: Number of UTC calendar days to look back when scanning merged PRs
         required: false
-        default: "3"
+        default: "1"
       anchor_date:
         description: Optional UTC date to scan, in YYYY-MM-DD format
         required: false
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 
 env:
-  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '3' }}
+  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
 
 jobs:
   prepare-merged-branches:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -309,17 +309,18 @@ jobs:
             ## Planning task
 
             1. Read the branch notes and documentation assessment.
-            2. Inspect the source diff for `${{ matrix.first_parent }}...${{ matrix.second_parent }}` only enough to identify documentation-worthy changes.
-            3. Focus on the precomputed changed source files and likely documentation targets first.
-            4. Ignore tests, generated assets, lockfiles, and unrelated implementation-only changes unless they reveal public behavior.
-            5. For each changed source file you consider, classify whether it changes:
+            2. Use the branch notes, documentation assessment, changed source file list, and likely documentation targets as your primary evidence.
+            3. Read at most 8 source files and at most 5 documentation files. Prefer files that are clearly public API, CLI, configuration, examples, or user-facing docs targets.
+            4. Do not run shell commands or inspect the full diff. If the inputs are too broad, produce a conservative small plan instead of exploring further.
+            5. Ignore tests, generated assets, lockfiles, and unrelated implementation-only changes unless they reveal public behavior.
+            6. For each changed source file you consider, classify whether it changes:
                - public behavior
                - public API / imports / entrypoints
                - documented configuration or defaults
                - developer-facing extension semantics
                - examples or usage patterns
                - or only internal implementation details
-            6. Identify the smallest docs edit surface that could cover the public-facing changes.
+            7. Identify the smallest docs edit surface that could cover the public-facing changes.
 
             Write the final plan to `./${{ steps.branch_paths.outputs.docs_scope_plan }}`.
 
@@ -347,7 +348,7 @@ jobs:
 
             Do not edit files inside `./docs-repo`.
             Do not create commits.
-          claude_args: "--allowed-tools Read,Write,Glob,Grep,Bash --max-turns 20"
+          claude_args: "--allowed-tools Read,Write,Glob,Grep --max-turns 35"
 
       - name: Validate docs scope plan
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
@@ -512,44 +513,86 @@ jobs:
           PR_BODY: ${{ steps.pr_content.outputs.pr_body }}
           CHANGES_MADE: ${{ steps.commit_docs.outputs.changes_made }}
         run: |
-          EXISTING_PR_NUMBER="$(gh pr list \
-            --repo "${TARGET_REPO}" \
-            --head "${HEAD_BRANCH}" \
-            --base main \
-            --state open \
-            --json number \
-            --jq '.[0].number')"
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.parse
+          import urllib.request
 
-          if [ -n "${EXISTING_PR_NUMBER}" ]; then
-            gh pr edit "${EXISTING_PR_NUMBER}" \
-              --repo "${TARGET_REPO}" \
-              --title "${PR_TITLE}" \
-              --body "${PR_BODY}"
-            PR_NUMBER="${EXISTING_PR_NUMBER}"
-          elif [ "${CHANGES_MADE}" = "true" ]; then
-            gh pr create \
-              --repo "${TARGET_REPO}" \
-              --base main \
-              --head "${HEAD_BRANCH}" \
-              --title "${PR_TITLE}" \
-              --body "${PR_BODY}"
-            PR_NUMBER="$(gh pr list \
-              --repo "${TARGET_REPO}" \
-              --head "${HEAD_BRANCH}" \
-              --base main \
-              --state open \
-              --json number \
-              --jq '.[0].number')"
-          else
-            echo "Assessment expected documentation changes for ${HEAD_BRANCH}, but Claude made no docs edits and no open PR exists. Skipping PR creation."
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            echo "pr_url=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          token = os.environ["GH_TOKEN"]
+          target_repo = os.environ["TARGET_REPO"]
+          head_branch = os.environ["HEAD_BRANCH"]
+          pr_title = os.environ["PR_TITLE"]
+          pr_body = os.environ["PR_BODY"]
+          changes_made = os.environ["CHANGES_MADE"] == "true"
+          owner = target_repo.split("/", 1)[0]
 
-          PR_URL="$(gh pr view "${PR_NUMBER}" --repo "${TARGET_REPO}" --json url --jq '.url')"
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+          def github_request(method, path, payload=None, query=None):
+              url = f"https://api.github.com/repos/{target_repo}{path}"
+              if query:
+                  url = f"{url}?{urllib.parse.urlencode(query)}"
+              data = None
+              if payload is not None:
+                  data = json.dumps(payload).encode("utf-8")
+              request = urllib.request.Request(
+                  url,
+                  data=data,
+                  method=method,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "Content-Type": "application/json",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=20) as response:
+                      content = response.read().decode("utf-8")
+              except urllib.error.HTTPError as exc:
+                  print(exc.read().decode("utf-8"), flush=True)
+                  raise
+              return json.loads(content) if content else None
+
+          existing_prs = github_request(
+              "GET",
+              "/pulls",
+              query={
+                  "head": f"{owner}:{head_branch}",
+                  "base": "main",
+                  "state": "open",
+                  "per_page": "1",
+              },
+          )
+
+          if existing_prs:
+              pr = github_request(
+                  "PATCH",
+                  f"/pulls/{existing_prs[0]['number']}",
+                  {"title": pr_title, "body": pr_body},
+              )
+          elif changes_made:
+              pr = github_request(
+                  "POST",
+                  "/pulls",
+                  {"base": "main", "head": head_branch, "title": pr_title, "body": pr_body},
+              )
+          else:
+              print(
+                  f"Assessment expected documentation changes for {head_branch}, "
+                  "but Claude made no docs edits and no open PR exists. Skipping PR creation."
+              )
+              pr = None
+
+          output_path = os.environ["GITHUB_OUTPUT"]
+          with open(output_path, "a", encoding="utf-8") as fh:
+              if pr is None:
+                  fh.write("pr_number=\n")
+                  fh.write("pr_url=\n")
+              else:
+                  fh.write(f"pr_number={pr['number']}\n")
+                  fh.write(f"pr_url={pr['html_url']}\n")
+          PY
 
       - name: Summarize docs PR result
         env:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,7 +1,7 @@
 name: automation | Draft Docs PRs For Previous Day Dev PRs
 
 on:
-  push:
+  pull_request:
   workflow_dispatch:
     inputs:
       lookback_days:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,7 +1,6 @@
 name: automation | Draft Docs PRs For Previous Day Dev PRs
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       lookback_days:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,7 +1,6 @@
 name: automation | Draft Docs PRs For Current Day Dev Merges
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       lookback_days:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 
 env:
-  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
+  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '3' }}
 
 jobs:
   prepare-merged-branches:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       lookback_days:
-        description: Number of UTC calendar days to look back when scanning merged commits
+        description: Number of UTC calendar days to look back when scanning merged PRs
         required: false
-        default: "1"
+        default: "4"
       anchor_date:
         description: Optional UTC date to scan, in YYYY-MM-DD format
         required: false
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 
 env:
-  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
+  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '4' }}
 
 jobs:
   prepare-merged-branches:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -7,7 +7,7 @@ on:
       lookback_days:
         description: Number of UTC calendar days to look back when scanning merged PRs
         required: false
-        default: "3"
+        default: "1"
       anchor_date:
         description: Optional UTC date to scan, in YYYY-MM-DD format
         required: false
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 
 env:
-  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
+  lookback_days: '3' #${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
 
 jobs:
   prepare-merged-branches:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,7 +1,6 @@
 name: automation | Draft Docs PRs For Previous Day Dev PRs
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       lookback_days:
@@ -20,7 +19,7 @@ permissions:
   pull-requests: read
 
 env:
-  lookback_days: '3' #${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
+  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
 
 jobs:
   prepare-merged-branches:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,13 +1,12 @@
 name: automation | Draft Docs PRs For Previous Day Dev PRs
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       lookback_days:
         description: Number of UTC calendar days to look back when scanning merged PRs
         required: false
-        default: "4"
+        default: "1"
       anchor_date:
         description: Optional UTC date to scan, in YYYY-MM-DD format
         required: false
@@ -20,7 +19,7 @@ permissions:
   pull-requests: read
 
 env:
-  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '4' }}
+  lookback_days: ${{ github.event.inputs.lookback_days || vars.lookback_days || '1' }}
 
 jobs:
   prepare-merged-branches:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -109,6 +109,7 @@ jobs:
           echo "notes_markdown=${OUTPUT_DIR}/branch_notes.md" >> "${GITHUB_OUTPUT}"
           echo "assessment_json=${OUTPUT_DIR}/docs_assessment.json" >> "${GITHUB_OUTPUT}"
           echo "assessment_markdown=${OUTPUT_DIR}/docs_assessment.md" >> "${GITHUB_OUTPUT}"
+          echo "docs_scope_plan=${OUTPUT_DIR}/docs_scope_plan.md" >> "${GITHUB_OUTPUT}"
 
       - name: Generate branch notes
         env:
@@ -270,18 +271,17 @@ jobs:
               fh.write("EOF\n")
           PY
 
-      - name: Generate docs changes with Claude
+      - name: Plan docs changes with Claude
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
-        id: claude
+        id: claude_scope
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
-            You are a documentation improvement agent for the Cognee project.
+            You are a documentation scope planner for the Cognee project.
 
-            Update the existing Cognee documentation to reflect this merged branch.
-            Your job is to document the actual behavior and API changes introduced by this branch, not to make adjacent or generic documentation improvements.
+            Analyze this merged PR and produce a small documentation edit plan. Do not edit documentation files.
 
             - Branch: `${{ matrix.branch_name }}`
             - PR: `#${{ matrix.pr_number }} ${{ matrix.pr_title }}`
@@ -289,6 +289,7 @@ jobs:
             - Short SHA: `${{ matrix.short_sha }}`
             - First parent: `${{ matrix.first_parent }}`
             - Second parent: `${{ matrix.second_parent }}`
+            - Scope plan output: `./${{ steps.branch_paths.outputs.docs_scope_plan }}`
 
             ## Available resources
 
@@ -305,88 +306,107 @@ jobs:
             Likely documentation targets:
             ${{ steps.docs_scope.outputs.candidate_doc_files }}
 
-            ## Required approach
+            ## Planning task
 
-            Start by reading the branch notes, then inspect the actual code diff for this branch. Use the branch parents above to identify what really changed. Prefer the merge-base-aware diff `git diff ${{ matrix.first_parent }}...${{ matrix.second_parent }}` and read the touched source files before editing docs.
-            Focus on the precomputed source files and likely documentation targets first. Only search outside those targets if they are clearly not sufficient.
-            Document the net-new public-facing delta introduced by this branch, not the full current behavior of the subsystem.
-
-            Before making any docs edits:
-
-            1. List the source files changed by this branch.
-            2. For each changed source file, identify whether it changes:
+            1. Read the branch notes and documentation assessment.
+            2. Inspect the source diff for `${{ matrix.first_parent }}...${{ matrix.second_parent }}` only enough to identify documentation-worthy changes.
+            3. Focus on the precomputed changed source files and likely documentation targets first.
+            4. Ignore tests, generated assets, lockfiles, and unrelated implementation-only changes unless they reveal public behavior.
+            5. For each changed source file you consider, classify whether it changes:
                - public behavior
                - public API / imports / entrypoints
                - documented configuration or defaults
                - developer-facing extension semantics
                - examples or usage patterns
                - or only internal implementation details
-            3. Only edit docs for items that fall into the documented/public categories above.
-            4. If a proposed docs edit cannot be traced back to a concrete source diff in this branch, do not make that edit.
-            5. Check whether the described behavior already existed before this branch. If it did, do not describe it as newly introduced by this merge.
-            6. If the branch fixes migrations, registration, wiring, or visibility for an already-existing feature, document the upgrade or migration impact only. Do not expand into broad subsystem documentation unless it is strictly required to understand the branch.
+            6. Identify the smallest docs edit surface that could cover the public-facing changes.
 
-            ## Instructions
+            Write the final plan to `./${{ steps.branch_paths.outputs.docs_scope_plan }}`.
 
-            1. Read the branch notes and documentation assessment first.
-            2. Inspect the source diff for `${{ matrix.first_parent }}...${{ matrix.second_parent }}` and identify which changes are documentation-worthy.
-            3. Review the touched source files themselves, not just the merge summary.
-            4. Only document user-facing behavior, public API changes, examples, or developer-facing semantics that actually changed in this branch.
-            5. For each proposed docs edit, identify the exact branch delta it documents and which changed source file(s) prove it.
-            6. Check that the target page is the correct page type for the detail level:
-               - concept pages: high-level behavior and mental model
-               - guides: task-oriented usage
-               - API/reference pages: exact signatures, parameters, schemas, env vars, and defaults
-               - migration/changelog pages: upgrade impact and operational notes
-            7. If the content is too detailed for the chosen page, either move it to a more appropriate existing page or reduce it to a short note with a link.
-            8. Do not make unrelated cleanup edits, style edits, or generic improvements to nearby docs sections unless they are strictly required to explain the branch changes.
-            9. Prefer the smallest possible set of docs edits that fully covers the code changes.
-            10. Review the relevant existing documentation pages in `./docs-repo`.
-            11. Search the Cognee source code in the current workspace to verify technical details before editing docs.
-            12. Edit at most 3 documentation files unless the source diff clearly requires more.
-            13. Prefer updating existing pages over creating new ones.
-            14. Do not edit `docs.json` unless you are creating a new docs page that is strictly required by the code diff.
-            15. Do not edit any workflow files, automation files, integration docs, provider docs, or unrelated concept pages unless the changed source files in this branch directly require it.
-            16. Only edit documentation files inside `./docs-repo`. Do NOT modify the source repository files, workflow files, or any non-documentation assets.
-            17. Do NOT create git commits.
+            The plan must be Markdown with these exact sections:
 
-            ## What to prioritize
+            # Documentation Scope Plan
 
-            Give priority to documenting changes like:
+            ## Docs Needed
+            `true` or `false`
 
-            - user-facing behavior changes
-            - public API, CLI, SDK, or configuration changes
-            - example code that is now outdated because of the merged branch
-            - developer-facing semantics that custom integrators or extension authors rely on
-            - changes to documented imports, entrypoints, arguments, defaults, return shapes, or supported options
+            ## Reason
+            One concise paragraph.
 
-            Lower priority or likely no-doc items unless explicitly exposed in public docs:
+            ## Documentation-Worthy Changes
+            Bullets. Each bullet must name the change, the source files proving it, and the recommended docs page type.
 
-            - internal performance optimizations
-            - internal race-condition fixes
-            - private implementation details that users do not interact with directly
+            ## Files To Edit
+            Bullets of existing docs files to edit. Use paths relative to `docs-repo`. Leave empty if none.
 
-            If a change is purely internal and not represented in public docs, leave it undocumented rather than inventing a public-facing explanation.
+            ## Source Files To Inspect During Editing
+            Bullets of source files the editing step should inspect. Keep this list short and exclude tests/assets/lockfiles.
 
-            ## Output discipline
+            ## Out Of Scope
+            Bullets for changes intentionally skipped.
 
-            The resulting docs PR should be easy to justify from the code diff.
+            Do not edit files inside `./docs-repo`.
+            Do not create commits.
+          claude_args: "--allowed-tools Read,Write,Glob,Grep,Bash --max-turns 20"
 
-            - Keep the PR narrowly scoped to this merge.
-            - Do not present pre-existing behavior as if this branch introduced it.
-            - Do not broaden a narrow fix branch into full feature-area documentation.
-            - Do not turn a small migration or registration fix into a large conceptual backfill unless the branch itself changes the public concept.
-            - Avoid adding documentation for features, integrations, or guides that were not touched by this branch.
-            - Do not add new conceptual pages unless the source diff introduces a new public concept that cannot fit into an existing page.
-            - If the branch only warrants one or two doc edits, make only one or two doc edits.
-            - Every edited file must be explainable by pointing to one or more changed source files in this merge.
-            - Every edited paragraph should be defensible from a concrete branch delta, not just from the current state of the codebase.
-            - Prefer precise scope wording. For example:
-              - "for graph node and edge relational upserts" instead of "for all relational writes"
-              - "helps avoid race conditions and contention" instead of "prevents race conditions"
-              - "equivalent configurations now reuse the same adapter instance" instead of "the factory caches adapters"
-            - If you cannot justify an edit from the code diff, skip it.
-            - It is better to produce a very small PR than a broad PR with speculative documentation updates.
+      - name: Validate docs scope plan
+        if: ${{ steps.assessment.outputs.needs_update == 'true' }}
+        run: |
+          test -s "${{ steps.branch_paths.outputs.docs_scope_plan }}"
+          if [ -n "$(git -C docs-repo status --short)" ]; then
+            echo "The docs planning step modified docs-repo, but planning must not edit documentation." >&2
+            git -C docs-repo status --short >&2
+            exit 1
+          fi
+
+      - name: Generate docs changes with Claude
+        if: ${{ steps.assessment.outputs.needs_update == 'true' }}
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are a documentation improvement agent for the Cognee project.
+
+            Update the existing Cognee documentation to reflect this merged PR.
+            Your job is to document the actual behavior and API changes introduced by this PR, not to make adjacent or generic documentation improvements.
+
+            - Branch: `${{ matrix.branch_name }}`
+            - PR: `#${{ matrix.pr_number }} ${{ matrix.pr_title }}`
+            - Merge SHA: `${{ matrix.merge_sha }}`
+            - Short SHA: `${{ matrix.short_sha }}`
+            - First parent: `${{ matrix.first_parent }}`
+            - Second parent: `${{ matrix.second_parent }}`
+
+            ## Required inputs
+
+            Read these first:
+
+            - **Documentation scope plan** (`./${{ steps.branch_paths.outputs.docs_scope_plan }}`)
+            - **Branch notes** (`./${{ steps.branch_paths.outputs.notes_markdown }}`)
+            - **Documentation assessment** (`./${{ steps.branch_paths.outputs.assessment_markdown }}`)
+
+            ## Available resources
+
+            - **Documentation repo** (`./docs-repo`): Contains the documentation pages. Use existing `.md` and `.mdx` pages as the primary targets for edits. Read `./docs-repo/docs.json` only if the scope plan requires navigation context.
+            - **Cognee source code** (current workspace root): Use the source code to verify actual implementation details, defaults, supported options, function signatures, env vars, and behavior.
+
+            ## Editing rules
+
+            1. Follow the documentation scope plan.
+            2. If the scope plan says `Docs Needed` is `false`, make no documentation edits and print the reason.
+            3. Inspect only the source files listed in the scope plan unless they are insufficient to verify a specific planned edit.
+            4. Edit only docs files listed in the scope plan unless they are clearly the wrong target; if so, choose the smallest better existing docs target.
+            5. Document only user-facing behavior, public API changes, examples, or developer-facing semantics that actually changed in this PR.
+            6. If a proposed docs edit cannot be traced back to a concrete source diff in this PR, do not make that edit.
+            7. Do not present pre-existing behavior as if this PR introduced it.
+            8. Do not make unrelated cleanup edits, style edits, or generic improvements.
+            9. Edit at most 3 documentation files unless the scope plan explicitly justifies more.
+            10. Prefer updating existing pages over creating new ones.
+            11. Do not edit `docs.json` unless the scope plan says a new docs page is strictly required.
+            12. Only edit documentation files inside `./docs-repo`. Do NOT modify the source repository files, workflow files, or non-documentation assets.
+            13. Do NOT create git commits.
 
             When done, print a short summary of what you changed and which existing documentation pages you updated.
           claude_args: "--allowed-tools Read,Edit,Write,Glob,Grep,Bash --max-turns 50"

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,6 +1,7 @@
 name: automation | Draft Docs PRs For Previous Day Dev PRs
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       lookback_days:
@@ -142,10 +143,6 @@ jobs:
           NOTES_MARKDOWN: ${{ steps.branch_paths.outputs.notes_markdown }}
           ASSESSMENT_JSON: ${{ steps.branch_paths.outputs.assessment_json }}
           ASSESSMENT_MARKDOWN: ${{ steps.branch_paths.outputs.assessment_markdown }}
-          BRANCH_NAME: ${{ matrix.branch_name }}
-          BRANCH_SLUG: ${{ matrix.safe_branch }}
-          SHORT_SHA: ${{ matrix.short_sha }}
-          MERGE_SHA: ${{ matrix.merge_sha }}
         run: |
           uv run python tools/assess_branch_notes.py \
             --notes-json "${NOTES_JSON}" \
@@ -153,26 +150,11 @@ jobs:
             --json-output "${ASSESSMENT_JSON}" \
             --markdown-output "${ASSESSMENT_MARKDOWN}"
 
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          assessment = json.loads(Path(os.environ["ASSESSMENT_JSON"]).read_text())
-
-          needs_update = bool(assessment.get("needs_documentation_update"))
-          branch_slug = os.environ["BRANCH_SLUG"]
-          short_sha = os.environ["SHORT_SHA"]
-          pr_number = "${{ matrix.pr_number }}"
-          docs_branch = f"automation/docs-pr-{pr_number}-{branch_slug}-{short_sha}"
-          pr_title = f"docs: draft updates for PR #{pr_number}"
-
-          output_path = Path(os.environ["GITHUB_OUTPUT"])
-          with output_path.open("a", encoding="utf-8") as fh:
-              fh.write(f"needs_update={'true' if needs_update else 'false'}\n")
-              fh.write(f"docs_branch={docs_branch}\n")
-              fh.write(f"pr_title={pr_title}\n")
-          PY
+          python3 tools/write_docs_assessment_outputs.py \
+            --assessment-json "${ASSESSMENT_JSON}" \
+            --branch-slug "${{ matrix.safe_branch }}" \
+            --short-sha "${{ matrix.short_sha }}" \
+            --pr-number "${{ matrix.pr_number }}"
 
       - name: Skip docs PR creation when docs are not needed
         if: ${{ steps.assessment.outputs.needs_update != 'true' }}
@@ -204,71 +186,10 @@ jobs:
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
         id: docs_scope
         run: |
-          python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          from tools.merge_branch_diff import get_branch_changed_files
-
-          first_parent = "${{ matrix.first_parent }}"
-          second_parent = "${{ matrix.second_parent }}"
-          docs_root = Path("docs-repo")
-
-          changed_files = get_branch_changed_files(first_parent, second_parent)
-
-          doc_files = sorted(
-              path.relative_to(docs_root).as_posix()
-              for path in docs_root.rglob("*")
-              if path.is_file() and path.suffix.lower() == ".mdx"
-          )
-
-          ignored_parts = {
-              "cognee",
-              "__init__.py",
-              "models",
-              "operations",
-              "modules",
-              "tasks",
-              "routers",
-              "shared",
-              "infrastructure",
-          }
-
-          keywords: list[str] = []
-          for changed_file in changed_files:
-              path = Path(changed_file)
-              stem = path.stem.lower()
-              if len(stem) >= 3 and stem not in ignored_parts:
-                  keywords.append(stem)
-              for part in path.parts:
-                  token = part.lower()
-                  if len(token) >= 4 and token not in ignored_parts:
-                      keywords.append(token)
-
-          unique_keywords: list[str] = []
-          for keyword in keywords:
-              if keyword not in unique_keywords:
-                  unique_keywords.append(keyword)
-
-          scored: list[tuple[int, str]] = []
-          for doc_file in doc_files:
-              haystack = doc_file.lower()
-              score = sum(1 for keyword in unique_keywords if keyword in haystack)
-              if score > 0:
-                  scored.append((score, doc_file))
-
-          scored.sort(key=lambda item: (-item[0], item[1]))
-          candidate_doc_files = [doc_file for _, doc_file in scored[:5]]
-
-          output_path = Path(os.environ["GITHUB_OUTPUT"])
-          with output_path.open("a", encoding="utf-8") as fh:
-              fh.write("changed_source_files<<EOF\n")
-              fh.write("\n".join(changed_files) + "\n")
-              fh.write("EOF\n")
-              fh.write("candidate_doc_files<<EOF\n")
-              fh.write("\n".join(candidate_doc_files) + "\n")
-              fh.write("EOF\n")
-          PY
+          python3 tools/prepare_docs_edit_scope.py \
+            --first-parent "${{ matrix.first_parent }}" \
+            --second-parent "${{ matrix.second_parent }}" \
+            --docs-root docs-repo
 
       - name: Plan docs changes with Claude
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
@@ -278,9 +199,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
-            You are a documentation scope planner for the Cognee project.
-
-            Analyze this merged PR and produce a small documentation edit plan. Do not edit documentation files.
+            Read and follow `.github/prompts/docs_scope_plan.md`.
 
             - Branch: `${{ matrix.branch_name }}`
             - PR: `#${{ matrix.pr_number }} ${{ matrix.pr_title }}`
@@ -290,10 +209,6 @@ jobs:
             - Second parent: `${{ matrix.second_parent }}`
             - Scope plan output: `./${{ steps.branch_paths.outputs.docs_scope_plan }}`
 
-            ## Available resources
-
-            - **Documentation repo** (`./docs-repo`): Contains the documentation pages. Use existing `.md` and `.mdx` pages as the primary targets for edits. Read `./docs-repo/docs.json` if it exists to understand the documentation structure.
-            - **Cognee source code** (current workspace root): Use the source code to verify actual implementation details, defaults, supported options, function signatures, env vars, and behavior.
             - **Branch notes** (`./${{ steps.branch_paths.outputs.notes_markdown }}`): Summary of the merged branch.
             - **Documentation assessment** (`./${{ steps.branch_paths.outputs.assessment_markdown }}`): Candidate docs areas and rationale for the update.
 
@@ -304,49 +219,6 @@ jobs:
 
             Likely documentation targets:
             ${{ steps.docs_scope.outputs.candidate_doc_files }}
-
-            ## Planning task
-
-            1. Read the branch notes and documentation assessment.
-            2. Use the branch notes, documentation assessment, changed source file list, and likely documentation targets as your primary evidence.
-            3. Read at most 8 source files and at most 5 documentation files. Prefer files that are clearly public API, CLI, configuration, examples, or user-facing docs targets.
-            4. Do not run shell commands or inspect the full diff. If the inputs are too broad, produce a conservative small plan instead of exploring further.
-            5. Ignore tests, generated assets, lockfiles, and unrelated implementation-only changes unless they reveal public behavior.
-            6. For each changed source file you consider, classify whether it changes:
-               - public behavior
-               - public API / imports / entrypoints
-               - documented configuration or defaults
-               - developer-facing extension semantics
-               - examples or usage patterns
-               - or only internal implementation details
-            7. Identify the smallest docs edit surface that could cover the public-facing changes.
-
-            Write the final plan to `./${{ steps.branch_paths.outputs.docs_scope_plan }}`.
-
-            The plan must be Markdown with these exact sections:
-
-            # Documentation Scope Plan
-
-            ## Docs Needed
-            `true` or `false`
-
-            ## Reason
-            One concise paragraph.
-
-            ## Documentation-Worthy Changes
-            Bullets. Each bullet must name the change, the source files proving it, and the recommended docs page type.
-
-            ## Files To Edit
-            Bullets of existing docs files to edit. Use paths relative to `docs-repo`. Leave empty if none.
-
-            ## Source Files To Inspect During Editing
-            Bullets of source files the editing step should inspect. Keep this list short and exclude tests/assets/lockfiles.
-
-            ## Out Of Scope
-            Bullets for changes intentionally skipped.
-
-            Do not edit files inside `./docs-repo`.
-            Do not create commits.
           claude_args: "--allowed-tools Read,Write,Glob,Grep --max-turns 35"
 
       - name: Validate docs scope plan
@@ -367,10 +239,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
-            You are a documentation improvement agent for the Cognee project.
-
-            Update the existing Cognee documentation to reflect this merged PR.
-            Your job is to document the actual behavior and API changes introduced by this PR, not to make adjacent or generic documentation improvements.
+            Read and follow `.github/prompts/docs_edit.md`.
 
             - Branch: `${{ matrix.branch_name }}`
             - PR: `#${{ matrix.pr_number }} ${{ matrix.pr_title }}`
@@ -386,99 +255,25 @@ jobs:
             - **Documentation scope plan** (`./${{ steps.branch_paths.outputs.docs_scope_plan }}`)
             - **Branch notes** (`./${{ steps.branch_paths.outputs.notes_markdown }}`)
             - **Documentation assessment** (`./${{ steps.branch_paths.outputs.assessment_markdown }}`)
-
-            ## Available resources
-
-            - **Documentation repo** (`./docs-repo`): Contains the documentation pages. Use existing `.md` and `.mdx` pages as the primary targets for edits. Read `./docs-repo/docs.json` only if the scope plan requires navigation context.
-            - **Cognee source code** (current workspace root): Use the source code to verify actual implementation details, defaults, supported options, function signatures, env vars, and behavior.
-
-            ## Editing rules
-
-            1. Follow the documentation scope plan.
-            2. If the scope plan says `Docs Needed` is `false`, make no documentation edits and print the reason.
-            3. Inspect only the source files listed in the scope plan unless they are insufficient to verify a specific planned edit.
-            4. Edit only docs files listed in the scope plan unless they are clearly the wrong target; if so, choose the smallest better existing docs target.
-            5. Document only user-facing behavior, public API changes, examples, or developer-facing semantics that actually changed in this PR.
-            6. If a proposed docs edit cannot be traced back to a concrete source diff in this PR, do not make that edit.
-            7. Do not present pre-existing behavior as if this PR introduced it.
-            8. Do not make unrelated cleanup edits, style edits, or generic improvements.
-            9. Edit at most 3 documentation files unless the scope plan explicitly justifies more.
-            10. Prefer updating existing pages over creating new ones.
-            11. Do not edit `docs.json` unless the scope plan says a new docs page is strictly required.
-            12. Only edit documentation files inside `./docs-repo`. Do NOT modify the source repository files, workflow files, or non-documentation assets.
-            13. Do NOT create git commits.
-
-            When done, print a short summary of what you changed and which existing documentation pages you updated.
           claude_args: "--allowed-tools Read,Edit,Write,Glob,Grep,Bash --max-turns 50"
 
       - name: Prepare docs PR content
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
         id: pr_content
         env:
-          BRANCH_NAME: ${{ matrix.branch_name }}
-          SHORT_SHA: ${{ matrix.short_sha }}
           NOTES_JSON: ${{ steps.branch_paths.outputs.notes_json }}
           ASSESSMENT_JSON: ${{ steps.branch_paths.outputs.assessment_json }}
+          BRANCH_NAME: ${{ matrix.branch_name }}
+          SHORT_SHA: ${{ matrix.short_sha }}
           DEFAULT_PR_TITLE: ${{ steps.assessment.outputs.pr_title }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import subprocess
-          from pathlib import Path
-
-          notes = json.loads(Path(os.environ["NOTES_JSON"]).read_text())
-          assessment = json.loads(Path(os.environ["ASSESSMENT_JSON"]).read_text())
-          summary = notes.get("summary", "").strip()
-          highlights = notes.get("highlights", [])
-          reason = assessment.get("reason", "")
-
-          changed_files = [
-              line.rstrip()
-              for line in subprocess.check_output(
-                  ["git", "-C", "docs-repo", "status", "--short"],
-                  text=True,
-              ).splitlines()
-              if line.strip()
-          ]
-          normalized_files = [entry[3:] if len(entry) > 3 else entry for entry in changed_files]
-
-          pr_title = os.environ["DEFAULT_PR_TITLE"]
-          pr_body_lines = [
-              "## Summary",
-              "",
-              f"Automated documentation draft for merged branch `{os.environ['BRANCH_NAME']}` (`{os.environ['SHORT_SHA']}`).",
-              "",
-              summary
-              or "This PR updates existing docs to reflect the branch's user-facing documentation impact based on the source diff and current docs structure.",
-              "",
-              "## Why This PR Exists",
-              "",
-              reason
-              or "The merged branch appears to change behavior, configuration, API usage, or developer-facing semantics that are represented in the docs.",
-              "",
-              "## Source",
-              "",
-              f"- Branch: `{os.environ['BRANCH_NAME']}`",
-              f"- Merge short SHA: `{os.environ['SHORT_SHA']}`",
-          ]
-          if highlights:
-              pr_body_lines.extend(["", "## Branch Highlights", ""])
-              pr_body_lines.extend([f"- {item}" for item in highlights])
-          if normalized_files:
-              pr_body_lines.extend(["", "## Documentation Files Updated", ""])
-              pr_body_lines.extend([f"- `{item}`" for item in normalized_files])
-
-          output_path = Path(os.environ["GITHUB_OUTPUT"])
-          with output_path.open("a", encoding="utf-8") as fh:
-              fh.write(f"pr_title={pr_title}\n")
-              fh.write("pr_body<<EOF\n")
-              fh.write("\n".join(pr_body_lines) + "\n")
-              fh.write("EOF\n")
-              fh.write("changed_files<<EOF\n")
-              fh.write("\n".join(normalized_files) + "\n")
-              fh.write("EOF\n")
-          PY
+          python3 tools/prepare_docs_pr_content.py \
+            --notes-json "${NOTES_JSON}" \
+            --assessment-json "${ASSESSMENT_JSON}" \
+            --branch-name "${BRANCH_NAME}" \
+            --short-sha "${SHORT_SHA}" \
+            --default-pr-title "${DEFAULT_PR_TITLE}" \
+            --docs-root docs-repo
 
       - name: Create docs draft commit
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
@@ -503,101 +298,19 @@ jobs:
       - name: Create or update docs pull request
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
         id: manage_pr
-        working-directory: docs-repo
         env:
           GH_TOKEN: ${{ secrets.REPO_DISPATCH_PAT_TOKEN }}
-          TARGET_REPO: topoteretes/cognee-docs
           HEAD_BRANCH: ${{ steps.assessment.outputs.docs_branch }}
           PR_TITLE: ${{ steps.pr_content.outputs.pr_title }}
           PR_BODY: ${{ steps.pr_content.outputs.pr_body }}
           CHANGES_MADE: ${{ steps.commit_docs.outputs.changes_made }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import urllib.error
-          import urllib.parse
-          import urllib.request
-
-          token = os.environ["GH_TOKEN"]
-          target_repo = os.environ["TARGET_REPO"]
-          head_branch = os.environ["HEAD_BRANCH"]
-          pr_title = os.environ["PR_TITLE"]
-          pr_body = os.environ["PR_BODY"]
-          changes_made = os.environ["CHANGES_MADE"] == "true"
-          owner = target_repo.split("/", 1)[0]
-
-          def github_request(method, path, payload=None, query=None):
-              url = f"https://api.github.com/repos/{target_repo}{path}"
-              if query:
-                  url = f"{url}?{urllib.parse.urlencode(query)}"
-              data = None
-              if payload is not None:
-                  data = json.dumps(payload).encode("utf-8")
-              request = urllib.request.Request(
-                  url,
-                  data=data,
-                  method=method,
-                  headers={
-                      "Accept": "application/vnd.github+json",
-                      "Authorization": f"Bearer {token}",
-                      "Content-Type": "application/json",
-                      "X-GitHub-Api-Version": "2022-11-28",
-                  },
-              )
-              try:
-                  with urllib.request.urlopen(request, timeout=20) as response:
-                      content = response.read().decode("utf-8")
-              except urllib.error.HTTPError as exc:
-                  print(exc.read().decode("utf-8"), flush=True)
-                  raise
-              return json.loads(content) if content else None
-
-          existing_prs = github_request(
-              "GET",
-              "/pulls",
-              query={
-                  "head": f"{owner}:{head_branch}",
-                  "base": "main",
-                  "state": "open",
-                  "per_page": "1",
-              },
-          )
-
-          if existing_prs:
-              pr = github_request(
-                  "PATCH",
-                  f"/pulls/{existing_prs[0]['number']}",
-                  {"title": pr_title, "body": pr_body},
-              )
-          elif changes_made:
-              pr = github_request(
-                  "POST",
-                  "/pulls",
-                  {
-                      "base": "main",
-                      "head": head_branch,
-                      "title": pr_title,
-                      "body": pr_body,
-                      "draft": True,
-                  },
-              )
-          else:
-              print(
-                  f"Assessment expected documentation changes for {head_branch}, "
-                  "but Claude made no docs edits and no open PR exists. Skipping PR creation."
-              )
-              pr = None
-
-          output_path = os.environ["GITHUB_OUTPUT"]
-          with open(output_path, "a", encoding="utf-8") as fh:
-              if pr is None:
-                  fh.write("pr_number=\n")
-                  fh.write("pr_url=\n")
-              else:
-                  fh.write(f"pr_number={pr['number']}\n")
-                  fh.write(f"pr_url={pr['html_url']}\n")
-          PY
+          python3 tools/manage_docs_pr.py \
+            --target-repo topoteretes/cognee-docs \
+            --head-branch "${HEAD_BRANCH}" \
+            --pr-title "${PR_TITLE}" \
+            --pr-body "${PR_BODY}" \
+            --changes-made "${CHANGES_MADE}"
 
       - name: Summarize docs PR result
         env:

--- a/.github/workflows/dev_previous_day_commits.yml
+++ b/.github/workflows/dev_previous_day_commits.yml
@@ -1,6 +1,7 @@
 name: automation | Draft Docs PRs For Current Day Dev Merges
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       lookback_days:
@@ -376,7 +377,7 @@ jobs:
             - It is better to produce a very small PR than a broad PR with speculative documentation updates.
 
             When done, print a short summary of what you changed and which existing documentation pages you updated.
-          claude_args: "--allowed-tools Read,Edit,Write,Glob,Grep,Bash --max-turns 20"
+          claude_args: "--allowed-tools Read,Edit,Write,Glob,Grep,Bash --max-turns 50"
 
       - name: Prepare docs PR content
         if: ${{ steps.assessment.outputs.needs_update == 'true' }}
@@ -508,8 +509,10 @@ jobs:
               --json number \
               --jq '.[0].number')"
           else
-            echo "Expected documentation changes for ${HEAD_BRANCH}, but no docs changes were committed and no open PR exists." >&2
-            exit 1
+            echo "Assessment expected documentation changes for ${HEAD_BRANCH}, but Claude made no docs edits and no open PR exists. Skipping PR creation."
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "pr_url=" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           PR_URL="$(gh pr view "${PR_NUMBER}" --repo "${TARGET_REPO}" --json url --jq '.url')"

--- a/tools/assess_branch_notes.py
+++ b/tools/assess_branch_notes.py
@@ -18,6 +18,10 @@ from pathlib import Path
 from typing import Any
 
 
+def read_tool_prompt(prompt_name: str) -> str:
+    return (Path(__file__).parent / "prompts" / prompt_name).read_text(encoding="utf-8")
+
+
 def format_markdown(assessment: Any) -> str:
     needs_update = (
         assessment.needs_documentation_update
@@ -82,16 +86,7 @@ async def assess_with_llm(notes_json: str, notes_markdown: str) -> Any:
         recommended_next_steps: list[str] = Field(description="Practical next steps for docs work")
         confidence: str = Field(description="Confidence level and short explanation")
 
-    system_prompt = """You are a documentation strategist for the Cognee project.
-
-Analyze the provided daily dev notes and decide whether they imply documentation updates.
-
-Guidelines:
-- Focus on user-facing changes, APIs, integrations, setup, and operational behavior
-- Recommend docs work only when the notes indicate likely user impact
-- Keep recommendations concrete and concise
-"""
-
+    system_prompt = read_tool_prompt("docs_assessment_system.txt")
     user_prompt = (
         "Determine whether the daily dev notes imply that documentation updates are needed.\n\n"
         f"Dev notes JSON:\n{notes_json}\n\n"

--- a/tools/generate_branch_notes.py
+++ b/tools/generate_branch_notes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import json
 import os
 from pathlib import Path
@@ -29,7 +30,14 @@ except ModuleNotFoundError:
 
 
 def collect_branch_payload(
-    first_parent: str, second_parent: str, branch_name: str, merge_sha: str
+    first_parent: str,
+    second_parent: str,
+    branch_name: str,
+    merge_sha: str,
+    pr_number: str | None = None,
+    pr_title: str | None = None,
+    pr_body: str | None = None,
+    pr_url: str | None = None,
 ) -> dict[str, Any]:
     changed_files = get_branch_changed_files(first_parent, second_parent)
     commit_subjects = get_branch_commit_subjects(first_parent, second_parent)
@@ -39,6 +47,10 @@ def collect_branch_payload(
         "merge_sha": merge_sha,
         "first_parent": first_parent,
         "second_parent": second_parent,
+        "pr_number": pr_number,
+        "pr_title": pr_title,
+        "pr_body": pr_body,
+        "pr_url": pr_url,
         "changed_files": changed_files,
         "commit_subjects": commit_subjects,
         "diff_stat": diff_stat,
@@ -115,6 +127,9 @@ def format_markdown(notes: Any, payload: dict[str, Any]) -> str:
         f"# {get('title', 'Branch notes')}",
         "",
         f"**Branch:** {payload['branch_name']}",
+        f"**PR:** #{payload['pr_number']} {payload['pr_title']}"
+        if payload.get("pr_number")
+        else "**PR:** Not available",
         f"**Merge SHA:** {payload['merge_sha']}",
         "",
         "## Summary",
@@ -150,6 +165,11 @@ def parse_args():
     parser.add_argument("--merge-sha", required=True)
     parser.add_argument("--first-parent", required=True)
     parser.add_argument("--second-parent", required=True)
+    parser.add_argument("--pr-number", default=None)
+    parser.add_argument("--pr-title", default=None)
+    parser.add_argument("--pr-body", default=None)
+    parser.add_argument("--pr-body-base64", default=None)
+    parser.add_argument("--pr-url", default=None)
     parser.add_argument("--json-output", required=True, type=Path)
     parser.add_argument("--markdown-output", required=True, type=Path)
     return parser.parse_args()
@@ -157,8 +177,19 @@ def parse_args():
 
 async def main():
     args = parse_args()
+    pr_body = args.pr_body
+    if args.pr_body_base64:
+        pr_body = base64.b64decode(args.pr_body_base64).decode("utf-8")
+
     payload = collect_branch_payload(
-        args.first_parent, args.second_parent, args.branch_name, args.merge_sha
+        args.first_parent,
+        args.second_parent,
+        args.branch_name,
+        args.merge_sha,
+        pr_number=args.pr_number,
+        pr_title=args.pr_title,
+        pr_body=pr_body,
+        pr_url=args.pr_url,
     )
     notes = await generate_notes_with_llm(payload)
 

--- a/tools/generate_branch_notes.py
+++ b/tools/generate_branch_notes.py
@@ -29,6 +29,10 @@ except ModuleNotFoundError:
     )
 
 
+def read_tool_prompt(prompt_name: str) -> str:
+    return (Path(__file__).parent / "prompts" / prompt_name).read_text(encoding="utf-8")
+
+
 def collect_branch_payload(
     first_parent: str,
     second_parent: str,
@@ -80,12 +84,7 @@ async def generate_notes_with_llm(payload: dict[str, Any]) -> Any:
             description="What documentation areas may be affected"
         )
 
-    system_prompt = """You are a technical writer creating notes for a single merged branch in Cognee.
-
-Focus on user-facing changes, APIs, integrations, setup, and operational impact.
-Keep the output concise and concrete.
-"""
-
+    system_prompt = read_tool_prompt("branch_notes_system.txt")
     user_prompt = (
         f"Generate notes for this merged branch.\n\nBranch data:\n{json.dumps(payload, indent=2)}\n"
     )

--- a/tools/manage_docs_pr.py
+++ b/tools/manage_docs_pr.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Create or update an automated draft PR in the docs repository."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create or update a docs draft PR")
+    parser.add_argument("--target-repo", required=True)
+    parser.add_argument("--head-branch", required=True)
+    parser.add_argument("--base-branch", default="main")
+    parser.add_argument("--pr-title", required=True)
+    parser.add_argument("--pr-body", required=True)
+    parser.add_argument("--changes-made", required=True, choices=["true", "false"])
+    return parser.parse_args()
+
+
+def github_request(
+    token: str,
+    target_repo: str,
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    query: dict[str, str] | None = None,
+) -> Any:
+    url = f"https://api.github.com/repos/{target_repo}{path}"
+    if query:
+        url = f"{url}?{urllib.parse.urlencode(query)}"
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            content = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        print(exc.read().decode("utf-8"), flush=True)
+        raise
+    return json.loads(content) if content else None
+
+
+def write_pr_output(pr: dict[str, Any] | None) -> None:
+    output_path = Path(os.environ["GITHUB_OUTPUT"])
+    with output_path.open("a", encoding="utf-8") as fh:
+        if pr is None:
+            fh.write("pr_number=\n")
+            fh.write("pr_url=\n")
+        else:
+            fh.write(f"pr_number={pr['number']}\n")
+            fh.write(f"pr_url={pr['html_url']}\n")
+
+
+def main() -> None:
+    args = parse_args()
+    token = os.environ["GH_TOKEN"]
+    owner = args.target_repo.split("/", 1)[0]
+    changes_made = args.changes_made == "true"
+
+    existing_prs = github_request(
+        token,
+        args.target_repo,
+        "GET",
+        "/pulls",
+        query={
+            "head": f"{owner}:{args.head_branch}",
+            "base": args.base_branch,
+            "state": "open",
+            "per_page": "1",
+        },
+    )
+
+    if existing_prs:
+        pr = github_request(
+            token,
+            args.target_repo,
+            "PATCH",
+            f"/pulls/{existing_prs[0]['number']}",
+            {"title": args.pr_title, "body": args.pr_body},
+        )
+    elif changes_made:
+        pr = github_request(
+            token,
+            args.target_repo,
+            "POST",
+            "/pulls",
+            {
+                "base": args.base_branch,
+                "head": args.head_branch,
+                "title": args.pr_title,
+                "body": args.pr_body,
+                "draft": True,
+            },
+        )
+    else:
+        print(
+            f"Assessment expected documentation changes for {args.head_branch}, "
+            "but Claude made no docs edits and no open PR exists. Skipping PR creation."
+        )
+        pr = None
+
+    write_pr_output(pr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prepare_docs_edit_scope.py
+++ b/tools/prepare_docs_edit_scope.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Prepare source and documentation candidates for automated docs edits."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+try:
+    from tools.merge_branch_diff import get_branch_changed_files
+except ModuleNotFoundError:
+    from merge_branch_diff import get_branch_changed_files
+
+
+IGNORED_KEYWORD_PARTS = {
+    "cognee",
+    "__init__.py",
+    "models",
+    "operations",
+    "modules",
+    "tasks",
+    "routers",
+    "shared",
+    "infrastructure",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare docs edit scope candidates")
+    parser.add_argument("--first-parent", required=True)
+    parser.add_argument("--second-parent", required=True)
+    parser.add_argument("--docs-root", default="docs-repo", type=Path)
+    return parser.parse_args()
+
+
+def collect_keywords(changed_files: list[str]) -> list[str]:
+    keywords: list[str] = []
+    for changed_file in changed_files:
+        path = Path(changed_file)
+        stem = path.stem.lower()
+        if len(stem) >= 3 and stem not in IGNORED_KEYWORD_PARTS:
+            keywords.append(stem)
+        for part in path.parts:
+            token = part.lower()
+            if len(token) >= 4 and token not in IGNORED_KEYWORD_PARTS:
+                keywords.append(token)
+
+    unique_keywords: list[str] = []
+    for keyword in keywords:
+        if keyword not in unique_keywords:
+            unique_keywords.append(keyword)
+    return unique_keywords
+
+
+def get_candidate_doc_files(docs_root: Path, keywords: list[str]) -> list[str]:
+    doc_files = sorted(
+        path.relative_to(docs_root).as_posix()
+        for path in docs_root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".md", ".mdx"}
+    )
+
+    scored: list[tuple[int, str]] = []
+    for doc_file in doc_files:
+        haystack = doc_file.lower()
+        score = sum(1 for keyword in keywords if keyword in haystack)
+        if score > 0:
+            scored.append((score, doc_file))
+
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [doc_file for _, doc_file in scored[:5]]
+
+
+def write_multiline_output(name: str, lines: list[str]) -> None:
+    output_path = Path(os.environ["GITHUB_OUTPUT"])
+    with output_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{name}<<EOF\n")
+        fh.write("\n".join(lines) + "\n")
+        fh.write("EOF\n")
+
+
+def main() -> None:
+    args = parse_args()
+    changed_files = get_branch_changed_files(args.first_parent, args.second_parent)
+    keywords = collect_keywords(changed_files)
+    candidate_doc_files = get_candidate_doc_files(args.docs_root, keywords)
+
+    write_multiline_output("changed_source_files", changed_files)
+    write_multiline_output("candidate_doc_files", candidate_doc_files)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prepare_docs_pr_content.py
+++ b/tools/prepare_docs_pr_content.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Prepare pull request title, body, and changed-file outputs for docs drafts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare docs PR content")
+    parser.add_argument("--notes-json", required=True, type=Path)
+    parser.add_argument("--assessment-json", required=True, type=Path)
+    parser.add_argument("--branch-name", required=True)
+    parser.add_argument("--short-sha", required=True)
+    parser.add_argument("--default-pr-title", required=True)
+    parser.add_argument("--docs-root", default="docs-repo")
+    return parser.parse_args()
+
+
+def write_multiline_output(name: str, lines: list[str]) -> None:
+    output_path = Path(os.environ["GITHUB_OUTPUT"])
+    with output_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{name}<<EOF\n")
+        fh.write("\n".join(lines) + "\n")
+        fh.write("EOF\n")
+
+
+def main() -> None:
+    args = parse_args()
+    notes = json.loads(args.notes_json.read_text())
+    assessment = json.loads(args.assessment_json.read_text())
+    summary = notes.get("summary", "").strip()
+    highlights = notes.get("highlights", [])
+    reason = assessment.get("reason", "")
+
+    changed_files = [
+        line.rstrip()
+        for line in subprocess.check_output(
+            ["git", "-C", args.docs_root, "status", "--short"],
+            text=True,
+        ).splitlines()
+        if line.strip()
+    ]
+    normalized_files = [entry[3:] if len(entry) > 3 else entry for entry in changed_files]
+
+    pr_body_lines = [
+        "## Summary",
+        "",
+        f"Automated documentation draft for merged branch `{args.branch_name}` (`{args.short_sha}`).",
+        "",
+        summary
+        or "This PR updates existing docs to reflect the branch's user-facing documentation impact based on the source diff and current docs structure.",
+        "",
+        "## Why This PR Exists",
+        "",
+        reason
+        or "The merged branch appears to change behavior, configuration, API usage, or developer-facing semantics that are represented in the docs.",
+        "",
+        "## Source",
+        "",
+        f"- Branch: `{args.branch_name}`",
+        f"- Merge short SHA: `{args.short_sha}`",
+    ]
+    if highlights:
+        pr_body_lines.extend(["", "## Branch Highlights", ""])
+        pr_body_lines.extend([f"- {item}" for item in highlights])
+    if normalized_files:
+        pr_body_lines.extend(["", "## Documentation Files Updated", ""])
+        pr_body_lines.extend([f"- `{item}`" for item in normalized_files])
+
+    output_path = Path(os.environ["GITHUB_OUTPUT"])
+    with output_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"pr_title={args.default_pr_title}\n")
+    write_multiline_output("pr_body", pr_body_lines)
+    write_multiline_output("changed_files", normalized_files)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prepare_merged_branches.py
+++ b/tools/prepare_merged_branches.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Collect PR-integrated branches from a target branch within a configurable UTC lookback window.
+Collect PRs merged into a target branch within a configurable UTC lookback window.
 
 When GITHUB_OUTPUT and GITHUB_STEP_SUMMARY are present, this script writes the same
 workflow outputs and summary content expected by dev_previous_day_commits.yml.
@@ -9,12 +9,11 @@ workflow outputs and summary content expected by dev_previous_day_commits.yml.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import re
-import shutil
 import subprocess
-import urllib.error
 import urllib.request
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
@@ -26,9 +25,9 @@ def git(*args: str) -> str:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Collect merged branches from a git branch")
+    parser = argparse.ArgumentParser(description="Collect PRs merged into a git branch")
     parser.add_argument(
-        "--branch", default="origin/dev", help="Git ref to inspect for merge commits"
+        "--branch", default="origin/dev", help="Target branch to inspect for merged PRs"
     )
     parser.add_argument(
         "--lookback-days",
@@ -88,22 +87,6 @@ def resolve_time_window(
     return start, end, window_label
 
 
-def try_gh_head_ref(pr_number: str) -> str | None:
-    if shutil.which("gh") is None:
-        return None
-
-    try:
-        result = subprocess.check_output(
-            ["gh", "pr", "view", pr_number, "--json", "headRefName", "--jq", ".headRefName"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return None
-
-    return result or None
-
-
 def parse_github_repo(repo_url: str) -> str | None:
     ssh_match = re.match(r"git@github\.com:([^/]+/[^/]+?)(?:\.git)?$", repo_url)
     if ssh_match:
@@ -128,12 +111,9 @@ def get_github_repo(explicit_repo: str | None) -> str | None:
     return parse_github_repo(remote_url)
 
 
-def try_github_api_head_ref(pr_number: str, repo: str | None) -> str | None:
-    if not repo:
-        return None
-
+def github_api_json(url: str) -> Any:
     request = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
+        url,
         headers={
             "Accept": "application/vnd.github+json",
             "User-Agent": "prepare_merged_branches.py",
@@ -143,90 +123,74 @@ def try_github_api_head_ref(pr_number: str, repo: str | None) -> str | None:
     if token:
         request.add_header("Authorization", f"Bearer {token}")
 
-    try:
-        with urllib.request.urlopen(request, timeout=10) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
-        return None
-
-    head = payload.get("head")
-    if isinstance(head, dict):
-        ref = head.get("ref")
-        if isinstance(ref, str) and ref.strip():
-            return ref.strip()
-
-    return None
+    with urllib.request.urlopen(request, timeout=20) as response:
+        return json.loads(response.read().decode("utf-8"))
 
 
-def extract_subject_pr_number(subject: str) -> str | None:
-    merge_subject_match = re.search(r"^Merge pull request #(\d+)\b", subject)
-    if merge_subject_match:
-        return merge_subject_match.group(1)
+def search_merged_pr_numbers(
+    repo: str, base_branch: str, start: datetime, end: datetime
+) -> list[int]:
+    from urllib.parse import quote
 
-    squash_subject_match = re.search(r"\(#(\d+)\)$", subject.strip())
-    if squash_subject_match:
-        return squash_subject_match.group(1)
-
-    return None
-
-
-def extract_pr_number(subject: str, body: str) -> str | None:
-    subject_pr_number = extract_subject_pr_number(subject)
-    if subject_pr_number:
-        return subject_pr_number
-
-    for text in (subject, body):
-        pr_match = re.search(r"#(\d+)", text)
-        if pr_match:
-            return pr_match.group(1)
-    return None
-
-
-def find_branch_ref(text: str) -> str | None:
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-
-        pr_match = re.search(
-            r"^Merge pull request #\d+ from [^/\s]+/([A-Za-z0-9._/\-]+)$", stripped
-        )
-        if pr_match:
-            return pr_match.group(1)
-
-        from_match = re.search(r"^from [^/\s]+/([A-Za-z0-9._/\-]+)$", stripped)
-        if from_match:
-            return from_match.group(1)
-
-    return None
-
-
-def get_branch_name(subject: str, body: str, merge_sha: str, repo: str | None) -> str:
-    pr_match = re.search(r"^Merge pull request #\d+ from [^/\s]+/([A-Za-z0-9._/\-]+)$", subject)
-    if pr_match:
-        return pr_match.group(1).strip()
-
-    branch_match = re.search(r"Merge branch '([^']+)'", subject)
-    if branch_match:
-        return branch_match.group(1).strip()
-
-    body_ref = find_branch_ref(body)
-    if body_ref:
-        return body_ref
-
-    pr_number = extract_pr_number(subject, body)
-    if pr_number:
-        api_head_ref = try_github_api_head_ref(pr_number, repo)
-        if api_head_ref:
-            return api_head_ref
-
-        head_ref = try_gh_head_ref(pr_number)
-        if head_ref:
-            return head_ref
-
-    raise RuntimeError(
-        f"Could not resolve branch name for commit {merge_sha} from subject/body metadata."
+    query = " ".join(
+        [
+            f"repo:{repo}",
+            "is:pr",
+            "is:merged",
+            f"base:{base_branch}",
+            f"merged:{start.date().isoformat()}..{end.date().isoformat()}",
+        ]
     )
+    numbers: list[int] = []
+    for page in range(1, 11):
+        url = (
+            "https://api.github.com/search/issues"
+            f"?q={quote(query)}&sort=updated&order=desc&per_page=100&page={page}"
+        )
+        payload = github_api_json(url)
+        items = payload.get("items", []) if isinstance(payload, dict) else []
+        if not items:
+            break
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            number = item.get("number")
+            if isinstance(number, int):
+                numbers.append(number)
+
+        if len(items) < 100:
+            break
+
+    return numbers
+
+
+def get_pull_request(repo: str, pr_number: int) -> dict[str, Any]:
+    payload = github_api_json(f"https://api.github.com/repos/{repo}/pulls/{pr_number}")
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Unexpected GitHub API response for PR #{pr_number}.")
+    return payload
+
+
+def parse_github_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def get_commit_parents(commit_sha: str) -> list[str]:
+    line = git("rev-list", "--parents", "-n", "1", commit_sha)
+    parts = line.split()
+    return parts[1:]
+
+
+def resolve_pr_diff_range(merge_sha: str) -> tuple[str, str]:
+    parents = get_commit_parents(merge_sha)
+    if len(parents) >= 2:
+        return parents[0], parents[1]
+    if len(parents) == 1:
+        return parents[0], merge_sha
+    raise RuntimeError(f"Could not resolve parents for merged PR commit {merge_sha}.")
 
 
 def collect_merges(
@@ -235,53 +199,58 @@ def collect_merges(
     effective_lookback = max(1, lookback_days)
     start, end, window_label = resolve_time_window(effective_lookback, anchor_date)
 
-    raw_log = git(
-        "log",
-        branch,
-        "--first-parent",
-        f"--since={start.strftime('%Y-%m-%dT%H:%M:%SZ')}",
-        f"--until={end.strftime('%Y-%m-%dT%H:%M:%SZ')}",
-        "--pretty=format:%H%x1f%P%x1f%s%x1f%b%x1e",
-    )
+    github_repo = get_github_repo(repo)
+    if not github_repo:
+        raise RuntimeError(
+            "Could not determine GitHub repository. Pass --repo owner/repo or configure origin."
+        )
 
+    base_branch = branch.removeprefix("origin/")
     merges = []
-    for record in raw_log.split("\x1e"):
-        if not record.strip():
-            continue
-        merge_sha, parents, subject, body = record.strip().split("\x1f", 3)
-        parent_parts = parents.split()
-        if not parent_parts:
+    for pr_number in search_merged_pr_numbers(github_repo, base_branch, start, end):
+        pr = get_pull_request(github_repo, pr_number)
+        merged_at = parse_github_timestamp(pr.get("merged_at"))
+        if merged_at is None or not (start <= merged_at <= end):
             continue
 
-        pr_number = extract_subject_pr_number(subject)
-        is_merge_commit = len(parent_parts) >= 2
-        is_squash_merged_pr = len(parent_parts) == 1 and pr_number is not None
-        if not is_merge_commit and not is_squash_merged_pr:
+        merge_sha = pr.get("merge_commit_sha")
+        if not isinstance(merge_sha, str) or not merge_sha:
             continue
 
-        branch_name = get_branch_name(subject, body, merge_sha, repo)
+        first_parent, second_parent = resolve_pr_diff_range(merge_sha)
+        head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+        branch_name = str(head.get("ref") or f"pr-{pr_number}")
         safe_branch = re.sub(r"[^a-z0-9]+", "-", branch_name.lower()).strip("-")
         if not safe_branch:
             raise RuntimeError(
-                f"Could not derive a safe branch slug from branch name {branch_name!r} for merge {merge_sha}."
+                f"Could not derive a safe branch slug from branch name {branch_name!r} for PR #{pr_number}."
             )
 
-        first_parent = parent_parts[0]
-        second_parent = parent_parts[1] if is_merge_commit else merge_sha
+        title = str(pr.get("title") or f"PR #{pr_number}")
+        body = str(pr.get("body") or "")
+        body_b64 = base64.b64encode(body[:4000].encode("utf-8")).decode("ascii")
         merges.append(
             {
+                "pr_number": pr_number,
+                "pr_title": title,
+                "pr_body_b64": body_b64,
+                "pr_url": pr.get("html_url") or "",
+                "merged_at": merged_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "merge_sha": merge_sha,
                 "short_sha": merge_sha[:7],
                 "first_parent": first_parent,
                 "second_parent": second_parent,
                 "branch_name": branch_name,
                 "safe_branch": safe_branch,
-                "subject": subject,
+                "subject": f"PR #{pr_number}: {title}",
             }
         )
 
+    merges.sort(key=lambda item: item["merged_at"])
+
     merge_lines = [
-        f"- {item['branch_name']} ({item['short_sha']}): {item['subject']}" for item in merges
+        f"- #{item['pr_number']} {item['branch_name']} ({item['short_sha']}): {item['pr_title']}"
+        for item in merges
     ]
 
     return {
@@ -306,7 +275,7 @@ def format_time_window(payload: dict[str, Any]) -> str:
 
 def format_no_merges_message(payload: dict[str, Any], markdown_branch: bool = False) -> str:
     branch = f"`{payload['branch']}`" if markdown_branch else payload["branch"]
-    return f"No branches were merged into {branch} during the {payload['window_label']}."
+    return f"No PRs were merged into {branch} during the {payload['window_label']}."
 
 
 def get_merge_summary_lines(payload: dict[str, Any], markdown_branch: bool = False) -> list[str]:
@@ -339,18 +308,18 @@ def write_github_summary(payload: dict[str, Any]) -> None:
 
     summary_path = Path(github_summary)
     with summary_path.open("a", encoding="utf-8") as fh:
-        fh.write("## Merged branches on dev\n\n")
+        fh.write("## Merged PRs on dev\n\n")
         fh.write(f"- Source branch: `{payload['branch']}`\n")
         fh.write(f"- Lookback days: `{payload['lookback_days']}`\n")
         fh.write(f"- Time window (UTC): `{format_time_window(payload)}`\n\n")
         if payload["merge_lines"]:
-            fh.write("### Merged branches\n\n")
+            fh.write("### Merged PRs\n\n")
         fh.write("\n".join(get_merge_summary_lines(payload, markdown_branch=True)))
         fh.write("\n")
 
 
 def print_console_summary(payload: dict[str, Any]) -> None:
-    print(f"Merged branches on {payload['branch']}")
+    print(f"Merged PRs on {payload['branch']}")
     print(f"Lookback days: {payload['lookback_days']}")
     print(f"Time window (UTC): {format_time_window(payload)}")
     for line in get_merge_summary_lines(payload):

--- a/tools/prompts/branch_notes_system.txt
+++ b/tools/prompts/branch_notes_system.txt
@@ -1,0 +1,4 @@
+You are a technical writer creating notes for a single merged branch in Cognee.
+
+Focus on user-facing changes, APIs, integrations, setup, and operational impact.
+Keep the output concise and concrete.

--- a/tools/prompts/docs_assessment_system.txt
+++ b/tools/prompts/docs_assessment_system.txt
@@ -1,0 +1,8 @@
+You are a documentation strategist for the Cognee project.
+
+Analyze the provided daily dev notes and decide whether they imply documentation updates.
+
+Guidelines:
+- Focus on user-facing changes, APIs, integrations, setup, and operational behavior
+- Recommend docs work only when the notes indicate likely user impact
+- Keep recommendations concrete and concise

--- a/tools/write_docs_assessment_outputs.py
+++ b/tools/write_docs_assessment_outputs.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Write workflow outputs derived from a docs assessment result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Write docs assessment workflow outputs")
+    parser.add_argument("--assessment-json", required=True, type=Path)
+    parser.add_argument("--branch-slug", required=True)
+    parser.add_argument("--short-sha", required=True)
+    parser.add_argument("--pr-number", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    assessment = json.loads(args.assessment_json.read_text())
+
+    needs_update = bool(assessment.get("needs_documentation_update"))
+    docs_branch = f"automation/docs-pr-{args.pr_number}-{args.branch_slug}-{args.short_sha}"
+    pr_title = f"docs: draft updates for PR #{args.pr_number}"
+
+    output_path = Path(os.environ["GITHUB_OUTPUT"])
+    with output_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"needs_update={'true' if needs_update else 'false'}\n")
+        fh.write(f"docs_branch={docs_branch}\n")
+        fh.write(f"pr_title={pr_title}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
Refactor and harden the previous-day dev docs automation so it scans merged PRs, carries PR metadata through the docs pipeline, and keeps the generated docs changes tightly scoped.

This also extracts the larger workflow Python snippets and Claude prompts into reusable files, so the workflow remains orchestration-focused and the review diff is easier to follow.

## What Changed
- Collect merged PRs from GitHub search/API instead of relying only on merge commit parsing.
- Include PR number, title, URL, and body context in generated branch notes.
- Add a two-stage Claude flow: first create a documentation scope plan, then edit docs from that plan.
- Create or update draft docs PRs via a reusable helper script and skip PR creation gracefully when no docs edits are produced.
- Move inline workflow Python into helper scripts under `tools/`.
- Move reusable prompts into `.github/prompts/` and `tools/prompts/`.
- Increase Claude max-turns for planning/editing where needed.

## Acceptance Criteria
- Previous-day dev PR scan produces a matrix of merged PRs with branch and PR metadata.
- Docs automation keeps edits scoped to public-facing changes from the merged PR.
- Workflow YAML no longer contains large inline Python scripts or long prompt bodies.
- No-change docs runs skip PR creation instead of failing.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Code refactoring
- [ ] Other (please specify):

## Screenshots
N/A

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change has not been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## Local Validation
- `uv run ruff format tools/write_docs_assessment_outputs.py tools/prepare_docs_edit_scope.py tools/prepare_docs_pr_content.py tools/manage_docs_pr.py tools/generate_branch_notes.py tools/assess_branch_notes.py`
- `uv run ruff check tools/write_docs_assessment_outputs.py tools/prepare_docs_edit_scope.py tools/prepare_docs_pr_content.py tools/manage_docs_pr.py tools/generate_branch_notes.py tools/assess_branch_notes.py`
- `python3 -m py_compile tools/write_docs_assessment_outputs.py tools/prepare_docs_edit_scope.py tools/prepare_docs_pr_content.py tools/manage_docs_pr.py tools/generate_branch_notes.py tools/assess_branch_notes.py`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.