### PR TITLE
fix(storage): deep-copy metadata in index_data_points to prevent field mutation

### DIFF
--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -47,8 +47,9 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
                 await vector_engine.create_vector_index(type_name, field_name)
                 data_points_by_type[type_name][field_name] = []
 
-            indexed_data_point = data_point.model_copy()
-            indexed_data_point.metadata["index_fields"] = [field_name]
+            indexed_data_point = data_point.model_copy(
+                update={"metadata": {**data_point.metadata, "index_fields": [field_name]}}
+            )
             data_points_by_type[type_name][field_name].append(indexed_data_point)
 
     batch_size = vector_engine.embedding_engine.get_batch_size()

--- a/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock, call
+from unittest.mock import AsyncMock, patch, MagicMock
 from cognee.tasks.storage.index_data_points import index_data_points
 from cognee.infrastructure.engine import DataPoint
 
@@ -70,5 +70,5 @@ async def test_index_data_points_all_fields_indexed_independently():
     for field_name, index_fields in indexed_calls:
         assert index_fields == [field_name], (
             f"Metadata for field '{field_name}' had index_fields={index_fields!r}; "
-            "expected [{field_name!r}]. Shallow-copy mutation bug still present."
+            f"expected [{field_name!r}]. Shallow-copy mutation bug still present."
         )

--- a/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock, call
 from cognee.tasks.storage.index_data_points import index_data_points
 from cognee.infrastructure.engine import DataPoint
 
@@ -7,6 +7,13 @@ from cognee.infrastructure.engine import DataPoint
 class TestDataPoint(DataPoint):
     name: str
     metadata: dict = {"index_fields": ["name"]}
+
+
+class MultiFieldDataPoint(DataPoint):
+    title: str
+    summary: str
+    body: str
+    metadata: dict = {"index_fields": ["title", "summary", "body"]}
 
 
 @pytest.mark.asyncio
@@ -25,3 +32,43 @@ async def test_index_data_points_calls_vector_engine():
 
     assert mock_vector_engine.create_vector_index.await_count >= 1
     assert mock_vector_engine.index_data_points.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_index_data_points_all_fields_indexed_independently():
+    """Regression test for shallow-copy metadata mutation bug.
+
+    When a DataPoint has multiple index_fields, each field must be indexed
+    into its own vector collection with a copy that only lists that field.
+    The shared-metadata shallow-copy bug caused all copies to end up with
+    the last field's name, so only one field was ever truly indexed.
+    """
+    dp = MultiFieldDataPoint(title="T", summary="S", body="B")
+
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.embedding_engine.get_batch_size = MagicMock(return_value=100)
+
+    indexed_calls = []
+
+    async def capture_index(type_name, field_name, batch):
+        for point in batch:
+            indexed_calls.append((field_name, point.metadata["index_fields"]))
+
+    mock_vector_engine.index_data_points.side_effect = capture_index
+
+    with patch.dict(
+        index_data_points.__globals__,
+        {"get_vector_engine": lambda: mock_vector_engine},
+    ):
+        await index_data_points([dp])
+
+    indexed_field_names = [field for field, _ in indexed_calls]
+    assert sorted(indexed_field_names) == ["body", "summary", "title"], (
+        f"Expected all three fields to be indexed, got: {indexed_field_names}"
+    )
+
+    for field_name, index_fields in indexed_calls:
+        assert index_fields == [field_name], (
+            f"Metadata for field '{field_name}' had index_fields={index_fields!r}; "
+            "expected [{field_name!r}]. Shallow-copy mutation bug still present."
+        )


### PR DESCRIPTION
## Description

`index_data_points` iterates over a DataPoint's `index_fields` list and creates one copy per field, each tagged with only that field's name. The copy was produced with `model_copy()` (Pydantic v2 shallow copy), which shares the parent's `metadata` dict by reference. Assigning `indexed_data_point.metadata["index_fields"] = [field_name]` mutated the **shared** dict, so every previously-appended copy for other fields silently picked up the last field's name. The net result: only the last field in `index_fields` was ever indexed; all other collections contained embeddings labelled with the wrong field.

Fix: pass `update={"metadata": {**data_point.metadata, "index_fields": [field_name]}}` to `model_copy()`. This creates a fresh dict per copy, so mutations are isolated.

## Acceptance Criteria

* A DataPoint with three `index_fields` produces three separate `index_data_points` calls, each with the correct single field in `metadata["index_fields"]`.
* Verified by the new regression test `test_index_data_points_all_fields_indexed_independently`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

```
cognee/tests/unit/infrastructure/databases/test_index_data_points.py::test_index_data_points_calls_vector_engine PASSED
cognee/tests/unit/infrastructure/databases/test_index_data_points.py::test_index_data_points_all_fields_indexed_independently PASSED
2 passed in 0.05s
```

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

Closes #2529

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata handling when indexing multi-field data points so each field is indexed independently with the correct per-field metadata.

* **Tests**
  * Added a regression test ensuring all fields are indexed separately and each indexing call receives metadata scoped to that single field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->