### PR TITLE
fix: bind module-level asyncio locks to the running event loop

### DIFF
--- a/cognee/infrastructure/databases/relational/create_db_and_tables.py
+++ b/cognee/infrastructure/databases/relational/create_db_and_tables.py
@@ -1,8 +1,8 @@
-import asyncio
+from cognee.infrastructure.locks.loop_bound_lock import LoopBoundLock
 
 from .get_relational_engine import get_relational_engine
 
-_create_db_lock = asyncio.Lock()
+_create_db_lock = LoopBoundLock()
 
 
 async def create_db_and_tables():

--- a/cognee/infrastructure/locks/__init__.py
+++ b/cognee/infrastructure/locks/__init__.py
@@ -1,3 +1,9 @@
+from .loop_bound_lock import LoopBoundLock
 from .session_lock import release_improve_lock, session_lock, try_acquire_improve_lock
 
-__all__ = ["release_improve_lock", "session_lock", "try_acquire_improve_lock"]
+__all__ = [
+    "LoopBoundLock",
+    "release_improve_lock",
+    "session_lock",
+    "try_acquire_improve_lock",
+]

--- a/cognee/infrastructure/locks/loop_bound_lock.py
+++ b/cognee/infrastructure/locks/loop_bound_lock.py
@@ -1,0 +1,74 @@
+"""A module-safe async lock that binds to the running event loop on use.
+
+A plain ``asyncio.Lock()`` created at import time lazily binds to the first
+event loop that contends it (CPython 3.10+, via
+``asyncio.mixins._LoopBoundMixin``) and afterwards raises
+``RuntimeError: ... is bound to a different event loop`` if it is contended again
+from a different running loop. Any process that drives cognee from more than one
+event loop -- repeated ``asyncio.run(...)`` calls, a fresh loop per request,
+``pytest-asyncio`` with function-scoped loops, or a multi-worker ingest -- can
+therefore hit that error on cognee's module-level locks.
+
+``LoopBoundLock`` keeps one real ``asyncio.Lock`` per running loop, created on
+first use and stored in a ``WeakKeyDictionary`` keyed by the loop so locks for
+closed loops are garbage-collected. Each loop gets its own lock, which is the
+only thing an ``asyncio.Lock`` can do anyway -- it cannot synchronize across
+loops -- so a module-level singleton was already incorrect for multi-loop
+callers. Single-loop behavior is unchanged; the cross-loop failure is removed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import TracebackType
+from weakref import WeakKeyDictionary
+
+
+class LoopBoundLock:
+    """Drop-in replacement for a module-level ``asyncio.Lock``.
+
+    Lazily instantiates one underlying ``asyncio.Lock`` per running event loop,
+    so a single instance created at import time is safe to use from any number of
+    event loops. Supports ``async with`` and the ``acquire`` / ``release`` subset
+    of the ``asyncio.Lock`` interface that cognee uses.
+
+    Use it via ``async with`` (or a paired ``acquire`` / ``release`` on the same
+    loop). Like ``asyncio.Lock`` it serializes tasks within a single loop and does
+    not synchronize across loops.
+    """
+
+    __slots__ = ("_locks",)
+
+    def __init__(self) -> None:
+        self._locks: WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+            WeakKeyDictionary()
+        )
+
+    def _lock_for_running_loop(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def acquire(self) -> bool:
+        return await self._lock_for_running_loop().acquire()
+
+    def release(self) -> None:
+        lock = self._locks.get(asyncio.get_running_loop())
+        if lock is None:
+            raise RuntimeError("release() called without a matching acquire() on this event loop")
+        lock.release()
+
+    async def __aenter__(self) -> "LoopBoundLock":
+        await self.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.release()

--- a/cognee/infrastructure/locks/loop_bound_lock.py
+++ b/cognee/infrastructure/locks/loop_bound_lock.py
@@ -45,6 +45,7 @@ class LoopBoundLock:
         )
 
     def _lock_for_running_loop(self) -> asyncio.Lock:
+        """Return this loop's underlying lock, creating it on first use."""
         loop = asyncio.get_running_loop()
         lock = self._locks.get(loop)
         if lock is None:
@@ -53,9 +54,11 @@ class LoopBoundLock:
         return lock
 
     async def acquire(self) -> bool:
+        """Acquire the lock for the running event loop."""
         return await self._lock_for_running_loop().acquire()
 
     def release(self) -> None:
+        """Release the running loop's lock; raise if it was not acquired here."""
         lock = self._locks.get(asyncio.get_running_loop())
         if lock is None:
             raise RuntimeError("release() called without a matching acquire() on this event loop")

