### PR TITLE
fix: background remember fails on uploads with 'I/O operation on closed file'

### DIFF
--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -138,6 +138,39 @@ def _data_to_text(data) -> str:
     return f"[{type(data).__name__}]"
 
 
+class _DetachedUpload:
+    """Duck-types an UploadFile (.file / .filename) with a pipeline-owned buffer."""
+
+    def __init__(self, file, filename):
+        self.file = file
+        self.filename = filename
+
+
+def _detach_request_files(data):
+    """Copy request-scoped uploads into buffers the pipeline owns.
+
+    In background mode the HTTP response is sent before ingestion runs,
+    and Starlette closes each UploadFile's temp file on request teardown —
+    the pipeline would then fail with "I/O operation on closed file".
+    """
+    import shutil
+    from tempfile import SpooledTemporaryFile
+
+    def _detach(item):
+        file_obj = getattr(item, "file", None)
+        if file_obj is None or not hasattr(item, "filename"):
+            return item
+        buffer = SpooledTemporaryFile(max_size=10 * 1024 * 1024)
+        file_obj.seek(0)
+        shutil.copyfileobj(file_obj, buffer)
+        buffer.seek(0)
+        return _DetachedUpload(buffer, item.filename)
+
+    if isinstance(data, list):
+        return [_detach(item) for item in data]
+    return _detach(data)
+
+
 _SESSION_PLACEHOLDER_PREFIXES = ("[UploadFile]", "[file:", "[BinaryIO", "[SpooledTemporaryFile")
 
 
@@ -963,6 +996,9 @@ async def _remember_inner(
             await improve(**improve_kwargs)
 
     if run_in_background:
+        # Detach before returning the response — request teardown closes
+        # the original upload handles while the task is still running.
+        data = _detach_request_files(data)
 
         async def _remember_background():
             try:

--- a/cognee/tests/unit/api/test_remember_background_uploads.py
+++ b/cognee/tests/unit/api/test_remember_background_uploads.py
@@ -1,0 +1,46 @@
+"""Background remember must not read request-scoped uploads after teardown.
+
+When ``run_in_background=True`` the HTTP response is sent before ingestion
+runs, and Starlette closes each UploadFile's temp file on request teardown.
+``_detach_request_files`` copies uploads into pipeline-owned buffers so the
+background task survives that.
+"""
+
+from tempfile import SpooledTemporaryFile
+
+from cognee.api.v1.remember.remember import _detach_request_files
+
+
+class UploadFileStub:
+    def __init__(self, content: bytes, filename: str):
+        self.file = SpooledTemporaryFile()
+        self.file.write(content)
+        self.file.seek(0)
+        self.filename = filename
+
+
+def test_detached_upload_survives_original_close():
+    upload = UploadFileStub(b"hello cognee", "notes.txt")
+
+    detached = _detach_request_files([upload])
+    upload.file.close()  # simulates Starlette request teardown
+
+    assert len(detached) == 1
+    assert detached[0].filename == "notes.txt"
+    assert detached[0].file.read() == b"hello cognee"
+
+
+def test_detach_preserves_read_position_independence():
+    upload = UploadFileStub(b"0123456789", "data.bin")
+    upload.file.read(4)  # consumed by e.g. size estimation
+
+    detached = _detach_request_files([upload])
+
+    assert detached[0].file.read() == b"0123456789"
+
+
+def test_non_upload_items_pass_through_unchanged():
+    items = ["plain text", b"bytes too"]
+
+    assert _detach_request_files(items) == items
+    assert _detach_request_files("single") == "single"


### PR DESCRIPTION
## Summary
- With `run_in_background=true`, `POST /v1/remember` returns the response before ingestion runs; Starlette then closes each `UploadFile`'s temp file on request teardown, so the background pipeline fails every item with `I/O operation on closed file` → `PipelineRunFailedError (422)`. The endpoint still reports 200/"running", so uploads silently never appear in the dataset.
- Fix: before spawning the background task, copy each upload into a pipeline-owned `SpooledTemporaryFile` (`_detach_request_files`), preserving the filename via a small `UploadFile` duck-type. Blocking mode is untouched — the request is still open there.
- Affects any client uploading files with background mode, including the cloud UI which always sends `run_in_background=true`.

## Test plan
- [x] New unit tests: detached uploads survive closing the original handle, read position independence, non-file items pass through
- [x] `pytest cognee/tests/unit/api/` passes locally
- [ ] End-to-end: `curl -F 'data=@file.pdf' -F 'datasetName=x' -F 'run_in_background=true' /api/v1/remember` then confirm the document appears in the dataset and the pipeline run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)