### PR TITLE
fix: use sa.URL.create for migration example connection strings (follow-up to #2878)

### DIFF
--- a/examples/demos/complex_relational_database_migration_example/complex_relational_database_migration_example.py
+++ b/examples/demos/complex_relational_database_migration_example/complex_relational_database_migration_example.py
@@ -122,11 +122,16 @@ PRODUCTS = [
 
 def _get_postgres_engine() -> sa.Engine:
     # Requires a running Postgres database and a pre-created database (db_name).
-    connection_string = (
-        f"postgresql+psycopg2://{MIGRATION_DB_USERNAME}:{MIGRATION_DB_PASSWORD}"
-        f"@{MIGRATION_DB_HOST}:{MIGRATION_DB_PORT}/{MIGRATION_DB_NAME}"
+    # URL.create safely encodes credentials that contain URL-reserved characters.
+    connection_url = sa.URL.create(
+        "postgresql+psycopg2",
+        username=MIGRATION_DB_USERNAME,
+        password=MIGRATION_DB_PASSWORD,
+        host=MIGRATION_DB_HOST,
+        port=int(MIGRATION_DB_PORT),
+        database=MIGRATION_DB_NAME,
     )
-    return sa.create_engine(connection_string)
+    return sa.create_engine(connection_url)
 
 
 def create_example_postgres_db() -> None:

--- a/examples/demos/simple_relational_database_migration_example/simple_relational_database_migration_example.py
+++ b/examples/demos/simple_relational_database_migration_example/simple_relational_database_migration_example.py
@@ -75,11 +75,16 @@ Each of these companies has significantly impacted the technology landscape, dri
 
 def _get_postgres_engine() -> sa.Engine:
     # Requires a running Postgres database and a pre-created database (db_name).
-    connection_string = (
-        f"postgresql+psycopg2://{MIGRATION_DB_USERNAME}:{MIGRATION_DB_PASSWORD}"
-        f"@{MIGRATION_DB_HOST}:{MIGRATION_DB_PORT}/{MIGRATION_DB_NAME}"
+    # URL.create safely encodes credentials that contain URL-reserved characters.
+    connection_url = sa.URL.create(
+        "postgresql+psycopg2",
+        username=MIGRATION_DB_USERNAME,
+        password=MIGRATION_DB_PASSWORD,
+        host=MIGRATION_DB_HOST,
+        port=int(MIGRATION_DB_PORT),
+        database=MIGRATION_DB_NAME,
     )
-    return sa.create_engine(connection_string)
+    return sa.create_engine(connection_url)
 
 
 def create_example_postgres_db() -> None:


### PR DESCRIPTION
## Description
Follow-up to #2878, stacked on its head branch.

Addresses the unresolved CodeRabbit review comments (marked Major / quick win) on both relational database migration examples: the Postgres connection string was built via f-string interpolation, which breaks when `MIGRATION_DB_PASSWORD` (or other components) contain URL-reserved characters such as `@`, `:`, or `/`.

This replaces the raw f-strings in `_get_postgres_engine()` with `sa.URL.create(...)`, which percent-encodes credentials safely (verified locally with SQLAlchemy 2.0.50, which matches the project's `sqlalchemy>=2.0.39` requirement).

Files changed:
- `examples/demos/simple_relational_database_migration_example/simple_relational_database_migration_example.py`
- `examples/demos/complex_relational_database_migration_example/complex_relational_database_migration_example.py`

Merge after #2878.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)