### PR TITLE
fix(lancedb): create dataset database parent directory

### DIFF
--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py
@@ -17,6 +17,7 @@ class LanceDBDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
 
     @classmethod
     async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        """Create local LanceDB dataset connection details for a user's dataset."""
         vector_config = get_vectordb_config()
         base_config = get_base_config()
 
@@ -28,6 +29,7 @@ class LanceDBDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         databases_directory_path = os.path.join(
             base_config.system_root_directory, "databases", str(user.id)
         )
+        os.makedirs(databases_directory_path, exist_ok=True)
 
         vector_db_name = f"{dataset_id}.lance.db"
 

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_dataset_database_handler.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_dataset_database_handler.py
@@ -1,0 +1,39 @@
+from importlib import import_module
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+import cognee.infrastructure.databases.dataset_database_handler  # noqa: F401
+
+
+handler_module = import_module(
+    "cognee.infrastructure.databases.vector.lancedb.LanceDBDatasetDatabaseHandler"
+)
+
+
+@pytest.mark.asyncio
+async def test_lancedb_dataset_handler_creates_database_parent_directory(tmp_path, monkeypatch):
+    """Verify the handler creates the parent directory and returns the LanceDB path."""
+    system_root_directory = tmp_path / "system"
+    user = SimpleNamespace(id=uuid4())
+    dataset_id = uuid4()
+
+    monkeypatch.setattr(
+        handler_module,
+        "get_base_config",
+        lambda: SimpleNamespace(system_root_directory=str(system_root_directory)),
+    )
+    monkeypatch.setattr(
+        handler_module,
+        "get_vectordb_config",
+        lambda: SimpleNamespace(vector_db_provider="lancedb", vector_db_key=""),
+    )
+
+    dataset_config = await handler_module.LanceDBDatasetDatabaseHandler.create_dataset(
+        dataset_id, user
+    )
+
+    expected_parent = system_root_directory / "databases" / str(user.id)
+    assert expected_parent.is_dir()
+    assert dataset_config["vector_database_url"] == str(expected_parent / f"{dataset_id}.lance.db")


### PR DESCRIPTION
## Description
This PR creates the per-user LanceDB dataset database directory before returning the local LanceDB path.

The Windows report in #2941 shows Lance failing while persisting a temp file under `.cognee_system/databases/...`. The built-in LanceDB dataset handler was returning a nested `<system_root>/databases/<user_id>/<dataset_id>.lance.db` path without first ensuring the `<user_id>` parent directory exists. The custom LanceDB test handler already does that explicitly, so this applies the same behavior to the built-in handler.

AI assistance: moderate. I used AI-assisted code search/drafting while checking the existing handler and test patterns.

Closes #2941

## Acceptance Criteria
- The built-in LanceDB dataset handler creates `<system_root>/databases/<user_id>` before returning `vector_database_url`.
- Added focused unit coverage for the parent directory and returned LanceDB path.
- Verified the changed files with pytest, ruff, and `git diff --check`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
CLI verification:

```text
.venv/bin/python -m pytest cognee/tests/unit/infrastructure/databases/vector/test_lancedb_dataset_database_handler.py -q
1 passed, 10 warnings in 0.01s

.venv/bin/python -m ruff check cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py cognee/tests/unit/infrastructure/databases/vector/test_lancedb_dataset_database_handler.py
All checks passed!

.venv/bin/python -m ruff format --check cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py cognee/tests/unit/infrastructure/databases/vector/test_lancedb_dataset_database_handler.py
2 files already formatted

git diff --check
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically creates per-user directory structure when initializing a local vector dataset, preventing failures due to missing directories and ensuring database files are stored reliably.
* **Tests**
  * Added a unit test that verifies the per-user directory is created and the local dataset file path is set as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->