### PR TITLE
fix: parse file-like ontologies by RDF format

### DIFF
--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -29,6 +29,7 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
         self,
         ontology_file: Optional[Union[str, List[str], IO, List[IO]]] = None,
         matching_strategy: Optional[MatchingStrategy] = None,
+        ontology_format: Optional[str] = None,
     ) -> None:
         super().__init__(matching_strategy)
         self.ontology_file = ontology_file
@@ -58,8 +59,11 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                     for file_obj in file_objects:
                         try:
                             content = file_obj.read()
-                            guessed_format = guess_format(getattr(file_obj, "name", ""))
-                            formats = [guessed_format] if guessed_format else []
+                            source_name = getattr(file_obj, "name", "")
+                            guessed_format = guess_format(source_name)
+                            formats = [ontology_format] if ontology_format else []
+                            if guessed_format and guessed_format not in formats:
+                                formats.append(guessed_format)
                             formats.extend(
                                 rdf_format
                                 for rdf_format in ("xml", "turtle", "n3", "json-ld", "nt")
@@ -73,6 +77,11 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                                 except Exception:
                                     continue
                                 self.graph += graph
+                                logger.info(
+                                    "Successfully parsed ontology file object '%s' using format: %s",
+                                    source_name or "<unnamed>",
+                                    rdf_format,
+                                )
                                 break
                             else:
                                 raise ValueError("No supported RDF format could parse file object")

--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -4,6 +4,7 @@ from cognee.shared.logging_utils import get_logger
 from collections import deque
 from typing import List, Tuple, Dict, Optional, Any, Union, IO
 from rdflib import Graph, URIRef, RDF, RDFS, OWL
+from rdflib.util import guess_format
 
 from cognee.modules.ontology.exceptions import (
     OntologyInitializationError,
@@ -57,7 +58,25 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                     for file_obj in file_objects:
                         try:
                             content = file_obj.read()
-                            self.graph.parse(data=content, format="xml")
+                            guessed_format = guess_format(getattr(file_obj, "name", ""))
+                            formats = [guessed_format] if guessed_format else []
+                            formats.extend(
+                                rdf_format
+                                for rdf_format in ("xml", "turtle", "n3", "json-ld", "nt")
+                                if rdf_format not in formats
+                            )
+
+                            for rdf_format in formats:
+                                try:
+                                    graph = Graph()
+                                    graph.parse(data=content, format=rdf_format)
+                                except Exception:
+                                    continue
+                                self.graph += graph
+                                break
+                            else:
+                                raise ValueError("No supported RDF format could parse file object")
+
                             loaded_objects.append(file_obj)
                             logger.info("Ontology loaded successfully from file object")
                         except Exception as e:

--- a/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
+++ b/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
@@ -491,6 +491,24 @@ def test_get_ontology_resolver_from_env_resolver_functionality():
     assert start_node is None
 
 
+def test_file_object_ontology_loading_guesses_turtle_format():
+    """Test loading a Turtle ontology from a file-like object."""
+    import io
+
+    ttl = """
+        @prefix ex: <http://example.org/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+        ex:Car a owl:Class .
+    """
+    ontology_file = io.StringIO(ttl)
+    ontology_file.name = "ontology.ttl"
+
+    resolver = RDFLibOntologyResolver(ontology_file=ontology_file)
+
+    assert resolver.graph is not None
+    assert "car" in resolver.lookup["classes"]
+
 def test_multifile_ontology_loading_success():
     """Test successful loading of multiple ontology files."""
     ns1 = Namespace("http://example.org/cars#")

--- a/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
+++ b/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
@@ -509,6 +509,7 @@ def test_file_object_ontology_loading_guesses_turtle_format():
     assert resolver.graph is not None
     assert "car" in resolver.lookup["classes"]
 
+
 def test_multifile_ontology_loading_success():
     """Test successful loading of multiple ontology files."""
     ns1 = Namespace("http://example.org/cars#")

--- a/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
+++ b/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
@@ -510,6 +510,54 @@ def test_file_object_ontology_loading_guesses_turtle_format():
     assert "car" in resolver.lookup["classes"]
 
 
+def test_file_object_ontology_loading_falls_back_without_name():
+    """Test unnamed file-like ontology content falls back to supported RDF formats."""
+    import io
+
+    ttl = """
+        @prefix ex: <http://example.org/test#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+        ex:Truck a owl:Class .
+    """
+
+    resolver = RDFLibOntologyResolver(ontology_file=io.StringIO(ttl))
+
+    assert resolver.graph is not None
+    assert "truck" in resolver.lookup["classes"]
+
+
+def test_file_object_ontology_loading_invalid_content_sets_empty_graph():
+    """Test invalid file-like ontology content is skipped after all formats fail."""
+    import io
+
+    ontology_file = io.StringIO("@prefix ex: <http://example.org/test#> . ex:Broken a")
+    ontology_file.name = "ontology.ttl"
+
+    resolver = RDFLibOntologyResolver(ontology_file=ontology_file)
+
+    assert resolver.graph is None
+    assert resolver.lookup["classes"] == {}
+
+
+def test_file_object_ontology_loading_accepts_explicit_format():
+    """Test caller-provided ontology format is accepted for file-like content."""
+    import io
+
+    json_ld = """
+        {
+          "@context": {"ex": "http://example.org/test#", "owl": "http://www.w3.org/2002/07/owl#"},
+          "@id": "ex:Plane",
+          "@type": "owl:Class"
+        }
+    """
+
+    resolver = RDFLibOntologyResolver(ontology_file=io.StringIO(json_ld), ontology_format="json-ld")
+
+    assert resolver.graph is not None
+    assert "plane" in resolver.lookup["classes"]
+
+
 def test_multifile_ontology_loading_success():
     """Test successful loading of multiple ontology files."""
     ns1 = Namespace("http://example.org/cars#")


### PR DESCRIPTION
## Description
Fixes #2907.

File-like ontology uploads now use the stream name to infer the RDF serialization when possible, then fall back through common RDF formats instead of forcing RDF/XML for every upload. Parsed content is merged into the resolver graph only after a format succeeds, so Turtle/N3-style uploads no longer silently produce an empty ontology.

## Acceptance Criteria
* File-like RDF/XML uploads continue to parse.
* File-like Turtle uploads parse when the stream name has a `.ttl` suffix.
* Added a unit test covering Turtle content passed as a file-like object.
* Local checks passed:
  * `PYTHONPATH=/tmp/cognee uv run pytest cognee/tests/unit/modules/ontology/test_ontology_adapter.py -q`
  * `uv run ruff check cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py cognee/tests/unit/modules/ontology/test_ontology_adapter.py`

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
N/A — terminal checks listed above.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-like ontology inputs now try automatic RDF format detection, attempt multiple common RDF serializations (including an explicitly provided format), and surface an error if none succeed.

* **Tests**
  * Added unit tests covering format inference from file-like objects, fallback when no filename is present, explicit format usage, and graceful handling of invalid ontology content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->