### PR TITLE
fix(ontology): parse uploaded ontology formats

### DIFF
--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -4,6 +4,7 @@ from cognee.shared.logging_utils import get_logger
 from collections import deque
 from typing import List, Tuple, Dict, Optional, Any, Union, IO
 from rdflib import Graph, URIRef, RDF, RDFS, OWL
+from rdflib.util import guess_format
 
 from cognee.modules.ontology.exceptions import (
     OntologyInitializationError,
@@ -15,6 +16,21 @@ from cognee.modules.ontology.models import AttachedOntologyNode
 from cognee.modules.ontology.matching_strategies import MatchingStrategy, FuzzyMatchingStrategy
 
 logger = get_logger("OntologyAdapter")
+
+CONTENT_TYPE_FORMATS = {
+    "application/rdf+xml": "xml",
+    "application/xml": "xml",
+    "text/xml": "xml",
+    "text/turtle": "turtle",
+    "application/x-turtle": "turtle",
+    "text/n3": "n3",
+    "application/n-triples": "nt",
+    "application/n-quads": "nquads",
+    "application/trig": "trig",
+    "application/ld+json": "json-ld",
+}
+
+FALLBACK_FORMATS = ("xml", "turtle", "n3", "nt", "json-ld", "trig", "nquads")
 
 
 class RDFLibOntologyResolver(BaseOntologyResolver):
@@ -56,18 +72,25 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                     loaded_objects = []
                     for file_obj in file_objects:
                         try:
-                            content = file_obj.read()
-                            self.graph.parse(data=content, format="xml")
+                            parsed_format = self._parse_file_object(file_obj, self.graph)
                             loaded_objects.append(file_obj)
-                            logger.info("Ontology loaded successfully from file object")
+                            logger.info(
+                                "Ontology loaded successfully from file object '%s' as %s",
+                                self._get_file_object_name(file_obj),
+                                parsed_format,
+                            )
                         except Exception as e:
-                            logger.warning("Failed to parse ontology file object: %s", str(e))
+                            logger.warning(
+                                "Failed to parse ontology file object '%s': %s",
+                                self._get_file_object_name(file_obj),
+                                str(e),
+                            )
 
                     if not loaded_objects:
-                        logger.info(
-                            "No valid ontology file objects found. No owl ontology will be attached to the graph."
+                        raise ValueError(
+                            "No valid ontology file objects could be parsed. "
+                            "No owl ontology will be attached to the graph."
                         )
-                        self.graph = None
                     else:
                         logger.info("Total ontology file objects loaded: %d", len(loaded_objects))
 
@@ -104,8 +127,8 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
 
             self.build_lookup()
         except Exception as e:
-            logger.error("Failed to load ontology", exc_info=e)
-            raise OntologyInitializationError() from e
+            logger.error("Failed to load ontology", exc_info=True)
+            raise OntologyInitializationError(f"Failed to load ontology: {e}") from e
 
     def _uri_to_key(self, uri: URIRef) -> str:
         uri_str = str(uri)
@@ -114,6 +137,74 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
         else:
             name = uri_str.rstrip("/").split("/")[-1]
         return name.lower().replace(" ", "_").strip()
+
+    def _get_file_object_name(self, file_obj: IO) -> str:
+        return str(
+            getattr(file_obj, "filename", None)
+            or getattr(file_obj, "name", None)
+            or file_obj.__class__.__name__
+        )
+
+    def _get_content_type_format(self, file_obj: IO) -> Optional[str]:
+        content_type = getattr(file_obj, "content_type", None)
+        if not content_type:
+            return None
+
+        content_type = str(content_type).split(";", maxsplit=1)[0].strip().lower()
+        return CONTENT_TYPE_FORMATS.get(content_type)
+
+    def _get_candidate_formats(self, file_obj: IO) -> List[str]:
+        formats = []
+
+        filename = getattr(file_obj, "filename", None) or getattr(file_obj, "name", None)
+        if filename:
+            guessed_format = guess_format(str(filename))
+            if guessed_format:
+                formats.append(guessed_format)
+
+        content_type_format = self._get_content_type_format(file_obj)
+        if content_type_format:
+            formats.append(content_type_format)
+
+        formats.extend(FALLBACK_FORMATS)
+        return list(dict.fromkeys(formats))
+
+    def _parse_file_object(self, file_obj: IO, target_graph: Graph) -> str:
+        try:
+            file_obj.seek(0)
+        except (AttributeError, OSError):
+            pass
+
+        content = file_obj.read()
+        if not isinstance(content, (str, bytes)):
+            raise TypeError(
+                f"Ontology file object returned unsupported content type: {type(content)}"
+            )
+
+        candidate_formats = self._get_candidate_formats(file_obj)
+        parse_errors = []
+
+        for rdf_format in candidate_formats:
+            parsed_graph = Graph()
+            try:
+                parsed_graph.parse(data=content, format=rdf_format)
+            except Exception as error:
+                parse_errors.append(f"{rdf_format}: {error}")
+                continue
+
+            for prefix, namespace in parsed_graph.namespaces():
+                target_graph.bind(prefix, namespace, override=False)
+
+            for triple in parsed_graph:
+                target_graph.add(triple)
+
+            return rdf_format
+
+        raise ValueError(
+            f"Unable to parse ontology file object '{self._get_file_object_name(file_obj)}'. "
+            f"Tried formats: {', '.join(candidate_formats)}. "
+            f"Last error: {parse_errors[-1] if parse_errors else 'unknown error'}"
+        )
 
     def build_lookup(self) -> None:
         try:

--- a/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
+++ b/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
@@ -1,6 +1,9 @@
+import io
+
 import pytest
 from rdflib import Graph, Namespace, RDF, OWL, RDFS
 from cognee.modules.ontology.rdf_xml.RDFLibOntologyResolver import RDFLibOntologyResolver
+from cognee.modules.ontology.exceptions import OntologyInitializationError
 from cognee.modules.ontology.models import AttachedOntologyNode
 from cognee.modules.ontology.get_default_ontology_resolver import get_default_ontology_resolver
 
@@ -18,6 +21,30 @@ def test_ontology_adapter_initialization_file_not_found():
     """Test OntologyAdapter initialization with nonexistent file."""
     adapter = RDFLibOntologyResolver(ontology_file="nonexistent.owl")
     assert adapter.graph is None
+
+
+def test_ontology_adapter_initialization_turtle_file_object():
+    """Test loading Turtle ontology content from a file-like object."""
+    ontology_content = """
+    @prefix ex: <http://example.org/test#> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+    ex:Car a owl:Class .
+    ex:Audi a ex:Car .
+    """
+
+    resolver = RDFLibOntologyResolver(ontology_file=io.StringIO(ontology_content))
+
+    assert resolver.graph is not None
+    assert "car" in resolver.lookup["classes"]
+    assert "audi" in resolver.lookup["individuals"]
+    assert resolver.find_closest_match("Audi", "individuals") == "audi"
+
+
+def test_ontology_adapter_initialization_invalid_file_object_raises():
+    """Test invalid file-like ontology content fails instead of creating an empty lookup."""
+    with pytest.raises(OntologyInitializationError):
+        RDFLibOntologyResolver(ontology_file=io.StringIO("{"))
 
 
 def test_build_lookup():


### PR DESCRIPTION
## Summary
- parse file-like ontology inputs with filename/content-type format detection plus RDFLib fallback formats
- raise an ontology initialization error if no uploaded/file-like ontology can be parsed
- add unit coverage for Turtle file-like input and invalid file-like input

## Tests
- .venv/bin/python -m pytest cognee/tests/unit/modules/ontology/test_ontology_adapter.py -q
- .venv/bin/ruff check cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py cognee/tests/unit/modules/ontology/test_ontology_adapter.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ontology loading to support multi-format detection (RDF/XML, Turtle, etc.) with improved format identification.
  * Added support for loading ontologies from file-like objects with automatic format probing.

* **Bug Fixes**
  * Improved error handling during ontology initialization with clearer error messages.

* **Tests**
  * Added test coverage for ontology loading from file-like objects.
  * Added test coverage for invalid ontology error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2936?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->