### PR TITLE
fix(graph): key edges by relationship type, not field name

### DIFF
--- a/cognee/modules/graph/utils/get_graph_from_model.py
+++ b/cognee/modules/graph/utils/get_graph_from_model.py
@@ -277,8 +277,13 @@ async def get_graph_from_model(
     ):
         relationship_name = _get_relationship_key(field_name, edge_metadata)
 
-        # Create edge if not already added
-        edge_key = f"{data_point_id}_{target_datapoint.id}_{field_name}"
+        # Create edge if not already added.
+        # Key on relationship_name (not field_name) so that distinct relationship
+        # types between the same pair of nodes are preserved, and so the same
+        # (source, target, relationship) triple reached via different fields
+        # collapses to a single edge — matching the edge identity used by
+        # deduplicate_nodes_and_edges and the graph DB.
+        edge_key = f"{data_point_id}_{target_datapoint.id}_{relationship_name}"
         if edge_key not in added_edges:
             edge_properties = _create_edge_properties(
                 data_point.id, target_datapoint.id, relationship_name, edge_metadata

--- a/cognee/tests/unit/interfaces/graph/get_graph_from_model_unit_test.py
+++ b/cognee/tests/unit/interfaces/graph/get_graph_from_model_unit_test.py
@@ -41,8 +41,16 @@ class Employee(DataPoint):
     metadata: dict = {"index_fields": ["name"]}
 
 
+class MultiFieldNode(DataPoint):
+    name: str
+    primary: List[Any] = None
+    secondary: List[Any] = None
+    metadata: dict = {"index_fields": ["name"]}
+
+
 DocumentChunk.model_rebuild()
 Company.model_rebuild()
+MultiFieldNode.model_rebuild()
 
 
 @pytest.mark.asyncio
@@ -228,3 +236,65 @@ async def test_get_graph_from_model_flexible_edges():
     employee_ids = {str(emp.id) for emp in [manager, sales1, sales2, admin1, admin2]}
     edge_target_ids = {str(edge[1]) for edge in edges}
     assert employee_ids.issubset(edge_target_ids), "Not all employees are connected"
+
+
+@pytest.mark.asyncio
+async def test_same_field_same_target_distinct_relationships_both_survive():
+    """Tests two relationship types to the same target via one field are both kept."""
+    bob = Employee(name="Bob", role="Engineer")
+    company = Company(
+        name="Acme",
+        employees=[
+            (Edge(relationship_type="manages"), bob),
+            (Edge(relationship_type="mentors"), bob),
+        ],
+    )
+
+    nodes, edges = await get_graph_from_model(company, {}, {}, {})
+
+    # company + bob (bob is a single node despite two edges)
+    assert len(nodes) == 2, f"Expected 2 nodes, got {len(nodes)}"
+
+    bob_rels = sorted(edge[2] for edge in edges if str(edge[1]) == str(bob.id))
+    assert bob_rels == ["manages", "mentors"], (
+        f"Expected both 'manages' and 'mentors' edges to Bob, got {bob_rels}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_triple_via_two_fields_collapses_to_single_edge():
+    """Tests the same relationship to one target via two fields yields a single edge."""
+    bob = Employee(name="Bob", role="Engineer")
+    node = MultiFieldNode(
+        name="Root",
+        primary=[(Edge(relationship_type="knows"), bob)],
+        secondary=[(Edge(relationship_type="knows"), bob)],
+    )
+
+    nodes, edges = await get_graph_from_model(node, {}, {}, {})
+
+    knows_edges = [edge for edge in edges if edge[2] == "knows" and str(edge[1]) == str(bob.id)]
+    assert len(knows_edges) == 1, f"Expected 1 'knows' edge, got {len(knows_edges)}"
+
+
+@pytest.mark.asyncio
+async def test_distinct_relationships_survive_deduplication():
+    """Tests distinct relationships to the same target survive edge deduplication."""
+    from cognee.modules.graph.utils import deduplicate_nodes_and_edges
+
+    bob = Employee(name="Bob", role="Engineer")
+    company = Company(
+        name="Acme",
+        employees=[
+            (Edge(relationship_type="manages"), bob),
+            (Edge(relationship_type="mentors"), bob),
+        ],
+    )
+
+    nodes, edges = await get_graph_from_model(company, {}, {}, {})
+    _, deduped_edges = deduplicate_nodes_and_edges(nodes, edges)
+
+    bob_rels = sorted(edge[2] for edge in deduped_edges if str(edge[1]) == str(bob.id))
+    assert bob_rels == ["manages", "mentors"], (
+        f"Lost a relationship after deduplication: {bob_rels}"
+    )


### PR DESCRIPTION
### What this fixes

`get_graph_from_model` flattens a `DataPoint` tree into `(nodes, edges)` and dedups edges with a key built from the **field name**:

    edge_key = f"{data_point_id}_{target_datapoint.id}_{field_name}"

but stores and later dedups them by the resolved **relationship name** (`Edge.relationship_type`, falling back to the field name).

The two keys disagree, with two consequences:

- **Silent edge loss.** When one field holds several edges to the *same* target with *different* relationship types, e.g.

      employees = [
          (Edge(relationship_type="manages"), bob),
          (Edge(relationship_type="mentors"), bob),
      ]

  both produce the key `…_bob_employees`, so only the first edge is emitted and `mentors` is dropped before it ever reaches `deduplicate_nodes_and_edges` or the graph DB.

- **Spurious duplicates.** The same `(source, target, relationship)` reached through two different fields gets two different keys, so a duplicate is emitted that only the later dedup pass / `ON CONFLICT DO NOTHING` removes.

### The fix

Key the dedup set on `relationship_name` instead of `field_name`:

    edge_key = f"{data_point_id}_{target_datapoint.id}_{relationship_name}"

This is the same edge identity already used by `deduplicate_nodes_and_edges` (`source + relationship + target`) and the graph adapters. Distinct relationships between a node pair now survive, identical ones collapse at the source, and `added_edges` becomes consistent with the `visited_properties` cycle key (which already uses `relationship_name`). Behaviour is unchanged when `field_name == relationship_name`, the common case.

### Tests

Added to `cognee/tests/unit/interfaces/graph/get_graph_from_model_unit_test.py`:

- `test_same_field_same_target_distinct_relationships_both_survive` — two relationship types to the same target via one field are both emitted (fails before the fix: `['manages'] != ['manages', 'mentors']`).
- `test_same_triple_via_two_fields_collapses_to_single_edge` — same triple via two fields collapses to one edge.
- `test_distinct_relationships_survive_deduplication` — both survive the `get_graph_from_model → deduplicate_nodes_and_edges` hand-off used by `add_data_points`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edge deduplication now collapses duplicates by (source, target, relationship) so distinct relationship types between the same nodes are preserved and redundant edges are removed.

* **Tests**
  * Added regression tests covering multiple relationship types to the same target and deduplication across multiple fields to prevent edge loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->