### PR TITLE
fix(windows): atexit reaper for subprocess workers + skill-ingest/signal test fixes

### DIFF
--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -63,12 +63,34 @@ async def prune_system(graph=True, vector=True, metadata=True, cache=True):
     if graph and not backend_access_control_enabled():
         graph_engine = await get_graph_engine()
         await graph_engine.delete_graph()
+        # delete_graph() only does a transient drop and leaves any subprocess
+        # worker alive. Close the engine here so the worker is terminated and
+        # its inherited OS handles (e.g. the cognee_db relational file on
+        # Windows, where children inherit handles at multiprocessing 'spawn'
+        # time) are released BEFORE delete_database() removes those files.
+        # Mirrors the awaited per-dataset teardown in
+        # LadybugDatasetDatabaseHandler.delete_dataset (delete_graph ->
+        # evict -> await close()). Without this await the close() scheduled by
+        # cache_clear() below is fire-and-forget and races the file delete,
+        # producing PermissionError [WinError 32] on Windows.
+        # Only the ladybug/kuzu adapter exposes close(); neo4j/networkx don't,
+        # so guard with hasattr to stay provider-agnostic.
+        if hasattr(graph_engine, "close"):
+            await graph_engine.close()  # type: ignore[attr-defined]
     elif graph and backend_access_control_enabled():
         await prune_graph_databases()
 
     if vector and not backend_access_control_enabled():
         vector_engine = get_vector_engine()
         await vector_engine.prune()
+        # Same rationale as the graph engine above: deterministically close
+        # the vector engine (terminating any subprocess worker and releasing
+        # inherited handles) before metadata deletion, instead of relying on
+        # the fire-and-forget close scheduled by cache_clear(). Only the
+        # LanceDB adapter exposes close(); ChromaDB/PGVector don't, so guard
+        # with hasattr to stay provider-agnostic.
+        if hasattr(vector_engine, "close"):
+            await vector_engine.close()
     elif vector and backend_access_control_enabled():
         await prune_vector_databases()
 

--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -63,34 +63,12 @@ async def prune_system(graph=True, vector=True, metadata=True, cache=True):
     if graph and not backend_access_control_enabled():
         graph_engine = await get_graph_engine()
         await graph_engine.delete_graph()
-        # delete_graph() only does a transient drop and leaves any subprocess
-        # worker alive. Close the engine here so the worker is terminated and
-        # its inherited OS handles (e.g. the cognee_db relational file on
-        # Windows, where children inherit handles at multiprocessing 'spawn'
-        # time) are released BEFORE delete_database() removes those files.
-        # Mirrors the awaited per-dataset teardown in
-        # LadybugDatasetDatabaseHandler.delete_dataset (delete_graph ->
-        # evict -> await close()). Without this await the close() scheduled by
-        # cache_clear() below is fire-and-forget and races the file delete,
-        # producing PermissionError [WinError 32] on Windows.
-        # Only the ladybug/kuzu adapter exposes close(); neo4j/networkx don't,
-        # so guard with hasattr to stay provider-agnostic.
-        if hasattr(graph_engine, "close"):
-            await graph_engine.close()  # type: ignore[attr-defined]
     elif graph and backend_access_control_enabled():
         await prune_graph_databases()
 
     if vector and not backend_access_control_enabled():
         vector_engine = get_vector_engine()
         await vector_engine.prune()
-        # Same rationale as the graph engine above: deterministically close
-        # the vector engine (terminating any subprocess worker and releasing
-        # inherited handles) before metadata deletion, instead of relying on
-        # the fire-and-forget close scheduled by cache_clear(). Only the
-        # LanceDB adapter exposes close(); ChromaDB/PGVector don't, so guard
-        # with hasattr to stay provider-agnostic.
-        if hasattr(vector_engine, "close"):
-            await vector_engine.close()
     elif vector and backend_access_control_enabled():
         await prune_vector_databases()
 

--- a/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
+++ b/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
@@ -407,11 +407,20 @@ def test_describe_exitcode_decodes_signals():
 
 
 def test_init_signal_killed_worker_surfaces_signal_name():
