### PR TITLE
ci: add advisory Claude Code review job for core-team PRs

### DIFF
--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -321,3 +321,60 @@ jobs:
             echo "One or more test suites failed."
             exit 1
           fi
+
+  # ── Advisory Claude Code review (core-team PRs, only after the suite is green) ──
+  # Depends on `notify` (Test Completion Status), which fails when any test fails,
+  # so this runs ONLY when the whole suite is green. Advisory: continue-on-error +
+  # not a required check, so it can never block a merge.
+  claude-review:
+    name: Claude Code Review
+    needs: [ notify ]
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Core-team gate
+        id: gate
+        env:
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          author_lc="$(printf '%s' "$AUTHOR" | tr '[:upper:]' '[:lower:]')"
+          if grep -vE '^[[:space:]]*#' .github/core-team.txt \
+               | sed 's/^@//' | tr '[:upper:]' '[:lower:]' \
+               | grep -qxF "$author_lc"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "PR author '$AUTHOR' is core-team — running review."
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "PR author '$AUTHOR' is not in core-team.txt — skipping advisory review."
+          fi
+
+      - name: Claude Code review
+        if: ${{ steps.gate.outputs.run == 'true' }}
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Review this pull request (it targets the `dev` branch) for the Cognee project.
+            Prioritize high-confidence issues over style nits. Focus on:
+            - Correctness: bugs, race conditions, error handling, transaction boundaries
+            - Security and multi-tenant isolation: owner/dataset scoping, cross-tenant
+              data access, and any owner-blind lookups or non-tenant-scoped identifiers
+            - Architecture fit: pipeline tasks, GraphDB/VectorDB adapter interfaces,
+              the LLM gateway (see CLAUDE.md for the patterns)
+            - Database adapter correctness (graph/vector/relational; scrutinize Postgres adapters)
+            - Test coverage for new or changed behavior
+            Post specific findings as inline comments and end with a short summary comment.
+          claude_args: >-
+            --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"
+            --max-turns 20
+            --model claude-sonnet-4-5-20250929


### PR DESCRIPTION
## Description
Adds a `claude-review` job to `test_suites.yml` that runs an automated, advisory Claude Code review on PRs.

**Behavior**
- **Runs only on green PRs** — `needs: [notify]` (Test Completion Status), which `exit 1`s when any test fails, so the review never runs on a red PR.
- **Core-team only** — gate step matches the PR author against `.github/core-team.txt`; non-core / fork PRs are skipped.
- **Advisory** — `continue-on-error: true` and not a required check (branch protection keys on `notify`, which runs first), so it can never block a merge.
- Reuses the existing `anthropics/claude-code-action@v1` and the already-configured `ANTHROPIC_API_KEY` secret. Model: `claude-sonnet-4-5-20250929` (same as `test_llms.yml`).

**Note:** `.github/workflows/` is CODEOWNERS-routed to @dexters1 @siillee.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review integration to the continuous integration workflow for pull requests, enabling inline review feedback during the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->