### PR TITLE
perf(pipelines): suppress selectin datasets load in per-item status checks

### DIFF
--- a/cognee/modules/pipelines/operations/run_tasks_data_item.py
+++ b/cognee/modules/pipelines/operations/run_tasks_data_item.py
@@ -8,6 +8,7 @@ within pipeline operations, supporting both incremental and regular processing m
 import os
 from typing import Any, Dict, AsyncGenerator, Optional
 from sqlalchemy import select
+from sqlalchemy.orm import noload
 
 import cognee.modules.ingestion as ingestion
 from cognee.infrastructure.databases.relational import get_relational_engine
@@ -85,7 +86,9 @@ async def run_tasks_data_item_incremental(
     # Check pipeline status, if Data already processed for pipeline before skip current processing
     async with db_engine.get_async_session() as session:
         data_point = (
-            await session.execute(select(Data).filter(Data.id == data_id))
+            await session.execute(
+                select(Data).filter(Data.id == data_id).options(noload(Data.datasets))
+            )
         ).scalar_one_or_none()
         if data_point:
             if (
@@ -121,7 +124,9 @@ async def run_tasks_data_item_incremental(
         # Update pipeline status for Data element
         async with db_engine.get_async_session() as session:
             data_point = (
-                await session.execute(select(Data).filter(Data.id == data_id))
+                await session.execute(
+                    select(Data).filter(Data.id == data_id).options(noload(Data.datasets))
+                )
             ).scalar_one_or_none()
             status_for_pipeline = data_point.pipeline_status.setdefault(pipeline_name, {})
             status_for_pipeline[str(dataset.id)] = DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED


### PR DESCRIPTION
## Description

`run_tasks_data_item_incremental` fetches each `Data` row individually by primary key — once to read `pipeline_status` before processing, and once to update it after. The `Data.datasets` relationship is declared with `lazy="selectin"`, so every individual `select(Data).filter(Data.id == data_id)` silently emitted a second query:

```sql
SELECT data_1.id, datasets.id, datasets.name, ...
FROM data AS data_1
JOIN dataset_data ON data_1.id = dataset_data.data_id
JOIN datasets ON datasets.id = dataset_data.dataset_id
WHERE data_1.id IN ($1::UUID)
```

Because each fetch is for a single `Data` object, the IN-list always has exactly one UUID, and the query fires once per data item. Sentry traces showed 281 occurrences over 5 days — entirely from this code path.

**Root cause**: `Data.datasets` is not used anywhere in `run_tasks_data_item_incremental`; only `pipeline_status` is read/written. The selectin load is pure overhead.

**Fix**: add `.options(noload(Data.datasets))` to both per-item `select(Data)` queries in `run_tasks_data_item_incremental`. This tells SQLAlchemy not to populate the `datasets` attribute, eliminating the extra SELECT entirely.

No behavioral change — the relationship is never accessed within this code path.

## Acceptance Criteria

* Each call to `run_tasks_data_item_incremental` now issues at most 1 query per status check instead of 2.
* All 29 pipeline unit tests pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

```
======================== 29 passed in 9.06s ========================
```

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

Closes #2532

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized incremental pipeline database queries to enhance performance and operational efficiency. Streamlined data retrieval operations during status verification checks and post-processing steps by eliminating unnecessary data loading. These enhancements result in faster pipeline execution and optimized resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->