-    """End-to-end: a worker that dies to SIGTERM before READY surfaces
-    ``exitcode=-15 (SIGTERM …)`` in the error message. Regression guard
-    against the signal-decoding pipeline (faulthandler + ``_describe_exitcode``)
-    silently coming undone.
+    """End-to-end: a worker that dies to SIGTERM before READY surfaces the
+    signal name in the error message. Regression guard against the
+    signal-decoding pipeline (faulthandler + ``_describe_exitcode``) silently
+    coming undone.
+
+    POSIX delivers SIGTERM and the child dies with ``exitcode == -15``
+    (negated signal number), which ``_describe_exitcode`` decodes to
+    ``exitcode=-15 (SIGTERM …)``. On Windows there is no POSIX signal
+    delivery: ``os.kill(pid, SIGTERM)`` maps to ``TerminateProcess`` and the
+    child exits with the POSITIVE code ``15``; ``_describe_exitcode`` decodes
+    that to ``exitcode=15 (SIGTERM …)``. The expected numeric code is therefore
+    platform-dependent, but the decoded ``SIGTERM`` name must appear on both.
     """
+    import os as _os
     import signal as _signal
 
     ctx = mp.get_context("spawn")
@@ -424,7 +433,9 @@ def test_init_signal_killed_worker_surfaces_signal_name():
     with pytest.raises(SubprocessTransportError, match="exited before signalling ready") as excinfo:
         session.wait_for_ready()
     msg = str(excinfo.value)
-    expected_code = -int(_signal.SIGTERM)
+    # Windows TerminateProcess yields a positive exitcode == signal number;
+    # POSIX yields the negated signal number.
+    expected_code = int(_signal.SIGTERM) if _os.name == "nt" else -int(_signal.SIGTERM)
     assert f"exitcode={expected_code}" in msg, msg
     assert "SIGTERM" in msg, f"signal name not decoded into diagnostic: {msg}"
 

--- a/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
+++ b/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
@@ -12,6 +12,7 @@ Covers the scenarios that used to silently hang or leak:
 from __future__ import annotations
 
 import multiprocessing as mp
+import sys
 import time
 
 import pytest
@@ -406,21 +407,22 @@ def test_describe_exitcode_decodes_signals():
     assert _describe_exitcode(-999) == "-999"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "POSIX signal-exitcode semantics: os.kill(pid, SIGTERM) maps to "
+        "TerminateProcess on Windows with a positive exitcode (no negative "
+        "signal number), so signal-name surfacing cannot be guaranteed. "
+        "_describe_exitcode's POSIX decoding is covered by "
+        "test_describe_exitcode_decodes_signals."
+    ),
+)
 def test_init_signal_killed_worker_surfaces_signal_name():
-    """End-to-end: a worker that dies to SIGTERM before READY surfaces the
-    signal name in the error message. Regression guard against the
-    signal-decoding pipeline (faulthandler + ``_describe_exitcode``) silently
-    coming undone.
-
-    POSIX delivers SIGTERM and the child dies with ``exitcode == -15``
-    (negated signal number), which ``_describe_exitcode`` decodes to
-    ``exitcode=-15 (SIGTERM …)``. On Windows there is no POSIX signal
-    delivery: ``os.kill(pid, SIGTERM)`` maps to ``TerminateProcess`` and the
-    child exits with the POSITIVE code ``15``; ``_describe_exitcode`` decodes
-    that to ``exitcode=15 (SIGTERM …)``. The expected numeric code is therefore
-    platform-dependent, but the decoded ``SIGTERM`` name must appear on both.
+    """End-to-end: a worker that dies to SIGTERM before READY surfaces
+    ``exitcode=-15 (SIGTERM …)`` in the error message. Regression guard
+    against the signal-decoding pipeline (faulthandler + ``_describe_exitcode``)
+    silently coming undone.
     """
-    import os as _os
     import signal as _signal
 
     ctx = mp.get_context("spawn")
@@ -433,9 +435,7 @@ def test_init_signal_killed_worker_surfaces_signal_name():
     with pytest.raises(SubprocessTransportError, match="exited before signalling ready") as excinfo:
         session.wait_for_ready()
     msg = str(excinfo.value)
-    # Windows TerminateProcess yields a positive exitcode == signal number;
-    # POSIX yields the negated signal number.
-    expected_code = int(_signal.SIGTERM) if _os.name == "nt" else -int(_signal.SIGTERM)
+    expected_code = -int(_signal.SIGTERM)
     assert f"exitcode={expected_code}" in msg, msg
     assert "SIGTERM" in msg, f"signal name not decoded into diagnostic: {msg}"
 

--- a/cognee/tests/unit/modules/tools/test_skill_ingest.py
+++ b/cognee/tests/unit/modules/tools/test_skill_ingest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -64,7 +65,10 @@ class TestSkillContract(unittest.TestCase):
             skill = skills[0]
             assert skill.name == "code-review"
             assert skill.dataset_scope == [str(dataset.id)]
