### PR TITLE
fix(visualize): scalable schema view, readable labels, stable interactions, dark mode

### DIFF
--- a/cognee/modules/visualization/preprocessor.py
+++ b/cognee/modules/visualization/preprocessor.py
@@ -30,6 +30,16 @@ SCHEMA_GRAPH_NODE_TYPES = {
 # Maximum sample instance names attached to each schema type node.
 SCHEMA_SAMPLES_PER_TYPE: int = 5
 
+# Maximum semantic entity-type cards in the Schema view's Entity column.
+# Entity-type diversity grows with the data (every new EntityType the LLM
+# extracts becomes its own card), so beyond this cap the long tail is rolled
+# up into a single "Other entities" card — the renderer stacks one card per
+# type per rank column, which otherwise made the Entity column endless.
+SCHEMA_MAX_ENTITY_TYPES: int = 12
+
+# Display name of the rollup card holding the entity-type long tail.
+OTHER_ENTITY_TYPES_LABEL: str = "Other entities"
+
 # Internal graph taxonomy types that must not appear as separate type groups in
 # the schema view. EntityType is now surfaced as its own schema type group
 # alongside the resolved semantic entity types (Person/Field/...); Entity
@@ -464,6 +474,30 @@ def extract_type_schema_graph_data(
             if target_node and target_node.get("name"):
                 semantic_type_names.add(target_node["name"])
 
+    # Bound the Entity column: keep the most-populated semantic entity types
+    # as their own cards and remap the long tail onto one rollup type. The
+    # remap happens on node_type_by_id *before* any downstream aggregation, so
+    # relationship distributions, pair edges, instance drill-down, and the
+    # operation layer all treat the rollup as an ordinary type.
+    rolled_up_types: List[Dict[str, Any]] = []
+    entity_type_counts = Counter(
+        type_name for type_name in node_type_by_id.values() if type_name in semantic_type_names
+    )
+    if len(entity_type_counts) > SCHEMA_MAX_ENTITY_TYPES:
+        kept_types = {
+            name for name, _ in entity_type_counts.most_common(SCHEMA_MAX_ENTITY_TYPES - 1)
+        }
+        rolled_types = set(entity_type_counts) - kept_types
+        rolled_up_types = [
+            {"name": name, "count": count}
+            for name, count in entity_type_counts.most_common()
+            if name in rolled_types
+        ]
+        for node_id, type_name in node_type_by_id.items():
+            if type_name in rolled_types:
+                node_type_by_id[node_id] = OTHER_ENTITY_TYPES_LABEL
+        semantic_type_names = (semantic_type_names - rolled_types) | {OTHER_ENTITY_TYPES_LABEL}
+
     def _rank_for(type_name):
         if type_name in semantic_type_names:
             return node_type_rank("Entity")
@@ -535,22 +569,35 @@ def extract_type_schema_graph_data(
             key=lambda rel: (-rel["count"], rel["to_type"] or "", rel["relation"]),
         )
 
-        schema_nodes.append(
-            {
-                "id": f"type:{node_type_name}",
-                "name": node_type_name,
-                "type": "GraphNodeType",
-                "rank": _rank_for(node_type_name),
-                "fields": extract_type_schema_fields(type_nodes),
-                "source_pipeline": top_pipeline,
-                "source_task": top_task,
-                "source_user": top_user,
-                "instance_count": len(type_nodes),
-                "samples": samples,
-                "sample_size": len(samples),
-                "relationships": relationships,
-            }
-        )
+        schema_node = {
+            "id": f"type:{node_type_name}",
+            "name": node_type_name,
+            "type": "GraphNodeType",
+            "rank": _rank_for(node_type_name),
+            "fields": extract_type_schema_fields(type_nodes),
+            "source_pipeline": top_pipeline,
+            "source_task": top_task,
+            "source_user": top_user,
+            "instance_count": len(type_nodes),
+            "samples": samples,
+            "sample_size": len(samples),
+            "relationships": relationships,
+        }
+        if node_type_name == OTHER_ENTITY_TYPES_LABEL and rolled_up_types:
+            schema_node["rollup"] = True
+            schema_node["rolled_up_types"] = rolled_up_types
+            # Lead the card with the tail size and its largest types so the
+            # rollup is self-explanatory without inspector drill-down.
+            top_tail = ", ".join(f"{t['name']} ({t['count']})" for t in rolled_up_types[:3])
+            schema_node["fields"].insert(
+                1,
+                {
+                    "name": "entity types",
+                    "type": f"{len(rolled_up_types)} rolled up: {top_tail}, …",
+                    "required": True,
+                },
+            )
+        schema_nodes.append(schema_node)
 
     relation_counts_by_pair: Dict[Tuple[str, str], Counter] = defaultdict(Counter)
     for link in links_list:

--- a/cognee/modules/visualization/preprocessor.py
+++ b/cognee/modules/visualization/preprocessor.py
@@ -115,7 +115,10 @@ _TYPE_COLOR_MAP: Dict[str, str] = {
 }
 
 
-_ONTOLOGY_VALID_COLOR = "#D8D8D8"
+# Ontology-grounded nodes get a distinct fill: the old #D8D8D8 gray was
+# indistinguishable from the #DBD8D8 unknown-type fallback, so ontology
+# matches visually disappeared into untyped nodes.
+_ONTOLOGY_VALID_COLOR = "#FF5CA8"
 _UNKNOWN_TYPE_COLOR = "#DBD8D8"
 
 

--- a/cognee/modules/visualization/template.html
+++ b/cognee/modules/visualization/template.html
@@ -273,6 +273,32 @@ canvas:active{cursor:grabbing}
 .sd-edge-count{font-size:9.5px;fill:var(--text2);font-variant-numeric:tabular-nums;}
 .sd-stage-header{font-size:10px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;fill:#8792A2;}
 
+/* ── Schema dark theme ── card/chip colors come from the JS palette (re-rendered
+   on toggle); these override the CSS-styled and inline-styled chrome. */
+html:not(.light) #schema-view{background:#15181D !important;color:#E4E8EE !important;}
+html:not(.light) #schema-diagram-section{background:#15181D !important;}
+html:not(.light) .sd-edge-label-bg{fill:#23272F;stroke:#3A4049;}
+html:not(.light) .sd-edge-label{fill:#AEB7C2;}
+html:not(.light) .sd-edge-label.is-hot{fill:#3DD68C;}
+html:not(.light) .sd-stage-header{fill:#7E8894;}
+html:not(.light) .sd-node-box:hover{filter:drop-shadow(0 6px 16px rgba(0,0,0,0.55));}
+html:not(.light) .sd-mini-card:hover rect{fill:#1E3A2E;stroke:#2E6B4F;}
+html:not(.light) .sd-mini-card.is-spotlit rect{fill:#1E3A2E;stroke:#1F9E6E;}
+html:not(.light) .sd-mini-card.is-linked rect{fill:#23272F;stroke:#2E6B4F;}
+html:not(.light) .sd-spotlight-label{stroke:#15181D;}
+html:not(.light) #schema-zoom{background:#23272F !important;border-color:#3A4049 !important;}
+html:not(.light) #schema-zoom button{color:#C3CAD4 !important;}
+html:not(.light) #schema-zoom button:hover{background:#2E333C;color:#ECEFF4;}
+html:not(.light) #schema-ops-toggle{background:#23272F !important;border-color:#3A4049 !important;color:#C3CAD4 !important;}
+html:not(.light) #schema-ops-toggle.active{background:#1F9E6E !important;color:#fff !important;border-color:#1F9E6E !important;}
+html:not(.light) #schema-legend{background:#23272F !important;border-color:#3A4049 !important;color:#C3CAD4 !important;}
+html:not(.light) #schema-side-panel{background:#1B1F25 !important;border-left-color:#3A4049 !important;color:#E4E8EE;box-shadow:-12px 0 32px rgba(0,0,0,0.45) !important;}
+html:not(.light) .si-title{color:#ECEFF4;}
+html:not(.light) .si-close:hover{background:#2A2F37;color:#ECEFF4;}
+html:not(.light) .si-chip{background:#2A2F37;border-color:#3A4049;color:#E4E8EE;}
+html:not(.light) .si-chip:hover{background:#1E3A2E;border-color:#2E6B4F;color:#3DD68C;}
+html:not(.light) .si-rel{border-bottom-color:#2E333C;}
+
 /* ── Schema inspector side panel (PR3) — clean & airy Segment style ── */
 #schema-side-panel{font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;font-size:13px;color:#1A1F36;}
 .si-close{position:absolute;top:14px;right:16px;width:24px;height:24px;display:flex;align-items:center;justify-content:center;border-radius:6px;color:#8792A2;font-size:18px;line-height:1;cursor:pointer;transition:background .12s,color .12s;}

--- a/cognee/modules/visualization/template.html
+++ b/cognee/modules/visualization/template.html
@@ -174,9 +174,9 @@ canvas:active{cursor:grabbing}
   <button class="ctrl-btn" data-labelbudget="all" title="Labels: every node">All</button>
   <button class="ctrl-btn" data-labelbudget="off" title="Labels: hidden (hover to peek)">Off</button>
   <div class="ctrl-sep"></div>
-  <button class="ctrl-btn active" data-layout="story" title="Pipeline story: Documents &rarr; Chunks &rarr; Entities &rarr; Types &rarr; Summaries">Story</button>
-  <button class="ctrl-btn" data-layout="ranked" title="Left-to-right by topological rank">Flow</button>
-  <button class="ctrl-btn" data-layout="organic" title="Organic force layout">Force</button>
+  <button class="ctrl-btn active" data-layout="story" title="Story: fixed pipeline columns (Documents &rarr; Chunks &rarr; Entities &rarr; Types &rarr; Summaries). Nodes stay pinned in a readable grid.">Story</button>
+  <button class="ctrl-btn" data-layout="ranked" title="Flow: columns by processing order; vertical position settles by connectivity, so related nodes drift together.">Flow</button>
+  <button class="ctrl-btn" data-layout="organic" title="Force: no columns &mdash; a physics simulation pulls connected nodes together so clusters emerge. Drag nodes to rearrange.">Force</button>
   <div class="ctrl-sep"></div>
   <button class="ctrl-btn active" data-colorby="type" title="Color by node type">Type</button>
   <button class="ctrl-btn" data-colorby="nodeset" title="Color by source node set">Node set</button>

--- a/cognee/modules/visualization/views/schema_view.js
+++ b/cognee/modules/visualization/views/schema_view.js
@@ -313,6 +313,24 @@
           labelX = lx + 36;
           labelY = src.y + src.h / 2;
           sx = lx; sy = src.y + 30; tx = lx; ty = src.y + src.h - 30;
+        } else if (Math.abs(src.x - tgt.x) < LAYOUT.BOX_W * 0.5) {
+          // Same-column pair (vertically stacked cards — common in the tall
+          // Entity column). The horizontal-ease curve degenerates into an
+          // S-loop here, leaving arrowheads pointing backwards. Route a side
+          // loop instead: exit the source's right edge, bulge outward, enter
+          // the target's right edge — the head always points cleanly left
+          // into the target card.
+          const offset = (idxInPair - (group.length - 1) / 2) * 22;
+          const sxp = src.x + src.w, syp = src.y + Math.min(34, src.h / 2);
+          const txp = tgt.x + tgt.w, typ = tgt.y + Math.min(34, tgt.h / 2);
+          const bulge = 56 + Math.min(150, Math.abs(typ - syp) * 0.14) + Math.abs(offset);
+          pathD = 'M ' + sxp + ' ' + syp +
+                  ' C ' + (sxp + bulge) + ' ' + syp +
+                  ', ' + (txp + bulge) + ' ' + typ +
+                  ', ' + txp + ' ' + typ;
+          labelX = Math.max(sxp, txp) + bulge * 0.78;
+          labelY = (syp + typ) / 2;
+          sx = sxp; sy = syp; tx = txp; ty = typ;
         } else {
           const aSrc = boxAnchor(src, tgtCx, tgtCy);
           const aTgt = boxAnchor(tgt, srcCx, srcCy);
@@ -753,17 +771,23 @@
   function flowCurve(sx, sy, tx, ty, offset) {
     offset = offset || 0;
     const dx = tx - sx;
+    const dy = Math.abs(ty - sy);
     const span = Math.abs(dx) / (LAYOUT.BOX_W + LAYOUT.COL_GAP);
     const handle = Math.max(60, Math.abs(dx) * 0.5);
     const dir = dx >= 0 ? 1 : -1;
     let c1y = sy + offset, c2y = ty + offset;
     // Drop the control points below the card band so multi-column edges arc
-    // clearly under the intermediate cards rather than grazing them.
-    if (span >= 1.25) {
+    // clearly under the intermediate cards rather than grazing them. Only
+    // when the endpoints sit at similar heights: with a large vertical span
+    // (tall columns) the drop overshot below BOTH cards, hooking the curve
+    // back up so the arrowhead pointed the wrong way ("inverted" arrows).
+    // Vertically distant cards get the plain horizontal-ease instead, which
+    // already clears the band diagonally.
+    if (span >= 1.25 && dy < 140) {
       const drop = Math.max(sy, ty) + (64 + span * 40);
       c1y = drop + offset;
       c2y = drop + offset;
-    } else if (span >= 0.4) {
+    } else if (span >= 0.4 && dy < 90) {
       // Adjacent columns: a gentle downward bow so the edge clears the card edges.
       const drop = Math.max(sy, ty) + 34;
       c1y = drop + offset;

--- a/cognee/modules/visualization/views/schema_view.js
+++ b/cognee/modules/visualization/views/schema_view.js
@@ -235,9 +235,25 @@
   function renderSchemaDiagram(model, savedTransform) {
     const svg = d3.select('#schema-svg');
     svg.selectAll('*').remove();
-    // The schema explorer is always a clean, airy light surface (Segment-style),
-    // independent of the global graph-view theme toggle.
-    const isLight = true;
+    // Follow the global theme toggle (ui_chrome re-renders the schema on
+    // toggle). The light palette is the Segment-style airy surface; the dark
+    // palette mirrors it on deep neutrals.
+    const isLight = window._isLightMode !== false;
+    const P = isLight
+      ? {
+          card: '#ffffff', cardBorder: '#E6E8EB',
+          title: '#1A1F36', muted: '#8792A2',
+          pill: '#EEF1F4', pillText: '#4A5568',
+          mini: '#F6F8FA', miniBorder: '#EDF0F3', miniText: '#1A1F36',
+          shadow: '#1A1F36', shadowOpacity: 0.10,
+        }
+      : {
+          card: '#23272F', cardBorder: '#3A4049',
+          title: '#ECEFF4', muted: '#9AA4B2',
+          pill: '#2E333C', pillText: '#C3CAD4',
+          mini: '#2A2F37', miniBorder: '#3A4049', miniText: '#E4E8EE',
+          shadow: '#000000', shadowOpacity: 0.40,
+        };
     // Absolute rects captured during render so the spotlight overlay can draw
     // instance-level connectors without re-laying-out the diagram.
     window._miniCardRects = {};
@@ -324,10 +340,16 @@
           const sxp = src.x + src.w, syp = src.y + Math.min(34, src.h / 2);
           const txp = tgt.x + tgt.w, typ = tgt.y + Math.min(34, tgt.h / 2);
           const bulge = 56 + Math.min(150, Math.abs(typ - syp) * 0.14) + Math.abs(offset);
+          // Straight run-in/run-out segments at both ends: the arrow marker
+          // orients to the path tangent at its endpoint, so it must sit on a
+          // visibly straight piece of line or the head looks detached.
+          const RUN = 10;
           pathD = 'M ' + sxp + ' ' + syp +
+                  ' L ' + (sxp + RUN) + ' ' + syp +
                   ' C ' + (sxp + bulge) + ' ' + syp +
                   ', ' + (txp + bulge) + ' ' + typ +
-                  ', ' + txp + ' ' + typ;
+                  ', ' + (txp + RUN) + ' ' + typ +
+                  ' L ' + txp + ' ' + typ;
           labelX = Math.max(sxp, txp) + bulge * 0.78;
           labelY = (syp + typ) / 2;
           sx = sxp; sy = syp; tx = txp; ty = typ;
@@ -359,8 +381,8 @@
     shadow.append('feDropShadow')
       .attr('dx', 0).attr('dy', 2)
       .attr('stdDeviation', 5)
-      .attr('flood-color', '#1A1F36')
-      .attr('flood-opacity', 0.10);
+      .attr('flood-color', P.shadow)
+      .attr('flood-opacity', P.shadowOpacity);
 
     // Per-edge gradient: flows from the source type's accent to the target's.
     function gradId(e){ return 'sd-grad-' + String(e.id).replace(/[^a-zA-Z0-9_-]/g, ''); }
@@ -381,14 +403,18 @@
     drawnEdges.forEach(function(de) { markerTypes[accentTypeByName[de.edge.target_type] || de.edge.target_type] = true; });
     function arrowId(tname){ return 'sd-arrow-' + String(tname).replace(/[^a-zA-Z0-9_-]/g, ''); }
     Object.keys(markerTypes).forEach(function(tname) {
+      // Tip at viewBox x=10 with refX=10: the tip sits exactly on the path
+      // endpoint with the head body covering the line behind it — no empty
+      // marker margin past the tip (which left the path's round linecap
+      // poking out as a detached nub).
       defs.append('marker')
         .attr('id', arrowId(tname))
         .attr('viewBox', '0 -5 10 10')
-        .attr('refX', 8).attr('refY', 0)
-        .attr('markerWidth', 6.5).attr('markerHeight', 6.5)
+        .attr('refX', 10).attr('refY', 0)
+        .attr('markerWidth', 7).attr('markerHeight', 7)
         .attr('orient', 'auto')
         .append('path')
-        .attr('d', 'M0,-3.5L8,0L0,3.5')
+        .attr('d', 'M0,-4L10,0L0,4')
         .attr('fill', accentFor(tname));
     });
 
@@ -453,13 +479,13 @@
         .attr('data-node-id', t.id || '')
         .attr('transform', 'translate(' + p.x + ',' + p.y + ')');
 
-      // Card body — soft white card with a gentle drop shadow.
+      // Card body — soft themed card with a gentle drop shadow.
       g.append('rect')
         .attr('width', p.w)
         .attr('height', p.h)
         .attr('rx', 14)
-        .attr('fill', '#ffffff')
-        .attr('stroke', '#E6E8EB')
+        .attr('fill', P.card)
+        .attr('stroke', P.cardBorder)
         .attr('stroke-width', 1)
         .attr('filter', 'url(#sd-card-shadow)');
 
@@ -467,7 +493,7 @@
         // Single-instance card: the instance name is the headline.
         g.append('circle').attr('cx', 21).attr('cy', 25).attr('r', 5).attr('fill', accent);
         g.append('text').attr('x', 34).attr('y', 30)
-          .attr('font-size', 14.5).attr('font-weight', 700).attr('fill', '#1A1F36')
+          .attr('font-size', 14.5).attr('font-weight', 700).attr('fill', P.title)
           .text(truncate(name, 15));
         return;
       }
@@ -477,7 +503,7 @@
       g.append('circle').attr('cx', 18).attr('cy', 22).attr('r', 4).attr('fill', accent);
       g.append('text').attr('x', 30).attr('y', 25.5)
         .attr('font-size', 10.5).attr('font-weight', 700).attr('letter-spacing', '0.04em')
-        .attr('fill', '#8792A2')
+        .attr('fill', P.muted)
         .text(truncate(String(name).toUpperCase(), 18));
 
       // Count pill (top-right).
@@ -486,11 +512,11 @@
       g.append('rect')
         .attr('x', p.w - 14 - pw).attr('y', 13)
         .attr('width', pw).attr('height', 19).attr('rx', 9.5)
-        .attr('fill', '#EEF1F4');
+        .attr('fill', P.pill);
       g.append('text')
         .attr('x', p.w - 14 - pw / 2).attr('y', 26.5)
         .attr('text-anchor', 'middle')
-        .attr('font-size', 11).attr('font-weight', 600).attr('fill', '#4A5568')
+        .attr('font-size', 11).attr('font-weight', 600).attr('fill', P.pillText)
         .text(cstr);
 
       // "Modified by operations" badge (amber dot) — see the Transformations layer.
@@ -516,13 +542,13 @@
           .attr('x', 13).attr('y', cy)
           .attr('width', p.w - 26).attr('height', LAYOUT.CARD_H - 6)
           .attr('rx', 7)
-          .attr('fill', '#F6F8FA')
-          .attr('stroke', '#EDF0F3')
+          .attr('fill', P.mini)
+          .attr('stroke', P.miniBorder)
           .attr('stroke-width', 1);
         card.append('text')
           .attr('x', 25).attr('y', cy + (LAYOUT.CARD_H - 6) / 2 + 4)
           .attr('font-size', 11.5)
-          .attr('fill', '#1A1F36')
+          .attr('fill', P.miniText)
           .text(truncate(inst.name || inst.id, 24));
       });
       const total = t.instance_count || insts.length;
@@ -559,11 +585,11 @@
         const kindColor = OP_KIND_COLORS[op.op_kind] || '#8792A2';
         const g = opGroup.append('g').attr('class', 'sd-op-chip').attr('data-op', op.id);
         g.append('rect').attr('x', x).attr('y', railY).attr('width', chipW).attr('height', chipH)
-          .attr('rx', 8).attr('fill', '#FFFFFF').attr('stroke', kindColor).attr('stroke-width', 1.5)
+          .attr('rx', 8).attr('fill', P.card).attr('stroke', kindColor).attr('stroke-width', 1.5)
           .attr('filter', 'url(#sd-card-shadow)');
         g.append('circle').attr('cx', x + 13).attr('cy', railY + chipH / 2).attr('r', 4).attr('fill', kindColor);
         g.append('text').attr('x', x + 24).attr('y', railY + chipH / 2 + 4)
-          .attr('font-size', 11.5).attr('font-weight', 600).attr('fill', '#1A1F36')
+          .attr('font-size', 11.5).attr('font-weight', 600).attr('fill', P.title)
           .text(truncate(op.name, 16));
       });
     }
@@ -794,8 +820,16 @@
       c2y = drop + offset;
     }
     const c1x = sx + dir * handle, c2x = tx - dir * handle;
+    // Straight run-in/run-out segments: the arrow marker orients to the path
+    // tangent at the endpoint, so it must sit on a visibly straight piece of
+    // line or the head appears detached/rotated off the curve.
+    const RUN = 10;
+    const sx2 = sx + dir * RUN, tx2 = tx - dir * RUN;
     return {
-      d: 'M ' + sx + ' ' + sy + ' C ' + c1x + ' ' + c1y + ', ' + c2x + ' ' + c2y + ', ' + tx + ' ' + ty,
+      d: 'M ' + sx + ' ' + sy +
+         ' L ' + sx2 + ' ' + sy +
+         ' C ' + c1x + ' ' + c1y + ', ' + c2x + ' ' + c2y + ', ' + tx2 + ' ' + ty +
+         ' L ' + tx + ' ' + ty,
       mx: (c1x + c2x) / 2,
       my: (c1y + c2y) / 2,
     };

--- a/cognee/modules/visualization/views/schema_view.js
+++ b/cognee/modules/visualization/views/schema_view.js
@@ -962,9 +962,26 @@
       const accent = accentFor(focus.type);
       const marker = overlay.append('defs').append('marker')
         .attr('id', 'sd-spot-arrow').attr('viewBox', '0 -5 10 10')
-        .attr('refX', 8).attr('refY', 0).attr('markerWidth', 7).attr('markerHeight', 7)
+        .attr('refX', 10).attr('refY', 0).attr('markerWidth', 7).attr('markerHeight', 7)
         .attr('orient', 'auto');
-      marker.append('path').attr('d', 'M0,-3.5L8,0L0,3.5').attr('fill', accent);
+      marker.append('path').attr('d', 'M0,-4L10,0L0,4').attr('fill', accent);
+      let sameCardIdx = 0;
+      let crossCardIdx = 0;
+      // Greedy vertical declutter: connector labels for links to nearby
+      // instances land on nearly the same midpoint and overprint into
+      // garbage. Push each new label below any already-placed neighbor.
+      const placedLabelYs = [];
+      function declutterY(y) {
+        let moved = true;
+        while (moved) {
+          moved = false;
+          for (let i = 0; i < placedLabelYs.length; i++) {
+            if (Math.abs(y - placedLabelYs[i]) < 13) { y = placedLabelYs[i] + 13; moved = true; }
+          }
+        }
+        placedLabelYs.push(y);
+        return y;
+      }
       links.forEach(function(l) {
         const n = index[l.id];
         if (!n) return;
@@ -972,13 +989,46 @@
         if (!tgtRect) return;
         let s = focusRect, t = tgtRect;
         if (l.dir === 'in') { s = tgtRect; t = focusRect; }
-        const a = anchorBetween(s, t);
-        const curve = flowCurve(a.sx, a.sy, a.tx, a.ty, 0);
-        overlay.append('path').attr('class', 'sd-spotlight-edge-halo').attr('fill', 'none').attr('stroke', accent).attr('d', curve.d);
+        let d, lx, ly, anchor = 'middle';
+        if (n.type === focus.type) {
+          // Connection between two instances of the SAME type card. The
+          // facing-side anchors degenerate here: the connector cut straight
+          // across the card with its label overprinting the others. Route a
+          // side loop out of the card's LEFT edge instead (the right side
+          // already hosts the type-pair loops), nesting loops and labels by
+          // index so multiple relations stay individually readable.
+          sameCardIdx += 1;
+          const sx = s.x, sy = s.y + s.h / 2;
+          const tx = t.x, ty = t.y + t.h / 2;
+          const bulge = 46 + Math.min(140, Math.abs(ty - sy) * 0.18) + sameCardIdx * 16;
+          const RUN = 8;
+          d = 'M ' + sx + ' ' + sy +
+              ' L ' + (sx - RUN) + ' ' + sy +
+              ' C ' + (sx - bulge) + ' ' + sy +
+              ', ' + (tx - bulge) + ' ' + ty +
+              ', ' + (tx - RUN) + ' ' + ty +
+              ' L ' + tx + ' ' + ty;
+          // Right-align the label just left of the loop apex so the text
+          // extends away from the nested loop strokes.
+          lx = Math.min(sx, tx) - bulge - 4;
+          ly = declutterY((sy + ty) / 2);
+          anchor = 'end';
+        } else {
+          // Cross-card connector: spread vertically so labels between the
+          // same pair of cards don't land on one coincident midpoint.
+          crossCardIdx += 1;
+          const spread = ((crossCardIdx % 5) - 2) * 16;
+          const a = anchorBetween(s, t);
+          const curve = flowCurve(a.sx, a.sy, a.tx, a.ty, spread);
+          d = curve.d;
+          lx = curve.mx;
+          ly = declutterY(curve.my);
+        }
+        overlay.append('path').attr('class', 'sd-spotlight-edge-halo').attr('fill', 'none').attr('stroke', accent).attr('d', d);
         overlay.append('path').attr('class', 'sd-spotlight-edge').attr('fill', 'none').attr('stroke', accent)
-          .attr('marker-end', 'url(#sd-spot-arrow)').attr('d', curve.d);
+          .attr('marker-end', 'url(#sd-spot-arrow)').attr('d', d);
         overlay.append('text').attr('class', 'sd-spotlight-label')
-          .attr('x', curve.mx).attr('y', curve.my).attr('text-anchor', 'middle')
+          .attr('x', lx).attr('y', ly).attr('text-anchor', anchor)
           .attr('fill', accent).text(l.relation);
       });
     }

--- a/cognee/modules/visualization/views/story_view.js
+++ b/cognee/modules/visualization/views/story_view.js
@@ -1199,16 +1199,33 @@ function isInViewport(wx,wy,margin,vp){
 
 // ── Mouse ──
 var isDragging=false,dragNode=null,isPanning=false;
-var lastMx=0,lastMy=0;
+// A press only becomes a drag after the cursor moves DRAG_THRESHOLD px.
+// Plain clicks must never touch node pins or reheat the simulation —
+// doing so unpinned the clicked node and let repulsion push it off into
+// space (the layout anchors are much weaker than the charge force).
+var dragStarted=false;
+var DRAG_THRESHOLD=3;
+var lastMx=0,lastMy=0,downMx=0,downMy=0;
+
+function releaseDragNode(){
+  if(!dragNode)return;
+  if(layoutMode==="story"){
+    // Story pins every node into its lane; snap the dragged node back so
+    // interaction can never degrade the deterministic grid.
+    dragNode.fx=(typeof dragNode._targetX==="number")?dragNode._targetX:null;
+    dragNode.fy=(typeof dragNode._targetY==="number")?dragNode._targetY:null;
+  }else{
+    dragNode.fx=null;dragNode.fy=null;
+  }
+  if(dragStarted)simulation.alphaTarget(0);
+}
 
 canvas.addEventListener("mousedown",function(ev){
   var mx=ev.offsetX,my=ev.offsetY;
-  lastMx=mx;lastMy=my;
+  lastMx=mx;lastMy=my;downMx=mx;downMy=my;
   var hit=findNodeAt(mx,my);
   if(hit){
-    dragNode=hit;isDragging=true;
-    dragNode.fx=dragNode.x;dragNode.fy=dragNode.y;
-    simulation.alphaTarget(0.3).restart();
+    dragNode=hit;isDragging=true;dragStarted=false;
     canvas.style.cursor="grabbing";
   }else{
     isPanning=true;
@@ -1219,6 +1236,12 @@ canvas.addEventListener("mousedown",function(ev){
 canvas.addEventListener("mousemove",function(ev){
   var mx=ev.offsetX,my=ev.offsetY;
   if(isDragging&&dragNode){
+    if(!dragStarted){
+      var dx=mx-downMx,dy=my-downMy;
+      if(dx*dx+dy*dy<DRAG_THRESHOLD*DRAG_THRESHOLD){lastMx=mx;lastMy=my;return}
+      dragStarted=true;
+      simulation.alphaTarget(0.3).restart();
+    }
     var w=screenToWorld(mx,my);
     dragNode.fx=w.x;dragNode.fy=w.y;
   }else if(isPanning){
@@ -1243,17 +1266,14 @@ canvas.addEventListener("mousemove",function(ev){
 });
 
 canvas.addEventListener("mouseup",function(){
-  if(isDragging&&dragNode){
-    dragNode.fx=null;dragNode.fy=null;
-    simulation.alphaTarget(0);
-  }
-  isDragging=false;dragNode=null;isPanning=false;
+  if(isDragging)releaseDragNode();
+  isDragging=false;dragNode=null;isPanning=false;dragStarted=false;
   canvas.style.cursor="grab";
 });
 
 canvas.addEventListener("mouseleave",function(){
-  if(isDragging&&dragNode){dragNode.fx=null;dragNode.fy=null;simulation.alphaTarget(0)}
-  isDragging=false;dragNode=null;isPanning=false;
+  if(isDragging)releaseDragNode();
+  isDragging=false;dragNode=null;isPanning=false;dragStarted=false;
   hoveredNode=null;draw();
 });
 
@@ -1441,10 +1461,11 @@ function updateFps(){
 }
 
 // Top-chrome reserved zone in screen-pixels. Tabs (32px), header (~40px),
-// theme toggle, search box all live in the first ~64px of the viewport.
-// Column gridlines and column labels must start below this so they don't
-// bleed into the chrome.
-var TOP_CHROME_PAD=72;
+// theme toggle, and the fixed search box (top:56px, ~34px tall — see
+// #search-box in template.html) live in the first ~90px of the viewport.
+// Column gridlines and column labels must start below ALL of it, or the
+// first column's "Documents" pill collides with the "Search nodes" input.
+var TOP_CHROME_PAD=104;
 // Bottom-chrome zone for the floating controls bar.
 var BOT_CHROME_PAD=64;
 function drawRankColumns(vp,_light){
@@ -1815,33 +1836,39 @@ function draw(){
       else if(N>500){labelEvery=scale<0.3?Math.ceil(N/20):scale<0.8?Math.ceil(N/80):1}
       else{labelEvery=1}
 
+      // Two-pass labeling: collect candidates first, then place them in
+      // priority order with rectangle-collision rejection. Drawing labels
+      // node-by-node let neighbors overprint each other, which made
+      // entity names unreadable even on small graphs.
+      var labelCandidates=[];
       nodes.forEach(function(n,i){
         if(typeof n.x!=="number")return;
         // Viewport culling for labels
         if(!isInViewport(n.x,n.y,n._r+fontSize*2+vpMargin,vp))return;
 
-        var shouldLabel=false;
+        // Priority: hovered focus (3) > search match (2) > key node (1).
+        var prio=-1;
 
         // Always label hovered + neighbors (budget-independent)
-        if(hoveredNode&&neighborSet&&neighborSet.has(n.id))shouldLabel=true;
+        if(hoveredNode&&neighborSet&&neighborSet.has(n.id))prio=3;
         // Always label search matches
-        if(hasSearch&&searchMatches.has(n.id))shouldLabel=true;
+        if(hasSearch&&searchMatches.has(n.id))prio=Math.max(prio,2);
 
         if(labelBudget==="key"){
           // Default: label only nodes the preprocessor marked as
           // label_priority (documents, entity-types, top-quartile
           // importance). Hovered/searched already opted-in above.
-          if(n.label_priority===true)shouldLabel=true;
+          if(n.label_priority===true)prio=Math.max(prio,1);
         }else if(N>5000){
           // "all" mode on a huge graph still has to cap somewhere
-          if(topDegreeSet.has(n.id))shouldLabel=true;
+          if(topDegreeSet.has(n.id))prio=Math.max(prio,1);
         }else{
           // "all" mode — original legacy adaptive behavior
-          if(n._degree>=maxDeg*0.3)shouldLabel=true;
-          if(labelEvery<Infinity&&i%labelEvery===0)shouldLabel=true;
+          if(n._degree>=maxDeg*0.3)prio=Math.max(prio,1);
+          if(labelEvery<Infinity&&i%labelEvery===0)prio=Math.max(prio,0);
         }
 
-        if(!shouldLabel)return;
+        if(prio<0)return;
 
         var alpha2=0.85;
         if(hoveredNode){
@@ -1851,14 +1878,44 @@ function draw(){
           alpha2=searchMatches.has(n.id)?1:0.08;
         }
 
+        labelCandidates.push({n:n,prio:prio,alpha:alpha2});
+      });
+
+      // Important labels claim space first; ties broken by degree so hubs
+      // keep their names when space runs out.
+      labelCandidates.sort(function(a,b){
+        if(a.prio!==b.prio)return b.prio-a.prio;
+        return (b.n._degree||0)-(a.n._degree||0);
+      });
+
+      var placedLabelRects=[];
+      var MAX_PLACED_LABELS=250;
+      labelCandidates.forEach(function(c){
+        if(placedLabelRects.length>=MAX_PLACED_LABELS)return;
+        var n=c.n;
         var label=truncate(n.name||"",30);
+        if(!label)return;
         var yOff=n._r+fontSize*0.8;
+        var halfW=ctx.measureText(label).width/2+2;
+        var rect={
+          x1:n.x-halfW,x2:n.x+halfW,
+          y1:n.y+yOff-fontSize*0.7,y2:n.y+yOff+fontSize*0.7,
+        };
+        // The hovered node's neighborhood is the user's focus — always
+        // drawn. Everything else must not overlap an already-placed label.
+        if(c.prio<3){
+          for(var p=0;p<placedLabelRects.length;p++){
+            var r=placedLabelRects[p];
+            if(rect.x1<r.x2&&rect.x2>r.x1&&rect.y1<r.y2&&rect.y2>r.y1)return;
+          }
+        }
+        placedLabelRects.push(rect);
 
         // Text shadow
-        ctx.fillStyle=_light ? "rgba(255,255,255,"+alpha2*0.8+")" : "rgba(0,0,0,"+alpha2*0.8+")";
+        ctx.fillStyle=_light ? "rgba(255,255,255,"+c.alpha*0.8+")" : "rgba(0,0,0,"+c.alpha*0.8+")";
         ctx.fillText(label,n.x+0.5,n.y+yOff+0.5);
 
-        ctx.fillStyle=_light ? "rgba(30,30,30,"+alpha2+")" : "rgba(244,244,244,"+alpha2+")";
+        ctx.fillStyle=_light ? "rgba(30,30,30,"+c.alpha+")" : "rgba(244,244,244,"+c.alpha+")";
         ctx.fillText(label,n.x,n.y+yOff);
       });
     }else if(hoveredNode){

--- a/cognee/modules/visualization/views/story_view.js
+++ b/cognee/modules/visualization/views/story_view.js
@@ -392,8 +392,8 @@ nodes.forEach(function(n){
   }
   n._rgb=typeRgbCache[n.type];
   if(n.ontology_valid===true){
-    n.color="#D8D8D8";
-    n._rgb=[216,216,216];
+    n.color="#FF5CA8";
+    n._rgb=[255,92,168];
   }
 });
 
@@ -508,6 +508,7 @@ function updateLegend(){
   var ontologySection=
     '<div class="legend-section">'+
       '<span class="legend-title">Ontology</span>'+
+      '<span class="legend-item"><span class="legend-dot" style="background:#FF5CA8"></span>grounded node</span>'+
       '<span class="legend-item"><span class="legend-ring"></span>matched in OWL</span>'+
     '</div>';
   var importanceSection=

--- a/cognee/modules/visualization/views/ui_chrome.js
+++ b/cognee/modules/visualization/views/ui_chrome.js
@@ -2,8 +2,13 @@
 (function(){
   const btn = document.getElementById('theme-toggle');
   // Expose for canvas draw() to read. Default light so the Graph view matches
-  // the (always-light) Schema view instead of opening dark.
+  // the Schema view instead of opening dark.
   window._isLightMode = true;
+  // Sync the CSS theme class with the JS default. Without this the page
+  // loads with dark :root variables while the JS believes it's light, and
+  // the first "Dark mode" click ADDS the light class — a visual no-op — so
+  // dark mode was unreachable.
+  document.documentElement.classList.add('light');
   btn.addEventListener('click', () => {
     document.documentElement.classList.toggle('light');
     const isLight = document.documentElement.classList.contains('light');

--- a/cognee/tests/unit/modules/visualization/test_preprocessor.py
+++ b/cognee/tests/unit/modules/visualization/test_preprocessor.py
@@ -282,10 +282,16 @@ def test_node_color_preserved_from_type_map():
 
 
 def test_ontology_valid_overrides_color():
-    nodes_data = [("e", {"type": "Entity", "name": "X", "ontology_valid": True})]
+    """Ontology-grounded nodes get a distinct fill — it must differ from the
+    unknown-type fallback gray so ontology matches stand apart visually."""
+    nodes_data = [
+        ("e", {"type": "Entity", "name": "X", "ontology_valid": True}),
+        ("u", {"type": "MysteryType", "name": "Y"}),
+    ]
     edges_data = []
     result = preprocess((nodes_data, edges_data))
-    assert result.nodes[0]["color"] == "#D8D8D8"
+    assert result.nodes[0]["color"] == "#FF5CA8"
+    assert result.nodes[0]["color"] != result.nodes[1]["color"]
 
 
 def test_schema_graph_falls_back_to_type_graph_when_no_schema_nodes():

--- a/cognee/tests/unit/modules/visualization/test_preprocessor.py
+++ b/cognee/tests/unit/modules/visualization/test_preprocessor.py
@@ -17,6 +17,8 @@ from raw graph adapter output. These tests pin the contract:
 import pytest
 
 from cognee.modules.visualization.preprocessor import (
+    OTHER_ENTITY_TYPES_LABEL,
+    SCHEMA_MAX_ENTITY_TYPES,
     STAGE_ORDER,
     PreprocessedGraph,
     preprocess,
@@ -383,6 +385,76 @@ def test_schema_type_nodes_carry_full_relationship_distribution():
     }
     assert chunk_rels[("contains", "Person")] == 2
     assert chunk_rels[("contains", "Field")] == 1
+
+
+def _many_entity_types_graph(num_types):
+    """num_types semantic entity types with strictly descending instance counts:
+    Type00 has num_types instances, Type01 has num_types-1, ... down to 1."""
+    nodes_data = []
+    edges_data = []
+    for i in range(num_types):
+        type_name = f"Type{i:02d}"
+        type_id = f"etype{i}"
+        nodes_data.append((type_id, {"type": "EntityType", "name": type_name}))
+        for j in range(num_types - i):
+            entity_id = f"e{i}_{j}"
+            nodes_data.append((entity_id, {"type": "Entity", "name": f"{type_name}_inst{j}"}))
+            edges_data.append((entity_id, type_id, "is_a", {}))
+    return (nodes_data, edges_data)
+
+
+def test_entity_type_long_tail_rolls_up_into_other_entities():
+    """Beyond SCHEMA_MAX_ENTITY_TYPES, the tail of semantic entity types
+    collapses into one rollup card so the Entity column stays bounded."""
+    num_types = SCHEMA_MAX_ENTITY_TYPES + 3
+    result = preprocess(_many_entity_types_graph(num_types))
+    type_nodes = {
+        n["name"]: n for n in result.schema_graph["nodes"] if n["type"] == "GraphNodeType"
+    }
+
+    semantic_cards = [name for name in type_nodes if name.startswith("Type")] + (
+        [OTHER_ENTITY_TYPES_LABEL] if OTHER_ENTITY_TYPES_LABEL in type_nodes else []
+    )
+    assert len(semantic_cards) == SCHEMA_MAX_ENTITY_TYPES
+
+    # Top types keep their own cards; the smallest types are rolled up.
+    assert "Type00" in type_nodes
+    assert f"Type{num_types - 1:02d}" not in type_nodes
+
+    rollup = type_nodes[OTHER_ENTITY_TYPES_LABEL]
+    assert rollup["rollup"] is True
+    tail_size = num_types - (SCHEMA_MAX_ENTITY_TYPES - 1)
+    assert len(rollup["rolled_up_types"]) == tail_size
+    # Tail of descending counts ends at 1: tail_size + (tail_size-1) + ... + 1.
+    assert rollup["instance_count"] == tail_size * (tail_size + 1) // 2
+    # Rollup keeps the same rank as the kept entity-type cards (one column).
+    assert rollup["rank"] == type_nodes["Type00"]["rank"]
+    # The lead field announces the rollup.
+    assert any(f["name"] == "entity types" for f in rollup["fields"])
+
+    # Pair-relationship nodes never reference a rolled-up type name.
+    rolled_names = {t["name"] for t in rollup["rolled_up_types"]}
+    for node in result.schema_graph["nodes"]:
+        if node["type"] == "GraphRelationshipType":
+            assert node["source_type"] not in rolled_names
+            assert node["target_type"] not in rolled_names
+
+    # Instance drill-down still reaches the rolled-up instances.
+    instances = result.schema_graph["instances_by_type"][OTHER_ENTITY_TYPES_LABEL]
+    assert len(instances) == rollup["instance_count"]
+
+
+def test_entity_types_under_cap_are_not_rolled_up():
+    result = preprocess(_alice_like_graph())
+    names = {n["name"] for n in result.schema_graph["nodes"] if n["type"] == "GraphNodeType"}
+    assert OTHER_ENTITY_TYPES_LABEL not in names
+
+    result_at_cap = preprocess(_many_entity_types_graph(SCHEMA_MAX_ENTITY_TYPES))
+    names_at_cap = {
+        n["name"] for n in result_at_cap.schema_graph["nodes"] if n["type"] == "GraphNodeType"
+    }
+    assert OTHER_ENTITY_TYPES_LABEL not in names_at_cap
+    assert sum(1 for name in names_at_cap if name.startswith("Type")) == SCHEMA_MAX_ENTITY_TYPES
 
 
 def test_empty_graph_does_not_crash():


### PR DESCRIPTION
## What

Five commits of graph/schema visualization fixes, driven by user-reported issues on real datasets (a job-description upload and a 542-node / 46-entity-type, 4-document corpus used for verification throughout).

### Schema view scales with entity diversity
- **Entity column rollup** (`preprocessor.py`): the Schema view renders one card per semantic entity type, stacked vertically — entity-type diversity grows with the data, so the column became endless even on small datasets. Beyond `SCHEMA_MAX_ENTITY_TYPES` (12), the long tail now collapses into one **"Other entities"** rollup card (top types keep their own cards). The remap happens before all downstream aggregation, so relationship distributions, pair edges, instance drill-down, and the operation layer treat the rollup as an ordinary type — no renderer changes needed. The rollup card leads with the tail size and largest types and carries `rolled_up_types` for the inspector.

### Readable graph
- **Label decluttering** (`story_view.js`): labels were drawn node-by-node with no collision handling, overprinting until entity names were unreadable on small graphs. Two-pass placement: collect candidates, sort by priority (hovered focus > search match > key node, ties by degree), place greedily with rectangle-collision rejection.
- **Distinct ontology color**: ontology-grounded nodes were `#D8D8D8` — indistinguishable from the `#DBD8D8` unknown-type fallback. Now `#FF5CA8` plus the existing green ring, with a legend swatch. Unit test pins the colors apart.

### Stable interactions
- **Click no longer sends nodes drifting**: mousedown pinned the node + reheated the simulation, and mouseup nulled `fx`/`fy` — a plain click permanently unpinned the node from its Story lane and charge repulsion pushed it into space. A press only becomes a drag after 3px of movement, and release restores the layout's own pinning.
- **Schema arrows no longer look inverted**: `flowCurve`'s drop-below-the-band heuristics assumed cards at similar heights; tall columns produced S-loops and hooks with arrowheads pointing backwards. Same-column pairs now route as side loops (right edge), and the drop only applies when endpoints sit at similar heights.
- **Arrowheads attached to their lines**: markers orient to the path tangent at the endpoint, which on steep approaches didn't match the visible line direction, and the marker viewBox left empty margin past the tip where the path's round linecap poked out as a floating nub. Every edge ends in a straight 10px run-in, and the marker tip sits at `refX=10`.
- **Same-card spotlight connectors**: clicking an instance drew its same-card connections straight across the card with all labels overprinting on one midpoint. They now route as nested side loops out of the card's left edge, with greedy vertical label decluttering — each relation reads on its own line.

### Chrome & theming
- **Dark mode actually works**: the page loads with dark `:root` variables but the JS assumed light and never set `html.light` — the first "Dark mode" click *added* the light class (a no-op), making dark mode unreachable. The class is now synced on load, and the Schema view (previously hardcoded `isLight = true`) follows the theme via a JS palette + `html:not(.light)` CSS overrides for the inline-styled chrome.
- **"Documents" header no longer collides with the Search nodes input** (`TOP_CHROME_PAD` 72 → 104).
- **Layout buttons have explanatory tooltips** (Story = pinned pipeline grid, Flow = rank columns with settling, Force = physics clustering).

## Testing

- 37 unit tests pass (`cognee/tests/unit/modules/visualization/`), including 2 new rollup tests and the updated ontology-color test; `node --check` on all edited JS.
- Every visual fix verified with Playwright screenshots against the rendered HTML of a real 542-node graph, in both themes: arrowhead attachment, side-loop routing, label stacking, dark-mode cards/panel, and the rollup card engaging at 46 entity types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dark theme support for schema view visualizations
  * Implemented entity-type rollup feature that collapses numerous entity types into a single "Other entities" card for improved readability

* **Bug Fixes**
  * Fixed theme synchronization issue on page load
  * Improved drag interaction behavior with threshold to prevent unintended node movements

* **Improvements**
  * Updated ontology-valid nodes to use pink color indicator
  * Enhanced label rendering with collision detection for better readability
  * Optimized edge routing and label placement in schema diagrams
  * Updated layout spacing to prevent element collisions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->