### PR TITLE
feat(sessions): label + query_count on GET /v1/sessions list (minimal alternative to session-scoped-search-history)

### DIFF
--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -90,7 +90,9 @@ def _entry_field(entry, name: str):
     return getattr(entry, name, None)
 
 
-async def _label_and_query_count(sm, owner_user_id: str, session_id: str) -> tuple[Optional[str], int]:
+async def _label_and_query_count(
+    sm, owner_user_id: str, session_id: str
+) -> tuple[Optional[str], int]:
     """Derive ``(label, query_count)`` for one session from the session cache.
 
     Mirrors how GET /v1/sessions/{session_id} derives ``label``/``msg_count``

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -90,6 +90,40 @@ def _entry_field(entry, name: str):
     return getattr(entry, name, None)
 
 
+async def _generated_by_for_user_ids(owner_user_ids: list[str]) -> dict[str, str]:
+    """Return whether each owner user is a human user or an agent user."""
+    parsed_ids: list[UUIDType] = []
+    for owner_user_id in owner_user_ids:
+        try:
+            parsed_ids.append(UUIDType(str(owner_user_id)))
+        except (TypeError, ValueError):
+            continue
+
+    if not parsed_ids:
+        return {}
+
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        from cognee.modules.users.models import User as UserModel
+
+        rows = (
+            await session.execute(
+                select(UserModel.id, UserModel.parent_user_id, UserModel.email).where(
+                    UserModel.id.in_(parsed_ids)
+                )
+            )
+        ).all()
+
+    generated_by: dict[str, str] = {}
+    for row in rows:
+        email = getattr(row, "email", "") or ""
+        is_agent = getattr(row, "parent_user_id", None) is not None or email.endswith(
+            "@cognee.agent"
+        )
+        generated_by[str(row.id)] = "agent" if is_agent else "user"
+    return generated_by
+
+
 async def _label_and_query_count(
     sm, owner_user_id: str, session_id: str
 ) -> tuple[Optional[str], int]:
@@ -167,6 +201,9 @@ def get_sessions_router() -> APIRouter:
             from cognee.infrastructure.session.get_session_manager import get_session_manager
 
             sm = get_session_manager()
+            owner_types = await _generated_by_for_user_ids(
+                [rec.get("user_id", "") for rec in records]
+            )
             enrichments = await asyncio.gather(
                 *(
                     _label_and_query_count(sm, rec.get("user_id", ""), rec.get("session_id", ""))
@@ -176,6 +213,7 @@ def get_sessions_router() -> APIRouter:
             for rec, (label, query_count) in zip(records, enrichments):
                 rec["label"] = label
                 rec["query_count"] = query_count
+                rec["generated_by"] = owner_types.get(rec.get("user_id", ""), "unknown")
 
             return jsonable_encoder(
                 {
@@ -374,6 +412,8 @@ def get_sessions_router() -> APIRouter:
                 pass
 
         record = row.to_dict()
+        owner_types = await _generated_by_for_user_ids([owner_user_id])
+        record["generated_by"] = owner_types.get(owner_user_id, "unknown")
         # Label = first QA's question, else first trace's origin_function
         # (so trace-only sessions — the plugin case — still have a label).
         label = None

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -5,6 +5,7 @@ by model. Effective status is computed in SQL with the
 abandonment-by-idle rule so no sweeper is needed.
 """
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Literal, Optional
 from uuid import UUID as UUIDType
@@ -77,6 +78,44 @@ async def _visible_user_ids(user: User) -> list[UUIDType]:
     return ids
 
 
