### PR TITLE
fix(neptune): quote relationship types in openCypher and fix batch fallback

### DIFF
--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -37,6 +37,17 @@ except ImportError:
 NEPTUNE_ENDPOINT_URL = "neptune-graph://"
 
 
+def _quote_relationship_type(relationship_name: str) -> str:
+    """Backtick-quote a relationship type for safe interpolation into openCypher.
+
+    openCypher cannot parameterize a created relationship type, so the type is
+    interpolated into the query text. Backtick-quoting it (and doubling any internal
+    backtick, per the Cypher escaping rules) lets a label contain spaces, hyphens, or
+    other characters without breaking the query or allowing injection.
+    """
+    return "`" + relationship_name.replace("`", "``") + "`"
+
+
 class NeptuneGraphDB(GraphDBInterface):
     """
     Adapter for interacting with Amazon Neptune Analytics graph store.
@@ -505,13 +516,14 @@ class NeptuneGraphDB(GraphDBInterface):
             # Prepare edge properties
             edge_props = properties or {}
             serialized_properties = self._serialize_properties(edge_props)
+            quoted_relationship = _quote_relationship_type(relationship_name)
 
             query = f"""
             MATCH (source:{self._GRAPH_NODE_LABEL})
             WHERE id(source) = $source_id
             MATCH (target:{self._GRAPH_NODE_LABEL})
             WHERE id(target) = $target_id
-            MERGE (source)-[r:{relationship_name}]->(target)
+            MERGE (source)-[r:{quoted_relationship}]->(target)
             ON CREATE SET r = $properties, r.updated_at = timestamp()
             ON MATCH SET r = $properties, r.updated_at = timestamp()
             RETURN r
@@ -555,6 +567,7 @@ class NeptuneGraphDB(GraphDBInterface):
         results = {}
         for relationship_name, edges_for_relationship in edges_by_relationship.items():
             try:
+                quoted_relationship = _quote_relationship_type(relationship_name)
                 # Create the bulk-edge OpenCypher query using UNWIND
                 query = f"""
                     UNWIND $edges AS edge
@@ -562,7 +575,7 @@ class NeptuneGraphDB(GraphDBInterface):
                     WHERE id(source) = edge.from_node
                     MATCH (target:{self._GRAPH_NODE_LABEL})
                     WHERE id(target) = edge.to_node
-                    MERGE (source)-[r:{relationship_name}]->(target)
+                    MERGE (source)-[r:{quoted_relationship}]->(target)
                     ON CREATE SET r = edge.properties, r.updated_at = timestamp()
                     ON MATCH SET r = edge.properties, r.updated_at = timestamp()
                     RETURN count(*) AS edges_processed
@@ -588,7 +601,7 @@ class NeptuneGraphDB(GraphDBInterface):
                     f"Failed to add edges for relationship {relationship_name}: {format_neptune_error(e)}"
                 )
                 logger.info("Falling back to individual edge creation")
-                for edge in edges_by_relationship:
+                for edge in edges_for_relationship:
                     try:
                         source_id, target_id, relationship_name = edge[0], edge[1], edge[2]
                         properties = edge[3] if len(edge) > 3 else {}

--- a/cognee/tests/unit/infrastructure/databases/test_neptune_relationship_quoting.py
+++ b/cognee/tests/unit/infrastructure/databases/test_neptune_relationship_quoting.py
@@ -1,0 +1,76 @@
+"""Unit tests for relationship-type quoting and batch fallback in ``NeptuneGraphDB``.
+
+openCypher cannot parameterize a created relationship type, so the type is interpolated
+into the query string. It must be backtick-quoted (and internal backticks doubled) so that
+labels produced by LLM extraction -- which routinely contain spaces, hyphens, or other
+characters -- do not break the query or allow injection.
+
+Skipped automatically when the Neptune optional dependencies (langchain_aws, botocore) are
+not installed.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+pytest.importorskip("langchain_aws", reason="Neptune tests require langchain_aws")
+pytest.importorskip("botocore", reason="Neptune tests require botocore")
+
+from cognee.infrastructure.databases.graph.neptune_driver.adapter import (  # noqa: E402
+    NeptuneGraphDB,
+)
+
+
+class _FakeGraphDB:
+    """Binds the methods under test onto a stand-in with a mocked ``query()``."""
+
+    add_edge = NeptuneGraphDB.add_edge
+    add_edges = NeptuneGraphDB.add_edges
+    _GRAPH_NODE_LABEL = NeptuneGraphDB._GRAPH_NODE_LABEL
+
+    def __init__(self):
+        self.query = AsyncMock(return_value=[])
+        self._serialize_properties = lambda properties: properties
+
+
+def _last_query(fake) -> str:
+    return fake.query.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_add_edge_quotes_relationship_with_space():
+    fake = _FakeGraphDB()
+    await fake.add_edge("src", "tgt", "works at", {})
+    query = _last_query(fake)
+    assert "[r:`works at`]" in query
+    assert "[r:works at]" not in query
+
+
+@pytest.mark.asyncio
+async def test_add_edge_escapes_internal_backtick():
+    fake = _FakeGraphDB()
+    await fake.add_edge("src", "tgt", "weird`name", {})
+    query = _last_query(fake)
+    assert "[r:`weird``name`]" in query
+
+
+@pytest.mark.asyncio
+async def test_add_edges_batch_quotes_relationship_with_space():
+    fake = _FakeGraphDB()
+    await fake.add_edges([("a", "b", "located in", {})])
+    query = _last_query(fake)
+    assert "[r:`located in`]" in query
+    assert "[r:located in]" not in query
+
+
+@pytest.mark.asyncio
+async def test_add_edges_fallback_retries_real_edges_on_batch_failure():
+    fake = _FakeGraphDB()
+    # The batch query fails, so add_edges falls back to per-edge creation.
+    fake.query = AsyncMock(side_effect=Exception("boom"))
+    fake.add_edge = AsyncMock()
+    edges = [("a", "b", "REL", {"k": "v"}), ("c", "d", "REL", {})]
+    await fake.add_edges(edges)
+    # The fallback must retry the real edge tuples, not characters of the relationship name.
+    fake.add_edge.assert_any_await("a", "b", "REL", {"k": "v"})
+    fake.add_edge.assert_any_await("c", "d", "REL", {})
+    assert fake.add_edge.await_count == 2


