### PR TITLE
fix(remember): materialize UploadFile bytes before background task

### DIFF
--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
@@ -84,6 +85,21 @@ def get_remember_router() -> APIRouter:
                 status_code=400,
                 detail="Either datasetId or datasetName must be provided.",
             )
+
+        # Pre-read all UploadFile bytes into BytesIO while the request scope is
+        # still open. FastAPI's UploadFile is backed by SpooledTemporaryFile,
+        # which Starlette closes when the HTTP response is sent. With
+        # run_in_background=True the response is sent before the background
+        # asyncio task calls add(), so the file handles are already closed by
+        # then. Materialising the bytes here ensures data survives into the task.
+        if run_in_background and data:
+            materialized: list[BytesIO] = []
+            for f in data:
+                content = await f.read()
+                bio = BytesIO(content)
+                bio.name = f.filename or "upload"
+                materialized.append(bio)
+            data = materialized
 
         from cognee.api.v1.remember import remember as cognee_remember
         from cognee.api.v1.ontologies.ontologies import OntologyService


### PR DESCRIPTION
## Summary

With `run_in_background=True`, `POST /v1/remember` returns an HTTP response immediately. Starlette then closes the request scope, which invalidates the `UploadFile` objects (backed by `SpooledTemporaryFile`). The asyncio background task calls `add()` on already-closed file handles — so uploaded files were never stored.

**Fix**: pre-read all file bytes into `BytesIO` during the request handler (while the scope is still open) before calling `cognee_remember()`, so data is available when the background task runs.

## Test plan
- [ ] `POST /v1/remember` with files and `run_in_background=true` — files should be stored and cognify should run
- [ ] `POST /v1/remember` with files and `run_in_background=false` (blocking) — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed an issue where uploaded files became inaccessible when using background processing mode. Files are now properly retained in memory and remain fully accessible throughout the entire background processing workflow, improving reliability of asynchronous file operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->