--- a/cognee/infrastructure/locks/session_lock.py
+++ b/cognee/infrastructure/locks/session_lock.py
@@ -19,25 +19,25 @@ row-level SQL advisory lock or Redis SETNX on top — the call sites
 are factored so that's a local change.
 """
 
-import asyncio
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
+from cognee.infrastructure.locks.loop_bound_lock import LoopBoundLock
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("session_lock")
 
 
-_locks: dict[tuple[str, str], asyncio.Lock] = {}
-_registry_lock = asyncio.Lock()
+_locks: dict[tuple[str, str], LoopBoundLock] = {}
+_registry_lock = LoopBoundLock()
 
 
-async def _get_lock(session_id: str, op: str) -> asyncio.Lock:
+async def _get_lock(session_id: str, op: str) -> LoopBoundLock:
     key = (session_id, op)
     async with _registry_lock:
         lock = _locks.get(key)
         if lock is None:
-            lock = asyncio.Lock()
+            lock = LoopBoundLock()
             _locks[key] = lock
         return lock
 
@@ -70,7 +70,7 @@ async def session_lock(session_id: str, op: str = "write") -> AsyncGenerator[Non
 # registry lock's critical section, so the test is atomic.
 
 _improving_sessions: set[str] = set()
-_improve_registry_lock = asyncio.Lock()
+_improve_registry_lock = LoopBoundLock()
 
 
 async def try_acquire_improve_lock(session_id: str) -> bool:

--- a/cognee/modules/pipelines/layers/setup_and_check_environment.py
+++ b/cognee/modules/pipelines/layers/setup_and_check_environment.py
@@ -1,5 +1,5 @@
 import os
-
+import asyncio
 from cognee.context_global_variables import (
     graph_db_config as context_graph_db_config,
     vector_db_config as context_vector_db_config,
@@ -11,13 +11,12 @@ from cognee.infrastructure.databases.relational import (
 from cognee.infrastructure.databases.vector.pgvector import (
     create_db_and_tables as create_pgvector_db_and_tables,
 )
-from cognee.infrastructure.locks.loop_bound_lock import LoopBoundLock
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
 
 _first_run_done = False
-_first_run_lock = LoopBoundLock()
+_first_run_lock = asyncio.Lock()
 
 
 async def setup_and_check_environment(

--- a/cognee/modules/pipelines/layers/setup_and_check_environment.py
+++ b/cognee/modules/pipelines/layers/setup_and_check_environment.py
@@ -1,5 +1,5 @@
 import os
-import asyncio
+
 from cognee.context_global_variables import (
     graph_db_config as context_graph_db_config,
     vector_db_config as context_vector_db_config,
@@ -11,12 +11,13 @@ from cognee.infrastructure.databases.relational import (
 from cognee.infrastructure.databases.vector.pgvector import (
     create_db_and_tables as create_pgvector_db_and_tables,
 )
+from cognee.infrastructure.locks.loop_bound_lock import LoopBoundLock
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
 
 _first_run_done = False
-_first_run_lock = asyncio.Lock()
+_first_run_lock = LoopBoundLock()
 
 
 async def setup_and_check_environment(

--- a/cognee/tests/unit/infrastructure/locks/test_loop_bound_lock.py
+++ b/cognee/tests/unit/infrastructure/locks/test_loop_bound_lock.py
@@ -1,0 +1,98 @@
+"""Unit tests for the loop-bound async lock helper."""
+
+import asyncio
+import gc
+
+import pytest
+
+from cognee.infrastructure.locks.loop_bound_lock import LoopBoundLock
+
+
+@pytest.mark.asyncio
+async def test_serializes_concurrent_tasks_in_one_loop():
+    """Within a single loop the lock gives mutual exclusion: two tasks cannot be
+    inside the critical section at the same time."""
+    lock = LoopBoundLock()
+    events: list[str] = []
+
+    async def worker(name: str, hold: float):
+        async with lock:
+            events.append(f"enter-{name}")
+            await asyncio.sleep(hold)
+            events.append(f"exit-{name}")
+
+    await asyncio.gather(worker("a", 0.02), worker("b", 0.0))
+
+    # Each enter is immediately followed by its matching exit (no overlap),
+    # whichever task won the lock first.
+    assert events in (
+        ["enter-a", "exit-a", "enter-b", "exit-b"],
+        ["enter-b", "exit-b", "enter-a", "exit-a"],
+    )
+
+
+def test_reused_across_event_loops_without_runtime_error():
+    """A LoopBoundLock built once (e.g. at module scope) must work from more than
+    one event loop. A plain module-level ``asyncio.Lock`` raises "bound to a
+    different event loop" here once it has been contended on the first loop."""
+    lock = LoopBoundLock()
+
+    async def contend_once():
+        async def hold():
+            async with lock:
+                await asyncio.sleep(0.01)
+
+        # Two tasks contend so the contended (slow) acquire path runs -- that is
+        # the path that performs asyncio's loop-binding check.
+        await asyncio.gather(hold(), hold())
+
+    asyncio.run(contend_once())  # binds the underlying lock to loop #1
+    asyncio.run(contend_once())  # loop #2: must not raise
+
+
+def test_underlying_lock_is_released_when_loop_is_gone():
+    """Locks for closed loops are not retained (no per-loop leak)."""
+    lock = LoopBoundLock()
+
+    async def use():
+        async with lock:
+            pass
+
+    asyncio.run(use())
+    gc.collect()
+
+    assert len(lock._locks) == 0
+
+
+def test_each_loop_gets_an_independent_lock():
+    """Two event loops must not serialize against each other: holding the lock
+    in one loop does not block a different loop from acquiring it. A single
+    shared lock would make loop B block on loop A here."""
+    lock = LoopBoundLock()
+
+    loop_a = asyncio.new_event_loop()
+    try:
+        loop_a.run_until_complete(lock.acquire())  # held in loop A, never released
+
+        async def acquire_in_loop_b():
+            # Independent per-loop lock -> acquires immediately; a shared lock
+            # would block until the (never released) loop-A hold timed out.
+            await asyncio.wait_for(lock.acquire(), timeout=1.0)
+            lock.release()
+
+        asyncio.run(acquire_in_loop_b())
+    finally:
+        loop_a.close()
+
+
+def test_release_without_acquire_raises_without_creating_a_lock():
+    """A release() with no matching acquire() raises and does not leave a stray
+    lock behind."""
+    lock = LoopBoundLock()
+
+    async def bad_release():
+        with pytest.raises(RuntimeError):
+            lock.release()
+        return len(lock._locks)
+
+    assert asyncio.run(bad_release()) == 0

