### PR TITLE
fix(retrieval): ground Evidence in the generated answer; default include_references off

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -335,7 +335,7 @@ async def recall(
     retriever_specific_config: dict | None = None,
     neighborhood_depth: int | None = None,
     neighborhood_seed_top_k: int | None = None,
-    include_references: bool = True,
+    include_references: bool = False,
     user: object | None = None,
     llm_config: LLMConfig | None = None,
     embedding_config: EmbeddingConfig | None = None,

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -37,7 +37,7 @@ class RecallPayloadDTO(InDTO):
     top_k: Optional[int] = Field(default=15)
     only_context: bool = Field(default=False)
     verbose: bool = Field(default=False)
-    include_references: bool = Field(default=True)
+    include_references: bool = Field(default=False)
     session_id: Optional[str] = Field(default=None, examples=[None])
     scope: Optional[Union[str, list[str]]] = Field(
         default=None,

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -37,7 +37,7 @@ class SearchPayloadDTO(InDTO):
     skills: Optional[list[str]] = Field(default=None, examples=[None])
     tools: Optional[list[str]] = Field(default=None, examples=[None])
     max_iter: Optional[int] = Field(default=None, examples=[None])
-    include_references: bool = Field(default=True)
+    include_references: bool = Field(default=False)
 
 
 def get_search_router() -> APIRouter:

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -51,7 +51,7 @@ async def search(
     skills: Optional[List[Union[str, Skill]]] = None,
     tools: Optional[List[str]] = None,
     max_iter: Optional[int] = None,
-    include_references: bool = True,
+    include_references: bool = False,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[SearchResult]:

--- a/cognee/modules/chunking/text_chunker_with_overlap.py
+++ b/cognee/modules/chunking/text_chunker_with_overlap.py
@@ -19,6 +19,7 @@ class TextChunkerWithOverlap(Chunker):
         get_chunk_data: callable = None,
     ):
         super().__init__(document, get_text, max_chunk_size)
+        self.document_name = document.name or basename(document.raw_data_location)
         self._accumulated_chunk_data = []
         self._accumulated_size = 0
         self.chunk_overlap_ratio = chunk_overlap_ratio
@@ -78,7 +79,7 @@ class TextChunkerWithOverlap(Chunker):
                 cut_type=cut_type,
                 contains=[],
                 document_id=str(self.document.id),
-                document_name=self.document.name or basename(self.document.raw_data_location),
+                document_name=self.document_name,
                 metadata={"index_fields": ["text"]},
             )
         except Exception as e:

--- a/cognee/modules/retrieval/agentic_retriever.py
+++ b/cognee/modules/retrieval/agentic_retriever.py
@@ -279,9 +279,8 @@ class AgenticRetriever(GraphCompletionRetriever):
             triplets=retrieved_objects.get("triplets"),
         )
 
-        # Append code-assembled entity-fallback Evidence to the final answer using
-        # the memory triplets gathered for this turn (graph path, str answers only).
-        return await self._append_graph_evidence([final], retrieved_objects.get("triplets"))
+        # Append answer-grounded Evidence to the final answer (str answers only).
+        return await self._append_graph_evidence([final])
 
     @staticmethod
     async def _record_skill_runs(

--- a/cognee/modules/retrieval/completion_retriever.py
+++ b/cognee/modules/retrieval/completion_retriever.py
@@ -10,7 +10,7 @@ from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
 from cognee.context_global_variables import session_user
 from cognee.infrastructure.databases.cache.config import CacheConfig
-from cognee.modules.retrieval.utils.references import format_chunk_references
+from cognee.modules.retrieval.utils.references import append_chunk_evidence
 
 logger = get_logger("CompletionRetriever")
 
@@ -28,7 +28,7 @@ class CompletionRetriever(BaseRetriever):
         top_k: Optional[int] = 1,
         session_id: Optional[str] = None,
         response_model: Type = str,
-        include_references: bool = True,
+        include_references: bool = False,
     ):
         """Initialize retriever with optional custom prompt paths."""
         self.user_prompt_path = user_prompt_path
@@ -100,25 +100,6 @@ class CompletionRetriever(BaseRetriever):
         completion = await generate_completion(query=query, **kwargs)
         return [completion]
 
