### PR TITLE
feat(retrieval): expose result score and max_distance filter for chunks and summaries

### DIFF
--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -98,12 +98,23 @@ async def search(
         **CHUNKS**:
             Raw text segments that match the query semantically.
             Best for: Finding specific passages, citations, exact content.
-            Returns: Ranked list of relevant text chunks with metadata.
+            Returns: Ranked list of relevant text chunks, each carrying a "score"
+            (the raw vector distance, where lower is a closer match).
 
         **SUMMARIES**:
             Pre-generated summaries of content.
             Best for: Quick overviews, document abstracts, topic summaries.
-            Returns: Generated content summaries.
+            Returns: Generated content summaries, each carrying a "score" (the raw
+            vector distance, where lower is a closer match).
+
+        For CHUNKS and SUMMARIES you can drop weak matches by passing a distance
+        cutoff through retriever_specific_config, e.g.
+        retriever_specific_config={"max_distance": 0.3}. Results whose distance is
+        greater than max_distance are removed; the default (None) keeps every result.
+        The cutoff is applied after top_k, so raise top_k to surface more matches
+        within the same distance. max_distance assumes a lower score means a closer
+        match (the ScoredResult contract that cognee's built-in cosine adapters
+        follow); it is not metric-aware.
 
         **CODE**:
             Code-specific search with syntax and semantic understanding.
@@ -161,7 +172,7 @@ async def search(
 
         verbose: If True, returns detailed result information including graph representation (when possible).
 
-        retriever_specific_config: Optional dictionary of additional configuration parameters specific to the retriever being used.
+        retriever_specific_config: Optional dictionary of additional configuration parameters specific to the retriever being used. For CHUNKS and SUMMARIES, supports "max_distance" (float) to drop results whose vector distance exceeds the cutoff.
         skills: Explicit skill names or Skill objects to load into the agentic retriever.
         tools: Optional whitelist of tool names available to the agentic retriever.
         max_iter: Maximum number of agentic tool-call iterations before forcing a final answer.

--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -4,6 +4,7 @@ from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.retrieval.base_retriever import BaseRetriever
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
+from cognee.modules.retrieval.utils.scoring import attach_scores, filter_by_max_distance
 
 logger = get_logger("ChunksRetriever")
 
@@ -25,6 +26,7 @@ class ChunksRetriever(BaseRetriever):
         top_k: Optional[int] = 5,
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
+        max_distance: Optional[float] = None,
     ):
         """
         Initializes the chunk retriever.
@@ -39,10 +41,14 @@ class ChunksRetriever(BaseRetriever):
               node set filtering.
             - node_name_filter_operator (str): Logical operator used when applying
               multiple node_name filters, such as "OR" or "AND". Defaults to "OR".
+            - max_distance (Optional[float]): Maximum vector distance to keep. Results
+              with a larger distance (a weaker match) are dropped. Defaults to None,
+              which keeps every result.
         """
         self.top_k = top_k
         self.node_name = node_name
         self.node_name_filter_operator = node_name_filter_operator
+        self.max_distance = max_distance
 
     async def get_completion_from_context(
         self, query: str, retrieved_objects: Any, context: Any
@@ -66,8 +72,7 @@ class ChunksRetriever(BaseRetriever):
         """
         # TODO: Do we want to generate a completion using LLM here?
         if retrieved_objects:
-            chunk_payloads = [found_chunk.payload for found_chunk in retrieved_objects]
-            return chunk_payloads
+            return attach_scores(retrieved_objects)
         else:
             return []
 
@@ -123,7 +128,7 @@ class ChunksRetriever(BaseRetriever):
             )
             logger.info(f"Found {len(found_chunks)} chunks from vector search")
 
-            return found_chunks
+            return filter_by_max_distance(found_chunks, self.max_distance)
 
         except CollectionNotFoundError as error:
             logger.error("DocumentChunk_text collection not found in vector database")

--- a/cognee/modules/retrieval/summaries_retriever.py
+++ b/cognee/modules/retrieval/summaries_retriever.py
@@ -5,6 +5,7 @@ from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.retrieval.base_retriever import BaseRetriever
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
+from cognee.modules.retrieval.utils.scoring import attach_scores, filter_by_max_distance
 
 logger = get_logger("SummariesRetriever")
 
@@ -22,10 +23,21 @@ class SummariesRetriever(BaseRetriever):
     - top_k: int - Number of top summaries to retrieve.
     """
 
-    def __init__(self, top_k: int = 5, session_id: Optional[str] = None):
-        """Initialize retriever with search parameters."""
+    def __init__(
+        self,
+        top_k: int = 5,
+        session_id: Optional[str] = None,
+        max_distance: Optional[float] = None,
+    ):
+        """Initialize retriever with search parameters.
+
+        ``max_distance`` is an optional vector-distance cutoff. Results with a
+        larger distance (a weaker match) are dropped. Defaults to None, which
+        keeps every result.
+        """
         self.top_k = top_k
         self.session_id = session_id
+        self.max_distance = max_distance
 
     async def get_retrieved_objects(self, query: str) -> Any:
         """
@@ -57,7 +69,7 @@ class SummariesRetriever(BaseRetriever):
             )
             logger.info(f"Found {len(summaries_results)} summaries from vector search")
 
-            return summaries_results
+            return filter_by_max_distance(summaries_results, self.max_distance)
         except CollectionNotFoundError as error:
             logger.error("TextSummary_text collection not found in vector database")
             raise NoDataError("No data found in the system, please add data first.") from error
@@ -109,7 +121,7 @@ class SummariesRetriever(BaseRetriever):
         """
         # TODO: Do we want to generate a completion using LLM here?
         if retrieved_objects:
-            summary_payloads = [summary.payload for summary in retrieved_objects]
+            summary_payloads = attach_scores(retrieved_objects)
             logger.info(f"Returning {len(summary_payloads)} summary payloads")
             return summary_payloads
         else:

--- a/cognee/modules/retrieval/utils/scoring.py
+++ b/cognee/modules/retrieval/utils/scoring.py
@@ -1,0 +1,39 @@
+"""Helpers for exposing and filtering vector-retrieval distance scores.
+
+cognee's vector adapters return ``ScoredResult`` objects whose ``score`` is a raw
+backend distance (cosine distance for the built-in adapters) where a lower value
+means a closer match. The chunk and summary retrievers historically returned only
+the payloads, so that distance was dropped before it reached the caller. These
+helpers let a retriever keep the signal: attach the distance to each returned
+payload, and drop matches that are farther away than a caller-supplied cutoff.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+
+
+def filter_by_max_distance(
+    results: List[ScoredResult], max_distance: Optional[float]
+) -> List[ScoredResult]:
+    """Drop results whose distance is greater than ``max_distance``.
+
+    Relies on the ``ScoredResult`` contract that a lower score is a closer match
+    (cognee's built-in adapters report cosine distance), so a result is kept when
+    its score is less than or equal to the cutoff. ``max_distance=None`` disables
+    filtering and the input list is returned unchanged.
+    """
+    if max_distance is None:
+        return results
+    return [result for result in results if result.score <= max_distance]
+
+
+def attach_scores(results: List[ScoredResult]) -> List[Dict[str, Any]]:
+    """Return each result's payload with its retrieval distance added as ``score``.
+
+    This matches the ``"score"`` key that ``SearchResultItem`` already reads when it
+    normalizes search output, so the distance reaches the caller. A result with no
+    payload yields a dict carrying just the ``score`` key. If a payload already has a
+    ``score`` key it is overwritten with the retrieval distance.
+    """
+    return [{**(result.payload or {}), "score": result.score} for result in results]

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -1,6 +1,8 @@
+import math
 import os
 from typing import Callable, List, Optional, Type, Tuple
 
+from cognee.exceptions import CogneeValidationError
 from cognee.modules.retrieval.base_retriever import BaseRetriever
 
 from cognee.modules.engine.models.node_set import NodeSet
@@ -55,6 +57,20 @@ async def get_search_type_retriever_instance(
     if retriever_specific_config is None:
         retriever_specific_config = {}
 
+    # max_distance is an optional vector-distance cutoff (lower is a closer match).
+    # Reject values the `<=` comparison cannot handle (non-numbers, bool, NaN) here,
+    # before they reach a retriever and abort an otherwise-valid search mid-flight.
+    max_distance = retriever_specific_config.get("max_distance")
+    if max_distance is not None and (
+        isinstance(max_distance, bool)
+        or not isinstance(max_distance, (int, float))
+        or math.isnan(max_distance)
+    ):
+        raise CogneeValidationError(
+            message="max_distance must be a real number.",
+            name="InvalidMaxDistance",
+        )
+
     # Extract common defaults with fallback values from kwargs
     top_k = kwargs.get("top_k", 10)
     system_prompt_path = kwargs.get("system_prompt_path", "answer_simple_question.txt")
@@ -71,13 +87,21 @@ async def get_search_type_retriever_instance(
 
     # Registry mapping search types to their corresponding retriever classes and input parameters
     search_core_registry: dict[SearchType, Tuple[BaseRetriever, dict]] = {
-        SearchType.SUMMARIES: (SummariesRetriever, {"top_k": top_k, "session_id": session_id}),
+        SearchType.SUMMARIES: (
+            SummariesRetriever,
+            {
+                "top_k": top_k,
+                "session_id": session_id,
+                "max_distance": max_distance,
+            },
+        ),
         SearchType.CHUNKS: (
             ChunksRetriever,
             {
                 "top_k": top_k,
                 "node_name": node_name,
                 "node_name_filter_operator": node_name_filter_operator,
+                "max_distance": max_distance,
             },
         ),
         SearchType.RAG_COMPLETION: (

--- a/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/chunks_retriever_test.py
@@ -200,3 +200,70 @@ async def test_get_context_empty_payload(mock_vector_engine):
         )
 
     assert context == ""
+
+
+@pytest.mark.asyncio
+async def test_get_completion_attaches_score_to_payloads():
+    """get_completion_from_context exposes each chunk's retrieval distance as 'score'."""
+    retriever = ChunksRetriever()
+
+    objects = [
+        SimpleNamespace(payload={"text": "a"}, score=0.2),
+        SimpleNamespace(payload={"text": "b"}, score=0.7),
+    ]
+
+    completion = await retriever.get_completion_from_context("test query", objects, None)
+
+    assert completion == [
+        {"text": "a", "score": 0.2},
+        {"text": "b", "score": 0.7},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_init_max_distance_default_none():
+    """max_distance defaults to None, leaving distance filtering off."""
+    assert ChunksRetriever().max_distance is None
+
+
+@pytest.mark.asyncio
+async def test_init_custom_max_distance():
+    """max_distance is stored when supplied."""
+    assert ChunksRetriever(max_distance=0.35).max_distance == 0.35
+
+
+@pytest.mark.asyncio
+async def test_get_retrieved_objects_filters_by_max_distance(mock_vector_engine):
+    """Chunks farther than max_distance are dropped before they reach the caller."""
+    near = SimpleNamespace(payload={"text": "near"}, score=0.1)
+    far = SimpleNamespace(payload={"text": "far"}, score=0.9)
+    mock_vector_engine.search.return_value = [near, far]
+
+    retriever = ChunksRetriever(max_distance=0.5)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
+        return_value=_make_unified_mock(mock_vector_engine),
+    ):
+        objects = await retriever.get_retrieved_objects("test query")
+
+    assert [o.payload["text"] for o in objects] == ["near"]
+
+
+@pytest.mark.asyncio
+async def test_max_distance_survivors_carry_score_end_to_end(mock_vector_engine):
+    """A chunk surviving the max_distance filter carries its score in the completion."""
+    near = SimpleNamespace(payload={"text": "near"}, score=0.1)
+    far = SimpleNamespace(payload={"text": "far"}, score=0.9)
+    mock_vector_engine.search.return_value = [near, far]
+
+    retriever = ChunksRetriever(max_distance=0.5)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
+        return_value=_make_unified_mock(mock_vector_engine),
+    ):
+        objects = await retriever.get_retrieved_objects("test query")
+        completion = await retriever.get_completion_from_context("test query", objects, None)
+
+    assert completion == [{"text": "near", "score": 0.1}]

--- a/cognee/tests/unit/modules/retrieval/scoring_test.py
+++ b/cognee/tests/unit/modules/retrieval/scoring_test.py
@@ -1,0 +1,64 @@
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.modules.recall.methods.normalize_search_payload import normalize_search_payload
+from cognee.modules.retrieval.utils.scoring import attach_scores, filter_by_max_distance
+from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
+from cognee.modules.search.types import SearchType
+
+
+def _scored(score, payload=None):
+    return ScoredResult(id=uuid4(), score=score, payload=payload)
+
+
+def test_filter_by_max_distance_drops_results_above_cutoff():
+    results = [_scored(0.1), _scored(0.5), _scored(0.9)]
+    kept = filter_by_max_distance(results, 0.5)
+    assert [r.score for r in kept] == [0.1, 0.5]
+
+
+def test_filter_by_max_distance_keeps_boundary_value():
+    results = [_scored(0.5)]
+    assert filter_by_max_distance(results, 0.5) == results
+
+
+def test_filter_by_max_distance_none_returns_all_unchanged():
+    results = [_scored(0.1), _scored(0.9)]
+    assert filter_by_max_distance(results, None) is results
+
+
+def test_attach_scores_adds_distance_to_each_payload():
+    results = [_scored(0.2, {"text": "a"}), _scored(0.4, {"text": "b"})]
+    assert attach_scores(results) == [
+        {"text": "a", "score": 0.2},
+        {"text": "b", "score": 0.4},
+    ]
+
+
+def test_attach_scores_handles_missing_payload():
+    assert attach_scores([_scored(0.3, None)]) == [{"score": 0.3}]
+
+
+def test_attach_scores_preserves_all_payload_fields():
+    results = [_scored(0.2, {"text": "a", "chunk_index": 3, "metadata": {"k": "v"}})]
+    assert attach_scores(results) == [
+        {"text": "a", "chunk_index": 3, "metadata": {"k": "v"}, "score": 0.2}
+    ]
+
+
+@pytest.mark.parametrize("search_type", [SearchType.CHUNKS, SearchType.SUMMARIES])
+def test_attached_score_reaches_searchresultitem(search_type):
+    """End-to-end: attach_scores output is read by the SearchResultItem.score consumer.
+
+    This is the whole point of the feature -- the score key it adds is exactly the
+    key normalize_search_payload already reads to populate SearchResultItem.score.
+    """
+    results = [_scored(0.2, {"text": "a"}), _scored(0.6, {"text": "b"})]
+    payload = SearchResultPayload(completion=attach_scores(results), search_type=search_type)
+
+    items = normalize_search_payload(payload)
+
+    assert [item.score for item in items] == [0.2, 0.6]
+    assert items[0].raw == {"text": "a", "score": 0.2}

--- a/cognee/tests/unit/modules/retrieval/summaries_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/summaries_retriever_test.py
@@ -194,3 +194,45 @@ async def test_get_completion_with_session_id(mock_vector_engine):
 
     assert len(completion) == 1
     assert completion[0]["text"] == "S.R."
+
+
+@pytest.mark.asyncio
+async def test_get_completion_attaches_score_to_payloads():
+    """get_completion_from_context exposes each summary's retrieval distance as 'score'."""
+    retriever = SummariesRetriever()
+
+    objects = [SimpleNamespace(payload={"text": "a"}, score=0.3)]
+
+    completion = await retriever.get_completion_from_context("test query", objects, None)
+
+    assert completion == [{"text": "a", "score": 0.3}]
+
+
+@pytest.mark.asyncio
+async def test_init_max_distance_default_none():
+    """max_distance defaults to None, leaving distance filtering off."""
+    assert SummariesRetriever().max_distance is None
+
+
+@pytest.mark.asyncio
+async def test_init_custom_max_distance():
+    """max_distance is stored when supplied."""
+    assert SummariesRetriever(max_distance=0.35).max_distance == 0.35
+
+
+@pytest.mark.asyncio
+async def test_get_retrieved_objects_filters_by_max_distance(mock_vector_engine):
+    """Summaries farther than max_distance are dropped before they reach the caller."""
+    near = SimpleNamespace(payload={"text": "near"}, score=0.1)
+    far = SimpleNamespace(payload={"text": "far"}, score=0.9)
+    mock_vector_engine.search.return_value = [near, far]
+
+    retriever = SummariesRetriever(max_distance=0.5)
+
+    with patch(
+        "cognee.modules.retrieval.summaries_retriever.get_unified_engine",
+        return_value=_make_unified_mock(mock_vector_engine),
+    ):
+        objects = await retriever.get_retrieved_objects("test query")
+
+    assert [o.payload["text"] for o in objects] == ["near"]

--- a/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
+++ b/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
@@ -228,3 +228,76 @@ async def test_graph_completion_decomposition_defaults_to_answer_per_subquery():
 
     assert isinstance(retriever_instance, GraphCompletionDecompositionRetriever)
     assert retriever_instance.decomposition_mode is DecompositionMode.ANSWER_PER_SUBQUERY
+
+
+@pytest.mark.asyncio
+async def test_chunks_retriever_receives_max_distance_from_config():
+    import cognee.modules.search.methods.get_search_type_retriever_instance as mod
+    from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
+
+    retriever_instance = await mod.get_search_type_retriever_instance(
+        SearchType.CHUNKS,
+        query_text="q",
+        retriever_specific_config={"max_distance": 0.42},
+    )
+
+    assert isinstance(retriever_instance, ChunksRetriever)
+    assert retriever_instance.max_distance == 0.42
+
+
+@pytest.mark.asyncio
+async def test_summaries_retriever_receives_max_distance_from_config():
+    import cognee.modules.search.methods.get_search_type_retriever_instance as mod
+    from cognee.modules.retrieval.summaries_retriever import SummariesRetriever
+
+    retriever_instance = await mod.get_search_type_retriever_instance(
+        SearchType.SUMMARIES,
+        query_text="q",
+        retriever_specific_config={"max_distance": 0.42},
+    )
+
+    assert isinstance(retriever_instance, SummariesRetriever)
+    assert retriever_instance.max_distance == 0.42
+
+
+@pytest.mark.asyncio
+async def test_max_distance_defaults_to_none_when_not_configured():
+    import cognee.modules.search.methods.get_search_type_retriever_instance as mod
+    from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
+
+    retriever_instance = await mod.get_search_type_retriever_instance(
+        SearchType.CHUNKS, query_text="q"
+    )
+
+    assert isinstance(retriever_instance, ChunksRetriever)
+    assert retriever_instance.max_distance is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", ["0.3", float("nan"), True, False, [], {}])
+async def test_max_distance_rejects_invalid_values(bad_value):
+    import cognee.modules.search.methods.get_search_type_retriever_instance as mod
+    from cognee.exceptions import CogneeValidationError
+
+    with pytest.raises(CogneeValidationError, match="max_distance"):
+        await mod.get_search_type_retriever_instance(
+            SearchType.CHUNKS,
+            query_text="q",
+            retriever_specific_config={"max_distance": bad_value},
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("good_value", [0.3, 0, -1.0, float("inf"), None])
+async def test_max_distance_accepts_valid_values(good_value):
+    import cognee.modules.search.methods.get_search_type_retriever_instance as mod
+    from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
+
+    retriever_instance = await mod.get_search_type_retriever_instance(
+        SearchType.CHUNKS,
+        query_text="q",
+        retriever_specific_config={"max_distance": good_value},
+    )
+
+    assert isinstance(retriever_instance, ChunksRetriever)
+    assert retriever_instance.max_distance == good_value


### PR DESCRIPTION
## What

CHUNKS and SUMMARIES searches now return the vector distance score for each
result, and accept an optional `max_distance` cutoff to drop weak matches.

## Why

Both retrievers returned only the matched payloads and threw away the score from
the vector search, so a caller had no way to tell how close each result was or to
filter out distant matches. The plumbing for a score already half-exists:
`SearchResultItem` reads a `"score"` key when it normalizes search output
(`normalize_search_payload._score_from`), and the temporal retriever already
attaches one. CHUNKS and SUMMARIES were the gap.

## What changed

- `score` is added to each payload returned by the CHUNKS and SUMMARIES
  retrievers. It is the raw backend distance from `ScoredResult` (lower is a
  closer match), which matches the existing `"score"` convention. This is
  additive: a new key on dicts that were already returned.
- An optional `max_distance` drops results whose distance is greater than the
  cutoff. It is read from `retriever_specific_config` (e.g.
  `retriever_specific_config={"max_distance": 0.3}`), the same channel used for
  other retriever-specific options like `response_model` and `decomposition_mode`.
  Default is `None`, which keeps every result, so existing behavior is unchanged.
- Filtering happens in `get_retrieved_objects`, so the context, completion, and
  raw result objects all see the same filtered set.
- `max_distance` is validated where it is read in the retriever factory: a
  non-number, bool, or NaN raises `CogneeValidationError` up front, the same way
  the sibling numeric search params are validated, instead of failing later in the
  `<=` comparison and aborting an otherwise-valid search.
- A small `retrieval/utils/scoring.py` helper holds the two operations
  (`attach_scores`, `filter_by_max_distance`) so both retrievers share them and
  they can be unit tested without a database.

## Scope

This covers the two raw-retrieval search types (CHUNKS, SUMMARIES) where the score
was being dropped. Completion and graph search types are out of scope; their
`SearchResultItem.score` stays `None` as before.

## Assumptions

`max_distance` relies on cognee's documented `ScoredResult` contract that a lower
score is a closer match. The three built-in vector adapters (LanceDB, pgvector,
ChromaDB) report cosine distance, and the optional `neptune_analytics` adapter
returns Neptune's topK distance (per AWS the score is "the distance between the
input embedding and the embedding of this node", default squared-L2), so every
built-in backend honors the contract and the filter is correct for them. The filter
is not metric-aware: it trusts the lower-is-better convention rather than inspecting
the backend's metric, the same assumption cognee's existing distance-ordered code
(for example the temporal retriever's ascending sort) already makes.

## Tests

69 unit tests covering the helper (filter cutoff, boundary, None passthrough;
attach with and without payload; full payload-field preservation), both retrievers
(score attached in completion, max_distance stored and applied, end-to-end survivor
carries score), the factory plumbing for both search types, max_distance validation
(rejects string, NaN, and bool; accepts float, int, inf, negative, and None), and an
end-to-end check that the attached score flows through normalize_search_payload to
populate SearchResultItem.score for both CHUNKS and SUMMARIES. `ruff check` and
`ruff format --check` are clean.

## Usage

    results = cognee.search(
        "query",
        SearchType.CHUNKS,
        retriever_specific_config={"max_distance": 0.3},
    )
    # each result carries a "score" (vector distance, lower is closer)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added distance-based filtering for search results with an optional `max_distance` cutoff parameter for chunks and summaries
  * Search results now include a `score` field representing vector distance, where lower values indicate closer matches

* **Documentation**
  * Clarified search result semantics, score interpretation, and distance-based filtering behavior in API documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->