### PR TITLE
feat(agents): cognee.agents SDK namespace + CLI command with permissioning

### DIFF
--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -26,6 +26,7 @@ from .modules.run_custom_pipeline import run_custom_pipeline
 from .api.v1.update import update
 from .api.v1.config.config import config
 from .api.v1.datasets.datasets import datasets
+from .api.v1.agents.agents import agents
 from .api.v1.prune import prune
 from .api.v1.search import SearchType, search
 from .api.v1.visualize import (

--- a/cognee/api/v1/agents/agents.py
+++ b/cognee/api/v1/agents/agents.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from typing import Optional, Union
+from uuid import UUID
+
+from cognee.modules.users.models import User
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.permissions.methods import give_permission_on_dataset
+from cognee.modules.data.methods import get_authorized_dataset, get_datasets_by_name
+from cognee.modules.agents.create_agent import create_agent
+from cognee.modules.agents.list_agents import list_agents
+from cognee.modules.agents.get_agent import get_agent
+from cognee.modules.agents.delete_agent import delete_agent
+from cognee.modules.agents.agent_mode import register_agent, unregister_agent
+from cognee.modules.agents.operations import (
+    RangeLiteral,
+    list_agent_connections,
+    get_agent_connection_detail,
+)
+from cognee.modules.agents.models import (
+    AgentConnectionType,
+    AgentMemoryMode,
+    AgentSource,
+    RegisterAgentRequest,
+    UnregisterAgentRequest,
+)
+
+
+def _display_email(email: str) -> str:
+    """Convert an internal agent email to its display form.
+
+    Internal agent emails are minted as ``{slug}+{parent_id}@cognee.agent``;
+    this strips the ``+{parent_id}`` segment to produce ``{slug}@cognee.agent``.
+    """
+    local, _, domain = email.partition("@")
+    slug = local.split("+", 1)[0]
+    return f"{slug}@{domain}"
+
+
+class agents:
+    """
+    Agent management namespace for Cognee.
+
+    All methods are static and provide operations for creating, listing,
+    inspecting, and deleting agents, as well as registering and listing
+    agent connections. Permission scoping is enforced per acting user.
+
+    Example:
+        ```python
+        import cognee
+
+        # Create an agent with read/write on a dataset
+        agent = await cognee.agents.create("my-agent", datasets=["my_project"])
+
+        # List your agents
+        all_agents = await cognee.agents.list()
+
+        # Register an agent connection
+        connection = await cognee.agents.register("session-1")
+        ```
+    """
+
+    @staticmethod
+    async def create(
+        name: str,
+        datasets: Optional[list[Union[str, UUID]]] = None,
+        user: Optional[User] = None,
+    ) -> dict:
+        if user is None:
+            user = await get_default_user()
+
+        # Resolve and authorize EVERY requested dataset before minting the agent.
+        # Doing this first means a failed authorization never leaves an orphaned
+        # agent user with a live API key (and no partial dataset grants).
+        authorized_dataset_ids: list[UUID] = []
+        for entry in datasets or []:
+            # Resolve the entry to a dataset id (UUID).
+            try:
+                dataset_id = UUID(str(entry))
+            except ValueError:
+                matched = await get_datasets_by_name(str(entry), user.id)
+                if not matched:
+                    raise ValueError(f"Dataset '{entry}' not found.")
+                dataset_id = UUID(str(matched[0].id))
+
+            # Verify the CALLING user is authorized read on the dataset BEFORE
+            # granting the new agent any access.
+            authorized_dataset = await get_authorized_dataset(user, dataset_id, "read")
+            if authorized_dataset is None:
+                raise PermissionDeniedError(f"Dataset {dataset_id} not accessible.")
+            authorized_dataset_ids.append(dataset_id)
+
+        agent_user, agent_api_key = await create_agent(name, user)
+
+        # Grant the new agent user read and write on each authorized dataset.
+        for dataset_id in authorized_dataset_ids:
+            await give_permission_on_dataset(agent_user, dataset_id, "read")
+            await give_permission_on_dataset(agent_user, dataset_id, "write")
+
+        return {
+            "agent_id": str(agent_user.id),
+            "agent_email": _display_email(agent_user.email),
+            "agent_api_key": agent_api_key,
+        }
+
+    @staticmethod
+    async def list(user: Optional[User] = None) -> list[dict]:
+        if user is None:
+            user = await get_default_user()
+
+        infos = await list_agents(user.id)
+
+        return [
+            {
+                "agent_id": str(info.user.id),
+                "agent_email": _display_email(info.user.email),
+                "api_key_label": info.api_key_label,
+            }
+            for info in infos
+        ]
+
+    @staticmethod
+    async def get(agent_id: Union[str, UUID], user: Optional[User] = None) -> dict:
+        if user is None:
+            user = await get_default_user()
+
+        agent_uuid = agent_id if isinstance(agent_id, UUID) else UUID(str(agent_id))
+
+        try:
+            info = await get_agent(agent_uuid, user.id)
+        except LookupError:
+            raise ValueError(f"Agent {agent_id} not found")
+        except PermissionError:
+            raise PermissionDeniedError("Not authorized to view this agent")
+
+        return {
+            "agent_id": str(info.user.id),
+            "agent_email": _display_email(info.user.email),
+            "api_key_label": info.api_key_label,
+        }
+
+    @staticmethod
+    async def delete(agent_id: Union[str, UUID], user: Optional[User] = None) -> None:
+        if user is None:
+            user = await get_default_user()
+
+        agent_uuid = agent_id if isinstance(agent_id, UUID) else UUID(str(agent_id))
+
+        try:
+            await delete_agent(agent_uuid, user.id)
+        except LookupError:
+            raise ValueError(f"Agent {agent_id} not found")
+        except PermissionError:
+            raise PermissionDeniedError("Not authorized to delete this agent")
+
+    @staticmethod
+    async def register(
+        agent_session_name: str,
+        user: Optional[User] = None,
+        type: AgentConnectionType = "api",
+        memory_mode: AgentMemoryMode = "unknown",
+        session_id: Optional[str] = None,
+        dataset_ids: Optional[list[str]] = None,
+        dataset_names: Optional[list[str]] = None,
+        source: AgentSource = "api",
+        origin_function: Optional[str] = None,
+        metadata: Optional[dict] = None,
+    ) -> dict:
+        if user is None:
+            user = await get_default_user()
+
+        # Validate the calling user is authorized read on every supplied dataset
+        # BEFORE building/sending the register request.
+        for did in dataset_ids or []:
+            dataset = await get_authorized_dataset(user, UUID(str(did)), "read")
+            if dataset is None:
+                raise PermissionDeniedError(f"Dataset {did} not accessible.")
+
+        for dname in dataset_names or []:
+            matched = await get_datasets_by_name(dname, user.id)
+            if not matched:
+                raise PermissionDeniedError(f"Dataset '{dname}' not accessible.")
+            dataset = await get_authorized_dataset(user, UUID(str(matched[0].id)), "read")
+            if dataset is None:
+                raise PermissionDeniedError(f"Dataset '{dname}' not accessible.")
+
+        request = RegisterAgentRequest(
+            agent_session_name=agent_session_name,
+            type=type,
+            memory_mode=memory_mode,
+            session_id=session_id,
+            dataset_ids=dataset_ids or [],
+            dataset_names=dataset_names or [],
+            source=source,
+            origin_function=origin_function,
+            metadata=metadata or {},
+        )
+
+        connection = await register_agent(user, request)
+
+        return connection.model_dump(mode="json")
+
+    @staticmethod
+    async def unregister(agent_session_name: str, user: Optional[User] = None) -> int:
+        if user is None:
+            user = await get_default_user()
+
+        request = UnregisterAgentRequest(agent_session_name=agent_session_name)
+
+        return await unregister_agent(user, request)
+
+    @staticmethod
+    async def list_connections(
+        user: Optional[User] = None,
+        agent_id: Optional[Union[str, UUID]] = None,
+        range_key: RangeLiteral = "30d",
+        status_filter: Optional[str] = None,
+        include_sources: bool = True,
+        active_only: bool = True,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict:
+        if user is None:
+            user = await get_default_user()
+
+        if agent_id is not None and not isinstance(agent_id, UUID):
+            agent_id = UUID(str(agent_id))
+
+        response = await list_agent_connections(
+            user=user,
+            agent_id=agent_id,
+            range_key=range_key,
+            status_filter=status_filter,
+            include_sources=include_sources,
+            active_only=active_only,
+            limit=limit,
+            offset=offset,
+        )
+
+        # Defensive scope filter: the backend visibility rule treats in-memory
+        # registered connections with no owning user AND no datasets as visible to
+        # everyone. Drop them here so a caller never sees connections that are not
+        # bound to their own user scope or a dataset they can read.
+        scoped_agents = [
+            agent for agent in response.agents if agent.user_id is not None or agent.datasets
+        ]
+        removed = len(response.agents) - len(scoped_agents)
+        if removed:
+            response.agents = scoped_agents
+            response.total = max(0, response.total - removed)
+            response.has_more = response.offset + len(scoped_agents) < response.total
+
+        return response.model_dump(mode="json")
+
+    @staticmethod
+    async def get_connection(
+        agent_id: Union[str, UUID],
+        user: Optional[User] = None,
+        agent_session_name: Optional[str] = None,
+    ) -> Optional[dict]:
+        if user is None:
+            user = await get_default_user()
+
+        agent_uuid = agent_id if isinstance(agent_id, UUID) else UUID(str(agent_id))
+
+        detail = await get_agent_connection_detail(
+            user=user,
+            agent_id=agent_uuid,
+            agent_session_name=agent_session_name,
+        )
+
+        return detail.model_dump(mode="json") if detail is not None else None

--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -93,6 +93,7 @@ def _discover_commands() -> List[Type[SupportsCliCommand]]:
         ("cognee.cli.commands.delete_command", "DeleteCommand"),
         ("cognee.cli.commands.config_command", "ConfigCommand"),
         ("cognee.cli.commands.datasets_command", "DatasetsCommand"),
+        ("cognee.cli.commands.agents_command", "AgentsCommand"),
         ("cognee.cli.commands.sessions_command", "SessionsCommand"),
         ("cognee.cli.commands.feedback_command", "FeedbackCommand"),
         ("cognee.cli.commands.memify_command", "MemifyCommand"),

--- a/cognee/cli/commands/agents_command.py
+++ b/cognee/cli/commands/agents_command.py
@@ -1,0 +1,262 @@
+import argparse
+import asyncio
+import json
+from uuid import UUID
+
+from cognee.cli.reference import SupportsCliCommand
+from cognee.cli import DEFAULT_DOCS_URL
+import cognee.cli.echo as fmt
+from cognee.cli.exceptions import CliCommandException
+
+
+class AgentsCommand(SupportsCliCommand):
+    command_string = "agents"
+    help_string = "Manage agents (create, list, get, delete, register, unregister, connections)"
+    docs_url = DEFAULT_DOCS_URL
+    description = """
+Manage Cognee agents and their connections.
+
+Subcommands:
+  create        Create a new agent and grant it access to datasets
+  list          List all agents you own
+  get           Show details for a single agent
+  delete        Delete an agent by ID
+  register      Register an agent connection (session)
+  unregister    Unregister an agent connection (session)
+  connections   List active agent connections and their memory sources
+"""
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        sub = parser.add_subparsers(dest="agents_action", title="actions")
+
+        # create
+        p_create = sub.add_parser("create", help="Create a new agent")
+        p_create.add_argument("name", help="Agent name")
+        p_create.add_argument(
+            "--datasets",
+            nargs="*",
+            default=None,
+            help="Dataset names or UUIDs to grant the agent read/write access to",
+        )
+
+        # list
+        sub.add_parser("list", help="List all agents you own")
+
+        # get
+        p_get = sub.add_parser("get", help="Show details for a single agent")
+        p_get.add_argument("agent_id", help="Agent UUID")
+
+        # delete
+        p_del = sub.add_parser("delete", help="Delete an agent by ID")
+        p_del.add_argument("agent_id", help="Agent UUID")
+        p_del.add_argument("-f", "--force", action="store_true", help="Skip confirmation")
+
+        # register
+        p_reg = sub.add_parser("register", help="Register an agent connection")
+        p_reg.add_argument("agent_session_name", help="Agent session name")
+        p_reg.add_argument("--type", default="api", help="Connection type (default: api)")
+        p_reg.add_argument(
+            "--memory-mode",
+            dest="memory_mode",
+            default="unknown",
+            help="Memory mode (default: unknown)",
+        )
+        p_reg.add_argument(
+            "--session-id",
+            dest="session_id",
+            default=None,
+            help="Optional session id",
+        )
+        p_reg.add_argument(
+            "--dataset-ids",
+            dest="dataset_ids",
+            nargs="*",
+            default=None,
+            help="Dataset UUIDs to associate with the connection",
+        )
+        p_reg.add_argument(
+            "--dataset-names",
+            dest="dataset_names",
+            nargs="*",
+            default=None,
+            help="Dataset names to associate with the connection",
+        )
+
+        # unregister
+        p_unreg = sub.add_parser("unregister", help="Unregister an agent connection")
+        p_unreg.add_argument("agent_session_name", help="Agent session name")
+
+        # connections
+        p_conn = sub.add_parser("connections", help="List active agent connections")
+        p_conn.add_argument(
+            "--agent-id",
+            dest="agent_id",
+            default=None,
+            help="Filter by agent UUID",
+        )
+        p_conn.add_argument(
+            "--range",
+            dest="range_key",
+            default="30d",
+            help="Time range key (default: 30d)",
+        )
+        p_conn.add_argument(
+            "--status",
+            dest="status_filter",
+            default=None,
+            help="Filter by connection status",
+        )
+        p_conn.add_argument("--limit", type=int, default=50, help="Max results (default: 50)")
+        p_conn.add_argument("--offset", type=int, default=0, help="Result offset (default: 0)")
+
+    def execute(self, args: argparse.Namespace) -> None:
+        action = getattr(args, "agents_action", None)
+        if not action:
+            fmt.error("No action specified. Use --help to see available actions.")
+            raise CliCommandException("No action specified", error_code=1)
+
+        dispatch = {
+            "create": self._create,
+            "list": self._list,
+            "get": self._get,
+            "delete": self._delete,
+            "register": self._register,
+            "unregister": self._unregister,
+            "connections": self._connections,
+        }
+        dispatch[action](args)
+
+    def _create(self, args: argparse.Namespace) -> None:
+        async def run():
+            import cognee
+            from cognee.cli.user_resolution import resolve_cli_user
+
+            user = await resolve_cli_user(getattr(args, "user_id", None), strict=True)
+            result = await cognee.agents.create(args.name, datasets=args.datasets, user=user)
+
+            fmt.success(f"Created agent '{args.name}' ({result['agent_id']})")
+            fmt.echo(f"Agent ID:    {result['agent_id']}")
+            fmt.echo(f"Agent email: {result['agent_email']}")
+            fmt.echo(f"API key:     {result['agent_api_key']}")
+            fmt.warning(
+                "Store this API key now. It is a one-time secret and cannot be retrieved again."
+            )
+
+        asyncio.run(run())
+
+    def _list(self, args: argparse.Namespace) -> None:
+        async def run():
+            import cognee
+            from cognee.cli.user_resolution import resolve_cli_user
+
+            user = await resolve_cli_user(getattr(args, "user_id", None), strict=True)
+            agents = await cognee.agents.list(user=user)
+            if not agents:
+                fmt.echo("No agents found.")
+                return
+            fmt.echo(f"{'Agent ID':<38} {'Agent Email':<40} {'API Key Label'}")
+            fmt.echo("-" * 100)
+            for a in agents:
+                fmt.echo(f"{str(a['agent_id']):<38} {a['agent_email']:<40} {a['api_key_label']}")
+
+        asyncio.run(run())
+
+    def _get(self, args: argparse.Namespace) -> None:
+        async def run():
+            import cognee
+            from cognee.cli.user_resolution import resolve_cli_user
+
+            user = await resolve_cli_user(getattr(args, "user_id", None), strict=True)
+            info = await cognee.agents.get(args.agent_id, user=user)
+            fmt.echo(f"Agent ID:      {info['agent_id']}")
+            fmt.echo(f"Agent email:   {info['agent_email']}")
+            fmt.echo(f"API key label: {info['api_key_label']}")
+
+        asyncio.run(run())
+
+    def _delete(self, args: argparse.Namespace) -> None:
+        agent_id = args.agent_id
+        if not args.force:
+            if not fmt.confirm(f"Delete agent {agent_id}? This cannot be undone"):
+                fmt.echo("Cancelled.")
+                return
+
+        async def run():
+            import cognee
+            from cognee.cli.user_resolution import resolve_cli_user
+
+            user = await resolve_cli_user(getattr(args, "user_id", None), strict=True)
+            await cognee.agents.delete(agent_id, user=user)
+            fmt.success(f"Agent {agent_id} deleted.")
+
+        asyncio.run(run())
+
+    def _register(self, args: argparse.Namespace) -> None:
+        async def run():
+            import cognee
+            from cognee.cli.user_resolution import resolve_cli_user
+
+            user = await resolve_cli_user(getattr(args, "user_id", None), strict=True)
+            connection = await cognee.agents.register(
+                args.agent_session_name,
+                user=user,
+                type=args.type,
+                memory_mode=args.memory_mode,
+                session_id=args.session_id,
+                dataset_ids=args.dataset_ids,
+                dataset_names=args.dataset_names,
+            )
+            connection_id = connection.get("id", args.agent_session_name)
+            fmt.success(f"Registered agent connection {connection_id}")
+            fmt.echo(json.dumps(connection, indent=2, default=str))
+
+        asyncio.run(run())
+
+    def _unregister(self, args: argparse.Namespace) -> None:
+        async def run():
+            import cognee
+            from cognee.cli.user_resolution import resolve_cli_user
+
+            user = await resolve_cli_user(getattr(args, "user_id", None), strict=True)
+            count = await cognee.agents.unregister(args.agent_session_name, user=user)
+            fmt.success(f"Active connections: {count}")
+
+        asyncio.run(run())
+
+    def _connections(self, args: argparse.Namespace) -> None:
+        async def run():
+            import cognee
+            from cognee.cli.user_resolution import resolve_cli_user
+
+            user = await resolve_cli_user(getattr(args, "user_id", None), strict=True)
+            agent_id = UUID(args.agent_id) if args.agent_id else None
+            response = await cognee.agents.list_connections(
+                user=user,
+                agent_id=agent_id,
+                range_key=args.range_key,
+                status_filter=args.status_filter,
+                limit=args.limit,
+                offset=args.offset,
+            )
+
+            agents = response.get("agents", []) or []
+            if not agents:
+                fmt.echo("No agent connections found.")
+            else:
+                fmt.echo(f"{'Agent ID':<38} {'Session':<30} {'Status':<12} {'Last Active'}")
+                fmt.echo("-" * 100)
+                for a in agents:
+                    fmt.echo(
+                        f"{str(a.get('agent_id', '')):<38} "
+                        f"{str(a.get('agent_session_name', '')):<30} "
+                        f"{str(a.get('status', '')):<12} "
+                        f"{a.get('last_active_at', '')}"
+                    )
+
+            memory_sources = response.get("memory_sources")
+            if memory_sources:
+                fmt.echo("")
+                fmt.echo("Memory sources:")
+                fmt.echo(json.dumps(memory_sources, indent=2, default=str))
+
+        asyncio.run(run())

--- a/cognee/cli/config.py
+++ b/cognee/cli/config.py
@@ -14,6 +14,7 @@ COMMAND_DESCRIPTIONS = {
     "delete": "Delete data from cognee knowledge base",
     "config": "Manage cognee configuration settings",
     "datasets": "Manage datasets (list, create, inspect, status, delete)",
+    "agents": "Manage agents (create, list, get, delete, register, unregister, connections)",
     "sessions": "View conversation sessions and Q&A history",
     "feedback": "Add or remove feedback on session Q&A entries",
     "memify": "Run the memory enrichment pipeline on a dataset",

--- a/cognee/cli/user_resolution.py
+++ b/cognee/cli/user_resolution.py
@@ -6,11 +6,15 @@ from uuid import UUID
 import cognee.cli.echo as fmt
 
 
-async def resolve_cli_user(user_id: Optional[str] = None):
+async def resolve_cli_user(user_id: Optional[str] = None, strict: bool = False):
     """Return the User for the given --user-id, or the default user when omitted.
 
     Raises ValueError with a clear message if user_id is not a valid UUID.
-    Warns and falls back to the default user if the UUID is valid but unknown.
+
+    When ``strict`` is False (default), a valid-but-unknown UUID warns and falls
+    back to the default user. When ``strict`` is True, an unknown UUID is a hard
+    error instead — used by ownership-sensitive commands (e.g. ``agents``) where a
+    silent fallback to the default user would break the isolation the flag promises.
     """
     from cognee.modules.users.methods import get_default_user
 
@@ -30,6 +34,12 @@ async def resolve_cli_user(user_id: Optional[str] = None):
     try:
         return await get_user(uid)
     except Exception:
+        if strict:
+            raise ValueError(
+                f"--user-id {uid} does not exist.  Refusing to fall back to the default "
+                f"user because that would silently break isolation.  Create the user first "
+                f"or omit --user-id to act as the default user."
+            )
         fmt.warning(
             f"User {uid} not found — falling back to the default user.  "
             f"The --user-id will not provide isolation."

--- a/cognee/tests/unit/test_agents_sdk_cli.py
+++ b/cognee/tests/unit/test_agents_sdk_cli.py
@@ -1,0 +1,547 @@
+"""Unit tests for the agents SDK namespace (``cognee.agents``) and the
+``AgentsCommand`` CLI command.
+
+These tests run WITHOUT a live LLM, network, or relational database. The
+backend ``cognee.modules.agents.*`` functions and permission helpers are
+monkeypatched at the names imported into the SDK module, so the SDK's own
+glue logic (display-email stripping, permission ordering, error translation,
+return-shape) is exercised against fakes.
+
+If the SDK module is not yet importable (it is built alongside these tests)
+the whole module is skipped rather than erroring at collection time.
+"""
+
+import argparse
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+agents_sdk = pytest.importorskip(
+    "cognee.api.v1.agents.agents",
+    reason="agents SDK namespace not yet available",
+)
+
+agents = agents_sdk.agents
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_user(user_id=None):
+    """A minimal stand-in for a cognee User object."""
+    return SimpleNamespace(id=user_id or uuid4(), tenant_id=None)
+
+
+def _make_agent_info(parent_id, slug="support", api_key_label="support"):
+    """Build an AgentInfo-like object whose email mirrors create_agent output."""
+    agent_id = uuid4()
+    email = f"{slug}+{parent_id}@cognee.agent"
+    agent_user = SimpleNamespace(id=agent_id, email=email, parent_user_id=parent_id)
+    return SimpleNamespace(user=agent_user, api_key_label=api_key_label)
+
+
+def _patch(monkeypatch, name, value):
+    """Patch ``name`` on the agents SDK module if it is referenced there."""
+    if hasattr(agents_sdk, name):
+        monkeypatch.setattr(agents_sdk, name, value)
+
+
+# --------------------------------------------------------------------------- #
+# create -> list -> get -> delete round trip
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_list_get_delete_round_trip(monkeypatch):
+    parent = _make_user()
+    store = {}  # agent_id -> AgentInfo
+
+    async def fake_create_agent(name, parent_user):
+        slug = name.lower().replace(" ", "-")
+        info = _make_agent_info(parent_user.id, slug=slug, api_key_label=slug)
+        store[info.user.id] = info
+        return info.user, "agent-api-key-123"
+
+    async def fake_list_agents(owner_id):
+        return [i for i in store.values() if i.user.parent_user_id == owner_id]
+
+    async def fake_get_agent(agent_id, owner_id):
+        info = store.get(agent_id)
+        if info is None:
+            raise LookupError("Agent not found")
+        if info.user.parent_user_id != owner_id:
+            raise PermissionError("Not authorized to view this agent")
+        return info
+
+    async def fake_delete_agent(agent_id, owner_id):
+        info = store.get(agent_id)
+        if info is None:
+            raise LookupError("Agent not found")
+        if info.user.parent_user_id != owner_id:
+            raise PermissionError("Not authorized to delete this agent")
+        del store[agent_id]
+
+    _patch(monkeypatch, "create_agent", fake_create_agent)
+    _patch(monkeypatch, "list_agents", fake_list_agents)
+    _patch(monkeypatch, "get_agent", fake_get_agent)
+    _patch(monkeypatch, "delete_agent", fake_delete_agent)
+
+    # create (no datasets -> no permission helpers touched)
+    created = await agents.create("Support Bot", user=parent)
+    assert created["agent_api_key"] == "agent-api-key-123"
+    # display email strips the '+{parent_id}' segment
+    assert created["agent_email"] == "support-bot@cognee.agent"
+    assert "+" not in created["agent_email"]
+    agent_id = created["agent_id"]
+    assert agent_id == str(next(iter(store)))
+
+    # list shows the created agent
+    listed = await agents.list(user=parent)
+    assert len(listed) == 1
+    assert listed[0]["agent_id"] == agent_id
+    assert listed[0]["agent_email"] == "support-bot@cognee.agent"
+    assert listed[0]["api_key_label"] == "support-bot"
+
+    # get returns it
+    got = await agents.get(agent_id, user=parent)
+    assert got["agent_id"] == agent_id
+    assert got["agent_email"] == "support-bot@cognee.agent"
+
+    # delete removes it
+    result = await agents.delete(agent_id, user=parent)
+    assert result is None
+    assert await agents.list(user=parent) == []
+
+
+@pytest.mark.asyncio
+async def test_create_grants_agent_read_write_after_caller_check(monkeypatch):
+    parent = _make_user()
+    dataset_id = uuid4()
+    call_order = []
+
+    async def fake_create_agent(name, parent_user):
+        info = _make_agent_info(parent_user.id, slug="bot")
+        return info.user, "key"
+
+    async def fake_get_authorized_dataset(user, ds_id, permission="read"):
+        call_order.append(("authorize", user.id, ds_id, permission))
+        return SimpleNamespace(id=ds_id)
+
+    granted = []
+
+    async def fake_give_permission_on_dataset(user, ds_id, permission):
+        call_order.append(("grant", user.id, ds_id, permission))
+        granted.append((user.id, ds_id, permission))
+
+    _patch(monkeypatch, "create_agent", fake_create_agent)
+    _patch(monkeypatch, "get_authorized_dataset", fake_get_authorized_dataset)
+    _patch(monkeypatch, "give_permission_on_dataset", fake_give_permission_on_dataset)
+
+    await agents.create("Bot", datasets=[dataset_id], user=parent)
+
+    # caller authorization happens before any grant to the agent
+    assert call_order[0][0] == "authorize"
+    assert call_order[0][1] == parent.id
+    grant_perms = {(g[2]) for g in granted}
+    assert grant_perms == {"read", "write"}
+    # the agent (not the parent) receives the grants
+    assert all(g[0] != parent.id for g in granted)
+
+
+@pytest.mark.asyncio
+async def test_create_resolves_dataset_name(monkeypatch):
+    parent = _make_user()
+    resolved_id = uuid4()
+
+    async def fake_create_agent(name, parent_user):
+        info = _make_agent_info(parent_user.id, slug="bot")
+        return info.user, "key"
+
+    async def fake_get_datasets_by_name(name, owner_id):
+        if name == "known":
+            return [SimpleNamespace(id=resolved_id, name="known")]
+        return []
+
+    authorized = []
+
+    async def fake_get_authorized_dataset(user, ds_id, permission="read"):
+        authorized.append(ds_id)
+        return SimpleNamespace(id=ds_id)
+
+    async def fake_give_permission_on_dataset(user, ds_id, permission):
+        pass
+
+    _patch(monkeypatch, "create_agent", fake_create_agent)
+    _patch(monkeypatch, "get_datasets_by_name", fake_get_datasets_by_name)
+    _patch(monkeypatch, "get_authorized_dataset", fake_get_authorized_dataset)
+    _patch(monkeypatch, "give_permission_on_dataset", fake_give_permission_on_dataset)
+
+    await agents.create("Bot", datasets=["known"], user=parent)
+    assert resolved_id in authorized
+
+
+# --------------------------------------------------------------------------- #
+# Permissioning
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_unauthorized_dataset_raises(monkeypatch):
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    parent = _make_user()
+    dataset_id = uuid4()
+
+    async def fake_create_agent(name, parent_user):
+        info = _make_agent_info(parent_user.id, slug="bot")
+        return info.user, "key"
+
+    async def fake_get_authorized_dataset(user, ds_id, permission="read"):
+        # Either raising or returning None signals "no access".
+        return None
+
+    grant_calls = []
+
+    async def fake_give_permission_on_dataset(user, ds_id, permission):
+        grant_calls.append((ds_id, permission))
+
+    _patch(monkeypatch, "create_agent", fake_create_agent)
+    _patch(monkeypatch, "get_authorized_dataset", fake_get_authorized_dataset)
+    _patch(monkeypatch, "give_permission_on_dataset", fake_give_permission_on_dataset)
+
+    with pytest.raises((PermissionDeniedError, ValueError)):
+        await agents.create("Bot", datasets=[dataset_id], user=parent)
+
+    # the agent must never be granted access to a dataset the caller can't read
+    assert grant_calls == []
+
+
+@pytest.mark.asyncio
+async def test_get_other_users_agent_is_denied(monkeypatch):
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    owner = _make_user()
+    other_agent_id = uuid4()
+
+    async def fake_get_agent(agent_id, owner_id):
+        # backend raises PermissionError when parent_user_id != owner_id
+        raise PermissionError("Not authorized to view this agent")
+
+    _patch(monkeypatch, "get_agent", fake_get_agent)
+
+    with pytest.raises((PermissionDeniedError, PermissionError)):
+        await agents.get(other_agent_id, user=owner)
+
+
+@pytest.mark.asyncio
+async def test_delete_other_users_agent_is_denied(monkeypatch):
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    owner = _make_user()
+    other_agent_id = uuid4()
+
+    async def fake_delete_agent(agent_id, owner_id):
+        raise PermissionError("Not authorized to delete this agent")
+
+    _patch(monkeypatch, "delete_agent", fake_delete_agent)
+
+    with pytest.raises((PermissionDeniedError, PermissionError)):
+        await agents.delete(other_agent_id, user=owner)
+
+
+@pytest.mark.asyncio
+async def test_get_missing_agent_raises_value_error(monkeypatch):
+    owner = _make_user()
+    missing_id = uuid4()
+
+    async def fake_get_agent(agent_id, owner_id):
+        raise LookupError("Agent not found")
+
+    _patch(monkeypatch, "get_agent", fake_get_agent)
+
+    with pytest.raises(ValueError):
+        await agents.get(missing_id, user=owner)
+
+
+# --------------------------------------------------------------------------- #
+# register -> list_connections -> unregister
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_register_list_connections_unregister(monkeypatch):
+    from cognee.modules.agents.models import (
+        AgentConnection,
+        AgentsListResponse,
+    )
+
+    user = _make_user()
+    session_name = "session-A"
+
+    captured_request = {}
+
+    async def fake_register_agent(u, request):
+        captured_request["request"] = request
+        return AgentConnection(
+            id=f"{u.id}:{request.agent_session_name}",
+            agent_session_name=request.agent_session_name,
+            type=request.type,
+            memory_mode=request.memory_mode,
+            user_id=u.id,
+        )
+
+    async def fake_list_agent_connections(**kwargs):
+        conn = AgentConnection(
+            id=f"{user.id}:{session_name}",
+            agent_session_name=session_name,
+            user_id=user.id,
+            status="active",
+        )
+        return AgentsListResponse(
+            agents=[conn],
+            memory_sources=[],
+            total=1,
+            limit=kwargs.get("limit", 50),
+            offset=kwargs.get("offset", 0),
+            has_more=False,
+        )
+
+    async def fake_unregister_agent(u, request):
+        # mimic active-count drop to zero after unregister
+        return 0
+
+    _patch(monkeypatch, "register_agent", fake_register_agent)
+    _patch(monkeypatch, "list_agent_connections", fake_list_agent_connections)
+    _patch(monkeypatch, "unregister_agent", fake_unregister_agent)
+
+    # register
+    registered = await agents.register(session_name, user=user, memory_mode="hybrid")
+    assert isinstance(registered, dict)
+    assert registered["agent_session_name"] == session_name
+    # the SDK should have forwarded the kwargs into the request model
+    assert captured_request["request"].memory_mode == "hybrid"
+
+    # list_connections shows the connection (range_key kwarg, not range)
+    listing = await agents.list_connections(user=user, range_key="30d")
+    assert isinstance(listing, dict)
+    assert listing["total"] == 1
+    assert listing["agents"][0]["agent_session_name"] == session_name
+
+    # unregister deactivates it -> active count int
+    count = await agents.unregister(session_name, user=user)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_register_unauthorized_dataset_id_raises(monkeypatch):
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    user = _make_user()
+    bad_dataset = str(uuid4())
+
+    register_called = []
+
+    async def fake_get_authorized_dataset(u, ds_id, permission="read"):
+        return None  # no access
+
+    async def fake_register_agent(u, request):
+        register_called.append(request)
+        return SimpleNamespace(model_dump=lambda mode="json": {})
+
+    _patch(monkeypatch, "get_authorized_dataset", fake_get_authorized_dataset)
+    _patch(monkeypatch, "register_agent", fake_register_agent)
+
+    with pytest.raises((PermissionDeniedError, ValueError)):
+        await agents.register("sess", user=user, dataset_ids=[bad_dataset])
+
+    # register must NOT be reached if a dataset is not accessible
+    assert register_called == []
+
+
+@pytest.mark.asyncio
+async def test_list_connections_drops_unscoped_connections(monkeypatch):
+    """Connections with no owning user AND no datasets are visible-to-all in the
+    backend; the SDK must defensively filter them out and adjust the totals."""
+    from cognee.modules.agents.models import AgentConnection, AgentsListResponse
+
+    user = _make_user()
+
+    async def fake_list_agent_connections(**kwargs):
+        scoped = AgentConnection(
+            id="scoped",
+            agent_session_name="mine",
+            user_id=user.id,
+            status="active",
+        )
+        # ownerless + datasetless -> backend marks visible to everyone
+        leaked = AgentConnection(
+            id="leaked",
+            agent_session_name="someone-elses",
+            user_id=None,
+            status="active",
+        )
+        return AgentsListResponse(
+            agents=[scoped, leaked],
+            memory_sources=[],
+            total=2,
+            limit=kwargs.get("limit", 50),
+            offset=kwargs.get("offset", 0),
+            has_more=False,
+        )
+
+    _patch(monkeypatch, "list_agent_connections", fake_list_agent_connections)
+
+    listing = await agents.list_connections(user=user)
+    session_names = [a["agent_session_name"] for a in listing["agents"]]
+    assert session_names == ["mine"]
+    assert "someone-elses" not in session_names
+    # total is decremented for the removed leaked connection
+    assert listing["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_connection_returns_none_when_missing(monkeypatch):
+    user = _make_user()
+    agent_id = uuid4()
+
+    async def fake_get_agent_connection_detail(**kwargs):
+        return None
+
+    _patch(monkeypatch, "get_agent_connection_detail", fake_get_agent_connection_detail)
+
+    result = await agents.get_connection(agent_id, user=user, agent_session_name="x")
+    assert result is None
+
+
+# --------------------------------------------------------------------------- #
+# CLI smoke test
+# --------------------------------------------------------------------------- #
+
+
+cli_module = pytest.importorskip(
+    "cognee.cli.commands.agents_command",
+    reason="AgentsCommand CLI not yet available",
+)
+
+
+def test_agents_command_parser_configures_actions():
+    command = cli_module.AgentsCommand()
+    assert command.command_string == "agents"
+
+    parser = argparse.ArgumentParser()
+    command.configure_parser(parser)
+
+    # parsing a "list" invocation succeeds and selects the list action
+    args = parser.parse_args(["list"])
+    assert getattr(args, "agents_action") == "list"
+
+
+def test_agents_command_execute_list(monkeypatch):
+    command = cli_module.AgentsCommand()
+    parser = argparse.ArgumentParser()
+    command.configure_parser(parser)
+    args = parser.parse_args(["list"])
+
+    # avoid any DB work: resolve_cli_user and the SDK list call are mocked
+    fake_user = _make_user()
+
+    async def fake_resolve_cli_user(_user_id, strict=False):
+        return fake_user
+
+    monkeypatch.setattr("cognee.cli.user_resolution.resolve_cli_user", fake_resolve_cli_user)
+
+    listed_rows = [
+        {
+            "agent_id": str(uuid4()),
+            "agent_email": "bot@cognee.agent",
+            "api_key_label": "bot",
+        }
+    ]
+
+    async def fake_list(user=None):
+        assert user is fake_user
+        return listed_rows
+
+    import cognee
+
+    # The top-level ``cognee.agents`` export may be wired in a separate edit.
+    # Ensure the CLI can resolve it regardless, then patch ``list`` on the
+    # SDK class object that the CLI calls through.
+    if not hasattr(cognee, "agents"):
+        monkeypatch.setattr(cognee, "agents", agents, raising=False)
+    monkeypatch.setattr(cognee.agents, "list", staticmethod(fake_list))
+
+    captured = []
+    monkeypatch.setattr("cognee.cli.echo.echo", lambda *a, **k: captured.append(a))
+
+    # execute() runs the list action without raising
+    command.execute(args)
+    assert any("bot@cognee.agent" in str(c) for c in captured)
+
+
+def test_agents_command_execute_no_action_raises(monkeypatch):
+    from cognee.cli.exceptions import CliCommandException
+
+    command = cli_module.AgentsCommand()
+    parser = argparse.ArgumentParser()
+    command.configure_parser(parser)
+    args = parser.parse_args([])  # no subcommand
+
+    monkeypatch.setattr("cognee.cli.echo.error", lambda *a, **k: None)
+
+    with pytest.raises(CliCommandException):
+        command.execute(args)
+
+
+# --------------------------------------------------------------------------- #
+# Strict --user-id resolution (no silent fallback for agent commands)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_resolve_cli_user_strict_unknown_uuid_raises(monkeypatch):
+    """A valid-but-unknown --user-id must be a hard error in strict mode rather
+    than silently falling back to the default user."""
+    from cognee.cli import user_resolution
+
+    async def fake_get_user(uid):
+        raise Exception("user not found")
+
+    async def fake_get_default_user():
+        raise AssertionError("strict mode must not fall back to the default user")
+
+    monkeypatch.setattr("cognee.modules.users.methods.get_user", fake_get_user, raising=False)
+    monkeypatch.setattr(
+        "cognee.modules.users.methods.get_default_user", fake_get_default_user, raising=False
+    )
+
+    with pytest.raises(ValueError):
+        await user_resolution.resolve_cli_user(str(uuid4()), strict=True)
+
+
+@pytest.mark.asyncio
+async def test_resolve_cli_user_non_strict_falls_back(monkeypatch):
+    """Default (non-strict) behaviour still warns and falls back, preserving the
+    existing contract for other commands (e.g. datasets)."""
+    from cognee.cli import user_resolution
+
+    sentinel = _make_user()
+
+    async def fake_get_user(uid):
+        raise Exception("user not found")
+
+    async def fake_get_default_user():
+        return sentinel
+
+    monkeypatch.setattr("cognee.modules.users.methods.get_user", fake_get_user, raising=False)
+    monkeypatch.setattr(
+        "cognee.modules.users.methods.get_default_user", fake_get_default_user, raising=False
+    )
+    monkeypatch.setattr("cognee.cli.echo.warning", lambda *a, **k: None)
+
+    resolved = await user_resolution.resolve_cli_user(str(uuid4()))
+    assert resolved is sentinel


### PR DESCRIPTION
## Summary

Surfaces the existing agent backend (`cognee/modules/agents/`, currently only reachable via the FastAPI `/api/v1/agents` router) at the **Python SDK** and **CLI** levels, with permissioning enforced end-to-end.

### SDK — `cognee.agents` namespace
New `cognee/api/v1/agents/agents.py`, exported from `cognee/__init__.py`, mirroring the `cognee.datasets` static-method pattern. Every method defaults `user` to `get_default_user()`:

- `create(name, datasets=None, user=None)` — mint an agent + API key, optionally grant it dataset access
- `list` / `get` / `delete` — owner-scoped agent management
- `register` / `unregister` — agent connection (session) lifecycle
- `list_connections` / `get_connection` — connection inspection

### CLI — `cognee-cli agents`
New `cognee/cli/commands/agents_command.py` (registered in `_cognee.py`) with subcommands: `create`, `list`, `get`, `delete`, `register`, `unregister`, `connections`.

```bash
cognee-cli agents create my-agent --datasets my_project
cognee-cli agents register session-1 --dataset-names my_project --memory-mode hybrid
cognee-cli agents connections
```

## Permissioning

- **`create()` authorizes before minting.** The caller's `read` access is checked on *every* requested dataset **before** the agent user + API key are created, then the agent is granted read/write. A failed authorization can no longer leave an orphaned agent with live credentials or partial grants.
- **`register()`** validates caller access on attached datasets before registering the connection.
- **`list_connections()` defensive scope filter** drops backend "visible-to-all" connections (no owning user *and* no datasets) so they never leak across users; totals are adjusted accordingly.
- **`resolve_cli_user(..., strict=True)`** — agent commands treat an unknown (but valid) `--user-id` as a hard error instead of silently falling back to the default user, preserving the isolation the flag promises. Default (non-strict) behavior is unchanged for other commands (e.g. `datasets`).

## Tests

`cognee/tests/unit/test_agents_sdk_cli.py` (16 tests, no live LLM/network/DB — backend is monkeypatched): create→list→get→delete round trip, authorize-before-grant ordering, dataset-name resolution, unauthorized-dataset denial, cross-user get/delete denial, register→list→unregister, register dataset-authorization, defensive connection filter, strict vs non-strict `--user-id` resolution, and CLI parser/execute smoke tests.

## Verification

- `uv run ruff format .` / `ruff check` — clean
- `uv run pytest cognee/tests/unit/test_agents_sdk_cli.py -q` — **16 passed**
- `import cognee; cognee.agents` exposes all 8 methods; `cognee-cli agents --help` lists subcommands

## Scope notes

- **In-process only.** `--api-url` dispatch (`api_dispatch.py`) is not wired for `agents`; agent-connection registration is inherently server-process state (in-memory registry + agent-mode watchdog). Unsupported commands already fall through with a clear "run without --api-url" message. Can be a follow-up.
- `uv.lock` is intentionally **not** included — the local `uv` rewrote the lockfile format wholesale (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents management: create, list, retrieve, delete agents and manage agent connections (register/unregister, list, details) with filtering and pagination.
  * CLI: new agents subcommand with full create/list/get/delete/register/unregister/connections support.

* **Behavior Changes**
  * CLI user resolution gains a strict mode that enforces explicit user existence.

* **Tests**
  * Added comprehensive unit tests covering SDK and CLI agent workflows.

* **Chores**
  * Exposed agents API at package level and registered the CLI command description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->