### PR TITLE
fix(api): correct DTO types in configuration & datasets routers

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -47,22 +47,22 @@ class DataDTO(OutDTO):
     name: str
     created_at: datetime
     updated_at: Optional[datetime] = None
-    extension: str
-    mime_type: str
-    raw_data_location: str
+    extension: Optional[str] = None
+    mime_type: Optional[str] = None
+    raw_data_location: Optional[str] = None
     dataset_id: UUID
 
 
 class GraphNodeDTO(OutDTO):
-    id: UUID
+    id: str
     label: str
     type: str
     properties: dict
 
 
 class GraphEdgeDTO(OutDTO):
-    source: UUID
-    target: UUID
+    source: str
+    target: str
     label: str
 
 

--- a/cognee/api/v1/users/routers/get_configuration_router.py
+++ b/cognee/api/v1/users/routers/get_configuration_router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from fastapi import Form, Depends
+from fastapi import Depends
 from uuid import UUID
 
 from cognee.api.DTO import InDTO
@@ -19,8 +19,8 @@ logger = get_logger()
 
 
 class StorePrincipalConfigurationPayloadDTO(InDTO):
-    name: str = (Form(..., description="Name of the configuration to store"),)
-    config: dict = (Form(..., description="The configuration data to store as a JSON object"),)
+    name: str
+    config: dict
 
 
 def get_configuration_router() -> APIRouter:

--- a/cognee/tests/unit/api/test_configuration_router_dto.py
+++ b/cognee/tests/unit/api/test_configuration_router_dto.py
@@ -1,0 +1,29 @@
+from importlib import import_module
+
+
+router_module = import_module("cognee.api.v1.users.routers.get_configuration_router")
+StorePrincipalConfigurationPayloadDTO = router_module.StorePrincipalConfigurationPayloadDTO
+
+
+def test_store_configuration_payload_fields_are_scalars():
+    """The DTO fields must be plain scalars, not 1-tuples wrapping Form()."""
+    payload = StorePrincipalConfigurationPayloadDTO(
+        name="default_llm_settings",
+        config={"temperature": 0.2},
+    )
+
+    assert payload.name == "default_llm_settings"
+    assert isinstance(payload.name, str)
+    assert payload.config == {"temperature": 0.2}
+    assert isinstance(payload.config, dict)
+
+
+def test_store_configuration_payload_field_annotations_are_scalars():
+    """Field annotations must be str/dict, never a tuple type with a Form default."""
+    fields = StorePrincipalConfigurationPayloadDTO.model_fields
+
+    assert fields["name"].annotation is str
+    assert fields["config"].annotation is dict
+    # No default value should have been baked in as a tuple.
+    assert not isinstance(fields["name"].default, tuple)
+    assert not isinstance(fields["config"].default, tuple)


### PR DESCRIPTION
## Summary

Fixes router⇄core type-consistency bugs in the configuration and datasets routers. All changes are minimal and SAFE: each DTO field is changed to a type the actual returned/ingested object already satisfies.

## Audit items implemented

- **A1 (HIGH, correctness)** — `cognee/api/v1/users/routers/get_configuration_router.py`: `StorePrincipalConfigurationPayloadDTO` declared its fields as 1-tuples wrapping `Form()` on a JSON body model (`name: str = (Form(...),)`), baking tuple-typed defaults into a `BaseModel`. Replaced with plain required scalars (`name: str`, `config: dict`), removed the trailing-comma tuples and the now-unused `Form` import. Added a unit test asserting both instantiated values and field annotations are scalars (not tuples).
  - Response model: `store_user_configuration` returns `None` (it does not return the `method_store_principal_configuration` result), and `PrincipalConfiguration` is a SQLAlchemy ORM model, not a Pydantic `BaseModel`. No response_model added (kept `response_model=None`).
- **A2 (correctness)** — `cognee/api/v1/datasets/routers/get_datasets_router.py`: `GraphNodeDTO.id` and `GraphEdgeDTO.source`/`target` were typed `UUID`, but `get_formatted_graph_data` `str()`-encodes node/edge ids that are not guaranteed to be UUIDs → `ValidationError` on real data. Changed those three fields to `str`.
- **A3 (correctness)** — same file: `DataDTO.extension`/`mime_type`/`raw_data_location` were required `str`, but the `Data` ORM columns are nullable → serialization 500s. Made them `Optional[str] = None`.

## Response models (item C)

The datasets GET/list endpoints already carry concrete, satisfied response models, so no backfill was needed:
- `GET /` → `list[DatasetDTO]`
- `POST /` → `DatasetDTO`
- `GET /{dataset_id}/graph` → `GraphDTO` (now correct after A2)
- `GET /{dataset_id}/data` → `list[DataDTO]` (now correct after A3)
- `GET /status` → typed union of `PipelineRunStatus` maps

## Deferred

- `GET /{dataset_id}/schema` and `PUT /{dataset_id}/schema` (`response_model=dict`): the returned shape matches `DatasetSchemaPayloadDTO`, but that is an `InDTO` with a camelCase alias generator. Reusing it as a response_model would change the serialized key casing (snake_case → camelCase) and the `PUT` endpoint returns `{"status": "ok"}`, a different shape entirely. Skipped to avoid altering the existing response contract.
- `GET /get_user_configuration/{config_id}` (`response_model=dict`) and `GET /get_user_configuration/` (`response_model=list`): core methods return a raw `configuration` dict / list of `to_json()` dicts with no fixed schema. No safe concrete model to assert. Skipped.
- `GET /{dataset_id}/data/{data_id}/raw`: `FileResponse`/`StreamingResponse` binary download, not JSON. Not applicable.

## Verification

- `pytest cognee/tests/unit/api` (excluding the pre-existing broken `test_get_schema_router.py` collection error and two pre-existing `test_get_schema_inventory.py` failures, all present on `origin/dev` and unrelated to this change): 188 passed. New A1 DTO test passes.
- `python -c "import cognee.api.client"`: app wires up.
- `ruff format` + `ruff check` on changed files: clean.
- `ty check` on changed files: 20 errors vs 22 on `origin/dev` for the same files — this change REMOVES the two `tuple[Any]` errors from the A1 bug and adds ZERO new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset API responses now include additional metadata fields: file extension, MIME type, raw data location, and dataset identifiers.
  * Graph node and edge identifiers in API responses are now returned as strings.

* **Refactor**
  * Simplified configuration payload request handling.

* **Tests**
  * Added unit tests for configuration payload field validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->