### PR TITLE
refactor: simplify connection id for agents, let agents define a uniq…

### DIFF
--- a/cognee/api/v1/agents/routers/get_agents_router.py
+++ b/cognee/api/v1/agents/routers/get_agents_router.py
@@ -92,6 +92,12 @@ def get_agents_router() -> APIRouter:
 
     @router.get("/connections", tags=[CONNECTIONS_TAG])
     async def list_agents_connections(
+        agent_session_name: Optional[str] = Query(
+            None,
+            description="Filter by connection name. Use this to retrieve the stored "
+            "configuration for a specific agent connection. The agent authenticates "
+            "via API key and passes the name it used during registration.",
+        ),
         range: RangeLiteral = Query("30d"),
         status_filter: Optional[Literal["active", "inactive", "unknown"]] = Query(
             None,
@@ -109,6 +115,7 @@ def get_agents_router() -> APIRouter:
             status_filter=status_filter,
             include_sources=include_sources,
             active_only=active_only,
+            agent_session_name=agent_session_name,
             limit=limit,
             offset=offset,
         )

--- a/cognee/api/v1/agents/routers/get_agents_router.py
+++ b/cognee/api/v1/agents/routers/get_agents_router.py
@@ -92,6 +92,11 @@ def get_agents_router() -> APIRouter:
 
     @router.get("/connections", tags=[CONNECTIONS_TAG])
     async def list_agents_connections(
+        agent_id: Optional[UUID] = Query(
+            None,
+            description="Filter connections by agent user ID. "
+            "Only returns connections belonging to this specific agent.",
+        ),
         range: RangeLiteral = Query("30d"),
         status_filter: Optional[Literal["active", "inactive", "unknown"]] = Query(
             None,
@@ -105,6 +110,7 @@ def get_agents_router() -> APIRouter:
     ):
         response = await list_agent_connections(
             user=user,
+            agent_id=agent_id,
             range_key=range,
             status_filter=status_filter,
             include_sources=include_sources,
@@ -114,12 +120,30 @@ def get_agents_router() -> APIRouter:
         )
         return jsonable_encoder(response)
 
-    @router.get("/connections/{agent_id}", tags=[CONNECTIONS_TAG])
-    async def get_connection_detail(
-        agent_id: str,
+    @router.get("/connections/me", tags=[CONNECTIONS_TAG])
+    async def get_my_connection_detail(
         agent_session_name: Optional[str] = Query(
             None,
-            description="Filter by connection name within the authenticated user's connections.",
+            description="Filter by connection name. "
+            "Uses the authenticated user's ID as the agent ID.",
+        ),
+        user: User = Depends(get_authenticated_user),
+    ):
+        response = await get_agent_connection_detail(
+            user=user,
+            agent_id=user.id,
+            agent_session_name=agent_session_name,
+        )
+        if response is None:
+            raise HTTPException(status_code=404, detail="connection not found")
+        return jsonable_encoder(response)
+
+    @router.get("/connections/{agent_id}", tags=[CONNECTIONS_TAG])
+    async def get_connection_detail(
+        agent_id: UUID,
+        agent_session_name: Optional[str] = Query(
+            None,
+            description="Filter by connection name within the agent's connections.",
         ),
         user: User = Depends(get_authenticated_user),
     ):

--- a/cognee/api/v1/agents/routers/get_agents_router.py
+++ b/cognee/api/v1/agents/routers/get_agents_router.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from cognee.api.DTO import OutDTO
 from cognee.modules.agents.agent_mode import register_agent, unregister_agent
-from cognee.modules.agents.models import RegisterAgentRequest
+from cognee.modules.agents.models import RegisterAgentRequest, UnregisterAgentRequest
 from cognee.modules.agents.create_agent import create_agent
 from cognee.modules.agents.get_agent import get_agent
 from cognee.modules.agents.list_agents import list_agents
@@ -139,7 +139,7 @@ def get_agents_router() -> APIRouter:
 
     @router.post("/unregister", tags=[CONNECTIONS_TAG])
     async def unregister_agent_endpoint(
-        request: RegisterAgentRequest,
+        request: UnregisterAgentRequest,
         user: User = Depends(get_authenticated_user),
     ) -> AgentModeDTO:
         count = await unregister_agent(user, request)

--- a/cognee/api/v1/agents/routers/get_agents_router.py
+++ b/cognee/api/v1/agents/routers/get_agents_router.py
@@ -92,12 +92,6 @@ def get_agents_router() -> APIRouter:
 
     @router.get("/connections", tags=[CONNECTIONS_TAG])
     async def list_agents_connections(
-        agent_session_name: Optional[str] = Query(
-            None,
-            description="Filter by connection name. Use this to retrieve the stored "
-            "configuration for a specific agent connection. The agent authenticates "
-            "via API key and passes the name it used during registration.",
-        ),
         range: RangeLiteral = Query("30d"),
         status_filter: Optional[Literal["active", "inactive", "unknown"]] = Query(
             None,
@@ -115,7 +109,6 @@ def get_agents_router() -> APIRouter:
             status_filter=status_filter,
             include_sources=include_sources,
             active_only=active_only,
-            agent_session_name=agent_session_name,
             limit=limit,
             offset=offset,
         )
@@ -124,13 +117,16 @@ def get_agents_router() -> APIRouter:
     @router.get("/connections/{agent_id}", tags=[CONNECTIONS_TAG])
     async def get_connection_detail(
         agent_id: str,
-        range: RangeLiteral = Query("all"),
+        agent_session_name: Optional[str] = Query(
+            None,
+            description="Filter by connection name within the authenticated user's connections.",
+        ),
         user: User = Depends(get_authenticated_user),
     ):
         response = await get_agent_connection_detail(
             user=user,
             agent_id=agent_id,
-            range_key=range,
+            agent_session_name=agent_session_name,
         )
         if response is None:
             raise HTTPException(status_code=404, detail="connection not found")

--- a/cognee/modules/agent_memory/decorator.py
+++ b/cognee/modules/agent_memory/decorator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import uuid
 from typing import Any, Callable, Optional
 
 from cognee.exceptions import CogneeValidationError
@@ -18,11 +19,16 @@ from cognee.modules.agent_memory.runtime import (
     set_current_agent_memory_context,
     validate_agent_memory_config,
 )
-from cognee.modules.agents.registry import derive_memory_mode, register_agent_connection
+from cognee.modules.agents.registry import (
+    deactivate_agent_connection,
+    derive_memory_mode,
+    register_agent_connection,
+)
 
 
 def agent_memory(
     *,
+    agent_session_name: Optional[str] = None,
     with_memory: bool = True,
     with_session_memory: bool = False,
     save_session_traces: bool = False,
@@ -99,8 +105,9 @@ def agent_memory(
                 user=resolved_user,
                 scope=scope,
             )
-            await register_agent_connection(
-                name=fn.__qualname__,
+            connection_name = agent_session_name or str(uuid.uuid4())
+            connection = await register_agent_connection(
+                agent_session_name=connection_name,
                 connection_type="sdk",
                 memory_mode=derive_memory_mode(
                     with_memory=config.with_memory,
@@ -150,6 +157,8 @@ def agent_memory(
             finally:
                 reset_current_agent_memory_context(token)
                 await persist_trace(context)
+                if resolved_user is not None and resolved_user.id is not None:
+                    await deactivate_agent_connection(resolved_user.id, connection.id)
 
         return wrapper
 

--- a/cognee/modules/agents/agent_mode.py
+++ b/cognee/modules/agents/agent_mode.py
@@ -27,7 +27,11 @@ from typing import TYPE_CHECKING
 from cognee.shared.logging_utils import get_logger
 
 if TYPE_CHECKING:
-    from cognee.modules.agents.models import AgentConnection, RegisterAgentRequest
+    from cognee.modules.agents.models import (
+        AgentConnection,
+        RegisterAgentRequest,
+        UnregisterAgentRequest,
+    )
     from cognee.modules.users.models.User import User
 
 logger = get_logger(__name__)
@@ -91,7 +95,7 @@ async def register_agent(user: User, request: RegisterAgentRequest) -> AgentConn
     return connection
 
 
-async def unregister_agent(user: User, request: RegisterAgentRequest) -> int:
+async def unregister_agent(user: User, request: UnregisterAgentRequest) -> int:
     global _active_count
 
     from cognee.modules.agents.registry import (
@@ -100,10 +104,8 @@ async def unregister_agent(user: User, request: RegisterAgentRequest) -> int:
     )
 
     connection_id = build_agent_connection_id(
-        name=request.name,
+        agent_session_name=request.agent_session_name,
         user_id=str(user.id) if user.id is not None else None,
-        session_id=request.session_id,
-        connection_type=request.type,
     )
 
     await deactivate_agent_connection(user.id, connection_id)

--- a/cognee/modules/agents/models.py
+++ b/cognee/modules/agents/models.py
@@ -23,7 +23,7 @@ class AgentDatasetRef(BaseModel):
 
 class AgentConnection(BaseModel):
     id: str
-    name: str
+    agent_session_name: str
     type: AgentConnectionType = "unknown"
     memory_mode: AgentMemoryMode = "unknown"
     session_id: Optional[str] = None
@@ -66,7 +66,10 @@ class AgentDetailResponse(BaseModel):
 
 
 class RegisterAgentRequest(BaseModel):
-    name: str
+    agent_session_name: str = Field(
+        description="A unique name for this agent connection. "
+        "Combined with the authenticated user's ID to identify the connection."
+    )
     type: AgentConnectionType = "api"
     memory_mode: AgentMemoryMode = "unknown"
     session_id: Optional[str] = None
@@ -75,3 +78,10 @@ class RegisterAgentRequest(BaseModel):
     source: AgentSource = "api"
     origin_function: Optional[str] = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class UnregisterAgentRequest(BaseModel):
+    agent_session_name: str = Field(
+        description="The name used when registering the connection. "
+        "Combined with the authenticated user's ID to identify which connection to deactivate."
+    )

--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -189,17 +189,13 @@ async def _trace_agents_for_user(
         )
         status = "active" if row.effective_status == "running" else "inactive"
         agent_id = build_agent_connection_id(
-            name=name,
-            origin_function=origin_function,
+            agent_session_name=name,
             user_id=owner_user_id,
-            session_id=session_id,
-            dataset_id=datasets[0].id if datasets else None,
-            connection_type=connection_type,
         )
         agents.append(
             AgentConnection(
                 id=agent_id,
-                name=name,
+                agent_session_name=name,
                 type=connection_type,
                 memory_mode="hybrid" if datasets else "session",
                 session_id=session_id,
@@ -396,7 +392,7 @@ async def register_agent_from_request(user: User, request: RegisterAgentRequest)
         for dataset_name in request.dataset_names
     )
     return await register_agent_connection(
-        name=request.name,
+        agent_session_name=request.agent_session_name,
         connection_type=request.type,
         memory_mode=request.memory_mode,
         source=request.source,

--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -278,6 +278,7 @@ async def list_agent_connections(
     status_filter: Optional[str] = None,
     include_sources: bool = True,
     active_only: bool = True,
+    agent_session_name: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> AgentsListResponse:
@@ -310,6 +311,8 @@ async def list_agent_connections(
         since=since,
     )
     agents = _merge_agents([*registered_agents, *persisted_agents, *trace_agents])
+    if agent_session_name:
+        agents = [agent for agent in agents if agent.agent_session_name == agent_session_name]
     if status_filter:
         agents = [agent for agent in agents if agent.status == status_filter]
 

--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -16,14 +16,11 @@ from cognee.modules.agents.models import (
     RegisterAgentRequest,
 )
 from cognee.modules.agents.registry import (
-    build_agent_connection_id,
     classify_memory_source_type,
-    derive_connection_type,
     list_persisted_agent_connections,
     list_registered_agent_connections,
     register_agent_connection,
 )
-from cognee.modules.session_lifecycle.metrics import list_session_rows
 from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.models import User
 from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
@@ -45,12 +42,6 @@ def _range_since(range_key: RangeLiteral) -> Optional[datetime]:
     if range_key == "30d":
         return now - timedelta(days=30)
     return None
-
-
-def _entry_value(entry: Any, key: str, default: Any = None) -> Any:
-    if isinstance(entry, dict):
-        return entry.get(key, default)
-    return getattr(entry, key, default)
 
 
 def _entry_to_dict(entry: Any) -> dict[str, Any]:
@@ -114,108 +105,6 @@ def _memory_sources_from_datasets(datasets: list[Any]) -> list[MemorySourceConne
             )
         )
     return sources
-
-
-def _dataset_ref_for_id(
-    dataset_id: Any,
-    memory_sources_by_id: dict[str, MemorySourceConnection],
-) -> Optional[AgentDatasetRef]:
-    if dataset_id is None:
-        return None
-    source = memory_sources_by_id.get(str(dataset_id))
-    if source is None:
-        return AgentDatasetRef(id=str(dataset_id), role="read", type="dataset")
-    return AgentDatasetRef(id=source.id, name=source.name, role="read", type=source.type)
-
-
-async def _trace_agents_for_user(
-    *,
-    user: User,
-    visible_user_ids: list[UUIDType],
-    permitted_dataset_ids: list[UUIDType],
-    memory_sources_by_id: dict[str, MemorySourceConnection],
-    since: Optional[datetime],
-) -> list[AgentConnection]:
-    try:
-        page = await list_session_rows(
-            user_ids=visible_user_ids,
-            permitted_dataset_ids=permitted_dataset_ids,
-            since=since,
-            status_filter=None,
-            limit=500,
-            offset=0,
-            order_by="last_activity_at",
-            descending=True,
-        )
-    except Exception as error:
-        logger.warning("Failed to list session rows for agents API: %s", error)
-        return []
-
-    try:
-        from cognee.infrastructure.session.get_session_manager import get_session_manager
-
-        session_manager = get_session_manager()
-    except Exception:
-        session_manager = None
-
-    agents = []
-    for row in page.sessions:
-        record = row.record
-        owner_user_id = str(getattr(record, "user_id", ""))
-        session_id = getattr(record, "session_id", None)
-        if not owner_user_id or not session_id or session_manager is None:
-            continue
-
-        try:
-            traces = await session_manager.get_agent_trace_session(
-                user_id=owner_user_id,
-                session_id=session_id,
-                last_n=20,
-            )
-        except Exception:
-            traces = []
-        if not traces:
-            continue
-
-        first_trace = traces[0]
-        origin_function = _entry_value(first_trace, "origin_function", None)
-        name = str(origin_function or session_id)
-        dataset_ref = _dataset_ref_for_id(getattr(record, "dataset_id", None), memory_sources_by_id)
-        datasets = [dataset_ref] if dataset_ref else []
-        connection_type = derive_connection_type(
-            origin_function=origin_function,
-            session_id=session_id,
-            source="session_trace",
-        )
-        status = "active" if row.effective_status == "running" else "inactive"
-        agent_id = build_agent_connection_id(
-            agent_session_name=name,
-            user_id=owner_user_id,
-        )
-        agents.append(
-            AgentConnection(
-                id=agent_id,
-                agent_session_name=name,
-                type=connection_type,
-                memory_mode="hybrid" if datasets else "session",
-                session_id=session_id,
-                user_id=owner_user_id,
-                tenant_id=getattr(user, "tenant_id", None),
-                datasets=datasets,
-                last_active_at=getattr(record, "last_activity_at", None),
-                status=status,
-                source="session_trace",
-                origin_function=str(origin_function) if origin_function else None,
-                metadata={
-                    "session_status": getattr(record, "status", None),
-                    "effective_status": row.effective_status,
-                    "trace_count": len(traces),
-                    "error_count": getattr(record, "error_count", 0),
-                },
-            )
-        )
-
-    return agents
 
 
 def _is_visible_registered_agent(
@@ -284,12 +173,9 @@ async def list_agent_connections(
 ) -> AgentsListResponse:
     readable_datasets = await _readable_datasets_for(user)
     memory_sources = _memory_sources_from_datasets(readable_datasets)
-    memory_sources_by_id = {source.id: source for source in memory_sources}
-    permitted_dataset_ids = [UUIDType(source.id) for source in memory_sources]
     visible_user_ids = await _visible_user_ids(user)
     visible_user_id_set = set(visible_user_ids)
     permitted_dataset_id_strings = {source.id for source in memory_sources}
-    since = _range_since(range_key)
 
     registered_agents = [
         agent
@@ -303,14 +189,7 @@ async def list_agent_connections(
     persisted_agents = await list_persisted_agent_connections(
         visible_user_ids, active_only=active_only
     )
-    trace_agents = await _trace_agents_for_user(
-        user=user,
-        visible_user_ids=visible_user_ids,
-        permitted_dataset_ids=permitted_dataset_ids,
-        memory_sources_by_id=memory_sources_by_id,
-        since=since,
-    )
-    agents = _merge_agents([*registered_agents, *persisted_agents, *trace_agents])
+    agents = _merge_agents([*registered_agents, *persisted_agents])
     if agent_session_name:
         agents = [agent for agent in agents if agent.agent_session_name == agent_session_name]
     if status_filter:

--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -163,6 +163,7 @@ def _attach_connected_agent_ids(
 async def list_agent_connections(
     *,
     user: User,
+    agent_id: Optional[UUIDType] = None,
     range_key: RangeLiteral = "30d",
     status_filter: Optional[str] = None,
     include_sources: bool = True,
@@ -189,6 +190,13 @@ async def list_agent_connections(
         visible_user_ids, active_only=active_only
     )
     agents = _merge_agents([*registered_agents, *persisted_agents])
+    if agent_id:
+        agent_id_str = str(agent_id)
+        agents = [
+            agent
+            for agent in agents
+            if agent.user_id is not None and str(agent.user_id) == agent_id_str
+        ]
     if status_filter:
         agents = [agent for agent in agents if agent.status == status_filter]
 
@@ -208,24 +216,24 @@ async def list_agent_connections(
 async def get_agent_connection_detail(
     *,
     user: User,
-    agent_id: str,
+    agent_id: UUIDType,
     agent_session_name: Optional[str] = None,
 ) -> Optional[AgentDetailResponse]:
     response = await list_agent_connections(
         user=user,
+        agent_id=agent_id,
         include_sources=True,
         limit=10000,
         offset=0,
     )
-    agent = next(
-        (
-            item
-            for item in response.agents
-            if item.id == agent_id
-            and (agent_session_name is None or item.agent_session_name == agent_session_name)
-        ),
-        None,
-    )
+    if agent_session_name:
+        matching = [
+            item for item in response.agents if item.agent_session_name == agent_session_name
+        ]
+    else:
+        matching = list(response.agents)
+
+    agent = matching[0] if matching else None
     if agent is None:
         return None
 

--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -167,7 +167,6 @@ async def list_agent_connections(
     status_filter: Optional[str] = None,
     include_sources: bool = True,
     active_only: bool = True,
-    agent_session_name: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> AgentsListResponse:
@@ -190,8 +189,6 @@ async def list_agent_connections(
         visible_user_ids, active_only=active_only
     )
     agents = _merge_agents([*registered_agents, *persisted_agents])
-    if agent_session_name:
-        agents = [agent for agent in agents if agent.agent_session_name == agent_session_name]
     if status_filter:
         agents = [agent for agent in agents if agent.status == status_filter]
 
@@ -212,16 +209,23 @@ async def get_agent_connection_detail(
     *,
     user: User,
     agent_id: str,
-    range_key: RangeLiteral = "all",
+    agent_session_name: Optional[str] = None,
 ) -> Optional[AgentDetailResponse]:
     response = await list_agent_connections(
         user=user,
-        range_key=range_key,
         include_sources=True,
         limit=10000,
         offset=0,
     )
-    agent = next((item for item in response.agents if item.id == agent_id), None)
+    agent = next(
+        (
+            item
+            for item in response.agents
+            if item.id == agent_id
+            and (agent_session_name is None or item.agent_session_name == agent_session_name)
+        ),
+        None,
+    )
     if agent is None:
         return None
 

--- a/cognee/modules/agents/registry.py
+++ b/cognee/modules/agents/registry.py
@@ -75,24 +75,12 @@ def derive_connection_type(
 
 def build_agent_connection_id(
     *,
-    name: str | None = None,
-    origin_function: str | None = None,
+    agent_session_name: str,
     user_id: str | None = None,
-    session_id: str | None = None,
-    dataset_id: str | None = None,
-    connection_type: str | None = None,
 ) -> str:
-    identity = "|".join(
-        [
-            origin_function or name or "agent",
-            user_id or "",
-            session_id or "",
-            dataset_id or "",
-            connection_type or "",
-        ]
-    )
+    identity = f"{agent_session_name}|{user_id or ''}"
     digest = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:16]
-    base = re.sub(r"[^a-zA-Z0-9_-]+", "-", origin_function or name or "agent").strip("-")
+    base = re.sub(r"[^a-zA-Z0-9_-]+", "-", agent_session_name).strip("-")
     base = base[-48:] if len(base) > 48 else base
     return f"{base or 'agent'}-{digest}"
 
@@ -137,7 +125,7 @@ async def _persist_agent_connection(user_id: UUID, connection: AgentConnection) 
 
 async def register_agent_connection(
     *,
-    name: str,
+    agent_session_name: str,
     connection_type: AgentConnectionType = "unknown",
     memory_mode: AgentMemoryMode = "unknown",
     source: AgentSource = "api",
@@ -152,18 +140,13 @@ async def register_agent_connection(
     metadata: Optional[dict] = None,
 ) -> AgentConnection:
     dataset_refs = _normalize_datasets(datasets)
-    primary_dataset_id = next((dataset.id for dataset in dataset_refs if dataset.id), None)
     resolved_agent_id = agent_id or build_agent_connection_id(
-        name=name,
-        origin_function=origin_function,
+        agent_session_name=agent_session_name,
         user_id=str(user_id) if user_id is not None else None,
-        session_id=session_id,
-        dataset_id=primary_dataset_id,
-        connection_type=connection_type,
     )
     connection = AgentConnection(
         id=resolved_agent_id,
-        name=name,
+        agent_session_name=agent_session_name,
         type=connection_type,
         memory_mode=memory_mode,
         session_id=session_id,

--- a/cognee/tests/api/test_agent_mode.py
+++ b/cognee/tests/api/test_agent_mode.py
@@ -11,20 +11,20 @@ with patch("dotenv.load_dotenv"):
     from fastapi.testclient import TestClient
 
 from cognee.modules.agents import agent_mode
-from cognee.modules.agents.models import RegisterAgentRequest
+from cognee.modules.agents.models import RegisterAgentRequest, UnregisterAgentRequest
 from cognee.modules.users.models.User import User
 
 RUN_ID = uuid.uuid4().hex[:8]
 OWNER_EMAIL = f"agentmode-owner-{RUN_ID}@example.com"
 OWNER_PASSWORD = "ownerpass123!"
 
-REGISTER_BODY = {"name": "test-agent"}
-REGISTER_BODY_2 = {"name": "test-agent-2"}
+REGISTER_BODY = {"agent_session_name": "test-agent"}
+REGISTER_BODY_2 = {"agent_session_name": "test-agent-2"}
 
 _DUMMY_USER = User(email="test@test.com", hashed_password="!")
 _DUMMY_USER_2 = User(email="test2@test.com", hashed_password="!")
-_DUMMY_REQUEST = RegisterAgentRequest(name="test-agent")
-_DUMMY_REQUEST_2 = RegisterAgentRequest(name="test-agent-2")
+_DUMMY_REQUEST = RegisterAgentRequest(agent_session_name="test-agent")
+_DUMMY_REQUEST_2 = RegisterAgentRequest(agent_session_name="test-agent-2")
 
 
 def _reset_agent_mode():
@@ -105,14 +105,22 @@ class TestAgentMode:
         client.post("/api/v1/agents/register", json=REGISTER_BODY_2, headers=headers)
         assert agent_mode._active_count == 2
 
-        resp = client.post("/api/v1/agents/unregister", json=REGISTER_BODY, headers=headers)
+        resp = client.post(
+            "/api/v1/agents/unregister",
+            json={"agent_session_name": "test-agent"},
+            headers=headers,
+        )
         assert resp.status_code == 200
         assert resp.json()["activeAgents"] == 1
 
     def test_unregister_does_not_go_below_zero(self, client, owner_token):
         headers = {"Authorization": f"Bearer {owner_token}"}
 
-        resp = client.post("/api/v1/agents/unregister", json=REGISTER_BODY, headers=headers)
+        resp = client.post(
+            "/api/v1/agents/unregister",
+            json={"agent_session_name": "test-agent"},
+            headers=headers,
+        )
         assert resp.status_code == 200
         assert resp.json()["activeAgents"] == 0
 
@@ -133,8 +141,12 @@ class TestAgentMode:
     async def test_watchdog_shuts_down_after_all_unregister(self, mock_shutdown):
         await agent_mode.register_agent(_DUMMY_USER, _DUMMY_REQUEST)
         await agent_mode.register_agent(_DUMMY_USER_2, _DUMMY_REQUEST_2)
-        await agent_mode.unregister_agent(_DUMMY_USER, _DUMMY_REQUEST)
-        await agent_mode.unregister_agent(_DUMMY_USER_2, _DUMMY_REQUEST_2)
+        await agent_mode.unregister_agent(
+            _DUMMY_USER, UnregisterAgentRequest(agent_session_name="test-agent")
+        )
+        await agent_mode.unregister_agent(
+            _DUMMY_USER_2, UnregisterAgentRequest(agent_session_name="test-agent-2")
+        )
 
         agent_mode._watchdog()
         mock_shutdown.assert_called_once()

--- a/cognee/tests/api/test_agents_e2e.py
+++ b/cognee/tests/api/test_agents_e2e.py
@@ -88,7 +88,7 @@ class TestAgentsE2E:
             "/api/v1/agents/register",
             headers=headers,
             json={
-                "name": "support_bot",
+                "agent_session_name": "support_bot",
                 "type": "api",
                 "memory_mode": "hybrid",
                 "session_id": "sess-001",
@@ -101,7 +101,7 @@ class TestAgentsE2E:
         )
         assert resp.status_code == 201, resp.text
         connection = resp.json()
-        assert connection["name"] == "support_bot"
+        assert connection["agent_session_name"] == "support_bot"
         assert connection["type"] == "api"
         assert connection["memory_mode"] == "hybrid"
         assert connection["session_id"] == "sess-001"
@@ -119,11 +119,11 @@ class TestAgentsE2E:
         resp = client.post(
             "/api/v1/agents/register",
             headers=headers,
-            json={"name": "minimal_agent"},
+            json={"agent_session_name": "minimal_agent"},
         )
         assert resp.status_code == 201, resp.text
         connection = resp.json()
-        assert connection["name"] == "minimal_agent"
+        assert connection["agent_session_name"] == "minimal_agent"
         assert connection["type"] == "api"
         assert connection["memory_mode"] == "unknown"
         assert connection["source"] == "api"
@@ -135,7 +135,7 @@ class TestAgentsE2E:
             "/api/v1/agents/register",
             headers=headers,
             json={
-                "name": "list_test_agent",
+                "agent_session_name": "list_test_agent",
                 "type": "sdk",
                 "memory_mode": "cognee",
             },
@@ -148,7 +148,7 @@ class TestAgentsE2E:
         body = resp.json()
         assert body["total"] == 1
         assert body["agents"][0]["id"] == agent_id
-        assert body["agents"][0]["name"] == "list_test_agent"
+        assert body["agents"][0]["agent_session_name"] == "list_test_agent"
         assert body["limit"] == 50
         assert body["offset"] == 0
 
@@ -158,7 +158,7 @@ class TestAgentsE2E:
             client.post(
                 "/api/v1/agents/register",
                 headers=headers,
-                json={"name": f"paginated_{i}"},
+                json={"agent_session_name": f"paginated_{i}"},
             )
 
         resp = client.get("/api/v1/agents/connections?limit=2&offset=0", headers=headers)
@@ -180,7 +180,7 @@ class TestAgentsE2E:
         client.post(
             "/api/v1/agents/register",
             headers=headers,
-            json={"name": "active_agent"},
+            json={"agent_session_name": "active_agent"},
         )
 
         resp = client.get("/api/v1/agents/connections?status=active", headers=headers)
@@ -197,7 +197,7 @@ class TestAgentsE2E:
             "/api/v1/agents/register",
             headers=headers,
             json={
-                "name": "detail_agent",
+                "agent_session_name": "detail_agent",
                 "type": "mcp",
                 "memory_mode": "session",
                 "session_id": "detail-sess",
@@ -210,7 +210,7 @@ class TestAgentsE2E:
         assert resp.status_code == 200
         body = resp.json()
         assert body["agent"]["id"] == agent_id
-        assert body["agent"]["name"] == "detail_agent"
+        assert body["agent"]["agent_session_name"] == "detail_agent"
         assert body["agent"]["type"] == "mcp"
         assert "memory_sources" in body
         assert "recent_sessions" in body
@@ -231,7 +231,7 @@ class TestAgentsE2E:
             r = client.post(
                 "/api/v1/agents/register",
                 headers=headers,
-                json={"name": name, "type": "sdk"},
+                json={"agent_session_name": name, "type": "sdk"},
             )
             assert r.status_code == 201
             ids.append(r.json()["id"])
@@ -250,7 +250,7 @@ class TestAgentsE2E:
             "/api/v1/agents/register",
             headers=headers,
             json={
-                "name": "dataset_agent",
+                "agent_session_name": "dataset_agent",
                 "dataset_ids": [dataset_id],
             },
         )
@@ -263,7 +263,7 @@ class TestAgentsE2E:
     def test_register_connection_idempotent_update(self, client, headers, _patch_operations):
         clear_registered_agent_connections()
         payload = {
-            "name": "idempotent_agent",
+            "agent_session_name": "idempotent_agent",
             "type": "api",
             "metadata": {"version": "1"},
         }
@@ -354,15 +354,23 @@ class TestAgentsE2E:
         agent_mode._active_count = 0
         agent_mode._active_connection_ids.clear()
 
-        client.post("/api/v1/agents/register", headers=headers, json={"name": "unreg-a"})
-        client.post("/api/v1/agents/register", headers=headers, json={"name": "unreg-b"})
+        client.post(
+            "/api/v1/agents/register", headers=headers, json={"agent_session_name": "unreg-a"}
+        )
+        client.post(
+            "/api/v1/agents/register", headers=headers, json={"agent_session_name": "unreg-b"}
+        )
         assert agent_mode._active_count == 2
 
-        resp = client.post("/api/v1/agents/unregister", json={"name": "unreg-a"}, headers=headers)
+        resp = client.post(
+            "/api/v1/agents/unregister", json={"agent_session_name": "unreg-a"}, headers=headers
+        )
         assert resp.status_code == 200
         assert resp.json()["activeAgents"] == 1
 
-        resp2 = client.post("/api/v1/agents/unregister", json={"name": "unreg-b"}, headers=headers)
+        resp2 = client.post(
+            "/api/v1/agents/unregister", json={"agent_session_name": "unreg-b"}, headers=headers
+        )
         assert resp2.json()["activeAgents"] == 0
 
     def test_unregister_floor_at_zero(self, client, headers):
@@ -370,7 +378,7 @@ class TestAgentsE2E:
         agent_mode._active_connection_ids.clear()
 
         resp = client.post(
-            "/api/v1/agents/unregister", json={"name": "nonexistent"}, headers=headers
+            "/api/v1/agents/unregister", json={"agent_session_name": "nonexistent"}, headers=headers
         )
         assert resp.status_code == 200
         assert resp.json()["activeAgents"] == 0
@@ -387,12 +395,12 @@ class TestAgentsE2E:
         try:
             endpoints = [
                 ("GET", "/api/v1/agents/connections", None),
-                ("POST", "/api/v1/agents/register", {"name": "x"}),
+                ("POST", "/api/v1/agents/register", {"agent_session_name": "x"}),
                 ("GET", "/api/v1/agents/connections/some-id", None),
                 ("POST", "/api/v1/agents/create?name=nope", None),
                 ("GET", "/api/v1/agents/list", None),
                 ("DELETE", f"/api/v1/agents/{uuid.uuid4()}", None),
-                ("POST", "/api/v1/agents/unregister", {"name": "x"}),
+                ("POST", "/api/v1/agents/unregister", {"agent_session_name": "x"}),
             ]
             for method, path, body in endpoints:
                 resp = client.request(method, path, json=body)
@@ -523,7 +531,7 @@ class TestAgentPersistence:
             "/api/v1/agents/register",
             headers=headers,
             json={
-                "name": PERSIST_AGENT_NAME,
+                "agent_session_name": PERSIST_AGENT_NAME,
                 "type": "api",
                 "memory_mode": "hybrid",
                 "source": "api",
@@ -539,7 +547,7 @@ class TestAgentPersistence:
         assert agent_config["custom_setting"] == "keep_me", "pre-existing config was overwritten"
         assert agent_id in agent_config["agents"], "registered agent not persisted"
         persisted = agent_config["agents"][agent_id]
-        assert persisted["name"] == PERSIST_AGENT_NAME
+        assert persisted["agent_session_name"] == PERSIST_AGENT_NAME
         assert persisted["type"] == "api"
         assert persisted["memory_mode"] == "hybrid"
 
@@ -547,7 +555,7 @@ class TestAgentPersistence:
         resp = client.get("/api/v1/agents/connections", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
-        agent_names = {a["name"] for a in body["agents"]}
+        agent_names = {a["agent_session_name"] for a in body["agents"]}
         assert PERSIST_AGENT_NAME in agent_names
 
     def test_parent_sees_child_agent_connection(self, client, headers, owner, _patch_traces):
@@ -565,7 +573,7 @@ class TestAgentPersistence:
             "/api/v1/agents/register",
             headers=child_headers,
             json={
-                "name": child_connection_name,
+                "agent_session_name": child_connection_name,
                 "type": "sdk",
                 "memory_mode": "cognee",
                 "source": "api",
@@ -681,7 +689,7 @@ class TestAgentFullLifecycle:
         reg_a = client.post(
             "/api/v1/agents/register",
             headers={"X-Api-Key": agent_a_key},
-            json={"name": agent_a_name, "type": "api", "memory_mode": "cognee"},
+            json={"agent_session_name": agent_a_name, "type": "api", "memory_mode": "cognee"},
         )
         assert reg_a.status_code == 201, reg_a.text
         connection_a_id = reg_a.json()["id"]
@@ -690,7 +698,7 @@ class TestAgentFullLifecycle:
         reg_b = client.post(
             "/api/v1/agents/register",
             headers={"X-Api-Key": agent_b_key},
-            json={"name": agent_b_name, "type": "sdk", "memory_mode": "hybrid"},
+            json={"agent_session_name": agent_b_name, "type": "sdk", "memory_mode": "hybrid"},
         )
         assert reg_b.status_code == 201, reg_b.text
         connection_b_id = reg_b.json()["id"]
@@ -700,7 +708,7 @@ class TestAgentFullLifecycle:
         reg_a_again = client.post(
             "/api/v1/agents/register",
             headers={"X-Api-Key": agent_a_key},
-            json={"name": agent_a_name, "type": "api", "memory_mode": "cognee"},
+            json={"agent_session_name": agent_a_name, "type": "api", "memory_mode": "cognee"},
         )
         assert reg_a_again.status_code == 201
         assert agent_mode._active_count == 2, "re-register should not increment"
@@ -721,7 +729,7 @@ class TestAgentFullLifecycle:
         unreg_a = client.post(
             "/api/v1/agents/unregister",
             headers={"X-Api-Key": agent_a_key},
-            json={"name": agent_a_name, "type": "api"},
+            json={"agent_session_name": agent_a_name},
         )
         assert unreg_a.status_code == 200
         assert unreg_a.json()["activeAgents"] == 1
@@ -752,7 +760,7 @@ class TestAgentFullLifecycle:
         unreg_b = client.post(
             "/api/v1/agents/unregister",
             headers={"X-Api-Key": agent_b_key},
-            json={"name": agent_b_name, "type": "sdk"},
+            json={"agent_session_name": agent_b_name},
         )
         assert unreg_b.status_code == 200
         assert unreg_b.json()["activeAgents"] == 0
@@ -775,7 +783,7 @@ class TestAgentFullLifecycle:
         re_reg = client.post(
             "/api/v1/agents/register",
             headers={"X-Api-Key": agent_a_key},
-            json={"name": agent_a_name, "type": "api"},
+            json={"agent_session_name": agent_a_name, "type": "api"},
         )
         assert re_reg.status_code == 201
         assert agent_mode._active_count == 1, "re-register after unregister should increment"
@@ -803,7 +811,7 @@ class TestAgentFullLifecycle:
             "/api/v1/agents/register",
             headers={"X-Api-Key": agent_a_key},
             json={
-                "name": agent_a_name,
+                "agent_session_name": agent_a_name,
                 "type": "api",
                 "memory_mode": "session",
                 "metadata": {"version": "2"},
@@ -828,7 +836,7 @@ class TestAgentFullLifecycle:
             "/api/v1/agents/register",
             headers={"X-Api-Key": agent_a_key},
             json={
-                "name": f"{agent_a_name}-v2",
+                "agent_session_name": f"{agent_a_name}-v2",
                 "type": "api",
                 "memory_mode": "hybrid",
             },
@@ -847,7 +855,7 @@ class TestAgentFullLifecycle:
         client.post(
             "/api/v1/agents/unregister",
             headers={"X-Api-Key": agent_a_key},
-            json={"name": agent_a_name, "type": "api"},
+            json={"agent_session_name": agent_a_name},
         )
 
         conn_after_partial = client.get(
@@ -870,7 +878,7 @@ class TestAgentFullLifecycle:
         re_reg_after_deactivate = client.post(
             "/api/v1/agents/register",
             headers={"X-Api-Key": agent_a_key},
-            json={"name": agent_a_name, "type": "api", "memory_mode": "cognee"},
+            json={"agent_session_name": agent_a_name, "type": "api", "memory_mode": "cognee"},
         )
         assert re_reg_after_deactivate.status_code == 201
         reactivated_id = re_reg_after_deactivate.json()["id"]
@@ -896,7 +904,7 @@ class TestAgentFullLifecycle:
         reg_c = client.post(
             "/api/v1/agents/register",
             headers={"X-Api-Key": agent_c_key},
-            json={"name": agent_c_name, "type": "api"},
+            json={"agent_session_name": agent_c_name, "type": "api"},
         )
         assert reg_c.status_code == 201
         connection_c_id = reg_c.json()["id"]
@@ -1028,7 +1036,7 @@ class TestMultiTenantIsolation:
         reg_a = client.post(
             "/api/v1/agents/register",
             headers=headers_a,
-            json={"name": f"conn-a-{ISOLATION_RUN_ID}", "type": "api"},
+            json={"agent_session_name": f"conn-a-{ISOLATION_RUN_ID}", "type": "api"},
         )
         assert reg_a.status_code == 201
         conn_a_id = reg_a.json()["id"]
@@ -1037,7 +1045,7 @@ class TestMultiTenantIsolation:
         reg_b = client.post(
             "/api/v1/agents/register",
             headers=headers_b,
-            json={"name": f"conn-b-{ISOLATION_RUN_ID}", "type": "sdk"},
+            json={"agent_session_name": f"conn-b-{ISOLATION_RUN_ID}", "type": "sdk"},
         )
         assert reg_b.status_code == 201
         conn_b_id = reg_b.json()["id"]

--- a/cognee/tests/api/test_agents_e2e.py
+++ b/cognee/tests/api/test_agents_e2e.py
@@ -458,9 +458,6 @@ class TestAgentsE2E:
         async def visible_user_ids(_user):
             return [uuid.UUID(owner["id"])]
 
-        async def trace_agents_for_user(**_kwargs):
-            return []
-
         async def persisted_agent_connections(_user_id, active_only=True):
             return []
 
@@ -472,10 +469,6 @@ class TestAgentsE2E:
             patch(
                 "cognee.modules.agents.operations._visible_user_ids",
                 visible_user_ids,
-            ),
-            patch(
-                "cognee.modules.agents.operations._trace_agents_for_user",
-                trace_agents_for_user,
             ),
             patch(
                 "cognee.modules.agents.operations.list_persisted_agent_connections",
@@ -522,17 +515,6 @@ class TestAgentPersistence:
     def headers(self, owner):
         return {"Authorization": f"Bearer {owner['token']}"}
 
-    @pytest.fixture(scope="class")
-    def _patch_traces(self, owner):
-        async def trace_agents_for_user(**_kwargs):
-            return []
-
-        with patch(
-            "cognee.modules.agents.operations._trace_agents_for_user",
-            trace_agents_for_user,
-        ):
-            yield
-
     def _seed_configuration(self, client, headers):
         resp = client.post(
             "/api/v1/configuration/store_user_configuration",
@@ -552,7 +534,7 @@ class TestAgentPersistence:
                 return config["configuration"]
         return None
 
-    def test_register_persists_without_overwriting(self, client, headers, owner, _patch_traces):
+    def test_register_persists_without_overwriting(self, client, headers, owner):
         self._seed_configuration(client, headers)
 
         clear_registered_agent_connections()
@@ -580,14 +562,14 @@ class TestAgentPersistence:
         assert persisted["type"] == "api"
         assert persisted["memory_mode"] == "hybrid"
 
-    def test_list_returns_persisted_agent(self, client, headers, owner, _patch_traces):
+    def test_list_returns_persisted_agent(self, client, headers, owner):
         resp = client.get("/api/v1/agents/connections", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         agent_names = {a["agent_session_name"] for a in body["agents"]}
         assert PERSIST_AGENT_NAME in agent_names
 
-    def test_parent_sees_child_agent_connection(self, client, headers, owner, _patch_traces):
+    def test_parent_sees_child_agent_connection(self, client, headers, owner):
         child_name = f"child-agent-{PERSIST_RUN_ID}"
         create_resp = client.post(
             f"/api/v1/agents/create?name={child_name}",
@@ -657,17 +639,6 @@ class TestAgentFullLifecycle:
     def headers(self, owner):
         return {"Authorization": f"Bearer {owner['token']}"}
 
-    @pytest.fixture(scope="class")
-    def _patch_traces(self):
-        async def trace_agents_for_user(**_kwargs):
-            return []
-
-        with patch(
-            "cognee.modules.agents.operations._trace_agents_for_user",
-            trace_agents_for_user,
-        ):
-            yield
-
     @pytest.fixture(autouse=True)
     def _reset(self):
         agent_mode._active_count = 0
@@ -676,7 +647,7 @@ class TestAgentFullLifecycle:
         clear_registered_agent_connections()
         yield
 
-    def test_full_lifecycle(self, client, headers, owner, _patch_traces):
+    def test_full_lifecycle(self, client, headers, owner):
         agent_a_name = f"agent-a-{LIFECYCLE_RUN_ID}"
         agent_b_name = f"agent-b-{LIFECYCLE_RUN_ID}"
 
@@ -1006,17 +977,6 @@ class TestMultiTenantIsolation:
         assert login.status_code == 200
         return {"id": reg.json()["id"], "token": login.json()["access_token"]}
 
-    @pytest.fixture(scope="class")
-    def _patch_traces(self):
-        async def trace_agents_for_user(**_kwargs):
-            return []
-
-        with patch(
-            "cognee.modules.agents.operations._trace_agents_for_user",
-            trace_agents_for_user,
-        ):
-            yield
-
     @pytest.fixture(autouse=True)
     def _reset(self):
         agent_mode._active_count = 0
@@ -1057,7 +1017,7 @@ class TestMultiTenantIsolation:
         assert agent_b_id in b_agent_ids
         assert agent_a_id not in b_agent_ids, "user B should not see user A's agent"
 
-    def test_users_cannot_see_each_others_connections(self, client, user_a, user_b, _patch_traces):
+    def test_users_cannot_see_each_others_connections(self, client, user_a, user_b):
         headers_a = {"Authorization": f"Bearer {user_a['token']}"}
         headers_b = {"Authorization": f"Bearer {user_b['token']}"}
 

--- a/cognee/tests/api/test_agents_e2e.py
+++ b/cognee/tests/api/test_agents_e2e.py
@@ -191,7 +191,7 @@ class TestAgentsE2E:
         assert resp2.status_code == 200
         assert resp2.json()["total"] == 0
 
-    def test_get_connection_detail(self, client, headers, _patch_operations):
+    def test_get_connection_detail(self, client, headers, owner, _patch_operations):
         clear_registered_agent_connections()
         reg = client.post(
             "/api/v1/agents/register",
@@ -204,12 +204,13 @@ class TestAgentsE2E:
             },
         )
         assert reg.status_code == 201
-        agent_id = reg.json()["id"]
 
-        resp = client.get(f"/api/v1/agents/connections/{agent_id}", headers=headers)
+        resp = client.get(
+            f"/api/v1/agents/connections/{owner['id']}?agent_session_name=detail_agent",
+            headers=headers,
+        )
         assert resp.status_code == 200
         body = resp.json()
-        assert body["agent"]["id"] == agent_id
         assert body["agent"]["agent_session_name"] == "detail_agent"
         assert body["agent"]["type"] == "mcp"
         assert "memory_sources" in body
@@ -219,7 +220,8 @@ class TestAgentsE2E:
 
     def test_get_connection_detail_not_found(self, client, headers, _patch_operations):
         clear_registered_agent_connections()
-        resp = client.get("/api/v1/agents/connections/nonexistent-id-12345", headers=headers)
+        fake_id = str(uuid.uuid4())
+        resp = client.get(f"/api/v1/agents/connections/{fake_id}", headers=headers)
         assert resp.status_code == 404
         assert resp.json()["detail"] == "connection not found"
 
@@ -396,7 +398,7 @@ class TestAgentsE2E:
             endpoints = [
                 ("GET", "/api/v1/agents/connections", None),
                 ("POST", "/api/v1/agents/register", {"agent_session_name": "x"}),
-                ("GET", "/api/v1/agents/connections/some-id", None),
+                ("GET", f"/api/v1/agents/connections/{uuid.uuid4()}", None),
                 ("POST", "/api/v1/agents/create?name=nope", None),
                 ("GET", "/api/v1/agents/list", None),
                 ("DELETE", f"/api/v1/agents/{uuid.uuid4()}", None),
@@ -691,10 +693,13 @@ class TestAgentFullLifecycle:
         assert connection_a_id in conn_ids
         assert connection_b_id in conn_ids
 
-        # -- Step 7: Verify GET /connections/{id} returns detail --
-        detail_conn = client.get(f"/api/v1/agents/connections/{connection_a_id}", headers=headers)
+        # -- Step 7: Verify GET /connections/{agent_id} returns detail --
+        detail_conn = client.get(
+            f"/api/v1/agents/connections/{agent_a['agentId']}?agent_session_name={agent_a_name}",
+            headers=headers,
+        )
         assert detail_conn.status_code == 200
-        assert detail_conn.json()["agent"]["id"] == connection_a_id
+        assert detail_conn.json()["agent"]["agent_session_name"] == agent_a_name
 
         # -- Step 8: Unregister agent A's connection --
         unreg_a = client.post(

--- a/cognee/tests/api/test_agents_e2e.py
+++ b/cognee/tests/api/test_agents_e2e.py
@@ -243,6 +243,35 @@ class TestAgentsE2E:
         for agent_id in ids:
             assert agent_id in returned_ids
 
+    def test_filter_connections_by_agent_session_name(self, client, headers, _patch_operations):
+        clear_registered_agent_connections()
+        client.post(
+            "/api/v1/agents/register",
+            headers=headers,
+            json={"agent_session_name": "target_agent", "type": "api"},
+        )
+        client.post(
+            "/api/v1/agents/register",
+            headers=headers,
+            json={"agent_session_name": "other_agent", "type": "sdk"},
+        )
+
+        resp = client.get(
+            "/api/v1/agents/connections?agent_session_name=target_agent",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["agents"][0]["agent_session_name"] == "target_agent"
+
+        resp_none = client.get(
+            "/api/v1/agents/connections?agent_session_name=nonexistent",
+            headers=headers,
+        )
+        assert resp_none.status_code == 200
+        assert resp_none.json()["total"] == 0
+
     def test_register_connection_with_dataset_ids(self, client, headers, _patch_operations):
         clear_registered_agent_connections()
         dataset_id = str(uuid.uuid4())

--- a/cognee/tests/api/test_agents_e2e.py
+++ b/cognee/tests/api/test_agents_e2e.py
@@ -243,35 +243,6 @@ class TestAgentsE2E:
         for agent_id in ids:
             assert agent_id in returned_ids
 
-    def test_filter_connections_by_agent_session_name(self, client, headers, _patch_operations):
-        clear_registered_agent_connections()
-        client.post(
-            "/api/v1/agents/register",
-            headers=headers,
-            json={"agent_session_name": "target_agent", "type": "api"},
-        )
-        client.post(
-            "/api/v1/agents/register",
-            headers=headers,
-            json={"agent_session_name": "other_agent", "type": "sdk"},
-        )
-
-        resp = client.get(
-            "/api/v1/agents/connections?agent_session_name=target_agent",
-            headers=headers,
-        )
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["total"] == 1
-        assert body["agents"][0]["agent_session_name"] == "target_agent"
-
-        resp_none = client.get(
-            "/api/v1/agents/connections?agent_session_name=nonexistent",
-            headers=headers,
-        )
-        assert resp_none.status_code == 200
-        assert resp_none.json()["total"] == 0
-
     def test_register_connection_with_dataset_ids(self, client, headers, _patch_operations):
         clear_registered_agent_connections()
         dataset_id = str(uuid.uuid4())

--- a/cognee/tests/unit/modules/agents/test_agent_registry.py
+++ b/cognee/tests/unit/modules/agents/test_agent_registry.py
@@ -19,7 +19,7 @@ async def test_register_agent_connection_normalizes_memory_sources():
 
     default_user = await get_default_user()
     connection = await register_agent_connection(
-        name="support_agent",
+        agent_session_name="support_agent",
         connection_type="api",
         memory_mode="hybrid",
         source="api",
@@ -28,7 +28,7 @@ async def test_register_agent_connection_normalizes_memory_sources():
     )
 
     assert connection.id
-    assert connection.name == "support_agent"
+    assert connection.agent_session_name == "support_agent"
     assert connection.datasets[0].type == "company_brain"
     assert list_registered_agent_connections() == [connection]
 
@@ -47,7 +47,7 @@ def test_classify_memory_source_type(name, expected):
 
 
 @pytest.mark.asyncio
-async def test_agent_memory_registers_wrapped_agent(monkeypatch):
+async def test_agent_memory_registers_and_deactivates_connection(monkeypatch):
     clear_registered_agent_connections()
     default_user = await get_default_user()
     user = SimpleNamespace(id=default_user.id, tenant_id=getattr(default_user, "tenant_id", None))
@@ -56,9 +56,16 @@ async def test_agent_memory_registers_wrapped_agent(monkeypatch):
     async def noop_persist(_user_id, _connection):
         pass
 
+    async def noop_deactivate(_user_id, _connection_id):
+        pass
+
     monkeypatch.setattr(
         "cognee.modules.agents.registry._persist_agent_connection",
         noop_persist,
+    )
+    monkeypatch.setattr(
+        "cognee.modules.agents.registry._deactivate_persisted_connection",
+        noop_deactivate,
     )
 
     async def resolve_user(_config):
@@ -84,14 +91,18 @@ async def test_agent_memory_registers_wrapped_agent(monkeypatch):
     )
     monkeypatch.setattr("cognee.modules.agent_memory.decorator.persist_trace", persist_trace)
 
+    captured_connections = []
+
     @cognee.agent_memory(with_memory=True, with_session_memory=True, save_session_traces=True)
     async def support_agent(question: str) -> str:
+        captured_connections.extend(list_registered_agent_connections())
         return question
 
     assert await support_agent("hello") == "hello"
 
-    connections = list_registered_agent_connections()
-    assert len(connections) == 1
-    assert connections[0].name.endswith("support_agent")
-    assert connections[0].memory_mode == "hybrid"
-    assert connections[0].datasets[0].name == "company_brain"
+    assert len(captured_connections) == 1
+    assert captured_connections[0].memory_mode == "hybrid"
+    assert captured_connections[0].datasets[0].name == "company_brain"
+
+    after = list_registered_agent_connections()
+    assert len(after) == 0, "connection should be deactivated after function completes"


### PR DESCRIPTION
…ue name for their connections

<!-- .github/pull_request_template.md -->

## Description
Simplify agent connection id, leave the responsibility on the agent to form a unique name to register connection

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET /connections/me and optional agent_id query/filter for connection listing; session-name filtering supported for connection detail.

* **Bug Fixes**
  * Unregister endpoint now accepts the correct unregister payload format.

* **Changes**
  * Agent identifiers and connection payloads now use agent_session_name combined with user identity instead of name.
  * Memory handling can accept an agent_session_name and creates per-call session names.

* **Tests**
  * Unit and e2e tests updated to reflect agent_session_name usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->