### PR TITLE
fix(tools): make SKILL.md directory loading case-insensitive (follow-up to #2676)

### DIFF
--- a/cognee/modules/tools/ingest_skills.py
+++ b/cognee/modules/tools/ingest_skills.py
@@ -11,6 +11,7 @@ from typing import List, Union
 
 from cognee.modules.engine.models import Skill
 from cognee.modules.tools.loaders import (
+    iter_skill_md_files,
     load_skill_from_md,
     load_skills_from_directory,
 )
@@ -29,9 +30,9 @@ def looks_like_skill_source(data) -> bool:
     path = Path(data)
     try:
         if path.is_file():
-            return path.name.upper() == "SKILL.MD"
+            return path.name.lower() == "skill.md"
         if path.is_dir():
-            return any(path.rglob("SKILL.md")) or any(path.rglob("skill.md"))
+            return any(iter_skill_md_files(path))
     except OSError:
         return False
     return False

--- a/cognee/modules/tools/loaders/__init__.py
+++ b/cognee/modules/tools/loaders/__init__.py
@@ -1,10 +1,12 @@
 from cognee.modules.tools.loaders.skill_md_loader import (
+    iter_skill_md_files,
     load_skill_from_md,
     load_skills_from_directory,
     parse_skill_md,
 )
 
 __all__ = [
+    "iter_skill_md_files",
     "load_skill_from_md",
     "load_skills_from_directory",
     "parse_skill_md",

--- a/cognee/modules/tools/loaders/skill_md_loader.py
+++ b/cognee/modules/tools/loaders/skill_md_loader.py
@@ -15,7 +15,7 @@ The `allowed-tools` field may be either a YAML list or a comma-separated string.
 """
 
 from pathlib import Path
-from typing import List, Tuple
+from typing import Iterator, List, Tuple
 
 import yaml
 
@@ -86,7 +86,18 @@ def load_skill_from_md(path: Path) -> Skill:
     return parse_skill_md(text)
 
 
+def iter_skill_md_files(root: Path) -> Iterator[Path]:
+    """Yield every SKILL.md file under root, matching the name case-insensitively.
+
+    Shared by directory loading and skill-source detection so that both agree on
+    what counts as a SKILL.md (e.g. lowercase `skill.md` on case-sensitive
+    filesystems).
+    """
+    for path in sorted(Path(root).rglob("*")):
+        if path.is_file() and path.name.lower() == "skill.md":
+            yield path
+
+
 def load_skills_from_directory(root: Path) -> List[Skill]:
-    """Recursively load every SKILL.md under root."""
-    root_path = Path(root)
-    return [load_skill_from_md(p) for p in sorted(root_path.rglob("SKILL.md"))]
+    """Recursively load every SKILL.md (any case) under root."""
+    return [load_skill_from_md(p) for p in iter_skill_md_files(root)]

--- a/cognee/tests/unit/modules/tools/skill_md_loader_test.py
+++ b/cognee/tests/unit/modules/tools/skill_md_loader_test.py
@@ -1,0 +1,47 @@
+"""Tests for SKILL.md discovery: detection and directory loading must agree on
+which files count as a SKILL.md regardless of filename case."""
+
+import pytest
+
+from cognee.modules.tools.ingest_skills import looks_like_skill_source
+from cognee.modules.tools.loaders import iter_skill_md_files, load_skills_from_directory
+
+
+SKILL_MD = """---
+name: churn-analyst
+description: Find patterns in customer churn.
+allowed-tools: memory_search, load_skill
+---
+# Procedure
+1. Search memory for churn signals.
+"""
+
+
+@pytest.mark.parametrize("file_name", ["SKILL.md", "skill.md", "Skill.md"])
+def test_directory_detection_and_loading_agree(tmp_path, file_name):
+    """A directory detected as a skill source must load at least one skill."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / file_name).write_text(SKILL_MD, encoding="utf-8")
+
+    assert looks_like_skill_source(str(tmp_path)) is True
+
+    skills = load_skills_from_directory(tmp_path)
+    assert len(skills) == 1
+    assert skills[0].name == "churn-analyst"
+    assert skills[0].declared_tools == ["memory_search", "load_skill"]
+
+
+def test_iter_skill_md_files_ignores_other_markdown(tmp_path):
+    (tmp_path / "README.md").write_text("not a skill", encoding="utf-8")
+    (tmp_path / "skills.md").write_text("not a skill either", encoding="utf-8")
+
+    assert list(iter_skill_md_files(tmp_path)) == []
+    assert looks_like_skill_source(str(tmp_path)) is False
+
+
+def test_skill_md_file_detection_is_case_insensitive(tmp_path):
+    skill_file = tmp_path / "skill.md"
+    skill_file.write_text(SKILL_MD, encoding="utf-8")
+
+    assert looks_like_skill_source(str(skill_file)) is True


### PR DESCRIPTION
## Summary

Follow-up to #2676, addressing the unresolved review comment on `skill_md_loader.py`: `looks_like_skill_source()` treated a directory containing a lowercase `skill.md` as a skill source, but `load_skills_from_directory()` only globbed exact-case `SKILL.md`. On case-sensitive filesystems (e.g. Linux CI / prod) this let `remember()` route data down the skill ingest path and then load **zero** skills, silently dropping the input.

## Changes

- New `iter_skill_md_files()` helper in `cognee/modules/tools/loaders/skill_md_loader.py` that matches the `SKILL.md` filename case-insensitively.
- Both `load_skills_from_directory()` and `looks_like_skill_source()` now use it, so detection and loading always agree on what counts as a SKILL.md.
- Unit tests in `cognee/tests/unit/modules/tools/skill_md_loader_test.py` covering mixed-case discovery (`SKILL.md`, `skill.md`, `Skill.md`), non-skill markdown rejection, and case-insensitive file detection.

Stacked on the head branch of #2676; should merge into it (or after it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)