### PR TITLE
fix: clearer local/MCP setup errors (json extension, unsupported files, client errors)

### DIFF
--- a/cognee-frontend/src/utils/handleServerErrors.ts
+++ b/cognee-frontend/src/utils/handleServerErrors.ts
@@ -1,5 +1,32 @@
 import { redirect } from "next/navigation";
 
+// Build a real Error (not a bare object) from a server error response.
+//
+// Rejecting with a plain object is why callers logged "ERROR: {}" — a plain
+// object has no useful default serialization in console.error. An Error
+// serializes with its message (and stack). The server's parsed JSON fields
+// (detail/error/message/...) are copied onto the Error so existing callers that
+// read `error.detail`/`error.error`/`error.message` keep working.
+function buildServerError(body: string, status: number, statusText: string): Error {
+  let parsed: Record<string, unknown> = {};
+  if (body) {
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      parsed = { message: body };
+    }
+  }
+  const detail = parsed.detail ?? parsed.error ?? parsed.message;
+  const message =
+    typeof detail === "string" && detail.trim()
+      ? detail
+      : (body && body.trim()) || statusText || `Request failed with status ${status}`;
+  const error = Object.assign(new Error(message), parsed, { status, statusText });
+  // Ensure the resolved message wins even if `parsed` carried its own `message`.
+  error.message = message;
+  return error;
+}
+
 export default function handleServerErrors(
   response: Response,
   retry: ((response: Response) => Promise<Response>) | null = null,
@@ -22,8 +49,7 @@ export default function handleServerErrors(
           if (text.toLowerCase().includes("verify your email")) {
             return redirect("/verify-email");
           }
-          const error: Record<string, unknown> = { message: text || "Forbidden", status: 403, statusText: "Forbidden" };
-          reject(error);
+          reject(buildServerError(text || "Forbidden", 403, "Forbidden"));
         });
       }
       // 401 = not authenticated — redirect to sign-in
@@ -38,15 +64,7 @@ export default function handleServerErrors(
     }
     if (!response.ok) {
       return response.text().then(text => {
-        let error: Record<string, unknown> = {};
-        try {
-          error = JSON.parse(text);
-        } catch {
-          error = { message: text || response.statusText };
-        }
-        error.status = response.status;
-        error.statusText = response.statusText;
-        reject(error);
+        reject(buildServerError(text, response.status, response.statusText));
       });
     }
 
@@ -54,6 +72,6 @@ export default function handleServerErrors(
       return resolve(response);
     }
 
-    return reject(response);
+    return reject(buildServerError("", response.status, response.statusText));
   });
 }

--- a/cognee-mcp/Dockerfile
+++ b/cognee-mcp/Dockerfile
@@ -82,11 +82,23 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 ENV MCP_LOG_LEVEL=DEBUG
 ENV PYTHONPATH=/app
+# Give the non-root user a stable, writable HOME so Kuzu/Ladybug caches its
+# downloaded extensions in a consistent location across build and runtime.
+ENV HOME=/app
 
 # Add labels for API mode usage
 LABEL org.opencontainers.image.description="Cognee MCP Server with API mode support"
 
 USER cognee
+
+# Pre-install Kuzu/Ladybug's JSON extension at build time (network is available
+# here) so it is baked into the image. Runs the same install path the app uses,
+# as the same user with the same HOME, so the cached extension lands exactly
+# where the running server looks for it — avoiding the "Extension: json ... has
+# not been installed" Binder error when recall runs in a network-restricted
+# container. Best-effort: a failed download must not break the image build.
+RUN python -c "from cognee_db_workers._kuzu_helpers import install_json_extension_local; install_json_extension_local(buffer_pool_size=268435456)" \
+    || echo "WARNING: JSON extension pre-install skipped (no network at build time); it will be installed on first run if the container has network access."
 
 # Use the application name from pyproject.toml for normal operation
 # For testing, we'll override this with a direct command

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -113,11 +113,16 @@ def get_add_router() -> APIRouter:
             )
 
             if isinstance(add_run, PipelineRunErrored):
+                # The failing task's error is carried on ``payload`` (set to
+                # ``repr(error)`` by the pipeline runner). Surface it directly so
+                # the client gets an actionable message instead of an empty body
+                # or the model's repr.
+                detail = add_run.payload if isinstance(add_run.payload, str) else None
                 return JSONResponse(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     content=ErrorResponse(
                         error="Pipeline run errored",
-                        detail=getattr(add_run, "error", None) or str(add_run),
+                        detail=detail or str(add_run),
                     ).model_dump(),
                 )
             return add_run.model_dump()

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -346,8 +346,30 @@ class LadybugAdapter(GraphDBInterface):
             try:
                 self.connection.execute("LOAD EXTENSION JSON;")
                 logger.info("Loaded JSON extension")