-    def _append_chunk_evidence(self, completions: List[Any], retrieved_objects: Any) -> List[Any]:
-        """Append a code-assembled chunk Evidence block to string completions.
-
-        Evidence is appended only when references are enabled, the completion is a
-        plain string (never corrupt a structured response_model), and the built
-        Evidence block is non-empty. The block already carries its own header.
-        """
-        if not self.include_references or self.response_model is not str:
-            return completions
-
-        evidence = format_chunk_references(retrieved_objects)
-        if not evidence:
-            return completions
-
-        return [
-            f"{completion}\n\n{evidence}" if isinstance(completion, str) else completion
-            for completion in completions
-        ]
-
     async def get_completion_from_context(
         self,
         query: str,
@@ -171,5 +152,11 @@ class CompletionRetriever(BaseRetriever):
             completions = await self._generate_completion_without_session(query, context)
 
         # Both the session/cache branch and the non-session branch rejoin here so
-        # logged-in/cached calls also receive references.
-        return self._append_chunk_evidence(completions, retrieved_objects)
+        # logged-in/cached calls also receive references. Evidence is grounded in
+        # each completion's own text, so a cache-hit answer never cites chunks
+        # that share nothing with it.
+        return append_chunk_evidence(
+            completions,
+            retrieved_objects,
+            enabled=self.include_references and self.response_model is str,
+        )

--- a/cognee/modules/retrieval/graph_completion_context_extension_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_context_extension_retriever.py
@@ -34,7 +34,7 @@ class GraphCompletionContextExtensionRetriever(GraphCompletionRetriever):
         response_model: Type = str,
         neighborhood_depth: Optional[int] = None,
         neighborhood_seed_top_k: Optional[int] = 10,
-        include_references: bool = True,
+        include_references: bool = False,
     ):
         super().__init__(
             user_prompt_path=user_prompt_path,

--- a/cognee/modules/retrieval/graph_completion_cot_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_cot_retriever.py
@@ -70,7 +70,7 @@ class GraphCompletionCotRetriever(GraphCompletionRetriever):
         response_model: Type = str,
         neighborhood_depth: Optional[int] = None,
         neighborhood_seed_top_k: Optional[int] = 10,
-        include_references: bool = True,
+        include_references: bool = False,
     ):
         super().__init__(
             user_prompt_path=user_prompt_path,

--- a/cognee/modules/retrieval/graph_completion_decomposition_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_decomposition_retriever.py
@@ -46,7 +46,7 @@ class GraphCompletionDecompositionRetriever(GraphCompletionRetriever):
         neighborhood_depth: Optional[int] = None,
         neighborhood_seed_top_k: Optional[int] = 10,
         decomposition_mode: DecompositionMode = DecompositionMode.ANSWER_PER_SUBQUERY,
-        include_references: bool = True,
+        include_references: bool = False,
     ):
         super().__init__(
             user_prompt_path=user_prompt_path,

--- a/cognee/modules/retrieval/graph_completion_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_retriever.py
@@ -16,9 +16,8 @@ from cognee.modules.retrieval.utils.global_context import (
 from cognee.modules.retrieval.utils.used_graph_elements import (
     is_edge_list,
     extract_from_edges,
-    extract_from_temporal_dict,
 )
-from cognee.modules.retrieval.utils.references import build_graph_reference_context
+from cognee.modules.retrieval.utils.references import append_answer_grounded_evidence
 from cognee.modules.retrieval.utils.completion import (
     generate_completion,
     generate_completion_batch,
@@ -59,7 +58,7 @@ class GraphCompletionRetriever(BaseRetriever):
         neighborhood_seed_top_k: Optional[int] = 10,
         include_global_context_index: bool = False,
         global_context_index_top_k: int = 3,
-        include_references: bool = True,
+        include_references: bool = False,
     ):
         """Initialize retriever with prompt paths and search parameters."""
         self.user_prompt_path = user_prompt_path
@@ -306,49 +305,20 @@ class GraphCompletionRetriever(BaseRetriever):
         completion = await generate_completion(query=query, **kwargs)
         return [completion]
 
-    def _node_ids_from_retrieved(self, retrieved_objects: Any) -> List[str]:
-        """Collect entity node ids from retrieved edges (or a temporal dict)."""
-        extracted: Optional[Dict[str, List[str]]] = None
-        if isinstance(retrieved_objects, dict):
-            extracted = extract_from_temporal_dict(retrieved_objects)
-        elif is_edge_list(retrieved_objects):
-            extracted = extract_from_edges(retrieved_objects)
-        if not extracted:
-            return []
-        return extracted.get("node_ids", [])
+    async def _append_graph_evidence(self, completions: List[Any]) -> List[Any]:
+        """Append an answer-grounded chunk Evidence block to string completions.
 
-    async def _append_graph_evidence(
-        self, completions: List[Any], retrieved_objects: Any
-    ) -> List[Any]:
-        """Append a code-assembled entity-fallback Evidence block to string completions.
-
-        Evidence is appended only when references are enabled, the completion is a
-        plain string (never corrupt a structured response_model), and the built
-        Evidence block is non-empty. Traversal failures degrade to no Evidence.
+        Each answer is run as a vector query against the chunk index, so the
+        Evidence bullets reflect where the answer text is grounded in the corpus
+        rather than which graph elements happened to be retrieved. Evidence is
+        appended only when references are enabled and the completion is a plain
+        string (never corrupt a structured response_model); search failures
+        degrade to no Evidence.
         """
-        if not self.include_references or self.response_model is not str:
-            return completions
-
-        node_ids = self._node_ids_from_retrieved(retrieved_objects)
-        if not node_ids:
-            return completions
-
-        from cognee.infrastructure.databases.graph import get_graph_engine
-
-        try:
-            graph_engine = await get_graph_engine()
-        except Exception as error:  # pragma: no cover - defensive
-            logger.debug(f"Unable to obtain graph engine for references: {error}")
-            return completions
-
-        evidence = await build_graph_reference_context(node_ids, graph_engine)
-        if not evidence:
-            return completions
-
-        return [
-            f"{completion}\n\n{evidence}" if isinstance(completion, str) else completion
-            for completion in completions
-        ]
+        return await append_answer_grounded_evidence(
+            completions,
+            enabled=self.include_references and self.response_model is str,
+        )
 
     async def get_completion_from_context(
         self,
@@ -398,8 +368,10 @@ class GraphCompletionRetriever(BaseRetriever):
             )
 
         # Session and non-session branches rejoin here so every variant that calls
-        # this method (including via super()) appends graph references once.
-        return await self._append_graph_evidence(completions, retrieved_objects)
+        # this method (including via super()) appends references once. Evidence is
+        # grounded in each completion's own text, so a cache-hit answer never
+        # cites chunks that share nothing with it.
+        return await self._append_graph_evidence(completions)
 
     async def get_completion(
         self, query: Optional[str] = None, query_batch: Optional[List[str]] = None

--- a/cognee/modules/retrieval/graph_summary_completion_retriever.py
+++ b/cognee/modules/retrieval/graph_summary_completion_retriever.py
@@ -30,7 +30,7 @@ class GraphSummaryCompletionRetriever(GraphCompletionRetriever):
         triplet_distance_penalty: Optional[float] = 6.5,
         feedback_influence: float = 0.0,
         session_id: Optional[str] = None,
-        include_references: bool = True,
+        include_references: bool = False,
     ):
         """Initialize retriever with default prompt paths and search parameters."""
         super().__init__(

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -46,7 +46,7 @@ class TemporalRetriever(GraphCompletionRetriever):
         feedback_influence: float = 0.0,
         session_id: Optional[str] = None,
         response_model: Type = str,
-        include_references: bool = True,
+        include_references: bool = False,
     ):
         super().__init__(
             user_prompt_path=user_prompt_path,

--- a/cognee/modules/retrieval/triplet_retriever.py
+++ b/cognee/modules/retrieval/triplet_retriever.py
@@ -9,7 +9,7 @@ from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
 from cognee.context_global_variables import session_user
 from cognee.infrastructure.databases.cache.config import CacheConfig
-from cognee.modules.retrieval.utils.references import format_chunk_references
+from cognee.modules.retrieval.utils.references import append_chunk_evidence
 
 logger = get_logger("TripletRetriever")
 
@@ -31,7 +31,7 @@ class TripletRetriever(BaseRetriever):
         top_k: Optional[int] = 5,
         session_id: Optional[str] = None,
         response_model: Type = str,
-        include_references: bool = True,
+        include_references: bool = False,
     ):
         """Initialize retriever with optional custom prompt paths."""
         self.user_prompt_path = user_prompt_path
@@ -110,25 +110,6 @@ class TripletRetriever(BaseRetriever):
         completion = await generate_completion(query=query, **kwargs)
         return [completion]
 
-    def _append_chunk_evidence(self, completions: List[Any], retrieved_objects: Any) -> List[Any]:
-        """Append a code-assembled chunk Evidence block to string completions.
-
-        Evidence is appended only when references are enabled, the completion is a
-        plain string (never corrupt a structured response_model), and the built
-        Evidence block is non-empty. The block already carries its own header.
-        """
-        if not self.include_references or self.response_model is not str:
-            return completions
-
-        evidence = format_chunk_references(retrieved_objects)
-        if not evidence:
-            return completions
-
-        return [
-            f"{completion}\n\n{evidence}" if isinstance(completion, str) else completion
-            for completion in completions
-        ]
-
     async def get_completion_from_context(
         self, query: str, retrieved_objects: Any, context: Any
     ) -> Union[List[str], List[dict]]:
@@ -178,4 +159,8 @@ class TripletRetriever(BaseRetriever):
             completions = await self._generate_completion_without_session(query, context)
 
         # Both the session/cache branch and the non-session branch rejoin here.
-        return self._append_chunk_evidence(completions, retrieved_objects)
+        return append_chunk_evidence(
+            completions,
+            retrieved_objects,
+            enabled=self.include_references and self.response_model is str,
+        )

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -1,20 +1,25 @@
 """Deterministic, LLM-free helpers for building reference (Evidence) blocks.
 
-Two helpers are exposed:
+Evidence is grounded in the generated answer, not in whatever happened to be
+retrieved before the LLM was called:
 
 - ``format_chunk_references`` builds an Evidence block from retrieved vector
-  payloads (the ``RAG_COMPLETION`` / chunk path).
-- ``build_graph_reference_context`` builds an entity-fallback Evidence block by
-  walking the graph from entity node ids to their ``DocumentChunk`` -> ``Document``
-  via the :class:`GraphDBInterface` connection API (the graph completion path).
+  payloads, keeping only chunks that share significant terms with the answer
+  (the ``RAG_COMPLETION`` / chunk path, where candidates are the chunks the
+  LLM actually read).
+- ``build_answer_grounded_chunk_references`` runs the answer text as a vector
+  query against the chunk index and formats the results (the graph completion
+  path, where the LLM context is not chunk-shaped).
+- ``append_chunk_evidence`` / ``append_answer_grounded_evidence`` apply the
+  above to a list of completions, one Evidence block per string completion.
 
-Both are pure with respect to the LLM (no model calls) so they can be unit
-tested in isolation. Both return ``""`` when there is nothing usable, and
-``build_graph_reference_context`` never raises on a backend that cannot
-traverse (e.g. Postgres-graph).
+All helpers are pure with respect to the LLM (no model calls) so they can be
+unit tested in isolation. All return ``""`` (or the completions unchanged)
+when there is nothing usable, and never raise on backend failures.
 """
 
-from typing import Any, List, Optional
+import re
+from typing import Any, List, Optional, Set, Tuple
 
 from cognee.shared.logging_utils import get_logger
 
@@ -30,6 +35,26 @@ _SNIPPET_MAX_CHARS = 160
 # Hard upper bound on bullets regardless of the requested limit (3-5 range).
 _MAX_BULLETS = 5
 _MIN_LIMIT = 3
+
+# Vector collection holding document chunks (same one ChunksRetriever queries).
+_CHUNK_COLLECTION = "DocumentChunk_text"
+
+# How many vector candidates to fetch before answer-overlap filtering.
+_CANDIDATE_POOL = 10
+
+# Common English words excluded from answer/chunk term overlap scoring.
+_STOPWORDS = frozenset(
+    """
+    a about above after again all also an and any are as at be because been
+    before being below between both but by can did do does doing down during
+    each few for from further had has have having he her here hers him his how
+    i if in into is it its just me more most my no nor not of off on once only
+    or other our ours out over own same she should so some such than that the
+    their theirs them then there these they this those through to too under
+    until up very was we were what when where which while who whom why will
+    with you your yours
+    """.split()
+)
 
 
 def _clamp_limit(limit: int) -> int:
@@ -121,8 +146,16 @@ def _chunk_id(obj: Any, payload: dict) -> Optional[str]:
     return None
 
 
-def format_chunk_references(retrieved_objects: Any, limit: int = 5) -> str:
-    """Build an Evidence block from retrieved vector payloads.
+def _significant_terms(text: str) -> Set[str]:
+    """Lowercased alphanumeric terms of an answer, minus stopwords and stubs."""
+    tokens = re.findall(r"[a-z0-9]+", text.lower())
+    return {token for token in tokens if len(token) >= 3 and token not in _STOPWORDS}
+
+
+def format_chunk_references(
+    retrieved_objects: Any, answer: Optional[str] = None, limit: int = 5
+) -> str:
+    """Build an Evidence block from retrieved vector payloads, grounded in the answer.
 
     Reads ``payload["document_name"]``, ``payload["chunk_number"]`` (falling back
     to ``payload["chunk_index"] + 1``), and ``payload["text"]`` from each
@@ -130,11 +163,19 @@ def format_chunk_references(retrieved_objects: Any, limit: int = 5) -> str:
     metadata are skipped. Results are deduplicated by chunk id and capped at
     3-5 bullets.
 
+    When ``answer`` is provided, candidates that share no significant terms
+    with the answer are dropped and the remainder is ranked by term overlap,
+    so bullets reflect answer provenance rather than retrieval order. An
+    answer with no significant terms cannot be grounded and yields ``""``.
+
     Parameters
     ----------
     retrieved_objects:
         An iterable of retrieved vector results (``ScoredResult``-like objects
         exposing a ``.payload`` dict), or raw payload dicts.
+    answer:
+        The generated answer text used to filter and rank candidates. When
+        None, candidates keep their retrieval order unfiltered.
     limit:
         Desired maximum number of bullets, clamped into the 3-5 range.
 
@@ -152,14 +193,19 @@ def format_chunk_references(retrieved_objects: Any, limit: int = 5) -> str:
     except TypeError:
         return ""
 
-    max_bullets = _clamp_limit(limit)
-    bullets: List[str] = []
+    answer_terms: Optional[Set[str]] = None
+    if answer is not None:
+        answer_terms = _significant_terms(answer)
+        if not answer_terms:
+            # Nothing to ground the citation in (e.g. "Yes."): omit Evidence
+            # rather than presenting unverifiable retrieval order as provenance.
+            return ""
+
+    # (overlap_score, document_name, number, text) per usable candidate.
+    candidates: List[Tuple[int, str, int, str]] = []
     seen: set = set()
 
     for obj in iterator:
-        if len(bullets) >= max_bullets:
-            break
-
         payload = _get_payload(obj)
         if payload is None:
             continue
@@ -178,116 +224,51 @@ def format_chunk_references(retrieved_objects: Any, limit: int = 5) -> str:
             continue
         seen.add(dedup_key)
 
-        bullets.append(f'- chunk {number} of document {document_name}: "{_snippet(text)}"')
+        score = 0
+        if answer_terms is not None:
+            chunk_terms = set(re.findall(r"[a-z0-9]+", text.lower()))
+            score = len(answer_terms & chunk_terms)
+            if score == 0:
+                # No term from the answer appears in this chunk: it is almost
+                # certainly not a source of the answer.
+                continue
 
-    if not bullets:
+        candidates.append((score, document_name, number, text))
+
+    if not candidates:
         return ""
+
+    if answer_terms is not None:
+        # Stable sort: highest answer overlap first, retrieval order as tiebreak.
+        candidates.sort(key=lambda candidate: -candidate[0])
+
+    max_bullets = _clamp_limit(limit)
+    bullets = [
+        f'- chunk {number} of document {document_name}: "{_snippet(text)}"'
+        for _, document_name, number, text in candidates[:max_bullets]
+    ]
 
     return EVIDENCE_HEADER + "\n" + "\n".join(bullets)
 
 
-# Relationship names used to walk chunk <-> document and chunk <-> entity edges.
-# These are stored as edge properties (``relationship_name``) on the single EDGE
-# table, so we filter on them directly rather than on edge labels.
-_DOCUMENT_REL = "is_part_of"
-_CONTAINS_REL = "contains"
+async def build_answer_grounded_chunk_references(
+    answer: str, vector_engine: Any, limit: int = 5
+) -> str:
+    """Build an Evidence block by running the answer as a vector query over chunks.
 
-# Node type labels (stored as the ``type`` property on the single Node table).
-_DOCUMENT_CHUNK_TYPE = "DocumentChunk"
-_DOCUMENT_TYPE = "Document"
+    This grounds Evidence in the answer text itself, independent of how the
+    original retrieval was done (graph traversal, triplets, ...): the answer is
+    embedded once and matched against the existing chunk index, then candidates
+    are additionally filtered by term overlap with the answer.
 
-
-def _node_type(node: Any) -> Optional[str]:
-    """Best-effort node type extraction from a connection node dict."""
-    if not isinstance(node, dict):
-        return None
-    return _clean_str(node.get("type"))
-
-
-def _node_name(node: Any) -> Optional[str]:
-    """Best-effort node display name extraction from a connection node dict."""
-    if not isinstance(node, dict):
-        return None
-    return _clean_str(node.get("name"))
-
-
-def _other_node(self_id: Any, source: dict, target: dict) -> Optional[dict]:
-    """Return the connection endpoint that is NOT ``self_id``."""
-    self_id_str = str(self_id)
-    if isinstance(source, dict) and str(source.get("id")) == self_id_str:
-        return target if isinstance(target, dict) else None
-    if isinstance(target, dict) and str(target.get("id")) == self_id_str:
-        return source if isinstance(source, dict) else None
-    # Undirected fallback: prefer target when neither matches exactly.
-    return target if isinstance(target, dict) else None
-
-
-def _relationship_name(relationship: Any) -> Optional[str]:
-    """Extract relationship_name from a connection relationship element."""
-    if isinstance(relationship, dict):
-        return _clean_str(relationship.get("relationship_name"))
-    return _clean_str(relationship)
-
-
-def _chunk_display_number(chunk_node: dict) -> Optional[int]:
-    """Resolve a 1-based chunk number from a graph node dict."""
-    return _chunk_number(chunk_node)
-
-
-async def _document_name_for_chunk(chunk_node: dict, graph_engine: Any) -> Optional[str]:
-    """Resolve the document name for a chunk node.
-
-    Prefers the flat ``document_name`` scalar on the chunk; otherwise walks the
-    chunk's ``is_part_of`` connection to the ``Document`` node and uses its name.
-    """
-    flat_name = _clean_str(chunk_node.get("document_name"))
-    if flat_name is not None:
-        return flat_name
-
-    chunk_id = chunk_node.get("id")
-    if chunk_id is None:
-        return None
-
-    try:
-        connections = await graph_engine.get_connections(chunk_id)
-    except (NotImplementedError, AttributeError):
-        return None
-    except Exception as error:  # pragma: no cover - defensive
-        logger.debug(f"get_connections failed for chunk {chunk_id}: {error}")
-        return None
-
-    for connection in connections or []:
-        if not isinstance(connection, (tuple, list)) or len(connection) != 3:
-            continue
-        source, relationship, target = connection
-        if _relationship_name(relationship) != _DOCUMENT_REL:
-            continue
-        other = _other_node(chunk_id, source, target)
-        if other is not None and _node_type(other) == _DOCUMENT_TYPE:
-            name = _node_name(other)
-            if name is not None:
-                return name
-    return None
-
-
-async def build_graph_reference_context(node_ids: Any, graph_engine: Any, limit: int = 5) -> str:
-    """Build an entity-fallback Evidence block by traversing the graph.
-
-    For each entity node id, walks its connections to find ``DocumentChunk``
-    nodes (via the ``contains`` relationship), then resolves the owning
-    ``Document`` for each chunk. Emits compact entity/chunk/document bullets.
-
-    Uses only :class:`GraphDBInterface` connection methods (``get_connections``),
-    never raw Cypher, so it works uniformly across backends. Never raises: on a
-    backend that cannot traverse (e.g. Postgres-graph, which raises
-    ``NotImplementedError``) it returns ``""``.
+    Never raises: a missing collection or backend failure degrades to ``""``.
 
     Parameters
     ----------
-    node_ids:
-        Iterable of entity node identifiers to start traversal from.
-    graph_engine:
-        A graph engine implementing the ``GraphDBInterface`` connection API.
+    answer:
+        The generated answer text to ground.
+    vector_engine:
+        A vector engine exposing ``search(collection, query, limit, include_payload)``.
     limit:
         Desired maximum number of bullets, clamped into the 3-5 range.
 
@@ -295,91 +276,72 @@ async def build_graph_reference_context(node_ids: Any, graph_engine: Any, limit:
     -------
     str
         A multi-line Evidence block prefixed by an ``Evidence:`` header, or an
-        empty string when nothing usable was found or traversal is unsupported.
+        empty string when nothing usable was found or the search failed.
     """
-    if not node_ids or graph_engine is None:
+    cleaned_answer = _clean_str(answer)
+    if cleaned_answer is None or vector_engine is None:
         return ""
 
     try:
-        ids = list(node_ids)
-    except TypeError:
+        found_chunks = await vector_engine.search(
+            _CHUNK_COLLECTION,
+            cleaned_answer,
+            limit=_CANDIDATE_POOL,
+            include_payload=True,
+        )
+    except Exception as error:
+        logger.debug(f"Answer-grounded chunk search failed: {error}")
         return ""
 
-    max_bullets = _clamp_limit(limit)
-    bullets: List[str] = []
-    seen: set = set()
+    return format_chunk_references(found_chunks, answer=cleaned_answer, limit=limit)
+
+
+def append_chunk_evidence(
+    completions: List[Any], retrieved_objects: Any, enabled: bool
+) -> List[Any]:
+    """Append an answer-grounded chunk Evidence block to string completions.
+
+    Each string completion gets its own Evidence block, filtered and ranked by
+    that completion's text against the retrieved candidates. Non-string
+    completions (structured response models) are never touched, and an empty
+    Evidence block leaves the completion unchanged.
+    """
+    if not enabled:
+        return completions
+
+    appended: List[Any] = []
+    for completion in completions:
+        if not isinstance(completion, str):
+            appended.append(completion)
+            continue
+        evidence = format_chunk_references(retrieved_objects, answer=completion)
+        appended.append(f"{completion}\n\n{evidence}" if evidence else completion)
+    return appended
+
+
+async def append_answer_grounded_evidence(completions: List[Any], enabled: bool) -> List[Any]:
+    """Append an answer-grounded Evidence block to string completions.
+
+    Each string completion is run as a vector query against the chunk index
+    (see :func:`build_answer_grounded_chunk_references`). Non-string completions
+    are never touched; any backend failure degrades to no Evidence.
+    """
+    if not enabled:
+        return completions
 
     try:
-        for node_id in ids:
-            if len(bullets) >= max_bullets:
-                break
-            if node_id is None:
-                continue
+        from cognee.infrastructure.databases.vector import get_vector_engine
 
-            try:
-                connections = await graph_engine.get_connections(node_id)
-            except NotImplementedError:
-                # Backend cannot traverse (e.g. Postgres-graph): omit Evidence.
-                return ""
-            except AttributeError:
-                return ""
-            except Exception as error:  # pragma: no cover - defensive
-                logger.debug(f"get_connections failed for node {node_id}: {error}")
-                continue
+        vector_engine = get_vector_engine()
+    except Exception as error:
+        logger.debug(f"Unable to obtain vector engine for references: {error}")
+        return completions
 
-            for connection in connections or []:
-                if len(bullets) >= max_bullets:
-                    break
-                if not isinstance(connection, (tuple, list)) or len(connection) != 3:
-                    continue
-
-                source, relationship, target = connection
-                if _relationship_name(relationship) != _CONTAINS_REL:
-                    continue
-
-                # The entity is connected to a chunk via `contains`; the chunk is
-                # the endpoint that is not this entity node.
-                chunk_node = _other_node(node_id, source, target)
-                if chunk_node is None or _node_type(chunk_node) != _DOCUMENT_CHUNK_TYPE:
-                    continue
-
-                entity_name = (
-                    _node_name(source)
-                    if str(source.get("id") if isinstance(source, dict) else None) == str(node_id)
-                    else _node_name(target)
-                )
-                if entity_name is None:
-                    # Fall back to whichever endpoint is the entity (not chunk).
-                    entity_node = (
-                        source
-                        if isinstance(source, dict) and _node_type(source) != _DOCUMENT_CHUNK_TYPE
-                        else target
-                    )
-                    entity_name = _node_name(entity_node)
-                if entity_name is None:
-                    continue
-
-                number = _chunk_display_number(chunk_node)
-                if number is None:
-                    continue
-
-                document_name = await _document_name_for_chunk(chunk_node, graph_engine)
-                if document_name is None:
-                    continue
-
-                dedup_key = (entity_name, number, document_name)
-                if dedup_key in seen:
-                    continue
-                seen.add(dedup_key)
-
-                bullets.append(
-                    f"- Entity {entity_name} appears in chunk {number} of document {document_name}"
-                )
-    except Exception as error:  # pragma: no cover - defensive catch-all
-        logger.debug(f"build_graph_reference_context failed: {error}")
-        return ""
-
-    if not bullets:
-        return ""
-
-    return EVIDENCE_HEADER + "\n" + "\n".join(bullets)
+    appended: List[Any] = []
+    for completion in completions:
+        if not isinstance(completion, str):
+            appended.append(completion)
+            continue
+        evidence = await build_answer_grounded_chunk_references(completion, vector_engine)
+        appended.append(f"{completion}\n\n{evidence}" if evidence else completion)
+    return appended

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -69,7 +69,7 @@ async def get_search_type_retriever_instance(
     session_id = kwargs.get("session_id")
     neighborhood_depth = kwargs.get("neighborhood_depth")
     neighborhood_seed_top_k = kwargs.get("neighborhood_seed_top_k")
-    include_references = kwargs.get("include_references", True)
+    include_references = kwargs.get("include_references", False)
 
     # Registry mapping search types to their corresponding retriever classes and input parameters
     search_core_registry: dict[SearchType, Tuple[BaseRetriever, dict]] = {

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -56,7 +56,7 @@ async def search(
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
-    include_references: bool = True,
+    include_references: bool = False,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[SearchResult]:
@@ -168,7 +168,7 @@ async def authorized_search(
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
-    include_references: bool = True,
+    include_references: bool = False,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[SearchResultPayload]:
@@ -228,7 +228,7 @@ async def search_in_datasets_context(
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
-    include_references: bool = True,
+    include_references: bool = False,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[Tuple[Any, Union[str, List[Edge]], List[Dataset]]]:
@@ -255,7 +255,7 @@ async def search_in_datasets_context(
         retriever_specific_config: Optional[dict] = None,
         neighborhood_depth: Optional[int] = None,
         neighborhood_seed_top_k: Optional[int] = None,
-        include_references: bool = True,
+        include_references: bool = False,
     ) -> SearchResultPayload:
         with new_span("cognee.search.dataset") as span:
             span.set_attribute("cognee.search.dataset_name", dataset.name or "")

--- a/cognee/tests/test_permissions.py
+++ b/cognee/tests/test_permissions.py
@@ -146,7 +146,7 @@ async def test_permissions_example_flow(permissions_example_env):
     assert isinstance(recall_results, list) and len(recall_results) == 1
     assert recall_results[0].dataset_name == "AI"
     # GRAPH_COMPLETION appends an "Evidence:" section when include_references is
-    # on (the default), so match the mocked completion as a prefix.
+    # enabled (off by default), so match the mocked completion as a prefix.
     assert recall_results[0].text.startswith("MOCK_ANSWER")
 
     # user_1 can't read dataset owned by user_2.
@@ -181,7 +181,7 @@ async def test_permissions_example_flow(permissions_example_env):
     assert isinstance(recall_results, list) and len(recall_results) == 1
     assert recall_results[0].dataset_name == "QUANTUM"
     # GRAPH_COMPLETION appends an "Evidence:" section when include_references is
-    # on (the default), so match the mocked completion as a prefix.
+    # enabled (off by default), so match the mocked completion as a prefix.
     assert recall_results[0].text.startswith("MOCK_ANSWER")
 
     # Tenant + role scenario.
@@ -228,7 +228,7 @@ async def test_permissions_example_flow(permissions_example_env):
     assert isinstance(recall_results, list) and len(recall_results) == 1
     assert recall_results[0].dataset_name == "QUANTUM_COGNEE_LAB"
     # GRAPH_COMPLETION appends an "Evidence:" section when include_references is
-    # on (the default), so match the mocked completion as a prefix.
+    # enabled (off by default), so match the mocked completion as a prefix.
     assert recall_results[0].text.startswith("MOCK_ANSWER")
 
     # Remove user_3 from tenant (tenant owner user_2 removes user_3).

--- a/cognee/tests/unit/modules/retrieval/test_include_references_wiring.py
+++ b/cognee/tests/unit/modules/retrieval/test_include_references_wiring.py
@@ -2,9 +2,9 @@
 
 These verify the contracted append rules without any LLM or network:
 - include_references=False preserves the old answer text exactly (no Evidence).
-- include_references=True appends a non-empty Evidence block to str answers.
+- include_references=True appends an answer-grounded Evidence block to str answers.
 - Non-str response_model outputs are never corrupted.
-- Graph evidence degrades to no-op when the backend cannot traverse.
+- Evidence degrades to no-op when the backend fails or nothing overlaps the answer.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,6 +13,9 @@ import pytest
 
 from cognee.modules.retrieval.completion_retriever import CompletionRetriever
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
+
+
+MOCK_ANSWER = "Revenue grew 12 percent."
 
 
 def _cache_disabled():
@@ -33,7 +36,8 @@ def _chunk_scored():
     obj.payload = {
         "document_name": "report.pdf",
         "chunk_index": 0,
-        "text": "Relevant supporting text.",
+        # Shares terms with MOCK_ANSWER so answer-grounded filtering keeps it.
+        "text": "Revenue grew 12 percent year over year.",
     }
     return obj
 
@@ -46,7 +50,7 @@ async def test_completion_references_disabled_preserves_answer():
     with (
         patch(
             "cognee.modules.retrieval.completion_retriever.generate_completion",
-            return_value="Generated answer",
+            return_value=MOCK_ANSWER,
         ),
         patch(
             "cognee.modules.retrieval.completion_retriever.CacheConfig",
@@ -57,7 +61,29 @@ async def test_completion_references_disabled_preserves_answer():
             "q", [_chunk_scored()], context="ctx"
         )
 
-    assert completion == ["Generated answer"]
+    assert completion == [MOCK_ANSWER]
+
+
+@pytest.mark.asyncio
+async def test_completion_references_default_off():
+    """The default is include_references=False: answers stay untouched."""
+    retriever = CompletionRetriever()
+
+    with (
+        patch(
+            "cognee.modules.retrieval.completion_retriever.generate_completion",
+            return_value=MOCK_ANSWER,
+        ),
+        patch(
+            "cognee.modules.retrieval.completion_retriever.CacheConfig",
+            return_value=_cache_disabled(),
+        ),
+    ):
+        completion = await retriever.get_completion_from_context(
+            "q", [_chunk_scored()], context="ctx"
+        )
+
+    assert completion == [MOCK_ANSWER]
 
 
 @pytest.mark.asyncio
@@ -68,7 +94,7 @@ async def test_completion_references_enabled_appends_evidence():
     with (
         patch(
             "cognee.modules.retrieval.completion_retriever.generate_completion",
-            return_value="Generated answer",
+            return_value=MOCK_ANSWER,
         ),
         patch(
             "cognee.modules.retrieval.completion_retriever.CacheConfig",
@@ -80,8 +106,30 @@ async def test_completion_references_enabled_appends_evidence():
         )
 
     assert len(completion) == 1
-    assert completion[0].startswith("Generated answer\n\nEvidence:\n")
+    assert completion[0].startswith(f"{MOCK_ANSWER}\n\nEvidence:\n")
     assert "- chunk 1 of document report.pdf:" in completion[0]
+
+
+@pytest.mark.asyncio
+async def test_completion_references_omitted_when_answer_does_not_overlap():
+    """Chunks sharing no terms with the answer are not presented as provenance."""
+    retriever = CompletionRetriever(include_references=True)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.completion_retriever.generate_completion",
+            return_value="Penguins live in Antarctica.",
+        ),
+        patch(
+            "cognee.modules.retrieval.completion_retriever.CacheConfig",
+            return_value=_cache_disabled(),
+        ),
+    ):
+        completion = await retriever.get_completion_from_context(
+            "q", [_chunk_scored()], context="ctx"
+        )
+
+    assert completion == ["Penguins live in Antarctica."]
 
 
 @pytest.mark.asyncio
@@ -95,7 +143,7 @@ async def test_completion_references_enabled_but_no_usable_payload_omits_evidenc
     with (
         patch(
             "cognee.modules.retrieval.completion_retriever.generate_completion",
-            return_value="Generated answer",
+            return_value=MOCK_ANSWER,
         ),
         patch(
             "cognee.modules.retrieval.completion_retriever.CacheConfig",
@@ -104,7 +152,7 @@ async def test_completion_references_enabled_but_no_usable_payload_omits_evidenc
     ):
         completion = await retriever.get_completion_from_context("q", [bare], context="ctx")
 
-    assert completion == ["Generated answer"]
+    assert completion == [MOCK_ANSWER]
 
 
 @pytest.mark.asyncio
@@ -136,14 +184,14 @@ async def test_completion_references_skipped_for_non_str_response_model():
 
 
 # ---------------------------------------------------------------------------
-# GraphCompletionRetriever (graph entity-fallback evidence)
+# GraphCompletionRetriever (answer-grounded chunk evidence)
 # ---------------------------------------------------------------------------
 
 
-def _patch_graph_engine(engine):
+def _patch_vector_engine(engine):
     return patch(
-        "cognee.infrastructure.databases.graph.get_graph_engine",
-        new=AsyncMock(return_value=engine),
+        "cognee.infrastructure.databases.vector.get_vector_engine",
+        return_value=engine,
     )
 
 
@@ -151,68 +199,88 @@ def _patch_graph_engine(engine):
 async def test_graph_references_disabled_preserves_answer():
     """include_references=False -> graph answer returned verbatim, engine never queried."""
     retriever = GraphCompletionRetriever(include_references=False)
+    engine = AsyncMock()
 
-    # node_ids resolution should not even matter, but make it non-trivial.
-    with patch.object(retriever, "_node_ids_from_retrieved", return_value=["entity-1"]):
-        completion = await retriever._append_graph_evidence(["Graph answer"], object())
+    with _patch_vector_engine(engine):
+        completion = await retriever._append_graph_evidence(["Graph answer"])
 
     assert completion == ["Graph answer"]
+    engine.search.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_graph_references_enabled_appends_evidence():
-    """include_references=True -> entity-fallback Evidence appended to str answer."""
+async def test_graph_references_enabled_appends_answer_grounded_evidence():
+    """include_references=True -> the answer is vector-queried against the chunk index."""
     retriever = GraphCompletionRetriever(include_references=True)
 
     engine = AsyncMock()
-    engine.get_connections.return_value = [
-        (
-            {"id": "entity-1", "name": "Acme Corp", "type": "Entity"},
-            {"relationship_name": "contains"},
-            {
-                "id": "chunk-1",
-                "name": "chunk-1",
-                "type": "DocumentChunk",
-                "chunk_index": 2,
+    engine.search.return_value = [
+        MagicMock(
+            id="chunk-1",
+            payload={
                 "document_name": "report.pdf",
+                "chunk_index": 2,
+                "text": "Revenue grew 12 percent year over year.",
             },
         )
     ]
 
-    with (
-        patch.object(retriever, "_node_ids_from_retrieved", return_value=["entity-1"]),
-        _patch_graph_engine(engine),
-    ):
-        completion = await retriever._append_graph_evidence(["Graph answer"], object())
+    with _patch_vector_engine(engine):
+        completion = await retriever._append_graph_evidence([MOCK_ANSWER])
 
     assert len(completion) == 1
-    assert completion[0].startswith("Graph answer\n\nEvidence:\n")
-    assert "- Entity Acme Corp appears in chunk 3 of document report.pdf" in completion[0]
+    assert completion[0].startswith(f"{MOCK_ANSWER}\n\nEvidence:\n")
+    assert "- chunk 3 of document report.pdf:" in completion[0]
+    # The answer text itself is the vector query.
+    assert engine.search.await_args.args[1] == MOCK_ANSWER
 
 
 @pytest.mark.asyncio
-async def test_graph_references_degrade_on_non_traversable_backend():
-    """Postgres-graph (NotImplementedError) -> Evidence omitted, no raise."""
+async def test_graph_references_degrade_on_backend_failure():
+    """A failing chunk-index search -> Evidence omitted, no raise."""
     retriever = GraphCompletionRetriever(include_references=True)
 
     engine = AsyncMock()
-    engine.get_connections.side_effect = NotImplementedError("not supported")
+    engine.search.side_effect = RuntimeError("collection not found")
 
-    with (
-        patch.object(retriever, "_node_ids_from_retrieved", return_value=["entity-1"]),
-        _patch_graph_engine(engine),
-    ):
-        completion = await retriever._append_graph_evidence(["Graph answer"], object())
+    with _patch_vector_engine(engine):
+        completion = await retriever._append_graph_evidence(["Graph answer"])
 
     assert completion == ["Graph answer"]
 
 
 @pytest.mark.asyncio
-async def test_graph_references_no_node_ids_omits_evidence():
-    """No entity node ids resolved -> Evidence omitted, engine not consulted."""
+async def test_graph_references_omitted_when_nothing_overlaps_answer():
+    """Vector hits unrelated to the answer are not presented as provenance."""
     retriever = GraphCompletionRetriever(include_references=True)
 
-    with patch.object(retriever, "_node_ids_from_retrieved", return_value=[]):
-        completion = await retriever._append_graph_evidence(["Graph answer"], object())
+    engine = AsyncMock()
+    engine.search.return_value = [
+        MagicMock(
+            id="chunk-1",
+            payload={
+                "document_name": "report.pdf",
+                "chunk_index": 0,
+                "text": "Penguins live in Antarctica.",
+            },
+        )
+    ]
 
-    assert completion == ["Graph answer"]
+    with _patch_vector_engine(engine):
+        completion = await retriever._append_graph_evidence([MOCK_ANSWER])
+
+    assert completion == [MOCK_ANSWER]
+
+
+@pytest.mark.asyncio
+async def test_graph_references_skip_non_str_completions():
+    """Non-str completions are never corrupted with an Evidence string."""
+    retriever = GraphCompletionRetriever(include_references=True)
+    structured = {"answer": "structured"}
+    engine = AsyncMock()
+
+    with _patch_vector_engine(engine):
+        completion = await retriever._append_graph_evidence([structured])
+
+    assert completion == [structured]
+    engine.search.assert_not_awaited()

--- a/cognee/tests/unit/modules/retrieval/test_references_helpers.py
+++ b/cognee/tests/unit/modules/retrieval/test_references_helpers.py
@@ -1,8 +1,8 @@
 """Unit tests for the LLM-free reference (Evidence) helpers.
 
-Covers ``format_chunk_references`` (sync, payload-driven) and
-``build_graph_reference_context`` (async, GraphDBInterface-driven), including the
-old-data graceful-degradation cases and the non-traversable-backend case.
+Covers ``format_chunk_references`` (sync, payload-driven, answer-grounded) and
+``build_answer_grounded_chunk_references`` (async, vector-engine-driven),
+including the old-data graceful-degradation cases and backend-failure cases.
 """
 
 from unittest.mock import AsyncMock
@@ -11,13 +11,13 @@ import pytest
 
 from cognee.modules.retrieval.utils.references import (
     EVIDENCE_HEADER,
-    build_graph_reference_context,
+    build_answer_grounded_chunk_references,
     format_chunk_references,
 )
 
 
 # ---------------------------------------------------------------------------
-# format_chunk_references
+# format_chunk_references (no answer: legacy retrieval-order behavior)
 # ---------------------------------------------------------------------------
 
 
@@ -136,108 +136,118 @@ def test_format_chunk_references_snippet_truncated():
 
 
 # ---------------------------------------------------------------------------
-# build_graph_reference_context
+# format_chunk_references (answer-grounded filtering and ranking)
 # ---------------------------------------------------------------------------
 
 
-def _entity_node():
-    return {"id": "entity-1", "name": "Acme Corp", "type": "Entity"}
+def test_answer_filtering_drops_chunks_without_overlap():
+    """Chunks sharing no significant terms with the answer are not cited."""
+    matching = _payload(document_name="report.pdf", chunk_index=0, text="Revenue grew 12 percent.")
+    unrelated = _payload(
+        document_name="other.pdf", chunk_index=1, text="Penguins live in Antarctica."
+    )
+
+    result = format_chunk_references([matching, unrelated], answer="Revenue grew 12 percent.")
+
+    assert "report.pdf" in result
+    assert "other.pdf" not in result
 
 
-def _chunk_node(with_flat_name=True):
-    node = {"id": "chunk-1", "name": "chunk-1", "type": "DocumentChunk", "chunk_index": 2}
-    if with_flat_name:
-        node["document_name"] = "annual_report.pdf"
-    return node
+def test_answer_filtering_empty_when_nothing_overlaps():
+    """No candidate overlaps the answer -> Evidence omitted entirely."""
+    unrelated = _payload(text="Penguins live in Antarctica.")
+
+    assert format_chunk_references([unrelated], answer="Quarterly revenue increased.") == ""
 
 
-def _document_node():
-    return {"id": "doc-1", "name": "annual_report.pdf", "type": "Document"}
+def test_answer_filtering_ranks_by_overlap():
+    """Higher answer-term overlap is cited before lower overlap."""
+    weak = _payload(document_name="weak.pdf", chunk_index=0, text="Revenue is mentioned once.")
+    strong = _payload(
+        document_name="strong.pdf",
+        chunk_index=1,
+        text="Revenue grew twelve percent in the fourth quarter.",
+    )
+
+    result = format_chunk_references(
+        [weak, strong], answer="Revenue grew twelve percent in the fourth quarter."
+    )
+
+    assert result.index("strong.pdf") < result.index("weak.pdf")
+
+
+def test_answer_with_no_significant_terms_yields_no_evidence():
+    """An answer made of stopwords/stubs cannot be grounded -> empty string."""
+    assert format_chunk_references([_payload()], answer="It is.") == ""
+
+
+def test_answer_none_keeps_all_usable_candidates():
+    """answer=None preserves the unfiltered retrieval-order behavior."""
+    unrelated = _payload(text="Penguins live in Antarctica.")
+
+    assert "Penguins" in format_chunk_references([unrelated], answer=None)
+
+
+# ---------------------------------------------------------------------------
+# build_answer_grounded_chunk_references
+# ---------------------------------------------------------------------------
+
+
+def _scored(payload, id_):
+    class FakeScored:
+        def __init__(self, payload, id_):
+            self.payload = payload
+            self.id = id_
+
+    return FakeScored(payload, id_)
 
 
 @pytest.mark.asyncio
-async def test_build_graph_reference_context_uses_flat_document_name():
-    """Entity -> contains -> chunk with a flat document_name resolves directly."""
+async def test_answer_grounded_references_query_chunk_index_with_answer():
+    """The answer text is run as the vector query and grounds the bullets."""
     engine = AsyncMock()
-    engine.get_connections.return_value = [
-        (_entity_node(), {"relationship_name": "contains"}, _chunk_node(with_flat_name=True)),
+    engine.search.return_value = [
+        _scored(
+            _payload(document_name="report.pdf", chunk_index=2, text="Revenue grew 12 percent."),
+            "chunk-1",
+        )
     ]
 
-    result = await build_graph_reference_context(["entity-1"], engine)
+    result = await build_answer_grounded_chunk_references("Revenue grew 12 percent.", engine)
 
     assert result.startswith(EVIDENCE_HEADER + "\n")
-    assert "- Entity Acme Corp appears in chunk 3 of document annual_report.pdf" in result
-    # Only the single get_connections call was needed (flat name short-circuits).
-    engine.get_connections.assert_awaited_once_with("entity-1")
+    assert "- chunk 3 of document report.pdf:" in result
+    engine.search.assert_awaited_once()
+    assert engine.search.await_args.args[0] == "DocumentChunk_text"
+    assert engine.search.await_args.args[1] == "Revenue grew 12 percent."
 
 
 @pytest.mark.asyncio
-async def test_build_graph_reference_context_falls_back_to_is_part_of():
-    """Without a flat name, it walks is_part_of -> Document for the name."""
+async def test_answer_grounded_references_drop_unrelated_results():
+    """Vector hits that share no terms with the answer are filtered out."""
     engine = AsyncMock()
-
-    async def get_connections(node_id):
-        if node_id == "entity-1":
-            return [
-                (
-                    _entity_node(),
-                    {"relationship_name": "contains"},
-                    _chunk_node(with_flat_name=False),
-                )
-            ]
-        if node_id == "chunk-1":
-            return [
-                (
-                    _chunk_node(with_flat_name=False),
-                    {"relationship_name": "is_part_of"},
-                    _document_node(),
-                )
-            ]
-        return []
-
-    engine.get_connections.side_effect = get_connections
-
-    result = await build_graph_reference_context(["entity-1"], engine)
-
-    assert "- Entity Acme Corp appears in chunk 3 of document annual_report.pdf" in result
-
-
-@pytest.mark.asyncio
-async def test_build_graph_reference_context_returns_empty_on_not_implemented():
-    """Non-traversable backend (Postgres-graph) raises NotImplementedError -> empty, no raise."""
-    engine = AsyncMock()
-    engine.get_connections.side_effect = NotImplementedError("graph traversal not supported")
-
-    result = await build_graph_reference_context(["entity-1"], engine)
-
-    assert result == ""
-
-
-@pytest.mark.asyncio
-async def test_build_graph_reference_context_returns_empty_on_attribute_error():
-    """Engine missing get_connections -> AttributeError -> empty, no raise."""
-    engine = AsyncMock()
-    engine.get_connections.side_effect = AttributeError("no get_connections")
-
-    result = await build_graph_reference_context(["entity-1"], engine)
-
-    assert result == ""
-
-
-@pytest.mark.asyncio
-async def test_build_graph_reference_context_empty_for_no_node_ids_or_engine():
-    assert await build_graph_reference_context([], AsyncMock()) == ""
-    assert await build_graph_reference_context(["entity-1"], None) == ""
-
-
-@pytest.mark.asyncio
-async def test_build_graph_reference_context_empty_when_no_chunk_connections():
-    """Entity with no contains->DocumentChunk connection produces no evidence."""
-    engine = AsyncMock()
-    engine.get_connections.return_value = [
-        (_entity_node(), {"relationship_name": "related_to"}, _entity_node()),
+    engine.search.return_value = [
+        _scored(_payload(text="Penguins live in Antarctica."), "chunk-1"),
     ]
 
-    result = await build_graph_reference_context(["entity-1"], engine)
+    result = await build_answer_grounded_chunk_references("Quarterly revenue increased.", engine)
 
     assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_answer_grounded_references_empty_on_search_failure():
+    """A missing collection or backend failure degrades to no Evidence, no raise."""
+    engine = AsyncMock()
+    engine.search.side_effect = RuntimeError("collection not found")
+
+    result = await build_answer_grounded_chunk_references("Revenue grew.", engine)
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_answer_grounded_references_empty_for_blank_answer_or_engine():
+    assert await build_answer_grounded_chunk_references("", AsyncMock()) == ""
+    assert await build_answer_grounded_chunk_references("   ", AsyncMock()) == ""
+    assert await build_answer_grounded_chunk_references("Revenue grew.", None) == ""


### PR DESCRIPTION
## Summary

Evidence blocks were assembled from whatever was retrieved *before* the LLM was called, so they reflected retrieval provenance at best — and for the graph path, mere corpus occurrence of incidentally-retrieved entities. This PR makes Evidence answer-grounded and flips `include_references` to default off.

### Answer-grounded Evidence (no extra LLM calls)

- **Chunk path (RAG / triplet):** candidates are filtered and ranked by significant-term overlap with each completion's own text. Chunks sharing no terms with the answer are never cited; an answer that can't be grounded (e.g. "Yes.") gets no Evidence instead of misleading citations.
- **Graph path:** the per-entity `contains` traversal in `build_graph_reference_context` is replaced by running the answer text as a single vector query against the `DocumentChunk_text` index, then applying the same overlap filter. Evidence is now chunk-level and answer-grounded regardless of how retrieval was done. This also removes the N + N×chunks sequential graph round trips, the both-endpoints entity over-collection, and the ambiguous undirected-edge fallback in `_other_node`.
- **Session cache:** Evidence is derived per completion from its own text, so a cache-hit answer no longer cites chunks from an unrelated later search.

### `include_references` defaults to `False`

Flipped at every layer — SDK entry points (`search`, `recall`), API router DTOs, the retriever factory, and all retriever constructors — so existing callers keep byte-identical answers unless they explicitly opt in. No migration needed.

### Cleanups

- The duplicated `_append_chunk_evidence` bodies in `CompletionRetriever` and `TripletRetriever` are deduplicated into shared helpers in `utils/references.py` (`append_chunk_evidence`, `append_answer_grounded_evidence`).
- `TextChunkerWithOverlap` computes `document_name` once at construction instead of per chunk, matching the other chunkers.

## Test plan

- `cognee/tests/unit/modules/retrieval/test_references_helpers.py` — rewritten: keeps the payload/degradation coverage for `format_chunk_references`, adds answer-overlap filtering/ranking cases, and replaces the graph-traversal tests with `build_answer_grounded_chunk_references` tests (vector query shape, unrelated-hit filtering, backend-failure degradation).
- `cognee/tests/unit/modules/retrieval/test_include_references_wiring.py` — rewritten for the new wiring, including a default-off test and answer/chunk-mismatch omission tests for both retriever families.
- All 37 affected unit tests pass; ruff check/format and pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)