### PR TITLE
fix(chunks): reset row state between paragraphs in chunk_by_row

### DIFF
--- a/cognee/tasks/chunks/chunk_by_row.py
+++ b/cognee/tasks/chunks/chunk_by_row.py
@@ -92,3 +92,10 @@ def chunk_by_row(
             }
 
             yield chunk_dict
+
+            # Start a fresh chunk for the next row so its pairs are not
+            # accumulated onto this row's chunk and chunk indices stay
+            # monotonically increasing.
+            current_chunk_list = []
+            current_chunk_size = 0
+            chunk_index += 1

--- a/cognee/tests/unit/processing/chunks/chunk_by_row_test.py
+++ b/cognee/tests/unit/processing/chunks/chunk_by_row_test.py
@@ -9,6 +9,12 @@ from cognee.tasks.chunks import chunk_by_row
 INPUT_TEXTS = "name: John, age: 30, city: New York, country: USA"
 max_chunk_size_vals = [8, 32]
 
+# Two rows separated by a blank line. chunk_by_row splits its input on
+# "\n\n", so a single call can legitimately receive several rows (e.g. when
+# CsvChunker is applied to a multi-paragraph TextDocument, or chunk_by_row is
+# called directly). Each row must become its own chunk.
+MULTI_ROW_INPUT = "name: John, age: 30\n\nname: Jane, age: 25"
+
 
 @pytest.mark.parametrize(
     "input_text,max_chunk_size",
@@ -50,3 +56,31 @@ def test_chunk_by_row_chunk_numbering(input_text, max_chunk_size):
     assert np.all(chunk_indices == np.arange(len(chunk_indices))), (
         f"{chunk_indices = } are not monotonically increasing"
     )
+
+
+def test_chunk_by_row_multiple_rows_are_independent():
+    """Each "\\n\\n"-separated row must produce an independent chunk.
+
+    Regression test: row state (text/size) was not reset after yielding a
+    "row_end" chunk, so subsequent rows accumulated previous rows' pairs and
+    sizes, and the chunk index was never advanced. This corrupted the stored
+    chunk text and broke the reconstruction invariant.
+    """
+    chunks = list(chunk_by_row(data=MULTI_ROW_INPUT, max_chunk_size=128))
+
+    # One chunk per row, no leakage of one row's pairs into the next.
+    assert [chunk["text"] for chunk in chunks] == [
+        "name: John, age: 30",
+        "name: Jane, age: 25",
+    ]
+
+    # Concatenating the chunks reproduces the original rows exactly.
+    reconstructed = "\n\n".join(chunk["text"] for chunk in chunks)
+    assert reconstructed == MULTI_ROW_INPUT
+
+    # Indices are monotonically increasing across rows.
+    chunk_indices = [chunk["chunk_index"] for chunk in chunks]
+    assert chunk_indices == list(range(len(chunk_indices)))
+
+    # Identical rows must have identical sizes (no accumulation across rows).
+    assert chunks[0]["chunk_size"] == chunks[1]["chunk_size"]


### PR DESCRIPTION
## Description

`chunk_by_row` (used by `CsvChunker`) splits its input on `"\n\n"` and yields one chunk per row. But after emitting a row's `"row_end"` chunk it never resets the accumulator (`current_chunk_list` / `current_chunk_size`) and never advances `chunk_index`.

When a single call receives **multiple** rows, every row after the first re-accumulates all previous rows' pairs and sizes, and every chunk is emitted with `chunk_index == 0`.

### Reproduction

```python
from cognee.tasks.chunks import chunk_by_row

data = "name: John\n\nname: Jane"
for c in chunk_by_row(data, max_chunk_size=128):
    print(c["chunk_index"], repr(c["text"]))
```

Before this fix:
```
0 'name: John'
0 'name: John, name: Jane'      # <-- row 2 leaked row 1's pair; index not advanced
```

After this fix:
```
0 'name: John'
1 'name: Jane'
```

This breaks the function's own documented invariant ("when the generated chunks are concatenated, they reproduce the original text accurately") and corrupts what gets embedded/stored.

### Reachability

`CsvChunker` is user-selectable (`--chunker CsvChunker` in `cognify`/`remember`) and is applied uniformly to every document in a dataset via `extract_chunks_from_documents`, not just CSVs. `TextDocument.get_text()` reads up to 1 MB per yield and `UnstructuredDocument.get_text()` joins elements with `"\n\n"`, so a single `chunk_by_row` call routinely receives multi-row text on this path. (The normal `CsvDocument` path yields one row per `get_text()` call, which is why existing tests didn't catch it.)

The integration test `CsvDocument_test.py` (`chunk_size_128` ground truth) already encodes the intended behavior: each row is its own chunk with a distinct, increasing `chunk_index` and non-accumulating size.

## Fix

Reset the per-row accumulator and increment `chunk_index` after the `row_end` yield, mirroring the existing `row_cut` branch. Single-row inputs are unaffected.

## Tests

Added `test_chunk_by_row_multiple_rows_are_independent`, which asserts each row becomes an independent chunk with monotonic indices and no cross-row accumulation. It **fails before** this change and **passes after**. Full `cognee/tests/unit/processing/chunks/` suite + `CsvDocument_test.py` remain green (297 passed).

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where data from multiple rows could incorrectly bleed into each other during processing. Each row is now properly isolated and processed independently, ensuring accurate data handling when working with multi-row inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->