### PR TITLE
fix: make startup recovery best-effort at the discovery stage (follow-up to #2813)

### DIFF
--- a/cognee/modules/cognify/recovery.py
+++ b/cognee/modules/cognify/recovery.py
@@ -52,36 +52,48 @@ async def recover_stale_cognify_runs_on_startup() -> None:
     on every restart. After a successful rollback the dataset's pipeline status
     is reset to ``DATASET_PROCESSING_INITIATED`` so it is no longer reported as
     "already being processed" and can be cognified again.
+
+    Recovery is best-effort end to end: a failure while discovering candidates
+    (just like a failure while rolling back a single run) is logged and
+    swallowed so it can never prevent the API from starting.
     """
     db_engine = get_relational_engine()
 
-    async with db_engine.get_async_session() as session:
-        latest_per_dataset = (
-            select(
-                PipelineRun,
-                func.row_number()
-                .over(
-                    partition_by=PipelineRun.dataset_id,
-                    order_by=PipelineRun.created_at.desc(),
+    try:
+        async with db_engine.get_async_session() as session:
+            latest_per_dataset = (
+                select(
+                    PipelineRun,
+                    func.row_number()
+                    .over(
+                        partition_by=PipelineRun.dataset_id,
+                        order_by=PipelineRun.created_at.desc(),
+                    )
+                    .label("rn"),
                 )
-                .label("rn"),
+                .where(PipelineRun.pipeline_name == "cognify_pipeline")
+                .subquery()
             )
-            .where(PipelineRun.pipeline_name == "cognify_pipeline")
-            .subquery()
-        )
 
-        latest_run = aliased(PipelineRun, latest_per_dataset)
-        recovery_candidates = (
-            (
-                await session.execute(
-                    select(latest_run)
-                    .where(latest_per_dataset.c.rn == 1)
-                    .where(latest_run.status == PipelineRunStatus.DATASET_PROCESSING_STARTED)
+            latest_run = aliased(PipelineRun, latest_per_dataset)
+            recovery_candidates = (
+                (
+                    await session.execute(
+                        select(latest_run)
+                        .where(latest_per_dataset.c.rn == 1)
+                        .where(latest_run.status == PipelineRunStatus.DATASET_PROCESSING_STARTED)
+                    )
                 )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
+    except Exception as error:
+        logger.error(
+            "Startup recovery skipped: failed to query for stale cognify runs: %s",
+            error,
+            exc_info=True,
         )
+        return
 
     for pipeline_run in recovery_candidates:
         if not _is_older_than_threshold(getattr(pipeline_run, "created_at", None)):
@@ -93,18 +105,18 @@ async def recover_stale_cognify_runs_on_startup() -> None:
             )
             continue
 
-        async with db_engine.get_async_session() as session:
-            dataset = await session.get(Dataset, pipeline_run.dataset_id)
-
-        if dataset is None:
-            logger.warning(
-                "Skipping startup recovery for run %s: dataset %s not found.",
-                pipeline_run.pipeline_run_id,
-                pipeline_run.dataset_id,
-            )
-            continue
-
         try:
+            async with db_engine.get_async_session() as session:
+                dataset = await session.get(Dataset, pipeline_run.dataset_id)
+
+            if dataset is None:
+                logger.warning(
+                    "Skipping startup recovery for run %s: dataset %s not found.",
+                    pipeline_run.pipeline_run_id,
+                    pipeline_run.dataset_id,
+                )
+                continue
+
             async with set_database_global_context_variables(dataset.id, dataset.owner_id):
                 await cognify_rollback_handler(
                     pipeline_run_id=pipeline_run.pipeline_run_id,

--- a/cognee/tests/unit/modules/cognify/test_recovery.py
+++ b/cognee/tests/unit/modules/cognify/test_recovery.py
@@ -130,6 +130,32 @@ async def test_recover_stale_cognify_runs_skips_missing_dataset(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_recover_stale_cognify_runs_swallows_discovery_query_failure(monkeypatch):
+    """A failure while querying for stale runs must not propagate: the
+    function is called from FastAPI lifespan, so an exception here would
+    prevent the whole API from starting."""
+
+    class _FailingSession(_FakeSession):
+        async def execute(self, _statement):
+            raise RuntimeError("relational database unavailable")
+
+    engine = _FakeEngine([_FailingSession()])
+
+    rollback_calls = []
+
+    async def _rollback_handler(**kwargs):
+        rollback_calls.append(kwargs)
+
+    monkeypatch.setattr(recovery_module, "get_relational_engine", lambda: engine)
+    monkeypatch.setattr(recovery_module, "set_database_global_context_variables", _no_op_context)
+    monkeypatch.setattr(recovery_module, "cognify_rollback_handler", _rollback_handler)
+
+    await recovery_module.recover_stale_cognify_runs_on_startup()
+
+    assert rollback_calls == []
+
+
+@pytest.mark.asyncio
 async def test_recover_stale_cognify_runs_skips_recent_run(monkeypatch):
     """A STARTED run younger than the staleness threshold is left alone so a
     live run on another worker is not rolled back out from under it."""


### PR DESCRIPTION
## Description

Follow-up to #2813, stacked on its head branch (`feature/cog-2394-add-cognify-and-add-process-transactions`).

`recover_stale_cognify_runs_on_startup()` is awaited directly in the FastAPI lifespan (`cognee/api/client.py`), but only the per-run rollback was wrapped in `try/except`. If the candidate-discovery query failed (e.g. relational DB hiccup, or tables not yet migrated on a fresh deploy), the exception bubbled out of lifespan and the whole API never started. The same applied to the per-run dataset lookup, which sat outside the per-run guard.

This addresses the unresolved review comment on #2813 ("Keep startup recovery best-effort at the query stage too"):

- Wrap the candidate-discovery query in `try/except`; log and return early on failure so recovery can never take the service down.
- Move the per-run dataset lookup inside the existing per-run `try` so a transient DB error on one candidate cannot abort startup either.
- Add a unit test asserting that a discovery query failure is swallowed and no rollback is attempted.

No behavior change on the happy path; existing unit tests in `cognee/tests/unit/modules/cognify/test_recovery.py` still pass (4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)