### PR TITLE
fix: infer ontology format for file objects

### DIFF
--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -4,6 +4,7 @@ from cognee.shared.logging_utils import get_logger
 from collections import deque
 from typing import List, Tuple, Dict, Optional, Any, Union, IO
 from rdflib import Graph, URIRef, RDF, RDFS, OWL
+from rdflib.util import guess_format
 
 from cognee.modules.ontology.exceptions import (
     OntologyInitializationError,
@@ -57,7 +58,7 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                     for file_obj in file_objects:
                         try:
                             content = file_obj.read()
-                            self.graph.parse(data=content, format="xml")
+                            self.graph += self._parse_file_object(content, file_obj)
                             loaded_objects.append(file_obj)
                             logger.info("Ontology loaded successfully from file object")
                         except Exception as e:
@@ -106,6 +107,32 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
         except Exception as e:
             logger.error("Failed to load ontology", exc_info=e)
             raise OntologyInitializationError() from e
+
+    def _parse_file_object(self, content: Any, file_obj: IO) -> Graph:
+        """Parse an ontology read from a file-like object.
+
+        RDFLib cannot infer the format from raw ``data`` alone. When possible,
+        use the file object's name to guess the RDF serialization format, then
+        fall back through the common formats accepted by uploaded ontologies.
+        """
+        file_name = getattr(file_obj, "name", None)
+        guessed_format = guess_format(file_name) if file_name else None
+        formats_to_try = [guessed_format] if guessed_format else []
+
+        for rdf_format in ("xml", "turtle", "n3", "json-ld", "nt"):
+            if rdf_format not in formats_to_try:
+                formats_to_try.append(rdf_format)
+
+        errors = []
+        for rdf_format in formats_to_try:
+            graph = Graph()
+            try:
+                graph.parse(data=content, format=rdf_format)
+                return graph
+            except Exception as e:
+                errors.append(f"{rdf_format}: {e}")
+
+        raise ValueError("Could not parse ontology file object as RDF: " + "; ".join(errors))
 
     def _uri_to_key(self, uri: URIRef) -> str:
         uri_str = str(uri)

--- a/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
+++ b/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 from rdflib import Graph, Namespace, RDF, OWL, RDFS
 from cognee.modules.ontology.rdf_xml.RDFLibOntologyResolver import RDFLibOntologyResolver
@@ -640,3 +642,22 @@ def test_multifile_ontology_with_overlapping_entities():
 
         os.unlink(file1_path)
         os.unlink(file2_path)
+
+
+def test_file_object_ontology_uses_non_xml_serialization_from_filename():
+    """File-like Turtle ontologies should not be parsed as RDF/XML."""
+    ontology = b"""
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix ex: <http://example.org/test#> .
+
+        ex:Vehicle a owl:Class .
+        ex:Audi a ex:Vehicle .
+    """
+    file_obj = io.BytesIO(ontology)
+    file_obj.name = "vehicles.ttl"
+
+    resolver = RDFLibOntologyResolver(ontology_file=file_obj)
+
+    assert resolver.graph is not None
+    assert "vehicle" in resolver.lookup["classes"]
+    assert "audi" in resolver.lookup["individuals"]


### PR DESCRIPTION
## Description

Fixes #2907.

RDFLibOntologyResolver now parses file-like ontology inputs using the format inferred from the file name when available, with fallbacks for common RDF serializations. This prevents Turtle/N3-style uploaded ontology content from being forced through RDF/XML parsing and silently producing an empty graph.

## Acceptance Criteria

* File-like Turtle ontology inputs are parsed successfully instead of being treated as RDF/XML.
* Existing RDF/XML file-object behavior remains supported through fallback parsing.
* Added a regression test covering a `.ttl` file-like ontology input.
* Local tests and lint pass.

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

N/A — no UI changes. Local validation run:

```text
PYTHONPATH=. uv run pytest cognee/tests/unit/modules/ontology/test_ontology_adapter.py -q
36 passed, 8 warnings in 2.91s

PYTHONPATH=. uv run ruff check cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py cognee/tests/unit/modules/ontology/test_ontology_adapter.py
All checks passed!

PYTHONPATH=. uv run ruff format --check cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py cognee/tests/unit/modules/ontology/test_ontology_adapter.py
2 files already formatted
```

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple ontology file formats (Turtle, N3, JSON-LD, NT) alongside existing XML support.

* **Bug Fixes**
  * Enhanced file format detection with automatic fallback mechanisms and improved error messages when parsing fails.

* **Tests**
  * Added test validation for ontology file format handling and graph loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->