### PR TITLE
fix(llm): bound structured-output calls + tolerate preflight parse failures (#2456, #2752, #2796, #2902)

### DIFF
--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Coroutine
 from typing import Any, TypeVar
 
@@ -19,6 +20,25 @@ def _inject_agent_memory(text_input: str) -> str:
         return text_input
 
     return f"Additional Memory Context:\n{context.memory_context}\n\nOriginal Input:\n{text_input}"
+
+
+async def _with_call_timeout(coro: Coroutine) -> T:
+    """Bound a single LLM structured-output call so a non-responsive endpoint
+    cannot hang cognify/search/remember indefinitely.
+
+    A non-positive configured timeout disables the bound (back-compat escape hatch).
+    """
+    timeout = get_llm_config().llm_call_timeout_seconds
+    if not timeout or timeout <= 0:
+        return await coro
+    try:
+        return await asyncio.wait_for(coro, timeout=timeout)
+    except asyncio.TimeoutError as error:
+        raise TimeoutError(
+            f"LLM call did not complete within {timeout}s. The endpoint accepted the "
+            "connection but never responded. Check that your LLM endpoint is reachable "
+            "and responsive, or raise LLM_CALL_TIMEOUT_SECONDS."
+        ) from error
 
 
 async def _record_session_usage_after(
@@ -87,9 +107,10 @@ class LLMGateway:
                 **kwargs,
             )
 
-        # Wrap so usage is recorded against any active session tracker.
-        # No-op when no tracker is installed.
-        return _record_session_usage_after(inner, text_input=text_input)
+        # Bound the call so an unresponsive endpoint cannot hang forever, then
+        # wrap so usage is recorded against any active session tracker.
+        # The usage wrapper is a no-op when no tracker is installed.
+        return _record_session_usage_after(_with_call_timeout(inner), text_input=text_input)
 
     @staticmethod
     def create_transcript(input) -> Coroutine[Any, Any, TranscriptionReturnType | None]:

--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -28,7 +28,9 @@ async def _with_call_timeout(coro: Coroutine) -> T:
 
     A non-positive configured timeout disables the bound (back-compat escape hatch).
     """
-    timeout = get_llm_config().llm_call_timeout_seconds
+    # Defensive getattr: callers (and tests) may supply a partial/mock config
+    # that predates this field; fall back to the LLMConfig default (300s).
+    timeout = getattr(get_llm_config(), "llm_call_timeout_seconds", 300)
     if not timeout or timeout <= 0:
         return await coro
     try:

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -49,6 +49,11 @@ class LLMConfig(BaseSettings):
     llm_temperature: float = 0.0
     llm_streaming: bool = False
     llm_max_completion_tokens: int = 16384
+    # Hard upper bound (seconds) on a single structured-output LLM call. Prevents
+    # cognify/search/remember from hanging indefinitely when an endpoint (vLLM,
+    # Ollama, custom OpenAI-compatible servers, etc.) accepts the connection but
+    # never responds. See issues #2456, #2796, #2902.
+    llm_call_timeout_seconds: int = 300
 
     baml_llm_provider: str = "openai"
     baml_llm_model: str = "gpt-5-mini"

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -81,6 +81,14 @@ def get_model_max_completion_tokens(model_name: str) -> int | None:
 async def test_llm_connection() -> None:
     """
     Test connectivity to the LLM endpoint using a simple completion call.
+
+    The goal of this preflight is to verify *reachability* and credentials, not to
+    validate that the provider can emit a particular structured-output schema. Some
+    healthy non-OpenAI / local providers (vLLM, Ollama, custom OpenAI-compatible
+    servers) cannot reliably coerce a bare ``str`` response model and would otherwise
+    fail this check even though the endpoint is fully reachable (issue #2752).
+    Therefore a structured-output / parse failure is treated as a *successful*
+    reachability result, while only timeouts and auth/connection errors are fatal.
     """
     try:
         logger.info("Testing connection to LLM endpoint...")
@@ -92,7 +100,7 @@ async def test_llm_connection() -> None:
             ),
             timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
         )
-    except asyncio.TimeoutError:
+    except (asyncio.TimeoutError, TimeoutError):
         msg = (
             f"LLM connection test timed out after {CONNECTION_TEST_TIMEOUT_SECONDS}s. "
             "Check that your LLM endpoint is reachable and responding. "
@@ -107,10 +115,25 @@ async def test_llm_connection() -> None:
         )
         logger.error(msg)
         raise e
-    except Exception as e:
+    except (
+        litellm.exceptions.APIConnectionError,
+        litellm.exceptions.ServiceUnavailableError,
+        litellm.exceptions.Timeout,
+        ConnectionError,
+    ) as e:
+        # Endpoint is genuinely unreachable / not responding -> fatal.
         logger.error(e)
         logger.error("Connection to LLM could not be established.")
         raise e
+    except Exception as e:
+        # The endpoint responded but the structured-output round-trip failed
+        # (e.g. the provider can't coerce the response model, validation/parse
+        # error). That still proves reachability, so don't fail the preflight.
+        logger.warning(
+            "LLM endpoint is reachable but the structured-output test did not return a "
+            "valid schema (%s). Treating the connection as healthy.",
+            type(e).__name__,
+        )
 
 
 async def test_embedding_connection() -> int:

--- a/cognee/tests/unit/infrastructure/llm/test_llm_call_timeouts.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_call_timeouts.py
@@ -1,0 +1,122 @@
+"""Regression tests for LLM call hangs and preflight routing.
+
+Covers:
+  (b) #2456/#2796/#2902 — a structured-output / completion call against an endpoint
+      that accepts the connection but never responds must raise promptly instead of
+      hanging forever. ``LLMGateway.acreate_structured_output`` now wraps the call in
+      a bounded ``asyncio.wait_for``.
+  (a) #2752 — the preflight ``test_llm_connection`` must treat a structured-output /
+      parse failure from a *reachable* (non-OpenAI/local) endpoint as healthy, while
+      still failing on genuine timeouts / connection errors.
+"""
+
+import asyncio
+import importlib
+
+import pytest
+
+from cognee.infrastructure.llm import utils as llm_utils
+from cognee.infrastructure.llm.LLMGateway import LLMGateway
+
+# The package __init__ re-exports the ``LLMGateway`` *class* under the same dotted
+# name as the submodule, so a plain ``import ... as`` yields the class. Load the
+# real module object explicitly so we can monkeypatch module-level globals.
+gateway_module = importlib.import_module("cognee.infrastructure.llm.LLMGateway")
+
+
+class _StubConfig:
+    def __init__(self, timeout):
+        self.structured_output_framework = "instructor"
+        self.llm_call_timeout_seconds = timeout
+        self.llm_model = "openai/gpt-test"
+
+
+class _HangingClient:
+    """LLM client whose structured-output call never returns."""
+
+    async def acreate_structured_output(self, *args, **kwargs):
+        # Simulate an endpoint that accepted the connection but never responds.
+        await asyncio.sleep(3600)
+
+
+@pytest.mark.asyncio
+async def test_gateway_structured_output_does_not_hang(monkeypatch):
+    """A hanging endpoint must raise TimeoutError quickly, not hang."""
+    monkeypatch.setattr(gateway_module, "get_llm_config", lambda: _StubConfig(timeout=1))
+
+    # Patch the lazily-imported get_llm_client used inside acreate_structured_output.
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client as glc
+
+    monkeypatch.setattr(glc, "get_llm_client", lambda *a, **k: _HangingClient())
+
+    coro = LLMGateway.acreate_structured_output(
+        text_input="hi",
+        system_prompt="sys",
+        response_model=str,
+    )
+
+    # Outer guard (8s) is far larger than the configured 1s LLM timeout. If the
+    # gateway bound is missing the call hangs and the *outer* guard fires near the
+    # 8s mark; with the bound in place the gateway raises near the 1s mark. We
+    # assert the failure surfaces well before the guard, proving the bound works
+    # rather than masking a hang. (asyncio.TimeoutError is a subclass of
+    # TimeoutError on 3.11+, so timing is what distinguishes the two paths.)
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(coro, timeout=8)
+    elapsed = loop.time() - start
+    assert elapsed < 5, (
+        f"Call took {elapsed:.1f}s; the gateway timeout bound did not fire "
+        "promptly (likely missing)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_timeout_disabled_with_non_positive(monkeypatch):
+    """A non-positive timeout disables the bound (escape hatch)."""
+    monkeypatch.setattr(gateway_module, "get_llm_config", lambda: _StubConfig(timeout=0))
+
+    class _FastClient:
+        async def acreate_structured_output(self, *args, **kwargs):
+            return "ok"
+
+    import cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client as glc
+
+    monkeypatch.setattr(glc, "get_llm_client", lambda *a, **k: _FastClient())
+
+    result = await LLMGateway.acreate_structured_output(
+        text_input="hi",
+        system_prompt="sys",
+        response_model=str,
+    )
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_preflight_tolerates_structured_output_failure(monkeypatch):
+    """#2752: a reachable endpoint that fails the structured-output round-trip
+    (e.g. cannot coerce a bare ``str`` model) must NOT fail the preflight."""
+
+    async def _raise_parse_error(*args, **kwargs):
+        raise ValueError("could not parse response into str")
+
+    monkeypatch.setattr(gateway_module.LLMGateway, "acreate_structured_output", _raise_parse_error)
+
+    # Should return without raising.
+    await llm_utils.test_llm_connection()
+
+
+@pytest.mark.asyncio
+async def test_preflight_still_fails_on_timeout(monkeypatch):
+    """Genuine unresponsiveness must still surface as a TimeoutError."""
+
+    monkeypatch.setattr(llm_utils, "CONNECTION_TEST_TIMEOUT_SECONDS", 1)
+
+    async def _hang(*args, **kwargs):
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(gateway_module.LLMGateway, "acreate_structured_output", _hang)
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(llm_utils.test_llm_connection(), timeout=10)


### PR DESCRIPTION
## Why
Recurring root cause from a 6-month issue triage: LLM/embedding calls could hang indefinitely (#2119, #2362, #2456, #2752, #2796, #2902).

## What
Assessment found the **embedding paths** (LiteLLM/OpenAICompatible/Ollama engines) and the **tenacity retry decorators** were already fixed (timeouts + `retry_if_not_exception_type` for auth/validation). Two real gaps remained and are fixed here:

- **#2456 / #2796 / #2902** — structured-output adapters (Generic/CUSTOM/vLLM, OpenAI, Ollama) had no per-call timeout, so `cognify`/`search`/`remember` could hang forever. Bounded centrally at `LLMGateway.acreate_structured_output` via a new `LLM_CALL_TIMEOUT_SECONDS` (default 300; `<=0` disables). One change covers all providers + instructor/BAML.
- **#2752** — the preflight `test_llm_connection` re-raised any error from a `str`-response round-trip, so healthy non-OpenAI/local providers failed the check. Now only timeouts / genuine connection / auth errors are fatal; parse failures are treated as reachable.

## Tests
4 new tests in `test_llm_call_timeouts.py` (verified the gateway test fails at 8s without the wrapper and raises in ~1s with it; preflight test fails when tolerant clauses reverted). `ty` clean; ruff clean.

## Risk
The 300s default could cut off very-long completions — operators raise/disable via `LLM_CALL_TIMEOUT_SECONDS`. Centralized at the gateway, so a future adapter bypassing it wouldn't inherit the bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable per-call LLM timeout (default 300s); timed-out calls raise a clear TimeoutError and prevent post-call usage recording.

* **Bug Fixes**
  * Connection preflight now treats structured-output/parse failures as reachable (unless a timeout/auth/connection error occurs), reducing false negatives.

* **Tests**
  * Added unit tests covering timeout behavior, disabling timeouts, and preflight connection semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->