+def _entry_field(entry, name: str):
+    """Read a field from a QA/trace entry whether it's a dict or an object.
+
+    ``get_session(formatted=False)`` returns SessionQAEntry *objects* (not
+    dicts), so a dict-only lookup silently misses every field — which is why
+    the session label came back empty. Handle both shapes.
+    """
+    if isinstance(entry, dict):
+        return entry.get(name)
+    return getattr(entry, name, None)
+
+
+async def _label_and_query_count(sm, owner_user_id: str, session_id: str) -> tuple[Optional[str], int]:
+    """Derive ``(label, query_count)`` for one session from the session cache.
+
+    Mirrors how GET /v1/sessions/{session_id} derives ``label``/``msg_count``
+    from the cache QAs, so the list and detail views agree. Best-effort: cache
+    entries are keyed by the session OWNER (not the caller), and any cache miss
+    / unavailability degrades to ``(None, 0)`` rather than failing the list.
+    """
+    if not (sm.is_available and owner_user_id and session_id):
+        return None, 0
+    try:
+        qas_raw = await sm.get_session(
+            user_id=owner_user_id, session_id=session_id, formatted=False
+        )
+    except Exception:
+        return None, 0
+    qas = qas_raw if isinstance(qas_raw, list) else []
+    label = None
+    for entry in qas:
+        question = _entry_field(entry, "question")
+        if question:
+            label = str(question)[:120]
+            break
+    return label, len(qas)
+
+
 def get_sessions_router() -> APIRouter:
     router = APIRouter()
 
@@ -116,9 +155,29 @@ def get_sessions_router() -> APIRouter:
                 order_by=order_by,
                 descending=descending,
             )
