### PR TITLE
fix(api): backfill response_model on agents + sessions routers

### DIFF
--- a/cognee/api/v1/agents/routers/get_agents_router.py
+++ b/cognee/api/v1/agents/routers/get_agents_router.py
@@ -3,7 +3,13 @@ from uuid import UUID
 
 from cognee.api.DTO import OutDTO
 from cognee.modules.agents.agent_mode import register_agent, unregister_agent
-from cognee.modules.agents.models import RegisterAgentRequest, UnregisterAgentRequest
+from cognee.modules.agents.models import (
+    AgentConnection,
+    AgentDetailResponse,
+    AgentsListResponse,
+    RegisterAgentRequest,
+    UnregisterAgentRequest,
+)
 from cognee.modules.agents.create_agent import create_agent
 from cognee.modules.agents.get_agent import get_agent
 from cognee.modules.agents.list_agents import list_agents
@@ -15,7 +21,6 @@ from cognee.modules.agents.operations import (
 from cognee.modules.users.methods.get_authenticated_user import get_authenticated_user
 from cognee.modules.users.models.User import User
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.encoders import jsonable_encoder
 from fastapi_users.exceptions import UserAlreadyExists
 
 RangeLiteral = Literal["24h", "7d", "30d", "all"]
@@ -90,7 +95,7 @@ def get_agents_router() -> APIRouter:
     # Agent connections (fixed paths)
     # ------------------------------------------------------------------ #
 
-    @router.get("/connections", tags=[CONNECTIONS_TAG])
+    @router.get("/connections", tags=[CONNECTIONS_TAG], response_model=AgentsListResponse)
     async def list_agents_connections(
         agent_id: Optional[UUID] = Query(
             None,
@@ -118,9 +123,9 @@ def get_agents_router() -> APIRouter:
             limit=limit,
             offset=offset,
         )
-        return jsonable_encoder(response)
+        return response
 
-    @router.get("/connections/me", tags=[CONNECTIONS_TAG])
+    @router.get("/connections/me", tags=[CONNECTIONS_TAG], response_model=AgentDetailResponse)
     async def get_my_connection_detail(
         agent_session_name: Optional[str] = Query(
             None,
@@ -136,9 +141,11 @@ def get_agents_router() -> APIRouter:
         )
         if response is None:
             raise HTTPException(status_code=404, detail="connection not found")
-        return jsonable_encoder(response)
+        return response
 
-    @router.get("/connections/{agent_id}", tags=[CONNECTIONS_TAG])
+    @router.get(
+        "/connections/{agent_id}", tags=[CONNECTIONS_TAG], response_model=AgentDetailResponse
+    )
     async def get_connection_detail(
         agent_id: UUID,
         agent_session_name: Optional[str] = Query(
@@ -154,15 +161,20 @@ def get_agents_router() -> APIRouter:
         )
         if response is None:
             raise HTTPException(status_code=404, detail="connection not found")
-        return jsonable_encoder(response)
+        return response
 
-    @router.post("/register", status_code=status.HTTP_201_CREATED, tags=[CONNECTIONS_TAG])
+    @router.post(
+        "/register",
+        status_code=status.HTTP_201_CREATED,
+        tags=[CONNECTIONS_TAG],
+        response_model=AgentConnection,
+    )
     async def register_agent_endpoint(
         request: RegisterAgentRequest,
         user: User = Depends(get_authenticated_user),
     ):
         connection = await register_agent(user, request)
-        return jsonable_encoder(connection)
+        return connection
 
     @router.post("/unregister", tags=[CONNECTIONS_TAG])
     async def unregister_agent_endpoint(

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -12,6 +12,7 @@ from uuid import UUID as UUIDType
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, or_, select
 
 from cognee.infrastructure.databases.relational import get_relational_engine
@@ -34,6 +35,73 @@ logger = get_logger("sessions_api")
 
 
 _RangeLiteral = Literal["24h", "7d", "30d", "all"]
+
+
+# --------------------------------------------------------------------------- #
+# Response models
+#
+# These mirror the existing JSON contract exactly (snake_case keys). They use
+# a plain ``BaseModel`` (NOT ``OutDTO``) so field names serialize as-is rather
+# than being camelCased by ``OutDTO``'s alias generator.
+# --------------------------------------------------------------------------- #
+
+
+class SessionRowResponse(BaseModel):
+    """A session list/detail row — mirrors ``SessionRecord.to_dict()`` plus
+    the read-time computed ``effective_status``."""
+
+    session_id: str
+    user_id: str
+    dataset_id: Optional[str] = None
+    status: str
+    started_at: Optional[str] = None
+    last_activity_at: Optional[str] = None
+    ended_at: Optional[str] = None
+    tokens_in: int
+    tokens_out: int
+    cost_usd: float
+    error_count: int
+    last_model: Optional[str] = None
+    effective_status: str
+
+
+class SessionListResponse(BaseModel):
+    """Paginated envelope returned by ``GET /api/v1/sessions``."""
+
+    sessions: list[SessionRowResponse] = Field(default_factory=list)
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class SessionStatsResponse(BaseModel):
+    """Aggregate counters returned by ``GET /api/v1/sessions/stats``."""
+
+    range: _RangeLiteral
+    sessions: int
+    total_spend_usd: float
+    avg_spend_per_session_usd: float
+    tokens_in: int
+    tokens_out: int
+    tokens_total: int
+    agent_time_s: float
+    avg_session_s: float
+    success_rate: float
+    completed: int
+    failed: int
+    abandoned: int
+    running: int
+
+
+class CostByModelRow(BaseModel):
+    """One row of ``GET /api/v1/sessions/cost-by-model``."""
+
+    model: str
+    session_count: int
+    cost_usd: float
+    tokens_in: int
+    tokens_out: int
 
 
 def _range_since(range_key: _RangeLiteral) -> Optional[datetime]:
@@ -80,7 +148,7 @@ async def _visible_user_ids(user: User) -> list[UUIDType]:
 def get_sessions_router() -> APIRouter:
     router = APIRouter()
 
-    @router.get("")
+    @router.get("", response_model=SessionListResponse)
     async def list_sessions(
         range: _RangeLiteral = Query("30d"),
         status: Optional[str] = Query(None),
@@ -116,20 +184,18 @@ def get_sessions_router() -> APIRouter:
                 order_by=order_by,
                 descending=descending,
             )
-            return jsonable_encoder(
-                {
-                    "sessions": [r.to_dict() for r in page.sessions],
-                    "total": page.total,
-                    "limit": page.limit,
-                    "offset": page.offset,
-                    "has_more": page.has_more,
-                }
+            return SessionListResponse(
+                sessions=[SessionRowResponse(**r.to_dict()) for r in page.sessions],
+                total=page.total,
+                limit=page.limit,
+                offset=page.offset,
+                has_more=page.has_more,
             )
         except Exception as exc:
             logger.error("list_sessions failed: %s", exc, exc_info=True)
             return JSONResponse(status_code=500, content={"error": "list failed"})
 
-    @router.get("/stats")
+    @router.get("/stats", response_model=SessionStatsResponse)
     async def get_stats(
         range: _RangeLiteral = Query("30d"),
         user: User = Depends(get_authenticated_user),
@@ -197,26 +263,24 @@ def get_sessions_router() -> APIRouter:
         sessions_count = totals.sessions or 0
         avg_spend = (totals.cost_usd / sessions_count) if sessions_count else 0.0
 
-        return jsonable_encoder(
-            {
-                "range": range,
-                "sessions": sessions_count,
-                "total_spend_usd": float(totals.cost_usd or 0.0),
-                "avg_spend_per_session_usd": float(avg_spend),
-                "tokens_in": int(totals.tokens_in or 0),
-                "tokens_out": int(totals.tokens_out or 0),
-                "tokens_total": int((totals.tokens_in or 0) + (totals.tokens_out or 0)),
-                "agent_time_s": float(total_seconds),
-                "avg_session_s": float(avg_seconds),
-                "success_rate": float(success_rate),
-                "completed": int(completed),
-                "failed": int(failed),
-                "abandoned": int(abandoned),
-                "running": int(running),
-            }
+        return SessionStatsResponse(
+            range=range,
+            sessions=sessions_count,
+            total_spend_usd=float(totals.cost_usd or 0.0),
+            avg_spend_per_session_usd=float(avg_spend),
+            tokens_in=int(totals.tokens_in or 0),
+            tokens_out=int(totals.tokens_out or 0),
+            tokens_total=int((totals.tokens_in or 0) + (totals.tokens_out or 0)),
+            agent_time_s=float(total_seconds),
+            avg_session_s=float(avg_seconds),
+            success_rate=float(success_rate),
+            completed=int(completed),
+            failed=int(failed),
+            abandoned=int(abandoned),
+            running=int(running),
         )
 
-    @router.get("/cost-by-model")
+    @router.get("/cost-by-model", response_model=list[CostByModelRow])
     async def cost_by_model(
         range: _RangeLiteral = Query("30d"),
         user: User = Depends(get_authenticated_user),
@@ -260,18 +324,16 @@ def get_sessions_router() -> APIRouter:
 
             rows = (await session.execute(stmt)).all()
 
-        return jsonable_encoder(
-            [
-                {
-                    "model": row.model or "unknown",
-                    "session_count": int(row.session_count),
-                    "cost_usd": float(row.cost_usd or 0.0),
-                    "tokens_in": int(row.tokens_in or 0),
-                    "tokens_out": int(row.tokens_out or 0),
-                }
-                for row in rows
-            ]
-        )
+        return [
+            CostByModelRow(
+                model=row.model or "unknown",
+                session_count=int(row.session_count),
+                cost_usd=float(row.cost_usd or 0.0),
+                tokens_in=int(row.tokens_in or 0),
+                tokens_out=int(row.tokens_out or 0),
+            )
+            for row in rows
+        ]
 
     @router.get("/{session_id}")
     async def get_session_detail(


### PR DESCRIPTION
## What & why

Audit item **C** for the **agents** and **sessions** routers: backfill
`response_model` from each endpoint's actual core return type, return the
typed object directly, and remove `jsonable_encoder(...)` of already-typed
values. This makes the OpenAPI schema and response serialization accurate
without changing the wire contract.

## Audit items implemented

- **C** — agents router (`get_agents_router.py`)
- **C** — sessions router (`get_sessions_router.py`)

## Endpoints that got a `response_model`

**agents** (reuse existing core `BaseModel`s from `cognee.modules.agents.models`):
- `GET /connections` → `AgentsListResponse` (core `list_agent_connections`)
- `GET /connections/me` → `AgentDetailResponse` (core `get_agent_connection_detail`)
- `GET /connections/{agent_id}` → `AgentDetailResponse`
- `POST /register` → `AgentConnection` (core `register_agent`)

Dropped the now-unused `jsonable_encoder` import. The other agents
endpoints (`/list`, `/create`, `/{agent_id}`, `/unregister`, `DELETE
/{agent_id}`) already declared concrete return-type hints and were
unchanged.

**sessions** (`get_sessions_router.py`) — self-contained handlers, typed
from the exact dict shapes they already return. New DTOs are **plain
`BaseModel`s (not `OutDTO`)** so field names stay snake_case and the
existing JSON contract is preserved:
- `GET /` → `SessionListResponse` (rows = `SessionRowResponse`, mirrors `SessionRecord.to_dict()` + `effective_status`)
- `GET /stats` → `SessionStatsResponse`
- `GET /cost-by-model` → `list[CostByModelRow]`

The 500 fallback in `GET /` still returns an explicit `JSONResponse`
(bypasses response_model validation, as intended).

## Deferred

- `GET /sessions/{session_id}` — the response merges the session record
  with `qas` / `traces` pulled straight from the session cache. Those
  entries are arbitrary (raw dicts **or** `SessionQAEntry` Pydantic
  objects), so a `response_model` would risk dropping fields or raising a
  `ValidationError`. Left as `jsonable_encoder(record)` until a verified
  shape exists.

## Verification

- `python -c "import cognee.api.client"` — app wires up.
- `pytest cognee/tests/unit/api` — 186 passed (the only failures,
  `test_get_schema_router` collection + 2 in `test_get_schema_inventory`,
  reproduce identically on a clean `origin/dev` and are unrelated).
- `pytest cognee/tests/unit/api/v1/session cognee/tests/unit/api/v1/agents cognee/tests/unit/modules/agents` — 50 passed.
- `ruff format` + `ruff check` clean on both files.
- `ty check` — 12 diagnostics, identical before/after (all pre-existing
  SQLAlchemy `Column[Unknown]` argument typings); **zero new ty errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API response consistency across agent connection and session endpoints with structured response models
  * Enhanced clarity of session data retrieval, statistics aggregation, and cost-by-model reporting through refined API response formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->