### PR DESCRIPTION
### What this fixes

`NeptuneGraphDB` builds its edge-write queries by interpolating the relationship type directly into openCypher:

```
MERGE (source)-[r:{relationship_name}]->(target)
```

Relationship names come from LLM extraction, so they routinely contain spaces (`works at`), hyphens (`is-a`), dots, and parentheses. openCypher cannot parameterize a *created* relationship type, so the type has to be interpolated, but it was never quoted. Two consequences:

- Any edge whose relationship type has a space or other special character produces a malformed query and the write fails, so the edge is silently dropped from the graph.
- It is also an openCypher injection vector. A crafted label such as `Foo]->(x) DETACH DELETE x //` breaks out of the relationship and runs arbitrary Cypher.

`neo4j_driver` already backtick-quotes the type for exactly this reason.

### The fix

- Quote the relationship type with backticks at both write sites (`add_edge`, `add_edges`), doubling any internal backtick per the Cypher escaping rules. This matches the neo4j adapter and additionally handles a label that itself contains a backtick.
- Fix the `add_edges` batch fallback. On a failed bulk write it iterated `edges_by_relationship` (a dict, so it looped over the relationship-name strings and sliced their characters) instead of `edges_for_relationship`, so the per-edge retry never ran on the real edges. It now retries the actual edges.

For a valid identifier like `KNOWS`, `[r:KNOWS]` and ``[r:`KNOWS`]`` create the same type, so this does not change behaviour for labels that already worked, and read paths return the raw type unchanged.

### Tests

`test_neptune_relationship_quoting.py` covers: a spaced label is quoted in `add_edge` and in the batch path, an internal backtick is escaped, and the fallback retries the real edge tuples when the bulk write fails. They are skipped automatically when the Neptune optional deps are absent, matching the existing Neptune unit tests.

### Follow-up (not in this PR)

The same unquoted-interpolation pattern exists in six read/delete sites in this adapter: `has_edge`, `get_neighborhood` (the `edge_types` filter), `get_predecessors`, `get_successors`, and the two `remove_connection_to_*` methods. Those are not reached with raw extracted names in the current pipeline, so this PR is scoped to the active write-path corruption; the read/delete sites can take the same `_quote_relationship_type` treatment in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of relationship types with special characters in the Neptune graph database to ensure safe query construction.
  * Corrected bulk edge creation fallback behavior to properly process remaining edges when batch operations encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->