### PR TITLE
test: redact secrets from Docker e2e failure logs (follow-up to #2778)

### DIFF
--- a/cognee/tests/e2e/docker/test_docker_remember_recall.py
+++ b/cognee/tests/e2e/docker/test_docker_remember_recall.py
@@ -13,6 +13,7 @@ Example:
 from __future__ import annotations
 
 import os
+import re
 import socket
 import subprocess
 import time
@@ -27,6 +28,19 @@ import pytest
 PASSWORD = "securepassword123!"
 VERIFY_PHRASE = "crimson-river-2776"
 VERIFY_NOTE = "Vela-117"
+
+_SENSITIVE_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)([A-Z0-9_]*(?:API_KEY|SECRET|TOKEN|PASSWORD)[A-Z0-9_]*\s*[=:]\s*)\S+"
+)
+_BEARER_TOKEN_PATTERN = re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/-]+=*")
+_OPENAI_KEY_PATTERN = re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b")
+
+
+def _redact_secrets(text: str) -> str:
+    """Mask API keys, tokens, and passwords so failure output is safe to print in CI logs."""
+    text = _SENSITIVE_ASSIGNMENT_PATTERN.sub(r"\1****", text)
+    text = _BEARER_TOKEN_PATTERN.sub(r"\1****", text)
+    return _OPENAI_KEY_PATTERN.sub("sk-****", text)
 
 
 def _repo_root() -> Path:
@@ -96,12 +110,13 @@ def _run(
 
 
 def _container_logs(container_name: str, *, tail: int = 300) -> str:
+    """Return the container's recent logs with secret-looking values redacted."""
     result = _run(
         ["docker", "logs", "--tail", str(tail), container_name],
         check=False,
         timeout=30,
     )
-    return (result.stdout + "\n" + result.stderr).strip()
+    return _redact_secrets((result.stdout + "\n" + result.stderr).strip())
 
 
 def _container_status(container_name: str) -> str:


### PR DESCRIPTION
## Description

Follow-up to #2778, stacked on its head branch `codex/docker-remember-recall-e2e`.

The Docker remember/recall e2e test prints container logs verbatim when it fails (in `_wait_until_ready` and in the test's `except` block). If the container ever logs env/config values, that would leak API keys into public CI output. This was flagged as an unresolved Major review comment on #2778.

This PR routes all container log output through a `_redact_secrets` helper inside `_container_logs`, so every failure-print site is covered with one change. The helper masks:

- `*_API_KEY` / `*SECRET*` / `*TOKEN*` / `*PASSWORD*` assignments (`KEY=value` and `key: value` forms, case-insensitive)
- `Bearer <token>` headers
- raw OpenAI-style `sk-...` keys appearing anywhere in the logs

16 lines added, no behavior change on the happy path. Should merge into #2778's branch before that PR merges to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)