### PR TITLE
feat(api): add agents endpoint

### DIFF
--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -48,6 +48,7 @@ from cognee.api.v1.users.routers import (
 from cognee.api.v1.api_keys.routers import get_api_key_management_router
 from cognee.api.v1.activity.routers import get_activity_router
 from cognee.api.v1.sessions import get_sessions_router
+from cognee.api.v1.agents import get_agents_router
 from cognee.modules.users.methods.get_authenticated_user import REQUIRE_AUTHENTICATION
 
 # Ensure application logging is configured for container stdout/stderr
@@ -311,6 +312,12 @@ app.include_router(
     get_sessions_router(),
     prefix="/api/v1/sessions",
     tags=["sessions"],
+)
+
+app.include_router(
+    get_agents_router(),
+    prefix="/api/v1/agents",
+    tags=["agents"],
 )
 
 app.include_router(get_remember_router(), prefix="/api/v1/remember", tags=["remember"])

--- a/cognee/api/v1/agents/__init__.py
+++ b/cognee/api/v1/agents/__init__.py
@@ -1,0 +1,3 @@
+from cognee.api.v1.agents.routers import get_agents_router
+
+__all__ = ["get_agents_router"]

--- a/cognee/api/v1/agents/routers/__init__.py
+++ b/cognee/api/v1/agents/routers/__init__.py
@@ -1,0 +1,3 @@
+from cognee.api.v1.agents.routers.get_agents_router import get_agents_router
+
+__all__ = ["get_agents_router"]

--- a/cognee/api/v1/agents/routers/get_agents_router.py
+++ b/cognee/api/v1/agents/routers/get_agents_router.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.encoders import jsonable_encoder
+
+from cognee.modules.agents.models import RegisterAgentRequest
+from cognee.modules.agents.operations import (
+    get_agent_connection_detail,
+    list_agent_connections,
+    register_agent_from_request,
+)
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.models import User
+
+RangeLiteral = Literal["24h", "7d", "30d", "all"]
+
+
+def get_agents_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("")
+    async def list_agents(
+        range: RangeLiteral = Query("30d"),
+        status_filter: Optional[Literal["active", "inactive", "unknown"]] = Query(
+            None,
+            alias="status",
+        ),
+        include_sources: bool = Query(True),
+        limit: int = Query(50, ge=1, le=500),
+        offset: int = Query(0, ge=0),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """List agents and memory sources visible to the current user.
+
+        The endpoint combines live in-process registrations from SDK/API callers with
+        session-trace fallback data, then attaches readable datasets as memory sources.
+        """
+        response = await list_agent_connections(
+            user=user,
+            range_key=range,
+            status_filter=status_filter,
+            include_sources=include_sources,
+            limit=limit,
+            offset=offset,
+        )
+        return jsonable_encoder(response)
+
+    @router.post("/register", status_code=status.HTTP_201_CREATED)
+    async def register_agent(
+        request: RegisterAgentRequest,
+        user: User = Depends(get_authenticated_user),
+    ):
+        """Register a live agent/API/MCP/workflow connection with this API process.
+
+        This is intentionally non-durable until a migration-backed connection table is
+        added. Session traces still provide durable fallback after agents execute.
+        """
+        connection = register_agent_from_request(user, request)
+        return jsonable_encoder(connection)
+
+    @router.get("/{agent_id}")
+    async def get_agent(
+        agent_id: str,
+        range: RangeLiteral = Query("all"),
+        user: User = Depends(get_authenticated_user),
+    ):
+        response = await get_agent_connection_detail(
+            user=user,
+            agent_id=agent_id,
+            range_key=range,
+        )
+        if response is None:
+            raise HTTPException(status_code=404, detail="agent not found")
+        return jsonable_encoder(response)
+
+    return router

--- a/cognee/modules/agent_memory/decorator.py
+++ b/cognee/modules/agent_memory/decorator.py
@@ -18,6 +18,7 @@ from cognee.modules.agent_memory.runtime import (
     set_current_agent_memory_context,
     validate_agent_memory_config,
 )
+from cognee.modules.agents.registry import derive_memory_mode, register_agent_connection
 
 
 def agent_memory(
@@ -97,6 +98,44 @@ def agent_memory(
                 method_params=build_method_params(fn, args, kwargs),
                 user=resolved_user,
                 scope=scope,
+            )
+            register_agent_connection(
+                name=fn.__qualname__,
+                connection_type="sdk",
+                memory_mode=derive_memory_mode(
+                    with_memory=config.with_memory,
+                    with_session_memory=config.with_session_memory,
+                    save_session_traces=config.save_session_traces,
+                ),
+                source="agent_memory",
+                origin_function=fn.__qualname__,
+                user_id=str(resolved_user.id) if resolved_user is not None else None,
+                tenant_id=(
+                    str(getattr(resolved_user, "tenant_id"))
+                    if resolved_user is not None and getattr(resolved_user, "tenant_id", None)
+                    else None
+                ),
+                session_id=config.session_id,
+                datasets=[
+                    {
+                        "id": str(scope.dataset_id),
+                        "name": scope.dataset_name,
+                        "role": "read_write",
+                    }
+                ]
+                if scope is not None
+                else (
+                    [{"name": config.dataset_name, "role": "read_write"}]
+                    if config.dataset_name
+                    else []
+                ),
+                metadata={
+                    "memory_top_k": config.memory_top_k,
+                    "memory_only_context": config.memory_only_context,
+                    "save_session_traces": config.save_session_traces,
+                    "with_session_memory": config.with_session_memory,
+                    "with_memory": config.with_memory,
+                },
             )
             token = set_current_agent_memory_context(context)
 

--- a/cognee/modules/agents/__init__.py
+++ b/cognee/modules/agents/__init__.py
@@ -1,0 +1,33 @@
+from cognee.modules.agents.models import (
+    AgentConnection,
+    AgentDatasetRef,
+    AgentDetailResponse,
+    AgentsListResponse,
+    MemorySourceConnection,
+    RegisterAgentRequest,
+)
+from cognee.modules.agents.operations import (
+    get_agent_connection_detail,
+    list_agent_connections,
+    register_agent_from_request,
+)
+from cognee.modules.agents.registry import (
+    clear_registered_agent_connections,
+    derive_memory_mode,
+    register_agent_connection,
+)
+
+__all__ = [
+    "AgentConnection",
+    "AgentDatasetRef",
+    "AgentDetailResponse",
+    "AgentsListResponse",
+    "MemorySourceConnection",
+    "RegisterAgentRequest",
+    "clear_registered_agent_connections",
+    "derive_memory_mode",
+    "get_agent_connection_detail",
+    "list_agent_connections",
+    "register_agent_connection",
+    "register_agent_from_request",
+]

--- a/cognee/modules/agents/models.py
+++ b/cognee/modules/agents/models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+AgentConnectionType = Literal["sdk", "api", "mcp", "claude_code", "workflow", "unknown"]
+AgentMemoryMode = Literal["session", "cognee", "hybrid", "none", "unknown"]
+AgentStatus = Literal["active", "inactive", "unknown"]
+AgentSource = Literal["agent_memory", "session_trace", "serve", "api_key", "mcp", "api"]
+MemorySourceType = Literal["dataset", "company_brain", "knowledge_wiki", "project_dataset"]
+
+
+class AgentDatasetRef(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    role: str = "read"
+    type: MemorySourceType = "dataset"
+
+
+class AgentConnection(BaseModel):
+    id: str
+    name: str
+    type: AgentConnectionType = "unknown"
+    memory_mode: AgentMemoryMode = "unknown"
+    session_id: Optional[str] = None
+    user_id: Optional[str] = None
+    tenant_id: Optional[str] = None
+    datasets: list[AgentDatasetRef] = Field(default_factory=list)
+    last_active_at: Optional[datetime] = None
+    status: AgentStatus = "unknown"
+    source: AgentSource = "session_trace"
+    origin_function: Optional[str] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class MemorySourceConnection(BaseModel):
+    id: str
+    name: str
+    type: MemorySourceType = "dataset"
+    owner_id: Optional[str] = None
+    tenant_id: Optional[str] = None
+    status: AgentStatus = "active"
+    connected_agent_ids: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentsListResponse(BaseModel):
+    agents: list[AgentConnection]
+    memory_sources: list[MemorySourceConnection] = Field(default_factory=list)
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class AgentDetailResponse(BaseModel):
+    agent: AgentConnection
+    memory_sources: list[MemorySourceConnection] = Field(default_factory=list)
+    recent_sessions: list[dict[str, Any]] = Field(default_factory=list)
+    recent_traces: list[dict[str, Any]] = Field(default_factory=list)
+    recent_qas: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class RegisterAgentRequest(BaseModel):
+    name: str
+    type: AgentConnectionType = "api"
+    memory_mode: AgentMemoryMode = "unknown"
+    session_id: Optional[str] = None
+    dataset_ids: list[str] = Field(default_factory=list)
+    dataset_names: list[str] = Field(default_factory=list)
+    source: AgentSource = "api"
+    origin_function: Optional[str] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal, Optional
+from uuid import UUID as UUIDType
+
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.agents.models import (
+    AgentConnection,
+    AgentDatasetRef,
+    AgentDetailResponse,
+    AgentsListResponse,
+    MemorySourceConnection,
+    RegisterAgentRequest,
+)
+from cognee.modules.agents.registry import (
+    build_agent_connection_id,
+    classify_memory_source_type,
+    derive_connection_type,
+    list_registered_agent_connections,
+    register_agent_connection,
+)
+from cognee.modules.session_lifecycle.metrics import list_session_rows
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.models import User
+from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
+    get_specific_user_permission_datasets,
+)
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("agents")
+
+RangeLiteral = Literal["24h", "7d", "30d", "all"]
+
+
+def _range_since(range_key: RangeLiteral) -> Optional[datetime]:
+    now = datetime.now(timezone.utc)
+    if range_key == "24h":
+        return now - timedelta(hours=24)
+    if range_key == "7d":
+        return now - timedelta(days=7)
+    if range_key == "30d":
+        return now - timedelta(days=30)
+    return None
+
+
+def _entry_value(entry: Any, key: str, default: Any = None) -> Any:
+    if isinstance(entry, dict):
+        return entry.get(key, default)
+    return getattr(entry, key, default)
+
+
+def _entry_to_dict(entry: Any) -> dict[str, Any]:
+    if isinstance(entry, dict):
+        return entry
+    if hasattr(entry, "model_dump"):
+        return entry.model_dump(mode="json")
+    if hasattr(entry, "dict"):
+        return entry.dict()
+    return {"value": str(entry)}
+
+
+async def _readable_datasets_for(user: User) -> list[Any]:
+    try:
+        return await get_specific_user_permission_datasets(user.id, "read", None)
+    except PermissionDeniedError:
+        return []
+    except Exception as error:
+        logger.warning("Failed to resolve readable datasets for agents API: %s", error)
+        return []
+
+
+async def _child_agent_user_ids(user_id: UUIDType) -> list[UUIDType]:
+    try:
+        engine = get_relational_engine()
+        async with engine.get_async_session() as session:
+            from cognee.modules.users.models import User as UserModel
+
+            rows = (
+                await session.execute(
+                    select(UserModel.id).where(UserModel.parent_user_id == user_id)
+                )
+            ).all()
+            return [row.id for row in rows]
+    except Exception as error:
+        logger.debug("Failed to resolve child agent users for agents API: %s", error)
+        return []
+
+
+async def _visible_user_ids(user: User) -> list[UUIDType]:
+    ids = [user.id]
+    ids.extend(await _child_agent_user_ids(user.id))
+    return ids
+
+
+def _memory_sources_from_datasets(datasets: list[Any]) -> list[MemorySourceConnection]:
+    sources = []
+    for dataset in datasets:
+        dataset_id = getattr(dataset, "id", None)
+        dataset_name = getattr(dataset, "name", None)
+        if dataset_id is None or dataset_name is None:
+            continue
+        sources.append(
+            MemorySourceConnection(
+                id=str(dataset_id),
+                name=str(dataset_name),
+                type=classify_memory_source_type(str(dataset_name)),
+                owner_id=str(getattr(dataset, "owner_id", "")) or None,
+                tenant_id=str(getattr(dataset, "tenant_id", "")) or None,
+                status="active",
+            )
+        )
+    return sources
+
+
+def _dataset_ref_for_id(
+    dataset_id: Any,
+    memory_sources_by_id: dict[str, MemorySourceConnection],
+) -> Optional[AgentDatasetRef]:
+    if dataset_id is None:
+        return None
+    source = memory_sources_by_id.get(str(dataset_id))
+    if source is None:
+        return AgentDatasetRef(id=str(dataset_id), role="read", type="dataset")
+    return AgentDatasetRef(id=source.id, name=source.name, role="read", type=source.type)
+
+
+async def _trace_agents_for_user(
+    *,
+    user: User,
+    visible_user_ids: list[UUIDType],
+    permitted_dataset_ids: list[UUIDType],
+    memory_sources_by_id: dict[str, MemorySourceConnection],
+    since: Optional[datetime],
+) -> list[AgentConnection]:
+    try:
+        page = await list_session_rows(
+            user_ids=visible_user_ids,
+            permitted_dataset_ids=permitted_dataset_ids,
+            since=since,
+            status_filter=None,
+            limit=500,
+            offset=0,
+            order_by="last_activity_at",
+            descending=True,
+        )
+    except Exception as error:
+        logger.warning("Failed to list session rows for agents API: %s", error)
+        return []
+
+    try:
+        from cognee.infrastructure.session.get_session_manager import get_session_manager
+
+        session_manager = get_session_manager()
+    except Exception:
+        session_manager = None
+
+    agents = []
+    for row in page.sessions:
+        record = row.record
+        owner_user_id = str(getattr(record, "user_id", ""))
+        session_id = getattr(record, "session_id", None)
+        if not owner_user_id or not session_id or session_manager is None:
+            continue
+
+        try:
+            traces = await session_manager.get_agent_trace_session(
+                user_id=owner_user_id,
+                session_id=session_id,
+                last_n=20,
+            )
+        except Exception:
+            traces = []
+        if not traces:
+            continue
+
+        first_trace = traces[0]
+        origin_function = _entry_value(first_trace, "origin_function", None)
+        name = str(origin_function or session_id)
+        dataset_ref = _dataset_ref_for_id(getattr(record, "dataset_id", None), memory_sources_by_id)
+        datasets = [dataset_ref] if dataset_ref else []
+        connection_type = derive_connection_type(
+            origin_function=origin_function,
+            session_id=session_id,
+            source="session_trace",
+        )
+        status = "active" if row.effective_status == "running" else "inactive"
+        agent_id = build_agent_connection_id(
+            name=name,
+            origin_function=origin_function,
+            user_id=owner_user_id,
+            session_id=session_id,
+            dataset_id=datasets[0].id if datasets else None,
+            connection_type=connection_type,
+        )
+        agents.append(
+            AgentConnection(
+                id=agent_id,
+                name=name,
+                type=connection_type,
+                memory_mode="hybrid" if datasets else "session",
+                session_id=session_id,
+                user_id=owner_user_id,
+                tenant_id=str(getattr(user, "tenant_id", "")) or None,
+                datasets=datasets,
+                last_active_at=getattr(record, "last_activity_at", None),
+                status=status,
+                source="session_trace",
+                origin_function=str(origin_function) if origin_function else None,
+                metadata={
+                    "session_status": getattr(record, "status", None),
+                    "effective_status": row.effective_status,
+                    "trace_count": len(traces),
+                    "error_count": getattr(record, "error_count", 0),
+                },
+            )
+        )
+
+    return agents
+
+
+def _is_visible_registered_agent(
+    agent: AgentConnection,
+    *,
+    visible_user_ids: set[str],
+    permitted_dataset_ids: set[str],
+) -> bool:
+    if agent.user_id and agent.user_id in visible_user_ids:
+        return True
+    if any(dataset.id in permitted_dataset_ids for dataset in agent.datasets if dataset.id):
+        return True
+    return agent.user_id is None and not agent.datasets
+
+
+def _merge_agents(agents: list[AgentConnection]) -> list[AgentConnection]:
+    merged: dict[str, AgentConnection] = {}
+    for agent in agents:
+        existing = merged.get(agent.id)
+        if existing is None:
+            merged[agent.id] = agent
+            continue
+        existing_ts = existing.last_active_at or datetime.min.replace(tzinfo=timezone.utc)
+        agent_ts = agent.last_active_at or datetime.min.replace(tzinfo=timezone.utc)
+        if agent_ts >= existing_ts:
+            metadata = {**existing.metadata, **agent.metadata}
+            merged[agent.id] = agent.model_copy(update={"metadata": metadata})
+        else:
+            metadata = {**agent.metadata, **existing.metadata}
+            merged[agent.id] = existing.model_copy(update={"metadata": metadata})
+    return sorted(
+        merged.values(),
+        key=lambda item: item.last_active_at or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+
+
+def _attach_connected_agent_ids(
+    memory_sources: list[MemorySourceConnection],
+    agents: list[AgentConnection],
+) -> list[MemorySourceConnection]:
+    agents_by_dataset: dict[str, list[str]] = {}
+    for agent in agents:
+        for dataset in agent.datasets:
+            if dataset.id:
+                agents_by_dataset.setdefault(dataset.id, []).append(agent.id)
+
+    return [
+        source.model_copy(
+            update={"connected_agent_ids": sorted(set(agents_by_dataset.get(source.id, [])))}
+        )
+        for source in memory_sources
+    ]
+
+
+async def list_agent_connections(
+    *,
+    user: User,
+    range_key: RangeLiteral = "30d",
+    status_filter: Optional[str] = None,
+    include_sources: bool = True,
+    limit: int = 50,
+    offset: int = 0,
+) -> AgentsListResponse:
+    readable_datasets = await _readable_datasets_for(user)
+    memory_sources = _memory_sources_from_datasets(readable_datasets)
+    memory_sources_by_id = {source.id: source for source in memory_sources}
+    permitted_dataset_ids = [UUIDType(source.id) for source in memory_sources]
+    visible_user_ids = await _visible_user_ids(user)
+    visible_user_id_strings = {str(user_id) for user_id in visible_user_ids}
+    permitted_dataset_id_strings = {source.id for source in memory_sources}
+    since = _range_since(range_key)
+
+    registered_agents = [
+        agent
+        for agent in list_registered_agent_connections()
+        if _is_visible_registered_agent(
+            agent,
+            visible_user_ids=visible_user_id_strings,
+            permitted_dataset_ids=permitted_dataset_id_strings,
+        )
+    ]
+    trace_agents = await _trace_agents_for_user(
+        user=user,
+        visible_user_ids=visible_user_ids,
+        permitted_dataset_ids=permitted_dataset_ids,
+        memory_sources_by_id=memory_sources_by_id,
+        since=since,
+    )
+    agents = _merge_agents([*registered_agents, *trace_agents])
+    if status_filter:
+        agents = [agent for agent in agents if agent.status == status_filter]
+
+    memory_sources = _attach_connected_agent_ids(memory_sources, agents) if include_sources else []
+    total = len(agents)
+    sliced_agents = agents[offset : offset + limit]
+    return AgentsListResponse(
+        agents=sliced_agents,
+        memory_sources=memory_sources,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=offset + len(sliced_agents) < total,
+    )
+
+
+async def get_agent_connection_detail(
+    *,
+    user: User,
+    agent_id: str,
+    range_key: RangeLiteral = "all",
+) -> Optional[AgentDetailResponse]:
+    response = await list_agent_connections(
+        user=user,
+        range_key=range_key,
+        include_sources=True,
+        limit=10000,
+        offset=0,
+    )
+    agent = next((item for item in response.agents if item.id == agent_id), None)
+    if agent is None:
+        return None
+
+    recent_sessions = []
+    recent_traces = []
+    recent_qas = []
+    if agent.session_id and agent.user_id:
+        try:
+            from cognee.infrastructure.session.get_session_manager import get_session_manager
+
+            session_manager = get_session_manager()
+            qas = await session_manager.get_session(
+                user_id=agent.user_id,
+                session_id=agent.session_id,
+                formatted=False,
+            )
+            traces = await session_manager.get_agent_trace_session(
+                user_id=agent.user_id,
+                session_id=agent.session_id,
+                last_n=20,
+            )
+            recent_qas = (
+                [_entry_to_dict(entry) for entry in qas[-20:]] if isinstance(qas, list) else []
+            )
+            recent_traces = [_entry_to_dict(entry) for entry in traces[-20:]]
+            recent_sessions = [{"session_id": agent.session_id, "user_id": agent.user_id}]
+        except Exception as error:
+            logger.debug("Failed to hydrate agent detail from session cache: %s", error)
+
+    return AgentDetailResponse(
+        agent=agent,
+        memory_sources=response.memory_sources,
+        recent_sessions=recent_sessions,
+        recent_traces=recent_traces,
+        recent_qas=recent_qas,
+    )
+
+
+def register_agent_from_request(user: User, request: RegisterAgentRequest) -> AgentConnection:
+    datasets = [
+        AgentDatasetRef(id=dataset_id, role="read_write", type="dataset")
+        for dataset_id in request.dataset_ids
+    ]
+    datasets.extend(
+        AgentDatasetRef(
+            name=dataset_name,
+            role="read_write",
+            type=classify_memory_source_type(dataset_name),
+        )
+        for dataset_name in request.dataset_names
+    )
+    return register_agent_connection(
+        name=request.name,
+        connection_type=request.type,
+        memory_mode=request.memory_mode,
+        source=request.source,
+        origin_function=request.origin_function,
+        user_id=str(user.id),
+        tenant_id=str(getattr(user, "tenant_id", "")) or None,
+        session_id=request.session_id,
+        datasets=datasets,
+        metadata=request.metadata,
+    )

--- a/cognee/modules/agents/registry.py
+++ b/cognee/modules/agents/registry.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from threading import RLock
+from typing import Iterable, Optional
+
+from cognee.modules.agents.models import (
+    AgentConnection,
+    AgentConnectionType,
+    AgentDatasetRef,
+    AgentMemoryMode,
+    AgentSource,
+    MemorySourceType,
+)
+
+_registered_agent_connections: dict[str, AgentConnection] = {}
+_registry_lock = RLock()
+
+
+def classify_memory_source_type(name: str | None) -> MemorySourceType:
+    normalized = (name or "").lower()
+    if "brain" in normalized:
+        return "company_brain"
+    if "wiki" in normalized:
+        return "knowledge_wiki"
+    if "project" in normalized:
+        return "project_dataset"
+    return "dataset"
+
+
+def derive_memory_mode(
+    *,
+    with_memory: bool = False,
+    with_session_memory: bool = False,
+    save_session_traces: bool = False,
+) -> AgentMemoryMode:
+    if with_memory and (with_session_memory or save_session_traces):
+        return "hybrid"
+    if with_memory:
+        return "cognee"
+    if with_session_memory or save_session_traces:
+        return "session"
+    return "none"
+
+
+def derive_connection_type(
+    *,
+    origin_function: str | None = None,
+    session_id: str | None = None,
+    source: str | None = None,
+) -> AgentConnectionType:
+    source_lower = (source or "").lower()
+    if source_lower in {"mcp", "api", "api_key", "serve", "workflow", "sdk"}:
+        if source_lower == "serve":
+            return "api"
+        if source_lower == "api_key":
+            return "api"
+        return source_lower  # type: ignore[return-value]
+
+    text = f"{origin_function or ''} {session_id or ''}".lower()
+    if "claude" in text or "claude_code" in text or text.startswith("cc_"):
+        return "claude_code"
+    if "mcp" in text:
+        return "mcp"
+    return "sdk" if origin_function else "unknown"
+
+
+def build_agent_connection_id(
+    *,
+    name: str | None = None,
+    origin_function: str | None = None,
+    user_id: str | None = None,
+    session_id: str | None = None,
+    dataset_id: str | None = None,
+    connection_type: str | None = None,
+) -> str:
+    identity = "|".join(
+        [
+            origin_function or name or "agent",
+            user_id or "",
+            session_id or "",
+            dataset_id or "",
+            connection_type or "",
+        ]
+    )
+    digest = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:16]
+    base = re.sub(r"[^a-zA-Z0-9_-]+", "-", origin_function or name or "agent").strip("-")
+    base = base[-48:] if len(base) > 48 else base
+    return f"{base or 'agent'}-{digest}"
+
+
+def _normalize_datasets(datasets: Iterable[AgentDatasetRef | dict] | None) -> list[AgentDatasetRef]:
+    normalized = []
+    for dataset in datasets or []:
+        if isinstance(dataset, AgentDatasetRef):
+            ref = dataset
+        else:
+            ref = AgentDatasetRef(**dataset)
+        if ref.type == "dataset":
+            ref = ref.model_copy(update={"type": classify_memory_source_type(ref.name)})
+        normalized.append(ref)
+    return normalized
+
+
+def register_agent_connection(
+    *,
+    name: str,
+    connection_type: AgentConnectionType = "unknown",
+    memory_mode: AgentMemoryMode = "unknown",
+    source: AgentSource = "api",
+    agent_id: Optional[str] = None,
+    origin_function: Optional[str] = None,
+    user_id: Optional[str] = None,
+    tenant_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    datasets: Iterable[AgentDatasetRef | dict] | None = None,
+    status: str = "active",
+    last_active_at: Optional[datetime] = None,
+    metadata: Optional[dict] = None,
+) -> AgentConnection:
+    dataset_refs = _normalize_datasets(datasets)
+    primary_dataset_id = next((dataset.id for dataset in dataset_refs if dataset.id), None)
+    resolved_agent_id = agent_id or build_agent_connection_id(
+        name=name,
+        origin_function=origin_function,
+        user_id=user_id,
+        session_id=session_id,
+        dataset_id=primary_dataset_id,
+        connection_type=connection_type,
+    )
+    connection = AgentConnection(
+        id=resolved_agent_id,
+        name=name,
+        type=connection_type,
+        memory_mode=memory_mode,
+        session_id=session_id,
+        user_id=user_id,
+        tenant_id=tenant_id,
+        datasets=dataset_refs,
+        last_active_at=last_active_at or datetime.now(timezone.utc),
+        status=status if status in {"active", "inactive", "unknown"} else "unknown",
+        source=source,
+        origin_function=origin_function,
+        metadata=metadata or {},
+    )
+
+    with _registry_lock:
+        existing = _registered_agent_connections.get(connection.id)
+        if existing:
+            merged_metadata = {**existing.metadata, **connection.metadata}
+            connection = connection.model_copy(update={"metadata": merged_metadata})
+        _registered_agent_connections[connection.id] = connection
+
+    return connection
+
+
+def list_registered_agent_connections() -> list[AgentConnection]:
+    with _registry_lock:
+        return list(_registered_agent_connections.values())
+
+
+def clear_registered_agent_connections() -> None:
+    with _registry_lock:
+        _registered_agent_connections.clear()

--- a/cognee/tests/unit/api/v1/agents/test_agents_api.py
+++ b/cognee/tests/unit/api/v1/agents/test_agents_api.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cognee.api.v1.agents import get_agents_router
+from cognee.modules.agents.registry import clear_registered_agent_connections
+from cognee.modules.users.methods import get_authenticated_user
+
+
+def test_agents_register_and_list_endpoint(monkeypatch):
+    clear_registered_agent_connections()
+    user = SimpleNamespace(id=uuid4(), tenant_id=uuid4())
+    dataset_id = uuid4()
+    dataset = SimpleNamespace(
+        id=dataset_id,
+        name="company_brain",
+        owner_id=user.id,
+        tenant_id=user.tenant_id,
+    )
+
+    async def readable_datasets_for(_user):
+        return [dataset]
+
+    async def visible_user_ids(_user):
+        return [user.id]
+
+    async def trace_agents_for_user(**_kwargs):
+        return []
+
+    monkeypatch.setattr(
+        "cognee.modules.agents.operations._readable_datasets_for",
+        readable_datasets_for,
+    )
+    monkeypatch.setattr("cognee.modules.agents.operations._visible_user_ids", visible_user_ids)
+    monkeypatch.setattr(
+        "cognee.modules.agents.operations._trace_agents_for_user",
+        trace_agents_for_user,
+    )
+
+    app = FastAPI()
+    app.include_router(get_agents_router(), prefix="/api/v1/agents")
+    app.dependency_overrides[get_authenticated_user] = lambda: user
+
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/agents/register",
+            json={
+                "name": "support_agent",
+                "type": "api",
+                "memory_mode": "hybrid",
+                "session_id": "support-prod",
+                "dataset_ids": [str(dataset_id)],
+                "source": "api",
+            },
+        )
+        assert created.status_code == 201
+        assert created.json()["name"] == "support_agent"
+
+        response = client.get("/api/v1/agents")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 1
+        assert body["agents"][0]["name"] == "support_agent"
+        assert body["agents"][0]["datasets"][0]["id"] == str(dataset_id)
+        assert body["memory_sources"][0]["type"] == "company_brain"
+        assert body["memory_sources"][0]["connected_agent_ids"] == [created.json()["id"]]
+
+
+def test_agents_detail_endpoint_returns_404_for_unknown_agent(monkeypatch):
+    clear_registered_agent_connections()
+    user = SimpleNamespace(id=uuid4(), tenant_id=uuid4())
+
+    async def readable_datasets_for(_user):
+        return []
+
+    async def visible_user_ids(_user):
+        return [user.id]
+
+    async def trace_agents_for_user(**_kwargs):
+        return []
+
+    monkeypatch.setattr(
+        "cognee.modules.agents.operations._readable_datasets_for",
+        readable_datasets_for,
+    )
+    monkeypatch.setattr("cognee.modules.agents.operations._visible_user_ids", visible_user_ids)
+    monkeypatch.setattr(
+        "cognee.modules.agents.operations._trace_agents_for_user",
+        trace_agents_for_user,
+    )
+
+    app = FastAPI()
+    app.include_router(get_agents_router(), prefix="/api/v1/agents")
+    app.dependency_overrides[get_authenticated_user] = lambda: user
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/agents/missing")
+        assert response.status_code == 404

--- a/cognee/tests/unit/modules/agents/test_agent_registry.py
+++ b/cognee/tests/unit/modules/agents/test_agent_registry.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+import cognee
+from cognee.modules.agents.registry import (
+    classify_memory_source_type,
+    clear_registered_agent_connections,
+    list_registered_agent_connections,
+    register_agent_connection,
+)
+
+
+def test_register_agent_connection_normalizes_memory_sources():
+    clear_registered_agent_connections()
+
+    user_id = str(uuid4())
+    connection = register_agent_connection(
+        name="support_agent",
+        connection_type="api",
+        memory_mode="hybrid",
+        source="api",
+        user_id=user_id,
+        datasets=[{"id": str(uuid4()), "name": "company_brain", "role": "read_write"}],
+    )
+
+    assert connection.id
+    assert connection.name == "support_agent"
+    assert connection.datasets[0].type == "company_brain"
+    assert list_registered_agent_connections() == [connection]
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("company_brain", "company_brain"),
+        ("engineering wiki", "knowledge_wiki"),
+        ("project alpha", "project_dataset"),
+        ("main_dataset", "dataset"),
+    ],
+)
+def test_classify_memory_source_type(name, expected):
+    assert classify_memory_source_type(name) == expected
+
+
+@pytest.mark.asyncio
+async def test_agent_memory_registers_wrapped_agent(monkeypatch):
+    clear_registered_agent_connections()
+    user = SimpleNamespace(id=uuid4(), tenant_id=uuid4())
+    scope = SimpleNamespace(user=user, dataset_name="company_brain", dataset_id=uuid4())
+
+    async def resolve_user(_config):
+        return user
+
+    async def resolve_scope(_config, _user):
+        return scope
+
+    async def retrieve_memory(_context):
+        return ""
+
+    async def persist_trace(_context):
+        return None
+
+    monkeypatch.setattr("cognee.modules.agent_memory.decorator.resolve_agent_user", resolve_user)
+    monkeypatch.setattr(
+        "cognee.modules.agent_memory.decorator.resolve_agent_dataset_scope",
+        resolve_scope,
+    )
+    monkeypatch.setattr(
+        "cognee.modules.agent_memory.decorator.retrieve_memory_context",
+        retrieve_memory,
+    )
+    monkeypatch.setattr("cognee.modules.agent_memory.decorator.persist_trace", persist_trace)
+
+    @cognee.agent_memory(with_memory=True, with_session_memory=True, save_session_traces=True)
+    async def support_agent(question: str) -> str:
+        return question
+
+    assert await support_agent("hello") == "hello"
+
+    connections = list_registered_agent_connections()
+    assert len(connections) == 1
+    assert connections[0].name.endswith("support_agent")
+    assert connections[0].memory_mode == "hybrid"
+    assert connections[0].datasets[0].name == "company_brain"


