### PR TITLE
test: fix lancedb and pgvector tests, use chunks instead of graph com…

### DIFF
--- a/cognee/tests/test_lancedb.py
+++ b/cognee/tests/test_lancedb.py
@@ -182,7 +182,8 @@ async def test_vector_nodeset_filtering_retriever_integration():
     retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
 
-    assert len(retrieved_objects) == 3
+    assert any("NLP" in chunk.payload["text"] for chunk in retrieved_objects)
+    assert any("Quantum" in chunk.payload["text"] for chunk in retrieved_objects)
 
     # Search with "AND" operator
     retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
@@ -198,13 +199,13 @@ async def test_vector_nodeset_filtering_retriever_integration():
     retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
 
-    assert len(retrieved_objects) == 2
+    assert any("Alice" in chunk.payload["text"] for chunk in retrieved_objects)
 
     # Search with "AND" operator
     retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
 
-    assert len(retrieved_objects) == 1
+    assert all("Alice" not in chunk.payload["text"] for chunk in retrieved_objects)
 
 
 async def main():

--- a/cognee/tests/test_lancedb.py
+++ b/cognee/tests/test_lancedb.py
@@ -176,22 +176,16 @@ async def test_vector_nodeset_filtering_retriever_integration():
     node_set = ["NLP", "Quantum"]
     query_text = "Tell me about Quantum computers"
 
-    from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
+    from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
 
     # Search with "OR" operator
-    retriever = GraphCompletionRetriever(
-        node_name=node_set, node_name_filter_operator="OR", top_k=100
-    )
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
-    context = await retriever.get_context_from_objects(
-        query=query_text, retrieved_objects=retrieved_objects
-    )
 
-    assert "Quantum" in context
-    assert "NLP" in context
+    assert len(retrieved_objects) == 3
 
     # Search with "AND" operator
-    retriever = GraphCompletionRetriever(node_name=node_set, node_name_filter_operator="AND")
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
 
     assert len(retrieved_objects) == 0, (
@@ -201,26 +195,16 @@ async def test_vector_nodeset_filtering_retriever_integration():
     node_set = ["Quantum", "Computers"]
 
     # Search with "OR" operator
-    retriever = GraphCompletionRetriever(
-        node_name=node_set, node_name_filter_operator="OR", top_k=100
-    )
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
-    context = await retriever.get_context_from_objects(
-        query=query_text, retrieved_objects=retrieved_objects
-    )
 
-    assert "Alice" in context
+    assert len(retrieved_objects) == 2
 
     # Search with "AND" operator
-    retriever = GraphCompletionRetriever(
-        node_name=node_set, node_name_filter_operator="AND", top_k=100
-    )
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
-    context = await retriever.get_context_from_objects(
-        query=query_text, retrieved_objects=retrieved_objects
-    )
 
-    assert "Alice" not in context
+    assert len(retrieved_objects) == 1
 
 
 async def main():

--- a/cognee/tests/test_pgvector.py
+++ b/cognee/tests/test_pgvector.py
@@ -183,7 +183,8 @@ async def test_vector_nodeset_filtering_retriever_integration():
     retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
 
-    assert len(retrieved_objects) == 3
+    assert any("NLP" in chunk.payload["text"] for chunk in retrieved_objects)
+    assert any("Quantum" in chunk.payload["text"] for chunk in retrieved_objects)
 
     # Search with "AND" operator
     retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
@@ -199,13 +200,13 @@ async def test_vector_nodeset_filtering_retriever_integration():
     retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
 
-    assert len(retrieved_objects) == 2
+    assert any("Alice" in chunk.payload["text"] for chunk in retrieved_objects)
 
     # Search with "AND" operator
     retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
 
-    assert len(retrieved_objects) == 1
+    assert all("Alice" not in chunk.payload["text"] for chunk in retrieved_objects)
 
 
 async def main():

--- a/cognee/tests/test_pgvector.py
+++ b/cognee/tests/test_pgvector.py
@@ -177,22 +177,16 @@ async def test_vector_nodeset_filtering_retriever_integration():
     node_set = ["NLP", "Quantum"]
     query_text = "Tell me about Quantum computers"
 
-    from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
+    from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
 
     # Search with "OR" operator
-    retriever = GraphCompletionRetriever(
-        node_name=node_set, node_name_filter_operator="OR", top_k=250
-    )
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
-    context = await retriever.get_context_from_objects(
-        query=query_text, retrieved_objects=retrieved_objects
-    )
 
-    assert "Quantum" in context
-    assert "NLP" in context
+    assert len(retrieved_objects) == 3
 
     # Search with "AND" operator
-    retriever = GraphCompletionRetriever(node_name=node_set, node_name_filter_operator="AND")
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
 
     assert len(retrieved_objects) == 0, (
@@ -202,26 +196,16 @@ async def test_vector_nodeset_filtering_retriever_integration():
     node_set = ["Quantum", "Computers"]
 
     # Search with "OR" operator
-    retriever = GraphCompletionRetriever(
-        node_name=node_set, node_name_filter_operator="OR", top_k=250
-    )
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
-    context = await retriever.get_context_from_objects(
-        query=query_text, retrieved_objects=retrieved_objects
-    )
 
-    assert "Alice" in context
+    assert len(retrieved_objects) == 2
 
     # Search with "AND" operator
-    retriever = GraphCompletionRetriever(
-        node_name=node_set, node_name_filter_operator="AND", top_k=250
-    )
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
     retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
-    context = await retriever.get_context_from_objects(
-        query=query_text, retrieved_objects=retrieved_objects
-    )
 
-    assert "Alice" not in context
+    assert len(retrieved_objects) == 1
 
 
 async def main():


### PR DESCRIPTION
…pletion

<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
LanceDB and PGVector tests were using a lot of memory on CI, this PR fixes this issue.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated vector retrieval integration tests to use a chunk-based retriever and validate returned chunk text directly; removed generated-context assertions. Improved checks for OR/AND node-set filtering to assert correct presence or absence of expected text in results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->