-            except Exception as e:
-                logger.info(f"JSON extension already loaded or unavailable: {e}")
+            except Exception:
+                # LOAD failed — the extension is not installed for this
+                # connection's extension dir (the throwaway pre-install above can
+                # miss it when offline, or when it cached to a different path).
+                # Try installing + loading directly on the real connection before
+                # giving up. INSTALL is idempotent and a no-op when already cached.
+                try:
+                    self.connection.execute("INSTALL JSON;")
+                    self.connection.execute("LOAD EXTENSION JSON;")
+                    logger.info("Installed and loaded JSON extension")
+                except Exception as e:
+                    # Surface loudly: queries that use JSON (recall, temporal
+                    # search) will otherwise fail later with a cryptic Binder
+                    # error. This usually means no network access to download the
+                    # extension at startup.
+                    logger.warning(
+                        "Could not install/load the Kuzu/Ladybug JSON extension (%s). "
+                        "Graph queries that use JSON (e.g. recall, temporal search) will "
+                        "fail with 'Extension: json ... has not been installed'. Ensure the "
+                        "process has network access at startup to download the extension, "
+                        "pre-install it in your image, or run `INSTALL json; LOAD json;` "
+                        "once against the database.",
+                        e,
+                    )
 
             # Create node table with essential fields and timestamp
             self.connection.execute("""

--- a/cognee/infrastructure/loaders/LoaderEngine.py
+++ b/cognee/infrastructure/loaders/LoaderEngine.py
@@ -141,7 +141,7 @@ class LoaderEngine:
         """
         loader = self.get_loader(file_path, preferred_loaders)
         if not loader:
-            raise ValueError(f"No loader found for file: {file_path}")
+            raise ValueError(self._no_loader_message(file_path))
 
         logger.debug(f"Loading {file_path} with {loader.loader_name}")
 
@@ -154,6 +154,54 @@ class LoaderEngine:
         merged_kwargs = {**loader_config, **kwargs}
 
         return await loader.load(file_path, **merged_kwargs)
+
+    # Extensions handled only by optional document loaders, mapped to the
+    # cognee extra that provides the loader. Used to turn an opaque
+    # "no loader found" into an actionable install hint.
+    _OPTIONAL_FORMAT_EXTRAS = {
+        "pptx": "docling",
+        "ppt": "docling",
+        "odp": "docling",
+        "docx": "docling",
+        "doc": "docling",
+        "odt": "docling",
+        "xlsx": "docling",
+        "xls": "docling",
+        "ods": "docling",
+        "rtf": "docling",
+        "html": "docling",
+        "htm": "docling",
+        "eml": "docling",
+        "msg": "docling",
+        "epub": "docling",
+    }
+
+    def _no_loader_message(self, file_path: str) -> str:
+        """Build an actionable error for a file no registered loader can handle.
+
+        Names the extension, lists the currently supported extensions, and — for
+        office/document formats that only ship via an optional loader — tells the
+        user which extra to install (e.g. ``.pptx`` needs ``cognee[docling]``).
+        """
+        from pathlib import Path
+
+        ext = Path(file_path).suffix.lstrip(".").lower()
+        supported = ", ".join(sorted(self._extension_map.keys())) or "none"
+
+        message = f"No loader found for file '{file_path}'"
+        if ext:
+            message += f" (extension '.{ext}')"
+        message += "."
+
+        extra = self._OPTIONAL_FORMAT_EXTRAS.get(ext)
+        if extra:
+            message += (
+                f" '.{ext}' files need an optional document loader that is not installed. "
+                f"Install it with `pip install cognee[{extra}]` (or `cognee[unstructured]`) and retry."
+            )
+
+        message += f" Supported extensions: {supported}."
+        return message
 
     def get_available_loaders(self) -> list[str]:
         """


### PR DESCRIPTION
Addresses three rough edges reported during local + Cognee MCP setup.

## 1. `recall` fails with `Extension: json ... has not been installed`

Kuzu/Ladybug's `json` extension was installed best-effort against a throwaway DB and **silently swallowed** at two layers, so a network-restricted MCP container never actually got it — and the failure only surfaced later as a cryptic Binder error when `recall`/temporal queries run `json_extract(...)`.

- **`cognee-mcp/Dockerfile`**: pre-install the extension at **build time** (network available) so it's baked into the image. Runs the same install path the app uses, as the same non-root user with a stable `HOME=/app`, so the cached extension lands exactly where the running server looks for it.
- **`ladybug/adapter.py`**: on the real connection, fall back to `INSTALL JSON; LOAD JSON;` when `LOAD` alone fails (idempotent, no-op when cached), and emit a **loud, actionable warning** instead of a silent `info` log when it genuinely can't load — pointing at the network/pre-install/`INSTALL json; LOAD json;` fixes.

## 2. Uploading an unsupported file (e.g. `.pptx`) returned `ERROR: {}`

Two compounding bugs:
- The loader raised `No loader found for file: <path>` with no hint that `.pptx` needs an optional loader.
- `PipelineRunErrored` carries the error on `payload` (`repr(error)`), but the add router read a non-existent `error` attribute and fell back to the model repr — so the client got an unhelpful body.

Fixes:
- **`LoaderEngine`**: new error names the extension, lists supported extensions, and tells the user which extra to install for office/doc formats — e.g. ``'.pptx' files need an optional document loader... Install it with `pip install cognee[docling]` (or `cognee[unstructured]`)``.
- **add router** (`get_add_router.py`): surface `add_run.payload` as the error detail.

## 3. Frontend logged `[LOCAL-API] ✗ ... ERROR: {}`

`handleServerErrors` rejected with a **plain object**, which serializes to `{}` in `console.error`.
- **`handleServerErrors.ts`**: reject with a real `Error` carrying the server's `detail`/`error`/`message`, while still copying parsed fields onto it so callers reading `error.detail` keep working.

## Testing
- `ruff` / `pre-commit` clean; Python files compile; `tsc` clean on the frontend file.
- Loader message verified locally: `.pptx` →
  `No loader found for file '...deck.pptx' (extension '.pptx'). '.pptx' files need an optional document loader that is not installed. Install it with \`pip install cognee[docling]\` (or \`cognee[unstructured]\`) and retry. Supported extensions: ...`

## Notes
- The Dockerfile pre-install is best-effort (`|| echo …`): a failed build-time download won't break the image, and the adapter fallback installs on first run if the container has network.
- The `json`-extension fix targets the default Ladybug/Kuzu backend; other graph backends are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server and authentication errors now display more detailed, actionable messages
  * Pipeline failures provide clearer error feedback to users
  * File loader errors include available formats and installation instructions when applicable

* **Improvements**
  * JSON extension automatically installs as fallback when initial load fails, improving database compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->