### PR TITLE
fix(graph): add get_id_filtered_graph_data to PostgresAdapter

### DIFF
--- a/cognee/infrastructure/databases/graph/postgres/adapter.py
+++ b/cognee/infrastructure/databases/graph/postgres/adapter.py
@@ -516,11 +516,11 @@ class PostgresAdapter(GraphDBInterface):
                 text("""
                     SELECT DISTINCT n.id, n.name, n.type, n.properties
                     FROM graph_node n
-                    WHERE n.id IN :target_ids
+                    WHERE n.id = ANY(:target_ids)
                        OR n.id IN (
-                           SELECT e.source_id FROM graph_edge e WHERE e.target_id IN :target_ids
+                           SELECT e.source_id FROM graph_edge e WHERE e.target_id = ANY(:target_ids)
                            UNION
-                           SELECT e.target_id FROM graph_edge e WHERE e.source_id IN :target_ids
+                           SELECT e.target_id FROM graph_edge e WHERE e.source_id = ANY(:target_ids)
                        )
                 """),
                 {"target_ids": tuple(target_ids)},
@@ -542,7 +542,7 @@ class PostgresAdapter(GraphDBInterface):
                 text("""
                     SELECT source_id, target_id, relationship_name, properties
                     FROM graph_edge
-                    WHERE source_id IN :target_ids OR target_id IN :target_ids
+                    WHERE source_id = ANY(:target_ids) OR target_id = ANY(:target_ids)
                 """),
                 {"target_ids": tuple(target_ids)},
             )

--- a/cognee/infrastructure/databases/graph/postgres/adapter.py
+++ b/cognee/infrastructure/databases/graph/postgres/adapter.py
@@ -483,6 +483,83 @@ class PostgresAdapter(GraphDBInterface):
 
             return nodes, edges
 
+    async def get_id_filtered_graph_data(
+        self, target_ids: list[str]
+    ) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[Tuple[str, str, str, Dict[str, Any]]]]:
+        """Retrieve graph data filtered by specific node IDs, including their direct neighbors
+        and only edges where one endpoint matches those IDs.
+
+        Mirrors the Neo4j/Ladybug implementations so that Postgres-backed graphs
+        also benefit from ID-filtered projection instead of falling back to full-graph
+        retrieval (which silently degrades retrieval quality — see #2720).
+
+        Parameters:
+        -----------
+            target_ids: Node IDs to seed the subgraph. Direct neighbors are included,
+                and only edges with at least one endpoint in target_ids are returned.
+
+        Returns:
+        --------
+            A tuple of (nodes, edges) in the same format as get_graph_data().
+        """
+        import time
+
+        start_time = time.time()
+
+        if not target_ids:
+            logger.warning("No target IDs provided for ID-filtered graph retrieval.")
+            return [], []
+
+        async with self._session() as session:
+            # Fetch nodes that are either in target_ids or are direct neighbors
+            node_result = await session.execute(
+                text("""
+                    SELECT DISTINCT n.id, n.name, n.type, n.properties
+                    FROM graph_node n
+                    WHERE n.id IN :target_ids
+                       OR n.id IN (
+                           SELECT e.source_id FROM graph_edge e WHERE e.target_id IN :target_ids
+                           UNION
+                           SELECT e.target_id FROM graph_edge e WHERE e.source_id IN :target_ids
+                       )
+                """),
+                {"target_ids": tuple(target_ids)},
+            )
+            nodes = []
+            node_ids = set()
+            for row in node_result.fetchall():
+                data = {"name": row[1], "type": row[2]}
+                if row[3]:
+                    data.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                nodes.append((row[0], data))
+                node_ids.add(row[0])
+
+            if not nodes:
+                return [], []
+
+            # Fetch only edges where at least one endpoint is in target_ids
+            edge_result = await session.execute(
+                text("""
+                    SELECT source_id, target_id, relationship_name, properties
+                    FROM graph_edge
+                    WHERE source_id IN :target_ids OR target_id IN :target_ids
+                """),
+                {"target_ids": tuple(target_ids)},
+            )
+            edges = []
+            for row in edge_result.fetchall():
+                props = {}
+                if row[3]:
+                    props = row[3] if isinstance(row[3], dict) else json.loads(row[3])
+                edges.append((row[0], row[1], row[2], props))
+
+            retrieval_time = time.time() - start_time
+            logger.info(
+                f"ID-filtered retrieval: {len(nodes)} nodes and {len(edges)} edges in {retrieval_time:.2f}s"
+            )
+
+            return nodes, edges
+
     async def get_filtered_graph_data(
         self, attribute_filters: List[Dict[str, List[Union[str, int]]]]
     ) -> Tuple[List[Tuple[str, Dict]], List[Tuple[str, str, str, Dict]]]:

--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -132,7 +132,13 @@ class CogneeGraph(CogneeAbstractGraph):
             logger.info("Retrieving ID-filtered graph from database.")
             nodes_data, edges_data = await get_graph_data_fn(target_ids=relevant_ids_to_filter)
         else:
-            logger.info("Retrieving full graph from database.")
+            logger.warning(
+                "Graph adapter %s does not implement get_id_filtered_graph_data; "
+                "falling back to full graph retrieval. This silently degrades retrieval "
+                "quality because the graph projection is not filtered by vector search hits. "
+                "See issue #2720.",
+                type(adapter).__name__,
+            )
             nodes_data, edges_data = await get_graph_data_fn()
         if hasattr(adapter, "get_id_filtered_graph_data") and (not nodes_data or not edges_data):
             logger.warning(


### PR DESCRIPTION
## Problem

When using Postgres as the graph backend, `CogneeGraph._get_full_or_id_filtered_graph` falls back to `get_graph_data()` (full graph retrieval) because `PostgresAdapter` does not implement `get_id_filtered_graph_data`. This means vector search results are silently ignored and every query projects the same subgraph regardless of query content.

This is a subset of the broader issue reported in #2720 — the Kuzu/Ladybug adapter has `get_id_filtered_graph_data` so the root cause there may differ, but the Postgres path is unambiguously broken.

## Silent failure mode

- API returns 200 OK with plausible-looking text
- No error, no warning, no status change
- Graph projection covers the full (or large fraction of the) dataset instead of a query-targeted subgraph
- Retrieval quality degrades silently — orthogonal queries return nearly identical results

## Changes

1. **`cognee/infrastructure/databases/graph/postgres/adapter.py`**: Implement `get_id_filtered_graph_data(target_ids)` using parameterized SQL that:
   - Fetches nodes in `target_ids` plus their direct neighbors (1-hop)
   - Fetches only edges where at least one endpoint is in `target_ids`
   - Mirrors the existing Neo4j and Ladybug adapter implementations
   - Uses `tuple()` parameterized binding to prevent SQL injection

2. **`cognee/modules/graph/cognee_graph/CogneeGraph.py`**: Upgrade the silent fallback from `logger.info` to `logger.warning` when an adapter lacks `get_id_filtered_graph_data`, and include the adapter class name so operators can identify which adapter needs the method.

## Testing

- Syntax validated via `ast.parse()` on both modified files
- The SQL query structure mirrors the existing Neo4j/Ladybug Cypher implementations (seed IDs + 1-hop neighbor expansion)
- The existing `idx_edge_source` and `idx_edge_target` indexes on `graph_edge` support efficient ID lookups

Refs #2720 (fixes the Postgres path; Kuzu/LanceDB path may need separate investigation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ID-based filtering for graph data retrieval, allowing users to query specific subgraphs based on target node identifiers for improved performance and efficiency.

* **Improvements**
  * Enhanced warning messages when the graph adapter falls back to full graph retrieval, providing better visibility into potential performance impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->