--- a/cognee/tests/unit/infrastructure/locks/test_module_level_locks.py
+++ b/cognee/tests/unit/infrastructure/locks/test_module_level_locks.py
@@ -1,0 +1,26 @@
+"""Guard: every module-level lock we converted stays loop-safe.
+
+These locks used to be plain ``asyncio.Lock()`` objects created at import time,
+which bind to the first event loop that contends them. They are now
+``LoopBoundLock`` so they work from any number of event loops. This test fails if
+a raw module-level ``asyncio.Lock`` is ever reintroduced at one of these sites.
+"""
+
+import importlib
+
+import pytest
+
+from cognee.infrastructure.locks.loop_bound_lock import LoopBoundLock
+
+
+@pytest.mark.parametrize(
+    ("module_path", "lock_name"),
+    [
+        ("cognee.infrastructure.locks.session_lock", "_registry_lock"),
+        ("cognee.infrastructure.locks.session_lock", "_improve_registry_lock"),
+        ("cognee.infrastructure.databases.relational.create_db_and_tables", "_create_db_lock"),
+    ],
+)
+def test_module_level_lock_is_loop_bound(module_path, lock_name):
+    module = importlib.import_module(module_path)
+    assert isinstance(getattr(module, lock_name), LoopBoundLock)

--- a/cognee/tests/unit/infrastructure/locks/test_session_lock.py
+++ b/cognee/tests/unit/infrastructure/locks/test_session_lock.py
@@ -1,0 +1,75 @@
+"""Tests for the per-session lock primitives, including cross-event-loop use.
+
+The cross-loop test exercises the public API from more than one event loop.
+Before the module-level locks were made loop-bound, the second loop raised
+``RuntimeError: ... is bound to a different event loop`` once a lock was
+contended. That failure is contention-gated on CPython 3.12+ (asyncio's
+uncontended acquire fast-path skips the loop-binding check), so the test forces
+real contention -- two concurrent operations on the same key -- otherwise it
+would pass even against the buggy code.
+
+The remaining tests pin the locking semantics the fix must preserve: same-key
+operations serialize, different-key operations run concurrently.
+"""
+
+import asyncio
+
+from cognee.infrastructure.locks.session_lock import session_lock
+
+
+def _run_contended_same_key():
+    async def scenario():
+        async def op():
+            async with session_lock("session-1", "update_qa"):
+                await asyncio.sleep(0.01)
+
+        # Two concurrent ops on the same key: one holds the per-key lock across
+        # an await while the other waits, forcing the contended acquire path.
+        await asyncio.gather(op(), op())
+
+    asyncio.run(scenario())
+
+
+def test_session_lock_works_across_event_loops():
+    # Loop #1 binds the module-level locks to itself; loop #2 (a second
+    # asyncio.run) must not raise "bound to a different event loop".
+    _run_contended_same_key()
+    _run_contended_same_key()
+
+
+def test_session_lock_serializes_same_key_within_a_loop():
+    async def scenario():
+        events: list[tuple[str, int]] = []
+
+        async def op(n: int):
+            async with session_lock("session-1", "write"):
+                events.append(("enter", n))
+                await asyncio.sleep(0.01)
+                events.append(("exit", n))
+
+        await asyncio.gather(op(1), op(2))
+        return events
+
+    events = asyncio.run(scenario())
+
+    # No interleaving: each enter is immediately followed by its own exit.
+    assert [e[0] for e in events] == ["enter", "exit", "enter", "exit"]
+
+
+def test_session_lock_allows_concurrency_across_different_keys():
+    async def scenario():
+        events: list[tuple[str, str]] = []
+
+        async def op(key: str):
+            async with session_lock(key, "write"):
+                events.append(("enter", key))
+                await asyncio.sleep(0.02)
+                events.append(("exit", key))
+
+        await asyncio.gather(op("a"), op("b"))
+        return events
+
+    events = asyncio.run(scenario())
+
+    # Different keys do not block each other: both enter before either exits.
+    assert [e[0] for e in events[:2]] == ["enter", "enter"]


