### PR TITLE
docs(llm): document bounding a stalled LLM provider via LLM_ARGS

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -59,6 +59,10 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 
 # Extra kwargs passed to every LLM completion call (JSON string).
 # Examples: LLM_ARGS='{"max_tokens": 16384, "temperature": 0.7}'
+# To bound a stalled provider on litellm-backed providers (openai/custom/gemini/
+# mistral/bedrock/azure), pass litellm's per-request timeout and disable its
+# inner retries (which would otherwise multiply the wait):
+#   LLM_ARGS='{"timeout": 120, "num_retries": 0}'
 #LLM_ARGS='{}'
 
 # LLM rate limiting


### PR DESCRIPTION
## What

Documents that litellm-backed providers can bound a stalled provider via the **existing `LLM_ARGS`** mechanism — no new config field to maintain:

```
LLM_ARGS='{"timeout": 120, "num_retries": 0}'
```

`timeout` bounds one attempt; `num_retries=0` stops litellm's inner retry loop from multiplying that wait (it's redundant with the adapter's own tenacity retry). These already flow through `merged_kwargs` into the litellm call, so this is a `.env.template` note only.

## History / scope change

Originally this PR added a dedicated `LLM_CALL_TIMEOUT_SECONDS` config field + a provider allowlist that auto-injected the kwargs. Per review, that's more surface than warranted — **reuse `LLM_ARGS`** instead. The code + allowlist machinery were dropped; only the documentation remains.

## Important: this is NOT the LanceDB CI flake fix

Investigation showed the LanceDB hang is **not** LLM-driven — the job still hangs with a timeout applied, and the symptom is "test finishes but the process never exits," i.e. a **subprocess-worker teardown** issue. Tracked separately. This PR is just a small robustness/doc note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)