### PR TITLE
feat(cache): SQL session-cache backend (sqlite default, postgres supported) replacing Redis requirement

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -375,7 +375,16 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # Session cache settings
 # To switch to Redis caching check our documentation page sessions-and-caching
 # CACHING=true
-# CACHE_BACKEND=fs
+# Backends: sqlite (default), postgres, redis, fs, tapes
+# CACHE_BACKEND=sqlite
+# CACHE_BACKEND=postgres
+# Optional explicit SQLAlchemy async URL for the sqlite/postgres backends.
+# sqlite default: cache.db next to the relational SQLite database.
+# postgres default: falls back to DB_* settings when DB_PROVIDER=postgres.
+# CACHE_DB_URL=sqlite+aiosqlite:///path/to/databases/cache.db
+# CACHE_DB_URL=postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db
+# Minimum seconds between global TTL purge sweeps (sqlite/postgres backends)
+# CACHE_PURGE_INTERVAL_SECONDS=900
 
 
 ###############################################################################

--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -77,7 +77,8 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        # postgres is needed so the SQL cache adapter tests run instead of skipping
+        run: uv sync --extra dev --extra postgres
 
       - name: Run mocked unit tests
         run: |

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -933,6 +933,94 @@ jobs:
           DB_PASSWORD: cognee
         run: uv run python ./cognee/tests/test_conversation_history.py
 
+  run_conversation_sessions_test_postgres:
+    name: Conversation sessions test (Postgres)
+    runs-on: ubuntu-latest
+    container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
+    defaults:
+      run:
+        shell: bash
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: cognee
+          POSTGRES_PASSWORD: cognee
+          POSTGRES_DB: cognee_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+          extra-dependencies: "postgres"
+
+      - name: Run Conversation session tests (Postgres)
+        env:
+          ENV: 'dev'
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_DIMENSIONS: 300
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+          GRAPH_DATABASE_PROVIDER: 'kuzu'
+          CACHING: true
+          AUTO_FEEDBACK: true
+          CACHE_BACKEND: 'postgres'
+          DB_PROVIDER: 'postgres'
+          DB_NAME: 'cognee_db'
+          DB_HOST: ${{ inputs.ci-image != '' && 'postgres' || '127.0.0.1' }}
+          DB_PORT: 5432
+          DB_USERNAME: cognee
+          DB_PASSWORD: cognee
+        run: uv run python ./cognee/tests/test_conversation_history.py
+
+  run_conversation_sessions_test_sqlite:
+    name: Conversation sessions test (SQLite)
+    runs-on: ubuntu-latest
+    container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Run Conversation session tests (SQLite)
+        env:
+          ENV: 'dev'
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_DIMENSIONS: 300
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+          GRAPH_DATABASE_PROVIDER: 'kuzu'
+          CACHING: true
+          AUTO_FEEDBACK: true
+          CACHE_BACKEND: 'sqlite'
+        run: uv run python ./cognee/tests/test_conversation_history.py
+
   run-feedback-weights-pipeline-smoke-kuzu:
     name: Feedback Weights Pipeline Smoke Test (Kuzu)
     runs-on: ubuntu-latest

--- a/.github/workflows/test_different_operating_systems.yml
+++ b/.github/workflows/test_different_operating_systems.yml
@@ -14,6 +14,12 @@ on:
         required: false
         type: string
         default: '["ubuntu-22.04", "macos-15", "windows-latest"]'
+      extra-dependencies:
+        # Space-separated package extras for the unit-test job (e.g. "postgres").
+        # Driver-dependent tests importorskip when their extra is absent.
+        required: false
+        type: string
+        default: ''
     secrets:
       LLM_PROVIDER:
         required: true
@@ -58,6 +64,7 @@ jobs:
         uses: ./.github/actions/cognee_setup
         with:
           python-version: ${{ matrix.python-version }}
+          extra-dependencies: ${{ inputs.extra-dependencies }}
 
       - name: Run unit tests
         shell: bash

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -166,6 +166,9 @@ jobs:
     with:
       python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"]'
       os: '["ubuntu-22.04"]'
+      # postgres so the SQL cache adapter tests run instead of skipping; omitted
+      # on macos/windows (extended) where psycopg2 has no prebuilt wheels.
+      extra-dependencies: 'postgres'
     secrets: inherit
 
   different-os-tests-extended:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ pre-commit install
 ```
 
 ### Available Installation Extras
-- **postgres** / **postgres-binary** - PostgreSQL + PGVector support
+- **postgres** / **postgres-binary** - PostgreSQL + PGVector support (also enables the Postgres session-cache backend, `CACHE_BACKEND=postgres`)
 - **neo4j** - Neo4j graph database support
 - **neptune** - AWS Neptune support
 - **chromadb** - ChromaDB vector database
@@ -284,6 +284,14 @@ GRAPH_DATABASE_PASSWORD=your_password
 # Does not support raw Cypher queries, natural language search, or Graphiti.
 GRAPH_DATABASE_PROVIDER=postgres
 GRAPH_DATABASE_URL=postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db
+```
+
+#### Session Cache
+```bash
+# Session/conversation cache backend: sqlite (default), postgres, redis, fs, tapes
+CACHE_BACKEND=sqlite
+# Optional explicit SQLAlchemy URL for sqlite/postgres cache backends (overrides defaults)
+CACHE_DB_URL=postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db
 ```
 
 ### LLM Provider Configuration

