### PR TITLE
fix(api): type-consistent response_models for retrieval endpoints

### DIFF
--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -1,9 +1,8 @@
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Optional, Union
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
-from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import Field
 
@@ -13,7 +12,7 @@ from cognee.api.v1.recall.recall import RecallResponse
 from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
 from cognee.modules.search.operations import get_history
-from cognee.modules.search.types import SearchResult, SearchType
+from cognee.modules.search.types import SearchType
 from cognee.modules.users.exceptions.exceptions import PermissionDeniedError, UserNotFoundError
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
@@ -23,10 +22,10 @@ from cognee.shared.utils import send_telemetry
 
 
 class RecallPayloadDTO(InDTO):
-    # Default preserved as GRAPH_COMPLETION for backward compatibility
-    # with existing HTTP clients. Pass ``search_type: null`` explicitly
-    # to opt into auto-routing (the new ``cognee.recall`` default).
-    search_type: Optional[SearchType] = Field(default=SearchType.GRAPH_COMPLETION)
+    # Default ``None`` so the core ``cognee.recall`` auto-router picks the
+    # best search strategy for the query. Pass an explicit ``search_type``
+    # to bypass auto-routing and force a specific strategy.
+    search_type: Optional[SearchType] = Field(default=None)
     datasets: Optional[list[str]] = Field(default=None)
     dataset_ids: Optional[list[UUID]] = Field(default=None, examples=[[]])
     query: str = Field(default="What is in the document?")
@@ -129,7 +128,7 @@ def get_recall_router() -> APIRouter:
                 session_id=payload.session_id,
                 scope=payload.scope,
             )
-            return jsonable_encoder(results)
+            return results
         except (DatabaseNotCreatedError, UserNotFoundError, CogneeValidationError) as e:
             logger = get_logger()
             logger.error("Recall prerequisites error: %s", e, exc_info=True)

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -2,10 +2,9 @@ import json
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
-from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from fastapi import Form, File, UploadFile as UF, Depends
-from typing import List, Optional, Union, Literal, Annotated
+from typing import Any, Dict, List, Optional, Union, Literal, Annotated
 from pydantic import BaseModel, Field, WithJsonSchema
 
 from cognee.memory import QAEntry, TraceEntry, FeedbackEntry, SkillRunEntry
@@ -23,10 +22,32 @@ logger = get_logger()
 UploadFile = Annotated[UF, WithJsonSchema({"type": "string", "format": "binary"})]
 
 
+class RememberResultDTO(BaseModel):
+    """Response body for the remember endpoints.
+
+    Mirrors ``cognee.api.v1.remember.remember.RememberResult.to_dict()``.
+    All fields except ``status`` and ``dataset_name`` are optional because
+    ``to_dict()`` only includes them when populated.
+    """
+
+    status: str
+    dataset_name: str
+    dataset_id: Optional[str] = None
+    pipeline_run_id: Optional[str] = None
+    items_processed: int = 0
+    elapsed_seconds: Optional[float] = None
+    session_ids: Optional[List[str]] = None
+    content_hash: Optional[str] = None
+    items: Optional[List[Dict[str, Any]]] = None
+    entry_type: Optional[str] = None
+    entry_id: Optional[str] = None
+    error: Optional[str] = None
+
+
 def get_remember_router() -> APIRouter:
     router = APIRouter()
 
