### PR TITLE
fix: copy caller-owned task_config dict in Task.__init__ (follow-up to #2871)

### DIFF
--- a/cognee/modules/pipelines/tasks/task.py
+++ b/cognee/modules/pipelines/tasks/task.py
@@ -302,9 +302,12 @@ class Task:
         else:
             raise ValueError(f"Unsupported task type: {executable}")
 
+        # Copy the caller's dict so the writes below (default batch_size,
+        # workers, timeout) never mutate caller-owned state that may be
+        # shared across tasks.
         if task_config is not None:
-            self.task_config = task_config
-            if "batch_size" not in task_config:
+            self.task_config = dict(task_config)
+            if "batch_size" not in self.task_config:
                 self.task_config["batch_size"] = 1
         else:
             self.task_config = {"batch_size": 1}

--- a/cognee/tests/unit/modules/pipelines/test_task_config_isolation.py
+++ b/cognee/tests/unit/modules/pipelines/test_task_config_isolation.py
@@ -1,0 +1,53 @@
+"""Tests for Task config ownership and legacy ``task_config`` compatibility.
+
+Covers two guarantees:
+- A caller-owned ``task_config`` dict is never mutated by ``Task`` and is not
+  shared between tasks constructed from the same dict.
+- The legacy ``Task(fn, task_config={"batch_size": N})`` style still resolves
+  to the same effective batch size as the newer ``batch_size=`` kwarg.
+"""
+
+from cognee.modules.pipelines.operations.worker_pipeline import FixedWorkers
+from cognee.modules.pipelines.tasks.task import Task
+
+
+async def _identity(value):
+    return value
+
+
+def test_caller_task_config_dict_is_not_mutated():
+    config = {"batch_size": 5}
+
+    task = Task(_identity, task_config=config, workers=FixedWorkers(3), timeout=10.0)
+
+    assert config == {"batch_size": 5}
+    assert task.task_config["batch_size"] == 5
+    assert isinstance(task.task_config["workers"], FixedWorkers)
+    assert task.task_config["timeout"] == 10.0
+
+
+def test_default_batch_size_not_injected_into_caller_dict():
+    config = {}
+
+    task = Task(_identity, task_config=config)
+
+    assert config == {}
+    assert task.task_config["batch_size"] == 1
+
+
+def test_shared_task_config_dict_does_not_leak_between_tasks():
+    shared = {"batch_size": 2}
+
+    first = Task(_identity, task_config=shared, workers=FixedWorkers(7))
+    second = Task(_identity, task_config=shared)
+
+    assert "workers" not in second.task_config
+    assert second.task_config["batch_size"] == 2
+    assert first.task_config["workers"].num_workers == 7
+
+
+def test_legacy_task_config_batch_size_matches_kwarg():
+    legacy = Task(_identity, task_config={"batch_size": 4})
+    modern = Task(_identity, batch_size=4)
+
+    assert legacy.task_config["batch_size"] == modern.task_config["batch_size"] == 4


### PR DESCRIPTION
## Summary

Follow-up to #2871, stacked on `feat/worker-pipeline-adaptive-concurrency`.

`Task.__init__` aliased a caller-provided `task_config` dict and then mutated it in place: it injected the default `batch_size`, and the new `workers=` / `timeout=` kwargs from #2871 were also written into the caller's dict. Consequences:

- Constructing a Task modified the caller's dict as a side effect.
- A config dict shared across several `Task(...)` instances (a plausible pattern for external pipelines) silently leaked `workers` / `timeout` settings from one task into the others.

## Changes

- `cognee/modules/pipelines/tasks/task.py`: copy `task_config` on init (`dict(task_config)`) so all subsequent writes stay on the Task's own copy.
- `cognee/tests/unit/modules/pipelines/test_task_config_isolation.py`: new unit tests for the no-mutation guarantee, no cross-task leakage from a shared dict, and the legacy `task_config={"batch_size": N}` style resolving identically to the `batch_size=` kwarg — this directly exercises the backwards-compatibility question raised in the open review thread on #2871.

## Testing

- `uv run pytest cognee/tests/unit/modules/pipelines/` — 43 passed (includes the 4 new tests).
- `ruff check` / `ruff format` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)