### PR TITLE
fix: send string data as plain form field in CloudClient.remember to enable session cache (closes #2888)

### DIFF
--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -68,10 +68,12 @@ class CloudClient:
 
         # Handle data — string or file-like objects
         if isinstance(data, str):
+            # Send plain strings as a regular form field so the backend
+            # treats them as text (not file uploads) and can write them
+            # to the session cache via _add_to_session.
             form.add_field(
                 "data",
-                io.BytesIO(data.encode("utf-8")),
-                filename="data.txt",
+                data,
                 content_type="text/plain",
             )
         elif isinstance(data, list):
@@ -79,8 +81,7 @@ class CloudClient:
                 if isinstance(item, str):
                     form.add_field(
                         "data",
-                        io.BytesIO(item.encode("utf-8")),
-                        filename="data.txt",
+                        item,
                         content_type="text/plain",
                     )
                 elif hasattr(item, "read"):


### PR DESCRIPTION
## What

When `CloudClient.remember()` receives a string `data` argument, it wraps it as a multipart file upload (`io.BytesIO` with `filename="data.txt"`). The backend's `_add_to_session` explicitly skips file-shaped data, so the session cache is never populated — causing the documented `remember → recall → improve` session-aware workflow to silently no-op for all HTTP/MCP paths.

## Fix

Remove the `io.BytesIO` wrapping and `filename` parameter when `data` (or list items) is a plain string. Plain strings are now sent as regular form fields with `content_type="text/plain"`, which the backend recognises as text content eligible for session cache storage.

File uploads (file-like objects with a `.read()` method) are unaffected and continue to be sent as multipart file fields.

Closes #2888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of text data submissions to use more efficient transmission format.
  * Ensured file uploads continue to work as expected while optimizing string data processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->