-    @router.post("", response_model=dict)
+    @router.post("", response_model=RememberResultDTO)
     @log_usage(function_name="POST /v1/remember", log_type="api_endpoint")
     async def remember(
         data: List[UploadFile] = File(default=None),
@@ -36,7 +57,7 @@ def get_remember_router() -> APIRouter:
         node_set: Optional[List[str]] = Form(default=[""], example=[""]),
         run_in_background: Optional[bool] = Form(default=False),
         custom_prompt: Optional[str] = Form(default=""),
-        chunk_size: Optional[int] = Form(default=4096),
+        chunk_size: Optional[int] = Form(default=None),
         chunks_per_batch: Optional[int] = Form(default=36),
         ontology_key: Optional[List[str]] = Form(
             default=None,
@@ -139,7 +160,7 @@ def get_remember_router() -> APIRouter:
                 **({"graph_model": graph_model_parsed} if graph_model_parsed else {}),
             )
 
-            return jsonable_encoder(result.to_dict())
+            return RememberResultDTO(**result.to_dict())
         except ValueError as error:
             logger.error("Remember endpoint validation error: %s", error, exc_info=True)
             return JSONResponse(
@@ -169,7 +190,7 @@ def get_remember_router() -> APIRouter:
         session_id: Optional[str] = None
         skill_improvement: Optional[dict] = None
 
-    @router.post("/entry", response_model=dict)
+    @router.post("/entry", response_model=RememberResultDTO)
     @log_usage(function_name="POST /v1/remember/entry", log_type="api_endpoint")
     async def remember_entry(
         payload: RememberEntryRequest,
@@ -208,7 +229,7 @@ def get_remember_router() -> APIRouter:
                 user=user,
                 skill_improvement=payload.skill_improvement,
             )
-            return jsonable_encoder(result.to_dict())
+            return RememberResultDTO(**result.to_dict())
         except ValueError as error:
             # Known validation errors: missing session_id, user not found, etc.
             return JSONResponse(status_code=400, content={"error": str(error)})

--- a/cognee/api/v1/responses/models.py
+++ b/cognee/api/v1/responses/models.py
@@ -70,7 +70,6 @@ class ResponseRequest(InDTO):
     tool_choice: Optional[Union[str, Dict[str, Any]]] = "auto"
     user: Optional[str] = None
     temperature: Optional[float] = 1.0
-    max_completion_tokens: Optional[int] = None
 
 
 class ToolCallOutput(BaseModel):

--- a/cognee/api/v1/responses/routers/get_responses_router.py
+++ b/cognee/api/v1/responses/routers/get_responses_router.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Any
 import openai
 from fastapi import APIRouter, Depends
 from cognee.api.v1.responses.models import (
+    CogneeModel,
     ResponseRequest,
     ResponseBody,
     ResponseToolCall,
@@ -35,6 +36,16 @@ def get_responses_router() -> APIRouter:
     router = APIRouter()
     logger = logging.getLogger(__name__)
 
+    # Maps the public CogneeModel enum to the concrete backing model string
+    # forwarded to the OpenAI SDK.
+    _MODEL_MAP = {
+        CogneeModel.COGNEEV1: "gpt-4o",
+    }
+
+    def _resolve_model(model: CogneeModel) -> str:
+        """Resolve a CogneeModel enum to a concrete backing model string."""
+        return _MODEL_MAP.get(model, "gpt-4o")
+
     def _get_model_client():
         """
         Get appropriate client based on model name
@@ -51,11 +62,10 @@ def get_responses_router() -> APIRouter:
     ) -> Dict[str, Any]:
         """
         Call appropriate model API based on model name
+
+        ``model`` is the concrete backing model string already resolved from
+        the CogneeModel enum by the caller via ``_resolve_model``.
         """
-
-        # TODO: Support other models (e.g. cognee-v1-openai-gpt-3.5-turbo, etc.)
-        model = "gpt-4o"
-
         client = _get_model_client()
 
         logger.debug(f"Using model: {model}")
@@ -100,13 +110,18 @@ def get_responses_router() -> APIRouter:
         - Supports function calling with Cognee tools
         - Uses default tools if none provided
         """
-        # Use default tools if none provided
-        tools = request.tools or DEFAULT_TOOLS
+        # Use default tools if none provided. ``request.tools`` is a list of
+        # ``ToolFunction`` Pydantic models; the OpenAI SDK expects plain dicts,
+        # so convert at the call site. ``DEFAULT_TOOLS`` is already dict-shaped.
+        tools = [t.model_dump() for t in request.tools] if request.tools else DEFAULT_TOOLS
+
+        # Map the CogneeModel enum to a concrete backing model string.
+        model = _resolve_model(request.model)
 
         # Call the API
         response = await call_openai_api_for_model(
             input_text=request.input,
-            model=request.model,
+            model=model,
             tools=tools,
             tool_choice=request.tool_choice,
             temperature=request.temperature,

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -1,9 +1,8 @@
 from datetime import datetime
-from typing import Any, List, Optional, Union
+from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
-from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import Field
 
@@ -95,7 +94,7 @@ def get_search_router() -> APIRouter:
 
     @router.post(
         "",
-        response_model=Union[List[SearchResult], List],
+        response_model=List[SearchResult],
         responses={
             403: {"model": ErrorResponse},
             422: {"model": ErrorResponse},
@@ -175,7 +174,7 @@ def get_search_router() -> APIRouter:
                 max_iter=payload.max_iter,
             )
 
-            return jsonable_encoder(results)
+            return results
         except PermissionDeniedError as e:
             return JSONResponse(
                 status_code=status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
## Summary

Backfills concrete `response_model`s and fixes router→core forwarding bugs across the **search**, **recall**, **remember**, and **responses** routers so the HTTP contract matches the core function return types. All typed objects are returned directly and redundant `jsonable_encoder(...)` calls of typed values are removed.

## Audit items implemented

### C — response_model backfill / typed returns
- **search** `POST /search`: `response_model` narrowed `Union[List[SearchResult], List]` → `List[SearchResult]`; returns the typed list directly (core `cognee.api.v1.search.search` returns `List[SearchResult]`), `jsonable_encoder` removed.
- **recall** `POST /recall`: keeps `list[RecallResponse]` (discriminated union on `source`); returns the typed list directly (core `recall()` returns `list[RecallResponse]`), `jsonable_encoder` removed.
- **remember** `POST /remember` and `POST /remember/entry`: `response_model` `dict` → new `RememberResultDTO`. The core `RememberResult` is a **plain Python class** (not a `BaseModel` or `dataclass`) exposing `to_dict()`, so a DTO mirroring `to_dict()`'s shape was added in the router package and built via `RememberResultDTO(**result.to_dict())`; `jsonable_encoder` removed.

### B1 — behavioral (remember)
- `chunk_size` form default `4096` → `None`, so the core's `None → auto model-based sizing` is honored.

### B3 — behavioral (recall)
- `search_type` default `GRAPH_COMPLETION` → `None`, so the core `recall()` auto-router selects the strategy.

### A5 — correctness (responses)
- `request.tools` is `List[ToolFunction]` (Pydantic models) and was forwarded to the OpenAI SDK without conversion; now converted via `[t.model_dump() for t in request.tools]` at the call site (`DEFAULT_TOOLS` is already dict-shaped).
- The `model` enum is now honored: added `_resolve_model` mapping `CogneeModel → concrete backing model string`, and the call helper no longer hard-overrides the passed model.
- Removed the unused/unhonored `max_completion_tokens` field from `ResponseRequest` (it was never forwarded to the SDK).

## Endpoints that got a response_model
- `POST /search` → `List[SearchResult]`
- `POST /recall` → `list[RecallResponse]` (already declared; now returns typed objects directly)
- `POST /remember` → `RememberResultDTO`
- `POST /remember/entry` → `RememberResultDTO`

## Deferred
- None for the listed routers. (The `GET /search` and `GET /recall` history endpoints already had concrete `response_model`s and were left unchanged.)

## Verification
- `pytest cognee/tests/unit/api` (excluding the pre-existing broken `test_get_schema_router.py` import and 2 pre-existing `test_get_schema_inventory.py` failures, both present on `origin/dev`): **186 passed**.
- Area test `cognee/tests/unit/api/test_api_error_responses.py`: **20 passed**.
- `python -c "import cognee.api.client"` wires up cleanly.
- `ruff format` + `ruff check` clean on all changed files.
- `ty check` on changed files: **zero new errors** vs `origin/dev` (18 vs 19 baseline; the enum→str mismatch in the responses router was actually fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-routing support in the recall endpoint for intelligent search strategy selection.
  * Enhanced model resolution for improved OpenAI API compatibility.

* **Improvements**
  * Strengthened type safety across remember and search endpoints.
  * Refined tool handling in responses endpoint.
  * Updated default parameters (chunk_size, search_type) for greater flexibility.
  * Removed unused `max_completion_tokens` field from responses request model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->