### PR TITLE
fix(chromadb): make belongs_to_set filter actually match (#2353, #2947, #2948)

### DIFF
--- a/cognee/infrastructure/databases/vector/chromadb/ChromaDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/chromadb/ChromaDBAdapter.py
@@ -18,6 +18,15 @@ from ..vector_db_interface import VectorDBInterface
 
 logger = get_logger("ChromaDBAdapter")
 
+# ChromaDB metadata values must be scalars (str/int/float/bool); arrays are not
+# supported and its ``where`` filter has no native "array contains" operator.
+# To make ``belongs_to_set`` membership queryable, each tag is flattened into a
+# dedicated boolean metadata key ``belongs_to_set::<tag>`` so an ``$eq True``
+# filter matches a single membership. The original list is also preserved as a
+# JSON string under ``belongs_to_set__list`` so payloads round-trip unchanged.
+BELONGS_TO_SET_KEY = "belongs_to_set"
+BELONGS_TO_SET_MEMBER_PREFIX = "belongs_to_set::"
+
 
 class IndexSchema(DataPoint):
     """
@@ -83,6 +92,13 @@ def process_data_for_chroma(data):
         elif isinstance(value, list):
             # Store lists as JSON strings with special prefix
             processed_data[f"{key}__list"] = json.dumps(value)
+            # belongs_to_set is filtered on at query time; ChromaDB cannot match
+            # against a JSON-encoded list, so additionally flatten each tag into a
+            # boolean membership key that an $eq filter can target.
+            if key == BELONGS_TO_SET_KEY:
+                for tag in value:
+                    if isinstance(tag, str):
+                        processed_data[f"{BELONGS_TO_SET_MEMBER_PREFIX}{tag}"] = True
         elif isinstance(value, (str, int, float, bool)):
             processed_data[key] = value
         else:
@@ -121,6 +137,10 @@ def restore_data_from_chroma(data):
             dict_keys.append(key)
         elif key.endswith("__list"):
             list_keys.append(key)
+        elif key.startswith(BELONGS_TO_SET_MEMBER_PREFIX):
+            # Flattened membership markers are an internal query aid; the original
+            # belongs_to_set list is restored from its __list entry.
+            continue
         else:
             restored_data[key] = data[key]
 
@@ -365,11 +385,18 @@ class ChromaDBAdapter(VectorDBInterface):
             )
         if not node_name:
             return None
+
+        def _member_clause(name: str) -> dict:
+            # Match the flattened boolean membership key written by
+            # process_data_for_chroma; belongs_to_set is stored as a JSON list
+            # which ChromaDB's where filter cannot match directly.
+            return {f"{BELONGS_TO_SET_MEMBER_PREFIX}{name}": {"$eq": True}}
+
         if len(node_name) == 1:
-            return {"belongs_to_set": {"$eq": node_name[0]}}
+            return _member_clause(node_name[0])
         if node_name_filter_operator == "AND":
-            return {"$and": [{"belongs_to_set": {"$eq": name}} for name in node_name]}
-        return {"$or": [{"belongs_to_set": {"$eq": name}} for name in node_name]}
+            return {"$and": [_member_clause(name) for name in node_name]}
+        return {"$or": [_member_clause(name) for name in node_name]}
 
     @staticmethod
     def _build_include_list(include_payload: bool, with_vector: bool) -> List[str]:

--- a/cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py
@@ -11,8 +11,15 @@ from uuid import uuid4
 chromadb = pytest.importorskip("chromadb", reason="ChromaDB tests require chromadb")
 
 from cognee.infrastructure.databases.vector.chromadb.ChromaDBAdapter import (  # noqa: E402
+    BELONGS_TO_SET_MEMBER_PREFIX,
     ChromaDBAdapter,
+    process_data_for_chroma,
+    restore_data_from_chroma,
 )
+
+
+def _member_key(name):
+    return f"{BELONGS_TO_SET_MEMBER_PREFIX}{name}"
 
 
 def _make_chroma_result(ids, distances, metadatas=None, embeddings=None):
@@ -114,7 +121,44 @@ async def test_search_node_name_single_applies_eq_filter():
 
     call_kwargs = collection.query.call_args[1]
     assert "where" in call_kwargs
-    assert call_kwargs["where"] == {"belongs_to_set": {"$eq": "Alice"}}
+    assert call_kwargs["where"] == {_member_key("Alice"): {"$eq": True}}
+
+
+def test_belongs_to_set_is_flattened_into_boolean_membership_keys():
+    """Regression for #2353/#2947/#2948: belongs_to_set must be stored as
+    queryable per-tag boolean keys, not only a JSON-encoded list that the
+    where filter can never match."""
+    stored = process_data_for_chroma(
+        {"id": "n1", "belongs_to_set": ["Alice", "Bob"], "text": "hello"}
+    )
+
+    # Each tag gets a boolean membership marker that an $eq True filter targets.
+    assert stored[_member_key("Alice")] is True
+    assert stored[_member_key("Bob")] is True
+    # The original list is preserved so payloads round-trip unchanged.
+    assert "belongs_to_set__list" in stored
+
+
+def test_where_filter_targets_stored_membership_key():
+    """The where filter key produced for a node_name must be a key that
+    process_data_for_chroma actually writes, otherwise the filter is silently
+    dropped (the original #2353 bug)."""
+    stored = process_data_for_chroma({"belongs_to_set": ["Alice"]})
+    where = ChromaDBAdapter._build_where_filter(["Alice"], "OR")
+
+    (filter_key,) = where.keys()
+    assert filter_key in stored
+    assert where[filter_key] == {"$eq": True}
+
+
+def test_belongs_to_set_round_trips_without_membership_markers():
+    """restore_data_from_chroma must drop the internal membership markers and
+    rebuild belongs_to_set from its JSON list."""
+    stored = process_data_for_chroma({"id": "n1", "belongs_to_set": ["Alice", "Bob"]})
+    restored = restore_data_from_chroma(stored)
+
+    assert restored["belongs_to_set"] == ["Alice", "Bob"]
+    assert not any(k.startswith(BELONGS_TO_SET_MEMBER_PREFIX) for k in restored)
 
 
 @pytest.mark.asyncio
@@ -137,8 +181,10 @@ async def test_search_node_name_or_operator_uses_dollar_or():
     assert "where" in call_kwargs
     where = call_kwargs["where"]
     assert "$or" in where
-    names = {clause["belongs_to_set"]["$eq"] for clause in where["$or"]}
-    assert names == {"Alice", "Bob"}
+    assert where["$or"] == [
+        {_member_key("Alice"): {"$eq": True}},
+        {_member_key("Bob"): {"$eq": True}},
+    ]
 
 
 @pytest.mark.asyncio
@@ -161,8 +207,10 @@ async def test_search_node_name_and_operator_uses_dollar_and():
     assert "where" in call_kwargs
     where = call_kwargs["where"]
     assert "$and" in where
-    names = {clause["belongs_to_set"]["$eq"] for clause in where["$and"]}
-    assert names == {"Alice", "Bob"}
+    assert where["$and"] == [
+        {_member_key("Alice"): {"$eq": True}},
+        {_member_key("Bob"): {"$eq": True}},
+    ]
 
 
 @pytest.mark.asyncio
@@ -228,4 +276,4 @@ async def test_batch_search_node_name_filter_is_forwarded():
 
     call_kwargs = collection.query.call_args[1]
     assert "where" in call_kwargs
-    assert call_kwargs["where"] == {"belongs_to_set": {"$eq": "Alice"}}
+    assert call_kwargs["where"] == {_member_key("Alice"): {"$eq": True}}


### PR DESCRIPTION
## Why
Recurring root cause: retrieval control params silently ignored (#2351, #2352, #2353, #2815, #2947, #2948).

## What
Fixes the highest-evidence bug — ChromaDB `belongs_to_set` filtering (#2353, #2947, #2948 — latter two are exact dupes). Tags were serialized to a JSON string under `belongs_to_set__list`, but `_build_where_filter` queried key `belongs_to_set` with `{"$eq": <name>}`, which never matched → `node_name`/`belongs_to_set` scoping silently dropped (empty or unfiltered results). Now each tag is also flattened into a boolean membership key (`belongs_to_set::<tag>=True`); the where-filter targets those (single/`$or`/`$and` preserved); `restore_data_from_chroma` strips the markers so payloads round-trip unchanged.

Assessed as **already fixed** (left untouched): `include_payload` in ChromaDB, `ChunksRetriever` filters (#2815), `top_k` propagation in `CompletionRetriever` (#2351).

## Remaining (out of scope)
`NeptuneAnalyticsAdapter` `include_payload` (#2352) needs a `VectorDBInterface` signature change.

## Tests
3 new tests in `test_chromadb_adapter_search.py` (incl. one that fails against the old key); no new `ty` errors; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optimized search and filtering capabilities with improved metadata handling for set membership queries, supporting more precise and efficient result filtering.

* **Tests**
  * Added comprehensive regression tests validating metadata transformation accuracy, filter correctness, and complete data recovery during round-trip operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->