### PR TITLE
fix(api): notebook validation correctness + router response_model backfills

### DIFF
--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -4,9 +4,10 @@ Exposes pipeline run history and in-memory OTEL spans so the frontend
 can render an activity timeline and trace viewer.
 """
 
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 from fastapi import APIRouter, Query, Depends
+from pydantic import BaseModel
 from cognee.modules.users.models import User
 from cognee.modules.users.methods.get_authenticated_user import get_authenticated_user
 from cognee.modules.users.exceptions import PermissionDeniedError
@@ -15,10 +16,24 @@ from cognee.modules.users.permissions.methods.get_specific_user_permission_datas
 )
 
 
+class PipelineRunActivity(BaseModel):
+    """A single pipeline run with dataset owner info for agent attribution."""
+
+    id: str
+    pipeline_name: Optional[str] = None
+    status: Optional[str] = None
+    dataset_id: Optional[str] = None
+    dataset_name: Optional[str] = None
+    owner_id: Optional[str] = None
+    owner_email: Optional[str] = None
+    created_at: Optional[str] = None
+    pipeline_run_id: Optional[str] = None
+
+
 def get_activity_router() -> APIRouter:
     router = APIRouter()
 
-    @router.get("/pipeline-runs")
+    @router.get("/pipeline-runs", response_model=List[PipelineRunActivity])
     async def get_pipeline_runs(
         dataset_id: Optional[UUID] = Query(None), user: User = Depends(get_authenticated_user)
     ):

--- a/cognee/api/v1/notebooks/routers/get_notebooks_router.py
+++ b/cognee/api/v1/notebooks/routers/get_notebooks_router.py
@@ -22,8 +22,14 @@ from cognee.modules.notebooks.methods import (
 
 
 class NotebookData(InDTO):
-    name: Optional[str] = Field(...)
+    name: str = Field(..., min_length=1)
     cells: Optional[List[NotebookCell]] = Field(default=[])
+    deletable: bool = Field(default=True)
+
+
+class NotebookUpdateData(InDTO):
+    name: Optional[str] = Field(default=None, min_length=1)
+    cells: Optional[List[NotebookCell]] = Field(default=None)
 
 
 def get_notebooks_router():
@@ -39,12 +45,14 @@ def get_notebooks_router():
         notebook_data: NotebookData, user: User = Depends(get_authenticated_user)
     ):
         return await create_notebook(
-            user.id, notebook_data.name, notebook_data.cells, deletable=True
+            user.id, notebook_data.name, notebook_data.cells, deletable=notebook_data.deletable
         )
 
     @router.put("/{notebook_id}")
     async def update_notebook_endpoint(
-        notebook_id: UUID, notebook_data: NotebookData, user: User = Depends(get_authenticated_user)
+        notebook_id: UUID,
+        notebook_data: NotebookUpdateData,
+        user: User = Depends(get_authenticated_user),
     ):
         async with get_async_session(auto_commit=True) as session:
             notebook: Notebook = await get_notebook(notebook_id, user.id, session)
@@ -55,7 +63,7 @@ def get_notebooks_router():
             if notebook_data.name and notebook_data.name != notebook.name:
                 notebook.name = notebook_data.name
 
-            if notebook_data.cells:
+            if notebook_data.cells is not None:
                 notebook.cells = notebook_data.cells
 
             return await update_notebook(notebook, session)

--- a/cognee/api/v1/ontologies/routers/get_ontology_router.py
+++ b/cognee/api/v1/ontologies/routers/get_ontology_router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, File, Form, UploadFile, Depends, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 from typing import Optional, List
 
 from cognee.modules.users.models import User
@@ -9,11 +10,34 @@ from cognee import __version__ as cognee_version
 from ..ontologies import OntologyService
 
 
+class UploadedOntology(BaseModel):
+    """Metadata for a single uploaded ontology (mirrors OntologyMetadata)."""
+
+    ontology_key: str
+    filename: str
+    size_bytes: int
+    uploaded_at: str
+    description: Optional[str] = None
+
+
+class UploadOntologyResponse(BaseModel):
+    """Response model for the ontology upload endpoint."""
+
+    uploaded_ontologies: List[UploadedOntology]
+
+
+class DeleteOntologyResponse(BaseModel):
+    """Response model for the ontology delete endpoint."""
+
+    status: str
+    ontology_key: str
+
+
 def get_ontology_router() -> APIRouter:
     router = APIRouter()
     ontology_service = OntologyService()
 
-    @router.post("", response_model=dict)
+    @router.post("", response_model=UploadOntologyResponse)
     async def upload_ontology(
         request: Request,
         ontology_key: str = Form(...),
@@ -64,23 +88,23 @@ def get_ontology_router() -> APIRouter:
                 description=description,
             )
 
-            return {
-                "uploaded_ontologies": [
-                    {
-                        "ontology_key": result.ontology_key,
-                        "filename": result.filename,
-                        "size_bytes": result.size_bytes,
-                        "uploaded_at": result.uploaded_at,
-                        "description": result.description,
-                    }
+            return UploadOntologyResponse(
+                uploaded_ontologies=[
+                    UploadedOntology(
+                        ontology_key=result.ontology_key,
+                        filename=result.filename,
+                        size_bytes=result.size_bytes,
+                        uploaded_at=result.uploaded_at,
+                        description=result.description,
+                    )
                 ]
-            }
+            )
         except ValueError as e:
             return JSONResponse(status_code=400, content={"error": str(e)})
         except Exception as e:
             return JSONResponse(status_code=500, content={"error": str(e)})
 
-    @router.delete("/{ontology_key}", response_model=dict)
+    @router.delete("/{ontology_key}", response_model=DeleteOntologyResponse)
     async def delete_ontology(
         ontology_key: str,
         user: User = Depends(get_authenticated_user),
@@ -106,7 +130,7 @@ def get_ontology_router() -> APIRouter:
 
         try:
             ontology_service.delete_ontology(ontology_key=ontology_key, user=user)
-            return {"status": "success", "ontology_key": ontology_key}
+            return DeleteOntologyResponse(status="success", ontology_key=ontology_key)
         except ValueError as e:
             return JSONResponse(status_code=400, content={"error": str(e)})
         except Exception as e:

--- a/cognee/api/v1/sync/routers/get_sync_router.py
+++ b/cognee/api/v1/sync/routers/get_sync_router.py
@@ -26,7 +26,7 @@ class SyncRequest(InDTO):
 def get_sync_router() -> APIRouter:
     router = APIRouter()
 
-    @router.post("", response_model=dict[str, SyncResponse])
+    @router.post("", response_model=SyncResponse)
     async def sync_to_cloud(
         request: SyncRequest,
         user: User = Depends(get_authenticated_user),

--- a/cognee/modules/notebooks/methods/create_notebook.py
+++ b/cognee/modules/notebooks/methods/create_notebook.py
@@ -16,7 +16,10 @@ async def create_notebook(
     session: AsyncSession,
 ) -> Notebook:
     notebook = Notebook(
-        name=notebook_name, owner_id=user_id, cells=cells, deletable=deletable or True
+        name=notebook_name,
+        owner_id=user_id,
+        cells=cells,
+        deletable=True if deletable is None else deletable,
     )
 
     session.add(notebook)


### PR DESCRIPTION
## Summary

FastAPI router⇄core type-consistency fixes for the notebooks, sync, ontologies, and activity routers.

## Audit items implemented

### A4 (HIGH, correctness) — notebooks
- `get_notebooks_router.py`: `NotebookData.name` changed from `Optional[str] = Field(...)` to required non-empty `str` (`min_length=1`). Previously a null/empty name passed validation but the DB column `notebooks.name` is `nullable=False`, producing a DB integrity error (500) instead of a clean 422.
- Added `deletable: bool = Field(default=True)` to `NotebookData`; the create endpoint now passes `deletable=notebook_data.deletable` instead of hardcoding `deletable=True`, so `deletable=False` is settable.
- `create_notebook.py`: replaced `deletable or True` (which coerced `False` → `True`) with `True if deletable is None else deletable`.
- PUT endpoint split out to a new `NotebookUpdateData` model with all-optional fields, so partial updates don't force a name to be present; `cells` is now applied on `is not None` (allows clearing to `[]`).

### A-related — sync
- `get_sync_router.py`: `POST /sync` `response_model` changed from `dict[str, SyncResponse]` to `SyncResponse` to match the single `SyncResponse` the handler returns (core `sync()` returns `SyncResponse`, `cognee/api/v1/sync/sync.py:86`).

### C — response_model backfills
Each endpoint now returns a concrete Pydantic object directly (no `jsonable_encoder` of typed objects).

| Endpoint | response_model |
|----------|----------------|
| `POST /api/v1/ontologies` | `UploadOntologyResponse` (wraps `List[UploadedOntology]`) |
| `DELETE /api/v1/ontologies/{ontology_key}` | `DeleteOntologyResponse` |
| `GET /api/v1/activity/pipeline-runs` | `List[PipelineRunActivity]` |
| `POST /api/v1/sync` | `SyncResponse` |

New DTOs live in their router modules; `SyncResponse` reuses the existing core `BaseModel`.

## Deferred (raw / ambiguous shapes — not safe to type without risking ValidationError)
- **notebooks** `GET ""`, `POST ""`, `PUT /{id}` — return raw ORM `Notebook` rows (SQLAlchemy model, not a BaseModel).
- **ontologies** `GET ""` (list) — returns the raw metadata dict loaded from a per-user JSON file; shape is user-data-driven. Left as `response_model=dict`.
- **activity** `/spans`, `/users`, `/agents` — handlers have `except` branches returning a different `{"error": ...}` / `[]` shape, so a single response_model can't safely cover them.
- **activity** `/export/{dataset_id}` — returns a `text/markdown` `Response`, not JSON.

## Verification
- `pytest cognee/tests/unit/api` (excluding pre-existing-broken `test_get_schema_router.py` and the 2 pre-existing `test_get_schema_inventory.py` failures, both failing identically on origin/dev): 186 passed.
- Notebook + ontology module tests: 73 passed.
- `import cognee.api.client` wires up cleanly.
- `ruff format` + `ruff check`: clean.
- `ty check` on changed files: 15 diagnostics, identical to the origin/dev baseline for the same files — zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected notebook creation logic to properly respect deletion flag settings.

* **API Improvements**
  * Formalized response schemas for activity, notebook, and ontology endpoints for improved consistency.
  * Enhanced notebook name validation with minimum length requirements.
  * Improved notebook updates to support empty cell lists.
  * Refined sync response model declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->