### PR DESCRIPTION
## Summary
- add /api/v1/agents list, detail, and register endpoints
- add a non-durable in-process agent connection registry plus session-trace fallback discovery
- register @cognee.agent_memory wrapped agents with memory mode and dataset source metadata

## Notes
- No Alembic migration is included; the registry is intentionally in-process until a durable AgentConnection table is added separately.
- Memory sources are inferred from readable datasets and classified as dataset, company_brain, knowledge_wiki, or project_dataset by name.

## Tests
- uv run pytest cognee/tests/unit/modules/agents/test_agent_registry.py cognee/tests/unit/api/v1/agents/test_agents_api.py -q
- uv run ruff check cognee/modules/agents cognee/api/v1/agents cognee/modules/agent_memory/decorator.py cognee/api/client.py cognee/tests/unit/modules/agents/test_agent_registry.py cognee/tests/unit/api/v1/agents/test_agents_api.py
- uv run ruff format --check cognee/modules/agents cognee/api/v1/agents cognee/modules/agent_memory/decorator.py cognee/api/client.py cognee/tests/unit/modules/agents/test_agent_registry.py cognee/tests/unit/api/v1/agents/test_agents_api.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added agents management API endpoints to list, register, and retrieve agent connections
* Agents can be filtered by time range (24h, 7d, 30d, all) and status
* Agent connections now track associated memory sources and datasets
* Agent activity history and details are queryable by user with pagination support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->