### PR DESCRIPTION
## Description

I hit this running cognee from a process that drives work through more than one event loop. After the first loop finished, later calls started failing with:

```
RuntimeError: <asyncio.locks.Lock object at 0x...> is bound to a different event loop
```

The cause is that a handful of locks are created at import time as module-level `asyncio.Lock()` objects. On CPython 3.10+ an `asyncio.Lock` binds itself to the running loop the first time it is awaited on the contended path (`asyncio/mixins.py` `_get_loop`). The uncontended `acquire()` fast path never calls `_get_loop()`, so the binding only happens once the lock is actually contended, which is why the failure looked intermittent to me at first. Once a module-level lock has bound to one loop, contending it from any other loop raises, so in practice a module-level lock can only be used from a single event loop for the lifetime of the process.

This affects anything that runs cognee from more than one loop in the same process:

- calling `asyncio.run()` more than once,
- a web framework that creates a fresh event loop per request,
- `pytest-asyncio` with function-scoped event loops,
- multi-worker or multi-loop ingestion.

The module-level locks this change covers are `_registry_lock`, `_improve_registry_lock` and the cached per-`(session_id, op)` locks in `cognee/infrastructure/locks/session_lock.py`, plus `_create_db_lock` in `cognee/infrastructure/databases/relational/create_db_and_tables.py`.

The fix is a small `LoopBoundLock` (`cognee/infrastructure/locks/loop_bound_lock.py`) that keeps one real `asyncio.Lock` per running loop, created on first use and stored in a `WeakKeyDictionary` keyed by the loop so locks for finished loops are garbage-collected. An `asyncio.Lock` can only synchronize tasks inside a single loop anyway, so a per-loop lock keeps the exact same single-loop guarantee while removing the cross-loop crash. I swapped `LoopBoundLock` into those sites.

On scope: I kept this to the sites where a per-loop lock is the correct primitive, which is also the highest-severity case (these locks bind at import time and are shared for the whole life of the process). I deliberately left `_first_run_lock` in `cognee/modules/pipelines/layers/setup_and_check_environment.py` alone: it guards a once-per-process flag (`_first_run_done`), so it wants a loop-agnostic single-flight guard rather than a per-loop lock, which is a separate change. Two other module-level `asyncio.Lock()` objects (`update_status_lock` in `cognee/api/v1/cognify/cognify.py` and `cognee/modules/pipelines/operations/pipeline.py`) are dead code (only referenced by a commented-out line), so they never bind to a loop and I left them untouched. Locks created per instance inside `__init__` on adapters that are then cached across loops (for example through `closing_lru_cache`) are the same class of problem but a larger, separate change. Happy to follow up on any of these.

## Acceptance Criteria

- cognee can be used from more than one event loop in the same process without raising "bound to a different event loop".
- Single-loop behavior is unchanged: same-key session operations still serialize, different-key operations still run concurrently, and database setup is still guarded by a lock.
- New unit tests cover the cross-loop case and pin the preserved semantics, and they fail without the change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

I added unit tests in `cognee/tests/unit/infrastructure/locks/`. Local run:

    $ python -m pytest cognee/tests/unit/infrastructure/locks/ -q
    11 passed

    $ ruff check cognee/infrastructure/locks/
    All checks passed!

    $ ty check cognee/infrastructure/locks/loop_bound_lock.py cognee/infrastructure/locks/session_lock.py
    All checks passed!

The cross-loop tests force contention on purpose, so they fail against the current code: without the fix, `test_session_lock_works_across_event_loops` raises `RuntimeError: ... is bound to a different event loop`. I also checked that the bug reproduces and the fix holds on Python 3.11, 3.13 and 3.14.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved event loop binding errors in async locking that could cause runtime failures when handling multiple concurrent event loops.

* **Tests**
  * Added comprehensive unit tests for lock behavior across multiple event loops and contention scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/topoteretes/cognee/pull/2938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->