### PR TITLE
fix(visualize): first-session quick wins — UUID names, theme repaint, search navigation, honest stats

### DIFF
--- a/cognee/api/v1/visualize/visualize.py
+++ b/cognee/api/v1/visualize/visualize.py
@@ -14,11 +14,38 @@ import asyncio
 logger = get_logger()
 
 
-async def visualize_graph(destination_file_path: str = None) -> str:
+async def visualize_graph(
+    destination_file_path: str = None,
+    include_session_events: bool = True,
+    session_ids: list = None,
+    user=None,
+) -> str:
+    """Render the knowledge graph to a self-contained HTML file.
+
+    Args:
+        destination_file_path: Where to write the HTML (default: home dir).
+        include_session_events: When True (default), best-effort collect the
+            backend's search and feedback history from the session layer and
+            show it on the Memory tab's timeline — searches as retrieval
+            spotlights, rated answers as reinforcement (improve) events.
+            Collection never fails the render; an unavailable session layer
+            simply yields no events.
+        session_ids: Restrict event collection to these sessions. Defaults to
+            the user's most recently active sessions.
+        user: User whose sessions are read. Defaults to the default user.
+    """
     graph_engine = await get_graph_engine()
     graph_data = await graph_engine.get_graph_data()
 
-    graph = await cognee_network_visualization(graph_data, destination_file_path)
+    search_events = None
+    if include_session_events:
+        from cognee.modules.visualization.session_events import collect_session_events
+
+        search_events = await collect_session_events(user=user, session_ids=session_ids)
+
+    graph = await cognee_network_visualization(
+        graph_data, destination_file_path, search_events=search_events
+    )
 
     if destination_file_path:
         logger.info(f"The HTML file has been stored at path: {destination_file_path}")

--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -65,19 +65,27 @@ async def cognee_network_visualization(
             ``~/graph_visualization.html``.
         schema_data: Optional pre-built schema payload.  When absent, the
             preprocessor derives a type-graph from the nodes/links it sees.
-        search_events: Optional list of search/retrieval events shown on the
-            Memory tab's timeline. Each entry is a dict::
+        search_events: Optional list of operation events shown on the Memory
+            tab's timeline. Two kinds::
 
-                {"time": "2026-06-10T10:31:02", "qa_id": "...",
-                 "question": "...", "answer": "...",
+                {"kind": "search", "time": "2026-06-10T10:31:02",
+                 "qa_id": "...", "question": "...", "answer": "...",
                  "node_ids": ["uuid", ...], "edge_ids": ["uuid", ...]}
 
-            This is the documented injection hook — no cache is read here.
-            To capture events from a session: run
-            ``await cognee.search(..., session_id="viz_demo")``, then
-            ``entries = await cognee.session.get_session(session_id="viz_demo")``
-            and map each ``SessionQAEntry`` to the dict above (flattening
-            ``used_graph_element_ids`` into ``node_ids``/``edge_ids``).
+                {"kind": "improve", "time": "...", "qa_id": "...",
+                 "question": "...", "rating": 5, "feedback_text": "...",
+                 "applied": true,
+                 "node_ids": ["uuid", ...], "edge_ids": ["uuid", ...]}
+
+            ``search`` renders a retrieval spotlight; ``improve`` renders a
+            reinforcement overlay (the elements whose feedback_weight the
+            rated answer updated — green for positive ratings, amber for
+            negative). Entries without ``kind`` default to ``search``.
+
+            No cache is read here — ``visualize_graph(include_session_events
+            =True)`` collects these automatically from the session layer via
+            ``cognee.modules.visualization.session_events``; pass them
+            explicitly only for custom pipelines.
 
     Returns:
         The full HTML as a string.

--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -27,6 +27,7 @@ from cognee.infrastructure.files.storage.LocalFileStorage import LocalFileStorag
 from cognee.modules.visualization.preprocessor import preprocess
 from cognee.modules.visualization.views import (
     inspector,
+    memory_map,
     schema_view,
     story_view,
     ui_chrome,
@@ -53,6 +54,7 @@ async def cognee_network_visualization(
     graph_data,
     destination_file_path: Optional[str] = None,
     schema_data: Optional[dict] = None,
+    search_events: Optional[list] = None,
 ) -> str:
     """Render the graph to a self-contained HTML file and return the HTML.
 
@@ -63,6 +65,19 @@ async def cognee_network_visualization(
             ``~/graph_visualization.html``.
         schema_data: Optional pre-built schema payload.  When absent, the
             preprocessor derives a type-graph from the nodes/links it sees.
+        search_events: Optional list of search/retrieval events shown on the
+            Memory tab's timeline. Each entry is a dict::
+
+                {"time": "2026-06-10T10:31:02", "qa_id": "...",
+                 "question": "...", "answer": "...",
+                 "node_ids": ["uuid", ...], "edge_ids": ["uuid", ...]}
+
+            This is the documented injection hook — no cache is read here.
+            To capture events from a session: run
+            ``await cognee.search(..., session_id="viz_demo")``, then
+            ``entries = await cognee.session.get_session(session_id="viz_demo")``
+            and map each ``SessionQAEntry`` to the dict above (flattening
+            ``used_graph_element_ids`` into ``node_ids``/``edge_ids``).
 
     Returns:
         The full HTML as a string.
@@ -78,6 +93,7 @@ async def cognee_network_visualization(
     html = html.replace("__STORY_VIEW_JS__", story_view.emit_js(pre))
     html = html.replace("__PIPELINE_LAYOUT_JS__", pipeline_layout.emit_js(pre))
     html = html.replace("__INSPECTOR_JS__", inspector.emit_js(pre))
+    html = html.replace("__MEMORY_VIEW_JS__", memory_map.emit_js(pre))
 
     # 2) Data tokens: substituted last so JSON-embedded ``__SCHEMA_GRAPH_DATA__``
     #    inside the schema JS chunk gets resolved correctly.
@@ -95,6 +111,10 @@ async def cognee_network_visualization(
         "__SCHEMA_GRAPH_DATA__",
         _safe_json_embed(pre.schema_graph or {"nodes": [], "links": []}),
     )
+    # Unconditional, JSON-fallback substitutions: a leaked __MEMORY_DATA__ /
+    # __SEARCH_EVENTS__ token would fail the no-placeholder assembly test.
+    html = html.replace("__MEMORY_DATA__", _safe_json_embed(pre.memory_map or {}))
+    html = html.replace("__SEARCH_EVENTS__", _safe_json_embed(search_events or []))
 
     if not destination_file_path:
         destination_file_path = os.path.join(os.path.expanduser("~"), "graph_visualization.html")

--- a/cognee/modules/visualization/preprocessor.py
+++ b/cognee/modules/visualization/preprocessor.py
@@ -856,6 +856,290 @@ def _compact_provenance(node_info):
     return payload or None
 
 
+# ── Memory-map payload ───────────────────────────────────────────────────────
+
+
+# Gap (ms) between consecutive ``t_created`` values beyond which the timeline
+# starts a new run event. 5 minutes cleanly separates pipeline runs while
+# merging the sub-second spread within one cognify batch.
+MEMORY_TIMELINE_GAP_MS: int = 300_000
+
+# Members per entity group flagged ``important`` even when they did not earn
+# a Key-mode ``label_priority`` slot — the Memory view renders these as named
+# cards and collapses the rest into a "+K" pill.
+MEMORY_GROUP_TOP_MEMBERS: int = 8
+
+
+def _t_sort_key(t_created) -> Tuple[bool, int]:
+    """Sort key tolerant of missing timestamps: untimed values sort last."""
+    return (t_created is None, t_created if t_created is not None else 0)
+
+
+def _build_memory_map(nodes: List[Dict[str, Any]], links: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build the Memory-tab payload (embedded via the ``__MEMORY_DATA__`` token).
+
+    The payload carries *structure only*: ids, deterministic ordering,
+    grouping, an index of structural edges (integer positions into the links
+    array) and the run timeline. Node/link details are read at render time
+    from the Story view's already-embedded data, so nothing is duplicated.
+
+    Deterministic-position rule: every list is sorted by keys intrinsic to
+    the data (``chunk_index``, names, ids, ``t_created``), so the layout the
+    JS derives from it is reproducible and append-stable as the graph grows.
+    """
+    nodes_by_id = {n["id"]: n for n in nodes}
+
+    doc_nodes = [n for n in nodes if n["stage"] == "document"]
+    chunk_nodes = [n for n in nodes if n["stage"] == "chunk"]
+    entity_nodes = [n for n in nodes if n["stage"] == "entity"]
+    summary_nodes = [n for n in nodes if n["stage"] == "summary"]
+    context_nodes = [n for n in nodes if n["stage"] == "context"]
+
+    doc_ids = {n["id"] for n in doc_nodes}
+    chunk_ids = {n["id"] for n in chunk_nodes}
+    entity_ids = {n["id"] for n in entity_nodes}
+    summary_ids = {n["id"] for n in summary_nodes}
+    context_ids = {n["id"] for n in context_nodes}
+
+    # ── Structural edge index + relation maps (single pass over links) ─────
+    edge_index: Dict[str, List[int]] = {
+        "contains": [],
+        "made_from": [],
+        "is_part_of": [],
+        "summarized_in": [],
+        "semantic": [],
+    }
+    chunk_doc_via_edge: Dict[str, str] = {}
+    summary_chunks: Dict[str, set] = defaultdict(set)
+    bucket_children: Dict[str, set] = defaultdict(set)
+    members_by_type: Dict[str, set] = defaultdict(set)
+
+    for position, link in enumerate(links):
+        source, target = link["source"], link["target"]
+        rel = (_link_relation(link) or "").lower()
+        endpoint_stages = {link.get("source_stage"), link.get("target_stage")}
+
+        if rel in ("is_part_of", "part_of") or (
+            rel == "contains" and endpoint_stages == {"document", "chunk"}
+        ):
+            # Chunk↔document membership: modern graphs use is_part_of
+            # (chunk→doc); some legacy graphs use contains (doc→chunk).
+            edge_index["is_part_of"].append(position)
+            chunk_end = source if source in chunk_ids else target
+            doc_end = target if target in doc_ids else source
+            if chunk_end in chunk_ids and doc_end in doc_ids:
+                chunk_doc_via_edge.setdefault(chunk_end, doc_end)
+        elif rel == "contains":
+            edge_index["contains"].append(position)
+        elif rel == "made_from":
+            edge_index["made_from"].append(position)
+            summary_end = source if source in summary_ids else target
+            chunk_end = target if target in chunk_ids else source
+            if summary_end in summary_ids and chunk_end in chunk_ids:
+                summary_chunks[summary_end].add(chunk_end)
+        elif rel == "summarized_in":
+            edge_index["summarized_in"].append(position)
+            if target in context_ids:
+                bucket_children[target].add(source)
+        elif rel == ENTITY_TYPE_RELATION:
+            # Entity → EntityType grouping edge. Entity→Entity is_a edges do
+            # NOT group (only true EntityType targets count).
+            if source in entity_ids and nodes_by_id.get(target, {}).get("type") == "EntityType":
+                members_by_type[target].add(source)
+        elif link.get("edge_class") == "semantic" and source in entity_ids and target in entity_ids:
+            edge_index["semantic"].append(position)
+
+    # ── Documents with ordered chunk cells ─────────────────────────────────
+    chunks_by_doc: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    legacy_chunks_by_doc: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    orphan_chunks: List[str] = []
+    for chunk in chunk_nodes:
+        raw_doc_id = chunk.get("document_id")
+        doc_id = str(raw_doc_id) if raw_doc_id is not None else None
+        if doc_id in doc_ids:
+            chunks_by_doc[doc_id].append(chunk)
+        elif chunk["id"] in chunk_doc_via_edge:
+            legacy_chunks_by_doc[chunk_doc_via_edge[chunk["id"]]].append(chunk)
+        else:
+            orphan_chunks.append(chunk["id"])
+    orphan_chunks.sort()
+
+    def _chunk_index_of(chunk):
+        index = chunk.get("chunk_index")
+        return index if isinstance(index, int) and not isinstance(index, bool) else None
+
+    def _chunk_sort_key(chunk):
+        index = _chunk_index_of(chunk)
+        return (index is None, index or 0, *_t_sort_key(chunk.get("t_created")), chunk["id"])
+
+    def _chunk_cell(chunk):
+        return {
+            "id": chunk["id"],
+            "chunk_index": _chunk_index_of(chunk),
+            "t_created": chunk.get("t_created"),
+        }
+
+    documents: List[Dict[str, Any]] = []
+    for doc in doc_nodes:
+        primary = sorted(chunks_by_doc.get(doc["id"], []), key=_chunk_sort_key)
+        # Legacy chunks (attributed only via the is_part_of edge) append
+        # after the chunk_index-ordered run so existing cells never shift.
+        legacy = sorted(legacy_chunks_by_doc.get(doc["id"], []), key=_chunk_sort_key)
+        ordered = primary + legacy
+        times = [
+            t
+            for t in [doc.get("t_created")] + [c.get("t_created") for c in ordered]
+            if t is not None
+        ]
+        documents.append(
+            {
+                "id": doc["id"],
+                "name": doc.get("name") or doc["id"],
+                "t_first": min(times) if times else None,
+                "chunks": [_chunk_cell(c) for c in ordered],
+            }
+        )
+    documents.sort(key=lambda d: (*_t_sort_key(d["t_first"]), d["name"], d["id"]))
+
+    # ── Entity groups (one per EntityType node) ────────────────────────────
+    entity_groups: List[Dict[str, Any]] = []
+    grouped_entity_ids: set = set()
+    type_nodes = sorted(
+        (n for n in nodes if n.get("type") == "EntityType"),
+        key=lambda n: (n.get("name") or "", n["id"]),
+    )
+    for type_node in type_nodes:
+        member_nodes = sorted(
+            (nodes_by_id[mid] for mid in members_by_type.get(type_node["id"], ())),
+            key=lambda n: (
+                not n.get("label_priority"),
+                -(n.get("importance") or 0.0),
+                n.get("name") or "",
+                n["id"],
+            ),
+        )
+        grouped_entity_ids.update(n["id"] for n in member_nodes)
+        entity_groups.append(
+            {
+                "type_id": type_node["id"],
+                "type_name": type_node.get("name") or type_node["id"],
+                "members": [
+                    {
+                        "id": member["id"],
+                        "important": bool(member.get("label_priority"))
+                        or rank < MEMORY_GROUP_TOP_MEMBERS,
+                    }
+                    for rank, member in enumerate(member_nodes)
+                ],
+            }
+        )
+    ungrouped_entities = [
+        n["id"]
+        for n in sorted(
+            (n for n in entity_nodes if n["id"] not in grouped_entity_ids),
+            key=lambda n: (n.get("name") or "", n["id"]),
+        )
+    ]
+
+    # ── Summaries ──────────────────────────────────────────────────────────
+    summaries: List[Dict[str, Any]] = []
+    for summary in sorted(summary_nodes, key=lambda n: (*_t_sort_key(n.get("t_created")), n["id"])):
+        bucket_id = summary.get("global_context_bucket_id")
+        summaries.append(
+            {
+                "id": summary["id"],
+                "chunk_ids": sorted(summary_chunks.get(summary["id"], ())),
+                "bucket_id": str(bucket_id) if bucket_id is not None else None,
+            }
+        )
+
+    # ── Global context (None → the view renders its empty state) ──────────
+    context: Optional[Dict[str, Any]] = None
+    if context_nodes:
+        root_ids = sorted(n["id"] for n in context_nodes if n.get("is_root"))
+        buckets = [
+            {
+                "id": n["id"],
+                "level": n.get("level") if isinstance(n.get("level"), int) else None,
+                "child_ids": sorted(bucket_children.get(n["id"], ())),
+            }
+            for n in sorted(
+                context_nodes,
+                key=lambda n: (
+                    n.get("level") if isinstance(n.get("level"), int) else -1,
+                    n["id"],
+                ),
+            )
+        ]
+        context = {"root_id": root_ids[0] if root_ids else None, "buckets": buckets}
+
+    # ── Timeline: gap-cluster t_created into run events ────────────────────
+    timed = sorted(
+        (n for n in nodes if n.get("t_created") is not None),
+        key=lambda n: (n["t_created"], n["id"]),
+    )
+    untimed_ids = sorted(n["id"] for n in nodes if n.get("t_created") is None)
+
+    clusters: List[List[Dict[str, Any]]] = []
+    for node in timed:
+        if clusters and node["t_created"] - clusters[-1][-1]["t_created"] <= MEMORY_TIMELINE_GAP_MS:
+            clusters[-1].append(node)
+        else:
+            clusters.append([node])
+
+    timeline: List[Dict[str, Any]] = []
+    for index, cluster in enumerate(clusters):
+        node_ids = [n["id"] for n in cluster]
+        if index == 0 and untimed_ids:
+            # Nodes without t_created (legacy/defensive) join the first event.
+            node_ids = untimed_ids + node_ids
+        pipeline_counts = Counter(
+            n.get("source_pipeline") for n in cluster if n.get("source_pipeline")
+        )
+        if any(n["stage"] == "context" for n in cluster):
+            label = "global_context_index"
+        elif pipeline_counts:
+            label = min(pipeline_counts.items(), key=lambda kv: (-kv[1], kv[0]))[0]
+        else:
+            label = "ingestion"
+        timeline.append(
+            {
+                "index": index,
+                "kind": "run",
+                "label": label,
+                "t0": cluster[0]["t_created"],
+                "t1": cluster[-1]["t_created"],
+                "node_count": len(node_ids),
+                "node_ids": node_ids,
+            }
+        )
+    if not timeline and untimed_ids:
+        # No node carries t_created at all: emit one synthetic event so the
+        # view always has a "current state" selection on non-empty graphs.
+        timeline.append(
+            {
+                "index": 0,
+                "kind": "run",
+                "label": "ingestion",
+                "t0": 0,
+                "t1": 0,
+                "node_count": len(untimed_ids),
+                "node_ids": untimed_ids,
+            }
+        )
+
+    return {
+        "documents": documents,
+        "orphan_chunks": orphan_chunks,
+        "entity_groups": entity_groups,
+        "ungrouped_entities": ungrouped_entities,
+        "summaries": summaries,
+        "context": context,
+        "edges": edge_index,
+        "timeline": timeline,
+    }
+
+
 # ── Public API ───────────────────────────────────────────────────────────────
 
 
@@ -878,6 +1162,7 @@ class PreprocessedGraph:
     bundles: Dict[str, int] = field(default_factory=dict)
     provenance_index: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     has_meaningful_topological_rank: bool = False
+    memory_map: Dict[str, Any] = field(default_factory=dict)
 
 
 def _label_priority_threshold(importances: List[float], percentile: float = 0.75) -> float:
@@ -931,6 +1216,11 @@ def preprocess(graph_data, schema_data: Optional[Dict[str, Any]] = None) -> Prep
         node_info["is_unnamed"] = looks_like_identifier(raw_name) or node_info["name"].startswith(
             "Unnamed "
         )
+        created_at = node_info.get("created_at")
+        if isinstance(created_at, int) and not isinstance(created_at, bool):
+            # Preserve the creation timestamp (epoch ms) for the Memory
+            # timeline before the raw audit columns are dropped below.
+            node_info["t_created"] = created_at
         node_info.pop("updated_at", None)
         node_info.pop("created_at", None)
 
@@ -1062,4 +1352,5 @@ def preprocess(graph_data, schema_data: Optional[Dict[str, Any]] = None) -> Prep
         bundles=dict(bundle_counts),
         provenance_index=provenance_index,
         has_meaningful_topological_rank=has_meaningful_rank,
+        memory_map=_build_memory_map(nodes, links),
     )

--- a/cognee/modules/visualization/preprocessor.py
+++ b/cognee/modules/visualization/preprocessor.py
@@ -13,6 +13,7 @@ Schema, Context, Retrieval) sees the same enrichment.
 import colorsys
 import json
 import math
+import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
@@ -146,19 +147,38 @@ def generate_provenance_colors(values):
     return color_map
 
 
+# UUID- or content-hash-shaped strings: never useful as display names.
+_IDENTIFIER_LIKE_RE = re.compile(
+    r"^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32,64})$",
+    re.IGNORECASE,
+)
+
+
+def looks_like_identifier(value) -> bool:
+    """True for UUID/hash-shaped strings that would read as noise in the UI."""
+    return isinstance(value, str) and bool(_IDENTIFIER_LIKE_RE.match(value.strip()))
+
+
 def derive_node_name(node_info, node_id):
-    """Pick a human-readable label for a node, falling back through name/title/text/etc."""
+    """Pick a human-readable label for a node, falling back through name/title/text/etc.
+
+    Identifier-shaped values (UUIDs, content hashes) are never used as
+    display names — surfacing them as labels was the single biggest
+    first-session trust killer in user testing. Nodes with no readable
+    field get an explicit "Unnamed <Type>" placeholder instead.
+    """
     name = node_info.get("name")
-    if name:
+    if name and not looks_like_identifier(name):
         return name
 
     for key in ("title", "text", "summary", "description", "content"):
         value = node_info.get(key)
-        if isinstance(value, str) and value.strip():
+        if isinstance(value, str) and value.strip() and not looks_like_identifier(value):
             normalized = " ".join(value.split())
             return normalized[:120]
 
-    return str(node_id)
+    node_type = node_info.get("type") or "node"
+    return f"Unnamed {node_type} ({str(node_id)[:8]})"
 
 
 def node_type_rank(node_type):
@@ -904,7 +924,13 @@ def preprocess(graph_data, schema_data: Optional[Dict[str, Any]] = None) -> Prep
         )
         if node_info.get("ontology_valid") is True:
             node_info["color"] = _ONTOLOGY_VALID_COLOR