-            assert skill.source_file.endswith("code-review/SKILL.md")
+            # source_file/source_dir are native normalized paths (see
+            # skill_parser._normalize_path), so use os.sep rather than a
+            # hard-coded "/" — on Windows the separator is "\".
+            assert skill.source_file.endswith(os.path.join("code-review", "SKILL.md"))
             assert skill.source_dir.endswith("code-review")
             assert isinstance(skill.belongs_to_set[0], NodeSet)
             assert skill.belongs_to_set[0].name == "skills"

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -7,6 +7,7 @@ Stdlib only. Never import cognee from this module.
 from __future__ import annotations
 
 import asyncio
+import atexit
 import ctypes
 import ctypes.util
 import itertools
@@ -493,6 +494,31 @@ def collect_garbage_in_all_workers(timeout: float = 5.0) -> int:
         finally:
             session._rpc_lock.release()
     return collected
+
+
+def _reap_all_sessions_atexit() -> None:
+    """Force-reap any still-live subprocess workers at interpreter exit.
+
+    Workers are normally reaped via ``SubprocessSession.__del__ -> shutdown
+    -> _terminate`` during garbage collection. At interpreter shutdown,
+    however, GC and ``__del__`` ordering is not guaranteed to run — notably
+    on Windows with ``spawn`` daemon processes — which can leave a worker
+    alive and block the parent from exiting until an external timeout (e.g.
+    the 60-minute CI job timeout on ``Custom Graph Delete``). Registering an
+    ``atexit`` reaper makes teardown deterministic: every live session's
+    worker is force-terminated (bounded ``_terminate`` kill chain) before the
+    interpreter exits, regardless of GC timing. Best-effort and idempotent —
+    ``_terminate`` is serialized by ``_terminate_lock`` and safe to call on an
+    already-closed session.
+    """
+    for session in list(_all_sessions):
+        try:
+            session._terminate(timeout=2.0)
+        except Exception:
+            pass
+
+
+atexit.register(_reap_all_sessions_atexit)
 
 
 class SubprocessSession:

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -173,16 +173,37 @@ _SIGNAL_HINTS: Dict[str, str] = {
 def _describe_exitcode(exitcode: Optional[int]) -> str:
     """Render an exitcode for human consumption.
 
-    ``None`` and non-negative codes pass through unchanged; negative codes
-    are decoded into the signal that killed the worker (``-9`` → ``SIGKILL``)
-    with a short hint about the typical cause in production. POSIX exit
-    semantics: ``multiprocessing.Process.exitcode`` is the negated signal
-    number when the child died from an uncaught signal.
+    ``None`` passes through unchanged. POSIX exit semantics:
+    ``multiprocessing.Process.exitcode`` is the negated signal number when the
+    child died from an uncaught signal, so negative codes are decoded into the
+    signal that killed the worker (``-9`` → ``SIGKILL``) with a short hint about
+    the typical cause in production.
+
+    Windows has no POSIX signal-delivery semantics: CPython implements
+    ``os.kill(pid, sig)`` via ``TerminateProcess(pid, sig)``, so a worker
+    "killed" with e.g. SIGTERM exits with a POSITIVE code equal to the signal
+    number (15) rather than ``-15``. On Windows we therefore also decode
+    positive codes that match a known signal so the diagnostic stays readable
+    (``exitcode=15 (SIGTERM …)``). Other non-negative codes pass through.
     """
-    if exitcode is None or exitcode >= 0:
+    if exitcode is None:
         return str(exitcode)
+    if exitcode >= 0:
+        # On Windows a positive exitcode can be a TerminateProcess signal
+        # number (no negative-code POSIX semantics). Decode it the same way
+        # as the negative POSIX path; on POSIX this branch is skipped because
+        # genuine signal deaths surface as negative codes.
+        if os.name == "nt" and exitcode > 0:
+            return _decode_signal_exitcode(exitcode, exitcode)
+        return str(exitcode)
+    return _decode_signal_exitcode(-exitcode, exitcode)
+
+
+def _decode_signal_exitcode(signal_number: int, exitcode: int) -> str:
+    """Render ``exitcode`` annotated with the signal ``signal_number`` names,
+    falling back to the bare exitcode string when it isn't a known signal."""
     try:
-        sig = signal.Signals(-exitcode)
+        sig = signal.Signals(signal_number)
     except (ValueError, AttributeError):
         return str(exitcode)
     hint = _SIGNAL_HINTS.get(sig.name)

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -173,37 +173,22 @@ _SIGNAL_HINTS: Dict[str, str] = {
 def _describe_exitcode(exitcode: Optional[int]) -> str:
     """Render an exitcode for human consumption.
 
-    ``None`` passes through unchanged. POSIX exit semantics:
-    ``multiprocessing.Process.exitcode`` is the negated signal number when the
-    child died from an uncaught signal, so negative codes are decoded into the
-    signal that killed the worker (``-9`` → ``SIGKILL``) with a short hint about
-    the typical cause in production.
+    ``None`` and non-negative codes pass through unchanged; negative codes
+    are decoded into the signal that killed the worker (``-9`` → ``SIGKILL``)
+    with a short hint about the typical cause in production. POSIX exit
+    semantics: ``multiprocessing.Process.exitcode`` is the negated signal
+    number when the child died from an uncaught signal.
 
-    Windows has no POSIX signal-delivery semantics: CPython implements
-    ``os.kill(pid, sig)`` via ``TerminateProcess(pid, sig)``, so a worker
-    "killed" with e.g. SIGTERM exits with a POSITIVE code equal to the signal
-    number (15) rather than ``-15``. On Windows we therefore also decode
-    positive codes that match a known signal so the diagnostic stays readable
-    (``exitcode=15 (SIGTERM …)``). Other non-negative codes pass through.
+    Note: positive exitcodes are NOT decoded as signals. On Windows a process
+    "killed" via ``os.kill(pid, sig)`` (``TerminateProcess``) exits with a
+    positive code, but positive codes are overwhelmingly ordinary exit codes
+    (e.g. ``1`` = generic error), so decoding them as signals would mislabel
+    normal exits.
     """
-    if exitcode is None:
+    if exitcode is None or exitcode >= 0:
         return str(exitcode)
-    if exitcode >= 0:
-        # On Windows a positive exitcode can be a TerminateProcess signal
-        # number (no negative-code POSIX semantics). Decode it the same way
-        # as the negative POSIX path; on POSIX this branch is skipped because
-        # genuine signal deaths surface as negative codes.
-        if os.name == "nt" and exitcode > 0:
-            return _decode_signal_exitcode(exitcode, exitcode)
-        return str(exitcode)
-    return _decode_signal_exitcode(-exitcode, exitcode)
-
-
-def _decode_signal_exitcode(signal_number: int, exitcode: int) -> str:
-    """Render ``exitcode`` annotated with the signal ``signal_number`` names,
-    falling back to the bare exitcode string when it isn't a known signal."""
     try:
-        sig = signal.Signals(signal_number)
+        sig = signal.Signals(-exitcode)
     except (ValueError, AttributeError):
         return str(exitcode)
     hint = _SIGNAL_HINTS.get(sig.name)


### PR DESCRIPTION
Targets the Windows CI failures. Honest scope after CI iteration:

## ✅ Fixed (confirmed in CI)
- **`Custom Graph Delete test … windows-latest` 60m hang** — `atexit` reaper that force-`_terminate()`s live `_all_sessions` subprocess workers at interpreter exit (GC/`__del__` ordering isn't guaranteed on Windows spawn daemons). **Now passes** (was timing out at 60m); all `Custom Graph Delete` / `Soft Delete` jobs green across OS/Python.
- **`test_skill_ingest…` (assert False)** — assertion used a hard-coded `/`; now `os.path.join("code-review", "SKILL.md")` (paths are native-normalized → `\` on Windows).
- **`test_init_signal_killed_worker_surfaces_signal_name`** — `skipif(win32)`: `os.kill(SIGTERM)` maps to `TerminateProcess` (positive exitcode), so signal-name surfacing can't be guaranteed on Windows. POSIX decoding stays covered by `test_describe_exitcode_decodes_signals`.

## ❌ Not fixed here — pre-existing, needs a deeper fix
- **3× `PermissionError [WinError 32]`** (`run_tasks`, `run_task_from_queue`, `run_tasks_with_context`) deleting the SQLite `cognee_db`. These fail on `dev` **independently of this PR**. `delete_database()` already disposes the relational engine + sleeps before unlinking, so the holder is a **subprocess worker that inherited the `cognee_db` OS handle at `multiprocessing` 'spawn' time** (Windows inherits handles). Closing the graph/vector engines does **not** release it (I tried — reverted). Proper fix: make the SQLite handle non-inheritable when spawning workers, or reap all workers before `delete_database`. Tracked as follow-up — needs Windows iteration (not reproducible on macOS/Linux, which allow unlinking open files).

## Verification
- macOS: affected tests pass (13 passed locally; full unit suite green on macos/ubuntu).
- Windows: net effect is **5 failing → 3 failing** (the 3 pre-existing `WinError 32`), with **no regressions** (the earlier positive-exitcode-decode attempt that broke `test_describe_exitcode_decodes_signals` has been reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved subprocess cleanup during application shutdown to ensure proper process termination
  * Enhanced platform compatibility for Windows environments in signal handling and file path assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->