### PR TITLE
feat: BM25 Retriever

### DIFF
--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -121,7 +121,7 @@ async def search(
             Returns: The results from the automatically selected search type.
 
         **CHUNKS_LEXICAL**:
-            Token-based lexical chunk search (e.g., Jaccard). Best for: exact-term matching, stopword-aware lookups.
+            Token-based lexical chunk search (BM25-style lexical ranking). Best for: exact-term matching, stopword-aware lookups.
             Returns: Ranked text chunks (optionally with scores).
 
     Args:

--- a/cognee/modules/retrieval/bm25_retriever.py
+++ b/cognee/modules/retrieval/bm25_retriever.py
@@ -1,0 +1,99 @@
+import math
+from collections import Counter
+from typing import Optional
+
+from cognee.modules.retrieval.lexical_retriever import LexicalRetriever, tokenize_words
+
+
+class BM25ChunksRetriever(LexicalRetriever):
+    """
+    Retriever that specializes LexicalRetriever to rank chunks with Okapi BM25.
+
+    Corpus statistics (per-token IDF and average chunk length) are computed once during
+    initialize() from the already-tokenized chunks, then read by the scorer. This keeps the
+    in-memory model of LexicalRetriever and adds no dependency or persistence.
+    """
+
+    def __init__(
+        self,
+        top_k: int = 15,
+        with_scores: bool = False,
+        stop_words: Optional[list[str]] = None,
+        k1: float = 1.5,
+        b: float = 0.75,
+    ):
+        """
+        Parameters
+        ----------
+        top_k : int
+            Number of top results to return.
+        with_scores : bool
+            If True, return (payload, score) pairs. Otherwise, only payloads.
+        stop_words : list[str], optional
+            Tokens to filter out during tokenization.
+        k1 : float
+            BM25 term-frequency saturation parameter.
+        b : float
+            BM25 length-normalization parameter.
+        """
+        self.stop_words = {t.lower() for t in stop_words} if stop_words else set()
+        self.k1 = k1
+        self.b = b
+
+        # Corpus statistics, populated once by initialize().
+        self.idf: dict[str, float] = {}
+        self.avg_chunk_length: float = 0.0
+        self._stats_built = False
+
+        super().__init__(
+            tokenizer=self._tokenizer, scorer=self._scorer, top_k=top_k, with_scores=with_scores
+        )
+
+    def _tokenizer(self, text: str) -> list[str]:
+        """Lowercases, splits on word characters (w+), filters stopwords."""
+        return tokenize_words(text, self.stop_words)
+
+    async def initialize(self):
+        """Load chunks via the parent, then build BM25 corpus statistics once.
+
+        The parent owns ``_initialized`` and returns early on re-entry, so a separate
+        ``_stats_built`` guard is needed to avoid recomputing stats on a repeated call.
+        """
+        await super().initialize()
+        if self._stats_built:
+            return
+        self._build_corpus_stats()
+        self._stats_built = True
+
+    def _build_corpus_stats(self):
+        """Compute average chunk length and per-token IDF from the tokenized chunks."""
+        total_chunks = len(self.chunks)
+        document_frequency: Counter = Counter()
+        total_length = 0
+        for tokens in self.chunks.values():
+            total_length += len(tokens)
+            for token in set(tokens):
+                document_frequency[token] += 1
+
+        self.avg_chunk_length = total_length / total_chunks if total_chunks else 0.0
+        self.idf = {
+            token: math.log(1 + (total_chunks - df + 0.5) / (df + 0.5))
+            for token, df in document_frequency.items()
+        }
+
+    def _scorer(self, query_tokens: list[str], chunk_tokens: list[str]) -> float:
+        """Okapi BM25 score of a chunk against the query, summed over unique query terms."""
+        if not query_tokens or not chunk_tokens or self.avg_chunk_length == 0:
+            return 0.0
+
+        term_frequencies = Counter(chunk_tokens)
+        length_norm = self.k1 * (1 - self.b + self.b * len(chunk_tokens) / self.avg_chunk_length)
+
+        score = 0.0
+        for token in set(query_tokens):
+            tf = term_frequencies.get(token, 0)
+            if tf == 0:
+                continue
+            idf = self.idf.get(token, 0.0)
+            score += idf * (tf * (self.k1 + 1)) / (tf + length_norm)
+        return score

--- a/cognee/modules/retrieval/bm25_retriever.py
+++ b/cognee/modules/retrieval/bm25_retriever.py
@@ -3,6 +3,7 @@ from collections import Counter
 from typing import Optional
 
 from cognee.modules.retrieval.lexical_retriever import LexicalRetriever, tokenize_words
+from cognee.modules.retrieval.utils.stop_words import DEFAULT_STOP_WORDS
 
 
 class BM25ChunksRetriever(LexicalRetriever):
@@ -30,13 +31,17 @@ class BM25ChunksRetriever(LexicalRetriever):
         with_scores : bool
             If True, return (payload, score) pairs. Otherwise, only payloads.
         stop_words : list[str], optional
-            Tokens to filter out during tokenization.
+            Tokens to filter out during tokenization. Defaults to DEFAULT_STOP_WORDS;
+            pass an empty list to disable stopword filtering.
         k1 : float
             BM25 term-frequency saturation parameter.
         b : float
             BM25 length-normalization parameter.
         """
-        self.stop_words = {t.lower() for t in stop_words} if stop_words else set()
+        if stop_words is None:
+            self.stop_words = set(DEFAULT_STOP_WORDS)
+        else:
+            self.stop_words = {t.lower() for t in stop_words}
         self.k1 = k1
         self.b = b
 

--- a/cognee/modules/retrieval/jaccard_retrival.py
+++ b/cognee/modules/retrieval/jaccard_retrival.py
@@ -1,5 +1,4 @@
-from cognee.modules.retrieval.lexical_retriever import LexicalRetriever
-import re
+from cognee.modules.retrieval.lexical_retriever import LexicalRetriever, tokenize_words
 from collections import Counter
 from typing import Optional
 
@@ -36,11 +35,8 @@ class JaccardChunksRetriever(LexicalRetriever):
         )
 
     def _tokenizer(self, text: str) -> list[str]:
-        """
-        Tokenizer: lowercases, splits on word characters (w+), filters stopwords.
-        """
-        tokens = re.findall(r"\w+", text.lower())
-        return [t for t in tokens if t not in self.stop_words]
+        """Tokenizer: lowercases, splits on word characters (w+), filters stopwords."""
+        return tokenize_words(text, self.stop_words)
 
     def _scorer(self, query_tokens: list[str], chunk_tokens: list[str]) -> float:
         """

--- a/cognee/modules/retrieval/lexical_retriever.py
+++ b/cognee/modules/retrieval/lexical_retriever.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from typing import Any, Callable, Optional, List, Union
 from heapq import nlargest
 
@@ -9,6 +10,17 @@ from cognee.shared.logging_utils import get_logger
 
 
 logger = get_logger("LexicalRetriever")
+
+
+def tokenize_words(text: str, stop_words: Optional[set[str]] = None) -> list[str]:
+    """Lowercase, split on word characters, and drop any stop words.
+
+    Shared by the lexical retrievers so tokenization stays consistent across scorers.
+    """
+    tokens = re.findall(r"\w+", text.lower())
+    if not stop_words:
+        return tokens
+    return [token for token in tokens if token not in stop_words]
 
 
 class LexicalRetriever(BaseRetriever):

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -19,7 +19,7 @@ from cognee.modules.retrieval.graph_completion_decomposition_retriever import (
 )
 from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
 from cognee.modules.retrieval.coding_rules_retriever import CodingRulesRetriever
-from cognee.modules.retrieval.jaccard_retrival import JaccardChunksRetriever
+from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
 from cognee.modules.retrieval.graph_summary_completion_retriever import (
     GraphSummaryCompletionRetriever,
 )
@@ -260,7 +260,7 @@ async def get_search_type_retriever_instance(
                 "node_name_filter_operator": node_name_filter_operator,
             },
         ),
