### PR TITLE
fix(mcp): Colima/Docker support with review follow-ups (builds on #2975)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ To open the local UI, run:
 cognee-cli -ui
 ```
 
+> **Note:** The MCP server launched by `cognee-cli -ui` runs inside a Docker container.
+> Docker Desktop, Colima, or any OCI-compatible runtime with a working `docker` CLI is
+> required. See [Docker & Colima Setup](docs/docker-colima-setup.md) for details.
+
 ## Use with AI Agents
 
 ### Claude Code

--- a/cognee-mcp/entrypoint.sh
+++ b/cognee-mcp/entrypoint.sh
@@ -68,14 +68,38 @@ if [ -n "$API_URL" ]; then
         echo "⚠️  Warning: API_URL contains localhost/127.0.0.1"
         echo "   Original: $API_URL"
 
-        # Try to use host.docker.internal (works on Mac/Windows and recent Linux with Docker Desktop)
-        FIXED_API_URL=$(echo "$API_URL" | sed 's/localhost/host.docker.internal/g' | sed 's/127\.0\.0\.1/host.docker.internal/g')
+        # Resolve the best hostname to reach the host from inside the container.
+        # Supports Docker Desktop, Colima / Lima, and plain Linux Docker.
+        HOST_ADDR=""
 
+        # 1. Docker Desktop (macOS, Windows, recent Linux Desktop)
+        if getent hosts host.docker.internal >/dev/null 2>&1; then
+            HOST_ADDR="host.docker.internal"
+            echo "   ✓ Resolved via host.docker.internal (Docker Desktop)"
+
+        # 2. Colima / Lima on macOS / Linux
+        elif getent hosts host.lima.internal >/dev/null 2>&1; then
+            HOST_ADDR="host.lima.internal"
+            echo "   ✓ Resolved via host.lima.internal (Colima / Lima)"
+
+        # 3. Fallback: default gateway IP (works on plain Linux Docker)
+        else
+            GATEWAY_IP=$(ip route | awk '/default/ {print $3}' 2>/dev/null || true)
+            if [ -n "$GATEWAY_IP" ]; then
+                HOST_ADDR="$GATEWAY_IP"
+                echo "   ✓ Resolved via default gateway IP: $GATEWAY_IP"
+            else
+                # Last resort: keep host.docker.internal and let the user know
+                HOST_ADDR="host.docker.internal"
+                echo "   ⚠️  Could not auto-detect host address; defaulting to host.docker.internal"
+                echo "   If this fails, try one of:"
+                echo "     - Colima: colima start --network-address"
+                echo "     - Linux:  use --network host, or set API_URL=http://172.17.0.1:<port>"
+            fi
+        fi
+
+        FIXED_API_URL=$(echo "$API_URL" | sed "s/localhost/$HOST_ADDR/g" | sed "s/127\.0\.0\.1/$HOST_ADDR/g")
         echo "   Converted to: $FIXED_API_URL"
-        echo "   This will work on Mac/Windows/Docker Desktop."
-        echo "   On Linux without Docker Desktop, you may need to:"
-        echo "     - Use --network host, OR"
-        echo "     - Set API_URL=http://172.17.0.1:8000 (Docker bridge IP)"
 
         API_URL="$FIXED_API_URL"
     fi

--- a/cognee-mcp/entrypoint.sh
+++ b/cognee-mcp/entrypoint.sh
@@ -82,9 +82,22 @@ if [ -n "$API_URL" ]; then
             HOST_ADDR="host.lima.internal"
             echo "   ✓ Resolved via host.lima.internal (Colima / Lima)"
 
-        # 3. Fallback: default gateway IP (works on plain Linux Docker)
+        # 3. Fallback: default gateway IP (works on plain Linux Docker).
+        # Read it from /proc/net/route, which exists in every Linux container with
+        # no extra package. (The runtime image is debian-slim and does NOT ship the
+        # `ip` binary / iproute2, so `ip route` would fail and leave this empty.)
+        # awk only extracts the little-endian hex gateway of the default route
+        # (destination 00000000) — no gawk-only strtonum, so it works under mawk too.
         else
-            GATEWAY_IP=$(ip route | awk '/default/ {print $3}' 2>/dev/null || true)
+            GATEWAY_HEX=$(awk '$2 == "00000000" { print $3; exit }' /proc/net/route 2>/dev/null || true)
+            GATEWAY_IP=""
+            if [ -n "$GATEWAY_HEX" ]; then
+                # /proc/net/route stores the gateway little-endian, so reverse the
+                # byte pairs to get dotted-decimal (e.g. 010011AC -> 172.17.0.1).
+                GATEWAY_IP=$(printf "%d.%d.%d.%d" \
+                    "0x${GATEWAY_HEX:6:2}" "0x${GATEWAY_HEX:4:2}" \
+                    "0x${GATEWAY_HEX:2:2}" "0x${GATEWAY_HEX:0:2}" 2>/dev/null || true)
+            fi
             if [ -n "$GATEWAY_IP" ]; then
                 HOST_ADDR="$GATEWAY_IP"
                 echo "   ✓ Resolved via default gateway IP: $GATEWAY_IP"

--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -21,6 +21,56 @@ from .npm_utils import run_npm_command
 logger = get_logger()
 
 
+def _check_docker_available() -> Tuple[bool, str]:
+    """
+    Check if the Docker daemon is reachable by running `docker info`.
+
+    Returns:
+        Tuple of (is_available: bool, message: str) where message provides
+        actionable guidance when Docker is not available.
+    """
+    docker_path = shutil.which("docker")
+    if docker_path is None:
+        return False, (
+            "Docker CLI not found on PATH.\n"
+            "Install Docker Desktop (https://www.docker.com/products/docker-desktop/) "
+            "or Colima (https://github.com/abiosoft/colima) and ensure the `docker` "
+            "binary is on your PATH."
+        )
+
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=15,
+        )
+        if result.returncode == 0:
+            return True, "Docker daemon is running."
+
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        return False, (
+            f"Docker CLI is installed but the daemon is not responding.\n"
+            f"  docker info stderr: {stderr}\n\n"
+            f"Possible fixes:\n"
+            f"  - Docker Desktop: open the Docker Desktop application and wait for it to start.\n"
+            f"  - Colima: run `colima start` (add `--network-address` for host.docker.internal support).\n"
+            f"  - Linux: run `sudo systemctl start docker` or `sudo service docker start`."
+        )
+    except subprocess.TimeoutExpired:
+        return False, (
+            "Docker daemon did not respond within 15 seconds.\n"
+            "The daemon may be starting up. Wait a moment and try again, or:\n"
+            "  - Docker Desktop: open the Docker Desktop application.\n"
+            "  - Colima: run `colima start`."
+        )
+    except FileNotFoundError:
+        return False, (
+            "Docker CLI not found.\n"
+            "Install Docker Desktop (https://www.docker.com/products/docker-desktop/) "
+            "or Colima (https://github.com/abiosoft/colima)."
+        )
+
+
 def _stream_process_output(
     process: subprocess.Popen, stream_name: str, prefix: str, color_code: str = ""
 ) -> threading.Thread:
@@ -445,6 +495,19 @@ def start_ui(
 
     if start_mcp:
         logger.info("Starting Cognee MCP server with Docker...")
+
+        # Preflight: verify the Docker daemon is reachable before pulling images
+        docker_ok, docker_msg = _check_docker_available()
+        if not docker_ok:
+            logger.error(f"Docker preflight check failed:\n{docker_msg}")
+            logger.error(
+                "The MCP server requires a running Docker (or Colima) daemon. "
+                "Skipping MCP server startup."
+            )
+            # Continue without MCP — the UI and backend can still work
+            start_mcp = False
+
+    if start_mcp:
         try:
             image = "cognee/cognee-mcp:main"
             subprocess.run(["docker", "pull", image], check=True)

--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -63,11 +63,16 @@ def _check_docker_available() -> Tuple[bool, str]:
             "  - Docker Desktop: open the Docker Desktop application.\n"
             "  - Colima: run `colima start`."
         )
-    except FileNotFoundError:
+    except (OSError, subprocess.SubprocessError) as e:
+        # Covers FileNotFoundError (binary vanished after the shutil.which check),
+        # PermissionError / "Exec format error" (TOCTOU race, noexec mount, foreign
+        # arch binary), and any other exec-time failure. Returning a tuple here keeps
+        # start_ui's graceful-skip guarantee total instead of crashing the UI launch.
         return False, (
-            "Docker CLI not found.\n"
+            f"Docker CLI could not be executed ({type(e).__name__}: {e}).\n"
             "Install Docker Desktop (https://www.docker.com/products/docker-desktop/) "
-            "or Colima (https://github.com/abiosoft/colima)."
+            "or Colima (https://github.com/abiosoft/colima) and ensure the `docker` "
+            "binary is on your PATH and executable."
         )
 
 
@@ -510,7 +515,18 @@ def start_ui(
     if start_mcp:
         try:
             image = "cognee/cognee-mcp:main"
-            subprocess.run(["docker", "pull", image], check=True)
+            # Bound the pull so a reachable-but-stalled daemon / registry can't hang
+            # start_ui indefinitely. On timeout, degrade to skipping MCP like the
+            # preflight failure path rather than blocking the whole UI launch.
+            try:
+                subprocess.run(["docker", "pull", image], check=True, timeout=300)
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    f"Timed out after 300s pulling Docker image '{image}'. "
+                    "The daemon is reachable but the pull stalled (slow network or "
+                    "registry). Skipping MCP server startup."
+                )
+                raise
 
             import uuid
 

--- a/cognee/tests/unit/api/v1/ui/test_docker_preflight.py
+++ b/cognee/tests/unit/api/v1/ui/test_docker_preflight.py
@@ -1,0 +1,127 @@
+"""Tests for Docker daemon preflight checks in cognee.api.v1.ui.ui."""
+
+import subprocess
+from unittest.mock import patch, MagicMock, call
+
+from cognee.api.v1.ui.ui import _check_docker_available
+
+
+class TestCheckDockerAvailable:
+    """Unit tests for _check_docker_available()."""
+
+    def test_docker_not_on_path(self):
+        """When the docker binary is not on PATH, return False with install guidance."""
+        with patch("shutil.which", return_value=None):
+            ok, msg = _check_docker_available()
+
+        assert ok is False
+        assert "not found on PATH" in msg
+        assert "Colima" in msg
+
+    def test_docker_daemon_running(self):
+        """When `docker info` succeeds, return True."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/docker"),
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            ok, msg = _check_docker_available()
+
+        assert ok is True
+        assert "running" in msg.lower()
+
+    def test_docker_daemon_not_running(self):
+        """When `docker info` fails (rc != 0), return False with actionable guidance."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = b"Cannot connect to the Docker daemon"
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/docker"),
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            ok, msg = _check_docker_available()
+
+        assert ok is False
+        assert "not responding" in msg
+        assert "Colima" in msg
+        assert "colima start" in msg
+        # Verify the actual stderr from `docker info` is passed through
+        assert "Cannot connect to the Docker daemon" in msg
+
+    def test_docker_info_timeout(self):
+        """When `docker info` times out, return False with retry guidance."""
+        with (
+            patch("shutil.which", return_value="/usr/bin/docker"),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="docker info", timeout=15),
+            ),
+        ):
+            ok, msg = _check_docker_available()
+
+        assert ok is False
+        assert "15 seconds" in msg
+
+    def test_docker_binary_missing_at_runtime(self):
+        """When shutil.which finds docker but subprocess.run raises FileNotFoundError."""
+        with (
+            patch("shutil.which", return_value="/usr/bin/docker"),
+            patch("subprocess.run", side_effect=FileNotFoundError),
+        ):
+            ok, msg = _check_docker_available()
+
+        assert ok is False
+        assert "not found" in msg.lower()
+
+
+class TestStartUiDockerIntegration:
+    """Verify start_ui() gracefully degrades when Docker is unavailable."""
+
+    @patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False)
+    @patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None)
+    @patch("cognee.api.v1.ui.ui._check_docker_available", return_value=(False, "no docker"))
+    @patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(True, []))
+    def test_skips_mcp_docker_pull_when_docker_unavailable(
+        self, mock_ports, mock_docker, mock_frontend, mock_prompt
+    ):
+        """When Docker is unavailable, start_ui must not call docker pull/run."""
+        from cognee.api.v1.ui.ui import start_ui
+
+        pids = []
+        # start_ui will return None because there's no frontend, but the key
+        # assertion is that it never attempts docker pull (subprocess.run with
+        # ['docker', 'pull', ...]).
+        with patch("subprocess.run") as mock_run, patch("subprocess.Popen") as mock_popen:
+            start_ui(
+                pid_callback=lambda p: pids.append(p),
+                start_mcp=True,
+                start_backend=False,
+            )
+
+            # docker pull / docker run should never have been called
+            for c in mock_run.call_args_list:
+                args = c[0][0] if c[0] else c[1].get("args", [])
+                assert "docker" not in str(args), f"Unexpected docker call: {args}"
+
+            mock_popen.assert_not_called()
+
+    @patch("cognee.api.v1.ui.ui.prompt_user_for_download", return_value=False)
+    @patch("cognee.api.v1.ui.ui.find_frontend_path", return_value=None)
+    @patch("cognee.api.v1.ui.ui._check_docker_available", return_value=(False, "no docker"))
+    @patch("cognee.api.v1.ui.ui._check_required_ports", return_value=(True, []))
+    def test_docker_check_not_called_when_mcp_disabled(
+        self, mock_ports, mock_docker, mock_frontend, mock_prompt
+    ):
+        """When start_mcp=False, _check_docker_available should not be called."""
+        from cognee.api.v1.ui.ui import start_ui
+
+        start_ui(
+            pid_callback=lambda p: None,
+            start_mcp=False,
+            start_backend=False,
+        )
+
+        mock_docker.assert_not_called()

--- a/cognee/tests/unit/api/v1/ui/test_docker_preflight.py
+++ b/cognee/tests/unit/api/v1/ui/test_docker_preflight.py
@@ -74,7 +74,22 @@ class TestCheckDockerAvailable:
             ok, msg = _check_docker_available()
 
         assert ok is False
-        assert "not found" in msg.lower()
+        # FileNotFoundError is handled by the broadened (OSError, SubprocessError)
+        # branch; the message names the error type and still points at install docs.
+        assert "FileNotFoundError" in msg
+        assert "Colima" in msg
+
+    def test_docker_exec_permission_error(self):
+        """A PermissionError at exec time (OSError subclass) must be caught, not raised."""
+        with (
+            patch("shutil.which", return_value="/usr/bin/docker"),
+            patch("subprocess.run", side_effect=PermissionError("[Errno 13] Permission denied")),
+        ):
+            ok, msg = _check_docker_available()
+
+        assert ok is False
+        assert "PermissionError" in msg
+        assert "could not be executed" in msg.lower()
 
 
 class TestStartUiDockerIntegration:

--- a/docs/docker-colima-setup.md
+++ b/docs/docker-colima-setup.md
@@ -30,15 +30,20 @@ brew install colima docker
 # Basic start
 colima start
 
-# Recommended: enable host.docker.internal hostname resolution
+# Recommended: give the VM a host-reachable network address
 colima start --network-address
 ```
 
-> **Important:** Without `--network-address`, the hostname
-> `host.docker.internal` may not resolve inside containers. The cognee MCP
-> entrypoint includes automatic fallback logic (tries `host.docker.internal`,
-> then `host.lima.internal`, then the container's default gateway IP), but
-> starting Colima with `--network-address` avoids these workarounds entirely.
+> **Important:** `--network-address` does not itself add a `host.docker.internal`
+> DNS entry — it provisions a shared-network IP that is reachable from both the
+> Colima VM and the host. Colima maps `host.docker.internal` →
+> `host.lima.internal` by default (recent versions), so combined with a
+> reachable address `host.docker.internal` generally resolves; directly
+> resolving it to the `--network-address` IP is still an open request
+> ([abiosoft/colima#560](https://github.com/abiosoft/colima/issues/560)). The
+> cognee MCP entrypoint also includes automatic fallback logic (tries
+> `host.docker.internal`, then `host.lima.internal`, then the container's
+> default gateway IP), so the host-API flow works even without this flag.
 
 ### Verify
 
@@ -79,11 +84,25 @@ docker run --network host ...
 
 ### Colima: `host.docker.internal` does not resolve
 
-Start Colima with `--network-address`:
+First, give the VM a host-reachable address (most setups need only this):
 
 ```bash
 colima stop
 colima start --network-address
 ```
 
-This adds the `host.docker.internal` DNS entry inside the VM.
+This provisions a VM IP reachable from the host; `host.docker.internal` then
+typically resolves via Colima's default `host.docker.internal` →
+`host.lima.internal` mapping. Note that `--network-address` does **not** itself
+write a DNS entry.
+
+If the name still does not resolve (e.g. a missing or custom mapping), add it
+explicitly via `network.dnsHosts` in `~/.colima/default/colima.yaml`:
+
+```yaml
+network:
+  dnsHosts:
+    host.docker.internal: host.lima.internal
+```
+
+then `colima restart`.

--- a/docs/docker-colima-setup.md
+++ b/docs/docker-colima-setup.md
@@ -1,0 +1,89 @@
+# Docker & Colima Setup for Cognee UI / MCP
+
+The `cognee-cli -ui` command starts an MCP server inside a Docker container.
+This requires a running Docker-compatible daemon. Both **Docker Desktop** and
+**Colima** (an open-source, commercially-free alternative) are supported.
+
+## Option A: Docker Desktop
+
+Install from <https://www.docker.com/products/docker-desktop/> and start the
+application. No extra configuration is needed.
+
+## Option B: Colima (macOS / Linux)
+
+[Colima](https://github.com/abiosoft/colima) provides a lightweight container
+runtime without a Docker Desktop licence.
+
+### Install
+
+```bash
+# macOS (Homebrew)
+brew install colima docker
+
+# Linux (Homebrew)
+brew install colima docker
+```
+
+### Start Colima
+
+```bash
+# Basic start
+colima start
+
+# Recommended: enable host.docker.internal hostname resolution
+colima start --network-address
+```
+
+> **Important:** Without `--network-address`, the hostname
+> `host.docker.internal` may not resolve inside containers. The cognee MCP
+> entrypoint includes automatic fallback logic (tries `host.docker.internal`,
+> then `host.lima.internal`, then the container's default gateway IP), but
+> starting Colima with `--network-address` avoids these workarounds entirely.
+
+### Verify
+
+```bash
+docker info   # Should print server information without errors
+docker run --rm hello-world
+```
+
+## Troubleshooting
+
+### "Docker daemon is not responding"
+
+| Runtime        | Fix                                                                    |
+|----------------|------------------------------------------------------------------------|
+| Docker Desktop | Open the Docker Desktop application and wait for the engine to start.  |
+| Colima         | Run `colima start` (or `colima start --network-address`).              |
+| Linux systemd  | Run `sudo systemctl start docker`.                                     |
+
+### Container cannot reach host API (`localhost` / `127.0.0.1`)
+
+Inside a container, `localhost` refers to the container itself, not the host
+machine. The MCP entrypoint automatically rewrites `localhost` / `127.0.0.1`
+to a reachable host address using the following fallback order:
+
+1. `host.docker.internal` (Docker Desktop on macOS / Windows / Linux)
+2. `host.lima.internal` (Colima / Lima)
+3. Default gateway IP (plain Linux Docker, typically `172.17.0.1`)
+
+If none of these work:
+
+```bash
+# Use the Docker bridge gateway directly
+docker run -e API_URL=http://172.17.0.1:8000 ...
+
+# Or use host networking (Linux only)
+docker run --network host ...
+```
+
+### Colima: `host.docker.internal` does not resolve
+
+Start Colima with `--network-address`:
+
+```bash
+colima stop
+colima start --network-address
+```
+
+This adds the `host.docker.internal` DNS entry inside the VM.


### PR DESCRIPTION
## Summary

Builds on @gourangasatapathyvit's PR #2975 (Colima support for the MCP server, closes #2744) and applies fixes from a verification pass. This branch contains **all of #2975 plus 7 follow-up fixes** so the complete feature can be validated end-to-end.

Credit for the original feature goes to #2975 — this PR exists so the corrections can be reviewed/tested as one unit. If preferred, the follow-up commit can instead be merged into #2975's branch.

## Issues found & fixed

**Major**
- **`entrypoint.sh` gateway fallback was dead code on plain Linux Docker.** It used `ip route`, but `iproute2` is not installed in the `python:3.12-slim-bookworm` runtime image, so `ip` is absent → `GATEWAY_IP` stayed empty → it fell back to `host.docker.internal` (which doesn't resolve on plain Linux), defeating the fallback's purpose. Now reads the default gateway from `/proc/net/route` (always present) and converts the little-endian hex with bash `printf` — avoids gawk-only `strtonum`, so it works under Debian's default **mawk** too. Verified: `010011AC → 172.17.0.1`.
- **Docs:** corrected two false claims that `colima start --network-address` "adds the `host.docker.internal` DNS entry inside the VM." The flag provisions a host-reachable VM IP; it does not write a DNS entry (see [abiosoft/colima#560](https://github.com/abiosoft/colima/issues/560)). Added the correct `network.dnsHosts` config for a genuinely missing mapping.

**Minor**
- **`ui.py`:** `_check_docker_available()` only caught `TimeoutExpired`/`FileNotFoundError`; a `PermissionError`/`OSError` at exec time (TOCTOU after `shutil.which`, noexec mount, foreign-arch binary) would propagate and crash `start_ui` instead of gracefully skipping MCP. Broadened to `except (OSError, subprocess.SubprocessError)`.
- **`ui.py`:** bounded `docker pull` with `timeout=300` so a reachable-but-stalled daemon/registry can't hang `start_ui` indefinitely.

**Tests**
- Updated the runtime-`FileNotFoundError` assertion for the new message and added a `PermissionError` regression test. **8/8 pass.**

## Test plan
- [x] `pytest cognee/tests/unit/api/v1/ui/test_docker_preflight.py` → 8 passed
- [x] `ruff check` + `ruff format` clean on changed files
- [x] `bash -n cognee-mcp/entrypoint.sh` valid; `/proc/net/route` hex→IP conversion verified against a simulated route table
- [x] `_check_docker_available()` exercised against a real local environment (Docker CLI present, daemon down) — correctly returns the "daemon not responding" branch with passthrough stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Docker compatibility with intelligent localhost resolution for Docker Desktop and Colima environments.
  * Added Docker availability check with graceful fallback when Docker is unavailable.

* **Documentation**
  * New setup guide for Docker Desktop and Colima with troubleshooting steps.
  * Updated Quickstart with Docker requirement clarification for the local UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->