--- a/SESSION_POSTGRES_CACHE_PLAN.md
+++ b/SESSION_POSTGRES_CACHE_PLAN.md
@@ -1,0 +1,344 @@
+# Implementation Plan: Postgres-backed Session Store (CacheDBInterface adapter)
+
+**Goal:** store cognee session data (QA entries, agent traces, graph-knowledge snapshots, sync checkpoints, usage logs) in Postgres via a new `CacheDBInterface` adapter, removing the Redis requirement for session memory. Default backend stays `fs`; Redis and Tapes keep working unchanged. The design keeps a clean seam for a future Turbopuffer backend.
+
+**Design stance:** minimal-surface adapter that slots into the existing backend plug point (like `FSCacheAdapter`), follows the graph Postgres adapter's engine/schema patterns, and adds **zero new dependencies** (SQLAlchemy is core; asyncpg/psycopg2 ship in the existing `postgres` extra). Where the minimal approach was naive (TTL purging, multi-worker RMW, lock semantics, prune scope), the robust alternatives are grafted in below — each divergence from the minimal design is justified inline.
+
+---
+
+## 1. Overview & goals
+
+- Add `CACHE_BACKEND=postgres` as a fourth cache backend alongside `redis`, `fs`, `tapes`.
+- Implement `PostgresCacheAdapter(CacheDBInterface)` with full behavioral parity to `RedisAdapter`/`FSCacheAdapter` (TTL semantics, merge semantics, error contracts), improving on known Redis races where doing so is observably identical (atomic deletes, `FOR UPDATE` updates).
+- Support the **hidden KV contract** (graph-knowledge snapshots + sync checkpoints) that `SessionManager` and `sync_graph_to_session` access via `adapter.async_redis` duck-typing — via a shim in the core PR, formalized on the interface in a follow-up.
+- Non-goals (v1): data migration tooling (cache is 7-day-TTL ephemeral), per-dataset DB isolation (sessions are per-user), distributed `SHARED_LADYBUG_LOCK` support on Postgres (Phase 6), multi-worker `improve()` mutex.
+
+---
+
+## 2. Current state
+
+**Cache interface** — `cognee/infrastructure/databases/cache/cache_db_interface.py`: ABC with sync lock methods (`acquire_lock`/`release_lock`, concrete `hold_lock()` contextmanager), async QA CRUD (`create_qa_entry`, `get_latest_qa_entries`, `get_all_qa_entries`, `update_qa_entry`, `delete_feedback`, `delete_qa_entry`, `delete_session`), agent traces (`append_agent_trace_step`, `get_agent_trace_session`, `get_agent_trace_feedback`, `get_agent_trace_count`), `prune`, `close`, `log_usage`/`get_usage_logs`, plus concrete back-compat shims `add_qa`/`get_latest_qa`/`get_all_qas` (do not reimplement). Base `__init__(host, port, lock_key="default_lock", log_key="usage_logs")`. Payload models: `SessionQAEntry`/`SessionAgentTraceEntry` in `cognee/infrastructure/databases/cache/models.py` (validators: feedback_score 1–5, `used_graph_element_ids` only `node_ids`/`edge_ids`, `memify_metadata` str→bool, trace sanitization/truncation).
+
+**Backends** — `cache/redis/RedisAdapter.py` (sync `redis.Redis` for locks + async `redis.asyncio.Redis` for data; one Redis LIST per key `agent_sessions:{user_id}:{session_id}` / `agent_traces:{user_id}:{session_id}` / `{log_key}:{user_id}`; JSON-string elements; `EXPIRE`-on-write sliding TTL; `FLUSHDB` prune); `cache/fscache/FsCacheAdapter.py` (diskcache, whole list as one JSON value under `self.cache`, `cache.transact()`, lock methods raise `SharedLadybugLockRequiresRedisError`); `cache/tapes/TapesCacheAdapter.py` (FS subclass mirroring QA creates over HTTP).
+
+**Factory** — `cache/get_cache_engine.py`: `@lru_cache`'d `create_cache_engine(...)` branches on `CacheConfig.cache_backend` (`Literal["redis","fs","tapes"]`, default `"fs"`, in `cache/config.py`); returns `None` when `caching` and `usage_logging` are both off; `close_cache_engine()` closes + `cache_clear()`s. **Verified gotcha:** `from ...RedisAdapter import RedisAdapter` executes unconditionally inside the caching-on block, *before* the backend dispatch — it only works because the unused core dep `fakeredis[lua]` transitively installs `redis`.
+
+**Session manager** — `cognee/infrastructure/session/session_manager.py` (built by `get_session_manager.py`): wraps every interface method, no-ops when `cache_engine is None`. **Verified hidden contract:** `get_graph_context`/`set_graph_context`/`delete_session` (lines ~792–862) and `cognee/tasks/memify/sync_graph_to_session.py::_load_checkpoint/_save_checkpoint` (lines ~42–71) call `cache_engine.async_redis.get/set/expire/delete` directly, with an `AttributeError` fallback to `cache_engine._cache` — which is **wrong for FSCacheAdapter** (its attribute is `self.cache`, line 33), so graph-knowledge snapshots and sync checkpoints silently no-op on fs/tapes today. `set_graph_context` also reads `self._cache.session_ttl_seconds`, so any adapter must expose that attribute.
+
+**Locks** — two unrelated systems: (1) `cognee/infrastructure/locks/session_lock.py`: pure in-process asyncio locks (per-`(session_id, op)` dict + improve-lock set), explicitly single-worker scope, **no Redis dependency, no change required**; (2) `CacheDBInterface.acquire_lock`/`release_lock`: **sync** methods used only by the Ladybug graph adapter (`graph/ladybug/adapter.py` ~line 187, via `asyncio.to_thread`) when `SHARED_LADYBUG_LOCK=true` — Redis-only today.
+
+**Relational sibling** — `cognee/modules/session_lifecycle/models.py` (`session_records`, `session_model_usage`): alembic-managed lifecycle/metrics rows, already Postgres-compatible, untouched by this plan. No FK between cache rows and `session_records` (cache rows TTL-expire; lifecycle rows persist — by design).
+
+**Template** — `cognee/infrastructure/databases/graph/postgres/adapter.py` + `tables.py`: own `create_async_engine(uri, json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder), **pool_args)` (verified, lines 40–58), `async_sessionmaker(expire_on_commit=False)`, private `MetaData()` with `create_all(checkfirst=True)` in `initialize()` — not alembic.
+
+---
+
+## 3. Target architecture
+
+```
+SessionManager / usage_logger / forget / prune_system / sync_graph_to_session / memify tasks
+        │  (unchanged call sites)
+        ▼
+get_cache_engine()  ──reads──  CacheConfig (.env: CACHE_BACKEND, CACHE_DB_URL, ...)
+        │ @lru_cache create_cache_engine()
+        ├── "redis"    → RedisAdapter            (unchanged)
+        ├── "fs"       → FSCacheAdapter          (unchanged)
+        ├── "tapes"    → TapesCacheAdapter       (unchanged)
+        └── "postgres" → PostgresCacheAdapter    (NEW, lazy import)
+                            │
+                            ├── own async engine (postgresql+asyncpg://...)
+                            │     json_serializer=JSONEncoder  (UUID/datetime-safe JSONB)
+                            ├── tables (private MetaData, create-on-init):
+                            │     cache_qa_entries   ← agent_sessions:{u}:{s} lists
+                            │     cache_trace_entries← agent_traces:{u}:{s} lists
+                            │     cache_usage_logs   ← {log_key}:{u} lists
+                            │     cache_kv           ← graph_knowledge:* / graph_sync_checkpoint:*
+                            └── self.async_redis = _PostgresKVShim(self)   # hidden-contract duck-type
+```
+
+---
+
+## 4. Postgres adapter design
+
+### 4.1 Module layout
+
+Mirror the existing backend layout:
+
+```
+cognee/infrastructure/databases/cache/postgres/
+├── __init__.py                  # re-export PostgresCacheAdapter
+├── tables.py                    # private MetaData + SQLAlchemy Core tables
+└── PostgresCacheAdapter.py      # class PostgresCacheAdapter(CacheDBInterface)
+```
+
+### 4.2 Class skeleton
+
+```python
+class PostgresCacheAdapter(CacheDBInterface):
+    def __init__(
+        self,
+        connection_string: str,                  # any SQLAlchemy async URL (asyncpg in prod, aiosqlite in tests)
+        lock_key: str = "default_lock",
+        log_key: str = "usage_logs",
+        session_ttl_seconds: int | None = 604800,
+        agentic_lock_expire: int = 240,          # stored now, used by Phase 6 advisory locks
+        agentic_lock_timeout: int = 300,
+        purge_interval_seconds: int = 900,
+    ):
+        super().__init__(host="", port=0, lock_key=lock_key, log_key=log_key)
+        self.db_uri = connection_string
+        self.session_ttl_seconds = session_ttl_seconds   # read by SessionManager.set_graph_context
+        pool_args = dict(get_relational_config().pool_args or {})
+        self.engine = create_async_engine(
+            connection_string,
+            json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
+            **pool_args,
+        )
+        self.sessionmaker = async_sessionmaker(bind=self.engine, expire_on_commit=False)
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+        self._last_purge = 0.0
+        self.async_redis = _PostgresKVShim(self)         # §4.6
+```
+
+Notes:
+- Call `super().__init__` (Redis does; FS doesn't — calling it gives `lock_key`/`log_key`/`lock` attributes).
+- Single hashable `connection_string` arg keeps the `@lru_cache`'d factory happy.
+- Owning the engine (rather than borrowing `get_relational_engine()`'s) keeps `close()` safe: `close_cache_engine()` → `adapter.close()` → `engine.dispose()` must not kill the shared relational pool.
+- Engine-level `json_serializer` with `cognee.modules.storage.utils.JSONEncoder` is load-bearing: without it, asyncpg JSONB inserts containing UUIDs/datetimes fail (graph-adapter gotcha, replicated).
+- Connection validation is **lazy** (in `_ensure_initialized`), not eager like Redis's `ping()` — the constructor must stay sync and lru_cache-friendly; the contract only requires `CacheConnectionError` to surface, which it does on first use. Also raise a clear `CacheConnectionError("CACHE_BACKEND=postgres requires cognee[postgres]")` if the asyncpg import fails.
+
+### 4.3 Table DDL (`cache/postgres/tables.py`)
+
+Private `MetaData()` — **not** the relational declarative `Base`, **not** alembic-managed (graph-adapter precedent: `graph_node`/`graph_edge` are create-on-init while `session_records` is alembic-managed; private MetaData keeps alembic autogenerate from seeing these). Payload columns use `JSONB().with_variant(JSON(), "sqlite")` so unit tests run on aiosqlite. `cache_`-prefixed names avoid collision with `session_records`/`session_model_usage`.
+
+```sql
+-- QA entries: one row per entry; qa_id promoted to a column for direct UPDATE
+-- (Redis buries it in JSON and does linear scan + LSET)
+CREATE TABLE cache_qa_entries (
+    seq         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- insertion order
+    user_id     TEXT NOT NULL,
+    session_id  TEXT NOT NULL,
+    qa_id       TEXT NOT NULL,
+    payload     JSONB NOT NULL,            -- full SessionQAEntry.model_dump() (incl. qa_id, time)
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ NULL,          -- NULL = no expiry
+    UNIQUE (user_id, session_id, qa_id)
+);
+CREATE INDEX idx_cache_qa_session  ON cache_qa_entries (user_id, session_id, seq);
+CREATE INDEX idx_cache_qa_expires  ON cache_qa_entries (expires_at) WHERE expires_at IS NOT NULL;
+
+-- Agent traces: append-only
+CREATE TABLE cache_trace_entries (
+    seq         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id     TEXT NOT NULL,
+    session_id  TEXT NOT NULL,
+    payload     JSONB NOT NULL,            -- SessionAgentTraceEntry.model_dump()
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ NULL
+);
+CREATE INDEX idx_cache_trace_session ON cache_trace_entries (user_id, session_id, seq);
+CREATE INDEX idx_cache_trace_expires ON cache_trace_entries (expires_at) WHERE expires_at IS NOT NULL;
+
+-- Usage logs (Redis key {log_key}:{user_id})
+CREATE TABLE cache_usage_logs (
+    seq         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    log_key     TEXT NOT NULL,             -- adapter's self.log_key
+    user_id     TEXT NOT NULL,
+    payload     JSONB NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ NULL
+);
+CREATE INDEX idx_cache_usage ON cache_usage_logs (log_key, user_id, seq);
+
+-- String KV: graph_knowledge:{u}:{s}, graph_sync_checkpoint:{u}:{d}:{s} — keys kept verbatim
+CREATE TABLE cache_kv (
+    key         TEXT PRIMARY KEY,
+    value       TEXT NOT NULL,
+    expires_at  TIMESTAMPTZ NULL
+);
+```
+
+Notes:
+- `session_id` stays a **plain string, no FK** to `session_records` (same `session_id` exists under multiple users; cache rows expire while lifecycle rows persist). Keying is always `(user_id, session_id)` — the exact relational analogue of the Redis key prefixes, which also preserves cross-user reads (recall / sessions router resolve the *owner's* `user_id` from `SessionRecord`).
+- JSONB, not bytea/pickle: parity with `graph_node.properties` and the Redis JSON-string encoding; queryable for debugging.
+- Hot-path: `get_latest_qa_entries` runs on every completion (last 10); `idx_cache_qa_session` makes the tail read an index scan. Rows can be tens of KB (payload embeds `context`) — a later `payload - 'context'` projection optimization is possible, but the contract returns full entries today; don't change behavior.
+
+### 4.4 Method-by-method implementation
+
+Every public async method: `await self._ensure_initialized()` first (once-flag under `self._init_lock`; runs `conn.run_sync(cache_metadata.create_all, checkfirst=True)`, wraps first-connect failure in `CacheConnectionError`), then `async with self.sessionmaker() as session, session.begin():`. Error contract (pinned by `test_redis_adapter_crud.py`/`test_fs_adapter_crud.py`): backend/SQLAlchemy errors → wrap in `CacheConnectionError`; create-path *validation* failures → also `CacheConnectionError` (odd but tested); update-path validation → `SessionQAEntryValidationError` **propagated unwrapped**.
+
+| Method | Implementation |
+|---|---|
+| `create_qa_entry(user_id, session_id, question, context, answer, qa_id=None, ...)` | `qa_id: str \| None = None` with `str(uuid4())` fallback — match the adapters, not the ABC's `qa_id: str`. Build `SessionQAEntry` (stamps `time=datetime.utcnow().isoformat()`, runs validators; failure → `CacheConnectionError`). `INSERT` `payload=entry.model_dump()`; session-wide TTL refresh (§4.5); scoped lazy purge. One transaction. |
+| `get_latest_qa_entries(u, s, last_n=5)` | `SELECT payload WHERE u/s AND not-expired ORDER BY seq DESC LIMIT :n`, reverse in Python → chronological; `SessionQAEntry.model_validate` each. **Return `[]` always on empty, including `last_n==1`** — the Redis `None`-on-`last_n==1` quirk is not replicated; all callers go through `SessionManager` and treat falsy uniformly (FS already returns `[]`). Pin in the unit test. |
+| `get_all_qa_entries(u, s)` | Same, `ORDER BY seq ASC`, no LIMIT; `[]` if none. |
+| `update_qa_entry(u, s, qa_id, ...)` | One transaction: `SELECT payload ... WHERE user_id/session_id/qa_id ... FOR UPDATE` (`with_for_update()`; no-op on the sqlite test variant, fine). No row → `False`. Merge in Python with exact existing semantics: `None` preserves every field; `memify_metadata = {**existing, **new}` (MERGE not replace — `apply_feedback_weights`/`apply_frequency_weights` idempotency flags depend on it); re-validate via `SessionQAEntry.model_validate`, letting `SessionQAEntryValidationError` propagate; `UPDATE payload`; TTL refresh; `True`. `FOR UPDATE` makes this RMW multi-worker-safe — strictly better than Redis's load/LSET race, observably identical. |
+| `delete_feedback(u, s, qa_id)` | Same `FOR UPDATE` pattern; set `feedback_text`/`feedback_score` to `None` in payload; TTL refresh; bool. (This is the only way to clear feedback — `update_qa_entry(feedback_score=None)` preserves.) |
+| `delete_qa_entry(u, s, qa_id)` | Single atomic `DELETE ... WHERE user_id/session_id/qa_id` (replaces Redis's non-atomic DEL+RPUSH-loop rewrite — crash-safe improvement); TTL refresh on remaining rows (Redis re-applies TTL after rewrite); return `rowcount > 0`. No "drop key when empty" step — empty session ≡ zero rows. |
+| `delete_session(u, s)` | One transaction: `DELETE FROM cache_qa_entries` + `DELETE FROM cache_trace_entries` for `(u, s)`; `True` if either rowcount > 0. (`SessionManager.delete_session` separately deletes the `graph_knowledge:` key via the KV shim — keep that division.) |
+| `append_agent_trace_step(u, s, trace_id, origin_function, status, ...)` | Build `SessionAgentTraceEntry` (`method_params or {}`; model validators do sanitization/truncation for free; blank `trace_id`/`origin_function` → `CacheConnectionError`); INSERT; trace-session TTL refresh. |
+| `get_agent_trace_session(u, s, last_n=None)` | `ORDER BY seq ASC`; when `last_n is not None`, `DESC LIMIT` + reverse. Reads do NOT refresh TTL. |
+| `get_agent_trace_feedback(u, s, last_n=None)` | `[e.session_feedback for e in await self.get_agent_trace_session(...)]` — exactly the delegation both adapters use. |
+| `get_agent_trace_count(u, s)` | `SELECT count(*)` with expiry filter; 0 for missing session. |
+| `prune()` | `DELETE FROM` / `TRUNCATE` the **four cache tables only**. Deliberate, documented divergence from Redis `FLUSHDB` (which nukes co-tenant keys and other users' data) — strictly safer; both proposals agree. |
+| `close()` | `await self.engine.dispose(close=True)`; dispose the sync lock engine if created (Phase 6); idempotent, swallow + debug-log errors (called by `close_cache_engine` and `prune_data.py`). Reset `self._initialized = False` so a reused instance re-inits. |
+| `log_usage(user_id, log_entry, ttl=604800)` | INSERT into `cache_usage_logs` with `log_key=self.log_key`, `expires_at = now()+ttl` if ttl else NULL; **also refresh `expires_at` on the user's existing rows** under the same `(log_key, user_id)` — Redis `EXPIRE`s the whole list, so per-row-only TTL would diverge. |
+| `get_usage_logs(user_id, limit=100)` | `SELECT payload WHERE log_key/user_id AND not-expired ORDER BY seq DESC LIMIT :limit` — already most-recent-first (Redis does lrange + reverse). |
+| `acquire_lock()` / `release_lock(lock=None)` | **SYNC — do not make async** (Ladybug calls them via `asyncio.to_thread`). **v1: raise `SharedLadybugLockRequiresRedisError`**, imported from `cognee.infrastructure.databases.exceptions.exceptions` directly (it is NOT re-exported in the package `__init__`) — exactly like `FsCacheAdapter`. Inherited `hold_lock()` then raises too — correct. Phase 6 upgrade in §7. |
+| Inherited (do not reimplement) | `hold_lock()`, `add_qa`, `get_latest_qa`, `get_all_qas`. |
+
+**Concurrency posture:** unlike the graph adapter, **no global `asyncio.Lock` serializing writes** — row-level `FOR UPDATE` + single-statement deletes give correct multi-worker behavior with better throughput; the graph adapter's lock exists for bulk upsert batches that don't occur here. Add the graph adapter's tenacity retry on asyncpg `DeadlockDetectedError` as belt-and-braces.
+
+### 4.5 TTL strategy: `expires_at` + read-time filter + lazy purge + throttled sweep
+
+Replicates Redis sliding whole-key TTL exactly:
+
+- **Write refresh:** every mutating op runs, inside its transaction, `UPDATE <table> SET expires_at = now() + :ttl WHERE user_id=:u AND session_id=:s` (skipped when `session_ttl_seconds` is `None`/`<= 0` — `expires_at` stays NULL, expiry disabled). Whole-session refresh matches `EXPIRE session_key`. Sessions are small (tens–hundreds of rows); cheap.
+- **Read filter:** every SELECT adds `AND (expires_at IS NULL OR expires_at > now())`. Reads never refresh TTL (tested Redis behavior). Correctness never depends on purging.
+- **Purge** ("purge on init only" would leak rows in long-lived processes): (a) scoped `DELETE ... WHERE user_id=:u AND session_id=:s AND expires_at <= now()` opportunistically on writes to that session; (b) a throttled global sweep `DELETE FROM <each table> WHERE expires_at <= now()` at most once per `purge_interval_seconds` (default 900) per process, guarded by `pg_try_advisory_lock` on Postgres (skip the guard on the sqlite test variant) so concurrent workers don't stampede. No external cron. Precedents: `FSCacheAdapter.cache.expire()` on init; `session_lifecycle` computing "abandoned" at read time.
+- **KV parity quirks preserved:** `graph_knowledge` gets TTL only when `set_graph_context` calls `expire()` (SessionManager drives it); `graph_sync_checkpoint` keys are written without TTL → immortal, exactly as today.
+
+### 4.6 The hidden contract: `_PostgresKVShim` (`async_redis` duck-type)
+
+Core PR ships a shim, not an interface change — zero edits to `session_manager.py`/`sync_graph_to_session.py` keeps the core PR's blast radius to new files + factory wiring. The ABC-level `get_value/set_value/delete_value` (which also fixes the live FS `_cache`-vs-`cache` bug) is preserved as its own follow-up phase (P6), because it touches Redis, FS, and two consumer files and deserves separate review.
+
+```python
+class _PostgresKVShim:
+    """async get/set/expire/delete over cache_kv, signature-compatible with the subset of
+    redis.asyncio.Redis used by SessionManager and sync_graph_to_session."""
+    def __init__(self, adapter): self._adapter = adapter
+    async def get(self, key) -> str | None:   # SELECT value WHERE key AND not-expired
+    async def set(self, key, value) -> None:  # pg_insert(cache_kv).on_conflict_do_update(index_elements=["key"], ...)
+                                              # (plain upsert emulation on the sqlite variant)
+    async def expire(self, key, ttl) -> None: # UPDATE expires_at = now() + ttl WHERE key
+    async def delete(self, key) -> None:      # DELETE WHERE key
+```
+
+`self.async_redis = _PostgresKVShim(self)` makes the Postgres backend the first non-Redis backend where graph-knowledge snapshots and sync checkpoints actually work. `get` returns `str` (the consumers handle both bytes and str — verified `raw.decode() if isinstance(raw, bytes) else raw`).
+
+---
+
+## 5. Config & provider selection changes
+
+**`cognee/infrastructure/databases/cache/config.py`:**
+- `cache_backend: Literal["redis", "fs", "tapes", "postgres"] = "fs"` (default **unchanged**).
+- New fields: `cache_db_url: Optional[str] = None` (env `CACHE_DB_URL`, e.g. `postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db`) and `cache_purge_interval_seconds: int = 900`. **Single-URL chosen over five discrete `CACHE_DB_*` fields**: one hashable kwarg through the lru_cache'd factory, one config field instead of five, and it matches the adapter's `connection_string` constructor. Do **not** reuse `cache_host`/`cache_port` — they default to Redis's `localhost:6379` (silent misdirection risk).
+- Fallback resolution (helper `_resolve_cache_db_url` in `get_cache_engine.py`, mirroring `get_graph_engine.py`'s GRAPH_DATABASE_* → DB_* fallback): `CACHE_DB_URL` if set; else, when `get_relational_config().db_provider == "postgres"`, build `postgresql+asyncpg://DB_USERNAME:DB_PASSWORD@DB_HOST:DB_PORT/DB_NAME` with a warning-level log; else raise `CacheConnectionError("CACHE_BACKEND=postgres requires CACHE_DB_URL or DB_PROVIDER=postgres")`.
+- Extend `to_dict()` and the class docstring (both pinned by `cognee/tests/unit/infrastructure/databases/cache/test_cache_config.py::test_cache_config_defaults/test_cache_config_to_dict`, which assert the exact full dict — update them).
+
+**`cognee/infrastructure/databases/cache/get_cache_engine.py`:**
+- Thread two new hashable params through both signatures (same pattern as the `tapes_*` params): `create_cache_engine(..., cache_db_url: str | None = None, cache_purge_interval_seconds: int = 900)`; pass from `get_cache_engine()`.
+- New branch with **lazy import** (verified pattern: `TapesCacheAdapter` is imported inside its branch):
+
+```python
+elif config.cache_backend == "postgres":
+    from cognee.infrastructure.databases.cache.postgres.PostgresCacheAdapter import (
+        PostgresCacheAdapter,
+    )
+    return PostgresCacheAdapter(
+        connection_string=_resolve_cache_db_url(cache_db_url),
+        lock_key=lock_key,
+        log_key=log_key,
+        session_ttl_seconds=session_ttl_seconds,
+        agentic_lock_expire=agentic_lock_expire,
+        agentic_lock_timeout=agentic_lock_timeout,
+        purge_interval_seconds=cache_purge_interval_seconds,
+    )
+```
+
+- Update the `ValueError` message to `"'redis', 'fs', 'tapes', 'postgres'"`.
+- Move the currently-unconditional `from ...RedisAdapter import RedisAdapter` (verified: executes for ALL backends once caching is on) inside the `== "redis"` branch — 2-line cleanup that removes the accidental reliance on `fakeredis` pulling in `redis`. Low-risk, do it in this PR.
+- lru_cache caveats respected: `cache_db_url` is a hashable string; constructor params frozen after first call until `cache_clear()` (existing behavior); note the existing pool-per-`lock_key` instantiation pattern (Ladybug per-db lock_key) in the adapter docstring.
+
+**`pyproject.toml`:** no changes — SQLAlchemy is core; asyncpg/psycopg2 are in the existing `postgres` extra. Document "`CACHE_BACKEND=postgres` requires `cognee[postgres]`".
+
+---
+
+## 6. Schema creation / migration approach
+
+Graph-adapter style, **not alembic**:
+- Tables on a private `MetaData()` in `cache/postgres/tables.py`; alembic's `env.py` (`target_metadata = Base.metadata`) never sees them; no migration files.
+- Idempotent `create_all(checkfirst=True)` inside `_ensure_initialized()` (once-flag + `asyncio.Lock`), re-run lazily after `close_cache_engine()`/`prune_system`'s `cache_clear()` recreates the adapter — necessary because the cache factory has no `_GraphEngineHandle` equivalent.
+- Rationale: cache content is ephemeral/TTL'd, schema is additive, and the repo precedent is explicit (`graph_node`/`graph_edge` create-on-init vs alembic-managed `session_records`).
+- **No per-dataset database handler** — do not register anything in `supported_dataset_database_handlers.py` or copy `PostgresGraphDatasetDatabaseHandler`. Sessions are per-user, not per-dataset; isolation parity comes from `(user_id, session_id)` columns. Deployments wanting physical separation point `CACHE_DB_URL` at a dedicated database.
+
+---
+
+## 7. Session lock handling
+
+- **`cognee/infrastructure/locks/session_lock.py`: no change.** It is pure in-process asyncio with no Redis dependency; its documented single-worker scope is unchanged. Note in the PR description that the adapter's `FOR UPDATE` in `update_qa_entry`/`delete_feedback` makes those RMW paths multi-worker-safe at the storage layer anyway (closes the gap session_lock.py's own docstring flags).
+- **`CacheDBInterface.acquire_lock`/`release_lock` (shared Ladybug lock):**
+  - **v1 (core PR):** raise `SharedLadybugLockRequiresRedisError` — established FS precedent; `SHARED_LADYBUG_LOCK=true + CACHE_BACKEND=postgres` stays unsupported with a clear error.
+  - **Phase 6 (separate PR):** lazy-create a small **sync** engine (`postgresql+psycopg2`, `pool_size=2`; psycopg2 is already in the `postgres` extra) used only for locks. `lock_id = int.from_bytes(sha256(self.lock_key.encode()).digest()[:8], "big", signed=True)`. `acquire_lock()`: check out a dedicated connection, loop `SELECT pg_try_advisory_lock(:id)` with 0.1 s sleeps until the `agentic_lock_timeout` deadline; on success return a handle object owning the connection; on timeout raise `RuntimeError` (mirrors Redis). `release_lock(lock=None)`: `pg_advisory_unlock` on the **passed** handle, not `self.lock` (explicitly tested Redis behavior); close/return the connection; swallow errors if not held. Handle-bound connections give `thread_local=False` parity (releasable from worker threads). Semantics note to document: advisory locks release on connection death (safer than, but different from, Redis's 240 s `agentic_lock_expire` auto-expiry, which has no direct equivalent).
+- Multi-worker `improve()` mutex via `pg_try_advisory_lock` behind `try_acquire_improve_lock`: explicit non-goal / future work.
+
+---
+
+## 8. Test plan
+
+**Unit CRUD** — new `cognee/tests/unit/infrastructure/databases/cache/test_postgres_adapter_crud.py`, mirroring `test_redis_adapter_crud.py`'s ~25 cases. No real Postgres in pytest (repo convention — Redis suites use a hand-rolled `_InMemoryRedisList` fake; here we get a real-engine equivalent for free): construct `PostgresCacheAdapter("sqlite+aiosqlite:///<tmp>/cache.db")` — the `with_variant(JSON(), "sqlite")` columns and identity-PK→autoincrement degradation make the same code paths run without a server. Cover:
+- QA create/get-latest/get-all ordering; uuid4 `qa_id` fallback; `[]` on empty **including `last_n=1`** (pins the FS-style choice)
+- update: None-preserves every field; `memify_metadata` MERGE; `SessionQAEntryValidationError` propagates unwrapped; `False` on missing qa_id
+- `delete_feedback` nulls both fields; `delete_qa_entry` rowcount semantics + TTL survival; `delete_session` clears both tables
+- traces: append/get/count/feedback delegation; sanitization via model validators; blank `trace_id` → `CacheConnectionError`
+- TTL: `expires_at` set/refreshed on create/update/delete_feedback/after-delete; NOT refreshed on reads; disabled when `session_ttl_seconds in (0, None)`; expired rows invisible to reads (assert via direct SQL with backdated `expires_at`)
+- `prune()` clears only the four cache tables; `close()` idempotent; legacy `add_qa`/`get_latest_qa`/`get_all_qas` shims
+- `acquire_lock`/`release_lock` raise `SharedLadybugLockRequiresRedisError`
+- KV shim get/set/expire/delete round-trips (new coverage no other backend has), checkpoint key without TTL stays readable
+
+**Integration** — add `"postgres"` to the `params=["fs", "redis"]` fixtures in `cognee/tests/integration/infrastructure/session/test_session_sdk_integration.py`, `test_session_persistence_memify_integration.py`, `test_feedback_weights_memify_integration.py` (aiosqlite URL, no server); new `test_session_manager_postgres.py` mirroring `test_session_manager_redis.py` (LLM mocked via `AsyncMock` on `LLMGateway.acreate_structured_output`).
+
+**Config/factory** — update `test_cache_config.py` exact-dict assertions; new factory tests: `CACHE_BACKEND=postgres` returns `PostgresCacheAdapter`, unknown backend `ValueError` lists all four, URL fallback resolution (CACHE_DB_URL → DB_* → error).
+
+**CI e2e (real Postgres)** — third twin job `run_conversation_sessions_test_postgres` in `.github/workflows/e2e_tests.yml`, copying `run_conversation_sessions_test_redis` minus the redis service (the pgvector/pg17 service is already provisioned there): env `CACHING=true AUTO_FEEDBACK=true CACHE_BACKEND=postgres DB_PROVIDER=postgres` (relying on the DB_* fallback, which also exercises it) or explicit `CACHE_DB_URL`; extras `"postgres"` only; runs `cognee/tests/test_conversation_history.py` unmodified. Phase 6 adds a `SHARED_LADYBUG_LOCK=true CACHE_BACKEND=postgres` variant of the concurrent-subprocess job running `test_concurrent_subprocess_access.py`, plus real-Postgres-gated advisory-lock unit tests (acquire/release of the *passed* handle, contention timeout → `RuntimeError`, cross-connection mutual exclusion).
+
+**Phase 6 regression (KV formalization)** — FS test proving `graph_knowledge`/checkpoint round-trips work on fs (they silently no-op today); Redis test proving key byte-parity.
+
+---
+
+## 9. Rollout & backward compatibility
+
+- **No behavior change by default:** `cache_backend` default stays `"fs"`; redis/tapes branches untouched; `get_cache_engine()` still returns `None` when caching + usage_logging are off (every consumer already handles `None`).
+- **No data migration tooling:** session cache is 7-day-TTL ephemeral; switching backends starts fresh — same story as redis↔fs today. One-liner in docs. `SessionRecord` rows in the relational DB are unaffected.
+- **`forget(everything=True)` / `prune_system` / `prune_data`** paths work unchanged (`prune()`, `close_cache_engine()`, `cache_clear()`); document that Postgres `prune()` is scoped to cognee cache tables (an improvement over `FLUSHDB`).
+- **Failure modes:** misconfigured backend raises `CacheConnectionError` (503) at first use; `SHARED_LADYBUG_LOCK=true` + postgres raises `SharedLadybugLockRequiresRedisError` with a clear message until Phase 6.
+- **Docs:** `.env.template` "Session cache settings" block (~line 375): add `# CACHE_BACKEND=postgres` + `# CACHE_DB_URL=postgresql+asyncpg://...`; `config.py` docstring backend list; factory `ValueError` message; `CLAUDE.md` extras note ("postgres — also enables the Postgres session-cache backend"); file a task for the external docs.cognee.ai "sessions-and-caching" page. `docker-compose.yml` needs nothing (postgres service exists; redis stays behind its profile).
+
+---
+
+## 10. Phased work breakdown
+
+| Phase | Scope | Size |
+|---|---|---|
+| **P1 — Adapter core** | `cache/postgres/tables.py` + `PostgresCacheAdapter.py`: engine, `_ensure_initialized`, QA CRUD (`FOR UPDATE` updates, atomic deletes), TTL refresh + read filter + scoped/throttled purge, prune, close | **L** (~1.5–2 days, ~450 LOC) |
+| **P2 — Traces, usage logs, locks-raise, KV shim** | `append_agent_trace_step`/trace reads, `log_usage`/`get_usage_logs` (whole-list TTL refresh), lock methods raising `SharedLadybugLockRequiresRedisError`, `_PostgresKVShim` | **M** (~0.5–1 day, ~150 LOC) |
+| **P3 — Wiring** | `config.py` Literal + `cache_db_url` + `cache_purge_interval_seconds` + `to_dict` + docstring; `get_cache_engine.py` branch + `_resolve_cache_db_url` fallback + error msg + RedisAdapter import moved into its branch; config-test fixes | **S** (~0.5 day) |
+| **P4 — Tests** | Unit CRUD suite (aiosqlite), `test_session_manager_postgres.py`, `"postgres"` params in 3 integration files, factory/config tests | **M** (~1 day, ~500 LOC tests) |
+| **P5 — CI + docs** | `run_conversation_sessions_test_postgres` e2e twin job, `.env.template`, `CLAUDE.md`, docs.cognee.ai task | **S** (~0.5 day) |
+| **P6 — Follow-up PR: KV formalization + advisory locks** | (a) `get_value/set_value/delete_value` on `CacheDBInterface` + Redis/FS impls (fixes the live FS `_cache` bug); rewrite `session_manager.py` ~792–862 and `sync_graph_to_session.py` ~42–71 to use them with a `hasattr`-guarded fallback for one release; regression tests. (b) psycopg2 `pg_try_advisory_lock` sync lock impl lifting the `SHARED_LADYBUG_LOCK` restriction + concurrent-subprocess CI variant | **M–L** (~2 days) |
+
+Core (P1–P5): **~4 days**, one reviewable PR (or two: adapter+tests, then wiring+CI). P6 ships separately.
+
+---
+
+## 11. Future: Turbopuffer adapter sketch (do not build now — verify the seam)
+
+Turbopuffer is a namespaced object/vector store with upsert-by-id, delete-by-id, and attribute-filtered queries. The same `CacheDBInterface` maps because every cognee cache access is by exact composite key, append-or-point-update, with no cross-key scans:
+
+- **Namespaces:** today's key strings verbatim (`agent_sessions:{user_id}:{session_id}`, `agent_traces:{...}`, `usage_logs:{user_id}`) — key-prefix tenancy carries over unchanged.
+- **Rows:** id = `qa_id` / trace uuid; attributes = entry fields plus a client-stamped monotonic `seq`/`created_at` for ordering (no serial column); vector optional (zero/1-dim placeholder if mandatory — or embed `question+answer` for free semantic recall later, a genuine upside).
+- **Operations:** create/append → upsert; `get_latest/get_all` → seq-ordered query (tail = desc + limit + reverse); `update_qa_entry`/`delete_feedback` → read-merge-upsert by id (back to Redis-grade RMW races — no `FOR UPDATE`; acceptable for a cache tier, flag in docs); `delete_session` → namespace delete; `prune()` → enumerate + delete `cognee-*` namespaces by prefix; KV → a `cache_kv` namespace with key-as-id rows; TTL → `expires_at` attribute + query filter + periodic GC (no native TTL — the Postgres TTL design transfers directly); locks → raise `SharedLadybugLockRequiresRedisError` (precedent).
+- **Seam requirements this plan satisfies:** (1) all storage details stay behind `CacheDBInterface` — after P6's KV formalization no caller touches adapter internals (the `async_redis` shim is the one soft spot, explicitly retired in P6, which is the prerequisite for a clean Turbopuffer backend); (2) entries cross the boundary only as pydantic `model_dump()` payloads; (3) ordering is adapter-internal (`seq` column vs `seq` attribute) — nothing leaks; do not let SQL row ids escape into return values during P2; (4) wiring is mechanical: `cache_backend` Literal += `"turbopuffer"`, lazy-import elif, `TURBOPUFFER_API_KEY`/`TURBOPUFFER_REGION` threaded through the lru_cache'd factory.
+
+---
+
+## 12. Open questions
+
+1. **Default fallback to the relational DB:** when `CACHE_DB_URL` is unset and `DB_PROVIDER=postgres`, the cache silently shares the relational database (distinct `cache_*` tables, warning logged). Is co-tenancy acceptable as the default, or should `CACHE_DB_URL` be mandatory?
+2. **Normalize the Redis `None`-on-`last_n==1` quirk in `RedisAdapter` itself** (return `[]` like FS/Postgres), or leave Redis as-is and only document Postgres's `[]` choice? (Some tests pin the Redis behavior.)
+3. **Hot-path payload size:** should `get_latest_qa_entries` eventually project `payload - 'context'` for history reads (formatted history uses `include_context=False` but still fetches full entries)? Behavior-preserving today; revisit with real latency data.
+4. **Throttled global purge tuning:** is 900 s / per-process advisory-lock-guarded sweep enough for high-volume deployments, or is a documented external cron (`DELETE ... WHERE expires_at <= now()`) preferable at scale?
+5. **P6 ordering:** should the KV formalization (P6a) land *before* the adapter to avoid shipping the `async_redis` shim at all? Trade-off: P6a touches Redis/FS/SessionManager/sync_graph and delays the backend; the shim is contained and removable.
+6. **`fakeredis[lua]` core dependency:** verified unused in-repo and only load-bearing because it transitively installs `redis` for the unconditional import this plan removes — candidate for deletion in a separate cleanup PR (needs a check that no downstream consumers rely on it).
+7. **Lock auto-expiry parity (Phase 6):** Redis locks auto-expire after `agentic_lock_expire=240` s; pg advisory locks hold until connection death. Is connection-scoped release acceptable, or do we need a watchdog that closes the lock connection after 240 s?

--- a/cognee/infrastructure/databases/cache/cache_db_interface.py
+++ b/cognee/infrastructure/databases/cache/cache_db_interface.py
@@ -159,6 +159,39 @@ class CacheDBInterface(ABC):
         """
         pass
 
+    async def get_value(self, key: str) -> str | None:
+        """
+        Retrieve a raw string value stored under the given key, or None if absent/expired.
+
+        Used for session-scoped key/value payloads such as graph context snapshots
+        (``graph_knowledge:{user_id}:{session_id}``) and graph sync checkpoints
+        (``graph_sync_checkpoint:...``). Adapters that do not support generic
+        key/value storage may leave this unimplemented.
+        """
+        raise NotImplementedError("This cache adapter does not support key/value storage.")
+
+    async def set_value(self, key: str, value: str, ttl: int | None = None) -> None:
+        """
+        Store a raw string value under the given key, optionally expiring after ttl seconds.
+
+        Used for session-scoped key/value payloads such as graph context snapshots
+        (``graph_knowledge:{user_id}:{session_id}``) and graph sync checkpoints
+        (``graph_sync_checkpoint:...``). Adapters that do not support generic
+        key/value storage may leave this unimplemented.
+        """
+        raise NotImplementedError("This cache adapter does not support key/value storage.")
+
+    async def delete_value(self, key: str) -> None:
+        """
+        Delete the value stored under the given key, if present.
+
+        Used for session-scoped key/value payloads such as graph context snapshots
+        (``graph_knowledge:{user_id}:{session_id}``) and graph sync checkpoints
+        (``graph_sync_checkpoint:...``). Adapters that do not support generic
+        key/value storage may leave this unimplemented.
+        """
+        raise NotImplementedError("This cache adapter does not support key/value storage.")
+
     @abstractmethod
     async def append_agent_trace_step(
         self,

--- a/cognee/infrastructure/databases/cache/config.py
+++ b/cognee/infrastructure/databases/cache/config.py
@@ -9,6 +9,15 @@ class CacheConfig(BaseSettings):
     Configuration for distributed cache systems (e.g., Redis), used for locking or coordination.
 
     Attributes:
+    - cache_backend: Session cache backend; one of "redis", "fs", "tapes", "sqlite", "postgres"
+      (default "sqlite"). "sqlite" and "postgres" use the SQL cache adapter, differing only in
+      default connection URL resolution.
+    - cache_db_url: SQLAlchemy async URL for the SQL cache backends (env CACHE_DB_URL, e.g.
+      postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db). When unset, "sqlite" uses a
+      cache.db file next to the relational SQLite database and "postgres" falls back to the
+      relational DB_* settings.
+    - cache_purge_interval_seconds: Minimum interval (in seconds) between global TTL purge
+      sweeps in the SQL cache backends (default: 900).
     - shared_ladybug_lock: Shared Ladybug lock logic on/off.
       SHARED_KUZU_LOCK remains supported as a legacy alias.
     - cache_host: Hostname of the cache service.
@@ -22,7 +31,9 @@ class CacheConfig(BaseSettings):
     - auto_feedback: When caching is True, run automatic feedback detection on each query (default False).
     """
 
-    cache_backend: Literal["redis", "fs", "tapes"] = "fs"
+    cache_backend: Literal["redis", "fs", "tapes", "sqlite", "postgres"] = "sqlite"
+    cache_db_url: Optional[str] = None
+    cache_purge_interval_seconds: int = 900
     caching: bool = True
     auto_feedback: bool = False
     shared_ladybug_lock: bool = False
@@ -54,6 +65,8 @@ class CacheConfig(BaseSettings):
     def to_dict(self) -> dict:
         return {
             "cache_backend": self.cache_backend,
+            "cache_db_url": self.cache_db_url,
+            "cache_purge_interval_seconds": self.cache_purge_interval_seconds,
             "caching": self.caching,
             "auto_feedback": self.auto_feedback,
             "shared_ladybug_lock": self.shared_ladybug_lock,

--- a/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
@@ -346,6 +346,34 @@ class FSCacheAdapter(CacheDBInterface):
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
 
+    async def get_value(self, key: str) -> str | None:
+        """Retrieve a raw string value stored under the given key, or None if absent/expired."""
+        try:
+            self.cache.expire()
+            return self.cache.get(key)
+        except Exception as e:
+            error_msg = f"Unexpected error while getting value from diskcache: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+
+    async def set_value(self, key: str, value: str, ttl: int | None = None) -> None:
+        """Store a raw string value under the given key, optionally expiring after ttl seconds."""
+        try:
+            self.cache.set(key, value, expire=ttl)
+        except Exception as e:
+            error_msg = f"Unexpected error while setting value in diskcache: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+
+    async def delete_value(self, key: str) -> None:
+        """Delete the value stored under the given key, if present."""
+        try:
+            self.cache.delete(key)
+        except Exception as e:
+            error_msg = f"Unexpected error while deleting value from diskcache: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+
     async def append_agent_trace_step(
         self,
         user_id: str,

--- a/cognee/infrastructure/databases/cache/get_cache_engine.py
+++ b/cognee/infrastructure/databases/cache/get_cache_engine.py
@@ -1,10 +1,62 @@
 """Factory to get the appropriate cache coordination engine (e.g., Redis)."""
 
+import os
 from functools import lru_cache
 from typing import Optional
+
+from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.cache.config import get_cache_config
 from cognee.infrastructure.databases.cache.cache_db_interface import CacheDBInterface
 from cognee.infrastructure.databases.cache.fscache.FsCacheAdapter import FSCacheAdapter
+from cognee.infrastructure.databases.exceptions import CacheConnectionError
+
+logger = get_logger("CacheEngine")
+
+
+def _resolve_cache_db_url(backend: str, cache_db_url: Optional[str]) -> str:
+    """
+    Resolve the SQLAlchemy async URL for the SQL cache backends.
+
+    CACHE_DB_URL wins when set. Otherwise "sqlite" mirrors the relational SQLite
+    engine's databases directory (with a dedicated cache.db file), and "postgres"
+    falls back to the relational DB_* settings when DB_PROVIDER=postgres.
+    """
+    if cache_db_url:
+        return cache_db_url
+
+    from cognee.infrastructure.databases.relational.config import get_relational_config
+
+    relational_config = get_relational_config()
+
+    if backend == "sqlite":
+        db_path = relational_config.db_path
+        if "s3://" in db_path:
+            raise CacheConnectionError(
+                "CACHE_BACKEND=sqlite cannot store cache.db on S3; "
+                "set CACHE_DB_URL or CACHE_BACKEND=postgres"
+            )
+        os.makedirs(db_path, exist_ok=True)
+        return f"sqlite+aiosqlite:///{db_path}/cache.db"
+
+    if relational_config.db_provider == "postgres":
+        from sqlalchemy import URL
+
+        logger.warning(
+            "CACHE_BACKEND=postgres without CACHE_DB_URL; "
+            "falling back to the relational DB_* settings."
+        )
+        return URL.create(
+            "postgresql+asyncpg",
+            username=relational_config.db_username,
+            password=relational_config.db_password,
+            host=relational_config.db_host,
+            port=int(relational_config.db_port),
+            database=relational_config.db_name,
+        ).render_as_string(hide_password=False)
+
+    raise CacheConnectionError(
+        "CACHE_BACKEND=postgres requires CACHE_DB_URL or DB_PROVIDER=postgres"
+    )
 
 
 @lru_cache
@@ -23,9 +75,11 @@ def create_cache_engine(
     tapes_agent_name: str = "cognee",
     tapes_model: str = "cognee-session",
     tapes_request_timeout: float = 5.0,
+    cache_db_url: str | None = None,
+    cache_purge_interval_seconds: int = 900,
 ):
     """
-    Factory function to instantiate a cache coordination backend (currently Redis).
+    Factory function to instantiate a cache coordination backend.
 
     Parameters:
     -----------
@@ -37,6 +91,8 @@ def create_cache_engine(
     - log_key: Identifier used for usage logging.
     - agentic_lock_expire: Duration to hold the lock after acquisition.
     - agentic_lock_timeout: Max time to wait for the lock before failing.
+    - cache_db_url: SQLAlchemy async URL for the SQL cache backends.
+    - cache_purge_interval_seconds: Minimum interval between global TTL purge sweeps.
 
     Returns:
     --------
@@ -44,9 +100,9 @@ def create_cache_engine(
     """
     config = get_cache_config()
     if config.caching or config.usage_logging:
-        from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
-
         if config.cache_backend == "redis":
+            from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+
             return RedisAdapter(
                 host=cache_host,
                 port=cache_port,
@@ -73,10 +129,24 @@ def create_cache_engine(
                 tapes_model=tapes_model,
                 tapes_request_timeout=tapes_request_timeout,
             )
+        elif config.cache_backend in ("sqlite", "postgres"):
+            from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import (
+                SqlCacheAdapter,
+            )
+
+            return SqlCacheAdapter(
+                connection_string=_resolve_cache_db_url(config.cache_backend, cache_db_url),
+                lock_key=lock_key,
+                log_key=log_key,
+                session_ttl_seconds=session_ttl_seconds,
+                agentic_lock_expire=agentic_lock_expire,
+                agentic_lock_timeout=agentic_lock_timeout,
+                purge_interval_seconds=cache_purge_interval_seconds,
+            )
         else:
             raise ValueError(
                 f"Unsupported cache backend: '{config.cache_backend}'. "
-                f"Supported backends are: 'redis', 'fs', 'tapes'"
+                f"Supported backends are: 'redis', 'fs', 'tapes', 'sqlite', 'postgres'"
             )
     else:
         return None
@@ -106,6 +176,8 @@ def get_cache_engine(
         tapes_agent_name=config.tapes_agent_name,
         tapes_model=config.tapes_model,
         tapes_request_timeout=config.tapes_request_timeout,
+        cache_db_url=config.cache_db_url,
+        cache_purge_interval_seconds=config.cache_purge_interval_seconds,
     )
 
 

--- a/cognee/infrastructure/databases/cache/get_cache_engine.py
+++ b/cognee/infrastructure/databases/cache/get_cache_engine.py
@@ -134,8 +134,25 @@ def create_cache_engine(
                 SqlCacheAdapter,
             )
 
+            try:
+                connection_string = _resolve_cache_db_url(config.cache_backend, cache_db_url)
+            except CacheConnectionError as error:
+                # An explicitly chosen backend must fail loudly. The implicit
+                # sqlite default, however, can land on deployments it cannot
+                # serve (e.g. system root on S3) - degrade to the filesystem
+                # cache there so sessions keep working out of the box.
+                explicitly_chosen = "cache_backend" in getattr(config, "model_fields_set", set())
+                if config.cache_backend != "sqlite" or explicitly_chosen:
+                    raise
+                logger.warning(
+                    f"Default sqlite cache backend is unavailable ({error}); "
+                    "falling back to the filesystem cache backend. "
+                    "Set CACHE_DB_URL or CACHE_BACKEND to override."
+                )
+                return FSCacheAdapter(session_ttl_seconds=session_ttl_seconds)
+
             return SqlCacheAdapter(
-                connection_string=_resolve_cache_db_url(config.cache_backend, cache_db_url),
+                connection_string=connection_string,
                 lock_key=lock_key,
                 log_key=log_key,
                 session_ttl_seconds=session_ttl_seconds,

--- a/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
+++ b/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
@@ -445,6 +445,50 @@ class RedisAdapter(CacheDBInterface):
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
 
+    async def get_value(self, key: str) -> str | None:
+        """Retrieve a raw string value stored under the given key, or None if absent."""
+        try:
+            value = await self.async_redis.get(key)
+            if isinstance(value, bytes):
+                return value.decode("utf-8")
+            return value
+        except (redis.ConnectionError, redis.TimeoutError) as e:
+            error_msg = f"Redis connection error while getting value: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+        except Exception as e:
+            error_msg = f"Unexpected error while getting value from Redis: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+
+    async def set_value(self, key: str, value: str, ttl: int | None = None) -> None:
+        """Store a raw string value under the given key, optionally expiring after ttl seconds."""
+        try:
+            await self.async_redis.set(key, value)
+            if ttl:
+                await self.async_redis.expire(key, ttl)
+        except (redis.ConnectionError, redis.TimeoutError) as e:
+            error_msg = f"Redis connection error while setting value: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+        except Exception as e:
+            error_msg = f"Unexpected error while setting value in Redis: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+
+    async def delete_value(self, key: str) -> None:
+        """Delete the value stored under the given key, if present."""
+        try:
+            await self.async_redis.delete(key)
+        except (redis.ConnectionError, redis.TimeoutError) as e:
+            error_msg = f"Redis connection error while deleting value: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+        except Exception as e:
+            error_msg = f"Unexpected error while deleting value from Redis: {str(e)}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from e
+
     async def append_agent_trace_step(
         self,
         user_id: str,

--- a/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
@@ -1,0 +1,937 @@
+"""Engine-agnostic SQL cache adapter (Postgres via asyncpg, SQLite via aiosqlite)."""
+
+import asyncio
+import json
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from typing import List, Optional
+
+from pydantic import ValidationError
+from sqlalchemy import create_engine, delete, event, func, insert, or_, select, text, update
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from cognee.infrastructure.databases.cache.cache_db_interface import CacheDBInterface
+from cognee.infrastructure.databases.cache.models import SessionAgentTraceEntry, SessionQAEntry
+from cognee.infrastructure.databases.exceptions.exceptions import (
+    CacheConnectionError,
+    SessionQAEntryValidationError,
+    SharedLadybugLockRequiresRedisError,
+)
+from cognee.infrastructure.databases.relational import get_relational_config
+from cognee.modules.storage.utils import JSONEncoder
+from cognee.shared.logging_utils import get_logger
+
+from .tables import (
+    cache_kv,
+    cache_metadata,
+    cache_qa_entries,
+    cache_trace_entries,
+    cache_usage_logs,
+)
+
+logger = get_logger("SqlCacheAdapter")
+
+# Attempts for write transactions that can deadlock under concurrent workers.
+_DEADLOCK_ATTEMPTS = 3
+
+# Advisory-lock id guarding the throttled global TTL sweep on Postgres.
+_PURGE_LOCK_ID = int.from_bytes(sha256(b"cognee_cache_ttl_sweep").digest()[:8], "big", signed=True)
+
+
+def _is_deadlock_error(error: Exception) -> bool:
+    """Best-effort detection of a Postgres deadlock without importing asyncpg."""
+    if not isinstance(error, DBAPIError):
+        return False
+    orig = getattr(error, "orig", None)
+    seen = set()
+    while orig is not None and id(orig) not in seen:
+        seen.add(id(orig))
+        if type(orig).__name__ == "DeadlockDetectedError":
+            return True
+        if getattr(orig, "sqlstate", None) == "40P01":
+            return True
+        orig = getattr(orig, "__cause__", None)
+    return "deadlock detected" in str(error).lower()
+
+
+class _SqlAdvisoryLockHandle:
+    """Handle returned by acquire_lock; owns one checked-out sync connection."""
+
+    def __init__(self, connection, lock_id: int):
+        self.connection = connection
+        self.lock_id = lock_id
+        self._released = False
+
+    def release(self) -> None:
+        """Unlock the advisory lock and return the connection to the pool."""
+        if self._released:
+            return
+        self._released = True
+        try:
+            self.connection.execute(
+                text("SELECT pg_advisory_unlock(:lock_id)"), {"lock_id": self.lock_id}
+            )
+        except Exception as error:
+            logger.debug("Error releasing Postgres advisory lock: %s", error)
+        finally:
+            try:
+                self.connection.close()
+            except Exception as error:
+                logger.debug("Error closing advisory lock connection: %s", error)
+
+
+class SqlCacheAdapter(CacheDBInterface):
+    """SQL-backed cache adapter for session QA, trace, usage-log, and KV storage.
+
+    Runs on any SQLAlchemy async URL — production Postgres (``postgresql+asyncpg``)
+    and serverless SQLite (``sqlite+aiosqlite``) share the same code paths; Postgres
+    extras (``FOR UPDATE``, advisory locks) degrade gracefully on SQLite.
+
+    Note: the factory caches one adapter per ``lock_key`` (Ladybug per-db lock_key
+    instantiation pattern), so several instances may share one database.
+    """
+
+    def __init__(
+        self,
+        connection_string: str,
+        lock_key: str = "default_lock",
+        log_key: str = "usage_logs",
+        session_ttl_seconds: Optional[int] = 604800,
+        agentic_lock_expire: int = 240,
+        agentic_lock_timeout: int = 300,
+        purge_interval_seconds: int = 900,
+    ):
+        """Create the async engine lazily-validated on first use (no eager connect)."""
+        super().__init__(host="", port=0, lock_key=lock_key, log_key=log_key)
+
+        self.db_uri = connection_string
+        self.session_ttl_seconds = session_ttl_seconds
+        self.agentic_lock_expire = agentic_lock_expire
+        self.agentic_lock_timeout = agentic_lock_timeout
+        self.purge_interval_seconds = purge_interval_seconds
+
+        try:
+            url = make_url(connection_string)
+            self._is_postgres = url.get_backend_name() == "postgresql"
+
+            is_sqlite = url.get_backend_name() == "sqlite"
+
+            relational_config = get_relational_config()
+            pool_args: dict = (
+                dict(relational_config.pool_args) if relational_config.pool_args else {}
+            )
+            if is_sqlite:
+                # Concurrency tuning: wait out writer locks instead of failing
+                # with SQLITE_BUSY when several processes share one cache.db.
+                connect_args = dict(pool_args.pop("connect_args", None) or {})
+                connect_args.setdefault("timeout", 30)
+                pool_args["connect_args"] = connect_args
+
+            self.engine = create_async_engine(
+                connection_string,
+                json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
+                **pool_args,
+            )
+            if is_sqlite:
+
+                @event.listens_for(self.engine.sync_engine, "connect")
+                def _set_sqlite_pragmas(dbapi_connection, connection_record):
+                    cursor = dbapi_connection.cursor()
+                    cursor.execute("PRAGMA journal_mode=WAL")
+                    cursor.execute("PRAGMA busy_timeout=30000")
+                    cursor.close()
+
+            self.sessionmaker = async_sessionmaker(bind=self.engine, expire_on_commit=False)
+        except ModuleNotFoundError as error:
+            raise CacheConnectionError(
+                "SQL cache backend driver is not installed "
+                "(CACHE_BACKEND=postgres requires cognee[postgres]): " + str(error)
+            ) from error
+        except Exception as error:
+            raise CacheConnectionError(
+                f"Failed to initialize SQL cache engine for {connection_string}: {error}"
+            ) from error
+
+        self._sync_lock_engine = None
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+        self._last_purge = 0.0
+
+    # --------------------------------------------------------------------- #
+    # Initialization / shared helpers
+    # --------------------------------------------------------------------- #
+
+    async def _ensure_initialized(self) -> None:
+        """Create cache tables on first use; wrap first-connect failures."""
+        if self._initialized:
+            return
+        async with self._init_lock:
+            if self._initialized:
+                return
+            try:
+                async with self.engine.begin() as connection:
+                    await connection.run_sync(cache_metadata.create_all, checkfirst=True)
+            except Exception as error:
+                error_msg = f"Failed to connect to SQL cache database: {error}"
+                logger.error(error_msg)
+                raise CacheConnectionError(error_msg) from error
+            self._initialized = True
+
+    @staticmethod
+    def _now() -> datetime:
+        """Current UTC time, timezone-aware (used for all expiry math)."""
+        return datetime.now(timezone.utc)
+
+    def _ttl_enabled(self) -> bool:
+        """Whether session-scoped sliding TTL is active."""
+        return bool(self.session_ttl_seconds and self.session_ttl_seconds > 0)
+
+    def _session_expiry(self) -> Optional[datetime]:
+        """Expiry timestamp for session-scoped rows, or None when TTL is disabled."""
+        if not self._ttl_enabled():
+            return None
+        return self._now() + timedelta(seconds=self.session_ttl_seconds)
+
+    def _not_expired(self, table):
+        """Read-time expiry filter shared by every SELECT."""
+        return or_(table.c.expires_at.is_(None), table.c.expires_at > self._now())
+
+    def _session_filter(self, table, user_id: str, session_id: str):
+        """WHERE clause for one session's rows."""
+        return (table.c.user_id == user_id) & (table.c.session_id == session_id)
+
+    async def _refresh_session_ttl(self, session, table, user_id: str, session_id: str) -> None:
+        """Slide the whole session's expiry forward (Redis EXPIRE-on-write parity)."""
+        if not self._ttl_enabled():
+            return
+        await session.execute(
+            update(table)
+            .where(self._session_filter(table, user_id, session_id))
+            .values(expires_at=self._session_expiry())
+        )
+
+    async def _purge_session_expired(self, session, table, user_id: str, session_id: str) -> None:
+        """Scoped lazy purge: drop this session's already-expired rows on write."""
+        await session.execute(
+            delete(table).where(
+                self._session_filter(table, user_id, session_id),
+                table.c.expires_at.isnot(None),
+                table.c.expires_at <= self._now(),
+            )
+        )
+
+    async def _maybe_purge_expired(self) -> None:
+        """Throttled global TTL sweep — at most once per purge_interval_seconds.
+
+        Guarded by a transaction-scoped Postgres advisory lock so concurrent
+        workers don't stampede; it auto-releases at COMMIT/ROLLBACK (even when
+        the transaction aborts) so it can never leak on a pooled connection.
+        The guard is skipped on SQLite. Failures are swallowed: correctness
+        never depends on purging (reads filter on expires_at).
+        """
+        if self.purge_interval_seconds <= 0:
+            return
+        now = time.monotonic()
+        if self._last_purge and (now - self._last_purge) < self.purge_interval_seconds:
+            return
+        self._last_purge = now
+
+        try:
+            async with self.sessionmaker() as session, session.begin():
+                acquired = True
+                if self._is_postgres:
+                    acquired = (
+                        await session.execute(
+                            text("SELECT pg_try_advisory_xact_lock(:lock_id)"),
+                            {"lock_id": _PURGE_LOCK_ID},
+                        )
+                    ).scalar()
+                if not acquired:
+                    return
+                cutoff = self._now()
+                for table in (
+                    cache_qa_entries,
+                    cache_trace_entries,
+                    cache_usage_logs,
+                    cache_kv,
+                ):
+                    await session.execute(
+                        delete(table).where(
+                            table.c.expires_at.isnot(None), table.c.expires_at <= cutoff
+                        )
+                    )
+        except Exception as error:
+            logger.debug("SQL cache TTL sweep failed (will retry next interval): %s", error)
+
+    @staticmethod
+    def _build_qa_entry_dump(
+        question: str,
+        context: str,
+        answer: str,
+        qa_id: Optional[str] = None,
+        feedback_text: Optional[str] = None,
+        feedback_score: Optional[int] = None,
+        used_graph_element_ids: Optional[dict] = None,
+        memify_metadata: Optional[dict] = None,
+    ) -> dict:
+        """Serialize one QA entry into the normalized cache payload shape."""
+        entry = SessionQAEntry(
+            time=datetime.utcnow().isoformat(),
+            question=question,
+            context=context,
+            answer=answer,
+            qa_id=qa_id or str(uuid.uuid4()),
+            feedback_text=feedback_text,
+            feedback_score=feedback_score,
+            used_graph_element_ids=used_graph_element_ids,
+            memify_metadata=memify_metadata,
+        )
+        return entry.model_dump()
+
+    @staticmethod
+    def _build_agent_trace_entry_dump(
+        trace_id: str,
+        origin_function: str,
+        status: str,
+        memory_query: str = "",
+        memory_context: str = "",
+        method_params: Optional[dict] = None,
+        method_return_value=None,
+        error_message: str = "",
+        session_feedback: str = "",
+    ) -> dict:
+        """Serialize one agent-trace step into the normalized cache payload shape."""
+        entry = SessionAgentTraceEntry(
+            trace_id=trace_id,
+            origin_function=origin_function,
+            status=status,
+            memory_query=memory_query,
+            memory_context=memory_context,
+            method_params=method_params or {},
+            method_return_value=method_return_value,
+            error_message=error_message,
+            session_feedback=session_feedback,
+        )
+        return entry.model_dump()
+
+    @staticmethod
+    def _merge_entry_update(
+        entry: dict,
+        question: Optional[str] = None,
+        context: Optional[str] = None,
+        answer: Optional[str] = None,
+        feedback_text: Optional[str] = None,
+        feedback_score: Optional[int] = None,
+        used_graph_element_ids: Optional[dict] = None,
+        memify_metadata: Optional[dict] = None,
+    ) -> dict:
+        """Merge partial QA updates into an existing payload; None preserves values."""
+        merged = {**entry}
+        if question is not None:
+            merged["question"] = question
+        if context is not None:
+            merged["context"] = context
+        if answer is not None:
+            merged["answer"] = answer
+        if feedback_text is not None:
+            merged["feedback_text"] = feedback_text
+        if feedback_score is not None:
+            merged["feedback_score"] = feedback_score
+        if used_graph_element_ids is not None:
+            merged["used_graph_element_ids"] = used_graph_element_ids
+        if memify_metadata is not None:
+            existing_metadata = merged.get("memify_metadata")
+            if isinstance(existing_metadata, dict):
+                merged["memify_metadata"] = {**existing_metadata, **memify_metadata}
+            else:
+                merged["memify_metadata"] = memify_metadata
+        return merged
+
+    @staticmethod
+    def _merge_entry_clear_feedback(entry: dict) -> dict:
+        """Return a copy of the entry with feedback fields cleared."""
+        return {**entry, "feedback_text": None, "feedback_score": None}
+
+    @staticmethod
+    def _validate_entry_dict(entry_dict: dict) -> dict:
+        """Validate one serialized QA entry and return its normalized dump."""
+        try:
+            return SessionQAEntry.model_validate(entry_dict).model_dump()
+        except ValidationError as error:
+            raise SessionQAEntryValidationError(
+                message=f"Session QA entry validation failed: {error!s}"
+            ) from error
+
+    # --------------------------------------------------------------------- #
+    # Locks (sync — called via asyncio.to_thread by the Ladybug graph adapter)
+    # --------------------------------------------------------------------- #
+
+    def _get_sync_lock_engine(self):
+        """Lazy sync engine (psycopg2, pool_size=2) used only for advisory locks."""
+        if self._sync_lock_engine is None:
+            sync_url = make_url(self.db_uri).set(drivername="postgresql+psycopg2")
+            self._sync_lock_engine = create_engine(
+                sync_url, pool_size=2, isolation_level="AUTOCOMMIT"
+            )
+        return self._sync_lock_engine
+
+    def acquire_lock(self):
+        """Acquire a Postgres advisory lock keyed by lock_key. (Sync because of Ladybug)
+
+        Returns a handle owning the checked-out connection; the lock lives for the
+        connection's lifetime (released on release_lock or connection death — no
+        Redis-style auto-expiry watchdog). Raises RuntimeError on timeout and
+        SharedLadybugLockRequiresRedisError on non-Postgres URLs.
+        """
+        if not self._is_postgres:
+            logger.error("Shared Ladybug lock requires Redis or Postgres cache backend.")
+            raise SharedLadybugLockRequiresRedisError()
+
+        lock_id = int.from_bytes(sha256(self.lock_key.encode()).digest()[:8], "big", signed=True)
+        deadline = time.monotonic() + self.agentic_lock_timeout
+
+        connection = self._get_sync_lock_engine().connect()
+        try:
+            while True:
+                acquired = connection.execute(
+                    text("SELECT pg_try_advisory_lock(:lock_id)"), {"lock_id": lock_id}
+                ).scalar()
+                if acquired:
+                    handle = _SqlAdvisoryLockHandle(connection, lock_id)
+                    self.lock = handle
+                    return handle
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(f"Could not acquire Postgres advisory lock: {self.lock_key}")
+                time.sleep(0.1)
+        except BaseException:
+            try:
+                connection.close()
+            except Exception as error:
+                logger.debug("Error closing advisory lock connection: %s", error)
+            raise
+
+    def release_lock(self, lock=None):
+        """Release the passed advisory-lock handle, if held. (Sync because of Ladybug)"""
+        if not self._is_postgres:
+            logger.error("Shared Ladybug lock requires Redis or Postgres cache backend.")
+            raise SharedLadybugLockRequiresRedisError()
+
+        handle = lock if lock is not None else self.lock
+        if handle is None:
+            return
+        try:
+            handle.release()
+        except Exception as error:
+            logger.debug("Error releasing Postgres advisory lock: %s", error)
+        finally:
+            if handle is self.lock:
+                self.lock = None
+
+    # --------------------------------------------------------------------- #
+    # QA entries
+    # --------------------------------------------------------------------- #
+
+    async def create_qa_entry(
+        self,
+        user_id: str,
+        session_id: str,
+        question: str,
+        context: str,
+        answer: str,
+        qa_id: Optional[str] = None,
+        feedback_text: Optional[str] = None,
+        feedback_score: Optional[int] = None,
+        used_graph_element_ids: Optional[dict] = None,
+        memify_metadata: Optional[dict] = None,
+    ) -> None:
+        """Append one QA entry to the session. Creates the session if it doesn't exist."""
+        await self._ensure_initialized()
+        try:
+            qa_entry = self._build_qa_entry_dump(
+                question,
+                context,
+                answer,
+                qa_id,
+                feedback_text,
+                feedback_score,
+                used_graph_element_ids=used_graph_element_ids,
+                memify_metadata=memify_metadata,
+            )
+            async with self.sessionmaker() as session, session.begin():
+                await self._purge_session_expired(session, cache_qa_entries, user_id, session_id)
+                await session.execute(
+                    insert(cache_qa_entries).values(
+                        user_id=user_id,
+                        session_id=session_id,
+                        qa_id=qa_entry["qa_id"],
+                        payload=qa_entry,
+                        expires_at=self._session_expiry(),
+                    )
+                )
+                await self._refresh_session_ttl(session, cache_qa_entries, user_id, session_id)
+        except Exception as error:
+            error_msg = f"Unexpected error while adding Q&A to SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+        await self._maybe_purge_expired()
+
+    async def get_latest_qa_entries(
+        self, user_id: str, session_id: str, last_n: int = 5
+    ) -> List[SessionQAEntry]:
+        """Return the most recent QA entries (chronological); [] when none, for all last_n."""
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session:
+                result = await session.execute(
+                    select(cache_qa_entries.c.payload)
+                    .where(
+                        self._session_filter(cache_qa_entries, user_id, session_id),
+                        self._not_expired(cache_qa_entries),
+                    )
+                    .order_by(cache_qa_entries.c.seq.desc())
+                    .limit(last_n)
+                )
+                rows = result.scalars().all()
+            return [SessionQAEntry.model_validate(payload) for payload in reversed(rows)]
+        except Exception as error:
+            error_msg = f"Unexpected error while reading Q&A from SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    async def get_all_qa_entries(self, user_id: str, session_id: str) -> List[SessionQAEntry]:
+        """Return all QA entries stored for the given session, oldest first."""
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session:
+                result = await session.execute(
+                    select(cache_qa_entries.c.payload)
+                    .where(
+                        self._session_filter(cache_qa_entries, user_id, session_id),
+                        self._not_expired(cache_qa_entries),
+                    )
+                    .order_by(cache_qa_entries.c.seq.asc())
+                )
+                rows = result.scalars().all()
+            return [SessionQAEntry.model_validate(payload) for payload in rows]
+        except Exception as error:
+            error_msg = f"Unexpected error while reading Q&A from SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    async def _update_qa_payload(self, user_id: str, session_id: str, qa_id: str, merge_fn) -> bool:
+        """Shared FOR UPDATE read-merge-write transaction for QA updates."""
+        attempt = 0
+        while True:
+            try:
+                async with self.sessionmaker() as session, session.begin():
+                    result = await session.execute(
+                        select(cache_qa_entries.c.payload)
+                        .where(
+                            self._session_filter(cache_qa_entries, user_id, session_id),
+                            cache_qa_entries.c.qa_id == qa_id,
+                            self._not_expired(cache_qa_entries),
+                        )
+                        .with_for_update()
+                    )
+                    payload = result.scalar_one_or_none()
+                    if payload is None:
+                        return False
+                    validated = self._validate_entry_dict(merge_fn(dict(payload)))
+                    await session.execute(
+                        update(cache_qa_entries)
+                        .where(
+                            self._session_filter(cache_qa_entries, user_id, session_id),
+                            cache_qa_entries.c.qa_id == qa_id,
+                        )
+                        .values(payload=validated)
+                    )
+                    await self._refresh_session_ttl(session, cache_qa_entries, user_id, session_id)
+                    return True
+            except DBAPIError as error:
+                attempt += 1
+                if _is_deadlock_error(error) and attempt < _DEADLOCK_ATTEMPTS:
+                    await asyncio.sleep(0.05 * (2**attempt))
+                    continue
+                raise
+
+    async def update_qa_entry(
+        self,
+        user_id: str,
+        session_id: str,
+        qa_id: str,
+        question: Optional[str] = None,
+        context: Optional[str] = None,
+        answer: Optional[str] = None,
+        feedback_text: Optional[str] = None,
+        feedback_score: Optional[int] = None,
+        used_graph_element_ids: Optional[dict] = None,
+        memify_metadata: Optional[dict] = None,
+    ) -> bool:
+        """
+        Update a QA entry by qa_id. Same QA fields as create_qa_entry.
+        Only passed fields are updated; None preserves existing values.
+        Returns True if updated, False if qa_id not found.
+        """
+        await self._ensure_initialized()
+        try:
+            return await self._update_qa_payload(
+                user_id,
+                session_id,
+                qa_id,
+                lambda entry: self._merge_entry_update(
+                    entry,
+                    question,
+                    context,
+                    answer,
+                    feedback_text,
+                    feedback_score,
+                    used_graph_element_ids=used_graph_element_ids,
+                    memify_metadata=memify_metadata,
+                ),
+            )
+        except SessionQAEntryValidationError:
+            raise
+        except Exception as error:
+            error_msg = f"Unexpected error while updating Q&A in SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    async def delete_feedback(self, user_id: str, session_id: str, qa_id: str) -> bool:
+        """Set feedback_text and feedback_score to None for a QA entry."""
+        await self._ensure_initialized()
+        try:
+            return await self._update_qa_payload(
+                user_id, session_id, qa_id, self._merge_entry_clear_feedback
+            )
+        except SessionQAEntryValidationError:
+            raise
+        except Exception as error:
+            error_msg = f"Unexpected error while clearing feedback in SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    async def delete_qa_entry(self, user_id: str, session_id: str, qa_id: str) -> bool:
+        """
+        Delete a single QA entry by qa_id (single atomic DELETE).
+        Returns True if deleted, False if qa_id not found.
+        """
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session, session.begin():
+                result = await session.execute(
+                    delete(cache_qa_entries).where(
+                        self._session_filter(cache_qa_entries, user_id, session_id),
+                        cache_qa_entries.c.qa_id == qa_id,
+                        self._not_expired(cache_qa_entries),
+                    )
+                )
+                deleted = result.rowcount > 0
+                if deleted:
+                    await self._refresh_session_ttl(session, cache_qa_entries, user_id, session_id)
+                return deleted
+        except Exception as error:
+            error_msg = f"Unexpected error while deleting Q&A from SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    async def delete_session(self, user_id: str, session_id: str) -> bool:
+        """
+        Delete the entire session (QA entries + agent traces).
+        Returns True if any live session data existed, False otherwise.
+        """
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session, session.begin():
+                deleted_rows = 0
+                for table in (cache_qa_entries, cache_trace_entries):
+                    # Expired rows are invisible — drop them first so they don't
+                    # count toward "session existed".
+                    await self._purge_session_expired(session, table, user_id, session_id)
+                    result = await session.execute(
+                        delete(table).where(self._session_filter(table, user_id, session_id))
+                    )
+                    deleted_rows += result.rowcount
+                return deleted_rows > 0
+        except Exception as error:
+            error_msg = f"Unexpected error while deleting session from SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    # --------------------------------------------------------------------- #
+    # Agent traces
+    # --------------------------------------------------------------------- #
+
+    async def append_agent_trace_step(
+        self,
+        user_id: str,
+        session_id: str,
+        trace_id: str,
+        origin_function: str,
+        status: str,
+        memory_query: str = "",
+        memory_context: str = "",
+        method_params: Optional[dict] = None,
+        method_return_value=None,
+        error_message: str = "",
+        session_feedback: str = "",
+    ) -> None:
+        """Append one trace step to the stored trace list for this session."""
+        await self._ensure_initialized()
+        try:
+            trace_entry = self._build_agent_trace_entry_dump(
+                trace_id=trace_id,
+                origin_function=origin_function,
+                status=status,
+                memory_query=memory_query,
+                memory_context=memory_context,
+                method_params=method_params,
+                method_return_value=method_return_value,
+                error_message=error_message,
+                session_feedback=session_feedback,
+            )
+            async with self.sessionmaker() as session, session.begin():
+                await self._purge_session_expired(session, cache_trace_entries, user_id, session_id)
+                await session.execute(
+                    insert(cache_trace_entries).values(
+                        user_id=user_id,
+                        session_id=session_id,
+                        payload=trace_entry,
+                        expires_at=self._session_expiry(),
+                    )
+                )
+                await self._refresh_session_ttl(session, cache_trace_entries, user_id, session_id)
+        except Exception as error:
+            error_msg = f"Unexpected error while appending agent trace step to SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+        await self._maybe_purge_expired()
+
+    async def get_agent_trace_session(
+        self, user_id: str, session_id: str, last_n: Optional[int] = None
+    ) -> List[SessionAgentTraceEntry]:
+        """Retrieve stored trace steps for the given session (reads don't refresh TTL)."""
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session:
+                query = select(cache_trace_entries.c.payload).where(
+                    self._session_filter(cache_trace_entries, user_id, session_id),
+                    self._not_expired(cache_trace_entries),
+                )
+                if last_n is not None:
+                    result = await session.execute(
+                        query.order_by(cache_trace_entries.c.seq.desc()).limit(last_n)
+                    )
+                    rows = list(reversed(result.scalars().all()))
+                else:
+                    result = await session.execute(query.order_by(cache_trace_entries.c.seq.asc()))
+                    rows = result.scalars().all()
+            return [SessionAgentTraceEntry.model_validate(payload) for payload in rows]
+        except Exception as error:
+            error_msg = f"Unexpected error while reading agent trace from SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    async def get_agent_trace_feedback(
+        self, user_id: str, session_id: str, last_n: Optional[int] = None
+    ) -> List[str]:
+        """Retrieve ordered per-step feedback for the given trace session."""
+        entries = await self.get_agent_trace_session(user_id, session_id, last_n=last_n)
+        return [entry.session_feedback for entry in entries]
+
+    async def get_agent_trace_count(self, user_id: str, session_id: str) -> int:
+        """Return the number of stored trace steps for the given session."""
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session:
+                result = await session.execute(
+                    select(func.count())
+                    .select_from(cache_trace_entries)
+                    .where(
+                        self._session_filter(cache_trace_entries, user_id, session_id),
+                        self._not_expired(cache_trace_entries),
+                    )
+                )
+                return result.scalar_one()
+        except Exception as error:
+            error_msg = f"Unexpected error while counting agent trace steps in SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    # --------------------------------------------------------------------- #
+    # Usage logs
+    # --------------------------------------------------------------------- #
+
+    async def log_usage(
+        self,
+        user_id: str,
+        log_entry: dict,
+        ttl: Optional[int] = 604800,
+    ):
+        """
+        Log usage information (API endpoint calls, MCP tool invocations) to SQL cache.
+
+        Args:
+            user_id: The user ID.
+            log_entry: Dictionary containing usage log information.
+            ttl: Optional time-to-live (seconds). If provided, the whole per-user
+                log list expires after this time (Redis EXPIREs the whole list,
+                so every existing row's expiry is refreshed too).
+
+        Raises:
+            CacheConnectionError: If the cache connection fails.
+        """
+        await self._ensure_initialized()
+        try:
+            expires_at = self._now() + timedelta(seconds=ttl) if ttl else None
+            async with self.sessionmaker() as session, session.begin():
+                await session.execute(
+                    insert(cache_usage_logs).values(
+                        log_key=self.log_key,
+                        user_id=user_id,
+                        payload=log_entry,
+                        expires_at=expires_at,
+                    )
+                )
+                if expires_at is not None:
+                    await session.execute(
+                        update(cache_usage_logs)
+                        .where(
+                            cache_usage_logs.c.log_key == self.log_key,
+                            cache_usage_logs.c.user_id == user_id,
+                        )
+                        .values(expires_at=expires_at)
+                    )
+        except Exception as error:
+            error_msg = f"Unexpected error while logging usage to SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+        await self._maybe_purge_expired()
+
+    async def get_usage_logs(self, user_id: str, limit: int = 100):
+        """
+        Retrieve usage logs for a given user.
+
+        Args:
+            user_id: The user ID.
+            limit: Maximum number of logs to retrieve (default: 100).
+
+        Returns:
+            List of usage log entries, most recent first.
+        """
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session:
+                result = await session.execute(
+                    select(cache_usage_logs.c.payload)
+                    .where(
+                        cache_usage_logs.c.log_key == self.log_key,
+                        cache_usage_logs.c.user_id == user_id,
+                        self._not_expired(cache_usage_logs),
+                    )
+                    .order_by(cache_usage_logs.c.seq.desc())
+                    .limit(limit)
+                )
+                return list(result.scalars().all())
+        except Exception as error:
+            error_msg = f"Unexpected error while retrieving usage logs from SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    # --------------------------------------------------------------------- #
+    # Key/value storage (graph snapshots + sync checkpoints; keys kept verbatim)
+    # --------------------------------------------------------------------- #
+
+    async def get_value(self, key: str) -> Optional[str]:
+        """Return the string value stored under key, or None if absent/expired."""
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session:
+                result = await session.execute(
+                    select(cache_kv.c.value).where(
+                        cache_kv.c.key == key, self._not_expired(cache_kv)
+                    )
+                )
+                return result.scalar_one_or_none()
+        except Exception as error:
+            error_msg = f"Unexpected error while reading key/value from SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    async def set_value(self, key: str, value: str, ttl: Optional[int] = None) -> None:
+        """Upsert a string value under key; ttl=None stores it without expiry."""
+        await self._ensure_initialized()
+        try:
+            if self._is_postgres:
+                from sqlalchemy.dialects.postgresql import insert as upsert_insert
+            else:
+                from sqlalchemy.dialects.sqlite import insert as upsert_insert
+
+            expires_at = self._now() + timedelta(seconds=ttl) if ttl else None
+            statement = upsert_insert(cache_kv).values(key=key, value=value, expires_at=expires_at)
+            statement = statement.on_conflict_do_update(
+                index_elements=[cache_kv.c.key],
+                set_={
+                    "value": statement.excluded.value,
+                    "expires_at": statement.excluded.expires_at,
+                },
+            )
+            async with self.sessionmaker() as session, session.begin():
+                await session.execute(statement)
+        except Exception as error:
+            error_msg = f"Unexpected error while writing key/value to SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+        await self._maybe_purge_expired()
+
+    async def delete_value(self, key: str) -> None:
+        """Delete the value stored under key, if present."""
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session, session.begin():
+                await session.execute(delete(cache_kv).where(cache_kv.c.key == key))
+        except Exception as error:
+            error_msg = f"Unexpected error while deleting key/value from SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    # --------------------------------------------------------------------- #
+    # Maintenance
+    # --------------------------------------------------------------------- #
+
+    async def prune(self) -> None:
+        """
+        Empty the cache. Scoped to the four cognee cache tables only — a deliberate,
+        safer divergence from Redis FLUSHDB (which nukes co-tenant keys).
+        """
+        await self._ensure_initialized()
+        try:
+            async with self.sessionmaker() as session, session.begin():
+                for table in (
+                    cache_qa_entries,
+                    cache_trace_entries,
+                    cache_usage_logs,
+                    cache_kv,
+                ):
+                    await session.execute(delete(table))
+        except Exception as error:
+            error_msg = f"Unexpected error while pruning SQL cache: {error}"
+            logger.error(error_msg)
+            raise CacheConnectionError(error_msg) from error
+
+    async def close(self):
+        """Dispose engines. Idempotent; a reused instance lazily re-initializes."""
+        try:
+            await self.engine.dispose(close=True)
+        except Exception as error:
+            logger.debug("Error closing SQL cache async engine: %s", error)
+        if self._sync_lock_engine is not None:
+            try:
+                self._sync_lock_engine.dispose(close=True)
+            except Exception as error:
+                logger.debug("Error closing SQL cache sync lock engine: %s", error)
+            self._sync_lock_engine = None
+        self._initialized = False

--- a/cognee/infrastructure/databases/cache/sql/__init__.py
+++ b/cognee/infrastructure/databases/cache/sql/__init__.py
@@ -1,0 +1,3 @@
+from .SqlCacheAdapter import SqlCacheAdapter
+
+__all__ = ["SqlCacheAdapter"]

--- a/cognee/infrastructure/databases/cache/sql/tables.py
+++ b/cognee/infrastructure/databases/cache/sql/tables.py
@@ -1,0 +1,116 @@
+"""Schema definitions for the SQL cache adapter (engine-agnostic: Postgres + SQLite).
+
+Tables live on a private MetaData (``cache_metadata``) — not the relational
+declarative Base and not alembic-managed — mirroring the Postgres graph adapter's
+create-on-init pattern. Payload columns use JSONB on Postgres and plain JSON on
+SQLite; seq primary keys degrade from BIGINT identity to INTEGER autoincrement
+on SQLite so unit tests can run on aiosqlite without a server.
+"""
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    JSON,
+    MetaData,
+    Table,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+
+cache_metadata = MetaData()
+
+
+def _payload_type():
+    """JSONB on Postgres, generic JSON on SQLite."""
+    return JSONB().with_variant(JSON(), "sqlite")
+
+
+def _seq_type():
+    """BIGINT identity on Postgres, INTEGER autoincrement on SQLite."""
+    return BigInteger().with_variant(Integer(), "sqlite")
+
+
+# QA entries: one row per entry; qa_id promoted to a column for direct UPDATE.
+cache_qa_entries = Table(
+    "cache_qa_entries",
+    cache_metadata,
+    Column("seq", _seq_type(), primary_key=True, autoincrement=True),
+    Column("user_id", Text, nullable=False),
+    Column("session_id", Text, nullable=False),
+    Column("qa_id", Text, nullable=False),
+    Column("payload", _payload_type(), nullable=False),
+    Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
+    Column("expires_at", DateTime(timezone=True), nullable=True),
+    UniqueConstraint("user_id", "session_id", "qa_id", name="uq_cache_qa_entry"),
+)
+
+Index(
+    "idx_cache_qa_session",
+    cache_qa_entries.c.user_id,
+    cache_qa_entries.c.session_id,
+    cache_qa_entries.c.seq,
+)
+Index(
+    "idx_cache_qa_expires",
+    cache_qa_entries.c.expires_at,
+    postgresql_where=cache_qa_entries.c.expires_at.isnot(None),
+    sqlite_where=cache_qa_entries.c.expires_at.isnot(None),
+)
+
+# Agent traces: append-only.
+cache_trace_entries = Table(
+    "cache_trace_entries",
+    cache_metadata,
+    Column("seq", _seq_type(), primary_key=True, autoincrement=True),
+    Column("user_id", Text, nullable=False),
+    Column("session_id", Text, nullable=False),
+    Column("payload", _payload_type(), nullable=False),
+    Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
+    Column("expires_at", DateTime(timezone=True), nullable=True),
+)
+
+Index(
+    "idx_cache_trace_session",
+    cache_trace_entries.c.user_id,
+    cache_trace_entries.c.session_id,
+    cache_trace_entries.c.seq,
+)
+Index(
+    "idx_cache_trace_expires",
+    cache_trace_entries.c.expires_at,
+    postgresql_where=cache_trace_entries.c.expires_at.isnot(None),
+    sqlite_where=cache_trace_entries.c.expires_at.isnot(None),
+)
+
+# Usage logs (Redis key {log_key}:{user_id} analogue).
+cache_usage_logs = Table(
+    "cache_usage_logs",
+    cache_metadata,
+    Column("seq", _seq_type(), primary_key=True, autoincrement=True),
+    Column("log_key", Text, nullable=False),
+    Column("user_id", Text, nullable=False),
+    Column("payload", _payload_type(), nullable=False),
+    Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
+    Column("expires_at", DateTime(timezone=True), nullable=True),
+)
+
+Index(
+    "idx_cache_usage",
+    cache_usage_logs.c.log_key,
+    cache_usage_logs.c.user_id,
+    cache_usage_logs.c.seq,
+)
+
+# String KV: graph_knowledge:{u}:{s}, graph_sync_checkpoint:{u}:{d}:{s} — keys kept verbatim.
+cache_kv = Table(
+    "cache_kv",
+    cache_metadata,
+    Column("key", Text, primary_key=True),
+    Column("value", Text, nullable=False),
+    Column("expires_at", DateTime(timezone=True), nullable=True),
+)

--- a/cognee/infrastructure/session/session_manager.py
+++ b/cognee/infrastructure/session/session_manager.py
@@ -800,8 +800,9 @@ class SessionManager:
         try:
             raw = await self._cache.get_value(key)
             return raw if raw else ""
-        except (NotImplementedError, AttributeError):
-            # Adapter predates the KV interface, fall back to legacy duck-typing
+        except (NotImplementedError, AttributeError, TypeError):
+            # Adapter predates the KV interface (missing, non-async, or
+            # different-signature get_value), fall back to legacy duck-typing
             pass
         except Exception:
             return ""
@@ -832,8 +833,9 @@ class SessionManager:
         try:
             await self._cache.set_value(key, context, ttl=self._cache.session_ttl_seconds)
             return
-        except (NotImplementedError, AttributeError):
-            # Adapter predates the KV interface, fall back to legacy duck-typing
+        except (NotImplementedError, AttributeError, TypeError):
+            # Adapter predates the KV interface (missing, non-async, or
+            # different-signature set_value), fall back to legacy duck-typing
             pass
         try:
             await self._cache.async_redis.set(key, context)
@@ -861,8 +863,9 @@ class SessionManager:
         graph_key = self._graph_context_key(user_id, session_id)
         try:
             await self._cache.delete_value(graph_key)
-        except (NotImplementedError, AttributeError):
-            # Adapter predates the KV interface, fall back to legacy duck-typing
+        except (NotImplementedError, AttributeError, TypeError):
+            # Adapter predates the KV interface (missing, non-async, or
+            # different-signature delete_value), fall back to legacy duck-typing
             try:
                 await self._cache.async_redis.delete(graph_key)
             except AttributeError:

--- a/cognee/infrastructure/session/session_manager.py
+++ b/cognee/infrastructure/session/session_manager.py
@@ -798,6 +798,14 @@ class SessionManager:
         session_id = self._resolve_session_id(session_id)
         key = self._graph_context_key(user_id, session_id)
         try:
+            raw = await self._cache.get_value(key)
+            return raw if raw else ""
+        except (NotImplementedError, AttributeError):
+            # Adapter predates the KV interface, fall back to legacy duck-typing
+            pass
+        except Exception:
+            return ""
+        try:
             raw = await self._cache.async_redis.get(key)
             if raw:
                 return raw.decode() if isinstance(raw, bytes) else raw
@@ -821,6 +829,12 @@ class SessionManager:
             return
         session_id = self._resolve_session_id(session_id)
         key = self._graph_context_key(user_id, session_id)
+        try:
+            await self._cache.set_value(key, context, ttl=self._cache.session_ttl_seconds)
+            return
+        except (NotImplementedError, AttributeError):
+            # Adapter predates the KV interface, fall back to legacy duck-typing
+            pass
         try:
             await self._cache.async_redis.set(key, context)
             if self._cache.session_ttl_seconds:
@@ -846,10 +860,16 @@ class SessionManager:
         # Also clean up the graph knowledge context key
         graph_key = self._graph_context_key(user_id, session_id)
         try:
-            await self._cache.async_redis.delete(graph_key)
-        except AttributeError:
+            await self._cache.delete_value(graph_key)
+        except (NotImplementedError, AttributeError):
+            # Adapter predates the KV interface, fall back to legacy duck-typing
             try:
-                del self._cache._cache[graph_key]
+                await self._cache.async_redis.delete(graph_key)
+            except AttributeError:
+                try:
+                    del self._cache._cache[graph_key]
+                except Exception:
+                    pass
             except Exception:
                 pass
         except Exception:

--- a/cognee/tasks/memify/sync_graph_to_session.py
+++ b/cognee/tasks/memify/sync_graph_to_session.py
@@ -48,8 +48,9 @@ async def _load_checkpoint(cache_engine, key: str) -> Optional[datetime]:
         if raw:
             return datetime.fromisoformat(raw)
         return None
-    except (NotImplementedError, AttributeError):
-        # Adapter predates the KV interface, fall back to legacy duck-typing
+    except (NotImplementedError, AttributeError, TypeError):
+        # Adapter predates the KV interface (missing, non-async, or
+        # different-signature get_value), fall back to legacy duck-typing
         pass
     except Exception:
         logger.debug("_load_checkpoint: cache read failed for key %s", key)
@@ -76,8 +77,9 @@ async def _save_checkpoint(cache_engine, key: str, ts: datetime) -> None:
     try:
         await cache_engine.set_value(key, value)
         return
-    except (NotImplementedError, AttributeError):
-        # Adapter predates the KV interface, fall back to legacy duck-typing
+    except (NotImplementedError, AttributeError, TypeError):
+        # Adapter predates the KV interface (missing, non-async, or
+        # different-signature set_value), fall back to legacy duck-typing
         pass
     try:
         await cache_engine.async_redis.set(key, value)

--- a/cognee/tasks/memify/sync_graph_to_session.py
+++ b/cognee/tasks/memify/sync_graph_to_session.py
@@ -44,6 +44,17 @@ async def _load_checkpoint(cache_engine, key: str) -> Optional[datetime]:
     if cache_engine is None:
         return None
     try:
+        raw = await cache_engine.get_value(key)
+        if raw:
+            return datetime.fromisoformat(raw)
+        return None
+    except (NotImplementedError, AttributeError):
+        # Adapter predates the KV interface, fall back to legacy duck-typing
+        pass
+    except Exception:
+        logger.debug("_load_checkpoint: cache read failed for key %s", key)
+        return None
+    try:
         raw = await cache_engine.async_redis.get(key)
         if raw:
             return datetime.fromisoformat(raw.decode() if isinstance(raw, bytes) else raw)
@@ -62,6 +73,12 @@ async def _load_checkpoint(cache_engine, key: str) -> Optional[datetime]:
 async def _save_checkpoint(cache_engine, key: str, ts: datetime) -> None:
     """Persist the high-water mark timestamp."""
     value = ts.isoformat()
+    try:
+        await cache_engine.set_value(key, value)
+        return
+    except (NotImplementedError, AttributeError):
+        # Adapter predates the KV interface, fall back to legacy duck-typing
+        pass
     try:
         await cache_engine.async_redis.set(key, value)
     except AttributeError:

--- a/cognee/tests/integration/infrastructure/session/test_feedback_weights_memify_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_feedback_weights_memify_integration.py
@@ -1,3 +1,4 @@
+import asyncio
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -77,7 +78,7 @@ class InMemoryGraphWithWeights:
         return result
 
 
-@pytest.fixture(params=["fs", "redis"])
+@pytest.fixture(params=["fs", "redis", "sqlite"])
 def session_manager_with_backend(request):
     backend = request.param
     if backend == "fs":
@@ -94,7 +95,7 @@ def session_manager_with_backend(request):
                 sm = SessionManager(cache_engine=adapter)
                 yield sm
                 adapter.cache.close()
-    else:
+    elif backend == "redis":
         store = _InMemoryRedisList()
         patch_mod = "cognee.infrastructure.databases.cache.redis.RedisAdapter"
         with (
@@ -106,6 +107,16 @@ def session_manager_with_backend(request):
             adapter = RedisAdapter(host="localhost", port=6379)
             sm = SessionManager(cache_engine=adapter)
             yield sm
+    else:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import (
+                SqlCacheAdapter,
+            )
+
+            adapter = SqlCacheAdapter(f"sqlite+aiosqlite:///{tmpdir}/cache.db")
+            sm = SessionManager(cache_engine=adapter)
+            yield sm
+            asyncio.run(adapter.close())
 
 
 def _make_user():

--- a/cognee/tests/integration/infrastructure/session/test_session_manager_sql.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_manager_sql.py
@@ -1,0 +1,488 @@
+"""Integration tests for SessionManager with SqlCacheAdapter (aiosqlite-backed)."""
+
+import asyncio
+import tempfile
+
+import pytest
+from sqlalchemy import select
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import SqlCacheAdapter
+from cognee.infrastructure.databases.cache.sql.tables import cache_qa_entries
+from cognee.infrastructure.session.feedback_models import (
+    AgentTraceFeedbackSummary,
+    FeedbackDetectionResult,
+)
+from cognee.infrastructure.session.session_manager import SessionManager
+
+
+@pytest.fixture
+def sql_adapter():
+    """SqlCacheAdapter backed by a temporary aiosqlite database."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        adapter = SqlCacheAdapter(f"sqlite+aiosqlite:///{tmpdir}/cache.db")
+        yield adapter
+        asyncio.run(adapter.close())
+
+
+@pytest.fixture
+def session_manager(sql_adapter):
+    """SessionManager wired to SqlCacheAdapter."""
+    return SessionManager(cache_engine=sql_adapter)
+
+
+async def _qa_expirations(adapter, user_id: str, session_id: str):
+    """Read expires_at for every QA row of a session directly from the table."""
+    async with adapter.sessionmaker() as session:
+        result = await session.execute(
+            select(cache_qa_entries.c.expires_at).where(
+                cache_qa_entries.c.user_id == user_id,
+                cache_qa_entries.c.session_id == session_id,
+            )
+        )
+        return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_add_qa_and_get_session(session_manager):
+    """Add QA via SessionManager and retrieve via get_session."""
+    qa_id = await session_manager.add_qa(
+        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+    )
+    assert qa_id is not None
+
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert len(entries) == 1
+    assert entries[0].question == "Q1?"
+    assert entries[0].answer == "A1."
+    assert entries[0].qa_id == qa_id
+
+
+@pytest.mark.asyncio
+async def test_add_qa_sets_session_ttl(session_manager, sql_adapter):
+    """Session writes through SessionManager stamp expires_at on the session rows."""
+    await session_manager.add_qa(
+        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+    )
+
+    expirations = await _qa_expirations(sql_adapter, "u1", "s1")
+    assert len(expirations) == 1
+    assert expirations[0] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_session_does_not_refresh_session_ttl(session_manager, sql_adapter):
+    """Read-only session access should not refresh expires_at."""
+    await session_manager.add_qa(
+        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+    )
+    before = await _qa_expirations(sql_adapter, "u1", "s1")
+
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+
+    after = await _qa_expirations(sql_adapter, "u1", "s1")
+    assert len(entries) == 1
+    assert before == after
+
+
+@pytest.mark.asyncio
+async def test_add_agent_trace_step_and_get_trace_session(session_manager):
+    """Trace steps appended via SessionManager are returned in append order."""
+    with (
+        patch(
+            "cognee.infrastructure.session.session_manager.read_query_prompt",
+            return_value="summarize this",
+        ),
+        patch(
+            "cognee.infrastructure.session.session_manager.LLMGateway.acreate_structured_output",
+            new_callable=AsyncMock,
+            return_value=AgentTraceFeedbackSummary(session_feedback="Plan created successfully."),
+        ),
+    ):
+        trace_id_1 = await session_manager.add_agent_trace_step(
+            user_id="u1",
+            session_id="s1",
+            origin_function="plan_trip",
+            status="success",
+            memory_query="trip preferences",
+            memory_context="User likes quiet places",
+            method_params={"city": "Tokyo"},
+            method_return_value="Plan created",
+        )
+        trace_id_2 = await session_manager.add_agent_trace_step(
+            user_id="u1",
+            session_id="s1",
+            origin_function="book_hotel",
+            status="error",
+            method_params={"area": "Shibuya"},
+            error_message="No availability",
+        )
+
+    entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    feedback = await session_manager.get_agent_trace_feedback(user_id="u1", session_id="s1")
+
+    assert [entry.trace_id for entry in entries] == [trace_id_1, trace_id_2]
+    assert entries[0].origin_function == "plan_trip"
+    assert entries[1].origin_function == "book_hotel"
+    assert feedback == [
+        "Plan created successfully.",
+        "book_hotel failed. Reason: No availability.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_add_agent_trace_step_can_disable_llm_feedback_generation(session_manager):
+    """Disabling LLM feedback generation stores deterministic fallback feedback."""
+    with patch(
+        "cognee.infrastructure.session.session_manager.LLMGateway.acreate_structured_output",
+        new_callable=AsyncMock,
+    ) as mock_llm:
+        trace_id = await session_manager.add_agent_trace_step(
+            user_id="u1",
+            session_id="s1",
+            origin_function="plan_trip",
+            status="success",
+            method_return_value="Plan created",
+            generate_feedback_with_llm=False,
+        )
+
+    assert trace_id is not None
+    mock_llm.assert_not_awaited()
+    entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    assert len(entries) == 1
+    assert entries[0].session_feedback == "plan_trip succeeded."
+
+
+@pytest.mark.asyncio
+async def test_agent_trace_session_isolated_by_user_and_session(session_manager):
+    """Agent trace sessions remain isolated by user_id and session_id."""
+    await session_manager.add_agent_trace_step(
+        user_id="u1",
+        session_id="s1",
+        origin_function="plan_trip",
+        status="success",
+    )
+    await session_manager.add_agent_trace_step(
+        user_id="u1",
+        session_id="s2",
+        origin_function="book_hotel",
+        status="error",
+        error_message="No availability",
+    )
+    await session_manager.add_agent_trace_step(
+        user_id="u2",
+        session_id="s1",
+        origin_function="book_flight",
+        status="success",
+    )
+
+    u1s1 = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    u1s2 = await session_manager.get_agent_trace_session(user_id="u1", session_id="s2")
+    u2s1 = await session_manager.get_agent_trace_session(user_id="u2", session_id="s1")
+
+    assert len(u1s1) == 1
+    assert u1s1[0].origin_function == "plan_trip"
+    assert len(u1s2) == 1
+    assert u1s2[0].origin_function == "book_hotel"
+    assert len(u2s1) == 1
+    assert u2s1[0].origin_function == "book_flight"
+
+
+@pytest.mark.asyncio
+async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager):
+    """add_qa with used_graph_element_ids stores and returns it via get_session."""
+    used_ids = {"node_ids": ["n1"], "edge_ids": ["e1"]}
+    qa_id = await session_manager.add_qa(
+        user_id="u1",
+        question="Q?",
+        context="C",
+        answer="A",
+        session_id="s1",
+        used_graph_element_ids=used_ids,
+    )
+    assert qa_id is not None
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert len(entries) == 1
+    assert entries[0].used_graph_element_ids == used_ids
+
+
+@pytest.mark.asyncio
+async def test_get_session_formatted(session_manager):
+    """get_session with formatted=True returns prompt string."""
+    await session_manager.add_qa(
+        user_id="u1", question="Q?", context="C", answer="A", session_id="s1"
+    )
+    formatted = await session_manager.get_session(user_id="u1", formatted=True, session_id="s1")
+    assert isinstance(formatted, str)
+    assert "Previous conversation" in formatted and "Q?" in formatted
+
+
+@pytest.mark.asyncio
+async def test_update_qa(session_manager):
+    """update_qa updates entry via SqlCacheAdapter."""
+    qa_id = await session_manager.add_qa(
+        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+    )
+    ok = await session_manager.update_qa(
+        user_id="u1", qa_id=qa_id, question="Q updated?", session_id="s1"
+    )
+    assert ok
+
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert entries[0].question == "Q updated?"
+
+
+@pytest.mark.asyncio
+async def test_add_feedback(session_manager):
+    """add_feedback sets feedback on entry."""
+    qa_id = await session_manager.add_qa(
+        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+    )
+    ok = await session_manager.add_feedback(
+        user_id="u1", qa_id=qa_id, feedback_score=5, session_id="s1"
+    )
+    assert ok
+
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert entries[0].feedback_score == 5
+
+
+@pytest.mark.asyncio
+async def test_delete_feedback(session_manager):
+    """delete_feedback clears feedback."""
+    qa_id = await session_manager.add_qa(
+        user_id="u1",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
+        feedback_text="good",
+        feedback_score=4,
+    )
+    ok = await session_manager.delete_feedback(user_id="u1", qa_id=qa_id, session_id="s1")
+    assert ok
+
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert entries[0].feedback_score is None
+    assert entries[0].feedback_text is None
+
+
+@pytest.mark.asyncio
+async def test_delete_qa(session_manager):
+    """delete_qa removes single entry."""
+    qa1 = await session_manager.add_qa(
+        user_id="u1", question="Q1", context="C1", answer="A1", session_id="s1"
+    )
+    await session_manager.add_qa(
+        user_id="u1", question="Q2", context="C2", answer="A2", session_id="s1"
+    )
+    ok = await session_manager.delete_qa(user_id="u1", qa_id=qa1, session_id="s1")
+    assert ok
+
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert len(entries) == 1
+    assert entries[0].question == "Q2"
+
+
+@pytest.mark.asyncio
+async def test_delete_session(session_manager):
+    """delete_session clears both QA and trace session entries."""
+    await session_manager.add_qa(
+        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+    )
+    trace_id = await session_manager.add_agent_trace_step(
+        user_id="u1",
+        session_id="s1",
+        origin_function="plan_trip",
+        status="success",
+    )
+    assert trace_id is not None
+    ok = await session_manager.delete_session(user_id="u1", session_id="s1")
+    assert ok
+
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert entries == []
+    trace_entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    assert trace_entries == []
+
+
+@pytest.mark.asyncio
+async def test_graph_context_round_trip_via_kv_interface(session_manager, sql_adapter):
+    """set/get_graph_context round-trips through the adapter's KV methods (cache_kv table)."""
+    await session_manager.set_graph_context(
+        user_id="u1", session_id="s1", context="graph snapshot text"
+    )
+
+    # Stored under the verbatim legacy key string, readable via the interface method.
+    assert await sql_adapter.get_value("graph_knowledge:u1:s1") == "graph snapshot text"
+    assert (
+        await session_manager.get_graph_context(user_id="u1", session_id="s1")
+        == "graph snapshot text"
+    )
+
+    # delete_session also removes the graph knowledge snapshot key.
+    await session_manager.delete_session(user_id="u1", session_id="s1")
+    assert await sql_adapter.get_value("graph_knowledge:u1:s1") is None
+    assert await session_manager.get_graph_context(user_id="u1", session_id="s1") == ""
+
+
+@pytest.mark.asyncio
+async def test_get_graph_context_returns_empty_when_unset(session_manager):
+    """get_graph_context returns empty string when no snapshot was stored."""
+    assert await session_manager.get_graph_context(user_id="u1", session_id="missing") == ""
+
+
+@pytest.mark.asyncio
+async def test_generate_completion_with_session_saves_qa(session_manager):
+    """generate_completion_with_session runs completion and saves QA to session (LLM mocked)."""
+    mock_user = MagicMock()
+    mock_user.id = "u1"
+    with (
+        patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
+        patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
+        patch(
+            "cognee.infrastructure.session.session_manager.generate_session_completion_with_optional_summary",
+            new_callable=AsyncMock,
+            return_value=("Integration test answer", "", None),
+        ),
+    ):
+        mock_session_user.get.return_value = mock_user
+        mock_config = MagicMock()
+        mock_config.caching = True
+        mock_config_cls.return_value = mock_config
+
+        used_ids = {"node_ids": ["n1"]}
+        result = await session_manager.generate_completion_with_session(
+            session_id="s1",
+            query="What is X?",
+            context="Context about X.",
+            user_prompt_path="user.txt",
+            system_prompt_path="sys.txt",
+            used_graph_element_ids=used_ids,
+        )
+
+    assert result == "Integration test answer"
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert len(entries) == 1
+    assert entries[0].question == "What is X?"
+    assert entries[0].answer == "Integration test answer"
+    assert entries[0].used_graph_element_ids == used_ids
+
+
+@pytest.mark.asyncio
+async def test_generate_completion_with_session_feedback_only_no_new_qa(session_manager):
+    """When feedback only is detected: feedback persisted on last QA, no new QA added."""
+    qa_id = await session_manager.add_qa(
+        user_id="u1",
+        question="What is X?",
+        context="Context about X.",
+        answer="X is something.",
+        session_id="s1",
+    )
+    assert qa_id is not None
+
+    mock_user = MagicMock()
+    mock_user.id = "u1"
+    with (
+        patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
+        patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
+        patch(
+            "cognee.infrastructure.session.session_manager.generate_session_completion_with_optional_summary",
+            new_callable=AsyncMock,
+            return_value=(
+                "Generated answer",
+                "",
+                FeedbackDetectionResult(
+                    feedback_detected=True,
+                    feedback_text="User said thanks.",
+                    feedback_score=5.0,
+                    response_to_user="Thanks for your feedback!",
+                    contains_followup_question=False,
+                ),
+            ),
+        ),
+    ):
+        mock_session_user.get.return_value = mock_user
+        mock_config = MagicMock()
+        mock_config.caching = True
+        mock_config.auto_feedback = True
+        mock_config_cls.return_value = mock_config
+
+        result = await session_manager.generate_completion_with_session(
+            session_id="s1",
+            query="thanks, that was helpful!",
+            context="ctx",
+            user_prompt_path="user.txt",
+            system_prompt_path="sys.txt",
+        )
+
+    assert result == "Thanks for your feedback!"
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert len(entries) == 1
+    assert entries[0].qa_id == qa_id
+    assert entries[0].question == "What is X?"
+    assert entries[0].feedback_text == "User said thanks."
+    assert entries[0].feedback_score == 5
+
+
+@pytest.mark.asyncio
+async def test_generate_completion_with_session_feedback_and_followup_adds_qa(session_manager):
+    """When feedback + follow-up: feedback on last QA and new QA added with answer."""
+    qa_id_first = await session_manager.add_qa(
+        user_id="u1",
+        question="What is X?",
+        context="Context about X.",
+        answer="X is something.",
+        session_id="s1",
+    )
+    assert qa_id_first is not None
+
+    mock_user = MagicMock()
+    mock_user.id = "u1"
+    with (
+        patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
+        patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
+        patch(
+            "cognee.infrastructure.session.session_manager.generate_session_completion_with_optional_summary",
+            new_callable=AsyncMock,
+            return_value=(
+                "Paris is the capital of France.",
+                "",
+                FeedbackDetectionResult(
+                    feedback_detected=True,
+                    feedback_text="User gave thanks and asked follow-up.",
+                    feedback_score=5.0,
+                    response_to_user="Thanks for your feedback!",
+                    contains_followup_question=True,
+                ),
+            ),
+        ),
+    ):
+        mock_session_user.get.return_value = mock_user
+        mock_config = MagicMock()
+        mock_config.caching = True
+        mock_config.auto_feedback = True
+        mock_config_cls.return_value = mock_config
+
+        result = await session_manager.generate_completion_with_session(
+            session_id="s1",
+            query="thanks! What is the capital of France?",
+            context="ctx",
+            user_prompt_path="user.txt",
+            system_prompt_path="sys.txt",
+        )
+
+    assert "Thanks for your feedback!" in result
+    assert "Paris is the capital of France." in result
+    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    assert len(entries) == 2
+    first_qa = next((e for e in entries if e.qa_id == qa_id_first), None)
+    followup_qa = next(
+        (e for e in entries if e.question == "thanks! What is the capital of France?"),
+        None,
+    )
+    assert first_qa is not None
+    assert first_qa.feedback_text == "User gave thanks and asked follow-up."
+    assert first_qa.feedback_score == 5
+    assert followup_qa is not None
+    assert followup_qa.answer == "Paris is the capital of France."

--- a/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
@@ -155,11 +155,11 @@ async def session_persistence_env(event_loop):
             _reset_cache_backend_caches()
 
 
-@pytest.fixture(params=["fs", "redis"])
+@pytest.fixture(params=["fs", "redis", "sqlite"])
 def session_manager_with_qa(request):
     """
-    SessionManager backed by either FsCache or in-memory Redis.
-    Tests run twice (once per backend).
+    SessionManager backed by FsCache, in-memory Redis, or SQL (aiosqlite).
+    Tests run once per backend.
     """
     backend = request.param
     if backend == "fs":
@@ -176,7 +176,7 @@ def session_manager_with_qa(request):
                 sm = SessionManager(cache_engine=adapter)
                 yield sm, adapter
                 adapter.cache.close()
-    else:
+    elif backend == "redis":
         store = _InMemoryRedisList()
         patch_mod = "cognee.infrastructure.databases.cache.redis.RedisAdapter"
         with (
@@ -190,6 +190,16 @@ def session_manager_with_qa(request):
             adapter = RedisAdapter(host="localhost", port=6379)
             sm = SessionManager(cache_engine=adapter)
             yield sm, adapter
+    else:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import (
+                SqlCacheAdapter,
+            )
+
+            adapter = SqlCacheAdapter(f"sqlite+aiosqlite:///{tmpdir}/cache.db")
+            sm = SessionManager(cache_engine=adapter)
+            yield sm, adapter
+            asyncio.run(adapter.close())
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/integration/infrastructure/session/test_session_sdk_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_sdk_integration.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import tempfile
 from types import SimpleNamespace
@@ -54,11 +55,11 @@ class _InMemoryRedisList:
         self.data.clear()
 
 
-@pytest.fixture(params=["fs", "redis"])
+@pytest.fixture(params=["fs", "redis", "sqlite"])
 def sdk_uses_session_manager(request):
     """
-    SessionManager backed by either FsCache or in-memory Redis; SDK is patched to use it.
-    Tests run twice (once per backend).
+    SessionManager backed by FsCache, in-memory Redis, or SQL (aiosqlite); SDK is
+    patched to use it. Tests run once per backend.
     """
     backend = request.param
     if backend == "fs":
@@ -80,7 +81,7 @@ def sdk_uses_session_manager(request):
                 ):
                     yield session_manager
                 adapter.cache.close()
-    else:
+    elif backend == "redis":
         store = _InMemoryRedisList()
         patch_mod = "cognee.infrastructure.databases.cache.redis.RedisAdapter"
         with (
@@ -99,6 +100,21 @@ def sdk_uses_session_manager(request):
                 return_value=session_manager,
             ):
                 yield session_manager
+    else:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import (
+                SqlCacheAdapter,
+            )
+
+            adapter = SqlCacheAdapter(f"sqlite+aiosqlite:///{tmpdir}/cache.db")
+            session_manager = SessionManager(cache_engine=adapter)
+            with patch.object(
+                _session_module(),
+                "get_session_manager",
+                return_value=session_manager,
+            ):
+                yield session_manager
+            asyncio.run(adapter.close())
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/infrastructure/databases/cache/test_cache_config.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_cache_config.py
@@ -8,6 +8,8 @@ def test_cache_config_defaults(monkeypatch):
     """Test that CacheConfig has the correct default values."""
     for env_var in (
         "CACHE_BACKEND",
+        "CACHE_DB_URL",
+        "CACHE_PURGE_INTERVAL_SECONDS",
         "CACHING",
         "AUTO_FEEDBACK",
         "SHARED_LADYBUG_LOCK",
@@ -26,7 +28,9 @@ def test_cache_config_defaults(monkeypatch):
 
     config = CacheConfig(_env_file=None)
 
-    assert config.cache_backend == "fs"
+    assert config.cache_backend == "sqlite"
+    assert config.cache_db_url is None
+    assert config.cache_purge_interval_seconds == 900
     assert config.caching is True
     assert config.shared_ladybug_lock is False
     assert config.shared_kuzu_lock is False
@@ -77,6 +81,8 @@ def test_cache_config_to_dict():
 
     assert config_dict == {
         "cache_backend": "fs",
+        "cache_db_url": None,
+        "cache_purge_interval_seconds": 900,
         "caching": True,
         "auto_feedback": False,
         "shared_ladybug_lock": True,

--- a/cognee/tests/unit/infrastructure/databases/cache/test_get_cache_engine.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_get_cache_engine.py
@@ -72,6 +72,7 @@ def test_sqlite_backend_prefers_explicit_cache_db_url(tmp_path):
 
 
 def test_postgres_backend_with_cache_db_url_returns_sql_adapter():
+    pytest.importorskip("asyncpg", reason="postgres extra not installed")
     explicit_url = "postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db"
 
     engine = _create_engine("postgres", cache_db_url=explicit_url)
@@ -116,6 +117,7 @@ def test_postgres_backend_without_url_or_postgres_relational_raises():
 
 
 def test_postgres_backend_falls_back_to_relational_postgres_settings():
+    pytest.importorskip("asyncpg", reason="postgres extra not installed")
     fake_relational = types.SimpleNamespace(
         db_provider="postgres",
         db_username="cognee",

--- a/cognee/tests/unit/infrastructure/databases/cache/test_get_cache_engine.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_get_cache_engine.py
@@ -1,0 +1,140 @@
+"""Tests for the cache engine factory (create_cache_engine backend dispatch)."""
+
+import importlib
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cognee.infrastructure.databases.exceptions import CacheConnectionError
+
+# The cache package __init__ re-exports the get_cache_engine function, shadowing
+# the submodule attribute; import the module itself to reach create_cache_engine.
+factory_mod = importlib.import_module("cognee.infrastructure.databases.cache.get_cache_engine")
+
+RELATIONAL_CONFIG_MOD = "cognee.infrastructure.databases.relational.config"
+REDIS_ADAPTER_MOD = "cognee.infrastructure.databases.cache.redis.RedisAdapter"
+
+
+@pytest.fixture(autouse=True)
+def clear_factory_cache():
+    """create_cache_engine is lru_cache'd; isolate every test case."""
+    factory_mod.create_cache_engine.cache_clear()
+    yield
+    factory_mod.create_cache_engine.cache_clear()
+
+
+def _fake_cache_config(backend: str):
+    return types.SimpleNamespace(caching=True, usage_logging=False, cache_backend=backend)
+
+
+def _create_engine(backend: str, cache_db_url=None):
+    with patch.object(factory_mod, "get_cache_config", return_value=_fake_cache_config(backend)):
+        return factory_mod.create_cache_engine(
+            cache_host="localhost",
+            cache_port=6379,
+            cache_username=None,
+            cache_password=None,
+            lock_key="default_lock",
+            log_key="usage_logs",
+            cache_db_url=cache_db_url,
+        )
+
+
+def test_sqlite_backend_returns_sql_adapter_with_aiosqlite_url(tmp_path):
+    fake_relational = types.SimpleNamespace(db_path=str(tmp_path), db_provider="sqlite")
+
+    with patch(f"{RELATIONAL_CONFIG_MOD}.get_relational_config", return_value=fake_relational):
+        engine = _create_engine("sqlite")
+
+    from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import SqlCacheAdapter
+
+    assert isinstance(engine, SqlCacheAdapter)
+    assert engine.db_uri == f"sqlite+aiosqlite:///{tmp_path}/cache.db"
+
+
+def test_sqlite_backend_prefers_explicit_cache_db_url(tmp_path):
+    explicit_url = f"sqlite+aiosqlite:///{tmp_path}/custom_cache.db"
+
+    engine = _create_engine("sqlite", cache_db_url=explicit_url)
+
+    from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import SqlCacheAdapter
+
+    assert isinstance(engine, SqlCacheAdapter)
+    assert engine.db_uri == explicit_url
+
+
+def test_postgres_backend_with_cache_db_url_returns_sql_adapter():
+    explicit_url = "postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db"
+
+    engine = _create_engine("postgres", cache_db_url=explicit_url)
+
+    from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import SqlCacheAdapter
+
+    assert isinstance(engine, SqlCacheAdapter)
+    assert engine.db_uri == explicit_url
+
+
+def test_postgres_backend_without_url_or_postgres_relational_raises():
+    fake_relational = types.SimpleNamespace(db_provider="sqlite")
+
+    with patch(f"{RELATIONAL_CONFIG_MOD}.get_relational_config", return_value=fake_relational):
+        with pytest.raises(CacheConnectionError, match="CACHE_DB_URL or DB_PROVIDER=postgres"):
+            _create_engine("postgres")
+
+
+def test_postgres_backend_falls_back_to_relational_postgres_settings():
+    fake_relational = types.SimpleNamespace(
+        db_provider="postgres",
+        db_username="cognee",
+        db_password="cognee",
+        db_host="localhost",
+        db_port=5432,
+        db_name="cognee_db",
+    )
+
+    with patch(f"{RELATIONAL_CONFIG_MOD}.get_relational_config", return_value=fake_relational):
+        engine = _create_engine("postgres")
+
+    from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import SqlCacheAdapter
+
+    assert isinstance(engine, SqlCacheAdapter)
+    assert engine.db_uri == "postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db"
+
+
+def test_unknown_backend_raises_value_error_listing_all_backends():
+    with pytest.raises(ValueError) as exc_info:
+        _create_engine("bogus")
+
+    message = str(exc_info.value)
+    assert "bogus" in message
+    for backend in ("redis", "fs", "tapes", "sqlite", "postgres"):
+        assert f"'{backend}'" in message
+
+
+def test_redis_backend_returns_redis_adapter():
+    with (
+        patch(f"{REDIS_ADAPTER_MOD}.redis.Redis", return_value=MagicMock(ping=MagicMock())),
+        patch(f"{REDIS_ADAPTER_MOD}.aioredis.Redis", return_value=MagicMock()),
+    ):
+        engine = _create_engine("redis")
+
+        from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+
+        assert isinstance(engine, RedisAdapter)
+
+
+def test_caching_disabled_returns_none():
+    fake_config = types.SimpleNamespace(caching=False, usage_logging=False, cache_backend="sqlite")
+
+    with patch.object(factory_mod, "get_cache_config", return_value=fake_config):
+        engine = factory_mod.create_cache_engine(
+            cache_host="localhost",
+            cache_port=6379,
+            cache_username=None,
+            cache_password=None,
+            lock_key="default_lock",
+            log_key="usage_logs",
+        )
+
+    assert engine is None

--- a/cognee/tests/unit/infrastructure/databases/cache/test_get_cache_engine.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_get_cache_engine.py
@@ -24,12 +24,19 @@ def clear_factory_cache():
     factory_mod.create_cache_engine.cache_clear()
 
 
-def _fake_cache_config(backend: str):
-    return types.SimpleNamespace(caching=True, usage_logging=False, cache_backend=backend)
+def _fake_cache_config(backend: str, explicit: bool = False):
+    return types.SimpleNamespace(
+        caching=True,
+        usage_logging=False,
+        cache_backend=backend,
+        model_fields_set={"cache_backend"} if explicit else set(),
+    )
 
 
-def _create_engine(backend: str, cache_db_url=None):
-    with patch.object(factory_mod, "get_cache_config", return_value=_fake_cache_config(backend)):
+def _create_engine(backend: str, cache_db_url=None, explicit: bool = False):
+    with patch.object(
+        factory_mod, "get_cache_config", return_value=_fake_cache_config(backend, explicit)
+    ):
         return factory_mod.create_cache_engine(
             cache_host="localhost",
             cache_port=6379,
@@ -73,6 +80,31 @@ def test_postgres_backend_with_cache_db_url_returns_sql_adapter():
 
     assert isinstance(engine, SqlCacheAdapter)
     assert engine.db_uri == explicit_url
+
+
+def test_default_sqlite_backend_falls_back_to_fs_when_db_path_on_s3():
+    """The implicit sqlite default degrades to the fs cache on S3 system roots."""
+    fake_relational = types.SimpleNamespace(
+        db_path="s3://bucket/cognee/system/databases", db_provider="sqlite"
+    )
+
+    with patch(f"{RELATIONAL_CONFIG_MOD}.get_relational_config", return_value=fake_relational):
+        engine = _create_engine("sqlite")
+
+    from cognee.infrastructure.databases.cache.fscache.FsCacheAdapter import FSCacheAdapter
+
+    assert isinstance(engine, FSCacheAdapter)
+
+
+def test_explicitly_chosen_sqlite_backend_on_s3_still_raises():
+    """An explicit CACHE_BACKEND=sqlite must fail loudly instead of degrading."""
+    fake_relational = types.SimpleNamespace(
+        db_path="s3://bucket/cognee/system/databases", db_provider="sqlite"
+    )
+
+    with patch(f"{RELATIONAL_CONFIG_MOD}.get_relational_config", return_value=fake_relational):
+        with pytest.raises(CacheConnectionError, match="cannot store cache.db on S3"):
+            _create_engine("sqlite", explicit=True)
 
 
 def test_postgres_backend_without_url_or_postgres_relational_raises():

--- a/cognee/tests/unit/infrastructure/databases/cache/test_kv_interface.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_kv_interface.py
@@ -1,0 +1,204 @@
+"""Regression tests for the formalized KV methods on CacheDBInterface.
+
+Covers:
+- FsCacheAdapter get_value/set_value/delete_value round-trip (this was the live
+  bug where graph snapshots silently no-op'd on fs: consumers fell back to a
+  non-existent ``adapter._cache`` attribute — the real attribute is ``cache``).
+- RedisAdapter KV methods producing byte-identical keys/values to the legacy
+  ``adapter.async_redis`` duck-typed path.
+- SessionManager graph-context consumers using the interface methods with
+  verbatim legacy key strings.
+"""
+
+import tempfile
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cognee.infrastructure.session.session_manager import SessionManager
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def fs_adapter():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch(
+            "cognee.infrastructure.databases.cache.fscache.FsCacheAdapter.get_storage_config",
+            return_value={"data_root_directory": tmpdir},
+        ):
+            from cognee.infrastructure.databases.cache.fscache.FsCacheAdapter import (
+                FSCacheAdapter,
+            )
+
+            inst = FSCacheAdapter()
+            yield inst
+            inst.cache.close()
+
+
+class _InMemoryRedisKV:
+    """Minimal in-memory Redis string-KV emulation (stores bytes, like real Redis)."""
+
+    def __init__(self):
+        self.kv: dict[str, bytes] = {}
+        self.expire_calls: list[tuple[str, int]] = []
+
+    async def set(self, key: str, value):
+        self.kv[key] = value.encode("utf-8") if isinstance(value, str) else value
+
+    async def get(self, key: str):
+        return self.kv.get(key)
+
+    async def delete(self, key: str):
+        self.expire_calls = [call for call in self.expire_calls if call[0] != key]
+        return 1 if self.kv.pop(key, None) is not None else 0
+
+    async def expire(self, key: str, ttl: int):
+        self.expire_calls.append((key, ttl))
+
+
+@pytest.fixture
+def redis_store():
+    return _InMemoryRedisKV()
+
+
+@pytest.fixture
+def redis_adapter(redis_store):
+    patch_mod = "cognee.infrastructure.databases.cache.redis.RedisAdapter"
+    with (
+        patch(f"{patch_mod}.redis.Redis", return_value=MagicMock(ping=MagicMock())),
+        patch(f"{patch_mod}.aioredis.Redis", return_value=redis_store),
+    ):
+        from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+
+        yield RedisAdapter(host="localhost", port=6379)
+
+
+# --------------------------------------------------------------------------- #
+# FsCacheAdapter KV round-trip (regression for the silent-no-op bug)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_fs_kv_set_get_round_trip(fs_adapter):
+    """set_value/get_value round-trips a raw string on the fs backend."""
+    await fs_adapter.set_value("graph_knowledge:u1:s1", "graph snapshot")
+    assert await fs_adapter.get_value("graph_knowledge:u1:s1") == "graph snapshot"
+
+
+@pytest.mark.asyncio
+async def test_fs_kv_get_returns_none_for_missing_key(fs_adapter):
+    assert await fs_adapter.get_value("graph_knowledge:u1:missing") is None
+
+
+@pytest.mark.asyncio
+async def test_fs_kv_delete_value(fs_adapter):
+    await fs_adapter.set_value("graph_knowledge:u1:s1", "snapshot")
+    await fs_adapter.delete_value("graph_knowledge:u1:s1")
+    assert await fs_adapter.get_value("graph_knowledge:u1:s1") is None
+    # Deleting a missing key is a no-op, not an error.
+    await fs_adapter.delete_value("graph_knowledge:u1:s1")
+
+
+@pytest.mark.asyncio
+async def test_fs_kv_set_with_ttl_overwrites_and_round_trips(fs_adapter):
+    """ttl is passed through to diskcache expire; value stays readable before expiry."""
+    await fs_adapter.set_value("k1", "v1", ttl=3600)
+    assert await fs_adapter.get_value("k1") == "v1"
+    await fs_adapter.set_value("k1", "v2", ttl=3600)
+    assert await fs_adapter.get_value("k1") == "v2"
+
+
+@pytest.mark.asyncio
+async def test_fs_graph_context_round_trip_through_session_manager(fs_adapter):
+    """SessionManager graph snapshots now actually persist on fs (previously no-op'd)."""
+    session_manager = SessionManager(cache_engine=fs_adapter)
+
+    await session_manager.set_graph_context(user_id="u1", session_id="s1", context="fs snapshot")
+
+    assert await session_manager.get_graph_context(user_id="u1", session_id="s1") == "fs snapshot"
+    # Stored under the verbatim legacy key in the diskcache (attribute is `cache`).
+    assert fs_adapter.cache.get("graph_knowledge:u1:s1") == "fs snapshot"
+
+    await session_manager.delete_session(user_id="u1", session_id="s1")
+    assert await session_manager.get_graph_context(user_id="u1", session_id="s1") == ""
+
+
+# --------------------------------------------------------------------------- #
+# RedisAdapter KV byte-parity with the legacy async_redis duck-typed path
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_redis_set_value_byte_identical_to_legacy_async_redis_set(redis_adapter, redis_store):
+    """set_value stores exactly the key/value bytes the legacy async_redis path stored."""
+    key = "graph_knowledge:u1:s1"
+    value = "graph snapshot text"
+
+    # Legacy duck-typed path (what session_manager used to call directly).
+    await redis_adapter.async_redis.set(key, value)
+    legacy_snapshot = dict(redis_store.kv)
+    redis_store.kv.clear()
+
+    # New interface method.
+    await redis_adapter.set_value(key, value)
+
+    assert redis_store.kv == legacy_snapshot
+    assert list(redis_store.kv.keys()) == [key]
+    assert redis_store.kv[key] == value.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_redis_get_value_decodes_bytes_like_legacy_consumers(redis_adapter, redis_store):
+    """get_value returns str even though Redis hands back bytes (legacy decode parity)."""
+    await redis_adapter.async_redis.set("k1", "legacy written")
+    assert isinstance(redis_store.kv["k1"], bytes)
+
+    result = await redis_adapter.get_value("k1")
+    assert result == "legacy written"
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_redis_get_value_returns_none_for_missing_key(redis_adapter):
+    assert await redis_adapter.get_value("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_redis_set_value_with_ttl_expires_like_legacy_path(redis_adapter, redis_store):
+    """set_value(ttl=N) issues the same set + expire(key, N) sequence the legacy code did."""
+    await redis_adapter.set_value("k1", "v1", ttl=604800)
+    assert redis_store.kv["k1"] == b"v1"
+    assert redis_store.expire_calls == [("k1", 604800)]
+
+
+@pytest.mark.asyncio
+async def test_redis_set_value_without_ttl_does_not_expire(redis_adapter, redis_store):
+    await redis_adapter.set_value("k1", "v1")
+    assert redis_store.expire_calls == []
+
+
+@pytest.mark.asyncio
+async def test_redis_delete_value_removes_legacy_written_key(redis_adapter, redis_store):
+    """delete_value targets the byte-identical key written by the legacy path."""
+    await redis_adapter.async_redis.set("graph_knowledge:u1:s1", "snapshot")
+    await redis_adapter.delete_value("graph_knowledge:u1:s1")
+    assert "graph_knowledge:u1:s1" not in redis_store.kv
+
+
+@pytest.mark.asyncio
+async def test_redis_graph_context_key_string_unchanged(redis_adapter, redis_store):
+    """SessionManager writes the verbatim legacy key graph_knowledge:{user}:{session}."""
+    session_manager = SessionManager(cache_engine=redis_adapter)
+
+    await session_manager.set_graph_context(user_id="u1", session_id="s1", context="ctx")
+
+    assert list(redis_store.kv.keys()) == ["graph_knowledge:u1:s1"]
+    assert redis_store.kv["graph_knowledge:u1:s1"] == b"ctx"
+    # TTL applied from adapter.session_ttl_seconds, exactly like the legacy path.
+    assert redis_store.expire_calls == [("graph_knowledge:u1:s1", 604800)]
+
+    assert await session_manager.get_graph_context(user_id="u1", session_id="s1") == "ctx"

--- a/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
@@ -1,0 +1,697 @@
+"""Unit tests for SqlCacheAdapter CRUD operations (run on sqlite+aiosqlite, no server)."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text, update
+
+from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import SqlCacheAdapter
+from cognee.infrastructure.databases.cache.sql.tables import (
+    cache_kv,
+    cache_qa_entries,
+    cache_trace_entries,
+    cache_usage_logs,
+)
+from cognee.infrastructure.databases.exceptions import (
+    CacheConnectionError,
+    SessionQAEntryValidationError,
+)
+from cognee.infrastructure.databases.exceptions.exceptions import (
+    SharedLadybugLockRequiresRedisError,
+)
+from cognee.tasks.memify.feedback_weights_constants import (
+    MEMIFY_METADATA_FEEDBACK_WEIGHTS_APPLIED_KEY,
+)
+
+
+def _make_adapter(tmp_path, **kwargs) -> SqlCacheAdapter:
+    return SqlCacheAdapter(f"sqlite+aiosqlite:///{tmp_path}/cache.db", **kwargs)
+
+
+@pytest_asyncio.fixture
+async def adapter(tmp_path):
+    inst = _make_adapter(tmp_path)
+    yield inst
+    await inst.close()
+
+
+async def _fetch_expirations(inst, table, **filters):
+    """Read raw expires_at values straight from the adapter's engine."""
+    query = select(table.c.expires_at)
+    for column_name, value in filters.items():
+        query = query.where(table.c[column_name] == value)
+    async with inst.engine.connect() as connection:
+        result = await connection.execute(query)
+        return [row[0] for row in result]
+
+
+async def _backdate_expirations(inst, table, when, **filters):
+    """Force expires_at via direct SQL on the adapter's engine."""
+    statement = update(table).values(expires_at=when)
+    for column_name, value in filters.items():
+        statement = statement.where(table.c[column_name] == value)
+    async with inst.engine.begin() as connection:
+        await connection.execute(statement)
+
+
+def _past():
+    return datetime.now(timezone.utc) - timedelta(seconds=10)
+
+
+# --------------------------------------------------------------------------- #
+# QA entries
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_and_get(adapter):
+    """Create a QA entry and retrieve it."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    entries = await adapter.get_all_qa_entries("u1", "s1")
+    assert len(entries) == 1 and entries[0].qa_id == "id1"
+    assert entries[0].question == "Q" and entries[0].context == "C" and entries[0].answer == "A"
+
+
+@pytest.mark.asyncio
+async def test_create_qa_entry_generates_uuid4_qa_id_when_missing(adapter):
+    """create_qa_entry without qa_id falls back to a generated uuid4."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A")
+    entries = await adapter.get_all_qa_entries("u1", "s1")
+    assert len(entries) == 1
+    parsed = uuid.UUID(entries[0].qa_id)
+    assert parsed.version == 4
+
+
+@pytest.mark.asyncio
+async def test_get_latest_qa_entries_chronological_ordering(adapter):
+    """get_latest_qa_entries returns the most recent entries in chronological order."""
+    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
+    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
+    await adapter.create_qa_entry("u1", "s1", "Q3", "C3", "A3", qa_id="id3")
+
+    latest = await adapter.get_latest_qa_entries("u1", "s1", last_n=2)
+    assert [entry.qa_id for entry in latest] == ["id2", "id3"]
+
+    all_entries = await adapter.get_all_qa_entries("u1", "s1")
+    assert [entry.qa_id for entry in all_entries] == ["id1", "id2", "id3"]
+
+
+@pytest.mark.asyncio
+async def test_empty_session_returns_empty_list_for_all_last_n(adapter):
+    """[] on empty for every last_n value — including last_n=1 (FS-style, not Redis quirk)."""
+    assert await adapter.get_latest_qa_entries("u1", "missing", last_n=1) == []
+    assert await adapter.get_latest_qa_entries("u1", "missing", last_n=5) == []
+    assert await adapter.get_all_qa_entries("u1", "missing") == []
+
+
+@pytest.mark.asyncio
+async def test_create_qa_entry_with_used_graph_element_ids_round_trip(adapter):
+    """create_qa_entry with used_graph_element_ids stores and returns it."""
+    used_ids = {"node_ids": ["n1"], "edge_ids": ["e1"]}
+    await adapter.create_qa_entry(
+        "u1", "s1", "Q", "C", "A", qa_id="id1", used_graph_element_ids=used_ids
+    )
+    entries = await adapter.get_all_qa_entries("u1", "s1")
+    assert len(entries) == 1
+    assert entries[0].used_graph_element_ids == used_ids
+
+
+@pytest.mark.asyncio
+async def test_create_qa_entry_invalid_used_graph_element_ids_raises(adapter):
+    """create_qa_entry with invalid used_graph_element_ids (disallowed keys) raises."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    with pytest.raises(CacheConnectionError):
+        await adapter.create_qa_entry(
+            "u1",
+            "s1",
+            "Q2",
+            "C2",
+            "A2",
+            qa_id="id2",
+            used_graph_element_ids={"invalid_key": ["x"]},
+        )
+
+
+@pytest.mark.asyncio
+async def test_update(adapter):
+    """Update a QA entry by qa_id."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    ok = await adapter.update_qa_entry("u1", "s1", "id1", feedback_score=5)
+    assert ok and (await adapter.get_all_qa_entries("u1", "s1"))[0].feedback_score == 5
+
+
+@pytest.mark.asyncio
+async def test_update_none_preserves_every_field(adapter):
+    """Passing None for a field on update preserves the existing value of every field."""
+    used_ids = {"node_ids": ["n1"], "edge_ids": ["e1"]}
+    await adapter.create_qa_entry(
+        "u1",
+        "s1",
+        "Q",
+        "C",
+        "A",
+        qa_id="id1",
+        feedback_text="good",
+        feedback_score=5,
+        used_graph_element_ids=used_ids,
+        memify_metadata={"persist_sessions_in_knowledge_graph": True},
+    )
+
+    ok = await adapter.update_qa_entry("u1", "s1", "id1")
+    assert ok is True
+
+    entry = (await adapter.get_all_qa_entries("u1", "s1"))[0]
+    assert entry.question == "Q"
+    assert entry.context == "C"
+    assert entry.answer == "A"
+    assert entry.qa_id == "id1"
+    assert entry.feedback_text == "good"
+    assert entry.feedback_score == 5
+    assert entry.used_graph_element_ids == used_ids
+    assert entry.memify_metadata == {"persist_sessions_in_knowledge_graph": True}
+
+
+@pytest.mark.asyncio
+async def test_update_memify_metadata_merges_existing_keys(adapter):
+    """update_qa_entry merges memify_metadata keys instead of replacing the map."""
+    await adapter.create_qa_entry(
+        "u1",
+        "s1",
+        "Q",
+        "C",
+        "A",
+        qa_id="id1",
+        memify_metadata={"persist_sessions_in_knowledge_graph": True},
+    )
+    ok = await adapter.update_qa_entry(
+        "u1",
+        "s1",
+        "id1",
+        memify_metadata={MEMIFY_METADATA_FEEDBACK_WEIGHTS_APPLIED_KEY: False},
+    )
+    assert ok
+    entries = await adapter.get_all_qa_entries("u1", "s1")
+    assert entries[0].memify_metadata == {
+        "persist_sessions_in_knowledge_graph": True,
+        MEMIFY_METADATA_FEEDBACK_WEIGHTS_APPLIED_KEY: False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_invalid_raises(adapter):
+    """SessionQAEntryValidationError propagates unwrapped on invalid update payloads."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    with pytest.raises(SessionQAEntryValidationError):
+        await adapter.update_qa_entry("u1", "s1", "id1", feedback_score=10)
+
+    with pytest.raises(SessionQAEntryValidationError):
+        await adapter.update_qa_entry("u1", "s1", "id1", feedback_text=5)
+
+
+@pytest.mark.asyncio
+async def test_update_missing_qa_id_returns_false(adapter):
+    """update_qa_entry returns False when qa_id does not exist."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    assert await adapter.update_qa_entry("u1", "s1", "missing", feedback_score=5) is False
+    assert await adapter.delete_feedback("u1", "s1", "missing") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_feedback(adapter):
+    """delete_feedback sets feedback_text and feedback_score to None."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    await adapter.update_qa_entry("u1", "s1", "id1", feedback_text="good", feedback_score=5)
+    ok = await adapter.delete_feedback("u1", "s1", "id1")
+    assert ok
+    entries = await adapter.get_all_qa_entries("u1", "s1")
+    e = entries[0]
+    assert e.feedback_text is None and e.feedback_score is None
+
+
+@pytest.mark.asyncio
+async def test_delete_entry(adapter):
+    """Delete a single QA entry by qa_id (rowcount semantics)."""
+    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
+    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
+    ok = await adapter.delete_qa_entry("u1", "s1", "id1")
+    assert ok and len(await adapter.get_all_qa_entries("u1", "s1")) == 1
+
+    assert await adapter.delete_qa_entry("u1", "s1", "id1") is False
+    assert await adapter.delete_qa_entry("u1", "s1", "missing") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_session(adapter):
+    """Delete the entire session, including QA and trace entries."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    await adapter.append_agent_trace_step(
+        "u1",
+        "s1",
+        trace_id="t1",
+        origin_function="plan_trip",
+        status="success",
+        session_feedback="plan_trip succeeded.",
+    )
+    ok = await adapter.delete_session("u1", "s1")
+    assert ok is True
+    assert await adapter.get_all_qa_entries("u1", "s1") == []
+    assert await adapter.get_agent_trace_session("u1", "s1") == []
+
+    assert await adapter.delete_session("u1", "s1") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_session_does_not_touch_other_sessions(adapter):
+    """delete_session removes only the targeted user+session rows."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    await adapter.create_qa_entry("u1", "s2", "Q", "C", "A", qa_id="id1")
+    await adapter.create_qa_entry("u2", "s1", "Q", "C", "A", qa_id="id1")
+
+    assert await adapter.delete_session("u1", "s1") is True
+    assert await adapter.get_all_qa_entries("u1", "s1") == []
+    assert len(await adapter.get_all_qa_entries("u1", "s2")) == 1
+    assert len(await adapter.get_all_qa_entries("u2", "s1")) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Agent traces
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_append_agent_trace_step_and_get_session(adapter):
+    """Append trace steps and retrieve them as a flat ordered session list."""
+    await adapter.append_agent_trace_step(
+        "u1",
+        "s1",
+        trace_id="t1",
+        origin_function="plan_trip",
+        status="success",
+        memory_query="trip preferences",
+        memory_context="User likes quiet places",
+        method_params={"city": "Tokyo"},
+        method_return_value="Plan created",
+        session_feedback="plan_trip succeeded.",
+    )
+    await adapter.append_agent_trace_step(
+        "u1",
+        "s1",
+        trace_id="t2",
+        origin_function="book_hotel",
+        status="error",
+        method_params={"area": "Shibuya"},
+        error_message="No availability",
+        session_feedback="book_hotel failed. Reason: No availability.",
+    )
+
+    entries = await adapter.get_agent_trace_session("u1", "s1")
+    assert [entry.trace_id for entry in entries] == ["t1", "t2"]
+    assert entries[0].origin_function == "plan_trip"
+    assert entries[1].origin_function == "book_hotel"
+    assert entries[1].error_message == "No availability"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_trace_session_last_n_returns_most_recent_in_order(adapter):
+    """last_n returns only the most recent trace steps, oldest first."""
+    for index in range(3):
+        await adapter.append_agent_trace_step(
+            "u1",
+            "s1",
+            trace_id=f"t{index}",
+            origin_function="plan_trip",
+            status="success",
+            session_feedback=f"step {index}.",
+        )
+
+    entries = await adapter.get_agent_trace_session("u1", "s1", last_n=2)
+    assert [entry.trace_id for entry in entries] == ["t1", "t2"]
+
+
+@pytest.mark.asyncio
+async def test_get_agent_trace_feedback_returns_feedback_only(adapter):
+    """Trace feedback helper delegates to get_agent_trace_session and keeps order."""
+    await adapter.append_agent_trace_step(
+        "u1",
+        "s1",
+        trace_id="t1",
+        origin_function="plan_trip",
+        status="success",
+        session_feedback="plan_trip succeeded.",
+    )
+    await adapter.append_agent_trace_step(
+        "u1",
+        "s1",
+        trace_id="t2",
+        origin_function="book_hotel",
+        status="error",
+        error_message="No availability",
+        session_feedback="book_hotel failed. Reason: No availability.",
+    )
+
+    feedback = await adapter.get_agent_trace_feedback("u1", "s1")
+    assert feedback == [
+        "plan_trip succeeded.",
+        "book_hotel failed. Reason: No availability.",
+    ]
+
+    assert await adapter.get_agent_trace_feedback("u1", "s1", last_n=1) == [
+        "book_hotel failed. Reason: No availability."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_agent_trace_count_returns_number_of_steps(adapter):
+    """Trace count helper returns the number of stored steps."""
+    assert await adapter.get_agent_trace_count("u1", "s1") == 0
+    for index in range(2):
+        await adapter.append_agent_trace_step(
+            "u1",
+            "s1",
+            trace_id=f"t{index}",
+            origin_function="plan_trip",
+            status="success",
+            session_feedback="ok.",
+        )
+    assert await adapter.get_agent_trace_count("u1", "s1") == 2
+
+
+@pytest.mark.asyncio
+async def test_get_agent_trace_session_missing_returns_empty(adapter):
+    """Missing trace sessions return an empty list."""
+    assert await adapter.get_agent_trace_session("u1", "missing") == []
+    assert await adapter.get_agent_trace_feedback("u1", "missing") == []
+
+
+@pytest.mark.asyncio
+async def test_append_agent_trace_step_sanitizes_non_json_safe_values(adapter):
+    """Trace persistence sanitizes UUIDs, datetimes, and custom objects into JSON-safe values."""
+
+    class _Obj:
+        def __init__(self):
+            self.id = "obj-1"
+
+    await adapter.append_agent_trace_step(
+        "u1",
+        "s1",
+        trace_id="t1",
+        origin_function="plan_trip",
+        status="success",
+        method_params={
+            "trip_id": uuid4(),
+            "created_at": datetime(2026, 4, 14, 12, 0, 0),
+            "obj": _Obj(),
+        },
+        method_return_value={"result_id": uuid4(), "owner": _Obj()},
+        session_feedback="plan_trip succeeded.",
+    )
+
+    entries = await adapter.get_agent_trace_session("u1", "s1")
+    assert isinstance(entries[0].method_params["trip_id"], str)
+    assert isinstance(entries[0].method_params["created_at"], str)
+    assert entries[0].method_params["obj"] == {"type": "_Obj", "id": "obj-1"}
+    assert isinstance(entries[0].method_return_value["result_id"], str)
+    assert entries[0].method_return_value["owner"] == {"type": "_Obj", "id": "obj-1"}
+
+
+@pytest.mark.asyncio
+async def test_append_agent_trace_step_rejects_blank_required_fields(adapter):
+    """Blank trace_id / origin_function raise CacheConnectionError (create-path contract)."""
+    with pytest.raises(CacheConnectionError):
+        await adapter.append_agent_trace_step(
+            "u1",
+            "s1",
+            trace_id=" ",
+            origin_function="plan_trip",
+            status="success",
+            session_feedback="plan_trip succeeded.",
+        )
+
+    with pytest.raises(CacheConnectionError):
+        await adapter.append_agent_trace_step(
+            "u1",
+            "s1",
+            trace_id="t1",
+            origin_function=" ",
+            status="success",
+            session_feedback="plan_trip succeeded.",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# TTL behavior
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_qa_entry_sets_session_ttl_when_enabled(adapter):
+    """Writes stamp expires_at on every row of the session when TTL is enabled."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+
+    expirations = await _fetch_expirations(adapter, cache_qa_entries, user_id="u1")
+    assert len(expirations) == 1
+    assert expirations[0] is not None
+
+
+@pytest.mark.asyncio
+async def test_writes_refresh_whole_session_ttl(adapter):
+    """A new write slides the expiry of existing rows in the same session forward."""
+    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
+    near_future = datetime.now(timezone.utc) + timedelta(seconds=30)
+    await _backdate_expirations(adapter, cache_qa_entries, near_future, qa_id="id1")
+
+    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
+
+    expirations = await _fetch_expirations(adapter, cache_qa_entries, qa_id="id1")
+    refreshed = expirations[0]
+    if refreshed.tzinfo is None:
+        refreshed = refreshed.replace(tzinfo=timezone.utc)
+    assert refreshed > near_future + timedelta(seconds=60)
+
+
+@pytest.mark.asyncio
+async def test_reads_do_not_refresh_ttl(adapter):
+    """Read-only access leaves expires_at untouched."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    await adapter.append_agent_trace_step(
+        "u1", "s1", trace_id="t1", origin_function="plan_trip", status="success"
+    )
+    qa_before = await _fetch_expirations(adapter, cache_qa_entries)
+    trace_before = await _fetch_expirations(adapter, cache_trace_entries)
+
+    await adapter.get_all_qa_entries("u1", "s1")
+    await adapter.get_latest_qa_entries("u1", "s1", last_n=1)
+    await adapter.get_agent_trace_session("u1", "s1")
+    await adapter.get_agent_trace_count("u1", "s1")
+
+    assert await _fetch_expirations(adapter, cache_qa_entries) == qa_before
+    assert await _fetch_expirations(adapter, cache_trace_entries) == trace_before
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disabled_ttl", [0, None])
+async def test_ttl_disabled_stores_rows_without_expiry(tmp_path, disabled_ttl):
+    """session_ttl_seconds in (0, None) disables expiry entirely (expires_at stays NULL)."""
+    inst = _make_adapter(tmp_path, session_ttl_seconds=disabled_ttl)
+    try:
+        await inst.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+        await inst.append_agent_trace_step(
+            "u1", "s1", trace_id="t1", origin_function="plan_trip", status="success"
+        )
+
+        assert await _fetch_expirations(inst, cache_qa_entries) == [None]
+        assert await _fetch_expirations(inst, cache_trace_entries) == [None]
+        assert len(await inst.get_all_qa_entries("u1", "s1")) == 1
+    finally:
+        await inst.close()
+
+
+@pytest.mark.asyncio
+async def test_expired_rows_are_invisible(adapter):
+    """Rows past expires_at are filtered out of every read and mutation path."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    await adapter.append_agent_trace_step(
+        "u1", "s1", trace_id="t1", origin_function="plan_trip", status="success"
+    )
+
+    past = _past()
+    await _backdate_expirations(adapter, cache_qa_entries, past)
+    await _backdate_expirations(adapter, cache_trace_entries, past)
+
+    assert await adapter.get_all_qa_entries("u1", "s1") == []
+    assert await adapter.get_latest_qa_entries("u1", "s1", last_n=1) == []
+    assert await adapter.get_agent_trace_session("u1", "s1") == []
+    assert await adapter.get_agent_trace_count("u1", "s1") == 0
+    assert await adapter.update_qa_entry("u1", "s1", "id1", feedback_score=5) is False
+    assert await adapter.delete_qa_entry("u1", "s1", "id1") is False
+    # Expired-only session counts as nonexistent.
+    assert await adapter.delete_session("u1", "s1") is False
+
+
+# --------------------------------------------------------------------------- #
+# Usage logs
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_log_usage_and_get_usage_logs(adapter):
+    """Usage logs round-trip, most recent first, scoped per user."""
+    await adapter.log_usage("u1", {"endpoint": "/add"})
+    await adapter.log_usage("u1", {"endpoint": "/search"})
+    await adapter.log_usage("u2", {"endpoint": "/cognify"})
+
+    logs = await adapter.get_usage_logs("u1")
+    assert [entry["endpoint"] for entry in logs] == ["/search", "/add"]
+    assert await adapter.get_usage_logs("u1", limit=1) == [{"endpoint": "/search"}]
+    assert await adapter.get_usage_logs("u3") == []
+
+
+# --------------------------------------------------------------------------- #
+# Key/value storage
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_kv_round_trip_and_overwrite(adapter):
+    """set_value/get_value/delete_value round-trip; set is an upsert."""
+    key = "graph_knowledge:u1:s1"
+    assert await adapter.get_value(key) is None
+
+    await adapter.set_value(key, "snapshot-1")
+    assert await adapter.get_value(key) == "snapshot-1"
+
+    await adapter.set_value(key, "snapshot-2")
+    assert await adapter.get_value(key) == "snapshot-2"
+
+    await adapter.delete_value(key)
+    assert await adapter.get_value(key) is None
+
+    # Deleting a missing key is a no-op.
+    await adapter.delete_value(key)
+
+
+@pytest.mark.asyncio
+async def test_kv_ttl_expiry(adapter):
+    """A keyed value with ttl becomes invisible once expires_at passes."""
+    key = "graph_sync_checkpoint:u1:d1:s1"
+    await adapter.set_value(key, "checkpoint", ttl=3600)
+    assert await adapter.get_value(key) == "checkpoint"
+
+    expirations = await _fetch_expirations(adapter, cache_kv, key=key)
+    assert expirations == [expirations[0]] and expirations[0] is not None
+
+    await _backdate_expirations(adapter, cache_kv, _past(), key=key)
+    assert await adapter.get_value(key) is None
+
+
+@pytest.mark.asyncio
+async def test_kv_without_ttl_is_immortal(adapter):
+    """ttl=None stores the value without expiry (expires_at stays NULL)."""
+    key = "graph_knowledge:u1:s1"
+    await adapter.set_value(key, "forever")
+
+    assert await _fetch_expirations(adapter, cache_kv, key=key) == [None]
+    assert await adapter.get_value(key) == "forever"
+
+
+# --------------------------------------------------------------------------- #
+# Maintenance: prune / close
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_prune_clears_only_the_four_cache_tables(adapter):
+    """prune empties cache tables but never touches co-tenant tables in the same DB."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    await adapter.append_agent_trace_step(
+        "u1", "s1", trace_id="t1", origin_function="plan_trip", status="success"
+    )
+    await adapter.log_usage("u1", {"endpoint": "/add"})
+    await adapter.set_value("graph_knowledge:u1:s1", "snapshot")
+
+    async with adapter.engine.begin() as connection:
+        await connection.execute(text("CREATE TABLE co_tenant (id INTEGER PRIMARY KEY, v TEXT)"))
+        await connection.execute(text("INSERT INTO co_tenant (v) VALUES ('keep me')"))
+
+    await adapter.prune()
+
+    assert await adapter.get_all_qa_entries("u1", "s1") == []
+    assert await adapter.get_agent_trace_session("u1", "s1") == []
+    assert await adapter.get_usage_logs("u1") == []
+    assert await adapter.get_value("graph_knowledge:u1:s1") is None
+
+    async with adapter.engine.connect() as connection:
+        survivors = (await connection.execute(text("SELECT v FROM co_tenant"))).scalars().all()
+    assert survivors == ["keep me"]
+
+    for table in (cache_qa_entries, cache_trace_entries, cache_usage_logs, cache_kv):
+        assert await _fetch_expirations(adapter, table) == []
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent_and_allows_reinitialization(adapter):
+    """close can be called repeatedly; a reused instance lazily re-initializes."""
+    await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
+    await adapter.close()
+    await adapter.close()
+
+    entries = await adapter.get_all_qa_entries("u1", "s1")
+    assert [entry.qa_id for entry in entries] == ["id1"]
+
+
+# --------------------------------------------------------------------------- #
+# Locks
+# --------------------------------------------------------------------------- #
+
+
+def test_acquire_lock_raises_on_sqlite(adapter):
+    """Advisory locks need Postgres (or Redis); sqlite URLs must refuse loudly."""
+    with pytest.raises(SharedLadybugLockRequiresRedisError):
+        adapter.acquire_lock()
+
+
+def test_release_lock_raises_on_sqlite(adapter):
+    """release_lock mirrors acquire_lock's refusal on sqlite URLs."""
+    with pytest.raises(SharedLadybugLockRequiresRedisError):
+        adapter.release_lock()
+
+
+# --------------------------------------------------------------------------- #
+# Backward-compatibility shims (add_qa, get_latest_qa, get_all_qas)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_add_qa_backward_compat(adapter):
+    """Legacy add_qa stores entry with auto-generated qa_id."""
+    await adapter.add_qa("u1", "s1", "Q", "C", "A")
+    entries = await adapter.get_all_qa_entries("u1", "s1")
+    assert len(entries) == 1
+    assert entries[0].qa_id is not None
+    assert entries[0].question == "Q" and entries[0].answer == "A"
+
+
+@pytest.mark.asyncio
+async def test_get_all_qas_backward_compat(adapter):
+    """Legacy get_all_qas returns same as get_all_qa_entries."""
+    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
+    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
+    via_legacy = await adapter.get_all_qas("u1", "s1")
+    via_new = await adapter.get_all_qa_entries("u1", "s1")
+    assert via_legacy == via_new
+    assert len(via_legacy) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_latest_qa_backward_compat(adapter):
+    """Legacy get_latest_qa returns same as get_latest_qa_entries."""
+    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
+    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
+    await adapter.create_qa_entry("u1", "s1", "Q3", "C3", "A3", qa_id="id3")
+    via_legacy = await adapter.get_latest_qa("u1", "s1", last_n=2)
+    via_new = await adapter.get_latest_qa_entries("u1", "s1", last_n=2)
+    assert via_legacy == via_new
+    assert len(via_legacy) == 2


### PR DESCRIPTION
## Summary

Adds an engine-agnostic SQL backend for the session cache so Redis is no longer required for session memory. One adapter, `SqlCacheAdapter` (`cognee/infrastructure/databases/cache/sql/`), serves two new `CACHE_BACKEND` values:

- **`sqlite`** — the new global default (was `fs`). Zero-setup: an aiosqlite `cache.db` next to the relational SQLite db, tuned with WAL journal mode and a 30s busy timeout for multi-process use.
- **`postgres`** — via `CACHE_DB_URL` (`postgresql+asyncpg://...`) or automatic fallback to the `DB_*` settings when `DB_PROVIDER=postgres`. Requires the existing `postgres` extra; **zero new dependencies**.

Session QA entries, agent traces, usage logs, and graph-knowledge/checkpoint KV land in four `cache_*` tables (create-on-init, private MetaData — same pattern as the Postgres graph adapter). Redis's sliding TTL is replicated with an `expires_at` column refreshed on writes, filtered on reads, plus a throttled 900s global sweep guarded by `pg_try_advisory_xact_lock` on Postgres. Update paths use `SELECT ... FOR UPDATE`, making read-modify-write multi-worker-safe.

## Bug fixes

- **Graph-knowledge snapshots and sync checkpoints silently no-op'd on the `fs` backend**: `session_manager.py` and `sync_graph_to_session.py` duck-typed `cache_engine.async_redis` with a fallback to `._cache`, but `FsCacheAdapter`'s attribute is `.cache`. The KV contract is now formalized as `get_value`/`set_value`/`delete_value` on `CacheDBInterface` with Redis/FS/SQL implementations; consumers use them with the legacy duck-typing kept as a fallback for third-party adapters. Key strings are unchanged.
- **`create_cache_engine` imported `RedisAdapter` unconditionally for every backend** — it only worked because the unused `fakeredis[lua]` core dep transitively installs `redis`. The import now lives inside the `redis` branch.

## Other behavior

- `SHARED_LADYBUG_LOCK` works on Postgres URLs via sync advisory locks (dedicated psycopg2 mini-pool, connection-scoped release); sqlite raises `SharedLadybugLockRequiresRedisError`, same as `fs`.
- `prune()` clears only cognee's four cache tables (safer than Redis `FLUSHDB`).
- `CACHE_BACKEND=sqlite` fails fast with an actionable error when system storage is S3-backed instead of producing an unusable URL.
- **`RedisAdapter` data paths are untouched**, including the `get_latest_qa_entries` `last_n==1` quirk.
- No data migration needed: the cache is 7-day-TTL ephemeral; switching backends starts fresh.

## Heads-up for reviewers

- The **default backend changed `fs` → `sqlite`** (inert unless `CACHING=true`). One-line revert in `cache/config.py` if we'd rather keep `fs`.
- Design doc with full rationale: `SESSION_POSTGRES_CACHE_PLAN.md` (includes a sketch for a future Turbopuffer backend behind the same interface).

## Testing

- New unit suites: `test_sql_adapter_crud.py` (runs on aiosqlite, no server), `test_kv_interface.py`, `test_get_cache_engine.py`; updated `test_cache_config.py` — **117/117 passing**.
- Integration: new `test_session_manager_sql.py`; `sqlite` params added to the three session integration suites — **106/106 passing**.
- New CI e2e jobs: `run_conversation_sessions_test_sqlite` and `run_conversation_sessions_test_postgres` twin the existing Redis conversation-sessions job.
- `ruff format` / `ruff check` / pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQLite is now the default session cache backend, replacing filesystem storage for improved performance and reliability.
  * PostgreSQL backend support added as an alternative cache option alongside Redis and filesystem storage.
  * New key-value storage interface in cache layer enables flexible session data persistence.

* **Configuration**
  * New `CACHE_DB_URL` and `CACHE_PURGE_INTERVAL_SECONDS` configuration options for cache backends.

* **Tests**
  * Comprehensive integration tests added for conversation session caching with multiple backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->