+        raw_name = node_info.get("name")
         node_info["name"] = derive_node_name(node_info, node_id)
+        # Unnamed nodes (UUID/hash names) must never become Key-mode label
+        # landmarks; pass 3 reads this flag.
+        node_info["is_unnamed"] = looks_like_identifier(raw_name) or node_info["name"].startswith(
+            "Unnamed "
+        )
         node_info.pop("updated_at", None)
         node_info.pop("created_at", None)
 
@@ -999,7 +1025,10 @@ def preprocess(graph_data, schema_data: Optional[Dict[str, Any]] = None) -> Prep
     importances = [n["importance"] for n in nodes]
     threshold = _label_priority_threshold(importances, percentile=0.75)
     for node in nodes:
-        if node["stage"] in _ALWAYS_LABEL_STAGES:
+        if node.get("is_unnamed"):
+            # A placeholder name is never worth a Key-mode label slot.
+            node["label_priority"] = False
+        elif node["stage"] in _ALWAYS_LABEL_STAGES:
             node["label_priority"] = True
         elif node["importance"] >= threshold and threshold > 0:
             node["label_priority"] = True

--- a/cognee/modules/visualization/session_events.py
+++ b/cognee/modules/visualization/session_events.py
@@ -1,0 +1,141 @@
+"""Collect memory-operation events from the session layer for the Memory tab.
+
+The "operation bench": searches run against the backend (with a session)
+record which graph elements produced each answer (``used_graph_element_ids``),
+and feedback entries record how those answers were rated. This module turns
+that history into timeline events for the visualization, so backend activity
+appears on the Memory tab automatically — no hand-built ``search_events``.
+
+Two event kinds are emitted per the renderer's contract:
+
+- ``search``  — one per QA entry: the query, answer, and the graph elements
+  retrieved to produce it (spotlight overlay).
+- ``improve`` — one per *rated* QA entry: the same elements plus the rating,
+  representing the reinforcement that ``improve()`` applies to them via
+  ``apply_feedback_weights`` (reinforcement overlay).
+"""
+
+from typing import Any, Dict, List, Optional
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("visualization.session_events")
+
+# Bound the number of sessions scanned when none are specified explicitly.
+MAX_SESSIONS_SCANNED = 10
+
+
+def map_session_entries_to_events(session_id: str, entries: List[Any]) -> List[Dict[str, Any]]:
+    """Map SessionQAEntry records to Memory-tab timeline events (pure).
+
+    Emits a ``search`` event per entry and, when the entry carries a feedback
+    score, an ``improve`` event immediately after it (the renderer's sort is
+    stable, so equal timestamps preserve this order).
+    """
+    events: List[Dict[str, Any]] = []
+    for entry in entries:
+        used = getattr(entry, "used_graph_element_ids", None) or {}
+        node_ids = list(used.get("node_ids") or [])
+        edge_ids = list(used.get("edge_ids") or [])
+        question = getattr(entry, "question", "") or ""
+        if not question.strip() and not node_ids:
+            # Placeholder/system entries with neither a query nor provenance
+            # add nothing to the timeline story.
+            continue
+
+        base = {
+            "session_id": session_id,
+            "qa_id": getattr(entry, "qa_id", None),
+            "time": getattr(entry, "time", "") or "",
+            "question": question,
+            "node_ids": node_ids,
+            "edge_ids": edge_ids,
+        }
+        events.append({**base, "kind": "search", "answer": getattr(entry, "answer", "") or ""})
+
+        score = getattr(entry, "feedback_score", None)
+        if score is not None:
+            memify_metadata = getattr(entry, "memify_metadata", None) or {}
+            events.append(
+                {
+                    **base,
+                    "kind": "improve",
+                    "rating": score,
+                    "feedback_text": getattr(entry, "feedback_text", None),
+                    "applied": bool(memify_metadata.get("feedback_weights_applied")),
+                }
+            )
+    return events
+
+
+async def _list_recent_session_ids(user_uuid, limit: int) -> List[str]:
+    """Most recently active session ids for a user, from the lifecycle table.
+
+    ``user_uuid`` must be the raw UUID (the column is UUID-typed; a string
+    fails the SQLAlchemy bind with "'str' object has no attribute 'hex'").
+    """
+    from sqlalchemy import select
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.session_lifecycle.models import SessionRecord
+
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(SessionRecord)
+                    .where(SessionRecord.user_id == user_uuid)
+                    .order_by(SessionRecord.last_activity_at.desc())
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return [str(row.session_id) for row in rows]
+
+
+async def collect_session_events(
+    user=None,
+    session_ids: Optional[List[str]] = None,
+    max_sessions: int = MAX_SESSIONS_SCANNED,
+) -> List[Dict[str, Any]]:
+    """Best-effort collection of search/improve events from the session cache.
+
+    Never raises: any unavailable layer (cache disabled, no lifecycle table,
+    no sessions) degrades to an empty list so visualization always renders.
+    """
+    try:
+        from cognee.infrastructure.session.get_session_manager import get_session_manager
+        from cognee.modules.users.methods import get_default_user
+
+        if user is None:
+            user = await get_default_user()
+        user_id = str(user.id)
+
+        session_manager = get_session_manager()
+        if not session_manager.is_available:
+            logger.debug("Session cache unavailable; no operation events collected.")
+            return []
+
+        if session_ids is None:
+            try:
+                session_ids = await _list_recent_session_ids(user.id, max_sessions)
+            except Exception as error:  # noqa: BLE001 — lifecycle table may not exist
+                logger.debug("Session listing unavailable (%s); no events collected.", error)
+                return []
+
+        events: List[Dict[str, Any]] = []
+        for session_id in session_ids[:max_sessions]:
+            entries = await session_manager.get_session(user_id=user_id, session_id=session_id)
+            if isinstance(entries, list) and entries:
+                events.extend(map_session_entries_to_events(session_id, entries))
+
+        events.sort(key=lambda event: (event.get("time") or "", event["kind"] == "improve"))
+        if events:
+            logger.info("Collected %d session operation events for the Memory tab.", len(events))
+        return events
+    except Exception as error:  # noqa: BLE001 — visualization must never fail on this
+        logger.warning("Session event collection failed; rendering without them: %s", error)
+        return []

--- a/cognee/modules/visualization/template.html
+++ b/cognee/modules/visualization/template.html
@@ -54,16 +54,23 @@ canvas:active{cursor:grabbing}
 }
 .ctrl-btn:hover{color:var(--text);background:var(--surface)}
 .ctrl-btn.active{color:#F4F4F4;background:rgba(101,16,244,0.2)}
+.ctrl-btn:disabled{opacity:0.35;cursor:not-allowed}
+.ctrl-btn:disabled:hover{color:var(--text2);background:transparent}
 .ctrl-sep{width:1px;background:var(--border);margin:2px 4px}
 
 #search-box{
   position:fixed;top:56px;left:20px;z-index:100;width:280px;
 }
 #search-input{
-  width:100%;padding:8px 12px 8px 32px;
+  width:100%;padding:8px 64px 8px 32px;
   font-size:12px;font-family:inherit;color:var(--text);
   background:var(--bg2);border:1px solid var(--border);border-radius:8px;
   outline:none;transition:border-color 0.15s;
+}
+#search-count{
+  position:absolute;right:10px;top:50%;transform:translateY(-50%);
+  font-size:10.5px;color:var(--text2);pointer-events:none;
+  font-variant-numeric:tabular-nums;white-space:nowrap;
 }
 #search-input:focus{border-color:var(--accent)}
 #search-input::placeholder{color:var(--text2)}
@@ -166,7 +173,8 @@ canvas:active{cursor:grabbing}
 
 <div id="search-box">
   <svg class="search-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-  <input type="text" id="search-input" placeholder="Search nodes..." autocomplete="off" spellcheck="false">
+  <input type="text" id="search-input" placeholder="Search nodes... (Enter jumps to match)" autocomplete="off" spellcheck="false">
+  <span id="search-count"></span>
 </div>
 
 <div id="controls">

--- a/cognee/modules/visualization/template.html
+++ b/cognee/modules/visualization/template.html
@@ -425,6 +425,14 @@ html:not(.light) #memory-view{
 .mm-unit.is-spotlit .mm-box,.mm-unit.is-spotlit .mm-frame{stroke:var(--mm-spot);stroke-width:2;}
 #memory-svg.mm-searching .mm-edge.is-trail{stroke:var(--mm-spot);opacity:0.45;stroke-width:1.4;}
 #memory-svg.mm-searching .mm-edge.is-spotlit-edge{stroke:var(--mm-spot);opacity:0.95;stroke-width:2;}
