### PR TITLE
fix(postgres): catch ProgrammingError for missing dataset_database table

### DIFF
--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -1,4 +1,4 @@
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from cognee.infrastructure.databases.exceptions import EntityNotFoundError
 from cognee.context_global_variables import backend_access_control_enabled
@@ -33,7 +33,7 @@ async def prune_graph_databases():
         for dataset_database in dataset_databases:
             handler = get_graph_dataset_database_handler(dataset_database)
             await handler["handler_instance"].delete_dataset(dataset_database)
-    except (OperationalError, EntityNotFoundError) as e:
+    except (OperationalError, ProgrammingError, EntityNotFoundError) as e:
         logger.debug(
             "Skipping pruning of graph DB. Error when accessing dataset_database table: %s",
             e,
@@ -49,7 +49,7 @@ async def prune_vector_databases():
         for dataset_database in dataset_databases:
             handler = get_vector_dataset_database_handler(dataset_database)
             await handler["handler_instance"].delete_dataset(dataset_database)
-    except (OperationalError, EntityNotFoundError) as e:
+    except (OperationalError, ProgrammingError, EntityNotFoundError) as e:
         logger.debug(
             "Skipping pruning of vector DB. Error when accessing dataset_database table: %s",
             e,

--- a/cognee/run_migrations.py
+++ b/cognee/run_migrations.py
@@ -64,7 +64,7 @@ async def run_vector_migrations():
     """
     Run adapter-specific vector storage migrations at startup.
     """
-    from sqlalchemy.exc import OperationalError
+    from sqlalchemy.exc import OperationalError, ProgrammingError
     from cognee.infrastructure.databases.exceptions import EntityNotFoundError
     from cognee.infrastructure.databases.vector.create_vector_engine import create_vector_engine
     from cognee.infrastructure.databases.utils.resolve_dataset_database_connection_info import (
@@ -74,7 +74,11 @@ async def run_vector_migrations():
 
     try:
         dataset_databases = await get_dataset_databases()
-    except (OperationalError, EntityNotFoundError) as e:
+    except (OperationalError, ProgrammingError, EntityNotFoundError) as e:
+        # The dataset_database table may not exist yet on a fresh database. A
+        # missing table surfaces as OperationalError on SQLite ("no such
+        # table") and as ProgrammingError on PostgreSQL/asyncpg
+        # (UndefinedTableError); skip vector startup migrations in both cases.
         logger.warning(
             "Skipping vector startup migrations. Could not access dataset_database table: %s",
             e,

--- a/cognee/tests/unit/test_run_migrations.py
+++ b/cognee/tests/unit/test_run_migrations.py
@@ -39,5 +39,43 @@ class TestRunMigrations(unittest.TestCase):
         self.assertEqual(cmd[1:], ["-m", "alembic", "upgrade", "head"])
 
 
+class TestRunVectorMigrations(unittest.TestCase):
+    """run_vector_migrations() must skip gracefully when dataset_database is absent."""
+
+    def _assert_skips(self, error):
+        """run_vector_migrations returns [] (no raise) when the getter raises ``error``."""
+        import asyncio
+
+        module = importlib.import_module("cognee.run_migrations")
+        with patch(
+            "cognee.modules.data.methods.get_dataset_databases.get_dataset_databases",
+            new=AsyncMock(side_effect=error),
+        ):
+            result = asyncio.run(module.run_vector_migrations())
+        self.assertEqual(result, [])
+
+    def test_skips_on_postgres_undefined_table(self):
+        """PostgreSQL/asyncpg raises ProgrammingError for a missing table (issue: the
+        dataset_database relation does not exist on a fresh DB). It must be caught
+        like SQLite's OperationalError, not propagate and crash startup."""
+        from sqlalchemy.exc import ProgrammingError
+
+        self._assert_skips(
+            ProgrammingError(
+                "SELECT * FROM dataset_database",
+                {},
+                Exception('relation "dataset_database" does not exist'),
+            )
+        )
+
+    def test_skips_on_sqlite_missing_table(self):
+        """SQLite raises OperationalError ('no such table') — the original guarded case."""
+        from sqlalchemy.exc import OperationalError
+
+        self._assert_skips(
+            OperationalError("SELECT * FROM dataset_database", {}, Exception("no such table"))
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The **PostgreSQL PGVector DB Example Test** ([failing job](https://github.com/topoteretes/cognee/actions/runs/27016684268/job/79733466630)) crashes on startup with:

```
asyncpg.exceptions.UndefinedTableError: relation "dataset_database" does not exist
```

…even though the job sets `ENABLE_BACKEND_ACCESS_CONTROL=false`. The SQLite/LanceDB examples pass — only Postgres fails.

## Root cause

`run_vector_migrations()` (and `prune_system`'s `prune_graph_databases` / `prune_vector_databases`) query the `dataset_database` table at startup and are **designed to skip gracefully** when that table doesn't exist on a fresh database (they log `"Could not access dataset_database table"` and return). But the guard only caught:

```python
except (OperationalError, EntityNotFoundError):
```

A missing table raises different exceptions per backend:
- **SQLite** → `OperationalError` ("no such table") → caught → skipped ✅
- **PostgreSQL/asyncpg** → `sqlalchemy.exc.ProgrammingError` (`UndefinedTableError`) → **not caught** → crash ❌

That backend asymmetry is exactly why SQLite examples pass while the Postgres example fails. It is not gated by access control (the query runs regardless of the flag).

## Fix

Add `ProgrammingError` to the caught exceptions in all three guards (`run_migrations.py`, `prune_system.py`), so the "table not present yet" case is skipped on both backends. Add regression tests for the Postgres (`ProgrammingError`) and SQLite (`OperationalError`) missing-table paths.

## Validation

Reproduced and verified against a **real local PostgreSQL** (the `dataset_database` table is relational, so pgvector isn't required to reproduce):
- before: `run_vector_migrations()` / `prune_*` raise `sqlalchemy.exc.ProgrammingError`
- after: all three return/skip gracefully (`RESULT: [] → NO CRASH`)

New unit tests pass (`test_run_migrations.py`), `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in system pruning and database migrations to gracefully manage missing database tables.

* **Tests**
  * Added test coverage for migration behavior when database tables are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->