### PR TITLE
test(llm): add unit tests for openai type-introspection cache (follow-up to #2876)

### DIFF
--- a/cognee/infrastructure/llm/openai_type_cache.py
+++ b/cognee/infrastructure/llm/openai_type_cache.py
@@ -31,7 +31,7 @@ from typing import Any, Callable
 
 from cognee.shared.logging_utils import get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 _INSTALLED = False
 

--- a/cognee/tests/unit/infrastructure/llm/test_openai_type_cache.py
+++ b/cognee/tests/unit/infrastructure/llm/test_openai_type_cache.py
@@ -1,0 +1,60 @@
+"""Unit tests for the openai type-introspection cache (cognee.infrastructure.llm.openai_type_cache)."""
+
+from typing import Annotated, List, Literal, Optional, Union
+
+import pytest
+
+pytest.importorskip("openai")
+
+# Importing the llm package installs the cache as an import side effect.
+from cognee.infrastructure.llm import openai_type_cache
+from openai import _models
+from openai._utils import _compat as ou_compat
+from openai._utils import _typing as ou_typing
+
+
+def test_cache_is_installed_on_package_import_and_install_is_idempotent():
+    assert openai_type_cache._INSTALLED is True
+    # A second install must be a no-op.
+    assert openai_type_cache.install() is False
+
+
+def test_helpers_are_rebound_to_shared_cached_wrappers():
+    # The same cached wrapper must be rebound at every import site, and
+    # functools.wraps exposes the uncached original via __wrapped__.
+    assert hasattr(ou_compat.get_origin, "__wrapped__")
+    assert hasattr(ou_compat.get_args, "__wrapped__")
+    assert hasattr(ou_compat.is_literal_type, "__wrapped__")
+    assert hasattr(ou_typing.is_annotated_type, "__wrapped__")
+
+    assert _models.get_origin is ou_compat.get_origin
+    assert _models.get_args is ou_compat.get_args
+    assert _models.is_literal_type is ou_compat.is_literal_type
+    assert _models.is_annotated_type is ou_typing.is_annotated_type
+
+
+def test_cached_helpers_match_uncached_originals():
+    type_cases = [
+        int,
+        list[int],
+        List[int],
+        dict[str, int],
+        Optional[str],
+        Union[int, str],
+        Literal["a", "b"],
+        Annotated[int, "meta"],
+    ]
+    for tp in type_cases:
+        # Call twice so the second hit comes from the cache.
+        for _ in range(2):
+            assert ou_compat.get_origin(tp) == ou_compat.get_origin.__wrapped__(tp)
+            assert ou_compat.get_args(tp) == ou_compat.get_args.__wrapped__(tp)
+            assert ou_compat.is_literal_type(tp) == ou_compat.is_literal_type.__wrapped__(tp)
+            assert ou_typing.is_annotated_type(tp) == ou_typing.is_annotated_type.__wrapped__(tp)
+
+
+def test_unhashable_argument_falls_back_to_uncached_call():
+    # Lists are unhashable, so lru_cache raises TypeError internally; the
+    # wrapper must swallow it and return the uncached result instead.
+    assert ou_compat.get_origin(["not", "a", "type"]) is None
+    assert ou_compat.get_args(["not", "a", "type"]) == ()


### PR DESCRIPTION
## Summary

Follow-up to #2876, stacked on `perf/openai-type-introspection-cache`.

#2876 adds `cognee/infrastructure/llm/openai_type_cache.py` but ships no tests for the new behavior. This PR adds a small unit test module (`cognee/tests/unit/infrastructure/llm/test_openai_type_cache.py`) that locks in the contract the perf patch relies on:

- the cache is installed as an import side effect of `cognee.infrastructure.llm` and `install()` is idempotent (returns `False` on repeat calls)
- all four helpers (`get_origin`, `get_args`, `is_literal_type`, `is_annotated_type`) are rebound to the same cached wrappers across the openai import sites (`openai._models`, `openai._utils._compat`, `openai._utils._typing`)
- cached results match the uncached originals (via `__wrapped__`) for common typing shapes, including repeated (cache-hit) calls
- unhashable arguments fall back to the uncached call instead of raising `TypeError`

If a future openai-python release moves these private modules, these tests fail fast instead of silently losing the ~28% cognify CPU saving measured in #2876.

Also addresses the open CodeRabbit nit by passing `__name__` to `get_logger()` so log records from the cache installer carry the module name.

Tests pass locally: `uv run pytest cognee/tests/unit/infrastructure/llm/test_openai_type_cache.py` (4 passed).

Should merge after #2876 (or be merged into it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)