### PR TITLE
fix(deps): drop vulnerable diskcache; JSON/SQLite session cache (#2957)

### DIFF
--- a/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
@@ -3,10 +3,10 @@ import os
 import uuid
 from datetime import datetime
 
-import diskcache as dc
 from pydantic import ValidationError
 
 from cognee.infrastructure.databases.cache.cache_db_interface import CacheDBInterface
+from cognee.infrastructure.databases.cache.fscache.json_sqlite_cache import JsonSqliteCache
 from cognee.infrastructure.databases.cache.models import SessionAgentTraceEntry, SessionQAEntry
 from cognee.infrastructure.databases.exceptions.exceptions import (
     CacheConnectionError,
@@ -30,7 +30,7 @@ class FSCacheAdapter(CacheDBInterface):
         data_root_directory = storage_config["data_root_directory"]
         self.cache_directory = os.path.join(data_root_directory, ".cognee_fs_cache", default_key)
         os.makedirs(self.cache_directory, exist_ok=True)
-        self.cache = dc.Cache(directory=self.cache_directory)
+        self.cache = JsonSqliteCache(directory=self.cache_directory)
         self.session_ttl_seconds = session_ttl_seconds
         # Evict any entries whose TTL has already elapsed
         self.cache.expire()
@@ -408,7 +408,7 @@ class FSCacheAdapter(CacheDBInterface):
     async def prune(self) -> None:
         """
         Remove all items from the cache. In Cognee, prune means emptying the cache.
-        Uses diskcache's clear() - does not delete the directory or recreate the cache.
+        Uses the store's clear() - does not delete the directory or recreate the cache.
         """
         try:
             self.cache.clear()
@@ -441,7 +441,7 @@ class FSCacheAdapter(CacheDBInterface):
         return []
 
     async def close(self):
-        """Flush diskcache expirations and close the underlying cache handle."""
+        """Flush cache expirations and close the underlying cache handle."""
         if self.cache is not None:
             self.cache.expire()
             self.cache.close()

--- a/cognee/infrastructure/databases/cache/fscache/json_sqlite_cache.py
+++ b/cognee/infrastructure/databases/cache/fscache/json_sqlite_cache.py
@@ -1,0 +1,146 @@
+"""A minimal JSON-only, SQLite-backed key/value store.
+
+This replaces the ``diskcache`` dependency for the filesystem session cache.
+``diskcache`` is flagged by the GitHub Advisory Database as GHSA-w8v5-vhqr-4h9v
+because its default serialization can fall back to ``pickle``. Cognee's
+filesystem session adapter only ever stores JSON strings, so it does not need
+DiskCache's general object-serialization surface.
+
+This store intentionally exposes the small subset of the DiskCache API that the
+``FSCacheAdapter`` relies on:
+
+- ``get(key)`` / ``set(key, value, expire=...)`` / ``delete(key)``
+- ``clear()`` / ``expire()``
+- ``transact()`` (context manager providing an atomic write boundary)
+- ``close()``
+
+Values are stored verbatim as TEXT. The adapter only ever passes JSON strings,
+so no pickling or arbitrary-object deserialization ever occurs.
+"""
+
+import os
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+
+__all__ = ["JsonSqliteCache"]
+
+_DB_FILENAME = "cache.sqlite3"
+
+
+class JsonSqliteCache:
+    """A small SQLite-backed string key/value store with TTL support.
+
+    The store keeps a single connection guarded by a re-entrant lock so that
+    ``transact()`` blocks (which the adapter uses to make read-modify-write
+    sequences atomic) execute as a single SQLite transaction.
+    """
+
+    def __init__(self, directory: str):
+        """Create (or open) a SQLite-backed cache rooted at ``directory``."""
+        self.directory = directory
+        os.makedirs(self.directory, exist_ok=True)
+        self._db_path = os.path.join(self.directory, _DB_FILENAME)
+        # check_same_thread=False so the single guarded connection can be used
+        # from any thread; concurrency is serialized by self._lock.
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS cache ("
+            "key TEXT PRIMARY KEY, "
+            "value TEXT NOT NULL, "
+            "expire_at REAL"  # absolute epoch seconds, or NULL for no expiry
+            ")"
+        )
+        self._conn.commit()
+        self._lock = threading.RLock()
+        # Depth of nested transact() contexts; only the outermost commits.
+        self._txn_depth = 0
+
+    @staticmethod
+    def _now() -> float:
+        return time.time()
+
+    def get(self, key: str):
+        """Return the stored value for ``key`` or ``None`` if absent/expired."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT value, expire_at FROM cache WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                return None
+            value, expire_at = row
+            if expire_at is not None and expire_at <= self._now():
+                self._conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+                self._maybe_commit()
+                return None
+            return value
+
+    def set(self, key: str, value, expire: float | None = None) -> None:
+        """Store ``value`` under ``key`` with an optional TTL (seconds)."""
+        expire_at = self._now() + expire if expire else None
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO cache (key, value, expire_at) VALUES (?, ?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+                "expire_at = excluded.expire_at",
+                (key, value, expire_at),
+            )
+            self._maybe_commit()
+
+    def delete(self, key: str) -> bool:
+        """Delete ``key``. Returns True if a row was removed."""
+        with self._lock:
+            cur = self._conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+            self._maybe_commit()
+            return cur.rowcount > 0
+
+    def clear(self) -> None:
+        """Remove all entries from the cache."""
+        with self._lock:
+            self._conn.execute("DELETE FROM cache")
+            self._maybe_commit()
+
+    def expire(self) -> int:
+        """Evict all entries whose TTL has elapsed. Returns the count removed."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM cache WHERE expire_at IS NOT NULL AND expire_at <= ?",
+                (self._now(),),
+            )
+            self._maybe_commit()
+            return cur.rowcount
+
+    @contextmanager
+    def transact(self):
+        """Run a block as a single atomic SQLite transaction.
+
+        Supports nesting: only the outermost ``transact()`` boundary commits or
+        rolls back, mirroring DiskCache's nestable transaction semantics.
+        """
+        with self._lock:
+            self._txn_depth += 1
+            try:
+                yield
+            except Exception:
+                if self._txn_depth == 1:
+                    self._conn.rollback()
+                raise
+            finally:
+                self._txn_depth -= 1
+            if self._txn_depth == 0:
+                self._conn.commit()
+
+    def _maybe_commit(self) -> None:
+        """Commit immediately unless inside an open ``transact()`` block."""
+        if self._txn_depth == 0:
+            self._conn.commit()
+
+    def close(self) -> None:
+        """Flush and close the underlying SQLite connection."""
+        with self._lock:
+            if self._conn is not None:
+                self._conn.commit()
+                self._conn.close()
+                self._conn = None

--- a/cognee/tests/unit/infrastructure/databases/cache/test_json_sqlite_cache.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_json_sqlite_cache.py
@@ -1,0 +1,120 @@
+"""Regression tests for the JSON-only SQLite cache store.
+
+These guard the GHSA-w8v5-vhqr-4h9v remediation (issue #2957): the filesystem
+session cache must NOT depend on ``diskcache`` (whose default serialization can
+fall back to ``pickle``). The store below only ever persists JSON strings.
+"""
+
+import importlib
+import json
+import tempfile
+
+import pytest
+
+from cognee.infrastructure.databases.cache.fscache.json_sqlite_cache import JsonSqliteCache
+
+
+@pytest.fixture
+def cache():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        inst = JsonSqliteCache(directory=tmpdir)
+        yield inst
+        inst.close()
+
+
+def test_diskcache_not_imported_by_fs_adapter():
+    """The FS cache adapter must not import the vulnerable ``diskcache`` package."""
+    adapter_module = importlib.import_module(
+        "cognee.infrastructure.databases.cache.fscache.FsCacheAdapter"
+    )
+    source = importlib.util.find_spec(adapter_module.__name__).origin
+    with open(source, "r", encoding="utf-8") as f:
+        text = f.read()
+    assert "import diskcache" not in text
+    assert "diskcache as dc" not in text
+
+
+def test_diskcache_not_a_declared_dependency():
+    """``diskcache`` must not be a declared runtime dependency in pyproject.toml."""
+    from pathlib import Path
+
+    pyproject = Path(__file__).resolve()
+    # Walk up to the repo root that contains pyproject.toml.
+    for parent in pyproject.parents:
+        candidate = parent / "pyproject.toml"
+        if candidate.exists():
+            content = candidate.read_text(encoding="utf-8")
+            break
+    else:  # pragma: no cover - defensive
+        pytest.skip("pyproject.toml not found")
+
+    # No dependency line should declare diskcache (e.g. "diskcache>=...").
+    for line in content.splitlines():
+        stripped = line.strip().strip(",").strip('"')
+        assert not stripped.startswith("diskcache"), f"diskcache still declared: {line!r}"
+
+
+def test_set_get_roundtrip(cache):
+    cache.set("k", json.dumps({"a": 1}))
+    assert json.loads(cache.get("k")) == {"a": 1}
+
+
+def test_get_missing_returns_none(cache):
+    assert cache.get("nope") is None
+
+
+def test_delete(cache):
+    cache.set("k", "v")
+    assert cache.delete("k") is True
+    assert cache.get("k") is None
+    assert cache.delete("k") is False
+
+
+def test_clear(cache):
+    cache.set("a", "1")
+    cache.set("b", "2")
+    cache.clear()
+    assert cache.get("a") is None and cache.get("b") is None
+
+
+def test_expire_evicts_elapsed_entries(cache):
+    cache.set("fresh", "1", expire=1000)
+    cache.set("stale", "1", expire=-1)  # already expired
+    removed = cache.expire()
+    assert removed == 1
+    assert cache.get("fresh") == "1"
+    assert cache.get("stale") is None
+
+
+def test_get_treats_expired_entry_as_missing(cache):
+    cache.set("k", "v", expire=-1)
+    assert cache.get("k") is None
+
+
+def test_transact_commits_on_success(cache):
+    with cache.transact():
+        cache.set("k", "v")
+    assert cache.get("k") == "v"
+
+
+def test_transact_rolls_back_on_error(cache):
+    cache.set("k", "original")
+    with pytest.raises(RuntimeError):
+        with cache.transact():
+            cache.set("k", "mutated")
+            raise RuntimeError("boom")
+    # The mutation inside the failed transaction must not persist.
+    assert cache.get("k") == "original"
+
+
+def test_persists_across_reopen():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c1 = JsonSqliteCache(directory=tmpdir)
+        c1.set("k", "v")
+        c1.close()
+
+        c2 = JsonSqliteCache(directory=tmpdir)
+        try:
+            assert c2.get("k") == "v"
+        finally:
+            c2.close()

--- a/cognee/tests/unit/test_vulnerable_dependency_bounds.py
+++ b/cognee/tests/unit/test_vulnerable_dependency_bounds.py
@@ -1,0 +1,83 @@
+"""Regression guards for previously-remediated vulnerable dependencies.
+
+These tests fail if a future change reintroduces a known-vulnerable lower bound
+or pin. They parse ``pyproject.toml`` directly so they do not depend on the deps
+being installed.
+
+Covered advisories:
+- cbor2 < 5.8.0 -> CVE-2025-68131 (issue #1950)
+- fastapi-users < 15 pinning python-multipart 0.0.20 (issue #2101)
+- diskcache pickle GHSA-w8v5-vhqr-4h9v (issue #2957) -> dependency removed
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None
+
+
+def _load_dependencies() -> list[str]:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "pyproject.toml"
+        if candidate.exists():
+            if tomllib is None:  # pragma: no cover
+                pytest.skip("tomllib unavailable")
+            data = tomllib.loads(candidate.read_text(encoding="utf-8"))
+            return list(data.get("project", {}).get("dependencies", []))
+    pytest.skip("pyproject.toml not found")
+
+
+def _find(deps: list[str], name: str) -> str | None:
+    pattern = re.compile(rf"^{re.escape(name)}\b", re.IGNORECASE)
+    for dep in deps:
+        # Strip extras, e.g. "fastapi-users[sqlalchemy]>=15.0.2".
+        base = re.sub(r"\[.*?\]", "", dep)
+        if pattern.match(base.strip()):
+            return dep
+    return None
+
+
+def _min_version(spec: str) -> tuple[int, ...]:
+    """Extract the >= lower bound from a PEP 508 spec as a version tuple."""
+    match = re.search(r">=\s*([0-9]+(?:\.[0-9]+)*)", spec)
+    assert match, f"expected a >= lower bound in {spec!r}"
+    return tuple(int(p) for p in match.group(1).split("."))
+
+
+def test_cbor2_lower_bound_not_vulnerable():
+    """cbor2 must require >= 5.8.0 (CVE-2025-68131, issue #1950)."""
+    deps = _load_dependencies()
+    spec = _find(deps, "cbor2")
+    assert spec is not None, "cbor2 dependency missing"
+    assert _min_version(spec) >= (5, 8, 0), spec
+
+
+def test_fastapi_users_lower_bound_not_vulnerable():
+    """fastapi-users must require >= 15 (issue #2101)."""
+    deps = _load_dependencies()
+    spec = _find(deps, "fastapi-users")
+    assert spec is not None, "fastapi-users dependency missing"
+    assert _min_version(spec) >= (15,), spec
+
+
+def test_python_multipart_not_pinned_to_vulnerable_version():
+    """python-multipart must not be pinned to the vulnerable 0.0.20 (issue #2101)."""
+    deps = _load_dependencies()
+    spec = _find(deps, "python-multipart")
+    if spec is None:
+        # Acceptable: not a direct dependency.
+        return
+    assert "==0.0.20" not in spec.replace(" ", ""), spec
+    assert _min_version(spec) >= (0, 0, 22), spec
+
+
+def test_diskcache_dependency_removed():
+    """diskcache (GHSA-w8v5-vhqr-4h9v) must not be a runtime dependency (issue #2957)."""
+    deps = _load_dependencies()
+    assert _find(deps, "diskcache") is None, "diskcache must be removed as a runtime dependency"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dependencies = [
     "websockets>=15.0.1,<16.0.0",
     "tenacity>=9.0.0",
     "fakeredis[lua]>=2.32.0",
-    "diskcache>=5.6.3",
     "aiolimiter>=1.2.1",
     "urllib3>=2.6.0",
     "cbor2>=5.8.0",


### PR DESCRIPTION
## Why
Recurring root cause: vulnerable transitive deps flagged by scanners (#1950 cbor2, #2101 fastapi-users/python-multipart, #2957 diskcache pickle).

## What
3 of 4 already remediated in `pyproject.toml` (cbor2 ≥5.8.0, fastapi-users ≥15, python-multipart ≥0.0.22). **diskcache (#2957) was NOT** — still a declared runtime dep and still imported in `FsCacheAdapter`, leaving an unfixable Dependabot alert (pickle deserialization, no upstream patch). Since the adapter only ever stores JSON strings, replaced diskcache with a minimal JSON-only, SQLite-backed `JsonSqliteCache` exposing the exact API the adapter used (get/set/delete/clear/expire/transact/close, TTL, nestable transactions) and removed the dependency. Behavior-preserving — all 21 existing FS-adapter CRUD tests pass unchanged.

## Tests
11 new `JsonSqliteCache` tests + 4 dependency-bound regression tests guarding all four clusters. 36 passed.

## Note
`uv.lock` still lists diskcache — intentionally not regenerated here to avoid lockfile churn; please refresh with `uv lock` (stale entry is harmless at runtime since diskcache is no longer imported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
