### PR TITLE
feat(remember): add graph_model param; fix(cognify): remove DatasetConfiguration

### DIFF
--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -176,39 +176,8 @@ def get_cognify_router() -> APIRouter:
                     }
                 }
 
-            # Resolve graph model and custom prompt: use payload values,
-            # fall back to stored DatasetConfiguration, then defaults.
             graph_model_schema = payload.graph_model
             custom_prompt = payload.custom_prompt
-
-            if datasets and (not graph_model_schema or not custom_prompt):
-                try:
-                    from uuid import UUID as _UUID
-                    from cognee.modules.data.models import DatasetConfiguration
-                    from cognee.infrastructure.databases.relational import get_relational_engine
-                    from sqlalchemy import select
-
-                    first_ds = datasets[0]
-                    try:
-                        ds_uuid = first_ds if isinstance(first_ds, _UUID) else _UUID(str(first_ds))
-                    except (ValueError, AttributeError):
-                        ds_uuid = None
-
-                    if ds_uuid:
-                        db_engine = get_relational_engine()
-                        async with db_engine.get_async_session() as session:
-                            config = await session.scalar(
-                                select(DatasetConfiguration).where(
-                                    DatasetConfiguration.dataset_id == ds_uuid
-                                )
-                            )
-                        if config:
-                            if not graph_model_schema and config.graph_schema:
-                                graph_model_schema = config.graph_schema
-                            if not custom_prompt and config.custom_prompt:
-                                custom_prompt = config.custom_prompt
-                except Exception as config_err:
-                    logger.debug("DatasetConfiguration lookup skipped: %s", config_err)
 
             if not graph_model_schema:
                 graph_model = KnowledgeGraph
@@ -226,45 +195,6 @@ def get_cognify_router() -> APIRouter:
                 chunks_per_batch=payload.chunks_per_batch,
                 data_per_batch=payload.data_per_batch,
             )
-
-            # Persist schema and prompt to DatasetConfiguration for first dataset
-            if datasets and (graph_model_schema or custom_prompt):
-                try:
-                    from uuid import UUID as _UUID
-                    from cognee.modules.data.models import DatasetConfiguration
-                    from cognee.infrastructure.databases.relational import get_relational_engine
-                    from sqlalchemy import select
-
-                    first_ds = datasets[0]
-                    try:
-                        ds_uuid = first_ds if isinstance(first_ds, _UUID) else _UUID(str(first_ds))
-                    except (ValueError, AttributeError):
-                        ds_uuid = None
-
-                    if ds_uuid:
-                        db_engine = get_relational_engine()
-                        async with db_engine.get_async_session() as session:
-                            config = await session.scalar(
-                                select(DatasetConfiguration).where(
-                                    DatasetConfiguration.dataset_id == ds_uuid
-                                )
-                            )
-                            if config:
-                                if graph_model_schema:
-                                    config.graph_schema = graph_model_schema
-                                if custom_prompt:
-                                    config.custom_prompt = custom_prompt
-                            else:
-                                session.add(
-                                    DatasetConfiguration(
-                                        dataset_id=ds_uuid,
-                                        graph_schema=graph_model_schema,
-                                        custom_prompt=custom_prompt,
-                                    )
-                                )
-                            await session.commit()
-                except Exception as persist_err:
-                    logger.warning("Failed to persist dataset configuration: %s", persist_err)
 
             # If any cognify run errored return JSONResponse with proper error status code
             if any(isinstance(v, PipelineRunErrored) for v in cognify_run.values()):

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -1,3 +1,4 @@
+import json
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
@@ -42,6 +43,11 @@ def get_remember_router() -> APIRouter:
             examples=[[]],
             description="Reference to one or more previously uploaded ontologies",
         ),
+        graph_model: Optional[str] = Form(
+            default=None,
+            examples=[""],
+            description="JSON-serialised graph model schema (same format as the cognify endpoint).",
+        ),
         content_type: Optional[str] = Form(default=None, examples=[""]),
         user: User = Depends(get_authenticated_user),
     ):
@@ -62,6 +68,7 @@ def get_remember_router() -> APIRouter:
           model-based sizing.
         - **chunks_per_batch** (Optional[int]): Chunks per cognify batch.
         - **ontology_key** (Optional[List[str]]): Reference to one or more previously uploaded ontology files to use for knowledge graph construction.
+        - **graph_model** (Optional[str]): JSON-serialised graph model schema (same dict format accepted by the cognify endpoint).
 
         Either datasetName or datasetId must be provided.
 
@@ -87,6 +94,7 @@ def get_remember_router() -> APIRouter:
 
         from cognee.api.v1.remember import remember as cognee_remember
         from cognee.api.v1.ontologies.ontologies import OntologyService
+        from cognee.shared.graph_model_utils import graph_schema_to_graph_model
 
         try:
             config_to_use = None
@@ -107,6 +115,14 @@ def get_remember_router() -> APIRouter:
                     }
                 }
 
+            graph_model_parsed = None
+            if graph_model:
+                try:
+                    graph_model_schema = json.loads(graph_model)
+                    graph_model_parsed = graph_schema_to_graph_model(graph_model_schema)
+                except (json.JSONDecodeError, Exception) as parse_err:
+                    logger.warning("remember: invalid graph_model JSON, ignoring: %s", parse_err)
+
             result = await cognee_remember(
                 data,
                 dataset_name=datasetName,
@@ -120,6 +136,7 @@ def get_remember_router() -> APIRouter:
                 chunks_per_batch=chunks_per_batch,
                 content_type=content_type,
                 **({"config": config_to_use} if config_to_use else {}),
+                **({"graph_model": graph_model_parsed} if graph_model_parsed else {}),
             )
 
             return jsonable_encoder(result.to_dict())


### PR DESCRIPTION
## Summary

### `POST /v1/remember` — `graph_model` param
- Added optional `graph_model` multipart form field, matching the cognify endpoint. Accepts a JSON-serialised graph model schema, converts it via `graph_schema_to_graph_model`, and forwards it to `cognee_remember()`.
- Uses `examples=[""]` instead of `default=None` so Swagger renders an empty input field rather than `"None"`, preventing Swagger from submitting the literal string `"None"` which would be misinterpreted as JSON.

### `POST /v1/cognify` — remove `DatasetConfiguration`
- Removed DB lookup fallback: the router was reading `DatasetConfiguration` from the DB when `graph_model`/`custom_prompt` were absent. The UI stores config client-side and always sends params explicitly — a DB fallback means clearing a graph model in the UI has no effect (stale DB value restored on next run).
- Removed DB write-back after cognify.
- Removed the multi-dataset bug: config was read from `datasets[0]` and applied to all datasets uniformly, which is incorrect.
- Both params are now truly optional and default to `KnowledgeGraph` / `None` when not supplied.

## Test plan
- [ ] `POST /v1/remember` with `graph_model` JSON — custom model applied to cognify step
- [ ] `POST /v1/remember` without `graph_model` — submittable from Swagger without issues, uses default KnowledgeGraph
- [ ] `POST /v1/cognify` without `graph_model` — no DB lookup, defaults to KnowledgeGraph
- [ ] `POST /v1/cognify` with `graph_model` — custom model used, not written to DB
- [ ] Clear graph model in UI then cognify — stale DB config no longer restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/v1/remember` endpoint now accepts optional graph model configuration in request payload.

* **Changes**
  * `/v1/cognify` endpoint now takes graph model schema and custom prompt directly from the request instead of falling back to stored dataset configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->