-        SearchType.CHUNKS_LEXICAL: (JaccardChunksRetriever, {"top_k": top_k}),
+        SearchType.CHUNKS_LEXICAL: (BM25ChunksRetriever, {"top_k": top_k}),
         SearchType.CODING_RULES: (
             CodingRulesRetriever,
             {"rules_nodeset_name": node_name},

--- a/cognee/tasks/summarization/models.py
+++ b/cognee/tasks/summarization/models.py
@@ -6,24 +6,6 @@ from cognee.modules.chunking.models import DocumentChunk
 from cognee.shared.CodeGraphEntities import CodeFile, CodePart
 
 
-class TextSummary(DataPoint):
-    """
-    Represent a text summary derived from a document chunk.
-
-    This class encapsulates a text summary as well as its associated metadata. The public
-    instance variables include 'text' for the summary content and 'made_from' which
-    indicates the source document chunk. The 'metadata' instance variable contains
-    additional information such as indexed fields.
-    """
-
-    text: str
-    made_from: DocumentChunk
-    summarized_in: Optional["GlobalContextSummary"] = None
-    global_context_bucket_id: Optional[str] = None
-    metadata: dict = {"index_fields": ["text"]}
-    importance_weight: Optional[float] = 0.5
-
-
 class GlobalContextSummary(DataPoint):
     """
     Summarizes a global context index bucket or dataset root.
@@ -36,6 +18,24 @@ class GlobalContextSummary(DataPoint):
     graph_bucket_entity_ids: list[str] | None = None
     summarized_in: Optional["GlobalContextSummary"] = None
     metadata: dict = {"index_fields": ["text"]}
+
+
+class TextSummary(DataPoint):
+    """
+    Represent a text summary derived from a document chunk.
+
+    This class encapsulates a text summary as well as its associated metadata. The public
+    instance variables include 'text' for the summary content and 'made_from' which
+    indicates the source document chunk. The 'metadata' instance variable contains
+    additional information such as indexed fields.
+    """
+
+    text: str
+    made_from: DocumentChunk
+    summarized_in: Optional[GlobalContextSummary] = None
+    global_context_bucket_id: Optional[str] = None
+    metadata: dict = {"index_fields": ["text"]}
+    importance_weight: Optional[float] = 0.5
 
 
 class CodeSummary(DataPoint):

--- a/cognee/tests/integration/retrieval/test_bm25_retriever.py
+++ b/cognee/tests/integration/retrieval/test_bm25_retriever.py
@@ -1,0 +1,82 @@
+import pytest
+import pathlib
+import pytest_asyncio
+import cognee
+
+from cognee.low_level import setup as setup_databases
+from cognee.tasks.storage import add_data_points
+from cognee.modules.chunking.models import DocumentChunk
+from cognee.modules.data.processing.document_types import TextDocument
+from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
+
+
+ALPHA_TEXT = "orion orion logistics common"
+BETA_TEXT = "orion logistics logistics logistics common"
+GAMMA_TEXT = "nebula archive common"
+
+
+def _clear_engine_caches():
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+
+
+@pytest_asyncio.fixture
+async def setup_bm25_corpus():
+    """Persist a tiny deterministic corpus as DocumentChunk graph nodes (no cognify/LLM)."""
+    base_dir = pathlib.Path(__file__).parent.parent.parent.parent
+    cognee.config.system_root_directory(str(base_dir / ".cognee_system/test_bm25_retriever"))
+    cognee.config.data_root_directory(str(base_dir / ".data_storage/test_bm25_retriever"))
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    _clear_engine_caches()
+    await setup_databases()
+
+    document = TextDocument(
+        name="Logistics notes",
+        raw_data_location="somewhere",
+        external_metadata="",
+        mime_type="text/plain",
+    )
+    chunks = [
+        DocumentChunk(
+            text=text,
+            chunk_size=len(text.split()),
+            chunk_index=index,
+            cut_type="sentence_end",
+            is_part_of=document,
+            contains=[],
+        )
+        for index, text in enumerate([ALPHA_TEXT, BETA_TEXT, GAMMA_TEXT])
+    ]
+    await add_data_points(chunks)
+
+    yield
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+        _clear_engine_caches()
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_bm25_ranks_repeated_term_chunk_first(setup_bm25_corpus):
+    """BM25 ranks the chunk with the most query-term occurrences highest, end to end."""
+    retriever = BM25ChunksRetriever(top_k=4)
+
+    chunks = await retriever.get_retrieved_objects("logistics")
+    texts = [chunk["text"] for chunk in chunks]
+
+    # beta repeats "logistics" three times, alpha once, gamma not at all.
+    # Only the matched chunks have a defined order; gamma ties with any other zero-score chunk.
+    assert texts[0] == BETA_TEXT
+    assert texts[1] == ALPHA_TEXT

--- a/cognee/tests/unit/modules/retrieval/test_bm25_retriever.py
+++ b/cognee/tests/unit/modules/retrieval/test_bm25_retriever.py
@@ -1,0 +1,78 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
+
+
+def _patch_graph(corpus: dict[str, str]):
+    """Patch the graph engine so the lexical loader sees the given {chunk_id: text} corpus."""
+    nodes = [
+        (chunk_id, {"id": chunk_id, "type": "DocumentChunk", "text": text})
+        for chunk_id, text in corpus.items()
+    ]
+    engine = AsyncMock()
+    engine.get_filtered_graph_data = AsyncMock(return_value=(nodes, {}))
+    return patch(
+        "cognee.modules.retrieval.lexical_retriever.get_graph_engine",
+        AsyncMock(return_value=engine),
+    )
+
+
+@pytest.mark.asyncio
+async def test_term_frequency_orders_results():
+    corpus = {
+        "chunk_a": "alpha alpha alpha project",
+        "chunk_b": "alpha project project project",
+        "chunk_c": "beta gamma delta",
+    }
+    retriever = BM25ChunksRetriever(top_k=3, with_scores=True)
+
+    with _patch_graph(corpus):
+        results = await retriever.get_retrieved_objects("project")
+
+    ranked_ids = [payload["id"] for payload, _ in results]
+    assert ranked_ids[:2] == ["chunk_b", "chunk_a"]
+    # chunk_c shares no term with the query → zero score, ranked last.
+    assert results[-1][0]["id"] == "chunk_c"
+    assert results[-1][1] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_rare_term_beats_common_term():
+    corpus = {
+        "chunk_a": "status project common",
+        "chunk_b": "status common common",
+        "chunk_c": "status common raremarker",
+    }
+    retriever = BM25ChunksRetriever(top_k=3, with_scores=True)
+
+    with _patch_graph(corpus):
+        results = await retriever.get_retrieved_objects("status raremarker")
+
+    ranked_ids = [payload["id"] for payload, _ in results]
+    # "status" is in every chunk (low IDF); "raremarker" is unique and drives the top result.
+    assert ranked_ids[0] == "chunk_c"
+
+
+@pytest.mark.asyncio
+async def test_empty_query_returns_empty_list():
+    corpus = {"chunk_a": "alpha beta", "chunk_b": "gamma delta"}
+    retriever = BM25ChunksRetriever(top_k=3)
+
+    with _patch_graph(corpus):
+        results = await retriever.get_retrieved_objects("   ")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_no_match_query_returns_zero_scored_chunks():
+    corpus = {"chunk_a": "alpha beta", "chunk_b": "gamma delta"}
+    retriever = BM25ChunksRetriever(top_k=3, with_scores=True)
+
+    with _patch_graph(corpus):
+        results = await retriever.get_retrieved_objects("zzz")
+
+    # LexicalRetriever still returns top_k payloads for a no-match query; all score 0.0.
+    assert len(results) == 2
+    assert all(score == 0.0 for _, score in results)

--- a/cognee/tests/unit/modules/retrieval/test_bm25_retriever.py
+++ b/cognee/tests/unit/modules/retrieval/test_bm25_retriever.py
@@ -66,6 +66,31 @@ async def test_empty_query_returns_empty_list():
 
 
 @pytest.mark.asyncio
+async def test_stop_words_filtered_by_default():
+    # "the" is a default stop word: it is dropped from both query and corpus, so a
+    # query of only stop words yields no usable tokens and returns nothing.
+    corpus = {"chunk_a": "the the the", "chunk_b": "the project"}
+    retriever = BM25ChunksRetriever(top_k=3)
+
+    with _patch_graph(corpus):
+        results = await retriever.get_retrieved_objects("the")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_stop_words_can_be_disabled():
+    corpus = {"chunk_a": "the the the", "chunk_b": "the project"}
+    retriever = BM25ChunksRetriever(top_k=3, stop_words=[])
+
+    with _patch_graph(corpus):
+        results = await retriever.get_retrieved_objects("the")
+
+    # With filtering disabled, "the" is a real term and both chunks are scorable.
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
 async def test_no_match_query_returns_zero_scored_chunks():
     corpus = {"chunk_a": "alpha beta", "chunk_b": "gamma delta"}
     retriever = BM25ChunksRetriever(top_k=3, with_scores=True)

--- a/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
+++ b/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
@@ -136,14 +136,15 @@ async def test_chunks_retriever_receives_nodeset_filter_arguments():
 
 
 @pytest.mark.asyncio
-async def test_chunks_lexical_returns_jaccard_tools():
+async def test_chunks_lexical_returns_bm25_retriever():
     import cognee.modules.search.methods.get_search_type_retriever_instance as mod
-    from cognee.modules.retrieval.jaccard_retrival import JaccardChunksRetriever
+    from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
 
     retriever_instance = await mod.get_search_type_retriever_instance(
         SearchType.CHUNKS_LEXICAL, query_text="q", top_k=3
     )
-    assert isinstance(retriever_instance, JaccardChunksRetriever)
+    assert isinstance(retriever_instance, BM25ChunksRetriever)
+    assert retriever_instance.top_k == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

- Adds a new `BM25ChunksRetriever` that ranks text chunks using BM25, a standard keyword-search algorithm that rewards rare matching words and down-weights common ones.
- Makes BM25 the default for `CHUNKS_LEXICAL` keyword search (it used to be Jaccard, which treats every word as equally important).
- Filters common stop words ("the", "of", "and"…) by default so they don't skew the ranking, with an option to turn that off.
- Pulls the shared word-splitting logic into one `tokenize_words` helper so the Jaccard and BM25 retrievers tokenize text the exact same way.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lexical chunk search now uses BM25-based ranking for improved relevance.

* **Refactor**
  * Shared tokenization/stop-word handling introduced and applied to lexical retrievers, simplifying token processing.

* **Tests**
  * Added unit and integration tests validating BM25 ranking behavior, stop-word handling, and edge cases.

* **Documentation**
  * Search documentation updated to describe the new token-based BM25-style lexical ranking.

* **Chores**
  * Summarization models extended with global-context linking and weighting fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->