### PR TITLE
ci(frontend): add timeout and concurrency to lockfile workflow (follow-up to #2834)

### DIFF
--- a/.github/workflows/frontend_lockfile.yml
+++ b/.github/workflows/frontend_lockfile.yml
@@ -15,6 +15,10 @@ on:
       - ".github/workflows/frontend_lockfile.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,6 +26,7 @@ jobs:
   frontend-lockfile:
     name: Frontend lockfile sync
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Follow-up to #2834, stacked on its head branch `fix/frontend-package-lock`.

Addresses the two unresolved CodeRabbit review suggestions on the new `frontend_lockfile.yml` workflow:

- Add `timeout-minutes: 10` to the `frontend-lockfile` job so a hung `npm ci` cannot occupy a runner for the default 6 hours — lockfile verification should finish in well under a minute.
- Add a top-level `concurrency` block (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`) so rapid successive pushes cancel superseded runs instead of queueing redundant ones.

No behavior change for the verification itself; this only tightens resource usage.

## Tests

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/frontend_lockfile.yml'))"` parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)