### PR TITLE
test(subprocess): skip POSIX signal-exitcode test on Windows (follow-up to #2826)

### DIFF
--- a/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
+++ b/cognee/tests/unit/infrastructure/databases/test_subprocess_session_failures.py
@@ -12,6 +12,7 @@ Covers the scenarios that used to silently hang or leak:
 from __future__ import annotations
 
 import multiprocessing as mp
+import sys
 import time
 
 import pytest
@@ -406,6 +407,16 @@ def test_describe_exitcode_decodes_signals():
     assert _describe_exitcode(-999) == "-999"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "POSIX signal-exitcode semantics: os.kill(pid, SIGTERM) maps to "
+        "TerminateProcess on Windows with a positive exitcode (no negative "
+        "signal number), so signal-name surfacing cannot be guaranteed. "
+        "_describe_exitcode's POSIX decoding is covered by "
+        "test_describe_exitcode_decodes_signals."
+    ),
+)
 def test_init_signal_killed_worker_surfaces_signal_name():
     """End-to-end: a worker that dies to SIGTERM before READY surfaces
     ``exitcode=-15 (SIGTERM …)`` in the error message. Regression guard


### PR DESCRIPTION
## Summary

Follow-up stacked on #2826, fixing its failing `OS and Python Tests Extended / Unit tests 3.13.x on windows-latest` CI job.

`test_init_signal_killed_worker_surfaces_signal_name` fails on Windows with:

```
AssertionError: Subprocess init exited before signalling ready after 10.0s (pid=6428 exitcode=15 alive=False)
```

On Windows `os.kill(pid, SIGTERM)` maps to `TerminateProcess` and the child exits with the POSITIVE code 15, so the test's asserted `exitcode=-15 (SIGTERM ...)` diagnostic genuinely cannot be produced there. dev already fixed this in 57102f0 ("skip signal test on Windows"), but the #2826 branch predates that commit and its harness-test rewrite dropped the skip.

This PR re-applies the exact `pytest.mark.skipif(sys.platform == "win32", ...)` decorator and `import sys` from dev's 57102f0, byte-identical, so the region matches dev verbatim and the eventual dev merge of #2826 resolves cleanly. POSIX signal decoding stays covered by `test_describe_exitcode_decodes_signals`.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on the changed file
- [x] Verified the test region now matches `origin/dev` exactly (only #2826's intentional `_closed_event` assertion changes remain in the file diff vs dev)
- [ ] CI: Windows unit-test job on the stacked branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin