### PR TITLE
ci: run Ollama tests on a GitHub larger runner (BuildJet was disabled)

### DIFF
--- a/.github/workflows/test_ollama.yml
+++ b/.github/workflows/test_ollama.yml
@@ -7,8 +7,9 @@ jobs:
 
   run_ollama_test:
 
-    # needs 32 Gb RAM for phi4 in a container
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    # needs 32 Gb RAM for phi4 in a container — GitHub-hosted larger runner
+    # (8 vCPU / 32 GB). ubuntu-latest (16 GB) is not enough.
+    runs-on: ubuntu-latest-8-cores
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Problem
The Ollama test suite (`.github/workflows/test_ollama.yml`) runs on `buildjet-8vcpu-ubuntu-2204`. That BuildJet runner was disabled, so the job has no runner to schedule on.

## Change
Switch to a **GitHub-hosted larger runner** with the same footprint:

```diff
- runs-on: buildjet-8vcpu-ubuntu-2204
+ runs-on: ubuntu-latest-8-cores
```

`ubuntu-latest-8-cores` is **8 vCPU / 32 GB** — matching the old BuildJet box and satisfying the job's own requirement (`# needs 32 Gb RAM for phi4 in a container`). The default `ubuntu-latest` (16 GB) is **not** enough to run `phi4` + the `sfr-embedding-mistral` embedder in the Ollama container.

## ⚠️ Requires GitHub larger runners to be enabled
`ubuntu-latest-8-cores` is GitHub's standard larger-runner label, but larger runners must be **enabled for the `topoteretes` org** (Org → Settings → Actions → Runners → larger runners). If the org uses a different label/runner group, swap the label accordingly — the only requirement is **≥ 32 GB RAM**. If 32 GB proves tight with Docker overhead, bump to `ubuntu-latest-16-cores` (64 GB).

## Scope
- Only `test_ollama.yml` referenced BuildJet; no other workflow changes needed.
- No test logic changed — runner label only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to use a different runner with enhanced resources for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->