+/* Reinforcement (improve) overlay: feedback valence on the same layout —
+   green = weights up from a positive rating, amber = weights down. */
+#memory-svg.mm-reinforcing .mm-unit.is-reinforced,
+#memory-svg.mm-reinforcing .mm-unit.is-weakened{opacity:1;}
+.mm-unit.is-reinforced .mm-box,.mm-unit.is-reinforced .mm-frame{stroke:#1F9E6E;stroke-width:2.2;}
+.mm-unit.is-weakened .mm-box,.mm-unit.is-weakened .mm-frame{stroke:#E2A33B;stroke-width:2.2;}
+.mm-rail-improve{border-radius:16px;background:rgba(31,158,110,0.10);}
+html:not(.light) .mm-rail-improve{background:rgba(31,158,110,0.18);}
 /* Memory side panel: dark-theme parity with the schema drawer. */
 html:not(.light) #memory-side-panel{box-shadow:-12px 0 32px rgba(0,0,0,0.45);}
 #memory-side-panel .si-title{color:var(--mm-text);}

--- a/cognee/modules/visualization/template.html
+++ b/cognee/modules/visualization/template.html
@@ -159,6 +159,7 @@ canvas:active{cursor:grabbing}
 <div id="view-tabs" style="position:fixed;top:0;left:50%;transform:translateX(-50%);z-index:1100;display:flex;gap:2px;align-items:center;background:var(--bg);border:1px solid var(--border);border-top:none;border-radius:0 0 8px 8px;padding:2px 6px;">
   <button class="tab-btn active" data-view="graph" style="background:#1F9E6E;color:#fff;border:none;padding:6px 18px;border-radius:6px 6px 0 0;cursor:pointer;font-size:12px;font-weight:600;">Graph</button>
   <button class="tab-btn" data-view="schema" style="background:transparent;color:var(--text2);border:none;padding:6px 18px;border-radius:6px 6px 0 0;cursor:pointer;font-size:12px;font-weight:600;">Schema</button>
+  <button class="tab-btn" data-view="memory" style="background:transparent;color:var(--text2);border:none;padding:6px 18px;border-radius:6px 6px 0 0;cursor:pointer;font-size:12px;font-weight:600;">Memory</button>
 </div>
 
 <button id="theme-toggle" style="position:fixed;top:12px;right:20px;z-index:1200;background:var(--bg2);border:1px solid var(--border);cursor:pointer;font-size:12px;padding:6px 14px;border-radius:8px;color:var(--text);font-family:inherit;font-weight:500;transition:all 0.15s;">Dark mode</button>
@@ -242,6 +243,24 @@ canvas:active{cursor:grabbing}
   <div id="schema-side-panel" style="display:none;position:absolute;top:104px;right:0;bottom:0;width:344px;background:#FFFFFF;border-left:1px solid #E6E8EB;box-shadow:-12px 0 32px rgba(16,24,40,0.08);padding:26px 24px;overflow-y:auto;z-index:5;">
     <!-- PR3: schema type details (count, sample chips, relationships) render here -->
   </div>
+</div>
+
+<!-- Memory tab: deterministic column map of the memory (documents → entities
+     → summaries → global context) with a run/search timeline rail. Rendered
+     lazily by views/memory_map.js into #memory-svg. -->
+<div id="memory-view" style="display:none;position:fixed;inset:0;padding:56px 0 0;overflow:hidden;z-index:900;">
+  <div id="memory-header"><div id="memory-status"></div></div>
+  <div id="memory-diagram-section">
+    <svg id="memory-svg"></svg>
+  </div>
+  <div id="memory-zoom">
+    <button id="memory-zoom-out" title="Zoom out">&minus;</button>
+    <button id="memory-zoom-in" title="Zoom in">+</button>
+    <button id="memory-zoom-fit" title="Fit to view">Fit</button>
+  </div>
+  <div id="memory-empty"><div>No memory content to map yet. Run <b>cognify</b> first.</div></div>
+  <div id="memory-side-panel"></div>
+  <div id="memory-timeline"></div>
 </div>
 <style>
 /* ── Schema diagram ─────────────────────────────────────────────── */
@@ -333,6 +352,87 @@ html:not(.light) .si-rel{border-bottom-color:#2E333C;}
 .si-highlight{margin-top:24px;width:100%;background:#1F9E6E;color:#fff;border:none;border-radius:8px;padding:11px 0;cursor:pointer;font-size:13px;font-weight:600;font-family:inherit;box-shadow:0 1px 2px rgba(16,24,40,0.12);transition:background .12s;}
 .si-highlight:hover{background:#18815B;}
 .si-empty{color:#8792A2;font-size:12px;}
+
+/* ── Memory map ──────────────────────────────────────────────────
+   All colors flow through --mm-* vars so both themes work without a
+   re-render: light defaults here, dark overrides under html:not(.light). */
+#memory-view{
+  --mm-bg:#F7F8FA;--mm-card:#FFFFFF;--mm-card2:#F2F5F8;--mm-border:#E6E8EB;
+  --mm-text:#1A1F36;--mm-muted:#8792A2;--mm-accent:#1F9E6E;--mm-spot:#6510F4;
+  --mm-edge:#A9B4C0;--mm-sem:#C2C9D1;--mm-chunk:#EDF4FB;--mm-chunk-stroke:#C8DCEF;
+  background:var(--mm-bg);color:var(--mm-text);
+  font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;
+}
+html:not(.light) #memory-view{
+  --mm-bg:#15181D;--mm-card:#23272F;--mm-card2:#1C2026;--mm-border:#3A4049;
+  --mm-text:#E4E8EE;--mm-muted:#7E8894;--mm-accent:#3DD68C;--mm-spot:#A550FF;
+  --mm-edge:#4A515B;--mm-sem:#3A4049;--mm-chunk:#1E2A38;--mm-chunk-stroke:#2C3E52;
+}
+#memory-header{position:absolute;top:56px;left:0;right:0;padding:14px 28px 10px;display:flex;align-items:center;gap:16px;}
+#memory-status{font-size:13px;color:var(--mm-muted);min-height:16px;}
+#memory-diagram-section{position:absolute;top:96px;left:0;right:0;bottom:64px;overflow:hidden;}
+#memory-svg{display:block;width:100%;height:100%;cursor:grab;font-family:'Inter',system-ui,sans-serif;}
+#memory-svg.is-panning{cursor:grabbing;}
+#memory-zoom{position:absolute;left:20px;bottom:84px;z-index:6;display:flex;gap:4px;background:var(--mm-card);border:1px solid var(--mm-border);border-radius:10px;padding:4px;box-shadow:0 2px 8px rgba(16,24,40,0.10);}
+#memory-zoom button{height:30px;min-width:30px;padding:0 10px;border:none;background:transparent;border-radius:7px;cursor:pointer;font-size:15px;font-weight:600;color:var(--mm-muted);font-family:inherit;}
+#memory-zoom button:hover{background:var(--mm-card2);color:var(--mm-text);}
+#memory-empty{display:none;position:absolute;inset:96px 0 64px;align-items:center;justify-content:center;}
+#memory-empty div{color:var(--mm-muted);text-align:center;font-size:15px;}
+#memory-side-panel{display:none;position:absolute;top:96px;right:0;bottom:64px;width:344px;background:var(--mm-card);border-left:1px solid var(--mm-border);box-shadow:-12px 0 32px rgba(16,24,40,0.08);padding:26px 24px;overflow-y:auto;z-index:5;font-size:13px;}
+#memory-timeline{position:absolute;left:0;right:0;bottom:0;height:64px;background:var(--mm-card);border-top:1px solid var(--mm-border);display:flex;align-items:center;gap:8px;padding:0 16px;overflow-x:auto;overflow-y:hidden;z-index:6;}
+.mm-rail-label{flex:0 0 auto;font-size:10px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--mm-muted);margin-right:6px;}
+.mm-rail-item{flex:0 0 auto;display:flex;flex-direction:column;align-items:flex-start;gap:1px;padding:5px 12px;border:1px solid var(--mm-border);border-radius:8px;background:var(--mm-card2);cursor:pointer;font-size:11px;font-weight:600;color:var(--mm-text);font-family:inherit;line-height:1.3;text-align:left;}
+.mm-rail-item .t{color:var(--mm-muted);font-size:10px;font-weight:500;font-variant-numeric:tabular-nums;}
+.mm-rail-item:hover{border-color:var(--mm-accent);}
+.mm-rail-item.active{border-color:var(--mm-accent);box-shadow:0 0 0 1px var(--mm-accent);}
+.mm-rail-search{border-radius:16px;background:rgba(101,16,244,0.08);}
+.mm-rail-search:hover{border-color:var(--mm-spot);}
+.mm-rail-search.active{border-color:var(--mm-spot);box-shadow:0 0 0 1px var(--mm-spot);}
+/* SVG element styling */
+.mm-band-header{font-size:12px;font-weight:600;letter-spacing:0.1em;text-transform:uppercase;fill:var(--mm-muted);}
+.mm-band-sub{font-size:10px;fill:var(--mm-muted);opacity:0.8;}
+.mm-node{cursor:pointer;}
+.mm-unit{transition:opacity 0.18s ease;}
+.mm-frame{fill:var(--mm-card);stroke:var(--mm-border);}
+.mm-title{font-size:12px;font-weight:600;fill:var(--mm-text);}
+.mm-sub{font-size:10px;fill:var(--mm-muted);}
+.mm-cell .mm-box{fill:var(--mm-chunk);stroke:var(--mm-chunk-stroke);}
+.mm-cell:hover .mm-box{stroke:var(--mm-accent);}
+.mm-cell text{font-size:10.5px;fill:var(--mm-text);}
+.mm-row .mm-box{fill:transparent;stroke:transparent;}
+.mm-row:hover .mm-box{fill:var(--mm-card2);}
+.mm-row text{font-size:11px;fill:var(--mm-text);}
+.mm-row .mm-dot{fill:var(--mm-accent);}
+.mm-pill .mm-box{fill:var(--mm-card2);stroke:var(--mm-border);}
+.mm-pill:hover .mm-box{stroke:var(--mm-accent);}
+.mm-pill text{font-size:10px;fill:var(--mm-muted);}
+.mm-count{font-size:10px;fill:var(--mm-muted);font-variant-numeric:tabular-nums;}
+.mm-sum .mm-box{fill:var(--mm-card);stroke:var(--mm-border);}
+.mm-sum:hover .mm-box{stroke:var(--mm-accent);}
+.mm-sum text{font-size:10.5px;fill:var(--mm-text);}
+.mm-ctx-empty rect{fill:none;stroke:var(--mm-muted);stroke-dasharray:5 4;opacity:0.55;}
+.mm-ctx-empty text{font-size:11px;fill:var(--mm-muted);}
+.mm-edge{fill:none;stroke:var(--mm-edge);stroke-width:1.1;opacity:0.20;transition:opacity 0.18s ease;}
+.mm-edge-semantic{stroke:var(--mm-sem);opacity:0.10;}
+.mm-edge-made_from{opacity:0.38;}
+.mm-node.is-selected .mm-box,.mm-node.is-selected .mm-frame{stroke:var(--mm-accent);stroke-width:2;}
+.mm-future{opacity:0.06 !important;pointer-events:none;}
+/* Search overlay: dim base, spotlight retrieved set — classes/opacity only,
+   never positions. */
+#memory-svg.mm-searching .mm-unit{opacity:0.14;}
+#memory-svg.mm-searching .mm-edge{opacity:0.03;}
+#memory-svg.mm-searching .mm-unit.is-spotlit{opacity:1;}
+.mm-unit.is-spotlit .mm-box,.mm-unit.is-spotlit .mm-frame{stroke:var(--mm-spot);stroke-width:2;}
+#memory-svg.mm-searching .mm-edge.is-trail{stroke:var(--mm-spot);opacity:0.45;stroke-width:1.4;}
+#memory-svg.mm-searching .mm-edge.is-spotlit-edge{stroke:var(--mm-spot);opacity:0.95;stroke-width:2;}
+/* Memory side panel: dark-theme parity with the schema drawer. */
+html:not(.light) #memory-side-panel{box-shadow:-12px 0 32px rgba(0,0,0,0.45);}
+#memory-side-panel .si-title{color:var(--mm-text);}
+#memory-side-panel .si-chip{background:var(--mm-card2);border-color:var(--mm-border);color:var(--mm-text);}
+#memory-side-panel .si-rel-name{color:var(--mm-text);}
+#memory-side-panel .mm-panel-text{font-size:12.5px;line-height:1.55;color:var(--mm-text);white-space:pre-wrap;word-break:break-word;background:var(--mm-card2);border:1px solid var(--mm-border);border-radius:8px;padding:10px 12px;}
+#memory-side-panel .panel-row .k{color:var(--mm-muted);}
+#memory-side-panel .panel-row .v{color:var(--mm-text);}
 </style>
 
 
@@ -346,6 +446,7 @@ __SCHEMA_VIEW_JS__
 __STORY_VIEW_JS__
 __PIPELINE_LAYOUT_JS__
 __INSPECTOR_JS__
+__MEMORY_VIEW_JS__
 </script>
 </body>
 </html>

--- a/cognee/modules/visualization/views/memory_map.js
+++ b/cognee/modules/visualization/views/memory_map.js
@@ -463,7 +463,9 @@
   function buildRail() {
     railItems = timelineP.map(function (e) { return { kind: 'run', t: e.t0 || 0, run: e }; })
       .concat((searchEvents || []).map(function (s) {
-        return { kind: 'search', t: Date.parse(s.time) || 0, search: s };
+        // Operation events: kind "search" (retrieval spotlight) or
+        // "improve" (feedback reinforcement). Missing kind = search.
+        return { kind: s.kind === 'improve' ? 'improve' : 'search', t: Date.parse(s.time) || 0, search: s };
       }))
       .sort(function (a, b) { return a.t - b.t || (a.kind === b.kind ? 0 : a.kind === 'run' ? -1 : 1); });
 
@@ -475,12 +477,20 @@
     rail.appendChild(lbl);
     railItems.forEach(function (item, i) {
       const btn = document.createElement('button');
-      btn.className = 'mm-rail-item' + (item.kind === 'search' ? ' mm-rail-search' : '');
+      btn.className = 'mm-rail-item' +
+        (item.kind === 'search' ? ' mm-rail-search' : item.kind === 'improve' ? ' mm-rail-improve' : '');
       if (item.kind === 'run') {
         btn.innerHTML = '<span>' + esc(trunc(item.run.label, 20)) + '</span>' +
           '<span class="t">' + esc(fmtT(item.run.t0)) + ' · ' + item.run.node_count + ' nodes</span>';
         btn.title = 'Show memory state after this run';
         btn.addEventListener('click', function () { applyRun(item.run.index, i); openRunPanel(item.run); });
+      } else if (item.kind === 'improve') {
+        const rating = item.search.rating;
+        const stars = rating != null ? '★' + rating : 'feedback';
+        btn.innerHTML = '<span>↑ improve · ' + esc(stars) + '</span>' +
+          '<span class="t">' + esc(trunc(item.search.question || '', 22)) + '</span>';
+        btn.title = 'Feedback reinforcement: ' + (item.search.question || '');
+        btn.addEventListener('click', function () { applyImprove(item.search, i); });
       } else {
         btn.innerHTML = '<span>⌕ ' + esc(trunc(item.search.question || 'search', 24)) + '</span>' +
           '<span class="t">' + esc(item.search.time || '') + '</span>';
@@ -567,7 +577,7 @@
     const spot = new Set(evt.node_ids || []);
     spot.forEach(function (id) {
       (unitEls[id] || []).forEach(function (el) { el.classList.add('is-spotlit'); });
-      if (!unitEls[id] && groupByMember[id]) promoteCollapsed(id);
+      if (!unitEls[id] && groupByMember[id]) promoteCollapsed(id, 'is-spotlit');
     });
     // Retrieved edges: join edge_ids on edge_object_id; provenance trail =
     // structural edges whose both endpoints were retrieved.
@@ -585,14 +595,45 @@
     updateStatus();
   }
 
+  // The reinforcement overlay: same stable layout, but the rated answer's
+  // elements glow by feedback valence — positive ratings reinforce (green),
+  // negative weaken (amber). This is the visual for apply_feedback_weights.
+  function applyImprove(evt, railIdx) {
+    clearSearch();
+    visibleSet = null;
+    applyVisibility();
+    activeSearch = evt;
+    svgSel.classed('mm-searching', true).classed('mm-reinforcing', true);
+    const rating = evt.rating;
+    const cls = rating == null || rating === 3 ? 'is-spotlit'
+      : rating >= 4 ? 'is-reinforced' : 'is-weakened';
+    const spot = new Set(evt.node_ids || []);
+    spot.forEach(function (id) {
+      (unitEls[id] || []).forEach(function (el) { el.classList.add(cls); });
+      if (!unitEls[id] && groupByMember[id]) promoteCollapsed(id, cls);
+    });
+    (evt.edge_ids || []).forEach(function (oid) {
+      (edgeByObjId[oid] || []).forEach(function (el) { el.classList.add('is-spotlit-edge'); });
+    });
+    edgeEls.forEach(function (e) {
+      if (e.s != null && e.t != null && spot.has(e.s) && spot.has(e.t) &&
+          !e.el.classList.contains('is-spotlit-edge')) {
+        e.el.classList.add('is-trail');
+      }
+    });
+    setActiveRail(railIdx);
+    openImprovePanel(evt);
+    updateStatus();
+  }
+
   // A collapsed retrieved entity is temporarily promoted out of its "+K"
   // pill into an overlay slot below its group — nothing else moves.
   let promotedCount = {};
-  function promoteCollapsed(id) {
+  function promoteCollapsed(id, highlightClass) {
     const grp = groupByMember[id];
     const i = promotedCount[grp.type_id] = (promotedCount[grp.type_id] || 0) + 1;
     const y = grp.y + grp.h + 2 + (i - 1) * ROW_H;
-    const gr = gOverlay.append('g').attr('class', 'mm-unit mm-node mm-row is-spotlit');
+    const gr = gOverlay.append('g').attr('class', 'mm-unit mm-node mm-row ' + (highlightClass || 'is-spotlit'));
     gr.append('rect').attr('class', 'mm-box')
       .attr('x', grp.x + 6).attr('y', y).attr('width', grp.w - 12).attr('height', ROW_H - 2).attr('rx', 3);
     gr.append('circle').attr('class', 'mm-dot').attr('cx', grp.x + 13).attr('cy', y + ROW_H / 2 - 1).attr('r', 2.5);
@@ -602,10 +643,10 @@
 
   function clearSearch() {
     activeSearch = null;
-    if (svgSel) svgSel.classed('mm-searching', false);
-    document.querySelectorAll('#memory-svg .is-spotlit').forEach(function (el) { el.classList.remove('is-spotlit'); });
-    document.querySelectorAll('#memory-svg .is-spotlit-edge').forEach(function (el) { el.classList.remove('is-spotlit-edge'); });
-    document.querySelectorAll('#memory-svg .is-trail').forEach(function (el) { el.classList.remove('is-trail'); });
+    if (svgSel) svgSel.classed('mm-searching', false).classed('mm-reinforcing', false);
+    ['is-spotlit', 'is-spotlit-edge', 'is-trail', 'is-reinforced', 'is-weakened'].forEach(function (cls) {
+      document.querySelectorAll('#memory-svg .' + cls).forEach(function (el) { el.classList.remove(cls); });
+    });
     if (gOverlay) gOverlay.selectAll('*').remove();
     promotedCount = {};
   }
@@ -723,9 +764,26 @@
       (n.description ? '<div class="mm-panel-text">' + esc(trunc(n.description, 320)) + '</div>' : '') +
       row('Degree', n.degree) +
       row('Created', fmtT(n.t_created)) +
+      weightRows(n) +
       (srcChunks.length ? heading('Source chunks') + chips(srcChunks) : '') +
       relHtml
     );
+  }
+
+  // Feedback/importance weights — the self-improvement loop's footprint on a
+  // node. 0.5 is the untouched default; any drift means rated answers have
+  // reinforced or weakened this element via improve().
+  function weightRows(n) {
+    let html = '';
+    if (typeof n.feedback_weight === 'number') {
+      const drift = n.feedback_weight - 0.5;
+      const tag = Math.abs(drift) < 0.005 ? '' : drift > 0 ? ' · reinforced' : ' · weakened';
+      html += row('Feedback weight', n.feedback_weight.toFixed(3) + tag);
+    }
+    if (typeof n.importance_weight === 'number' && n.importance_weight !== 0.5) {
+      html += row('Importance weight', n.importance_weight.toFixed(3));
+    }
+    return html;
   }
 
   function openGroupPanel(grp) {
@@ -795,6 +853,29 @@
       row('Retrieved edges', (evt.edge_ids || []).length) +
       (counts ? heading('Retrieved by stage') + counts : '') +
       (chunksRetrieved.length ? heading('Retrieved chunks') + chips(chunksRetrieved) : '')
+    );
+  }
+
+  function openImprovePanel(evt) {
+    const byStage = {};
+    (evt.node_ids || []).forEach(function (id) {
+      const s = stageOf(id);
+      byStage[s] = (byStage[s] || 0) + 1;
+    });
+    let counts = '';
+    Object.keys(byStage).sort().forEach(function (s) { counts += row(s, byStage[s]); });
+    const rating = evt.rating;
+    const valence = rating == null || rating === 3 ? 'neutral'
+      : rating >= 4 ? 'reinforced (weights up)' : 'weakened (weights down)';
+    showPanel(
+      title('Improve', evt.question || 'feedback') +
+      row('Rating', rating != null ? rating + ' / 5' : '—') +
+      row('Effect', valence) +
+      row('Weights applied', evt.applied ? 'yes' : 'pending (run improve with this session)') +
+      row('Time', evt.time) +
+      (evt.feedback_text ? heading('Feedback') + '<div class="mm-panel-text">' + esc(trunc(evt.feedback_text, 400)) + '</div>' : '') +
+      row('Elements touched', (evt.node_ids || []).length) +
+      (counts ? heading('Touched by stage') + counts : '')
     );
   }
 

--- a/cognee/modules/visualization/views/memory_map.js
+++ b/cognee/modules/visualization/views/memory_map.js
@@ -542,8 +542,10 @@
     L.groups.forEach(function (g) { g.memberIds.forEach(function (id) { entSet.add(id); }); });
     const nEnt = entSet.size;
     const nChunks = Object.keys(L.cellRect).length;
+    const nCtx = L.ctxBoxes.length;
     const base = docsP.length + ' documents · ' + nChunks + ' chunks · ' +
-      nEnt + ' entities · ' + sumsP.length + ' summaries';
+      nEnt + ' entities · ' + sumsP.length + ' summaries' +
+      (nCtx ? ' · ' + nCtx + ' context' : '');
     if (activeSearch) {
       el.textContent = base + ' — spotlighting retrieval: “' + trunc(activeSearch.question || '', 60) + '”';
     } else if (visibleSet) {

--- a/cognee/modules/visualization/views/memory_map.js
+++ b/cognee/modules/visualization/views/memory_map.js
@@ -1,0 +1,844 @@
+// Memory-map view (STEP 2).
+//
+// A deterministic column map of cognee memory: Documents (with ordered chunk
+// cells) → Entity-type groups (collapse-behind-count) → Summaries → Global
+// context, plus a run/search timeline rail and a search-retrieval overlay.
+//
+// Layout is a pure function of the sorted __MEMORY_DATA__ payload — no force
+// simulation, no randomness. Timeline scrubbing and the search overlay only
+// toggle classes/opacity; positions are never touched (layout-once rule).
+// Node/link details are read from window._vizNodeById / window._vizLinks,
+// which story_view.js exposes (the slim payload carries structure only).
+(function () {
+  'use strict';
+  const memoryMap = __MEMORY_DATA__;
+  const searchEvents = __SEARCH_EVENTS__;
+
+  const MM = memoryMap || {};
+  const docsP = MM.documents || [];
+  const orphansP = MM.orphan_chunks || [];
+  const groupsP = MM.entity_groups || [];
+  const ungroupedP = MM.ungrouped_entities || [];
+  const sumsP = MM.summaries || [];
+  const ctxP = MM.context || null;
+  const edgesP = MM.edges || {};
+  const timelineP = MM.timeline || [];
+
+  // ── Helpers ──────────────────────────────────────────────────────
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+  function trunc(s, n) {
+    s = String(s == null ? '' : s);
+    return s.length > n ? s.slice(0, n - 1) + '…' : s;
+  }
+  function fmtT(ms) {
+    if (!ms) return '';
+    try {
+      return new Date(ms).toLocaleString(undefined, {
+        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+      });
+    } catch (e) { return String(ms); }
+  }
+  function nodeOf(id) { return (window._vizNodeById && window._vizNodeById[id]) || { id: id }; }
+  function nameOf(id) { return nodeOf(id).name || String(id); }
+  function stageOf(id) { return nodeOf(id).stage || 'other'; }
+  function linkAt(pos) { return (window._vizLinks && window._vizLinks[pos]) || null; }
+  function endId(v) { return (typeof v === 'object' && v) ? (v.id || '') : v; }
+  function bez(a, b) {
+    const mx = (a.x + b.x) / 2;
+    return 'M' + a.x + ',' + a.y + ' C' + mx + ',' + a.y + ' ' + mx + ',' + b.y + ' ' + b.x + ',' + b.y;
+  }
+
+  // ── Geometry constants (deterministic layout) ────────────────────
+  const DOC_W = 250, DOC_HEAD = 30, CELL_H = 26, DOC_PAD = 8, DOC_GAP = 18;
+  const ENT_W = 216, ROW_H = 19, GRP_HEAD = 24, PILL_H = 20, GRP_PAD = 6, GRP_GAP = 16, ENT_COL_GAP = 26;
+  const SUM_W = 230, SUM_H = 48, SUM_GAP = 10;
+  const CTX_W = 230, BAND_GAP = 120, TARGET_COL_H = 1700;
+
+  // ── View state ───────────────────────────────────────────────────
+  let built = false;
+  let svgSel = null, rootSel = null, gOverlay = null, zoomBehavior = null;
+  let L = null;                 // layout
+  let unitEls = {};             // node id -> [unit <g> elements]
+  let edgeEls = [];             // {kind, s, t, el}
+  let edgeByObjId = {};         // edge_object_id -> [path elements]
+  let groupByMember = {};       // collapsed entity id -> group layout (for promote)
+  let entityGroupName = {};     // entity id -> type name
+  let chunkEntities = {}, entityChunks = {}, entitySemantic = {}, summariesByChunk = {};
+  let railItems = [], currentRunIdx = -1, visibleSet = null, activeSearch = null;
+  let selection = null;
+
+  // ── Layout (pure function of the payload arrays) ─────────────────
+  function computeLayout() {
+    const lay = {
+      docs: [], cellRect: {}, groups: [], entityAnchor: {}, sums: [],
+      ctxBoxes: [], ctxEmpty: null, bands: [], width: 0, height: 0,
+    };
+
+    // Documents column (+ pseudo-doc for orphan chunks).
+    const docDefs = docsP.map(function (d) { return { id: d.id, name: d.name, chunks: d.chunks, pseudo: false }; });
+    if (orphansP.length) {
+      docDefs.push({
+        id: '__orphans__', name: 'Unattributed chunks', pseudo: true,
+        chunks: orphansP.map(function (cid) { return { id: cid, chunk_index: null }; }),
+      });
+    }
+    let dy = 0;
+    docDefs.forEach(function (d) {
+      const h = DOC_HEAD + Math.max(1, d.chunks.length) * CELL_H + DOC_PAD;
+      const doc = { id: d.id, name: d.name, pseudo: d.pseudo, x: 0, y: dy, w: DOC_W, h: h, cells: [] };
+      d.chunks.forEach(function (c, i) {
+        const cell = {
+          id: c.id, index: c.chunk_index,
+          x: DOC_PAD, y: dy + DOC_HEAD + i * CELL_H, w: DOC_W - 2 * DOC_PAD, h: CELL_H - 4,
+        };
+        doc.cells.push(cell);
+        lay.cellRect[c.id] = cell;
+      });
+      lay.docs.push(doc);
+      dy += h + DOC_GAP;
+    });
+    const docColH = dy;
+
+    // Entity band: type groups in balanced sub-columns (sequential fill —
+    // deterministic given the sorted payload). Empty groups are skipped.
+    const groupDefs = groupsP
+      .filter(function (g) { return g.members.length > 0; })
+      .map(function (g) { return { type_id: g.type_id, type_name: g.type_name, members: g.members, pseudo: false }; });
+    if (ungroupedP.length) {
+      groupDefs.push({
+        type_id: '__ungrouped__', type_name: 'Other entities', pseudo: true,
+        members: ungroupedP.map(function (id, i) { return { id: id, important: i < 8 }; }),
+      });
+    }
+    const heights = groupDefs.map(function (g) {
+      const vis = g.members.filter(function (m) { return m.important; }).length;
+      const hidden = g.members.length - vis;
+      return GRP_HEAD + vis * ROW_H + (hidden ? PILL_H : 0) + GRP_PAD;
+    });
+    const totalH = heights.reduce(function (a, b) { return a + b + GRP_GAP; }, 0);
+    const nCols = Math.min(4, Math.max(1, Math.ceil(totalH / TARGET_COL_H)));
+    const colTarget = totalH / nCols;
+    const ENT_X0 = DOC_W + BAND_GAP;
+    let col = 0, cy = 0, entColH = 0;
+    groupDefs.forEach(function (g, gi) {
+      const h = heights[gi];
+      if (cy > 0 && cy + h / 2 > colTarget && col < nCols - 1) { col++; cy = 0; }
+      const gx = ENT_X0 + col * (ENT_W + ENT_COL_GAP);
+      const grp = {
+        type_id: g.type_id, type_name: g.type_name, pseudo: g.pseudo,
+        x: gx, y: cy, w: ENT_W, h: h, rows: [], pill: null,
+        memberIds: g.members.map(function (m) { return m.id; }), hiddenIds: [],
+      };
+      let ry = cy + GRP_HEAD;
+      g.members.forEach(function (m) {
+        if (m.important) {
+          const row = { id: m.id, x: gx + 6, y: ry, w: ENT_W - 12, h: ROW_H - 2 };
+          grp.rows.push(row);
+          lay.entityAnchor[m.id] = { lx: gx, rx: gx + ENT_W, cx: gx + ENT_W / 2, y: ry + ROW_H / 2 };
+          ry += ROW_H;
+        } else {
+          grp.hiddenIds.push(m.id);
+        }
+      });
+      if (grp.hiddenIds.length) {
+        grp.pill = { x: gx + 6, y: ry, w: ENT_W - 12, h: PILL_H - 4, count: grp.hiddenIds.length };
+        grp.hiddenIds.forEach(function (id) {
+          lay.entityAnchor[id] = { lx: gx, rx: gx + ENT_W, cx: gx + ENT_W / 2, y: ry + PILL_H / 2 };
+          groupByMember[id] = grp;
+        });
+      }
+      g.members.forEach(function (m) { entityGroupName[m.id] = g.type_name; });
+      lay.groups.push(grp);
+      cy += h + GRP_GAP;
+      entColH = Math.max(entColH, cy);
+    });
+    const entBandW = groupDefs.length ? nCols * (ENT_W + ENT_COL_GAP) - ENT_COL_GAP : 0;
+
+    // Summaries: y = mean of source chunk cell centers, collision-resolved
+    // by a stable downward sweep in payload order.
+    const SUM_X = ENT_X0 + (entBandW || ENT_W) + BAND_GAP;
+    let prevBottom = -Infinity;
+    sumsP.forEach(function (s) {
+      const ys = s.chunk_ids
+        .map(function (cid) { return lay.cellRect[cid]; })
+        .filter(Boolean)
+        .map(function (r) { return r.y + r.h / 2; });
+      const desired = ys.length
+        ? ys.reduce(function (a, b) { return a + b; }, 0) / ys.length - SUM_H / 2
+        : (prevBottom === -Infinity ? 0 : prevBottom + SUM_GAP);
+      const y = Math.max(desired, prevBottom + SUM_GAP);
+      lay.sums.push({ id: s.id, chunk_ids: s.chunk_ids, bucket_id: s.bucket_id, x: SUM_X, y: y, w: SUM_W, h: SUM_H });
+      prevBottom = y + SUM_H;
+    });
+    const sumColH = prevBottom === -Infinity ? 0 : prevBottom;
+
+    // Global context band: bucket cards in payload order, or the mandatory
+    // empty state when no GlobalContextSummary exists (the demo case).
+    const CTX_X = SUM_X + SUM_W + BAND_GAP;
+    let ctxColH = 0;
+    if (ctxP && ctxP.buckets && ctxP.buckets.length) {
+      let by = 0;
+      ctxP.buckets.forEach(function (b) {
+        const isRoot = ctxP.root_id != null && b.id === ctxP.root_id;
+        lay.ctxBoxes.push({
+          id: b.id, level: b.level, isRoot: isRoot,
+          child_ids: b.child_ids || [], x: CTX_X, y: by, w: CTX_W, h: 44,
+        });
+        by += 44 + 10;
+      });
+      ctxColH = by;
+    } else {
+      lay.ctxEmpty = { x: CTX_X, y: 0, w: CTX_W, h: 110 };
+      ctxColH = 110;
+    }
+
+    lay.bands = [
+      { x: 0, w: DOC_W, label: 'Documents', sub: docsP.length + (orphansP.length ? ' + orphans' : '') },
+      { x: ENT_X0, w: entBandW || ENT_W, label: 'Entities', sub: String(groupDefs.length) + ' types' },
+      { x: SUM_X, w: SUM_W, label: 'Summaries', sub: String(sumsP.length) },
+      { x: CTX_X, w: CTX_W, label: 'Global context', sub: ctxP ? String((ctxP.buckets || []).length) : 'none yet' },
+    ];
+    lay.width = CTX_X + CTX_W;
+    lay.height = Math.max(docColH, entColH, sumColH, ctxColH);
+    return lay;
+  }
+
+  // ── Adjacency (for detail panels), from the structural edge index ─
+  function buildAdjacency() {
+    (edgesP.contains || []).forEach(function (pos) {
+      const l = linkAt(pos); if (!l) return;
+      const s = endId(l.source), t = endId(l.target);
+      const c = stageOf(s) === 'chunk' ? s : (stageOf(t) === 'chunk' ? t : null);
+      const e = stageOf(s) === 'entity' ? s : (stageOf(t) === 'entity' ? t : null);
+      if (!c || !e) return;
+      (chunkEntities[c] = chunkEntities[c] || []).push(e);
+      (entityChunks[e] = entityChunks[e] || []).push(c);
+    });
+    (edgesP.semantic || []).forEach(function (pos) {
+      const l = linkAt(pos); if (!l) return;
+      const s = endId(l.source), t = endId(l.target);
+      (entitySemantic[s] = entitySemantic[s] || []).push({ rel: l.relation, other: t });
+      (entitySemantic[t] = entitySemantic[t] || []).push({ rel: l.relation, other: s });
+    });
+    sumsP.forEach(function (s) {
+      s.chunk_ids.forEach(function (cid) {
+        (summariesByChunk[cid] = summariesByChunk[cid] || []).push(s.id);
+      });
+    });
+  }
+
+  // ── SVG build ─────────────────────────────────────────────────────
+  function registerUnit(nid, el) { (unitEls[nid] = unitEls[nid] || []).push(el); }
+
+  function makeUnit(parent, classes, nid, kind) {
+    const g = parent.append('g').attr('class', classes);
+    if (nid) {
+      g.attr('data-nid', nid);
+      registerUnit(nid, g.node());
+    }
+    if (kind) {
+      g.on('click', function (event) {
+        event.stopPropagation();
+        select(kind, nid, this);
+      });
+    }
+    return g;
+  }
+
+  function buildSvg() {
+    const svg = d3.select('#memory-svg');
+    svg.selectAll('*').remove();
+    svgSel = svg;
+    const root = svg.append('g');
+    rootSel = root;
+    const gSem = root.append('g');
+    const gEdge = root.append('g');
+    const gMain = root.append('g');
+    gOverlay = root.append('g');
+
+    // Band headers.
+    L.bands.forEach(function (b) {
+      root.append('text').attr('class', 'mm-band-header').attr('x', b.x).attr('y', -34).text(b.label);
+      root.append('text').attr('class', 'mm-band-sub').attr('x', b.x).attr('y', -20).text(b.sub);
+    });
+
+    // Documents with ordered chunk cells.
+    L.docs.forEach(function (doc) {
+      const gDoc = gMain.append('g').attr('class', 'mm-doc');
+      const head = makeUnit(gDoc, 'mm-unit mm-doc-head' + (doc.pseudo ? '' : ' mm-node'),
+        doc.pseudo ? null : doc.id, doc.pseudo ? null : 'document');
+      head.append('rect').attr('class', 'mm-frame')
+        .attr('x', doc.x).attr('y', doc.y).attr('width', doc.w).attr('height', doc.h).attr('rx', 8);
+      head.append('text').attr('class', 'mm-title')
+        .attr('x', doc.x + 10).attr('y', doc.y + 19).text(trunc(doc.name, 26));
+      head.append('text').attr('class', 'mm-count')
+        .attr('x', doc.x + doc.w - 10).attr('y', doc.y + 19).attr('text-anchor', 'end')
+        .text(doc.cells.length);
+      doc.cells.forEach(function (cell) {
+        const n = nodeOf(cell.id);
+        const gc = makeUnit(gDoc, 'mm-unit mm-node mm-cell', cell.id, 'chunk');
+        gc.append('rect').attr('class', 'mm-box')
+          .attr('x', cell.x).attr('y', cell.y).attr('width', cell.w).attr('height', cell.h).attr('rx', 4);
+        const label = (cell.index != null ? '#' + cell.index + ' ' : '') + trunc(n.text || n.name || cell.id, 30);
+        gc.append('text').attr('x', cell.x + 7).attr('y', cell.y + cell.h / 2 + 4).text(label);
+      });
+    });
+
+    // Entity-type groups with collapse-behind-count pills.
+    L.groups.forEach(function (grp) {
+      const gG = gMain.append('g').attr('class', 'mm-group');
+      const head = makeUnit(gG, 'mm-unit mm-group-head' + (grp.pseudo ? '' : ' mm-node'),
+        grp.pseudo ? null : grp.type_id, grp.pseudo ? null : 'group');
+      head.append('rect').attr('class', 'mm-frame')
+        .attr('x', grp.x).attr('y', grp.y).attr('width', grp.w).attr('height', grp.h).attr('rx', 7);
+      head.append('text').attr('class', 'mm-title')
+        .attr('x', grp.x + 9).attr('y', grp.y + 16).text(trunc(grp.type_name, 22));
+      head.append('text').attr('class', 'mm-count')
+        .attr('x', grp.x + grp.w - 9).attr('y', grp.y + 16).attr('text-anchor', 'end')
+        .text(grp.memberIds.length);
+      grp.rows.forEach(function (row) {
+        const gr = makeUnit(gG, 'mm-unit mm-node mm-row', row.id, 'entity');
+        gr.append('rect').attr('class', 'mm-box')
+          .attr('x', row.x).attr('y', row.y).attr('width', row.w).attr('height', row.h).attr('rx', 3);
+        gr.append('circle').attr('class', 'mm-dot')
+          .attr('cx', row.x + 7).attr('cy', row.y + row.h / 2).attr('r', 2.5);
+        gr.append('text').attr('x', row.x + 15).attr('y', row.y + row.h / 2 + 4)
+          .text(trunc(nameOf(row.id), 26));
+      });
+      if (grp.pill) {
+        const gp = gG.append('g').attr('class', 'mm-unit mm-node mm-pill');
+        // Pseudo groups ('Other entities') have no graph node — never tie
+        // them to timeline visibility.
+        if (!grp.pseudo) {
+          gp.attr('data-nid', grp.type_id);
+          registerUnit(grp.type_id, gp.node());
+        }
+        gp.on('click', function (event) { event.stopPropagation(); openGroupPanel(grp); });
+        gp.append('rect').attr('class', 'mm-box')
+          .attr('x', grp.pill.x).attr('y', grp.pill.y).attr('width', grp.pill.w).attr('height', grp.pill.h).attr('rx', 8);
+        gp.append('text').attr('x', grp.pill.x + grp.pill.w / 2).attr('y', grp.pill.y + grp.pill.h / 2 + 3.5)
+          .attr('text-anchor', 'middle').text('+' + grp.pill.count + ' more');
+      }
+    });
+
+    // Summaries.
+    L.sums.forEach(function (s) {
+      const n = nodeOf(s.id);
+      const gs = makeUnit(gMain, 'mm-unit mm-node mm-sum', s.id, 'summary');
+      gs.append('rect').attr('class', 'mm-box')
+        .attr('x', s.x).attr('y', s.y).attr('width', s.w).attr('height', s.h).attr('rx', 7);
+      gs.append('text').attr('class', 'mm-sub')
+        .attr('x', s.x + 9).attr('y', s.y + 16).text('Summary');
+      gs.append('text').attr('x', s.x + 9).attr('y', s.y + 33).text(trunc(n.text || n.name || s.id, 32));
+    });
+
+    // Global context band — bucket cards or the dashed empty state.
+    if (L.ctxEmpty) {
+      const ge = gMain.append('g').attr('class', 'mm-ctx-empty');
+      ge.append('rect').attr('x', L.ctxEmpty.x).attr('y', L.ctxEmpty.y)
+        .attr('width', L.ctxEmpty.w).attr('height', L.ctxEmpty.h).attr('rx', 8);
+      ['No global context yet.', 'Global-context indexing runs', 'will appear here.'].forEach(function (line, i) {
+        ge.append('text').attr('x', L.ctxEmpty.x + L.ctxEmpty.w / 2).attr('y', L.ctxEmpty.y + 40 + i * 16)
+          .attr('text-anchor', 'middle').text(line);
+      });
+    }
+    L.ctxBoxes.forEach(function (b) {
+      const gb = makeUnit(gMain, 'mm-unit mm-node mm-sum', b.id, 'bucket');
+      gb.append('rect').attr('class', 'mm-box')
+        .attr('x', b.x).attr('y', b.y).attr('width', b.w).attr('height', b.h).attr('rx', 7);
+      gb.append('text').attr('class', 'mm-sub')
+        .attr('x', b.x + 9).attr('y', b.y + 16)
+        .text(b.isRoot ? 'Context root' : 'Bucket' + (b.level != null ? ' · level ' + b.level : ''));
+      gb.append('text').attr('x', b.x + 9).attr('y', b.y + 33).text(trunc(nameOf(b.id), 30));
+    });
+
+    buildEdges(gSem, gEdge);
+  }
+
+  function buildEdges(gSem, gEdge) {
+    const cellRight = function (id) {
+      const r = L.cellRect[id]; return r ? { x: r.x + r.w, y: r.y + r.h / 2 } : null;
+    };
+    const entLeft = function (id) {
+      const a = L.entityAnchor[id]; return a ? { x: a.lx, y: a.y } : null;
+    };
+    const sumRect = {};
+    L.sums.forEach(function (s) { sumRect[s.id] = s; });
+    const ctxRect = {};
+    L.ctxBoxes.forEach(function (b) { ctxRect[b.id] = b; });
+    const leftOf = function (r) { return { x: r.x, y: r.y + r.h / 2 }; };
+    const rightOf = function (r) { return { x: r.x + r.w, y: r.y + r.h / 2 }; };
+
+    function addEdge(parent, kind, pos, a, b, d) {
+      if (!a || !b) return;
+      const l = linkAt(pos);
+      const el = parent.append('path')
+        .attr('class', 'mm-edge mm-edge-' + kind)
+        .attr('d', d || bez(a, b))
+        .node();
+      const s = l ? endId(l.source) : null, t = l ? endId(l.target) : null;
+      edgeEls.push({ kind: kind, s: s, t: t, el: el });
+      const oid = l && l.edge_info && l.edge_info.edge_object_id;
+      if (oid) (edgeByObjId[oid] = edgeByObjId[oid] || []).push(el);
+    }
+
+    (edgesP.contains || []).forEach(function (pos) {
+      const l = linkAt(pos); if (!l) return;
+      const s = endId(l.source), t = endId(l.target);
+      const c = L.cellRect[s] ? s : (L.cellRect[t] ? t : null);
+      const e = L.entityAnchor[s] ? s : (L.entityAnchor[t] ? t : null);
+      if (c && e) addEdge(gEdge, 'contains', pos, cellRight(c), entLeft(e));
+    });
+    (edgesP.made_from || []).forEach(function (pos) {
+      const l = linkAt(pos); if (!l) return;
+      const s = endId(l.source), t = endId(l.target);
+      const su = sumRect[s] ? s : (sumRect[t] ? t : null);
+      const c = L.cellRect[s] ? s : (L.cellRect[t] ? t : null);
+      if (su && c) addEdge(gEdge, 'made_from', pos, cellRight(c), leftOf(sumRect[su]));
+    });
+    (edgesP.summarized_in || []).forEach(function (pos) {
+      const l = linkAt(pos); if (!l) return;
+      const s = endId(l.source), t = endId(l.target);
+      const child = sumRect[s] ? sumRect[s] : ctxRect[s];
+      const parent = ctxRect[t];
+      if (child && parent) addEdge(gEdge, 'summarized_in', pos, rightOf(child), leftOf(parent));
+    });
+    (edgesP.semantic || []).forEach(function (pos) {
+      const l = linkAt(pos); if (!l) return;
+      const a = L.entityAnchor[endId(l.source)], b = L.entityAnchor[endId(l.target)];
+      if (!a || !b) return;
+      let d;
+      if (Math.abs(a.cx - b.cx) > 1) {
+        const from = a.cx < b.cx ? { x: a.rx, y: a.y } : { x: a.lx, y: a.y };
+        const to = a.cx < b.cx ? { x: b.lx, y: b.y } : { x: b.rx, y: b.y };
+        d = bez(from, to);
+      } else {
+        const bow = Math.min(46, 14 + Math.abs(a.y - b.y) / 18);
+        const x = a.lx - bow;
+        d = 'M' + a.lx + ',' + a.y + ' C' + x + ',' + a.y + ' ' + x + ',' + b.y + ' ' + b.lx + ',' + b.y;
+      }
+      addEdge(gSem, 'semantic', pos, { x: 0, y: 0 }, { x: 0, y: 0 }, d);
+    });
+  }
+
+  // ── Pan / zoom (schema_view pattern) ─────────────────────────────
+  function panelOffset() {
+    const panel = document.getElementById('memory-side-panel');
+    return panel && panel.style.display === 'block' ? (panel.offsetWidth || 344) : 0;
+  }
+
+  function fitView(animate) {
+    if (!svgSel || !rootSel || !zoomBehavior) return;
+    const node = svgSel.node();
+    const W = node.clientWidth || node.getBoundingClientRect().width || 1200;
+    const H = node.clientHeight || node.getBoundingClientRect().height || 700;
+    const avail = Math.max(240, W - panelOffset());
+    let bbox;
+    try { bbox = rootSel.node().getBBox(); } catch (e) { return; }
+    const pad = 44;
+    const bw = bbox.width || 1, bh = bbox.height || 1;
+    const scale = Math.max(0.05, Math.min((avail - pad * 2) / bw, (H - pad * 2) / bh, 1.5));
+    const tx = pad + (avail - pad * 2 - bw * scale) / 2 - bbox.x * scale;
+    const ty = pad + (H - pad * 2 - bh * scale) / 2 - bbox.y * scale;
+    const t = d3.zoomIdentity.translate(tx, ty).scale(scale);
+    (animate ? svgSel.transition().duration(420) : svgSel).call(zoomBehavior.transform, t);
+  }
+
+  function wireZoom(savedTransform) {
+    zoomBehavior = d3.zoom()
+      .scaleExtent([0.04, 3])
+      .on('start', function () { svgSel.classed('is-panning', true); })
+      .on('zoom', function (event) { rootSel.attr('transform', event.transform); })
+      .on('end', function () { svgSel.classed('is-panning', false); });
+    svgSel.call(zoomBehavior).on('dblclick.zoom', null);
+    if (savedTransform) svgSel.call(zoomBehavior.transform, savedTransform);
+    else fitView(false);
+    svgSel.on('click', function () { clearAll(); });
+  }
+
+  // ── Timeline rail ─────────────────────────────────────────────────
+  function buildRail() {
+    railItems = timelineP.map(function (e) { return { kind: 'run', t: e.t0 || 0, run: e }; })
+      .concat((searchEvents || []).map(function (s) {
+        return { kind: 'search', t: Date.parse(s.time) || 0, search: s };
+      }))
+      .sort(function (a, b) { return a.t - b.t || (a.kind === b.kind ? 0 : a.kind === 'run' ? -1 : 1); });
+
+    const rail = document.getElementById('memory-timeline');
+    rail.innerHTML = '';
+    const lbl = document.createElement('span');
+    lbl.className = 'mm-rail-label';
+    lbl.textContent = 'Timeline';
+    rail.appendChild(lbl);
+    railItems.forEach(function (item, i) {
+      const btn = document.createElement('button');
+      btn.className = 'mm-rail-item' + (item.kind === 'search' ? ' mm-rail-search' : '');
+      if (item.kind === 'run') {
+        btn.innerHTML = '<span>' + esc(trunc(item.run.label, 20)) + '</span>' +
+          '<span class="t">' + esc(fmtT(item.run.t0)) + ' · ' + item.run.node_count + ' nodes</span>';
+        btn.title = 'Show memory state after this run';
+        btn.addEventListener('click', function () { applyRun(item.run.index, i); openRunPanel(item.run); });
+      } else {
+        btn.innerHTML = '<span>⌕ ' + esc(trunc(item.search.question || 'search', 24)) + '</span>' +
+          '<span class="t">' + esc(item.search.time || '') + '</span>';
+        btn.title = item.search.question || '';
+        btn.addEventListener('click', function () { applySearch(item.search, i); });
+      }
+      btn.dataset.rail = String(i);
+      rail.appendChild(btn);
+    });
+  }
+
+  function setActiveRail(i) {
+    document.querySelectorAll('#memory-timeline .mm-rail-item').forEach(function (el) {
+      el.classList.toggle('active', el.dataset.rail === String(i));
+    });
+  }
+
+  function railIndexOfRun(runIdx) {
+    for (let i = 0; i < railItems.length; i++) {
+      if (railItems[i].kind === 'run' && railItems[i].run.index === runIdx) return i;
+    }
+    return -1;
+  }
+
+  // ── Visibility (timeline scrub): classes only, never positions ────
+  function applyRun(runIdx, railIdx) {
+    clearSearch();
+    currentRunIdx = runIdx;
+    if (!timelineP.length || runIdx >= timelineP.length - 1) {
+      visibleSet = null;  // latest event = full current state
+    } else {
+      visibleSet = new Set();
+      timelineP.forEach(function (e) {
+        if (e.index <= runIdx) e.node_ids.forEach(function (id) { visibleSet.add(id); });
+      });
+    }
+    applyVisibility();
+    setActiveRail(railIdx != null ? railIdx : railIndexOfRun(runIdx));
+    updateStatus();
+  }
+
+  function isVisible(id) { return !visibleSet || visibleSet.has(id); }
+
+  function applyVisibility() {
+    Object.keys(unitEls).forEach(function (nid) {
+      const vis = isVisible(nid);
+      unitEls[nid].forEach(function (el) { el.classList.toggle('mm-future', !vis); });
+    });
+    edgeEls.forEach(function (e) {
+      const vis = (e.s == null || isVisible(e.s)) && (e.t == null || isVisible(e.t));
+      e.el.classList.toggle('mm-future', !vis);
+    });
+  }
+
+  function updateStatus() {
+    const el = document.getElementById('memory-status');
+    if (!el || !L) return;
+    const entSet = new Set();
+    L.groups.forEach(function (g) { g.memberIds.forEach(function (id) { entSet.add(id); }); });
+    const nEnt = entSet.size;
+    const nChunks = Object.keys(L.cellRect).length;
+    const base = docsP.length + ' documents · ' + nChunks + ' chunks · ' +
+      nEnt + ' entities · ' + sumsP.length + ' summaries';
+    if (activeSearch) {
+      el.textContent = base + ' — spotlighting retrieval: “' + trunc(activeSearch.question || '', 60) + '”';
+    } else if (visibleSet) {
+      const run = timelineP[currentRunIdx] || {};
+      el.textContent = base + ' — state as of ' + (run.label || 'run') + ' (' + fmtT(run.t1) + '), ' +
+        visibleSet.size + ' elements';
+    } else {
+      el.textContent = base + ' — current state';
+    }
+  }
+
+  // ── Search overlay: dim + spotlight on the SAME positions ────────
+  function applySearch(evt, railIdx) {
+    clearSearch();
+    visibleSet = null;
+    applyVisibility();
+    activeSearch = evt;
+    svgSel.classed('mm-searching', true);
+    const spot = new Set(evt.node_ids || []);
+    spot.forEach(function (id) {
+      (unitEls[id] || []).forEach(function (el) { el.classList.add('is-spotlit'); });
+      if (!unitEls[id] && groupByMember[id]) promoteCollapsed(id);
+    });
+    // Retrieved edges: join edge_ids on edge_object_id; provenance trail =
+    // structural edges whose both endpoints were retrieved.
+    (evt.edge_ids || []).forEach(function (oid) {
+      (edgeByObjId[oid] || []).forEach(function (el) { el.classList.add('is-spotlit-edge'); });
+    });
+    edgeEls.forEach(function (e) {
+      if (e.s != null && e.t != null && spot.has(e.s) && spot.has(e.t) &&
+          !e.el.classList.contains('is-spotlit-edge')) {
+        e.el.classList.add('is-trail');
+      }
+    });
+    setActiveRail(railIdx);
+    openSearchPanel(evt);
+    updateStatus();
+  }
+
+  // A collapsed retrieved entity is temporarily promoted out of its "+K"
+  // pill into an overlay slot below its group — nothing else moves.
+  let promotedCount = {};
+  function promoteCollapsed(id) {
+    const grp = groupByMember[id];
+    const i = promotedCount[grp.type_id] = (promotedCount[grp.type_id] || 0) + 1;
+    const y = grp.y + grp.h + 2 + (i - 1) * ROW_H;
+    const gr = gOverlay.append('g').attr('class', 'mm-unit mm-node mm-row is-spotlit');
+    gr.append('rect').attr('class', 'mm-box')
+      .attr('x', grp.x + 6).attr('y', y).attr('width', grp.w - 12).attr('height', ROW_H - 2).attr('rx', 3);
+    gr.append('circle').attr('class', 'mm-dot').attr('cx', grp.x + 13).attr('cy', y + ROW_H / 2 - 1).attr('r', 2.5);
+    gr.append('text').attr('x', grp.x + 21).attr('y', y + ROW_H / 2 + 3).text(trunc(nameOf(id), 26));
+    gr.on('click', function (event) { event.stopPropagation(); select('entity', id, this); });
+  }
+
+  function clearSearch() {
+    activeSearch = null;
+    if (svgSel) svgSel.classed('mm-searching', false);
+    document.querySelectorAll('#memory-svg .is-spotlit').forEach(function (el) { el.classList.remove('is-spotlit'); });
+    document.querySelectorAll('#memory-svg .is-spotlit-edge').forEach(function (el) { el.classList.remove('is-spotlit-edge'); });
+    document.querySelectorAll('#memory-svg .is-trail').forEach(function (el) { el.classList.remove('is-trail'); });
+    if (gOverlay) gOverlay.selectAll('*').remove();
+    promotedCount = {};
+  }
+
+  function clearAll() {
+    clearSearch();
+    clearSelection();
+    hidePanel();
+    if (currentRunIdx >= 0) applyRun(currentRunIdx);
+    updateStatus();
+  }
+
+  // ── Selection + detail panel ──────────────────────────────────────
+  function clearSelection() {
+    selection = null;
+    document.querySelectorAll('#memory-svg .is-selected').forEach(function (el) { el.classList.remove('is-selected'); });
+  }
+
+  function select(kind, id, el) {
+    clearSelection();
+    selection = { kind: kind, id: id };
+    if (el) el.classList.add('is-selected');
+    else (unitEls[id] || []).forEach(function (e) { e.classList.add('is-selected'); });
+    const fn = {
+      document: openDocumentPanel, chunk: openChunkPanel, entity: openEntityPanel,
+      summary: openSummaryPanel, bucket: openBucketPanel,
+      group: function (gid) {
+        const grp = L.groups.find(function (g) { return g.type_id === gid; });
+        if (grp) openGroupPanel(grp);
+      },
+    }[kind];
+    if (fn) fn(id);
+  }
+
+  function selectNodeById(id) {
+    const kindByStage = { document: 'document', chunk: 'chunk', entity: 'entity', summary: 'summary', context: 'bucket', type: 'group' };
+    const kind = kindByStage[stageOf(id)];
+    if (kind) select(kind, id, (unitEls[id] || [])[0] || null);
+  }
+
+  const panelEl = function () { return document.getElementById('memory-side-panel'); };
+  function showPanel(html) {
+    const p = panelEl();
+    p.innerHTML = '<div class="si-close" title="Close">×</div>' + html;
+    p.style.display = 'block';
+    p.querySelector('.si-close').addEventListener('click', function () { hidePanel(); clearSelection(); });
+    p.querySelectorAll('[data-goto]').forEach(function (chip) {
+      chip.addEventListener('click', function () { selectNodeById(chip.dataset.goto); });
+    });
+  }
+  function hidePanel() { const p = panelEl(); if (p) p.style.display = 'none'; }
+
+  function row(k, v) {
+    if (v == null || v === '') return '';
+    return '<div class="panel-row"><span class="k">' + esc(k) + '</span><span class="v">' + esc(v) + '</span></div>';
+  }
+  function chips(ids, limit) {
+    const lim = limit || 24;
+    let html = '<div class="si-chips">';
+    ids.slice(0, lim).forEach(function (id) {
+      html += '<span class="si-chip si-chip-link" data-goto="' + esc(id) + '">' + esc(trunc(nameOf(id), 28)) + '</span>';
+    });
+    if (ids.length > lim) html += '<span class="si-more">+' + (ids.length - lim) + ' more</span>';
+    return html + '</div>';
+  }
+  function heading(t) { return '<div class="si-heading">' + esc(t) + '</div>'; }
+  function title(badge, name) {
+    return '<div class="si-count">' + esc(badge) + '</div><div class="si-title">' + esc(trunc(name, 60)) + '</div>';
+  }
+
+  function openDocumentPanel(id) {
+    const n = nodeOf(id);
+    const doc = L.docs.find(function (d) { return d.id === id; });
+    showPanel(
+      title('Document', n.name || id) +
+      row('MIME type', n.mime_type) +
+      row('Chunks', doc ? doc.cells.length : '') +
+      row('Created', fmtT(n.t_created)) +
+      row('Location', trunc(n.raw_data_location, 70))
+    );
+  }
+
+  function openChunkPanel(id) {
+    const n = nodeOf(id);
+    let doc = null;
+    L.docs.forEach(function (d) { if (d.cells.some(function (c) { return c.id === id; })) doc = d; });
+    const ents = chunkEntities[id] || [];
+    const sums = summariesByChunk[id] || [];
+    showPanel(
+      title('Chunk' + (n.chunk_index != null ? ' #' + n.chunk_index : ''), doc ? doc.name : (n.name || id)) +
+      (n.text ? '<div class="mm-panel-text">' + esc(trunc(n.text, 400)) + '</div>' : '') +
+      row('Size', n.chunk_size) +
+      row('Cut type', n.cut_type) +
+      row('Created', fmtT(n.t_created)) +
+      (ents.length ? heading('Entities (' + ents.length + ')') + chips(ents) : '') +
+      (sums.length ? heading('Summaries') + chips(sums) : '')
+    );
+  }
+
+  function openEntityPanel(id) {
+    const n = nodeOf(id);
+    const rels = entitySemantic[id] || [];
+    let relHtml = '';
+    if (rels.length) {
+      relHtml = heading('Relations (' + rels.length + ')');
+      rels.slice(0, 15).forEach(function (r) {
+        relHtml += '<div class="si-rel"><span class="si-rel-name">' + esc(trunc(r.rel, 26)) + '</span>' +
+          '<span class="si-rel-to si-chip-link" data-goto="' + esc(r.other) + '">' + esc(trunc(nameOf(r.other), 24)) + '</span></div>';
+      });
+      if (rels.length > 15) relHtml += '<div class="si-more">+' + (rels.length - 15) + ' more</div>';
+    }
+    const srcChunks = entityChunks[id] || [];
+    showPanel(
+      title(entityGroupName[id] || 'Entity', n.name || id) +
+      (n.description ? '<div class="mm-panel-text">' + esc(trunc(n.description, 320)) + '</div>' : '') +
+      row('Degree', n.degree) +
+      row('Created', fmtT(n.t_created)) +
+      (srcChunks.length ? heading('Source chunks') + chips(srcChunks) : '') +
+      relHtml
+    );
+  }
+
+  function openGroupPanel(grp) {
+    clearSelection();
+    showPanel(
+      title('Entity type', grp.type_name) +
+      row('Members', grp.memberIds.length) +
+      heading('Members') + chips(grp.memberIds, 40)
+    );
+  }
+
+  function openSummaryPanel(id) {
+    const n = nodeOf(id);
+    const s = L.sums.find(function (x) { return x.id === id; });
+    showPanel(
+      title('Summary', n.name || 'TextSummary') +
+      (n.text ? '<div class="mm-panel-text">' + esc(n.text) + '</div>' : '') +
+      row('Created', fmtT(n.t_created)) +
+      (s && s.chunk_ids.length ? heading('Source chunks') + chips(s.chunk_ids) : '') +
+      (s && s.bucket_id ? heading('Context bucket') + chips([s.bucket_id]) : '')
+    );
+  }
+
+  function openBucketPanel(id) {
+    const n = nodeOf(id);
+    const b = L.ctxBoxes.find(function (x) { return x.id === id; });
+    showPanel(
+      title(b && b.isRoot ? 'Context root' : 'Context bucket', n.name || id) +
+      (n.text ? '<div class="mm-panel-text">' + esc(trunc(n.text, 400)) + '</div>' : '') +
+      row('Level', b ? b.level : n.level) +
+      row('Children', b ? b.child_ids.length : '') +
+      (b && b.child_ids.length ? heading('Children') + chips(b.child_ids) : '')
+    );
+  }
+
+  function openRunPanel(run) {
+    const byStage = {};
+    (run.node_ids || []).forEach(function (id) {
+      const s = stageOf(id);
+      byStage[s] = (byStage[s] || 0) + 1;
+    });
+    let breakdown = '';
+    Object.keys(byStage).sort().forEach(function (s) { breakdown += row(s, byStage[s]); });
+    showPanel(
+      title('Run event', run.label) +
+      row('Started', fmtT(run.t0)) +
+      row('Finished', fmtT(run.t1)) +
+      row('Nodes added', run.node_count) +
+      heading('By stage') + breakdown
+    );
+  }
+
+  function openSearchPanel(evt) {
+    const byStage = {};
+    (evt.node_ids || []).forEach(function (id) {
+      const s = stageOf(id);
+      byStage[s] = (byStage[s] || 0) + 1;
+    });
+    let counts = '';
+    Object.keys(byStage).sort().forEach(function (s) { counts += row(s, byStage[s]); });
+    const chunksRetrieved = (evt.node_ids || []).filter(function (id) { return stageOf(id) === 'chunk'; });
+    showPanel(
+      title('Search', evt.question || '') +
+      (evt.answer ? heading('Answer') + '<div class="mm-panel-text">' + esc(trunc(evt.answer, 600)) + '</div>' : '') +
+      row('Time', evt.time) +
+      row('Retrieved elements', (evt.node_ids || []).length) +
+      row('Retrieved edges', (evt.edge_ids || []).length) +
+      (counts ? heading('Retrieved by stage') + counts : '') +
+      (chunksRetrieved.length ? heading('Retrieved chunks') + chips(chunksRetrieved) : '')
+    );
+  }
+
+  // ── Entry point (lazy, called by ui_chrome on tab click / theme) ──
+  window._renderMemoryView = function (preserveTransform) {
+    const view = document.getElementById('memory-view');
+    if (!view) return;
+    if (built) {
+      // Theme changes are pure CSS (everything reads --mm-* vars); the
+      // existing transform, selection and overlay all stay valid.
+      if (!preserveTransform) updateStatus();
+      return;
+    }
+    const isEmpty = !docsP.length && !orphansP.length && !groupsP.length &&
+      !ungroupedP.length && !sumsP.length;
+    const emptyEl = document.getElementById('memory-empty');
+    if (isEmpty) {
+      if (emptyEl) emptyEl.style.display = 'flex';
+      document.getElementById('memory-diagram-section').style.display = 'none';
+      document.getElementById('memory-zoom').style.display = 'none';
+      document.getElementById('memory-timeline').style.display = 'none';
+      built = true;
+      return;
+    }
+    if (emptyEl) emptyEl.style.display = 'none';
+
+    L = computeLayout();
+    buildAdjacency();
+    buildSvg();
+    buildRail();
+    wireZoom(null);
+
+    // Zoom pill.
+    const bind = function (id, fn) {
+      const el = document.getElementById(id);
+      if (el) el.addEventListener('click', fn);
+    };
+    bind('memory-zoom-in', function () { svgSel.transition().duration(180).call(zoomBehavior.scaleBy, 1.35); });
+    bind('memory-zoom-out', function () { svgSel.transition().duration(180).call(zoomBehavior.scaleBy, 1 / 1.35); });
+    bind('memory-zoom-fit', function () { fitView(true); });
+
+    // Default selection: the latest run event (full current state).
+    const lastRun = timelineP.length ? timelineP[timelineP.length - 1].index : -1;
+    if (lastRun >= 0) applyRun(lastRun);
+    else { visibleSet = null; updateStatus(); }
+
+    built = true;
+  };
+})();

--- a/cognee/modules/visualization/views/memory_map.py
+++ b/cognee/modules/visualization/views/memory_map.py
@@ -1,0 +1,20 @@
+"""Memory view: the memory-map tab.
+
+Reads the sibling ``memory_map.js`` chunk. The chunk carries the
+``__MEMORY_DATA__`` and ``__SEARCH_EVENTS__`` tokens that the orchestrator
+substitutes with the preprocessor's ``memory_map`` payload and the optional
+``search_events`` argument.
+
+STEP 1 ships a stub JS chunk (token wiring + a no-op
+``window._renderMemoryView``) so the orchestrator assembly is complete
+end-to-end; the deterministic-layout renderer lands in STEP 2.
+"""
+
+import os
+
+_JS_PATH = os.path.join(os.path.dirname(__file__), "memory_map.js")
+
+
+def emit_js(_preprocessed=None) -> str:
+    with open(_JS_PATH, "r", encoding="utf-8") as f:
+        return f.read()

--- a/cognee/modules/visualization/views/story_view.js
+++ b/cognee/modules/visualization/views/story_view.js
@@ -41,6 +41,12 @@ nodes.forEach(function(n){
 });
 var nodeMap={};
 nodes.forEach(function(n){nodeMap[n.id]=n});
+// Share node/link details with the Memory view (views/memory_map.js) so its
+// slim structural payload never re-embeds the node JSON. _vizLinks must be
+// the UNFILTERED array: the memory payload's edge index holds integer
+// positions into the links array exactly as the preprocessor emitted it.
+window._vizNodeById=nodeMap;
+window._vizLinks=links;
 links=links.filter(function(l){
   var s=typeof l.source==="object"?(l.source.id||l.source):l.source;
   var t=typeof l.target==="object"?(l.target.id||l.target):l.target;

--- a/cognee/modules/visualization/views/story_view.js
+++ b/cognee/modules/visualization/views/story_view.js
@@ -450,20 +450,33 @@ var nodesetCounts={};
 nodes.forEach(function(n){var s=n.source_node_set||"Unknown";nodesetCounts[s]=(nodesetCounts[s]||0)+1});
 var userCounts={};
 nodes.forEach(function(n){var u=n.source_user||"Unknown";userCounts[u]=(userCounts[u]||0)+1});
-var uniqueTasks=Object.keys(taskCounts).length;
-var uniquePipelines=Object.keys(pipeCounts).length;
-var uniqueNodesets=Object.keys(nodesetCounts).length;
-var uniqueUsers=Object.keys(userCounts).length;
+// "Unknown" is the absence of provenance, not a value — counting it produced
+// stats like "1 node sets" on graphs with no node sets at all.
+function countKnown(counts){return Object.keys(counts).filter(function(k){return k!=="Unknown"}).length}
+function pluralize(n,word){return n.toLocaleString()+" "+word+(n===1?"":"s")}
+var uniqueTasks=countKnown(taskCounts);
+var uniquePipelines=countKnown(pipeCounts);
+var uniqueNodesets=countKnown(nodesetCounts);
+var uniqueUsers=countKnown(userCounts);
 var statsEl=document.getElementById("stats");
 var perfTier=N>10000?"large":N>2000?"medium":"small";
-statsEl.innerHTML='<span><span class="dot" style="background:#6510F4"></span>'+N.toLocaleString()+" nodes</span>"+
-  '<span><span class="dot" style="background:#747470"></span>'+M.toLocaleString()+" edges</span>"+
-  '<span>'+Object.keys(typeCounts).length+" types</span>"+
-  '<span>'+uniqueTasks+" tasks</span>"+
-  '<span>'+uniquePipelines+" pipelines</span>"+
-  '<span>'+uniqueNodesets+" node sets</span>"+
-  '<span>'+uniqueUsers+" users</span>"+
+statsEl.innerHTML='<span><span class="dot" style="background:#6510F4"></span>'+pluralize(N,"node")+"</span>"+
+  '<span><span class="dot" style="background:#747470"></span>'+pluralize(M,"edge")+"</span>"+
+  '<span title="Distinct node classes: documents, chunks, entities, types, summaries">'+pluralize(Object.keys(typeCounts).length,"node kind")+"</span>"+
+  '<span>'+pluralize(uniqueTasks,"task")+"</span>"+
+  '<span>'+pluralize(uniquePipelines,"pipeline")+"</span>"+
+  '<span>'+pluralize(uniqueNodesets,"node set")+"</span>"+
+  '<span>'+pluralize(uniqueUsers,"user")+"</span>"+
   '<span style="opacity:0.5">['+perfTier+']</span>';
+
+// Color-by modes for provenance the dataset doesn't carry render the whole
+// graph as one "Unknown" gray — disable them with an explanation instead.
+[["nodeset",uniqueNodesets,"No node sets in this graph"],["user",uniqueUsers,"No user provenance in this graph"]]
+  .forEach(function(entry){
+    if(entry[1]>0)return;
+    var btn=document.querySelector('.ctrl-btn[data-colorby="'+entry[0]+'"]');
+    if(btn){btn.disabled=true;btn.title=entry[2]}
+  });
 
 // ── Legend ──
 var legendEl=document.getElementById("legend");
@@ -473,7 +486,16 @@ function updateLegend(){
   if(colorByMode==="type"){
     counts=typeCounts;
     entries=Object.keys(counts).sort(function(a,b){return counts[b]-counts[a]});
-    colorSource=function(t){return colorByType[t]||typeColors[t]||"#DBD8D8"};
+    // Sample the color actually drawn on a node of this type (skipping the
+    // ontology-valid override) so the legend can never diverge from the
+    // canvas — the JS palette and the preprocessor palette had drifted apart.
+    colorSource=function(t){
+      for(var i=0;i<nodes.length;i++){
+        var n=nodes[i];
+        if(n.type===t&&n.ontology_valid!==true&&n.color)return n.color;
+      }
+      return colorByType[t]||typeColors[t]||"#DBD8D8";
+    };
     sectionLabel="Node type";
   }else if(colorByMode==="task"){
     counts=taskCounts;
@@ -833,17 +855,64 @@ var searchMatches=new Set();
 
 // ── Search ──
 var searchInput=document.getElementById("search-input");
+var searchCountEl=document.getElementById("search-count");
+var searchMatchList=[];  // matches ordered by importance, for Enter-cycling
+var searchMatchIdx=-1;
+
+function updateSearchCount(){
+  if(!searchCountEl)return;
+  if(!searchQuery){searchCountEl.textContent="";return}
+  var n=searchMatchList.length;
+  if(!n){searchCountEl.textContent="no matches";return}
+  searchCountEl.textContent=searchMatchIdx>=0?((searchMatchIdx%n)+1)+" / "+n:n+(n===1?" match":" matches");
+}
+
 searchInput.addEventListener("input",function(){
   searchQuery=searchInput.value.trim().toLowerCase();
   searchMatches.clear();
+  searchMatchList=[];
+  searchMatchIdx=-1;
   if(searchQuery){
     nodes.forEach(function(n){
       var name=(n.name||"").toLowerCase();
       var type=(n.type||"").toLowerCase();
-      if(name.indexOf(searchQuery)>=0||type.indexOf(searchQuery)>=0)searchMatches.add(n.id);
+      if(name.indexOf(searchQuery)>=0||type.indexOf(searchQuery)>=0){
+        searchMatches.add(n.id);
+        searchMatchList.push(n);
+      }
     });
+    searchMatchList.sort(function(a,b){return (b.importance||0)-(a.importance||0)});
   }
+  updateSearchCount();
   draw();
+});
+
+// Enter jumps to the best match and cycles onward (Shift+Enter backwards);
+// Escape clears. Search was previously display-only — highlighting with no
+// way to navigate to what you found.
+searchInput.addEventListener("keydown",function(ev){
+  if(ev.key==="Escape"){
+    searchInput.value="";
+    searchQuery="";
+    searchMatches.clear();
+    searchMatchList=[];
+    searchMatchIdx=-1;
+    updateSearchCount();
+    searchInput.blur();
+    draw();
+    return;
+  }
+  if(ev.key!=="Enter"||!searchMatchList.length)return;
+  ev.preventDefault();
+  searchMatchIdx=ev.shiftKey
+    ?(searchMatchIdx-1+searchMatchList.length)%searchMatchList.length
+    :(searchMatchIdx+1)%searchMatchList.length;
+  var match=searchMatchList[searchMatchIdx];
+  if(typeof match.x==="number"){
+    var ns=clamp(Math.max(scale,1.5),0.02,30);
+    smoothPanZoomTo(ns,W/2-match.x*ns,H/2-match.y*ns,300);
+  }
+  updateSearchCount();
 });
 
 // ── Schema → graph highlight bridge (PR3) ──
@@ -2198,5 +2267,10 @@ document.querySelectorAll(".ctrl-btn[data-layout], .ctrl-btn[data-labelbudget], 
 // Apply hash on initial load (deferred so all listeners are wired).
 setTimeout(readHashState,0);
 window.addEventListener("hashchange",readHashState);
+
+// The canvas only repaints on interaction; expose a redraw hook so the theme
+// toggle (ui_chrome.js) can request a frame instead of leaving the canvas in
+// the previous theme until the next pan/zoom.
+window._requestGraphRedraw=function(){draw()};
 
 })();

--- a/cognee/modules/visualization/views/ui_chrome.js
+++ b/cognee/modules/visualization/views/ui_chrome.js
@@ -17,6 +17,10 @@
     if (document.getElementById('schema-view').style.display !== 'none' && window._renderSchemaGraph) {
       window._renderSchemaGraph(true);  // preserve pan/zoom across the re-render
     }
+    const memoryViewEl = document.getElementById('memory-view');
+    if (memoryViewEl && memoryViewEl.style.display !== 'none' && window._renderMemoryView) {
+      window._renderMemoryView(true);  // preserve pan/zoom across the re-render
+    }
   }
 
   // Restore the user's last choice (default light). Syncing the CSS class on
@@ -38,6 +42,7 @@
   const tabs = document.querySelectorAll('.tab-btn');
   const graphView = document.getElementById('graph-view');
   const schemaView = document.getElementById('schema-view');
+  const memoryView = document.getElementById('memory-view');
   tabs.forEach(btn => {
     btn.addEventListener('click', () => {
       tabs.forEach(t => { t.style.background='transparent'; t.style.color='var(--text2)'; t.classList.remove('active'); });
@@ -45,7 +50,9 @@
       const view = btn.dataset.view;
       graphView.style.display = view === 'graph' ? '' : 'none';
       schemaView.style.display = view === 'schema' ? '' : 'none';
+      if (memoryView) memoryView.style.display = view === 'memory' ? '' : 'none';
       if (view === 'schema' && window._renderSchemaGraph) window._renderSchemaGraph();
+      if (view === 'memory' && window._renderMemoryView) window._renderMemoryView();
     });
   });
 })();

--- a/cognee/modules/visualization/views/ui_chrome.js
+++ b/cognee/modules/visualization/views/ui_chrome.js
@@ -1,26 +1,35 @@
 // Theme toggle
 (function(){
   const btn = document.getElementById('theme-toggle');
-  // Expose for canvas draw() to read. Default light so the Graph view matches
-  // the Schema view instead of opening dark.
-  window._isLightMode = true;
-  // Sync the CSS theme class with the JS default. Without this the page
-  // loads with dark :root variables while the JS believes it's light, and
-  // the first "Dark mode" click ADDS the light class — a visual no-op — so
-  // dark mode was unreachable.
-  document.documentElement.classList.add('light');
-  btn.addEventListener('click', () => {
-    document.documentElement.classList.toggle('light');
-    const isLight = document.documentElement.classList.contains('light');
+
+  // Apply a theme everywhere it matters: CSS class, JS flag (read by the
+  // canvas draw loop), button label, tab bar, the canvas itself (which only
+  // repaints on interaction — without an explicit frame the 95% of the
+  // screen that is canvas stayed in the old theme until the next pan), and
+  // the schema SVG when visible.
+  function applyTheme(isLight) {
     window._isLightMode = isLight;
+    document.documentElement.classList.toggle('light', isLight);
     btn.textContent = isLight ? 'Dark mode' : 'Light mode';
-    // Update tab bar background (fully opaque so canvas content can't bleed through)
     const tabBar = document.getElementById('view-tabs');
-    tabBar.style.background = isLight ? '#f5f5f5' : '#000000';
-    // Re-render schema if visible
+    if (tabBar) tabBar.style.background = isLight ? '#f5f5f5' : '#000000';
+    if (window._requestGraphRedraw) window._requestGraphRedraw();
     if (document.getElementById('schema-view').style.display !== 'none' && window._renderSchemaGraph) {
-      window._renderSchemaGraph();
+      window._renderSchemaGraph(true);  // preserve pan/zoom across the re-render
     }
+  }
+
+  // Restore the user's last choice (default light). Syncing the CSS class on
+  // load also fixes the original bug: the page shipped dark :root variables
+  // while the JS assumed light, so the first toggle was a visual no-op.
+  let stored = null;
+  try { stored = localStorage.getItem('cognee-viz-theme'); } catch (e) { /* file:// may block */ }
+  applyTheme(stored ? stored === 'light' : true);
+
+  btn.addEventListener('click', () => {
+    const isLight = !window._isLightMode;
+    try { localStorage.setItem('cognee-viz-theme', isLight ? 'light' : 'dark'); } catch (e) { /* best effort */ }
+    applyTheme(isLight);
   });
 })();
 

--- a/cognee/tests/unit/modules/visualization/test_memory_map_payload.py
+++ b/cognee/tests/unit/modules/visualization/test_memory_map_payload.py
@@ -1,0 +1,375 @@
+"""Unit tests for the Memory-tab payload builder (``_build_memory_map``).
+
+Pure tests over ``preprocess()`` with synthetic graphs — no DB, no LLM.
+They pin the STEP 1 contract the STEP 2 JS renderer builds on:
+
+  - ``t_created`` is preserved from ``created_at`` before the pop.
+  - Chunk cells order by ``chunk_index``; legacy chunks (attributed only via
+    the ``is_part_of`` edge) append after; unattributable chunks are orphans.
+  - Entity groups come from ``is_a`` → EntityType edges; the top-8 of each
+    group are flagged ``important``.
+  - Summaries carry ``chunk_ids`` from ``made_from`` edges.
+  - ``context`` is ``None`` when no GlobalContextSummary nodes exist.
+  - The timeline gap-clusters ``t_created`` into run events.
+  - The whole payload is deterministic: same input twice → identical JSON,
+    and node insertion order does not change any ordering.
+"""
+
+import json
+
+import pytest
+
+from cognee.modules.visualization.preprocessor import (
+    MEMORY_GROUP_TOP_MEMBERS,
+    MEMORY_TIMELINE_GAP_MS,
+    preprocess,
+)
+
+T0 = 1_768_164_683_000  # first run batch (epoch ms)
+T1 = T0 + 2 * MEMORY_TIMELINE_GAP_MS  # second run, 10 minutes later
+
+
+def _memory_graph():
+    """Two documents across two run batches, a legacy chunk attributed via
+    is_part_of, an orphan chunk, one entity group, one ungrouped entity and
+    one summary."""
+    nodes_data = [
+        ("doc1", {"type": "TextDocument", "name": "alice.md", "created_at": T0}),
+        ("doc2", {"type": "TextDocument", "name": "bob.md", "created_at": T1}),
+        (
+            "c1",
+            {
+                "type": "DocumentChunk",
+                "text": "chunk one",
+                "chunk_index": 1,
+                "document_id": "doc1",
+                "created_at": T0 + 100,
+                "source_pipeline": "cognify_pipeline",
+            },
+        ),
+        (
+            "c0",
+            {
+                "type": "DocumentChunk",
+                "text": "chunk zero",
+                "chunk_index": 0,
+                "document_id": "doc1",
+                "created_at": T0 + 200,
+                "source_pipeline": "cognify_pipeline",
+            },
+        ),
+        # Legacy chunk: no document_id, no created_at — attributed via edge.
+        ("c_legacy", {"type": "DocumentChunk", "text": "legacy chunk"}),
+        # Orphan chunk: no document_id and no is_part_of edge.
+        ("c_orphan", {"type": "DocumentChunk", "text": "orphan chunk", "created_at": T1 + 50}),
+        ("alice", {"type": "Entity", "name": "Alice", "created_at": T0 + 300}),
+        ("bob", {"type": "Entity", "name": "Bob", "created_at": T0 + 300}),
+        # Ungrouped entity: no is_a edge to an EntityType.
+        ("zed", {"type": "Entity", "name": "Zed", "created_at": T1 + 100}),
+        ("person", {"type": "EntityType", "name": "Person", "created_at": T0 + 250}),
+        ("sum1", {"type": "TextSummary", "text": "summary one", "created_at": T0 + 400}),
+    ]
+    edges_data = [
+        ("c0", "doc1", "is_part_of", {}),
+        ("c_legacy", "doc1", "is_part_of", {}),
+        ("c1", "alice", "contains", {}),
+        ("c0", "bob", "contains", {}),
+        ("alice", "person", "is_a", {}),
+        ("bob", "person", "is_a", {}),
+        ("alice", "bob", "knows", {"relationship_name": "knows"}),
+        ("sum1", "c0", "made_from", {}),
+    ]
+    return (nodes_data, edges_data)
+
+
+def _payload(graph=None):
+    return preprocess(graph or _memory_graph()).memory_map
+
+
+# ── t_created preservation ───────────────────────────────────────────────────
+
+
+def test_t_created_preserved_and_created_at_dropped():
+    result = preprocess(_memory_graph())
+    by_id = {n["id"]: n for n in result.nodes}
+    assert by_id["doc1"]["t_created"] == T0
+    assert by_id["c1"]["t_created"] == T0 + 100
+    for node in result.nodes:
+        assert "created_at" not in node
+        assert "updated_at" not in node
+    # Legacy node without created_at: no t_created key fabricated.
+    assert "t_created" not in by_id["c_legacy"]
+
+
+def test_non_integer_created_at_is_not_preserved():
+    nodes_data = [("d", {"type": "TextDocument", "name": "a", "created_at": "2026-06-10"})]
+    result = preprocess((nodes_data, []))
+    assert "t_created" not in result.nodes[0]
+    assert "created_at" not in result.nodes[0]
+
+
+# ── Documents and chunk cells ────────────────────────────────────────────────
+
+
+def test_documents_sorted_by_t_first_then_name():
+    payload = _payload()
+    assert [d["id"] for d in payload["documents"]] == ["doc1", "doc2"]
+    assert payload["documents"][0]["t_first"] == T0
+    assert payload["documents"][1]["t_first"] == T1
+
+
+def test_chunks_ordered_by_chunk_index_with_legacy_appended():
+    payload = _payload()
+    doc1 = payload["documents"][0]
+    # c0 (index 0) before c1 (index 1) despite later t_created and later
+    # input position; the legacy chunk (no chunk_index) appends last.
+    assert [c["id"] for c in doc1["chunks"]] == ["c0", "c1", "c_legacy"]
+    assert [c["chunk_index"] for c in doc1["chunks"]] == [0, 1, None]
+    assert doc1["chunks"][0]["t_created"] == T0 + 200
+    assert doc1["chunks"][2]["t_created"] is None
+
+
+def test_orphan_chunks_collected():
+    payload = _payload()
+    assert payload["orphan_chunks"] == ["c_orphan"]
+
+
+# ── Entity groups ────────────────────────────────────────────────────────────
+
+
+def test_entity_grouping_via_is_a_edges():
+    payload = _payload()
+    assert len(payload["entity_groups"]) == 1
+    group = payload["entity_groups"][0]
+    assert group["type_id"] == "person"
+    assert group["type_name"] == "Person"
+    assert [m["id"] for m in group["members"]] == ["alice", "bob"]
+    # Small group: everyone is within the top-8 budget.
+    assert all(m["important"] for m in group["members"])
+
+
+def test_ungrouped_entities_listed():
+    payload = _payload()
+    assert payload["ungrouped_entities"] == ["zed"]
+
+
+def _big_group_graph():
+    """12 equal-importance members in one group, plus high-degree ballast so
+    the 75th-percentile label threshold sits above the members — making the
+    top-8 ``important`` cut observable."""
+    nodes = [("t", {"type": "EntityType", "name": "Person"})]
+    edges = []
+    for i in range(12):
+        nodes.append((f"e{i}", {"type": "Entity", "name": f"E{i:02d}"}))
+        edges.append((f"e{i}", "t", "is_a", {}))
+    for i in range(40):
+        nodes.append((f"h{i}", {"type": "Entity", "name": f"H{i:02d}"}))
+    for i in range(40):
+        for j in range(3):
+            edges.append((f"h{i}", f"h{(i + j + 1) % 40}", "rel", {"relationship_name": "rel"}))
+    return (nodes, edges)
+
+
+def test_group_top_members_flagged_important():
+    payload = _payload(_big_group_graph())
+    groups = {g["type_name"]: g for g in payload["entity_groups"]}
+    members = groups["Person"]["members"]
+    assert len(members) == 12
+    # Equal importance, no label_priority → deterministic name order,
+    # first MEMORY_GROUP_TOP_MEMBERS important, the tail collapsible.
+    assert [m["id"] for m in members] == [f"e{i}" for i in range(12)]
+    assert [m["important"] for m in members] == [True] * MEMORY_GROUP_TOP_MEMBERS + [False] * 4
+
+
+def test_entity_to_entity_is_a_does_not_group():
+    """is_a edges between two Entity nodes must not create a group."""
+    nodes = [
+        ("a", {"type": "Entity", "name": "A"}),
+        ("b", {"type": "Entity", "name": "B"}),
+    ]
+    edges = [("a", "b", "is_a", {})]
+    payload = _payload((nodes, edges))
+    assert payload["entity_groups"] == []
+    assert payload["ungrouped_entities"] == ["a", "b"]
+
+
+# ── Summaries ────────────────────────────────────────────────────────────────
+
+
+def test_summaries_carry_chunk_ids_from_made_from():
+    payload = _payload()
+    assert payload["summaries"] == [{"id": "sum1", "chunk_ids": ["c0"], "bucket_id": None}]
+
+
+def test_summaries_sorted_by_t_created():
+    nodes = [
+        ("s_late", {"type": "TextSummary", "text": "later", "created_at": T0 + 500}),
+        ("s_early", {"type": "TextSummary", "text": "earlier", "created_at": T0 + 100}),
+    ]
+    payload = _payload((nodes, []))
+    assert [s["id"] for s in payload["summaries"]] == ["s_early", "s_late"]
+
+
+# ── Global context ───────────────────────────────────────────────────────────
+
+
+def test_context_is_none_without_global_context_nodes():
+    assert _payload()["context"] is None
+
+
+def test_context_built_from_summarized_in_edges():
+    nodes = [
+        ("sum1", {"type": "TextSummary", "text": "s", "created_at": T0}),
+        ("b1", {"type": "GlobalContextSummary", "text": "bucket", "level": 0}),
+        ("root", {"type": "GlobalContextSummary", "text": "root", "level": 1, "is_root": True}),
+    ]
+    edges = [
+        ("sum1", "b1", "summarized_in", {}),
+        ("b1", "root", "summarized_in", {}),
+    ]
+    context = _payload((nodes, edges))["context"]
+    assert context["root_id"] == "root"
+    buckets = {b["id"]: b for b in context["buckets"]}
+    assert buckets["b1"]["level"] == 0
+    assert buckets["b1"]["child_ids"] == ["sum1"]
+    assert buckets["root"]["child_ids"] == ["b1"]
+    # Sorted by level ascending.
+    assert [b["id"] for b in context["buckets"]] == ["b1", "root"]
+
+
+# ── Structural edge index ────────────────────────────────────────────────────
+
+
+def test_edge_index_points_into_links_array():
+    result = preprocess(_memory_graph())
+    edges = result.memory_map["edges"]
+    assert edges["is_part_of"] == [0, 1]
+    assert edges["contains"] == [2, 3]
+    assert edges["semantic"] == [6]
+    assert edges["made_from"] == [7]
+    assert edges["summarized_in"] == []
+    # Positions must resolve to the right links.
+    knows = result.links[edges["semantic"][0]]
+    assert (knows["source"], knows["target"], knows["relation"]) == ("alice", "bob", "knows")
+
+
+def test_doc_to_chunk_contains_counts_as_membership():
+    """Graphs where the doc→chunk edge is ``contains`` (not is_part_of)
+    still attribute chunks to their document."""
+    nodes = [
+        ("d", {"type": "TextDocument", "name": "d.md"}),
+        ("c", {"type": "DocumentChunk", "text": "x"}),
+    ]
+    edges = [("d", "c", "contains", {})]
+    payload = _payload((nodes, edges))
+    assert payload["documents"][0]["chunks"] == [
+        {"id": "c", "chunk_index": None, "t_created": None}
+    ]
+    assert payload["orphan_chunks"] == []
+    assert payload["edges"]["is_part_of"] == [0]
+    assert payload["edges"]["contains"] == []
+
+
+# ── Timeline ─────────────────────────────────────────────────────────────────
+
+
+def test_timeline_two_batches_yield_two_events():
+    timeline = _payload()["timeline"]
+    assert len(timeline) == 2
+    first, second = timeline
+    assert first["index"] == 0 and second["index"] == 1
+    assert first["kind"] == "run" and second["kind"] == "run"
+    assert (first["t0"], first["t1"]) == (T0, T0 + 400)
+    assert (second["t0"], second["t1"]) == (T1, T1 + 100)
+    # Batch 1: doc1, c1, c0, alice, bob, person, sum1 + untimed c_legacy.
+    assert first["node_count"] == 8
+    assert "c_legacy" in first["node_ids"]  # untimed nodes join event 0
+    assert set(second["node_ids"]) == {"doc2", "c_orphan", "zed"}
+    assert second["node_count"] == 3
+
+
+def test_timeline_labels_majority_pipeline_with_ingestion_fallback():
+    timeline = _payload()["timeline"]
+    assert timeline[0]["label"] == "cognify_pipeline"  # majority non-null pipeline
+    assert timeline[1]["label"] == "ingestion"  # all-null fallback
+
+
+def test_timeline_label_refines_to_global_context_index():
+    nodes = [
+        (
+            "c",
+            {
+                "type": "DocumentChunk",
+                "text": "x",
+                "created_at": T0,
+                "source_pipeline": "cognify_pipeline",
+            },
+        ),
+        ("g", {"type": "GlobalContextSummary", "text": "ctx", "created_at": T0 + 10}),
+    ]
+    timeline = _payload((nodes, []))["timeline"]
+    assert len(timeline) == 1
+    assert timeline[0]["label"] == "global_context_index"
+
+
+def test_timeline_same_batch_merges_into_one_event():
+    nodes = [
+        ("a", {"type": "Entity", "name": "A", "created_at": T0}),
+        ("b", {"type": "Entity", "name": "B", "created_at": T0 + MEMORY_TIMELINE_GAP_MS}),
+        ("c", {"type": "Entity", "name": "C", "created_at": T0 + 2 * MEMORY_TIMELINE_GAP_MS}),
+    ]
+    # Consecutive gaps equal the threshold — chained into a single cluster.
+    timeline = _payload((nodes, []))["timeline"]
+    assert len(timeline) == 1
+    assert timeline[0]["node_count"] == 3
+
+
+def test_timeline_without_any_timestamps_emits_one_synthetic_event():
+    nodes = [("a", {"type": "Entity", "name": "A"}), ("b", {"type": "Entity", "name": "B"})]
+    timeline = _payload((nodes, []))["timeline"]
+    assert len(timeline) == 1
+    assert timeline[0]["label"] == "ingestion"
+    assert sorted(timeline[0]["node_ids"]) == ["a", "b"]
+
+
+# ── Empty graph and determinism ──────────────────────────────────────────────
+
+
+def test_empty_graph_payload_has_all_keys_empty():
+    payload = _payload(([], []))
+    assert payload == {
+        "documents": [],
+        "orphan_chunks": [],
+        "entity_groups": [],
+        "ungrouped_entities": [],
+        "summaries": [],
+        "context": None,
+        "edges": {
+            "contains": [],
+            "made_from": [],
+            "is_part_of": [],
+            "summarized_in": [],
+            "semantic": [],
+        },
+        "timeline": [],
+    }
+
+
+def test_payload_is_deterministic_across_runs():
+    a = json.dumps(_payload(), sort_keys=True)
+    b = json.dumps(_payload(), sort_keys=True)
+    assert a == b
+
+
+def test_payload_ordering_independent_of_node_input_order():
+    """Reversing node insertion order must not change any ordering — every
+    sort key is intrinsic to the data. (Edge order is kept fixed because the
+    ``edges`` index stores positions into the links array.)"""
+    nodes_data, edges_data = _memory_graph()
+    baseline = _payload((nodes_data, edges_data))
+    reversed_nodes = _payload((list(reversed(nodes_data)), edges_data))
+    assert json.dumps(baseline, sort_keys=True) == json.dumps(reversed_nodes, sort_keys=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/cognee/tests/unit/modules/visualization/test_orchestrator_assembly.py
+++ b/cognee/tests/unit/modules/visualization/test_orchestrator_assembly.py
@@ -60,6 +60,8 @@ def test_all_view_modules_contribute(tmp_path):
     # story_view.js: canvas renderer + label budget
     assert "computeRankedLayout" in html
     assert "labelBudget" in html
+    # memory_map.js: lazy-render entry point for the Memory tab
+    assert "_renderMemoryView" in html
 
 
 def test_data_tokens_substituted_as_json(tmp_path):
@@ -72,6 +74,58 @@ def test_data_tokens_substituted_as_json(tmp_path):
     assert '"name": "hi"' in html or '"name": "b"' in html
     # color maps default to empty dicts {} when no provenance is set
     assert "taskColors" in html
+
+
+def test_memory_view_scaffolding_wired(tmp_path):
+    """The Memory tab needs its button, container and data payloads."""
+    html = _render(tmp_path)
+    assert 'data-view="memory"' in html
+    assert 'id="memory-view"' in html
+    # __MEMORY_DATA__ resolves to the memory_map JSON object…
+    assert "const memoryMap = {" in html
+    # …and __SEARCH_EVENTS__ falls back to an empty JSON array.
+    assert "const searchEvents = []" in html
+
+
+def test_memory_view_renderer_wired(tmp_path):
+    """STEP 2: the real renderer needs its containers (SVG, zoom pill,
+    timeline rail, side panel) and the story-view data globals it reads."""
+    html = _render(tmp_path)
+    # Containers in template.html
+    assert 'id="memory-svg"' in html
+    assert 'id="memory-timeline"' in html
+    assert 'id="memory-side-panel"' in html
+    assert 'id="memory-zoom-fit"' in html
+    assert 'id="memory-empty"' in html
+    # story_view.js shares node/link details with the memory view
+    assert "window._vizNodeById" in html
+    assert "window._vizLinks" in html
+    # memory_map.js: deterministic layout + overlay machinery present
+    assert "computeLayout" in html
+    assert "mm-searching" in html
+
+
+def test_search_events_kwarg_is_embedded(tmp_path):
+    """``search_events=`` is the documented injection hook for retrieval
+    events on the Memory timeline."""
+    events = [
+        {
+            "time": "2026-06-10T10:31:02",
+            "qa_id": "qa-1",
+            "question": "Who knows Bob?",
+            "answer": "Alice.",
+            "node_ids": ["a"],
+            "edge_ids": [],
+        }
+    ]
+    html = asyncio.run(
+        cognee_network_visualization(
+            _minimal_graph(), str(tmp_path / "out.html"), search_events=events
+        )
+    )
+    assert "const searchEvents = [{" in html
+    assert '"qa_id": "qa-1"' in html
+    assert '"question": "Who knows Bob?"' in html
 
 
 def test_schema_data_is_null_when_omitted(tmp_path):

--- a/cognee/tests/unit/modules/visualization/test_preprocessor.py
+++ b/cognee/tests/unit/modules/visualization/test_preprocessor.py
@@ -463,6 +463,43 @@ def test_entity_types_under_cap_are_not_rolled_up():
     assert sum(1 for name in names_at_cap if name.startswith("Type")) == SCHEMA_MAX_ENTITY_TYPES
 
 
+class TestUnnamedNodeFallbacks:
+    UUID_NAME = "13e52fce-2d52-4a8b-9f01-aabbccddeeff"
+    HASH_NAME = "a" * 64
+
+    def test_uuid_name_gets_readable_placeholder(self):
+        nodes_data = [("n1", {"type": "Entity", "name": self.UUID_NAME})]
+        result = preprocess((nodes_data, []))
+        node = result.nodes[0]
+        assert node["name"].startswith("Unnamed Entity")
+        assert self.UUID_NAME not in node["name"]
+        assert node["is_unnamed"] is True
+
+    def test_hash_fallback_fields_are_skipped(self):
+        nodes_data = [
+            ("n1", {"type": "DocumentChunk", "text": self.HASH_NAME, "description": "real text"})
+        ]
+        result = preprocess((nodes_data, []))
+        assert result.nodes[0]["name"] == "real text"
+
+    def test_unnamed_nodes_never_get_label_priority(self):
+        # Documents are always-label landmarks — unless they are unnamed.
+        nodes_data = [
+            ("d1", {"type": "TextDocument", "name": self.UUID_NAME}),
+            ("d2", {"type": "TextDocument", "name": "alice.md"}),
+        ]
+        result = preprocess((nodes_data, []))
+        by_name_priority = {n["is_unnamed"]: n["label_priority"] for n in result.nodes}
+        assert by_name_priority[True] is False
+        assert by_name_priority[False] is True
+
+    def test_regular_names_untouched(self):
+        result = preprocess(_alice_like_graph())
+        names = {n["name"] for n in result.nodes}
+        assert "Alice" in names
+        assert not any(name.startswith("Unnamed ") for name in names)
+
+
 def test_empty_graph_does_not_crash():
     result = preprocess(([], []))
     assert result.nodes == []

--- a/cognee/tests/unit/modules/visualization/test_session_events.py
+++ b/cognee/tests/unit/modules/visualization/test_session_events.py
@@ -1,0 +1,66 @@
+"""Unit tests for the session operation-event mapper (pure, no cache/DB)."""
+
+from cognee.infrastructure.databases.cache.models import SessionQAEntry
+from cognee.modules.visualization.session_events import map_session_entries_to_events
+
+
+def _entry(**overrides):
+    base = {
+        "time": "2026-06-11T10:00:00",
+        "qa_id": "qa-1",
+        "question": "Who is Alice?",
+        "context": "ctx",
+        "answer": "A curious girl.",
+        "used_graph_element_ids": {"node_ids": ["n1", "n2"], "edge_ids": ["e1"]},
+    }
+    base.update(overrides)
+    return SessionQAEntry(**base)
+
+
+class TestMapSessionEntriesToEvents:
+    def test_search_event_per_entry(self):
+        events = map_session_entries_to_events("s1", [_entry()])
+        assert len(events) == 1
+        event = events[0]
+        assert event["kind"] == "search"
+        assert event["session_id"] == "s1"
+        assert event["question"] == "Who is Alice?"
+        assert event["answer"] == "A curious girl."
+        assert event["node_ids"] == ["n1", "n2"]
+        assert event["edge_ids"] == ["e1"]
+
+    def test_rated_entry_also_emits_improve_event(self):
+        entry = _entry(
+            feedback_score=5,
+            feedback_text="great answer",
+            memify_metadata={"feedback_weights_applied": True},
+        )
+        events = map_session_entries_to_events("s1", [entry])
+        assert [e["kind"] for e in events] == ["search", "improve"]
+        improve = events[1]
+        assert improve["rating"] == 5
+        assert improve["feedback_text"] == "great answer"
+        assert improve["applied"] is True
+        # Reinforcement targets the same elements the search retrieved.
+        assert improve["node_ids"] == ["n1", "n2"]
+
+    def test_unapplied_feedback_marked_pending(self):
+        events = map_session_entries_to_events("s1", [_entry(feedback_score=2)])
+        assert events[1]["applied"] is False
+
+    def test_entries_without_provenance_still_map_when_question_present(self):
+        events = map_session_entries_to_events("s1", [_entry(used_graph_element_ids=None)])
+        assert len(events) == 1
+        assert events[0]["node_ids"] == []
+
+    def test_placeholder_entries_skipped(self):
+        events = map_session_entries_to_events(
+            "s1", [_entry(question="", used_graph_element_ids=None)]
+        )
+        assert events == []
+
+    def test_determinism(self):
+        entries = [_entry(), _entry(qa_id="qa-2", feedback_score=4)]
+        assert map_session_entries_to_events("s1", entries) == map_session_entries_to_events(
+            "s1", entries
+        )


### PR DESCRIPTION
## What

The top five impact-per-effort fixes from a six-persona first-time-user review of the visualization (every finding driven against the real rendered HTML with Playwright and independently reproduced before landing here). Follows on from #3026 (merged).

### 1. Never display UUIDs as names *(reviewers' #1 trust killer — flagged independently by 5 of 6 personas)*
`preprocessor.py`: identifier-shaped values (UUIDs, content hashes) are skipped when deriving display names — the fallback chain continues through title/text/summary, ending at a readable `Unnamed <Type> (id8)` placeholder — and unnamed nodes are excluded from Key-mode label landmarks (a raw UUID was being promoted as a top-3 landmark label next to `alice` and `white rabbit`). On the 542-node review corpus this removed **104 raw-UUID labels**.

### 2. Theme toggle repaints the canvas, theme persists
Clicking "Dark mode" flipped every DOM panel but left the canvas — 95% of the screen — in the old theme until the next pan forced a redraw, and the choice was lost on reload. `story_view.js` exposes `window._requestGraphRedraw`; the toggle (`ui_chrome.js`) requests a frame and persists the theme in localStorage, applied before first paint. Verified: canvas center pixel is dark 300ms after toggle; reload keeps the theme.

### 3. Search is navigable
Search was display-only: highlighting with no match count and a dead Enter key. Now: live match counter in the box, **Enter jumps to the best match and cycles onward** (`1 / 18`), Shift+Enter backwards, Escape clears.

### 4. Legend cannot contradict the canvas
Two divergent palettes existed (`story_view.js colorByType` vs `preprocessor.py _TYPE_COLOR_MAP`), so legend swatches didn't match drawn nodes. Type swatches now sample the color actually drawn on a node of that type — consistent by construction.

### 5. Honest stats and controls
- "Unknown" provenance no longer counts: `1 node sets` → `0 node sets`, with correct pluralization throughout (`1 pipeline`).
- `5 types` → `5 node kinds` + tooltip (it visibly contradicted the "Types (49)" column header).
- Color-by modes for provenance the dataset doesn't carry (Node set / User) are **disabled with an explanatory tooltip** instead of rendering the whole graph monochrome gray.

## Testing
- 39 visualization unit tests pass (4 new); `node --check` on edited JS; pre-commit clean.
- All five fixes verified live with Playwright against the regenerated 542-node demo graph: stats text, disabled buttons, search count + Enter-cycling, zero raw-UUID display names in the emitted data, canvas pixel color after toggle, and theme persistence across reload.

## Source
Six-persona Playwright-driven review (46 raw observations → 22 verified findings, 0 rejected). Remaining medium-effort items (entity-column clustering, schema initial fit, panel pinning, ops rail overlay) are documented for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Search now displays match counter and supports keyboard navigation—press Enter to jump between matches, Shift+Enter to reverse, or Escape to clear.
- Theme preference now persists across sessions.

**Bug Fixes**
- Legend colors now accurately reflect rendered node colors.
- Improved handling of unnamed nodes with readable placeholders.
- Enhanced stats display accuracy for missing provenance types.

**Style**
- Refined search input layout with integrated counter display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->