### PR TITLE
fix: resolve CI OOM caused by Rich traceback locals rendering

### DIFF
--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -459,6 +459,13 @@ def setup_logging(log_level=None, name=None) -> bool:
         processor=structlog.dev.ConsoleRenderer(
             colors=True,
             force_colors=True,
+            # show_locals=False: the default RichTracebackFormatter renders every
+            # frame's locals, which in the retrieval path include graph objects
+            # carrying embedding vectors and deep node/edge references. Rendering
+            # those recursively builds millions of objects + stringifies the
+            # embeddings, spiking RAM to multiple GB and OOM-killing the process
+            # whenever an exception is logged mid-search. Disable locals rendering.
+            exception_formatter=structlog.dev.RichTracebackFormatter(show_locals=False),
             level_styles={
                 "critical": structlog.dev.RED,
                 "exception": structlog.dev.RED,


### PR DESCRIPTION
## Summary

CI runs were getting OOM-killed whenever an exception was logged mid-search. The root cause is structlog's default `RichTracebackFormatter`, which renders every stack frame's locals. In the retrieval path those locals include graph objects carrying embedding vectors and deep node/edge references — recursively rendering them builds millions of objects and stringifies the embeddings, spiking RAM by multiple GB.

## Fix

Configure the console renderer's exception formatter with `RichTracebackFormatter(show_locals=False)` so tracebacks are still rendered by Rich, but without frame locals.

## Test plan

- Existing CI runs that previously OOM'd when an exception was logged during search should now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined exception traceback display in log output to improve readability by reducing verbose diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->