+            records = [r.to_dict() for r in page.sessions]
+            # Enrich each row with a human label (first QA question) and
+            # query_count, derived from the session cache the same way the
+            # detail endpoint does — so the list view shows a meaningful title
+            # and size without a second round trip. Reuses the existing
+            # session_id/cache concept (no new store). Bounded by the page
+            # size; reads run concurrently and degrade to (None, 0) on miss.
+            from cognee.infrastructure.session.get_session_manager import get_session_manager
+
+            sm = get_session_manager()
+            enrichments = await asyncio.gather(
+                *(
+                    _label_and_query_count(sm, rec.get("user_id", ""), rec.get("session_id", ""))
+                    for rec in records
+                )
+            )
+            for rec, (label, query_count) in zip(records, enrichments):
+                rec["label"] = label
+                rec["query_count"] = query_count
+
             return jsonable_encoder(
                 {
-                    "sessions": [r.to_dict() for r in page.sessions],
+                    "sessions": records,
                     "total": page.total,
                     "limit": page.limit,
                     "offset": page.offset,
@@ -317,13 +376,15 @@ def get_sessions_router() -> APIRouter:
         # (so trace-only sessions — the plugin case — still have a label).
         label = None
         for entry in qas:
-            if isinstance(entry, dict) and entry.get("question"):
-                label = str(entry["question"])[:120]
+            question = _entry_field(entry, "question")
+            if question:
+                label = str(question)[:120]
                 break
         if label is None:
             for entry in traces:
-                if isinstance(entry, dict) and entry.get("origin_function"):
-                    label = str(entry["origin_function"])
+                origin_function = _entry_field(entry, "origin_function")
+                if origin_function:
+                    label = str(origin_function)
                     break
         record["label"] = label
         record["msg_count"] = len(qas)

--- a/cognee/tests/unit/api/v1/session/test_sessions_router_enrichment.py
+++ b/cognee/tests/unit/api/v1/session/test_sessions_router_enrichment.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.api.v1.sessions.routers import get_sessions_router as sessions_router_module
+
+
+@pytest.mark.asyncio
+async def test_generated_by_for_user_ids_marks_agent_owners(monkeypatch):
+    human_id = uuid4()
+    agent_by_parent_id = uuid4()
+    agent_by_email_id = uuid4()
+    parent_id = uuid4()
+    rows = [
+        SimpleNamespace(id=human_id, parent_user_id=None, email="human@example.com"),
+        SimpleNamespace(
+            id=agent_by_parent_id,
+            parent_user_id=parent_id,
+            email="worker@example.com",
+        ),
+        SimpleNamespace(id=agent_by_email_id, parent_user_id=None, email="helper@cognee.agent"),
+    ]
+
+    class FakeResult:
+        def all(self):
+            return rows
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def execute(self, _stmt):
+            return FakeResult()
+
+    fake_engine = SimpleNamespace(get_async_session=lambda: FakeSession())
+    monkeypatch.setattr(
+        sessions_router_module,
+        "get_relational_engine",
+        lambda: fake_engine,
+    )
+
+    generated_by = await sessions_router_module._generated_by_for_user_ids(
+        [str(human_id), str(agent_by_parent_id), str(agent_by_email_id), "not-a-uuid"]
+    )
+
+    assert generated_by[str(human_id)] == "user"
+    assert generated_by[str(agent_by_parent_id)] == "agent"
+    assert generated_by[str(agent_by_email_id)] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_generated_by_for_user_ids_ignores_invalid_ids(monkeypatch):
+    fake_engine = SimpleNamespace(get_async_session=lambda: None)
+    monkeypatch.setattr(
+        sessions_router_module,
+        "get_relational_engine",
+        lambda: fake_engine,
+    )
+
+    generated_by = await sessions_router_module._generated_by_for_user_ids(["not-a-uuid"])
+
+    assert generated_by == {}


### PR DESCRIPTION
Implements the **minimal-new-concepts** alternative to `feature/session-scoped-search-history` (which adds a third session store + a parallel `/v1/search/sessions` endpoint + an alembic migration, and whose endpoint is currently non-functional due to a name-collision recursion bug).

## What this does
Adds **`label`** (first query, the title) and **`query_count`** to the existing **`GET /v1/sessions`** list response — computed from the session cache the same way `GET /v1/sessions/{id}` already derives `label`/`msg_count`. So the list shows a meaningful title + size without a second round trip, and list/detail agree.

- Reuses the **single existing session concept** (`session_lifecycle` `SessionRecord` + session-cache QAs). **No** new relational column, **no** parallel `/sessions` endpoint, **no migration**.
- Enrichment is **bounded by page size**, runs **concurrently**, and **degrades to `(None, 0)`** on cache miss/unavailability (best-effort; never fails the list).

## Also fixes a latent bug
Label derivation used `isinstance(entry, dict)`, but `SessionManager.get_session(formatted=False)` returns `SessionQAEntry` **objects** — so the label was always `None` in **both** the list (new) and the existing **detail** endpoint. `_entry_field()` now reads from an object or a dict; labels work in both and stay consistent. *(Verified locally: list + detail both return e.g. `"Refactor the auth middleware to use JWT"`.)*

## Why not the branch's approach (summary)
The per-session search/QA history it tries to expose **already exists** via the session cache (`add_qa`) and `GET /v1/sessions/{id}`. A relational `Query.session_id` would be a third, un-keyed (`session_id` without `user_id`) copy that diverges from `SessionRecord`/cache, plus a second differently-shaped, unpaginated `/sessions` listing. Recommend **closing that PR** in favor of this.

## Coverage caveat (verified)
The cache captures **completion-family** searches (`RAG/TRIPLET/GRAPH_COMPLETION` + variants, `AGENTIC`, `TEMPORAL`). Pure-retrieval types (`CHUNKS`, `SUMMARIES`, `CHUNKS_LEXICAL`, `CODING_RULES`) have no Q→A and are correctly absent. **`CYPHER` and `NATURAL_LANGUAGE` produce answers + receive `session_id` but bypass `add_qa`** — a small gap; if they should appear in session history, make those two retrievers persist via `add_qa` (same concept, no new ones) as a follow-up.

## Test plan
- [ ] `GET /v1/sessions` returns each session with `label` + `query_count`; matches `GET /v1/sessions/{id}.label`/`msg_count`.
- [ ] Sessions with no cached QAs return `label: null`, `query_count: 0` (no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session lists now show a human-readable label (first question), per-session cached query counts, and a per-owner "generated by" indicator.
  * Session detail view surfaces the same label and "generated by" information for trace-only or object-shaped entries.
* **Bug Fixes**
  * Cache lookups are performed with best-effort fallbacks when cache access is unavailable or errors occur.
* **Tests**
  * Added unit tests covering the enrichment and owner-derived labeling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->