### PR TITLE
fix(ontology): detect RDF serialization for file-object ontology uploads

### DIFF
--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -4,6 +4,7 @@ from cognee.shared.logging_utils import get_logger
 from collections import deque
 from typing import List, Tuple, Dict, Optional, Any, Union, IO
 from rdflib import Graph, URIRef, RDF, RDFS, OWL
+from rdflib.util import guess_format
 
 from cognee.modules.ontology.exceptions import (
     OntologyInitializationError,
@@ -15,6 +16,37 @@ from cognee.modules.ontology.models import AttachedOntologyNode
 from cognee.modules.ontology.matching_strategies import MatchingStrategy, FuzzyMatchingStrategy
 
 logger = get_logger("OntologyAdapter")
+
+# "xml" is first so nameless/unknown-extension uploads keep the prior default behaviour.
+_RDF_FORMAT_FALLBACKS = ("xml", "turtle", "n3", "json-ld", "nt")
+
+
+def _parse_rdf_into(graph: Graph, content, source_name: str = "") -> str:
+    """Parse RDF ``content`` into ``graph`` (mutated in place), detecting the
+    serialization instead of assuming RDF/XML.
+
+    Tries the format guessed from ``source_name`` first (when a filename is
+    available), then a small set of common serializations. Returns the format
+    that parsed. Raises the last parse error if none match, so the caller can
+    decide how to handle an unparseable input.
+    """
+    candidates = []
+    guessed = guess_format(source_name) if isinstance(source_name, str) and source_name else None
+    if guessed:
+        candidates.append(guessed)
+    candidates.extend(fmt for fmt in _RDF_FORMAT_FALLBACKS if fmt != guessed)
+
+    last_error = None
+    for fmt in candidates:
+        try:
+            parsed = Graph()
+            parsed.parse(data=content, format=fmt)
+        except Exception as exc:  # noqa: BLE001 - try the next serialization
+            last_error = exc
+            continue
+        graph += parsed
+        return fmt
+    raise last_error or ValueError("No supported RDF serialization matched the ontology content")
 
 
 class RDFLibOntologyResolver(BaseOntologyResolver):
@@ -57,9 +89,14 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                     for file_obj in file_objects:
                         try:
                             content = file_obj.read()
-                            self.graph.parse(data=content, format="xml")
+                            ontology_format = _parse_rdf_into(
+                                self.graph, content, getattr(file_obj, "name", "") or ""
+                            )
                             loaded_objects.append(file_obj)
-                            logger.info("Ontology loaded successfully from file object")
+                            logger.info(
+                                "Ontology loaded successfully from file object (format=%s)",
+                                ontology_format,
+                            )
                         except Exception as e:
                             logger.warning("Failed to parse ontology file object: %s", str(e))
 

--- a/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
+++ b/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
@@ -640,3 +640,62 @@ def test_multifile_ontology_with_overlapping_entities():
 
         os.unlink(file1_path)
         os.unlink(file2_path)
+
+
+def test_file_object_turtle_ontology_is_parsed():
+    """A Turtle ontology supplied as a file object must be parsed, not silently
+    dropped by a hardcoded ``format='xml'`` (regression for issue #2907)."""
+    import io
+
+    ns = Namespace("http://example.org/")
+    turtle = (
+        "@prefix ex: <http://example.org/> .\n"
+        "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+        "ex:Animal a rdfs:Class .\n"
+        "ex:Dog a rdfs:Class ; rdfs:subClassOf ex:Animal .\n"
+    )
+    file_obj = io.BytesIO(turtle.encode("utf-8"))
+    file_obj.name = "ontology.ttl"
+
+    resolver = RDFLibOntologyResolver(ontology_file=file_obj)
+
+    assert resolver.graph is not None
+    assert len(resolver.graph) > 0
+    assert (ns.Dog, RDFS.subClassOf, ns.Animal) in resolver.graph
+
+
+def test_file_object_turtle_without_name_is_parsed():
+    """Turtle file objects without a usable filename (e.g. upload spools) still parse
+    via the serialization fallback rather than failing as RDF/XML."""
+    import io
+
+    turtle = (
+        "@prefix ex: <http://example.org/> .\n"
+        "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+        "ex:Animal a rdfs:Class .\n"
+    )
+
+    resolver = RDFLibOntologyResolver(ontology_file=io.BytesIO(turtle.encode("utf-8")))
+
+    assert resolver.graph is not None
+    assert len(resolver.graph) > 0
+
+
+def test_file_object_rdfxml_ontology_still_parses():
+    """RDF/XML file objects continue to parse (no regression from format detection)."""
+    import io
+
+    rdfxml = (
+        '<?xml version="1.0"?>\n'
+        '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"\n'
+        '         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">\n'
+        '  <rdfs:Class rdf:about="http://example.org/Animal"/>\n'
+        "</rdf:RDF>\n"
+    )
+    file_obj = io.BytesIO(rdfxml.encode("utf-8"))
+    file_obj.name = "ontology.owl"
+
+    resolver = RDFLibOntologyResolver(ontology_file=file_obj)
+
+    assert resolver.graph is not None
+    assert len(resolver.graph) > 0


### PR DESCRIPTION
## Description

When an ontology is supplied as a file object instead of a path, the file-object branch of `RDFLibOntologyResolver` parses every upload with a hardcoded `format="xml"`:

    content = file_obj.read()
    self.graph.parse(data=content, format="xml")

So if you upload Turtle, N3, or JSON-LD, the parse raises, the surrounding `except` logs a warning, and you end up with an empty graph. It fails silently: `cognify` finishes without an error but nothing anchors, and every node comes back `ontology_valid: false`. The confusing part is that the path-based branch a few lines down does not force a format (`self.graph.parse(file_path)`), so the same ontology loads fine as a path and fails as a file object.

The fix makes the file-object branch behave like the path branch: detect the serialization instead of assuming RDF/XML. It uses the format guessed from the filename when one is available, then falls back to trying a small set of common serializations, and only gives up if none of them parse. I pulled the parsing into a small helper so the call site stays readable.

On scope: this is only about reading a single ontology file in the right serialization. It does not touch `index_fields` or multi-field retrieval, which was the concern that closed #2530. Nothing about that behavior changes here.

## Acceptance Criteria

- A Turtle, N3, or JSON-LD ontology supplied as a file object parses into a non-empty graph instead of being silently dropped.
- RDF/XML file objects still parse (no regression).
- Path-based loading is unchanged.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

I added three unit tests in `cognee/tests/unit/modules/ontology/test_ontology_adapter.py` (Turtle file object with a name, Turtle file object without a name, and an RDF/XML regression case). Local run:

    $ python -m pytest cognee/tests/unit/modules/ontology/test_ontology_adapter.py -q
    38 passed

    $ ruff check cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py cognee/tests/unit/modules/ontology/test_ontology_adapter.py
    All checks passed!

That is the 35 existing tests plus the 3 new ones.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

Closes #2907

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced ontology parser to automatically detect and support multiple RDF formats (Turtle, RDF/XML, N3, JSON-LD, NT) with intelligent fallback mechanism.
  * Improved handling of in-memory ontology files with better format detection.

* **Tests**
  * Added comprehensive test coverage for multi-format ontology parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->