### PR TITLE
fix: raise top_k on brittle batch-queries simple test

### DIFF
--- a/cognee/tests/integration/retrieval/test_graph_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_retriever.py
@@ -283,7 +283,7 @@ async def test_graph_completion_get_triplets_empty(setup_test_environment_empty)
 @pytest.mark.asyncio
 async def test_graph_completion_batch_queries_context_simple(setup_test_environment_simple):
     """Integration test: verify GraphCompletionRetriever can retrieve context with multiple queries (simple)."""
-    retriever = GraphCompletionRetriever()
+    retriever = GraphCompletionRetriever(top_k=20)
     query_batch = ["Who works at Canva?", "Who works at Figma?"]
 
     triplets = await retriever.get_retrieved_objects(query_batch=query_batch)


### PR DESCRIPTION
## Description

Raise top_k from the default 5 to 20 in test_graph_completion_batch_queries_context_simple so the seven node-presence assertions don't sit right at the edge of what the retriever can return, matching what its complex sibling test already does.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works — N/A (test-only change)
- [ ] I have added necessary documentation (if applicable) — N/A
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test configuration for graph completion retrieval with modified parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->