### PR TITLE
fix(tests): namespace entity-entity edge endpoint IDs in extract_relationships (fixes delete-test cluster on dev)

### DIFF
--- a/cognee/tests/utils/extract_relationships.py
+++ b/cognee/tests/utils/extract_relationships.py
@@ -1,6 +1,6 @@
 from cognee.shared.data_models import KnowledgeGraph
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
-from cognee.modules.engine.utils import generate_edge_id, generate_node_id
+from cognee.modules.engine.utils import generate_node_id
 
 
 def extract_relationships(
@@ -15,8 +15,8 @@ def extract_relationships(
 
         if edge_id not in cache:
             relationship = (
-                generate_edge_id(edge.source_node_id),
-                generate_edge_id(edge.target_node_id),
+                generate_node_id(f"entity:{edge.source_node_id}"),
+                generate_node_id(f"entity:{edge.target_node_id}"),
                 edge.relationship_name,
             )
             cache[edge_id] = relationship


### PR DESCRIPTION
## What's failing on `dev`
The "Test Suites" run on `dev` is red across a whole cluster:
- **Soft Delete test** (`test_delete_default_graph.py`) — failing on **every** OS/Python (3.10–3.14, ubuntu/macos/windows)
- **E2E delete tests** (delete default graph, delete with legacy data 1/2, delete two users same/different dataset), **agent-memory e2e**

All fail with the same assertion:
```
AssertionError: Edge 'works_for' not present between '<id>' and '<id>' in graph database.
```
— raised **before** any delete step (right after `cognify`).

## Root cause (empirically confirmed — this is NOT a production bug)
PR #2515 ("include node category in UUID generation to prevent Entity/EntityType ID collision", fixing #2510) intentionally namespaced node IDs with `entity:`/`type:` prefixes in the pipeline. In `expand_with_nodes_and_edges._process_graph_edges`, an edge `John --works_for--> Apple` is stored between:
```
generate_node_id("entity:john")  = a319bfc9-…
generate_node_id("entity:apple") = 0de7962a-…
```
The follow-up test-util commit `32f5f52d4` ("update test utilities to use namespaced node IDs matching pipeline") updated `extract_relationships.py` for the **node / is_a / contains** expectations but **missed the entity-entity edge loop**, which still computed:
```
generate_edge_id("john")  = d6f57eaa-…   # un-namespaced, never matches the stored edge
```
That's why `contains`/`is_a` edges pass but `works_for` fails. I verified the IDs directly (`generate_node_id("entity:john") == a319bfc9` = the **actual** stored endpoint; the test expected `d6f57eaa`), and confirmed from a local run that the `works_for` edge **is** persisted under the namespaced IDs.

## Fix
Align the edge loop in `cognee/tests/utils/extract_relationships.py` with the pipeline (the same change `32f5f52d4` made to the node loop):
```diff
-from cognee.modules.engine.utils import generate_edge_id, generate_node_id
+from cognee.modules.engine.utils import generate_node_id
@@
-                generate_edge_id(edge.source_node_id),
-                generate_edge_id(edge.target_node_id),
+                generate_node_id(f"entity:{edge.source_node_id}"),
+                generate_node_id(f"entity:{edge.target_node_id}"),
```

**Why fix the test util and not production:** the production pipeline is self-consistent and the namespacing is intentional (it fixes the #2510 Entity/EntityType UUID collision). Reverting the namespacing in production to satisfy the stale expectation would reintroduce that bug. This change corrects an expectation helper that was left out of sync by `32f5f52d4` — it does not weaken any assertion or test logic.

## Verification
- `python ./cognee/tests/test_delete_default_graph.py` — **now passes** (was: `Edge 'works_for' not present`). The same helper backs the E2E delete tests, so the cluster should go green.

## Out of scope (separate failures, not this bug)
- **Custom Graph Delete** + **Integration - Infrastructure** jobs that hit the 60m/6h **timeouts** (engine/DB hang class, not the missing-edge assertion).
- **Unit tests 3.13.x on windows-latest** (single-platform; the reviewed unit tests already match the namespaced pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test utilities to refine relationship extraction validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->