### PR TITLE
feat: hybrid retrieval with text summaries using rrf

### DIFF
--- a/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
+++ b/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
@@ -22,6 +22,10 @@ from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredRes
 logger = get_logger("NeptuneAnalyticsAdapter")
 
 
+def _optional_str(value):
+    return None if value is None else str(value)
+
+
 class IndexSchema(DataPoint):
     """
     Represents a schema for an index data point containing an ID and text.
@@ -42,6 +46,8 @@ class IndexSchema(DataPoint):
     document_id: Optional[str] = None
     document_name: Optional[str] = None
     chunk_index: Optional[int] = None
+    source_chunk_id: Optional[str] = None
+    importance_weight: Optional[float] = 0.5
     belongs_to_set: List[str] = []
     metadata: dict = {"index_fields": ["text"]}
 
@@ -477,6 +483,8 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
+                    source_chunk_id=_optional_str(getattr(data_point, "source_chunk_id", None)),
+                    importance_weight=getattr(data_point, "importance_weight", None),
                 )
                 for data_point in data_points
             ],
@@ -551,6 +559,11 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                 IndexSchema(
                     id=str(dp.id),
                     text=getattr(dp, field_name),
+                    document_id=getattr(dp, "document_id", None),
+                    document_name=getattr(dp, "document_name", None),
+                    chunk_index=getattr(dp, "chunk_index", None),
+                    source_chunk_id=_optional_str(getattr(dp, "source_chunk_id", None)),
+                    importance_weight=getattr(dp, "importance_weight", None),
                     belongs_to_set=dp.belongs_to_set or [],
                 )
                 for dp in points

--- a/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
+++ b/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
@@ -22,10 +22,6 @@ from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredRes
 logger = get_logger("NeptuneAnalyticsAdapter")
 
 
-def _optional_str(value):
-    return None if value is None else str(value)
-
-
 class IndexSchema(DataPoint):
     """
     Represents a schema for an index data point containing an ID and text.
@@ -483,7 +479,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
-                    source_chunk_id=_optional_str(getattr(data_point, "source_chunk_id", None)),
+                    source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),
                 )
                 for data_point in data_points
@@ -562,7 +558,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                     document_id=getattr(dp, "document_id", None),
                     document_name=getattr(dp, "document_name", None),
                     chunk_index=getattr(dp, "chunk_index", None),
-                    source_chunk_id=_optional_str(getattr(dp, "source_chunk_id", None)),
+                    source_chunk_id=getattr(dp, "source_chunk_id", None),
                     importance_weight=getattr(dp, "importance_weight", None),
                     belongs_to_set=dp.belongs_to_set or [],
                 )

--- a/cognee/infrastructure/databases/hybrid/postgres/adapter.py
+++ b/cognee/infrastructure/databases/hybrid/postgres/adapter.py
@@ -47,10 +47,6 @@ def _validate_table_name(name: str) -> str:
     return f'"{name}"'
 
 
-def _optional_str(value):
-    return None if value is None else str(value)
-
-
 class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
     """Hybrid adapter backed by a single Postgres database.
 
@@ -344,7 +340,7 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
                     document_id=getattr(dp, "document_id", None),
                     document_name=getattr(dp, "document_name", None),
                     chunk_index=getattr(dp, "chunk_index", None),
-                    source_chunk_id=_optional_str(getattr(dp, "source_chunk_id", None)),
+                    source_chunk_id=getattr(dp, "source_chunk_id", None),
                     importance_weight=getattr(dp, "importance_weight", None),
                     belongs_to_set=(dp.belongs_to_set or []),
                 )

--- a/cognee/infrastructure/databases/hybrid/postgres/adapter.py
+++ b/cognee/infrastructure/databases/hybrid/postgres/adapter.py
@@ -47,6 +47,10 @@ def _validate_table_name(name: str) -> str:
     return f'"{name}"'
 
 
+def _optional_str(value):
+    return None if value is None else str(value)
+
+
 class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
     """Hybrid adapter backed by a single Postgres database.
 
@@ -340,6 +344,8 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
                     document_id=getattr(dp, "document_id", None),
                     document_name=getattr(dp, "document_name", None),
                     chunk_index=getattr(dp, "chunk_index", None),
+                    source_chunk_id=_optional_str(getattr(dp, "source_chunk_id", None)),
+                    importance_weight=getattr(dp, "importance_weight", None),
                     belongs_to_set=(dp.belongs_to_set or []),
                 )
                 payload = serialize_data(index_point.model_dump())

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -51,6 +51,10 @@ _ORIGIN_DEFAULT_FACTORIES = {
 }
 
 
+def _optional_str(value):
+    return None if value is None else str(value)
+
+
 class IndexSchema(DataPoint):
     """
     Represents a schema for an index data point containing an ID and text.
@@ -72,6 +76,8 @@ class IndexSchema(DataPoint):
     document_id: Optional[str] = None
     document_name: Optional[str] = None
     chunk_index: Optional[int] = None
+    source_chunk_id: Optional[str] = None
+    importance_weight: Optional[float] = 0.5
 
     metadata: dict = {"index_fields": ["text"]}
     belongs_to_set: List[str] = []
@@ -1225,6 +1231,8 @@ class LanceDBAdapter(VectorDBInterface):
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
+                    source_chunk_id=_optional_str(getattr(data_point, "source_chunk_id", None)),
+                    importance_weight=getattr(data_point, "importance_weight", None),
                     belongs_to_set=(data_point.belongs_to_set or []),
                 )
                 for data_point in data_points

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -51,10 +51,6 @@ _ORIGIN_DEFAULT_FACTORIES = {
 }
 
 
-def _optional_str(value):
-    return None if value is None else str(value)
-
-
 class IndexSchema(DataPoint):
     """
     Represents a schema for an index data point containing an ID and text.
@@ -1231,7 +1227,7 @@ class LanceDBAdapter(VectorDBInterface):
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
-                    source_chunk_id=_optional_str(getattr(data_point, "source_chunk_id", None)),
+                    source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),
                     belongs_to_set=(data_point.belongs_to_set or []),
                 )

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -38,6 +38,10 @@ QUERY_BATCH_SIZE = 1000
 _ACCESS_CONTROL_DEFAULT_POOL_ARGS = {"pool_size": 2, "max_overflow": 2}
 
 
+def _optional_str(value):
+    return None if value is None else str(value)
+
+
 class IndexSchema(DataPoint):
     """
     Define a schema for indexing data points with a text field.
@@ -55,6 +59,8 @@ class IndexSchema(DataPoint):
     document_id: Optional[str] = None
     document_name: Optional[str] = None
     chunk_index: Optional[int] = None
+    source_chunk_id: Optional[str] = None
+    importance_weight: Optional[float] = 0.5
 
     metadata: dict = {"index_fields": ["text"]}
     belongs_to_set: List[str] = []
@@ -385,6 +391,8 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
+                    source_chunk_id=_optional_str(getattr(data_point, "source_chunk_id", None)),
+                    importance_weight=getattr(data_point, "importance_weight", None),
                     belongs_to_set=(data_point.belongs_to_set or []),
                 )
                 for data_point in data_points

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -38,10 +38,6 @@ QUERY_BATCH_SIZE = 1000
 _ACCESS_CONTROL_DEFAULT_POOL_ARGS = {"pool_size": 2, "max_overflow": 2}
 
 
-def _optional_str(value):
-    return None if value is None else str(value)
-
-
 class IndexSchema(DataPoint):
     """
     Define a schema for indexing data points with a text field.
@@ -391,7 +387,7 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
-                    source_chunk_id=_optional_str(getattr(data_point, "source_chunk_id", None)),
+                    source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),
                     belongs_to_set=(data_point.belongs_to_set or []),
                 )

--- a/cognee/modules/retrieval/hybrid/chunks.py
+++ b/cognee/modules/retrieval/hybrid/chunks.py
@@ -1,0 +1,263 @@
+import asyncio
+from typing import Any, Optional
+
+from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
+from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
+from cognee.modules.retrieval.exceptions.exceptions import NoDataError
+from cognee.modules.retrieval.hybrid.pairs import (
+    attach_source_chunks,
+    chunk_summary_pairs,
+    source_chunk_ids_to_load,
+    summary_id_for_chunk,
+    summary_text_by_chunk_id,
+)
+from cognee.modules.retrieval.hybrid.ranking import rank_chunk_summary_pairs
+from cognee.modules.retrieval.hybrid.results import (
+    display_value,
+    payload,
+    payload_matches_node_filter,
+    result_id,
+    scored_payload,
+)
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("HybridRetriever")
+
+
+async def retrieve_hybrid_chunks(
+    vector_engine: Any,
+    query: str,
+    chunks_top_k: int,
+    text_summaries_top_k: Optional[int],
+    node_name: Optional[list[str]],
+    node_name_filter_operator: str,
+    use_importance_weight: bool,
+) -> dict[str, Any]:
+    candidate_limit = max(0, chunks_top_k * 2)
+    summary_limit = summary_candidate_limit(chunks_top_k, text_summaries_top_k)
+    bm25_chunks, vector_chunks, summary_hits = await asyncio.gather(
+        search_bm25_chunks(query, candidate_limit, node_name, node_name_filter_operator),
+        search_collection(
+            vector_engine,
+            "DocumentChunk_text",
+            query,
+            candidate_limit,
+            node_name,
+            node_name_filter_operator,
+            required=True,
+        ),
+        search_collection(
+            vector_engine,
+            "TextSummary_text",
+            query,
+            summary_limit,
+            node_name,
+            node_name_filter_operator,
+        ),
+    )
+
+    pairs = chunk_summary_pairs(
+        bm25_chunks,
+        vector_chunks,
+        summary_hits,
+        node_name,
+        node_name_filter_operator,
+    )
+    missing_source_chunk_ids = source_chunk_ids_to_load(pairs)
+    if missing_source_chunk_ids:
+        source_chunks = await load_source_chunks_for_summaries(
+            vector_engine,
+            missing_source_chunk_ids,
+            node_name,
+            node_name_filter_operator,
+        )
+        attach_source_chunks(pairs, source_chunks)
+
+    ranked_pairs = rank_chunk_summary_pairs(pairs, chunks_top_k, use_importance_weight)
+    if summary_limit > 0:
+        await load_summary_text_for_ranked_pairs(
+            vector_engine,
+            ranked_pairs,
+            node_name,
+            node_name_filter_operator,
+        )
+
+    return {
+        "chunks": [pair["chunk"] for pair in ranked_pairs if pair["chunk"] is not None],
+        "chunk_summaries": summary_text_by_chunk_id(ranked_pairs),
+    }
+
+
+def summary_candidate_limit(chunks_top_k: int, text_summaries_top_k: Optional[int]) -> int:
+    if text_summaries_top_k is None:
+        return max(0, chunks_top_k)
+    return text_summaries_top_k
+
+
+async def search_bm25_chunks(
+    query: str,
+    limit: int,
+    node_name: Optional[list[str]],
+    node_name_filter_operator: str,
+) -> list[dict]:
+    if limit <= 0:
+        return []
+
+    try:
+        retriever = BM25ChunksRetriever(top_k=limit, with_scores=True)
+        scored_chunks = await retriever.get_retrieved_objects(query)
+    except NoDataError:
+        return []
+    except Exception as error:
+        logger.warning("BM25 chunk retrieval failed; using vector chunks only: %s", error)
+        return []
+
+    chunks = []
+    for item in scored_chunks:
+        chunk, score = scored_payload(item)
+        if score <= 0:
+            continue
+        if not isinstance(chunk, dict):
+            continue
+        if not payload_matches_node_filter(chunk, node_name, node_name_filter_operator):
+            continue
+        chunks.append(chunk)
+    return chunks
+
+
+async def search_collection(
+    vector_engine: Any,
+    collection_name: str,
+    query: str,
+    limit: int,
+    node_name: Optional[list[str]],
+    node_name_filter_operator: str,
+    *,
+    required: bool = False,
+    apply_node_filter: bool = True,
+) -> list[Any]:
+    if limit <= 0:
+        return []
+
+    search_node_name = node_name if apply_node_filter else None
+    search_operator = node_name_filter_operator if apply_node_filter else "OR"
+    try:
+        return await vector_engine.search(
+            collection_name,
+            query,
+            limit=limit,
+            include_payload=True,
+            node_name=search_node_name,
+            node_name_filter_operator=search_operator,
+        )
+    except CollectionNotFoundError as error:
+        if required:
+            logger.error("%s collection not found", collection_name)
+            raise NoDataError("No data found in the system, please add data first.") from error
+        logger.debug("%s collection not found; using empty channel", collection_name)
+        return []
+
+
+async def load_source_chunks_for_summaries(
+    vector_engine: Any,
+    chunk_ids: list[str],
+    node_name: Optional[list[str]],
+    node_name_filter_operator: str,
+) -> list[Any]:
+    chunks = await vector_engine.retrieve("DocumentChunk_text", chunk_ids)
+    found_ids = {result_id(chunk) for chunk in chunks}
+    missing_ids = sorted(set(chunk_ids) - {chunk_id for chunk_id in found_ids if chunk_id})
+    if missing_ids:
+        logger.warning(
+            "TextSummary_text hit referenced missing DocumentChunk_text row(s): %s",
+            missing_ids,
+        )
+
+    source_chunks = []
+    filtered_ids = []
+    for chunk in chunks:
+        if payload_matches_node_filter(payload(chunk), node_name, node_name_filter_operator):
+            source_chunks.append(chunk)
+            continue
+
+        chunk_id = result_id(chunk)
+        if chunk_id:
+            filtered_ids.append(chunk_id)
+
+    if filtered_ids:
+        logger.warning(
+            "TextSummary_text source chunk failed node filter: %s",
+            sorted(filtered_ids),
+        )
+    return source_chunks
+
+
+async def load_summary_text_for_ranked_pairs(
+    vector_engine: Any,
+    ranked_pairs: list[dict],
+    node_name: Optional[list[str]],
+    node_name_filter_operator: str,
+) -> None:
+    summary_ids_by_chunk_id = {}
+    for pair in ranked_pairs:
+        if pair["summary_text"]:
+            continue
+
+        chunk_id = pair["chunk_id"]
+        if not chunk_id:
+            continue
+
+        summary_id = pair["summary_id"] or summary_id_for_chunk(chunk_id)
+        if summary_id is None:
+            logger.debug("Cannot fetch paired TextSummary for non-UUID chunk id %s", chunk_id)
+            continue
+
+        pair["summary_id"] = summary_id
+        summary_ids_by_chunk_id[chunk_id] = summary_id
+
+    if not summary_ids_by_chunk_id:
+        return
+
+    try:
+        summaries = await vector_engine.retrieve(
+            "TextSummary_text",
+            list(summary_ids_by_chunk_id.values()),
+        )
+    except CollectionNotFoundError:
+        logger.warning("TextSummary_text collection missing while loading chunk summaries")
+        return
+
+    summaries_by_id = {result_id(summary): summary for summary in summaries}
+    for pair in ranked_pairs:
+        chunk_id = pair["chunk_id"]
+        summary_id = pair["summary_id"]
+        if not chunk_id or not summary_id:
+            continue
+
+        summary = summaries_by_id.get(summary_id)
+        if summary is None:
+            logger.warning(
+                "DocumentChunk_text row has no paired TextSummary_text row: chunk_id=%s",
+                chunk_id,
+            )
+            continue
+
+        summary_payload = payload(summary)
+        summary_text = display_value(summary_payload.get("text"))
+        if not summary_text:
+            logger.warning(
+                "Paired TextSummary_text row has no text: chunk_id=%s summary_id=%s",
+                chunk_id,
+                summary_id,
+            )
+            continue
+
+        if not payload_matches_node_filter(summary_payload, node_name, node_name_filter_operator):
+            logger.warning(
+                "Paired TextSummary_text row failed node filter: chunk_id=%s summary_id=%s",
+                chunk_id,
+                summary_id,
+            )
+            continue
+
+        pair["summary_text"] = summary_text

--- a/cognee/modules/retrieval/hybrid/context.py
+++ b/cognee/modules/retrieval/hybrid/context.py
@@ -1,0 +1,71 @@
+from typing import Any, Optional
+
+from cognee.modules.retrieval.hybrid.entities import format_entities
+from cognee.modules.retrieval.hybrid.results import display_value, payload, result_id
+
+
+def format_hybrid_context(global_context: str, retrieved_objects: Any) -> str:
+    retrieved_objects = retrieved_objects or {}
+    sections = []
+
+    if global_context:
+        sections.append(global_context)
+
+    passages = format_passages(
+        retrieved_objects.get("chunks", []),
+        retrieved_objects.get("chunk_summaries", {}),
+    )
+    if passages:
+        sections.append(passages)
+
+    entities = format_entities(retrieved_objects.get("entities", []))
+    if entities:
+        sections.append(entities)
+
+    return "\n\n".join(sections)
+
+
+def extract_context_object_ids(retrieved_objects: Any) -> Optional[dict[str, list[str]]]:
+    if not isinstance(retrieved_objects, dict):
+        return None
+
+    node_ids = set()
+    for chunk in retrieved_objects.get("chunks", []):
+        chunk_id = result_id(chunk)
+        if chunk_id:
+            node_ids.add(chunk_id)
+
+    for entity in retrieved_objects.get("entities", []):
+        if not isinstance(entity, dict):
+            continue
+        entity_id = display_value(entity.get("id"))
+        if entity_id:
+            node_ids.add(entity_id)
+        for edge in entity.get("edges", []):
+            if not isinstance(edge, dict):
+                continue
+            for key in ("source_id", "target_id"):
+                edge_node_id = display_value(edge.get(key))
+                if edge_node_id:
+                    node_ids.add(edge_node_id)
+
+    return {"node_ids": sorted(node_ids)} if node_ids else None
+
+
+def format_passages(chunks: list[Any], chunk_summaries: Optional[dict[str, str]] = None) -> str:
+    texts = []
+    chunk_summaries = chunk_summaries or {}
+    for chunk in chunks or []:
+        text = display_value(payload(chunk).get("text"))
+        if not text:
+            continue
+
+        chunk_id = result_id(chunk)
+        summary_text = chunk_summaries.get(chunk_id) if chunk_id else None
+        if summary_text:
+            texts.append(f"[Passage Summary]: {summary_text}\n[Raw Passage]: {text}")
+        else:
+            texts.append(text)
+    if not texts:
+        return ""
+    return "## Relevant passages\n" + "\n---\n".join(texts)

--- a/cognee/modules/retrieval/hybrid/entities.py
+++ b/cognee/modules/retrieval/hybrid/entities.py
@@ -1,0 +1,172 @@
+import asyncio
+from typing import Any, Optional
+
+from cognee.modules.retrieval.hybrid.results import (
+    display_value,
+    first_display_value,
+    payload,
+    result_id,
+)
+
+
+async def build_entities(graph_engine: Any, entity_hits: list[Any], max_edges_per_entity: int):
+    if not entity_hits:
+        return []
+
+    entities = [_entity_from_result(result) for result in entity_hits]
+    if await graph_engine.is_empty():
+        return entities
+
+    connections_by_entity = await asyncio.gather(
+        *[graph_engine.get_connections(entity["id"]) for entity in entities]
+    )
+    for entity, connections in zip(entities, connections_by_entity):
+        entity["edges"] = _edge_bullets_from_connections(connections, max_edges_per_entity)
+    return entities
+
+
+def format_entities(entities: list[dict]) -> str:
+    blocks = []
+    for entity in entities or []:
+        block = _format_entity(entity)
+        if block:
+            blocks.append(block)
+    if not blocks:
+        return ""
+    return "## Relevant entities\n" + "\n\n".join(blocks)
+
+
+def _entity_from_result(result: Any) -> dict:
+    result_payload = payload(result)
+    entity_id = result_id(result) or ""
+    return {
+        "id": entity_id,
+        "name": first_display_value(
+            result_payload.get("name"), result_payload.get("text"), entity_id
+        )
+        or "",
+        "description": display_value(result_payload.get("description")),
+        "type": _entity_type(result_payload),
+        "edges": [],
+    }
+
+
+def _format_entity(entity: dict) -> str:
+    name = display_value(entity.get("name"))
+    if not name:
+        return ""
+
+    entity_type = _entity_type(entity)
+    header = f"### {name} ({entity_type})" if entity_type else f"### {name}"
+
+    lines = [header]
+    description = display_value(entity.get("description"))
+    if description:
+        lines.append(description)
+
+    for edge in entity.get("edges", []):
+        edge_text = display_value(edge.get("text"))
+        if edge_text:
+            lines.append(f"- {edge_text}")
+
+    return "\n".join(lines)
+
+
+def _entity_type(result_payload: dict) -> Optional[str]:
+    for value in (result_payload.get("is_a"), result_payload.get("type")):
+        entity_type = display_value(value)
+        if entity_type and entity_type not in {"IndexSchema"}:
+            return entity_type
+    return None
+
+
+def _edge_bullets_from_connections(connections: list[Any], max_edges: int) -> list[dict]:
+    if max_edges <= 0:
+        return []
+
+    edges = []
+    seen_keys = set()
+    seen_texts = set()
+    for connection in connections or []:
+        unpacked = _unpack_connection(connection)
+        if unpacked is None:
+            continue
+
+        source, edge, target = unpacked
+        bullet = _edge_bullet(source, edge, target)
+        if not bullet:
+            continue
+
+        dedupe_key = _edge_dedupe_key(bullet)
+        if dedupe_key and dedupe_key in seen_keys:
+            continue
+        if not dedupe_key and bullet["text"] in seen_texts:
+            continue
+
+        if dedupe_key:
+            seen_keys.add(dedupe_key)
+        else:
+            seen_texts.add(bullet["text"])
+        edges.append(bullet)
+    edges.sort(key=lambda edge: 0 if _is_type_edge(edge) else 1)
+    return edges[:max_edges]
+
+
+def _unpack_connection(connection: Any) -> Optional[tuple[dict, dict, dict]]:
+    if not isinstance(connection, (list, tuple)) or len(connection) != 3:
+        return None
+    source, edge, target = connection
+    if not isinstance(source, dict) or not isinstance(edge, dict) or not isinstance(target, dict):
+        return None
+    return source, edge, target
+
+
+def _edge_bullet(source: dict, edge: dict, target: dict) -> Optional[dict]:
+    source_label = _node_label(source)
+    target_label = _node_label(target)
+    relationship = display_value(edge.get("relationship_name"))
+    text = first_display_value(edge.get("edge_text"), _nested_edge_text(edge))
+    if not text and source_label and relationship and target_label:
+        text = f"{source_label} -- {relationship} -- {target_label}"
+    if not text:
+        return None
+
+    return {
+        "text": text,
+        "source": source_label,
+        "target": target_label,
+        "source_id": display_value(source.get("id")),
+        "relationship": relationship,
+        "target_id": display_value(target.get("id")),
+    }
+
+
+def _edge_dedupe_key(edge: dict) -> Optional[tuple[str, str, str]]:
+    source_id = display_value(edge.get("source_id"))
+    relationship = display_value(edge.get("relationship"))
+    target_id = display_value(edge.get("target_id"))
+    if source_id and relationship and target_id:
+        return source_id, relationship, target_id
+    return None
+
+
+def _is_type_edge(edge: dict) -> bool:
+    relationship = display_value(edge.get("relationship"))
+    if relationship:
+        normalized = relationship.lower().replace("_", " ").replace("-", " ").strip()
+        if normalized == "is a":
+            return True
+
+    text = display_value(edge.get("text"))
+    return bool(text and " is a " in f" {text.lower()} ")
+
+
+def _nested_edge_text(edge: dict) -> Optional[str]:
+    properties = edge.get("properties")
+    if not isinstance(properties, dict):
+        return None
+    return display_value(properties.get("edge_text"))
+
+
+def _node_label(node: dict) -> Optional[str]:
+    return first_display_value(node.get("name"), node.get("id"))

--- a/cognee/modules/retrieval/hybrid/pairs.py
+++ b/cognee/modules/retrieval/hybrid/pairs.py
@@ -1,0 +1,127 @@
+from typing import Any, Optional
+from uuid import UUID, uuid5
+
+from cognee.modules.retrieval.hybrid.results import (
+    display_value,
+    payload,
+    payload_matches_node_filter,
+    result_id,
+)
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("HybridRetriever")
+
+
+def chunk_summary_pairs(
+    bm25_chunks: list[Any],
+    vector_chunks: list[Any],
+    summary_hits: list[Any],
+    node_name: Optional[list[str]] = None,
+    node_name_filter_operator: str = "OR",
+) -> list[dict]:
+    pairs = []
+
+    for rank_field, chunks in (("bm25_rank", bm25_chunks), ("vector_rank", vector_chunks)):
+        for rank, chunk in enumerate(chunks or []):
+            chunk_id = result_id(chunk)
+            chunk_text = display_value(payload(chunk).get("text"))
+            if not chunk_id and not chunk_text:
+                continue
+
+            pair = _find_chunk_summary_pair(pairs, chunk_id, chunk_text)
+            if pair is None:
+                pair = _new_chunk_summary_pair(chunk_id=chunk_id, chunk_text=chunk_text)
+                pairs.append(pair)
+            if pair["chunk"] is None:
+                set_pair_chunk(pair, chunk)
+            if pair[rank_field] is None:
+                pair[rank_field] = rank
+
+    for rank, summary in enumerate(summary_hits or []):
+        summary_payload = payload(summary)
+        if not payload_matches_node_filter(summary_payload, node_name, node_name_filter_operator):
+            continue
+
+        chunk_id = display_value(summary_payload.get("source_chunk_id"))
+        if not chunk_id:
+            logger.warning(
+                "TextSummary_text hit has no source_chunk_id: summary_id=%s", result_id(summary)
+            )
+            continue
+
+        pair = _find_chunk_summary_pair(pairs, chunk_id, None)
+        if pair is None:
+            pair = _new_chunk_summary_pair(chunk_id=chunk_id)
+            pairs.append(pair)
+        if pair["summary_rank"] is None:
+            pair["summary_rank"] = rank
+            pair["summary_id"] = result_id(summary)
+            pair["summary_text"] = display_value(summary_payload.get("text"))
+
+    return pairs
+
+
+def source_chunk_ids_to_load(pairs: list[dict]) -> list[str]:
+    return [
+        pair["chunk_id"]
+        for pair in pairs
+        if pair["summary_rank"] is not None and pair["chunk"] is None and pair["chunk_id"]
+    ]
+
+
+def attach_source_chunks(pairs: list[dict], chunks: list[Any]) -> None:
+    for chunk in chunks:
+        pair = _find_chunk_summary_pair(pairs, result_id(chunk), None)
+        if pair:
+            set_pair_chunk(pair, chunk)
+
+
+def summary_text_by_chunk_id(pairs: list[dict]) -> dict[str, str]:
+    summaries = {}
+    for pair in pairs:
+        if pair["chunk_id"] and pair["summary_text"]:
+            summaries[pair["chunk_id"]] = pair["summary_text"]
+    return summaries
+
+
+def summary_id_for_chunk(chunk_id: str) -> Optional[str]:
+    try:
+        chunk_uuid = UUID(chunk_id)
+    except (TypeError, ValueError):
+        return None
+    return str(uuid5(chunk_uuid, "TextSummary"))
+
+
+def set_pair_chunk(pair: dict, chunk: Any) -> None:
+    pair["chunk"] = chunk
+    pair["chunk_id"] = result_id(chunk) or pair["chunk_id"]
+    pair["chunk_text"] = display_value(payload(chunk).get("text")) or pair["chunk_text"]
+
+
+def _find_chunk_summary_pair(
+    pairs: list[dict],
+    chunk_id: Optional[str],
+    chunk_text: Optional[str],
+) -> Optional[dict]:
+    for pair in pairs:
+        if chunk_id and pair["chunk_id"] == chunk_id:
+            return pair
+        if chunk_text and pair["chunk_id"] is None and pair["chunk_text"] == chunk_text:
+            return pair
+    return None
+
+
+def _new_chunk_summary_pair(
+    chunk_id: Optional[str] = None,
+    chunk_text: Optional[str] = None,
+) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "chunk_text": chunk_text,
+        "summary_id": None,
+        "summary_text": None,
+        "chunk": None,
+        "bm25_rank": None,
+        "vector_rank": None,
+        "summary_rank": None,
+    }

--- a/cognee/modules/retrieval/hybrid/ranking.py
+++ b/cognee/modules/retrieval/hybrid/ranking.py
@@ -1,0 +1,47 @@
+from cognee.modules.retrieval.hybrid.results import payload, result_id
+
+
+def rank_chunk_summary_pairs(
+    pairs: list[dict],
+    limit: int,
+    use_importance_weight: bool,
+) -> list[dict]:
+    if limit <= 0:
+        return []
+
+    rrf_k = _rrf_k(limit)
+    ranked = []
+    for pair in pairs:
+        chunk = pair["chunk"]
+        if chunk is None:
+            continue
+
+        ranks = [
+            rank
+            for rank in (pair["bm25_rank"], pair["vector_rank"], pair["summary_rank"])
+            if rank is not None
+        ]
+        if not ranks:
+            continue
+
+        rrf_score = sum(1.0 / (rrf_k + rank + 1) for rank in ranks)
+        final_score = rrf_score
+        if use_importance_weight:
+            final_score *= _importance_factor(chunk)
+
+        chunk_id = pair["chunk_id"] or result_id(chunk) or ""
+        ranked.append((final_score, rrf_score, min(ranks), chunk_id, pair))
+
+    ranked.sort(key=lambda item: (-item[0], -item[1], item[2], item[3]))
+    return [pair for *_, pair in ranked[:limit]]
+
+
+def _rrf_k(chunks_top_k: int) -> int:
+    return max(30, min(60, 20 + 2 * chunks_top_k))
+
+
+def _importance_factor(chunk) -> float:
+    raw_importance = payload(chunk).get("importance_weight")
+    importance = raw_importance if isinstance(raw_importance, (int, float)) else 0.5
+    importance = max(0.0, min(1.0, importance))
+    return 0.75 + 0.5 * importance

--- a/cognee/modules/retrieval/hybrid/results.py
+++ b/cognee/modules/retrieval/hybrid/results.py
@@ -1,0 +1,59 @@
+from typing import Any, Optional
+from uuid import UUID
+
+
+def payload(result: Any) -> dict:
+    if isinstance(result, dict):
+        return result
+    result_payload = getattr(result, "payload", None)
+    return result_payload if isinstance(result_payload, dict) else {}
+
+
+def display_value(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool, UUID)):
+        text = str(value).strip()
+        return text or None
+    return None
+
+
+def result_id(result: Any) -> Optional[str]:
+    result_payload = payload(result)
+    return display_value(result_payload.get("id")) or display_value(getattr(result, "id", None))
+
+
+def scored_payload(item: Any) -> tuple[Any, float]:
+    if not isinstance(item, (list, tuple)) or len(item) != 2:
+        return item, 0.0
+    item_payload, score = item
+    if not isinstance(score, (int, float)):
+        return item_payload, 0.0
+    return item_payload, float(score)
+
+
+def payload_matches_node_filter(
+    result_payload: dict,
+    node_name: Optional[list[str]],
+    node_name_filter_operator: str,
+) -> bool:
+    if not node_name:
+        return True
+
+    belongs_to_set = result_payload.get("belongs_to_set")
+    if not isinstance(belongs_to_set, list):
+        return False
+
+    payload_sets = {str(name) for name in belongs_to_set}
+    requested_sets = {str(name) for name in node_name}
+    if node_name_filter_operator == "AND":
+        return requested_sets.issubset(payload_sets)
+    return bool(payload_sets & requested_sets)
+
+
+def first_display_value(*values: Any) -> Optional[str]:
+    for value in values:
+        text = display_value(value)
+        if text:
+            return text
+    return None

--- a/cognee/modules/retrieval/hybrid_retriever.py
+++ b/cognee/modules/retrieval/hybrid_retriever.py
@@ -1,6 +1,6 @@
 import asyncio
 from typing import Any, Dict, List, Optional, Type
-from uuid import UUID
+from uuid import UUID, uuid5
 
 from cognee.context_global_variables import session_user
 from cognee.infrastructure.databases.cache.config import CacheConfig
@@ -39,6 +39,8 @@ class HybridRetriever(BaseRetriever):
         user_prompt_path: str = "hybrid_context_for_question.txt",
         system_prompt_path: str = "answer_simple_question.txt",
         system_prompt: Optional[str] = None,
+        text_summaries_top_k: Optional[int] = None,
+        use_importance_weight: bool = True,
     ):
         self.chunks_top_k = chunks_top_k if chunks_top_k is not None else 5
         self.entities_top_k = entities_top_k if entities_top_k is not None else 5
@@ -52,6 +54,8 @@ class HybridRetriever(BaseRetriever):
         self.user_prompt_path = user_prompt_path
         self.system_prompt_path = system_prompt_path
         self.system_prompt = system_prompt
+        self.text_summaries_top_k = text_summaries_top_k
+        self.use_importance_weight = use_importance_weight
 
     def _use_session_cache(self) -> bool:
         user = session_user.get()
@@ -65,23 +69,57 @@ class HybridRetriever(BaseRetriever):
         validate_retriever_input(query, None, self._use_session_cache())
 
         self._unified_engine = await get_unified_engine()
-        chunks, entity_hits = await asyncio.gather(
-            self._build_chunks(query),
+        chunk_objects, entity_hits = await asyncio.gather(
+            self._build_chunk_objects(query),
             self._search_collection("Entity_name", query, self.entities_top_k),
         )
         entities = await self._build_entities(entity_hits)
 
-        return {"chunks": chunks, "entities": entities}
+        return {**chunk_objects, "entities": entities}
 
-    async def _build_chunks(self, query: str) -> List[Any]:
+    async def _build_chunk_objects(self, query: str) -> Dict[str, Any]:
+        summary_limit = self._summary_candidate_limit()
+        if summary_limit <= 0:
+            return {"chunks": await self._build_legacy_chunks(query), "chunk_summaries": {}}
+
+        candidate_limit = max(0, self.chunks_top_k * 2)
+        bm25_chunks, vector_chunks, summary_hits = await asyncio.gather(
+            self._search_bm25_chunks(query, limit=candidate_limit),
+            self._search_collection(
+                "DocumentChunk_text",
+                query,
+                candidate_limit,
+                required=True,
+            ),
+            self._search_collection(
+                "TextSummary_text",
+                query,
+                summary_limit,
+                apply_node_filter=False,
+            ),
+        )
+        chunks, chunk_summaries = await self._rank_summary_aware_chunks(
+            bm25_chunks,
+            vector_chunks,
+            summary_hits,
+        )
+        await self._fetch_final_chunk_summaries(chunks, chunk_summaries)
+        return {"chunks": chunks, "chunk_summaries": chunk_summaries}
+
+    async def _build_legacy_chunks(self, query: str) -> List[Any]:
         bm25_chunks, vector_chunks = await asyncio.gather(
             self._search_bm25_chunks(query),
             self._search_collection("DocumentChunk_text", query, self.chunks_top_k, required=True),
         )
         return _merge_chunks(bm25_chunks, vector_chunks, self.chunks_top_k)
 
-    async def _search_bm25_chunks(self, query: str) -> List[dict]:
-        bm25_top_k = _bm25_chunk_limit(self.chunks_top_k)
+    def _summary_candidate_limit(self) -> int:
+        if self.text_summaries_top_k is None:
+            return max(0, self.chunks_top_k)
+        return self.text_summaries_top_k
+
+    async def _search_bm25_chunks(self, query: str, limit: Optional[int] = None) -> List[dict]:
+        bm25_top_k = limit if limit is not None else _bm25_chunk_limit(self.chunks_top_k)
         if bm25_top_k <= 0:
             return []
 
@@ -109,16 +147,27 @@ class HybridRetriever(BaseRetriever):
         return chunks
 
     async def _search_collection(
-        self, collection_name: str, query: str, limit: int, *, required: bool = False
+        self,
+        collection_name: str,
+        query: str,
+        limit: int,
+        *,
+        required: bool = False,
+        apply_node_filter: bool = True,
     ) -> List[Any]:
+        if limit <= 0:
+            return []
+
+        node_name = self.node_name if apply_node_filter else None
+        node_name_filter_operator = self.node_name_filter_operator if apply_node_filter else "OR"
         try:
             return await self._unified_engine.vector.search(
                 collection_name,
                 query,
                 limit=limit,
                 include_payload=True,
-                node_name=self.node_name,
-                node_name_filter_operator=self.node_name_filter_operator,
+                node_name=node_name,
+                node_name_filter_operator=node_name_filter_operator,
             )
         except CollectionNotFoundError as error:
             if required:
@@ -126,6 +175,87 @@ class HybridRetriever(BaseRetriever):
                 raise NoDataError("No data found in the system, please add data first.") from error
             logger.debug("%s collection not found; using empty channel", collection_name)
             return []
+
+    async def _rank_summary_aware_chunks(
+        self,
+        bm25_chunks: List[Any],
+        vector_chunks: List[Any],
+        summary_hits: List[Any],
+    ) -> tuple[List[Any], Dict[str, str]]:
+        summary_ranks, summary_text_by_chunk_id = _summary_signal(summary_hits)
+
+        candidate_by_key = {}
+        _add_chunk_candidates(candidate_by_key, bm25_chunks)
+        _add_chunk_candidates(candidate_by_key, vector_chunks)
+
+        missing_chunk_ids = [
+            key[1] for key in summary_ranks if key not in candidate_by_key and key[0] == "id"
+        ]
+        if missing_chunk_ids:
+            _add_chunk_candidates(
+                candidate_by_key,
+                await self._fetch_summary_only_chunks(missing_chunk_ids),
+            )
+
+        bm25_ranks = _chunk_ranks(bm25_chunks)
+        vector_ranks = _chunk_ranks(vector_chunks)
+        ranked = _rank_chunk_candidates(
+            candidate_by_key,
+            [bm25_ranks, vector_ranks, summary_ranks],
+            self.chunks_top_k,
+            self.use_importance_weight,
+        )
+        ranked_keys = {_chunk_key(chunk) for chunk in ranked}
+        final_summary_text = {
+            chunk_id: text
+            for chunk_id, text in summary_text_by_chunk_id.items()
+            if ("id", chunk_id) in ranked_keys
+        }
+        return ranked, final_summary_text
+
+    async def _fetch_summary_only_chunks(self, chunk_ids: List[str]) -> List[Any]:
+        chunks = await self._unified_engine.vector.retrieve("DocumentChunk_text", chunk_ids)
+        return [
+            chunk
+            for chunk in chunks
+            if _payload_matches_node_filter(
+                _payload(chunk), self.node_name, self.node_name_filter_operator
+            )
+        ]
+
+    async def _fetch_final_chunk_summaries(
+        self,
+        chunks: List[Any],
+        summary_text_by_chunk_id: Dict[str, str],
+    ) -> None:
+        summary_ids_by_chunk_id = {}
+        for chunk in chunks:
+            chunk_id = _result_id(chunk)
+            if not chunk_id or chunk_id in summary_text_by_chunk_id:
+                continue
+            try:
+                chunk_uuid = UUID(chunk_id)
+            except (TypeError, ValueError):
+                logger.debug("Cannot fetch paired TextSummary for non-UUID chunk id %s", chunk_id)
+                continue
+            summary_ids_by_chunk_id[chunk_id] = str(uuid5(chunk_uuid, "TextSummary"))
+
+        if not summary_ids_by_chunk_id:
+            return
+
+        summaries = await self._unified_engine.vector.retrieve(
+            "TextSummary_text",
+            list(summary_ids_by_chunk_id.values()),
+        )
+        summaries_by_id = {_result_id(summary): summary for summary in summaries}
+        for chunk_id, summary_id in summary_ids_by_chunk_id.items():
+            summary = summaries_by_id.get(summary_id)
+            if summary is None:
+                logger.debug("No paired TextSummary found for chunk id %s", chunk_id)
+                continue
+            summary_text = _display_value(_payload(summary).get("text"))
+            if summary_text:
+                summary_text_by_chunk_id[chunk_id] = summary_text
 
     async def _build_entities(self, entity_hits: List[Any]) -> List[dict]:
         if not entity_hits:
@@ -157,7 +287,10 @@ class HybridRetriever(BaseRetriever):
         if global_context:
             sections.append(global_context)
 
-        passages = _format_passages(retrieved_objects.get("chunks", []))
+        passages = _format_passages(
+            retrieved_objects.get("chunks", []),
+            retrieved_objects.get("chunk_summaries", {}),
+        )
         if passages:
             sections.append(passages)
 
@@ -322,6 +455,81 @@ def _merge_chunks(bm25_chunks: List[Any], vector_chunks: List[Any], limit: int) 
     return chunks
 
 
+def _add_chunk_candidates(candidate_by_key: dict, chunks: List[Any]) -> None:
+    for chunk in chunks or []:
+        key = _chunk_key(chunk)
+        if key and key not in candidate_by_key:
+            candidate_by_key[key] = chunk
+
+
+def _chunk_ranks(chunks: List[Any]) -> dict:
+    ranks = {}
+    for rank, chunk in enumerate(chunks or []):
+        key = _chunk_key(chunk)
+        if key and key not in ranks:
+            ranks[key] = rank
+    return ranks
+
+
+def _summary_signal(summary_hits: List[Any]) -> tuple[dict, Dict[str, str]]:
+    ranks = {}
+    summary_text_by_chunk_id = {}
+    for rank, summary in enumerate(summary_hits or []):
+        payload = _payload(summary)
+        chunk_id = _display_value(payload.get("source_chunk_id"))
+        if not chunk_id:
+            continue
+
+        key = ("id", chunk_id)
+        if key not in ranks:
+            ranks[key] = rank
+
+        summary_text = _display_value(payload.get("text"))
+        if summary_text and chunk_id not in summary_text_by_chunk_id:
+            summary_text_by_chunk_id[chunk_id] = summary_text
+
+    return ranks, summary_text_by_chunk_id
+
+
+def _rank_chunk_candidates(
+    candidate_by_key: dict,
+    channel_ranks: List[dict],
+    limit: int,
+    use_importance_weight: bool,
+) -> List[Any]:
+    if limit <= 0:
+        return []
+
+    rrf_k = _rrf_k(limit)
+    ranked = []
+    for key, chunk in candidate_by_key.items():
+        ranks = [ranks[key] for ranks in channel_ranks if key in ranks]
+        if not ranks:
+            continue
+
+        rrf_score = sum(1.0 / (rrf_k + rank + 1) for rank in ranks)
+        final_score = rrf_score
+        if use_importance_weight:
+            final_score *= _importance_factor(chunk)
+
+        chunk_id = _result_id(chunk) or ""
+        ranked.append((final_score, rrf_score, min(ranks), chunk_id, chunk))
+
+    ranked.sort(key=lambda item: (-item[0], -item[1], item[2], item[3]))
+    return [chunk for *_, chunk in ranked[:limit]]
+
+
+def _rrf_k(chunks_top_k: int) -> int:
+    return max(30, min(60, 20 + 2 * chunks_top_k))
+
+
+def _importance_factor(chunk: Any) -> float:
+    raw_importance = _payload(chunk).get("importance_weight")
+    importance = raw_importance if isinstance(raw_importance, (int, float)) else 0.5
+    importance = max(0.0, min(1.0, importance))
+    return 0.75 + 0.5 * importance
+
+
 def _chunk_key(chunk: Any) -> Optional[tuple[str, str]]:
     chunk_id = _result_id(chunk)
     if chunk_id:
@@ -469,11 +677,19 @@ def _node_label(node: dict) -> Optional[str]:
     return _first_display_value(node.get("name"), node.get("id"))
 
 
-def _format_passages(chunks: List[Any]) -> str:
+def _format_passages(chunks: List[Any], chunk_summaries: Optional[Dict[str, str]] = None) -> str:
     texts = []
+    chunk_summaries = chunk_summaries or {}
     for chunk in chunks or []:
         text = _display_value(_payload(chunk).get("text"))
-        if text:
+        if not text:
+            continue
+
+        chunk_id = _result_id(chunk)
+        summary_text = chunk_summaries.get(chunk_id) if chunk_id else None
+        if summary_text:
+            texts.append(f"[Passage Summary]: {summary_text}\n[Raw Passage]: {text}")
+        else:
             texts.append(text)
     if not texts:
         return ""

--- a/cognee/modules/retrieval/hybrid_retriever.py
+++ b/cognee/modules/retrieval/hybrid_retriever.py
@@ -1,15 +1,18 @@
 import asyncio
 from typing import Any, Dict, List, Optional, Type
-from uuid import UUID, uuid5
 
 from cognee.context_global_variables import session_user
 from cognee.infrastructure.databases.cache.config import CacheConfig
 from cognee.infrastructure.databases.unified import get_unified_engine
-from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
 from cognee.infrastructure.session.get_session_manager import get_session_manager
 from cognee.modules.retrieval.base_retriever import BaseRetriever
-from cognee.modules.retrieval.bm25_retriever import BM25ChunksRetriever
-from cognee.modules.retrieval.exceptions.exceptions import NoDataError, QueryValidationError
+from cognee.modules.retrieval.exceptions.exceptions import QueryValidationError
+from cognee.modules.retrieval.hybrid.chunks import retrieve_hybrid_chunks, search_collection
+from cognee.modules.retrieval.hybrid.context import (
+    extract_context_object_ids,
+    format_hybrid_context,
+)
+from cognee.modules.retrieval.hybrid.entities import build_entities
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.modules.retrieval.utils.global_context import (
     format_global_context_prelude,
@@ -17,9 +20,6 @@ from cognee.modules.retrieval.utils.global_context import (
     search_top_global_context_summaries,
 )
 from cognee.modules.retrieval.utils.validate_queries import validate_retriever_input
-from cognee.shared.logging_utils import get_logger
-
-logger = get_logger("HybridRetriever")
 
 
 class HybridRetriever(BaseRetriever):
@@ -70,255 +70,31 @@ class HybridRetriever(BaseRetriever):
 
         self._unified_engine = await get_unified_engine()
         chunk_objects, entity_hits = await asyncio.gather(
-            self._build_chunk_objects(query),
-            self._search_collection("Entity_name", query, self.entities_top_k),
+            retrieve_hybrid_chunks(
+                vector_engine=self._unified_engine.vector,
+                query=query,
+                chunks_top_k=self.chunks_top_k,
+                text_summaries_top_k=self.text_summaries_top_k,
+                node_name=self.node_name,
+                node_name_filter_operator=self.node_name_filter_operator,
+                use_importance_weight=self.use_importance_weight,
+            ),
+            search_collection(
+                self._unified_engine.vector,
+                "Entity_name",
+                query,
+                self.entities_top_k,
+                self.node_name,
+                self.node_name_filter_operator,
+            ),
         )
-        entities = await self._build_entities(entity_hits)
+        entities = await build_entities(
+            self._unified_engine.graph,
+            entity_hits,
+            self.max_edges_per_entity,
+        )
 
         return {**chunk_objects, "entities": entities}
-
-    async def _build_chunk_objects(self, query: str) -> Dict[str, Any]:
-        candidate_limit = max(0, self.chunks_top_k * 2)
-        bm25_chunks, vector_chunks, summary_hits = await asyncio.gather(
-            self._search_bm25_chunks(query, limit=candidate_limit),
-            self._search_collection(
-                "DocumentChunk_text",
-                query,
-                candidate_limit,
-                required=True,
-            ),
-            self._search_collection(
-                "TextSummary_text",
-                query,
-                self._summary_candidate_limit(),
-            ),
-        )
-        chunks, chunk_summaries = await self._select_ranked_chunks(
-            bm25_chunks,
-            vector_chunks,
-            summary_hits,
-        )
-        return {"chunks": chunks, "chunk_summaries": chunk_summaries}
-
-    def _summary_candidate_limit(self) -> int:
-        if self.text_summaries_top_k is None:
-            return max(0, self.chunks_top_k)
-        return self.text_summaries_top_k
-
-    async def _search_bm25_chunks(self, query: str, limit: int) -> List[dict]:
-        if limit <= 0:
-            return []
-
-        try:
-            retriever = BM25ChunksRetriever(top_k=limit, with_scores=True)
-            scored_chunks = await retriever.get_retrieved_objects(query)
-        except NoDataError:
-            return []
-        except Exception as error:
-            logger.warning("BM25 chunk retrieval failed; using vector chunks only: %s", error)
-            return []
-
-        chunks = []
-        for item in scored_chunks:
-            chunk, score = _scored_payload(item)
-            if score <= 0:
-                continue
-            if not isinstance(chunk, dict):
-                continue
-            if not _payload_matches_node_filter(
-                chunk, self.node_name, self.node_name_filter_operator
-            ):
-                continue
-            chunks.append(chunk)
-        return chunks
-
-    async def _search_collection(
-        self,
-        collection_name: str,
-        query: str,
-        limit: int,
-        *,
-        required: bool = False,
-        apply_node_filter: bool = True,
-    ) -> List[Any]:
-        if limit <= 0:
-            return []
-
-        node_name = self.node_name if apply_node_filter else None
-        node_name_filter_operator = self.node_name_filter_operator if apply_node_filter else "OR"
-        try:
-            return await self._unified_engine.vector.search(
-                collection_name,
-                query,
-                limit=limit,
-                include_payload=True,
-                node_name=node_name,
-                node_name_filter_operator=node_name_filter_operator,
-            )
-        except CollectionNotFoundError as error:
-            if required:
-                logger.error("%s collection not found", collection_name)
-                raise NoDataError("No data found in the system, please add data first.") from error
-            logger.debug("%s collection not found; using empty channel", collection_name)
-            return []
-
-    async def _select_ranked_chunks(
-        self,
-        bm25_chunks: List[Any],
-        vector_chunks: List[Any],
-        summary_hits: List[Any],
-    ) -> tuple[List[Any], Dict[str, str]]:
-        chunk_summary_pairs = _chunk_summary_pairs(
-            bm25_chunks,
-            vector_chunks,
-            summary_hits,
-            self.node_name,
-            self.node_name_filter_operator,
-        )
-        source_chunk_ids_to_load = [
-            pair["chunk_id"]
-            for pair in chunk_summary_pairs
-            if pair["summary_rank"] is not None and pair["chunk"] is None and pair["chunk_id"]
-        ]
-        if source_chunk_ids_to_load:
-            loaded_source_chunks = await self._load_source_chunks_for_summaries(
-                source_chunk_ids_to_load
-            )
-            for chunk in loaded_source_chunks:
-                pair = _find_chunk_summary_pair(chunk_summary_pairs, _result_id(chunk), None)
-                if pair:
-                    _set_pair_chunk(pair, chunk)
-
-        ranked_pairs = _rank_chunk_summary_pairs(
-            chunk_summary_pairs,
-            self.chunks_top_k,
-            self.use_importance_weight,
-        )
-        if self._summary_candidate_limit() > 0:
-            await self._load_summary_text_for_ranked_pairs(ranked_pairs)
-
-        ranked_chunks = [pair["chunk"] for pair in ranked_pairs if pair["chunk"] is not None]
-
-        summary_text_by_chunk_id = {}
-        for pair in ranked_pairs:
-            if pair["chunk_id"] and pair["summary_text"]:
-                summary_text_by_chunk_id[pair["chunk_id"]] = pair["summary_text"]
-
-        return ranked_chunks, summary_text_by_chunk_id
-
-    async def _load_source_chunks_for_summaries(self, chunk_ids: List[str]) -> List[Any]:
-        chunks = await self._unified_engine.vector.retrieve("DocumentChunk_text", chunk_ids)
-        found_ids = {_result_id(chunk) for chunk in chunks}
-        missing_ids = sorted(set(chunk_ids) - {chunk_id for chunk_id in found_ids if chunk_id})
-        if missing_ids:
-            logger.warning(
-                "TextSummary_text hit referenced missing DocumentChunk_text row(s): %s",
-                missing_ids,
-            )
-
-        source_chunks = []
-        filtered_ids = []
-        for chunk in chunks:
-            if _payload_matches_node_filter(
-                _payload(chunk), self.node_name, self.node_name_filter_operator
-            ):
-                source_chunks.append(chunk)
-                continue
-
-            chunk_id = _result_id(chunk)
-            if chunk_id:
-                filtered_ids.append(chunk_id)
-
-        if filtered_ids:
-            logger.warning(
-                "TextSummary_text source chunk failed node filter: %s",
-                sorted(filtered_ids),
-            )
-        return source_chunks
-
-    async def _load_summary_text_for_ranked_pairs(self, ranked_pairs: List[dict]) -> None:
-        summary_ids_by_chunk_id = {}
-        for pair in ranked_pairs:
-            if pair["summary_text"]:
-                continue
-
-            chunk_id = pair["chunk_id"]
-            if not chunk_id:
-                continue
-
-            summary_id = pair["summary_id"]
-            if summary_id is None:
-                summary_id = _summary_id_for_chunk(chunk_id)
-            if summary_id is None:
-                logger.debug("Cannot fetch paired TextSummary for non-UUID chunk id %s", chunk_id)
-                continue
-
-            pair["summary_id"] = summary_id
-            summary_ids_by_chunk_id[chunk_id] = summary_id
-
-        if not summary_ids_by_chunk_id:
-            return
-
-        try:
-            summaries = await self._unified_engine.vector.retrieve(
-                "TextSummary_text",
-                list(summary_ids_by_chunk_id.values()),
-            )
-        except CollectionNotFoundError:
-            logger.warning("TextSummary_text collection missing while loading chunk summaries")
-            return
-
-        summaries_by_id = {_result_id(summary): summary for summary in summaries}
-        for pair in ranked_pairs:
-            chunk_id = pair["chunk_id"]
-            summary_id = pair["summary_id"]
-            if not chunk_id or not summary_id:
-                continue
-
-            summary = summaries_by_id.get(summary_id)
-            if summary is None:
-                logger.warning(
-                    "DocumentChunk_text row has no paired TextSummary_text row: chunk_id=%s",
-                    chunk_id,
-                )
-                continue
-
-            summary_payload = _payload(summary)
-            summary_text = _display_value(summary_payload.get("text"))
-            if not summary_text:
-                logger.warning(
-                    "Paired TextSummary_text row has no text: chunk_id=%s summary_id=%s",
-                    chunk_id,
-                    summary_id,
-                )
-                continue
-
-            if not _payload_matches_node_filter(
-                summary_payload, self.node_name, self.node_name_filter_operator
-            ):
-                logger.warning(
-                    "Paired TextSummary_text row failed node filter: chunk_id=%s summary_id=%s",
-                    chunk_id,
-                    summary_id,
-                )
-                continue
-
-            pair["summary_text"] = summary_text
-
-    async def _build_entities(self, entity_hits: List[Any]) -> List[dict]:
-        if not entity_hits:
-            return []
-
-        entities = [_entity_from_result(result) for result in entity_hits]
-        if await self._unified_engine.graph.is_empty():
-            return entities
-
-        connections_by_entity = await asyncio.gather(
-            *[self._unified_engine.graph.get_connections(entity["id"]) for entity in entities]
-        )
-        for entity, connections in zip(entities, connections_by_entity):
-            entity["edges"] = _edge_bullets_from_connections(connections, self.max_edges_per_entity)
-        return entities
 
     async def get_context_from_objects(
         self,
@@ -327,26 +103,8 @@ class HybridRetriever(BaseRetriever):
         retrieved_objects: Any = None,
     ) -> str:
         _reject_query_batch(query_batch)
-
-        retrieved_objects = retrieved_objects or {}
-        sections = []
-
         global_context = await self._build_global_context_section(query)
-        if global_context:
-            sections.append(global_context)
-
-        passages = _format_passages(
-            retrieved_objects.get("chunks", []),
-            retrieved_objects.get("chunk_summaries", {}),
-        )
-        if passages:
-            sections.append(passages)
-
-        entities = _format_entities(retrieved_objects.get("entities", []))
-        if entities:
-            sections.append(entities)
-
-        return "\n\n".join(sections)
+        return format_hybrid_context(global_context, retrieved_objects)
 
     async def _build_global_context_section(self, query: Optional[str]) -> str:
         if not self.include_global_context_index or not query:
@@ -365,32 +123,6 @@ class HybridRetriever(BaseRetriever):
         if not prelude:
             return ""
         return f"## Global context\n{prelude}"
-
-    def _extract_context_object_ids(self, retrieved_objects: Any) -> Optional[Dict[str, List[str]]]:
-        if not isinstance(retrieved_objects, dict):
-            return None
-
-        node_ids = set()
-        for chunk in retrieved_objects.get("chunks", []):
-            result_id = _result_id(chunk)
-            if result_id:
-                node_ids.add(result_id)
-
-        for entity in retrieved_objects.get("entities", []):
-            if not isinstance(entity, dict):
-                continue
-            entity_id = _display_value(entity.get("id"))
-            if entity_id:
-                node_ids.add(entity_id)
-            for edge in entity.get("edges", []):
-                if not isinstance(edge, dict):
-                    continue
-                for key in ("source_id", "target_id"):
-                    edge_node_id = _display_value(edge.get(key))
-                    if edge_node_id:
-                        node_ids.add(edge_node_id)
-
-        return {"node_ids": sorted(node_ids)} if node_ids else None
 
     async def get_completion_from_context(
         self,
@@ -412,7 +144,7 @@ class HybridRetriever(BaseRetriever):
                 system_prompt=self.system_prompt,
                 response_model=self.response_model,
                 summarize_context=False,
-                used_graph_element_ids=self._extract_context_object_ids(retrieved_objects),
+                used_graph_element_ids=extract_context_object_ids(retrieved_objects),
                 max_context_chars=getattr(self, "max_context_chars", None),
             )
             return [completion]
@@ -448,357 +180,3 @@ class HybridRetriever(BaseRetriever):
 def _reject_query_batch(query_batch: Optional[List[str]]) -> None:
     if query_batch is not None:
         raise QueryValidationError("HYBRID_COMPLETION does not support query_batch.")
-
-
-def _summary_id_for_chunk(chunk_id: str) -> Optional[str]:
-    try:
-        chunk_uuid = UUID(chunk_id)
-    except (TypeError, ValueError):
-        return None
-    return str(uuid5(chunk_uuid, "TextSummary"))
-
-
-def _payload(result: Any) -> dict:
-    if isinstance(result, dict):
-        return result
-    payload = getattr(result, "payload", None)
-    return payload if isinstance(payload, dict) else {}
-
-
-def _display_value(value: Any) -> Optional[str]:
-    if value is None:
-        return None
-    if isinstance(value, (str, int, float, bool, UUID)):
-        text = str(value).strip()
-        return text or None
-    return None
-
-
-def _result_id(result: Any) -> Optional[str]:
-    payload = _payload(result)
-    return _display_value(payload.get("id")) or _display_value(getattr(result, "id", None))
-
-
-def _scored_payload(item: Any) -> tuple[Any, float]:
-    if not isinstance(item, (list, tuple)) or len(item) != 2:
-        return item, 0.0
-    payload, score = item
-    if not isinstance(score, (int, float)):
-        return payload, 0.0
-    return payload, float(score)
-
-
-def _chunk_summary_pairs(
-    bm25_chunks: List[Any],
-    vector_chunks: List[Any],
-    summary_hits: List[Any],
-    node_name: Optional[List[str]] = None,
-    node_name_filter_operator: str = "OR",
-) -> List[dict]:
-    pairs = []
-
-    for rank_field, chunks in (("bm25_rank", bm25_chunks), ("vector_rank", vector_chunks)):
-        for rank, chunk in enumerate(chunks or []):
-            chunk_id = _result_id(chunk)
-            chunk_text = _display_value(_payload(chunk).get("text"))
-            if not chunk_id and not chunk_text:
-                continue
-
-            pair = _find_chunk_summary_pair(pairs, chunk_id, chunk_text)
-            if pair is None:
-                pair = _new_chunk_summary_pair(chunk_id=chunk_id, chunk_text=chunk_text)
-                pairs.append(pair)
-            if pair["chunk"] is None:
-                _set_pair_chunk(pair, chunk)
-            if pair[rank_field] is None:
-                pair[rank_field] = rank
-
-    for rank, summary in enumerate(summary_hits or []):
-        payload = _payload(summary)
-        if not _payload_matches_node_filter(payload, node_name, node_name_filter_operator):
-            continue
-
-        chunk_id = _display_value(payload.get("source_chunk_id"))
-        if not chunk_id:
-            logger.warning(
-                "TextSummary_text hit has no source_chunk_id: summary_id=%s", _result_id(summary)
-            )
-            continue
-
-        pair = _find_chunk_summary_pair(pairs, chunk_id, None)
-        if pair is None:
-            pair = _new_chunk_summary_pair(chunk_id=chunk_id)
-            pairs.append(pair)
-        if pair["summary_rank"] is None:
-            pair["summary_rank"] = rank
-            pair["summary_id"] = _result_id(summary)
-            pair["summary_text"] = _display_value(payload.get("text"))
-
-    return pairs
-
-
-def _find_chunk_summary_pair(
-    pairs: List[dict], chunk_id: Optional[str], chunk_text: Optional[str]
-) -> Optional[dict]:
-    for pair in pairs:
-        if chunk_id and pair["chunk_id"] == chunk_id:
-            return pair
-        if chunk_text and pair["chunk_id"] is None and pair["chunk_text"] == chunk_text:
-            return pair
-    return None
-
-
-def _new_chunk_summary_pair(
-    chunk_id: Optional[str] = None,
-    chunk_text: Optional[str] = None,
-) -> dict:
-    return {
-        "chunk_id": chunk_id,
-        "chunk_text": chunk_text,
-        "summary_id": None,
-        "summary_text": None,
-        "chunk": None,
-        "bm25_rank": None,
-        "vector_rank": None,
-        "summary_rank": None,
-    }
-
-
-def _set_pair_chunk(pair: dict, chunk: Any) -> None:
-    pair["chunk"] = chunk
-    pair["chunk_id"] = _result_id(chunk) or pair["chunk_id"]
-    pair["chunk_text"] = _display_value(_payload(chunk).get("text")) or pair["chunk_text"]
-
-
-def _rank_chunk_summary_pairs(
-    pairs: List[dict],
-    limit: int,
-    use_importance_weight: bool,
-) -> List[dict]:
-    if limit <= 0:
-        return []
-
-    rrf_k = _rrf_k(limit)
-    ranked = []
-    for pair in pairs:
-        chunk = pair["chunk"]
-        if chunk is None:
-            continue
-
-        ranks = [
-            rank
-            for rank in (pair["bm25_rank"], pair["vector_rank"], pair["summary_rank"])
-            if rank is not None
-        ]
-        if not ranks:
-            continue
-
-        rrf_score = sum(1.0 / (rrf_k + rank + 1) for rank in ranks)
-        final_score = rrf_score
-        if use_importance_weight:
-            final_score *= _importance_factor(chunk)
-
-        chunk_id = pair["chunk_id"] or _result_id(chunk) or ""
-        ranked.append((final_score, rrf_score, min(ranks), chunk_id, pair))
-
-    ranked.sort(key=lambda item: (-item[0], -item[1], item[2], item[3]))
-    return [pair for *_, pair in ranked[:limit]]
-
-
-def _rrf_k(chunks_top_k: int) -> int:
-    return max(30, min(60, 20 + 2 * chunks_top_k))
-
-
-def _importance_factor(chunk: Any) -> float:
-    raw_importance = _payload(chunk).get("importance_weight")
-    importance = raw_importance if isinstance(raw_importance, (int, float)) else 0.5
-    importance = max(0.0, min(1.0, importance))
-    return 0.75 + 0.5 * importance
-
-
-def _payload_matches_node_filter(
-    payload: dict, node_name: Optional[List[str]], node_name_filter_operator: str
-) -> bool:
-    if not node_name:
-        return True
-
-    belongs_to_set = payload.get("belongs_to_set")
-    if not isinstance(belongs_to_set, list):
-        return False
-
-    payload_sets = {str(name) for name in belongs_to_set}
-    requested_sets = {str(name) for name in node_name}
-    if node_name_filter_operator == "AND":
-        return requested_sets.issubset(payload_sets)
-    return bool(payload_sets & requested_sets)
-
-
-def _first_display_value(*values: Any) -> Optional[str]:
-    for value in values:
-        text = _display_value(value)
-        if text:
-            return text
-    return None
-
-
-def _entity_from_result(result: Any) -> dict:
-    payload = _payload(result)
-    entity_id = _result_id(result) or ""
-    return {
-        "id": entity_id,
-        "name": _first_display_value(payload.get("name"), payload.get("text"), entity_id) or "",
-        "description": _display_value(payload.get("description")),
-        "type": _entity_type(payload),
-        "edges": [],
-    }
-
-
-def _entity_type(payload: dict) -> Optional[str]:
-    for value in (payload.get("is_a"), payload.get("type")):
-        entity_type = _display_value(value)
-        if entity_type and entity_type not in {"IndexSchema"}:
-            return entity_type
-    return None
-
-
-def _edge_bullets_from_connections(connections: List[Any], max_edges: int) -> List[dict]:
-    if max_edges <= 0:
-        return []
-
-    edges = []
-    seen_keys = set()
-    seen_texts = set()
-    for connection in connections or []:
-        unpacked = _unpack_connection(connection)
-        if unpacked is None:
-            continue
-
-        source, edge, target = unpacked
-        bullet = _edge_bullet(source, edge, target)
-        if not bullet:
-            continue
-
-        dedupe_key = _edge_dedupe_key(bullet)
-        if dedupe_key and dedupe_key in seen_keys:
-            continue
-        if not dedupe_key and bullet["text"] in seen_texts:
-            continue
-
-        if dedupe_key:
-            seen_keys.add(dedupe_key)
-        else:
-            seen_texts.add(bullet["text"])
-        edges.append(bullet)
-    edges.sort(key=lambda edge: 0 if _is_type_edge(edge) else 1)
-    return edges[:max_edges]
-
-
-def _unpack_connection(connection: Any) -> Optional[tuple[dict, dict, dict]]:
-    if not isinstance(connection, (list, tuple)) or len(connection) != 3:
-        return None
-    source, edge, target = connection
-    if not isinstance(source, dict) or not isinstance(edge, dict) or not isinstance(target, dict):
-        return None
-    return source, edge, target
-
-
-def _edge_bullet(source: dict, edge: dict, target: dict) -> Optional[dict]:
-    source_label = _node_label(source)
-    target_label = _node_label(target)
-    relationship = _display_value(edge.get("relationship_name"))
-    text = _first_display_value(edge.get("edge_text"), _nested_edge_text(edge))
-    if not text and source_label and relationship and target_label:
-        text = f"{source_label} -- {relationship} -- {target_label}"
-    if not text:
-        return None
-
-    return {
-        "text": text,
-        "source": source_label,
-        "target": target_label,
-        "source_id": _display_value(source.get("id")),
-        "relationship": relationship,
-        "target_id": _display_value(target.get("id")),
-    }
-
-
-def _edge_dedupe_key(edge: dict) -> Optional[tuple[str, str, str]]:
-    source_id = _display_value(edge.get("source_id"))
-    relationship = _display_value(edge.get("relationship"))
-    target_id = _display_value(edge.get("target_id"))
-    if source_id and relationship and target_id:
-        return source_id, relationship, target_id
-    return None
-
-
-def _is_type_edge(edge: dict) -> bool:
-    relationship = _display_value(edge.get("relationship"))
-    if relationship:
-        normalized = relationship.lower().replace("_", " ").replace("-", " ").strip()
-        if normalized == "is a":
-            return True
-
-    text = _display_value(edge.get("text"))
-    return bool(text and " is a " in f" {text.lower()} ")
-
-
-def _nested_edge_text(edge: dict) -> Optional[str]:
-    properties = edge.get("properties")
-    if not isinstance(properties, dict):
-        return None
-    return _display_value(properties.get("edge_text"))
-
-
-def _node_label(node: dict) -> Optional[str]:
-    return _first_display_value(node.get("name"), node.get("id"))
-
-
-def _format_passages(chunks: List[Any], chunk_summaries: Optional[Dict[str, str]] = None) -> str:
-    texts = []
-    chunk_summaries = chunk_summaries or {}
-    for chunk in chunks or []:
-        text = _display_value(_payload(chunk).get("text"))
-        if not text:
-            continue
-
-        chunk_id = _result_id(chunk)
-        summary_text = chunk_summaries.get(chunk_id) if chunk_id else None
-        if summary_text:
-            texts.append(f"[Passage Summary]: {summary_text}\n[Raw Passage]: {text}")
-        else:
-            texts.append(text)
-    if not texts:
-        return ""
-    return "## Relevant passages\n" + "\n---\n".join(texts)
-
-
-def _format_entities(entities: List[dict]) -> str:
-    blocks = []
-    for entity in entities or []:
-        block = _format_entity(entity)
-        if block:
-            blocks.append(block)
-    if not blocks:
-        return ""
-    return "## Relevant entities\n" + "\n\n".join(blocks)
-
-
-def _format_entity(entity: dict) -> str:
-    name = _display_value(entity.get("name"))
-    if not name:
-        return ""
-
-    entity_type = _entity_type(entity)
-    header = f"### {name} ({entity_type})" if entity_type else f"### {name}"
-
-    lines = [header]
-    description = _display_value(entity.get("description"))
-    if description:
-        lines.append(description)
-
-    for edge in entity.get("edges", []):
-        edge_text = _display_value(edge.get("text"))
-        if edge_text:
-            lines.append(f"- {edge_text}")
-
-    return "\n".join(lines)

--- a/cognee/modules/retrieval/hybrid_retriever.py
+++ b/cognee/modules/retrieval/hybrid_retriever.py
@@ -78,10 +78,6 @@ class HybridRetriever(BaseRetriever):
         return {**chunk_objects, "entities": entities}
 
     async def _build_chunk_objects(self, query: str) -> Dict[str, Any]:
-        summary_limit = self._summary_candidate_limit()
-        if summary_limit <= 0:
-            return {"chunks": await self._build_legacy_chunks(query), "chunk_summaries": {}}
-
         candidate_limit = max(0, self.chunks_top_k * 2)
         bm25_chunks, vector_chunks, summary_hits = await asyncio.gather(
             self._search_bm25_chunks(query, limit=candidate_limit),
@@ -94,37 +90,27 @@ class HybridRetriever(BaseRetriever):
             self._search_collection(
                 "TextSummary_text",
                 query,
-                summary_limit,
-                apply_node_filter=False,
+                self._summary_candidate_limit(),
             ),
         )
-        chunks, chunk_summaries = await self._rank_summary_aware_chunks(
+        chunks, chunk_summaries = await self._select_ranked_chunks(
             bm25_chunks,
             vector_chunks,
             summary_hits,
         )
-        await self._fetch_final_chunk_summaries(chunks, chunk_summaries)
         return {"chunks": chunks, "chunk_summaries": chunk_summaries}
-
-    async def _build_legacy_chunks(self, query: str) -> List[Any]:
-        bm25_chunks, vector_chunks = await asyncio.gather(
-            self._search_bm25_chunks(query),
-            self._search_collection("DocumentChunk_text", query, self.chunks_top_k, required=True),
-        )
-        return _merge_chunks(bm25_chunks, vector_chunks, self.chunks_top_k)
 
     def _summary_candidate_limit(self) -> int:
         if self.text_summaries_top_k is None:
             return max(0, self.chunks_top_k)
         return self.text_summaries_top_k
 
-    async def _search_bm25_chunks(self, query: str, limit: Optional[int] = None) -> List[dict]:
-        bm25_top_k = limit if limit is not None else _bm25_chunk_limit(self.chunks_top_k)
-        if bm25_top_k <= 0:
+    async def _search_bm25_chunks(self, query: str, limit: int) -> List[dict]:
+        if limit <= 0:
             return []
 
         try:
-            retriever = BM25ChunksRetriever(top_k=bm25_top_k, with_scores=True)
+            retriever = BM25ChunksRetriever(top_k=limit, with_scores=True)
             scored_chunks = await retriever.get_retrieved_objects(query)
         except NoDataError:
             return []
@@ -176,86 +162,148 @@ class HybridRetriever(BaseRetriever):
             logger.debug("%s collection not found; using empty channel", collection_name)
             return []
 
-    async def _rank_summary_aware_chunks(
+    async def _select_ranked_chunks(
         self,
         bm25_chunks: List[Any],
         vector_chunks: List[Any],
         summary_hits: List[Any],
     ) -> tuple[List[Any], Dict[str, str]]:
-        summary_ranks, summary_text_by_chunk_id = _summary_signal(summary_hits)
-
-        candidate_by_key = {}
-        _add_chunk_candidates(candidate_by_key, bm25_chunks)
-        _add_chunk_candidates(candidate_by_key, vector_chunks)
-
-        missing_chunk_ids = [
-            key[1] for key in summary_ranks if key not in candidate_by_key and key[0] == "id"
+        chunk_summary_pairs = _chunk_summary_pairs(
+            bm25_chunks,
+            vector_chunks,
+            summary_hits,
+            self.node_name,
+            self.node_name_filter_operator,
+        )
+        source_chunk_ids_to_load = [
+            pair["chunk_id"]
+            for pair in chunk_summary_pairs
+            if pair["summary_rank"] is not None and pair["chunk"] is None and pair["chunk_id"]
         ]
-        if missing_chunk_ids:
-            _add_chunk_candidates(
-                candidate_by_key,
-                await self._fetch_summary_only_chunks(missing_chunk_ids),
+        if source_chunk_ids_to_load:
+            loaded_source_chunks = await self._load_source_chunks_for_summaries(
+                source_chunk_ids_to_load
             )
+            for chunk in loaded_source_chunks:
+                pair = _find_chunk_summary_pair(chunk_summary_pairs, _result_id(chunk), None)
+                if pair:
+                    _set_pair_chunk(pair, chunk)
 
-        bm25_ranks = _chunk_ranks(bm25_chunks)
-        vector_ranks = _chunk_ranks(vector_chunks)
-        ranked = _rank_chunk_candidates(
-            candidate_by_key,
-            [bm25_ranks, vector_ranks, summary_ranks],
+        ranked_pairs = _rank_chunk_summary_pairs(
+            chunk_summary_pairs,
             self.chunks_top_k,
             self.use_importance_weight,
         )
-        ranked_keys = {_chunk_key(chunk) for chunk in ranked}
-        final_summary_text = {
-            chunk_id: text
-            for chunk_id, text in summary_text_by_chunk_id.items()
-            if ("id", chunk_id) in ranked_keys
-        }
-        return ranked, final_summary_text
+        if self._summary_candidate_limit() > 0:
+            await self._load_summary_text_for_ranked_pairs(ranked_pairs)
 
-    async def _fetch_summary_only_chunks(self, chunk_ids: List[str]) -> List[Any]:
+        ranked_chunks = [pair["chunk"] for pair in ranked_pairs if pair["chunk"] is not None]
+
+        summary_text_by_chunk_id = {}
+        for pair in ranked_pairs:
+            if pair["chunk_id"] and pair["summary_text"]:
+                summary_text_by_chunk_id[pair["chunk_id"]] = pair["summary_text"]
+
+        return ranked_chunks, summary_text_by_chunk_id
+
+    async def _load_source_chunks_for_summaries(self, chunk_ids: List[str]) -> List[Any]:
         chunks = await self._unified_engine.vector.retrieve("DocumentChunk_text", chunk_ids)
-        return [
-            chunk
-            for chunk in chunks
+        found_ids = {_result_id(chunk) for chunk in chunks}
+        missing_ids = sorted(set(chunk_ids) - {chunk_id for chunk_id in found_ids if chunk_id})
+        if missing_ids:
+            logger.warning(
+                "TextSummary_text hit referenced missing DocumentChunk_text row(s): %s",
+                missing_ids,
+            )
+
+        source_chunks = []
+        filtered_ids = []
+        for chunk in chunks:
             if _payload_matches_node_filter(
                 _payload(chunk), self.node_name, self.node_name_filter_operator
-            )
-        ]
-
-    async def _fetch_final_chunk_summaries(
-        self,
-        chunks: List[Any],
-        summary_text_by_chunk_id: Dict[str, str],
-    ) -> None:
-        summary_ids_by_chunk_id = {}
-        for chunk in chunks:
-            chunk_id = _result_id(chunk)
-            if not chunk_id or chunk_id in summary_text_by_chunk_id:
+            ):
+                source_chunks.append(chunk)
                 continue
-            try:
-                chunk_uuid = UUID(chunk_id)
-            except (TypeError, ValueError):
+
+            chunk_id = _result_id(chunk)
+            if chunk_id:
+                filtered_ids.append(chunk_id)
+
+        if filtered_ids:
+            logger.warning(
+                "TextSummary_text source chunk failed node filter: %s",
+                sorted(filtered_ids),
+            )
+        return source_chunks
+
+    async def _load_summary_text_for_ranked_pairs(self, ranked_pairs: List[dict]) -> None:
+        summary_ids_by_chunk_id = {}
+        for pair in ranked_pairs:
+            if pair["summary_text"]:
+                continue
+
+            chunk_id = pair["chunk_id"]
+            if not chunk_id:
+                continue
+
+            summary_id = pair["summary_id"]
+            if summary_id is None:
+                summary_id = _summary_id_for_chunk(chunk_id)
+            if summary_id is None:
                 logger.debug("Cannot fetch paired TextSummary for non-UUID chunk id %s", chunk_id)
                 continue
-            summary_ids_by_chunk_id[chunk_id] = str(uuid5(chunk_uuid, "TextSummary"))
+
+            pair["summary_id"] = summary_id
+            summary_ids_by_chunk_id[chunk_id] = summary_id
 
         if not summary_ids_by_chunk_id:
             return
 
-        summaries = await self._unified_engine.vector.retrieve(
-            "TextSummary_text",
-            list(summary_ids_by_chunk_id.values()),
-        )
+        try:
+            summaries = await self._unified_engine.vector.retrieve(
+                "TextSummary_text",
+                list(summary_ids_by_chunk_id.values()),
+            )
+        except CollectionNotFoundError:
+            logger.warning("TextSummary_text collection missing while loading chunk summaries")
+            return
+
         summaries_by_id = {_result_id(summary): summary for summary in summaries}
-        for chunk_id, summary_id in summary_ids_by_chunk_id.items():
+        for pair in ranked_pairs:
+            chunk_id = pair["chunk_id"]
+            summary_id = pair["summary_id"]
+            if not chunk_id or not summary_id:
+                continue
+
             summary = summaries_by_id.get(summary_id)
             if summary is None:
-                logger.debug("No paired TextSummary found for chunk id %s", chunk_id)
+                logger.warning(
+                    "DocumentChunk_text row has no paired TextSummary_text row: chunk_id=%s",
+                    chunk_id,
+                )
                 continue
-            summary_text = _display_value(_payload(summary).get("text"))
-            if summary_text:
-                summary_text_by_chunk_id[chunk_id] = summary_text
+
+            summary_payload = _payload(summary)
+            summary_text = _display_value(summary_payload.get("text"))
+            if not summary_text:
+                logger.warning(
+                    "Paired TextSummary_text row has no text: chunk_id=%s summary_id=%s",
+                    chunk_id,
+                    summary_id,
+                )
+                continue
+
+            if not _payload_matches_node_filter(
+                summary_payload, self.node_name, self.node_name_filter_operator
+            ):
+                logger.warning(
+                    "Paired TextSummary_text row failed node filter: chunk_id=%s summary_id=%s",
+                    chunk_id,
+                    summary_id,
+                )
+                continue
+
+            pair["summary_text"] = summary_text
 
     async def _build_entities(self, entity_hits: List[Any]) -> List[dict]:
         if not entity_hits:
@@ -402,6 +450,14 @@ def _reject_query_batch(query_batch: Optional[List[str]]) -> None:
         raise QueryValidationError("HYBRID_COMPLETION does not support query_batch.")
 
 
+def _summary_id_for_chunk(chunk_id: str) -> Optional[str]:
+    try:
+        chunk_uuid = UUID(chunk_id)
+    except (TypeError, ValueError):
+        return None
+    return str(uuid5(chunk_uuid, "TextSummary"))
+
+
 def _payload(result: Any) -> dict:
     if isinstance(result, dict):
         return result
@@ -432,78 +488,108 @@ def _scored_payload(item: Any) -> tuple[Any, float]:
     return payload, float(score)
 
 
-def _bm25_chunk_limit(chunks_top_k: int) -> int:
-    if chunks_top_k <= 0:
-        return 0
-    return max(1, chunks_top_k // 2)
+def _chunk_summary_pairs(
+    bm25_chunks: List[Any],
+    vector_chunks: List[Any],
+    summary_hits: List[Any],
+    node_name: Optional[List[str]] = None,
+    node_name_filter_operator: str = "OR",
+) -> List[dict]:
+    pairs = []
 
+    for rank_field, chunks in (("bm25_rank", bm25_chunks), ("vector_rank", vector_chunks)):
+        for rank, chunk in enumerate(chunks or []):
+            chunk_id = _result_id(chunk)
+            chunk_text = _display_value(_payload(chunk).get("text"))
+            if not chunk_id and not chunk_text:
+                continue
 
-def _merge_chunks(bm25_chunks: List[Any], vector_chunks: List[Any], limit: int) -> List[Any]:
-    if limit <= 0:
-        return []
+            pair = _find_chunk_summary_pair(pairs, chunk_id, chunk_text)
+            if pair is None:
+                pair = _new_chunk_summary_pair(chunk_id=chunk_id, chunk_text=chunk_text)
+                pairs.append(pair)
+            if pair["chunk"] is None:
+                _set_pair_chunk(pair, chunk)
+            if pair[rank_field] is None:
+                pair[rank_field] = rank
 
-    chunks = []
-    seen = set()
-    for chunk in [*(bm25_chunks or []), *(vector_chunks or [])]:
-        key = _chunk_key(chunk)
-        if not key or key in seen:
-            continue
-        seen.add(key)
-        chunks.append(chunk)
-        if len(chunks) >= limit:
-            break
-    return chunks
-
-
-def _add_chunk_candidates(candidate_by_key: dict, chunks: List[Any]) -> None:
-    for chunk in chunks or []:
-        key = _chunk_key(chunk)
-        if key and key not in candidate_by_key:
-            candidate_by_key[key] = chunk
-
-
-def _chunk_ranks(chunks: List[Any]) -> dict:
-    ranks = {}
-    for rank, chunk in enumerate(chunks or []):
-        key = _chunk_key(chunk)
-        if key and key not in ranks:
-            ranks[key] = rank
-    return ranks
-
-
-def _summary_signal(summary_hits: List[Any]) -> tuple[dict, Dict[str, str]]:
-    ranks = {}
-    summary_text_by_chunk_id = {}
     for rank, summary in enumerate(summary_hits or []):
         payload = _payload(summary)
-        chunk_id = _display_value(payload.get("source_chunk_id"))
-        if not chunk_id:
+        if not _payload_matches_node_filter(payload, node_name, node_name_filter_operator):
             continue
 
-        key = ("id", chunk_id)
-        if key not in ranks:
-            ranks[key] = rank
+        chunk_id = _display_value(payload.get("source_chunk_id"))
+        if not chunk_id:
+            logger.warning(
+                "TextSummary_text hit has no source_chunk_id: summary_id=%s", _result_id(summary)
+            )
+            continue
 
-        summary_text = _display_value(payload.get("text"))
-        if summary_text and chunk_id not in summary_text_by_chunk_id:
-            summary_text_by_chunk_id[chunk_id] = summary_text
+        pair = _find_chunk_summary_pair(pairs, chunk_id, None)
+        if pair is None:
+            pair = _new_chunk_summary_pair(chunk_id=chunk_id)
+            pairs.append(pair)
+        if pair["summary_rank"] is None:
+            pair["summary_rank"] = rank
+            pair["summary_id"] = _result_id(summary)
+            pair["summary_text"] = _display_value(payload.get("text"))
 
-    return ranks, summary_text_by_chunk_id
+    return pairs
 
 
-def _rank_chunk_candidates(
-    candidate_by_key: dict,
-    channel_ranks: List[dict],
+def _find_chunk_summary_pair(
+    pairs: List[dict], chunk_id: Optional[str], chunk_text: Optional[str]
+) -> Optional[dict]:
+    for pair in pairs:
+        if chunk_id and pair["chunk_id"] == chunk_id:
+            return pair
+        if chunk_text and pair["chunk_id"] is None and pair["chunk_text"] == chunk_text:
+            return pair
+    return None
+
+
+def _new_chunk_summary_pair(
+    chunk_id: Optional[str] = None,
+    chunk_text: Optional[str] = None,
+) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "chunk_text": chunk_text,
+        "summary_id": None,
+        "summary_text": None,
+        "chunk": None,
+        "bm25_rank": None,
+        "vector_rank": None,
+        "summary_rank": None,
+    }
+
+
+def _set_pair_chunk(pair: dict, chunk: Any) -> None:
+    pair["chunk"] = chunk
+    pair["chunk_id"] = _result_id(chunk) or pair["chunk_id"]
+    pair["chunk_text"] = _display_value(_payload(chunk).get("text")) or pair["chunk_text"]
+
+
+def _rank_chunk_summary_pairs(
+    pairs: List[dict],
     limit: int,
     use_importance_weight: bool,
-) -> List[Any]:
+) -> List[dict]:
     if limit <= 0:
         return []
 
     rrf_k = _rrf_k(limit)
     ranked = []
-    for key, chunk in candidate_by_key.items():
-        ranks = [ranks[key] for ranks in channel_ranks if key in ranks]
+    for pair in pairs:
+        chunk = pair["chunk"]
+        if chunk is None:
+            continue
+
+        ranks = [
+            rank
+            for rank in (pair["bm25_rank"], pair["vector_rank"], pair["summary_rank"])
+            if rank is not None
+        ]
         if not ranks:
             continue
 
@@ -512,11 +598,11 @@ def _rank_chunk_candidates(
         if use_importance_weight:
             final_score *= _importance_factor(chunk)
 
-        chunk_id = _result_id(chunk) or ""
-        ranked.append((final_score, rrf_score, min(ranks), chunk_id, chunk))
+        chunk_id = pair["chunk_id"] or _result_id(chunk) or ""
+        ranked.append((final_score, rrf_score, min(ranks), chunk_id, pair))
 
     ranked.sort(key=lambda item: (-item[0], -item[1], item[2], item[3]))
-    return [chunk for *_, chunk in ranked[:limit]]
+    return [pair for *_, pair in ranked[:limit]]
 
 
 def _rrf_k(chunks_top_k: int) -> int:
@@ -528,16 +614,6 @@ def _importance_factor(chunk: Any) -> float:
     importance = raw_importance if isinstance(raw_importance, (int, float)) else 0.5
     importance = max(0.0, min(1.0, importance))
     return 0.75 + 0.5 * importance
-
-
-def _chunk_key(chunk: Any) -> Optional[tuple[str, str]]:
-    chunk_id = _result_id(chunk)
-    if chunk_id:
-        return ("id", chunk_id)
-    text = _display_value(_payload(chunk).get("text"))
-    if text:
-        return ("text", text)
-    return None
 
 
 def _payload_matches_node_filter(

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -111,6 +111,10 @@ async def get_search_type_retriever_instance(
                 "global_context_index_top_k": retriever_specific_config.get(
                     "global_context_index_top_k", 3
                 ),
+                "text_summaries_top_k": retriever_specific_config.get("text_summaries_top_k"),
+                "use_importance_weight": retriever_specific_config.get(
+                    "use_importance_weight", True
+                ),
             },
         ),
         SearchType.TRIPLET_COMPLETION: (

--- a/cognee/tasks/summarization/models.py
+++ b/cognee/tasks/summarization/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Union, Optional
+from uuid import UUID
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.shared.CodeGraphEntities import CodeFile, CodePart
@@ -32,6 +33,7 @@ class TextSummary(DataPoint):
 
     text: str
     made_from: DocumentChunk
+    source_chunk_id: Optional[UUID] = None
     summarized_in: Optional[GlobalContextSummary] = None
     global_context_bucket_id: Optional[str] = None
     metadata: dict = {"index_fields": ["text"]}

--- a/cognee/tasks/summarization/models.py
+++ b/cognee/tasks/summarization/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Union, Optional
-from uuid import UUID
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.shared.CodeGraphEntities import CodeFile, CodePart
@@ -33,7 +32,7 @@ class TextSummary(DataPoint):
 
     text: str
     made_from: DocumentChunk
-    source_chunk_id: Optional[UUID] = None
+    source_chunk_id: Optional[str] = None
     summarized_in: Optional[GlobalContextSummary] = None
     global_context_bucket_id: Optional[str] = None
     metadata: dict = {"index_fields": ["text"]}

--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -73,7 +73,7 @@ async def summarize_text(
         TextSummary(
             id=uuid5(chunk.id, "TextSummary"),
             made_from=chunk,
-            source_chunk_id=chunk.id,
+            source_chunk_id=str(chunk.id),
             belongs_to_set=chunk.belongs_to_set,
             text=chunk_summaries[chunk_index].summary,
             importance_weight=chunk.importance_weight,

--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -74,6 +74,7 @@ async def summarize_text(
             id=uuid5(chunk.id, "TextSummary"),
             made_from=chunk,
             source_chunk_id=chunk.id,
+            belongs_to_set=chunk.belongs_to_set,
             text=chunk_summaries[chunk_index].summary,
             importance_weight=chunk.importance_weight,
         )

--- a/cognee/tasks/summarization/summarize_text.py
+++ b/cognee/tasks/summarization/summarize_text.py
@@ -73,6 +73,7 @@ async def summarize_text(
         TextSummary(
             id=uuid5(chunk.id, "TextSummary"),
             made_from=chunk,
+            source_chunk_id=chunk.id,
             text=chunk_summaries[chunk_index].summary,
             importance_weight=chunk.importance_weight,
         )

--- a/cognee/tests/integration/retrieval/test_summaries_retriever.py
+++ b/cognee/tests/integration/retrieval/test_summaries_retriever.py
@@ -53,7 +53,7 @@ async def setup_test_environment_with_summaries():
     chunk1_summary = TextSummary(
         text="S.R.",
         made_from=chunk1,
-        source_chunk_id=chunk1.id,
+        source_chunk_id=str(chunk1.id),
         belongs_to_set=chunk1.belongs_to_set,
     )
     chunk2 = DocumentChunk(
@@ -67,7 +67,7 @@ async def setup_test_environment_with_summaries():
     chunk2_summary = TextSummary(
         text="M.B.",
         made_from=chunk2,
-        source_chunk_id=chunk2.id,
+        source_chunk_id=str(chunk2.id),
         belongs_to_set=chunk2.belongs_to_set,
     )
     chunk3 = DocumentChunk(
@@ -81,7 +81,7 @@ async def setup_test_environment_with_summaries():
     chunk3_summary = TextSummary(
         text="C.M.",
         made_from=chunk3,
-        source_chunk_id=chunk3.id,
+        source_chunk_id=str(chunk3.id),
         belongs_to_set=chunk3.belongs_to_set,
     )
     chunk4 = DocumentChunk(
@@ -95,7 +95,7 @@ async def setup_test_environment_with_summaries():
     chunk4_summary = TextSummary(
         text="R.R.",
         made_from=chunk4,
-        source_chunk_id=chunk4.id,
+        source_chunk_id=str(chunk4.id),
         belongs_to_set=chunk4.belongs_to_set,
     )
     chunk5 = DocumentChunk(
@@ -109,7 +109,7 @@ async def setup_test_environment_with_summaries():
     chunk5_summary = TextSummary(
         text="H.Y.",
         made_from=chunk5,
-        source_chunk_id=chunk5.id,
+        source_chunk_id=str(chunk5.id),
         belongs_to_set=chunk5.belongs_to_set,
     )
     chunk6 = DocumentChunk(
@@ -123,7 +123,7 @@ async def setup_test_environment_with_summaries():
     chunk6_summary = TextSummary(
         text="C.H.",
         made_from=chunk6,
-        source_chunk_id=chunk6.id,
+        source_chunk_id=str(chunk6.id),
         belongs_to_set=chunk6.belongs_to_set,
     )
 

--- a/cognee/tests/integration/retrieval/test_summaries_retriever.py
+++ b/cognee/tests/integration/retrieval/test_summaries_retriever.py
@@ -53,6 +53,8 @@ async def setup_test_environment_with_summaries():
     chunk1_summary = TextSummary(
         text="S.R.",
         made_from=chunk1,
+        source_chunk_id=chunk1.id,
+        belongs_to_set=chunk1.belongs_to_set,
     )
     chunk2 = DocumentChunk(
         text="Mike Broski",
@@ -65,6 +67,8 @@ async def setup_test_environment_with_summaries():
     chunk2_summary = TextSummary(
         text="M.B.",
         made_from=chunk2,
+        source_chunk_id=chunk2.id,
+        belongs_to_set=chunk2.belongs_to_set,
     )
     chunk3 = DocumentChunk(
         text="Christina Mayer",
@@ -77,6 +81,8 @@ async def setup_test_environment_with_summaries():
     chunk3_summary = TextSummary(
         text="C.M.",
         made_from=chunk3,
+        source_chunk_id=chunk3.id,
+        belongs_to_set=chunk3.belongs_to_set,
     )
     chunk4 = DocumentChunk(
         text="Range Rover",
@@ -89,6 +95,8 @@ async def setup_test_environment_with_summaries():
     chunk4_summary = TextSummary(
         text="R.R.",
         made_from=chunk4,
+        source_chunk_id=chunk4.id,
+        belongs_to_set=chunk4.belongs_to_set,
     )
     chunk5 = DocumentChunk(
         text="Hyundai",
@@ -101,6 +109,8 @@ async def setup_test_environment_with_summaries():
     chunk5_summary = TextSummary(
         text="H.Y.",
         made_from=chunk5,
+        source_chunk_id=chunk5.id,
+        belongs_to_set=chunk5.belongs_to_set,
     )
     chunk6 = DocumentChunk(
         text="Chrysler",
@@ -113,6 +123,8 @@ async def setup_test_environment_with_summaries():
     chunk6_summary = TextSummary(
         text="C.H.",
         made_from=chunk6,
+        source_chunk_id=chunk6.id,
+        belongs_to_set=chunk6.belongs_to_set,
     )
 
     entities = [
@@ -184,7 +196,7 @@ async def test_summaries_retriever_on_empty_graph(setup_test_environment_empty):
         await retriever.get_retrieved_objects(query)
 
     vector_engine = get_vector_engine()
-    await vector_engine.create_collection("TextSummary_text", payload_schema=TextSummary)
+    await vector_engine.create_vector_index("TextSummary", "text")
 
     summaries = await retriever.get_retrieved_objects(query)
     context = await retriever.get_context_from_objects(query=query, retrieved_objects=summaries)

--- a/cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py
@@ -8,7 +8,7 @@ from its payload — which would make chunk Evidence render empty on that backen
 
 import pytest
 
-REFERENCE_FIELDS = ("document_id", "document_name", "chunk_index")
+REFERENCE_FIELDS = ("document_id", "document_name", "chunk_index", "source_chunk_id")
 
 
 def _index_schema_classes():
@@ -63,8 +63,12 @@ def test_index_schema_round_trips_reference_fields(name, schema_cls):
         document_id="22222222-2222-2222-2222-222222222222",
         document_name="annual_report.pdf",
         chunk_index=4,
+        source_chunk_id="33333333-3333-3333-3333-333333333333",
+        importance_weight=0.8,
     )
     dumped = instance.model_dump()
     assert dumped["document_id"] == "22222222-2222-2222-2222-222222222222"
     assert dumped["document_name"] == "annual_report.pdf"
     assert dumped["chunk_index"] == 4
+    assert dumped["source_chunk_id"] == "33333333-3333-3333-3333-333333333333"
+    assert dumped["importance_weight"] == 0.8

--- a/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
+++ b/cognee/tests/unit/infrastructure/databases/test_postgres_hybrid_batching.py
@@ -9,6 +9,7 @@ before calling embed_data, mirroring index_data_points.
 
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
+import json
 
 import pytest
 
@@ -24,6 +25,12 @@ from cognee.infrastructure.databases.hybrid.postgres.adapter import (  # noqa: E
 class _Node(DataPoint):
     name: str
     metadata: dict = {"index_fields": ["name"]}
+
+
+class _SummaryNode(DataPoint):
+    text: str
+    source_chunk_id: str
+    metadata: dict = {"index_fields": ["text"]}
 
 
 def _make_fake_hybrid(batch_size: int):
@@ -64,6 +71,10 @@ def _make_fake_hybrid(batch_size: int):
     return fake
 
 
+def _session_from_fake_hybrid(adapter):
+    return adapter._graph._session.return_value.__aenter__.return_value
+
+
 @pytest.mark.asyncio
 async def test_add_nodes_with_vectors_chunks_by_batch_size():
     """5 nodes + batch_size=2 → embed_data must be called 3 times in chunks of ≤2."""
@@ -80,6 +91,21 @@ async def test_add_nodes_with_vectors_chunks_by_batch_size():
         assert len(texts) <= 2, f"chunk size {len(texts)} exceeds batch_size 2"
         all_texts.extend(texts)
     assert sorted(all_texts) == sorted(f"n{i}" for i in range(5))
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_with_vectors_preserves_summary_source_chunk_id_in_payload():
+    adapter = _make_fake_hybrid(batch_size=10)
+    source_chunk_id = str(uuid4())
+    node = _SummaryNode(text="summary", source_chunk_id=source_chunk_id, importance_weight=0.9)
+
+    await adapter.add_nodes_with_vectors([node])
+
+    session = _session_from_fake_hybrid(adapter)
+    vector_rows = session.execute.await_args_list[1].args[1]
+    payload = json.loads(vector_rows[0]["payload"])
+    assert payload["source_chunk_id"] == source_chunk_id
+    assert payload["importance_weight"] == 0.9
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_schema_migration.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_schema_migration.py
@@ -193,6 +193,24 @@ async def test_migration_uses_pydantic_defaults(tmp_path):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_migration_backfills_source_chunk_id_default(tmp_path):
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"), api_key=None, embedding_engine=_FakeEmbeddingEngine()
+    )
+    col = "Test_text"
+
+    old_point = _make_point(str(uuid4()), "old schema")
+    await _seed(adapter, col, [old_point])
+    await _strip_payload_named_field(adapter, col, "source_chunk_id")
+
+    await adapter.create_data_points(col, [_make_point(str(uuid4()), "new schema")])
+
+    result = (await adapter.retrieve(col, [old_point.id]))[0]
+    assert result.payload["source_chunk_id"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
 async def test_non_schema_errors_propagate(tmp_path):
     adapter = LanceDBAdapter(
         url=str(tmp_path / "db"), api_key=None, embedding_engine=_FakeEmbeddingEngine()

--- a/cognee/tests/unit/modules/retrieval/hybrid_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/hybrid_retriever_test.py
@@ -196,7 +196,7 @@ async def test_chunk_retrieval_ranks_bm25_and_vector_channels_with_dedupe():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=bm25_retriever,
         ) as bm25_cls,
     ):
@@ -237,7 +237,7 @@ async def test_bm25_chunks_respect_nodeset_filter_before_ranking():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=bm25_retriever,
         ),
     ):
@@ -268,7 +268,7 @@ async def test_zero_score_bm25_chunks_do_not_reserve_context_slots():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=bm25_retriever,
         ),
     ):
@@ -310,7 +310,7 @@ async def test_default_summary_search_participates_in_chunk_ranking():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=bm25_retriever,
         ),
     ):
@@ -337,7 +337,7 @@ async def test_summary_retrieval_opt_out_disables_summary_channel_only():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=bm25_retriever,
         ),
     ):
@@ -376,7 +376,7 @@ async def test_summary_only_hit_fetches_source_chunk():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -411,7 +411,7 @@ async def test_summary_only_hit_respects_source_chunk_nodeset_filter():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -435,7 +435,7 @@ async def test_summary_search_receives_nodeset_filters():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -462,7 +462,7 @@ async def test_summary_hit_without_source_chunk_id_is_skipped():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -490,7 +490,7 @@ async def test_missing_summary_collection_does_not_fail_hybrid_retrieval():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -518,7 +518,7 @@ async def test_importance_weight_adjusts_summary_enabled_ranking():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -546,7 +546,7 @@ async def test_importance_weight_can_be_disabled_for_summary_enabled_ranking():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -580,7 +580,7 @@ async def test_final_raw_chunk_gets_paired_summary_text():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -624,7 +624,7 @@ async def test_paired_summary_text_respects_nodeset_filter():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
         ),
     ):
@@ -670,7 +670,7 @@ async def test_independent_retrieval_channels_run_concurrently():
             return_value=_unified(vector=vector),
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=bm25_retriever,
         ),
     ):

--- a/cognee/tests/unit/modules/retrieval/hybrid_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/hybrid_retriever_test.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4, uuid5
 
 import pytest
 
@@ -22,7 +23,7 @@ def _unified(vector=None, graph=None):
     return unified
 
 
-def _vector_search(chunks=None, entities=None, missing_collections=None):
+def _vector_search(chunks=None, entities=None, summaries=None, missing_collections=None):
     missing_collections = set(missing_collections or [])
 
     async def search(collection_name, *args, **kwargs):
@@ -30,6 +31,8 @@ def _vector_search(chunks=None, entities=None, missing_collections=None):
             raise CollectionNotFoundError("missing")
         if collection_name == "DocumentChunk_text":
             return chunks or []
+        if collection_name == "TextSummary_text":
+            return summaries or []
         if collection_name == "Entity_name":
             return entities or []
         return []
@@ -46,7 +49,7 @@ def _search_call(vector, collection_name):
 
 @pytest.mark.asyncio
 async def test_passage_section_formatting():
-    retriever = HybridRetriever()
+    retriever = HybridRetriever(text_summaries_top_k=0)
     context = await retriever.get_context_from_objects(
         query="q",
         retrieved_objects={
@@ -60,6 +63,24 @@ async def test_passage_section_formatting():
     )
 
     assert context == "## Relevant passages\nFirst passage\n---\nSecond passage"
+
+
+@pytest.mark.asyncio
+async def test_passage_section_formats_paired_summary_and_raw_text():
+    retriever = HybridRetriever()
+    context = await retriever.get_context_from_objects(
+        query="q",
+        retrieved_objects={
+            "chunks": [_result("chunk-1", {"id": "chunk-1", "text": "Raw passage"})],
+            "chunk_summaries": {"chunk-1": "Short summary"},
+            "entities": [],
+        },
+    )
+
+    assert (
+        context
+        == "## Relevant passages\n[Passage Summary]: Short summary\n[Raw Passage]: Raw passage"
+    )
 
 
 @pytest.mark.asyncio
@@ -166,7 +187,7 @@ async def test_chunk_retrieval_uses_bm25_first_then_vector_fill_with_dedupe():
             _result("semantic-2", {"id": "semantic-2", "text": "Second semantic extra"}),
         ]
     )
-    retriever = HybridRetriever(chunks_top_k=4)
+    retriever = HybridRetriever(chunks_top_k=4, text_summaries_top_k=0)
 
     with (
         patch(
@@ -206,6 +227,7 @@ async def test_bm25_chunks_respect_nodeset_filter_before_merge():
         chunks_top_k=4,
         node_name=["KEN", "src_type:figure"],
         node_name_filter_operator="AND",
+        text_summaries_top_k=0,
     )
 
     with (
@@ -237,7 +259,7 @@ async def test_zero_score_bm25_chunks_do_not_reserve_context_slots():
     vector.search = _vector_search(
         chunks=[_result("semantic", {"id": "semantic", "text": "Semantic fallback"})]
     )
-    retriever = HybridRetriever(chunks_top_k=2)
+    retriever = HybridRetriever(chunks_top_k=2, text_summaries_top_k=0)
 
     with (
         patch(
@@ -256,6 +278,309 @@ async def test_zero_score_bm25_chunks_do_not_reserve_context_slots():
         "Positive lexical score",
         "Semantic fallback",
     ]
+
+
+@pytest.mark.asyncio
+async def test_default_summary_search_participates_in_chunk_ranking():
+    bm25_retriever = MagicMock()
+    bm25_retriever.get_retrieved_objects = AsyncMock(
+        return_value=[({"id": "lexical", "text": "Lexical"}, 2.0)]
+    )
+    vector = MagicMock()
+    vector.search = _vector_search(
+        chunks=[_result("semantic", {"id": "semantic", "text": "Semantic"})],
+        summaries=[
+            _result(
+                "summary",
+                {
+                    "id": "summary",
+                    "text": "Semantic summary",
+                    "source_chunk_id": "semantic",
+                },
+            )
+        ],
+    )
+    vector.retrieve = AsyncMock(return_value=[])
+    retriever = HybridRetriever(chunks_top_k=1)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=bm25_retriever,
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert [_payload_text(chunk) for chunk in retrieved["chunks"]] == ["Semantic"]
+    assert retrieved["chunk_summaries"] == {"semantic": "Semantic summary"}
+
+
+@pytest.mark.asyncio
+async def test_summary_retrieval_opt_out_uses_legacy_merge_path():
+    bm25_retriever = MagicMock()
+    bm25_retriever.get_retrieved_objects = AsyncMock(
+        return_value=[({"id": "bm25", "text": "BM25"}, 2.0)]
+    )
+    vector = MagicMock()
+    vector.search = _vector_search(chunks=[_result("semantic", {"id": "semantic", "text": "S"})])
+    retriever = HybridRetriever(chunks_top_k=2, text_summaries_top_k=0)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=bm25_retriever,
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert [_payload_text(chunk) for chunk in retrieved["chunks"]] == ["BM25", "S"]
+    assert retrieved["chunk_summaries"] == {}
+    assert not any(call.args[:1] == ("TextSummary_text",) for call in vector.search.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_summary_only_hit_fetches_source_chunk():
+    vector = MagicMock()
+    vector.search = _vector_search(
+        summaries=[
+            _result(
+                "summary",
+                {"id": "summary", "text": "Only summary", "source_chunk_id": "chunk-1"},
+            )
+        ]
+    )
+    vector.retrieve = AsyncMock(
+        return_value=[_result("chunk-1", {"id": "chunk-1", "text": "Fetched chunk"})]
+    )
+    retriever = HybridRetriever(chunks_top_k=1)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    vector.retrieve.assert_awaited_once_with("DocumentChunk_text", ["chunk-1"])
+    assert [_payload_text(chunk) for chunk in retrieved["chunks"]] == ["Fetched chunk"]
+
+
+@pytest.mark.asyncio
+async def test_summary_only_hit_respects_source_chunk_nodeset_filter():
+    vector = MagicMock()
+    vector.search = _vector_search(
+        summaries=[
+            _result(
+                "summary",
+                {"id": "summary", "text": "Only summary", "source_chunk_id": "chunk-1"},
+            )
+        ]
+    )
+    vector.retrieve = AsyncMock(
+        return_value=[
+            _result("chunk-1", {"id": "chunk-1", "text": "Filtered", "belongs_to_set": ["DROP"]})
+        ]
+    )
+    retriever = HybridRetriever(chunks_top_k=1, node_name=["KEEP"])
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert retrieved["chunks"] == []
+    assert retrieved["chunk_summaries"] == {}
+
+
+@pytest.mark.asyncio
+async def test_summary_search_does_not_receive_nodeset_filters():
+    vector = MagicMock()
+    vector.search = _vector_search()
+    vector.retrieve = AsyncMock(return_value=[])
+    retriever = HybridRetriever(node_name=["KEN"], node_name_filter_operator="AND")
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        await retriever.get_retrieved_objects(query="q")
+
+    chunk_call = _search_call(vector, "DocumentChunk_text")
+    summary_call = _search_call(vector, "TextSummary_text")
+    assert chunk_call.kwargs["node_name"] == ["KEN"]
+    assert summary_call.kwargs["node_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_summary_hit_without_source_chunk_id_is_skipped():
+    vector = MagicMock()
+    vector.search = _vector_search(summaries=[_result("summary", {"id": "summary", "text": "S"})])
+    vector.retrieve = AsyncMock(return_value=[])
+    retriever = HybridRetriever(chunks_top_k=1)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert retrieved["chunks"] == []
+    assert retrieved["chunk_summaries"] == {}
+    vector.retrieve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_summary_collection_does_not_fail_hybrid_retrieval():
+    vector = MagicMock()
+    vector.search = _vector_search(
+        chunks=[_result("chunk", {"id": "chunk", "text": "Chunk"})],
+        missing_collections={"TextSummary_text"},
+    )
+    vector.retrieve = AsyncMock(return_value=[])
+    retriever = HybridRetriever(chunks_top_k=1)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert [_payload_text(chunk) for chunk in retrieved["chunks"]] == ["Chunk"]
+
+
+@pytest.mark.asyncio
+async def test_importance_weight_adjusts_summary_enabled_ranking():
+    vector = MagicMock()
+    vector.search = _vector_search(
+        chunks=[
+            _result("low", {"id": "low", "text": "Low", "importance_weight": 0.0}),
+            _result("high", {"id": "high", "text": "High", "importance_weight": 1.0}),
+        ]
+    )
+    vector.retrieve = AsyncMock(return_value=[])
+    retriever = HybridRetriever(chunks_top_k=2)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert [_payload_text(chunk) for chunk in retrieved["chunks"]] == ["High", "Low"]
+
+
+@pytest.mark.asyncio
+async def test_importance_weight_can_be_disabled_for_summary_enabled_ranking():
+    vector = MagicMock()
+    vector.search = _vector_search(
+        chunks=[
+            _result("low", {"id": "low", "text": "Low", "importance_weight": 0.0}),
+            _result("high", {"id": "high", "text": "High", "importance_weight": 1.0}),
+        ]
+    )
+    vector.retrieve = AsyncMock(return_value=[])
+    retriever = HybridRetriever(chunks_top_k=2, use_importance_weight=False)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert [_payload_text(chunk) for chunk in retrieved["chunks"]] == ["Low", "High"]
+
+
+@pytest.mark.asyncio
+async def test_final_raw_chunk_gets_paired_summary_text():
+    chunk_id = uuid4()
+    summary_id = uuid5(chunk_id, "TextSummary")
+    vector = MagicMock()
+    vector.search = _vector_search(
+        chunks=[_result(str(chunk_id), {"id": str(chunk_id), "text": "Raw chunk"})]
+    )
+
+    async def retrieve(collection_name, ids):
+        if collection_name == "TextSummary_text":
+            assert ids == [str(summary_id)]
+            return [_result(str(summary_id), {"id": str(summary_id), "text": "Paired summary"})]
+        return []
+
+    vector.retrieve = AsyncMock(side_effect=retrieve)
+    retriever = HybridRetriever(chunks_top_k=1)
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert retrieved["chunk_summaries"] == {str(chunk_id): "Paired summary"}
 
 
 @pytest.mark.asyncio
@@ -301,7 +626,7 @@ async def test_independent_retrieval_channels_run_concurrently():
     ):
         retrieved = await asyncio.wait_for(retriever.get_retrieved_objects(query="q"), timeout=1)
 
-    assert retrieved == {"chunks": [], "entities": []}
+    assert retrieved == {"chunks": [], "chunk_summaries": {}, "entities": []}
 
 
 @pytest.mark.asyncio
@@ -537,7 +862,7 @@ async def test_missing_entity_collection_returns_empty_channel():
     ):
         retrieved = await retriever.get_retrieved_objects(query="q")
 
-    assert retrieved == {"chunks": [], "entities": []}
+    assert retrieved == {"chunks": [], "chunk_summaries": {}, "entities": []}
 
 
 @pytest.mark.asyncio
@@ -685,6 +1010,7 @@ async def test_session_path_calls_session_manager_with_used_node_ids():
     session_manager.generate_completion_with_session = AsyncMock(return_value="answer")
     retrieved_objects = {
         "chunks": [_result("chunk-result", {"id": "chunk-1", "text": "Chunk"})],
+        "chunk_summaries": {"chunk-1": "Summary helper text"},
         "entities": [
             {
                 "id": "entity-1",

--- a/cognee/tests/unit/modules/retrieval/hybrid_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/hybrid_retriever_test.py
@@ -171,7 +171,7 @@ async def test_chunk_search_receives_nodeset_filters():
 
 
 @pytest.mark.asyncio
-async def test_chunk_retrieval_uses_bm25_first_then_vector_fill_with_dedupe():
+async def test_chunk_retrieval_ranks_bm25_and_vector_channels_with_dedupe():
     bm25_retriever = MagicMock()
     bm25_retriever.get_retrieved_objects = AsyncMock(
         return_value=[
@@ -202,18 +202,18 @@ async def test_chunk_retrieval_uses_bm25_first_then_vector_fill_with_dedupe():
     ):
         retrieved = await retriever.get_retrieved_objects(query="q")
 
-    bm25_cls.assert_called_once_with(top_k=2, with_scores=True)
+    bm25_cls.assert_called_once_with(top_k=8, with_scores=True)
     bm25_retriever.get_retrieved_objects.assert_awaited_once_with("q")
     assert [_payload_text(chunk) for chunk in retrieved["chunks"]] == [
-        "BM25 first",
         "BM25 shared",
+        "BM25 first",
         "Semantic extra",
         "Second semantic extra",
     ]
 
 
 @pytest.mark.asyncio
-async def test_bm25_chunks_respect_nodeset_filter_before_merge():
+async def test_bm25_chunks_respect_nodeset_filter_before_ranking():
     bm25_retriever = MagicMock()
     bm25_retriever.get_retrieved_objects = AsyncMock(
         return_value=[
@@ -321,7 +321,7 @@ async def test_default_summary_search_participates_in_chunk_ranking():
 
 
 @pytest.mark.asyncio
-async def test_summary_retrieval_opt_out_uses_legacy_merge_path():
+async def test_summary_retrieval_opt_out_disables_summary_channel_only():
     bm25_retriever = MagicMock()
     bm25_retriever.get_retrieved_objects = AsyncMock(
         return_value=[({"id": "bm25", "text": "BM25"}, 2.0)]
@@ -355,7 +355,12 @@ async def test_summary_only_hit_fetches_source_chunk():
         summaries=[
             _result(
                 "summary",
-                {"id": "summary", "text": "Only summary", "source_chunk_id": "chunk-1"},
+                {
+                    "id": "summary",
+                    "text": "Only summary",
+                    "source_chunk_id": "chunk-1",
+                    "belongs_to_set": ["KEEP"],
+                },
             )
         ]
     )
@@ -417,7 +422,7 @@ async def test_summary_only_hit_respects_source_chunk_nodeset_filter():
 
 
 @pytest.mark.asyncio
-async def test_summary_search_does_not_receive_nodeset_filters():
+async def test_summary_search_receives_nodeset_filters():
     vector = MagicMock()
     vector.search = _vector_search()
     vector.retrieve = AsyncMock(return_value=[])
@@ -439,7 +444,8 @@ async def test_summary_search_does_not_receive_nodeset_filters():
     chunk_call = _search_call(vector, "DocumentChunk_text")
     summary_call = _search_call(vector, "TextSummary_text")
     assert chunk_call.kwargs["node_name"] == ["KEN"]
-    assert summary_call.kwargs["node_name"] is None
+    assert summary_call.kwargs["node_name"] == ["KEN"]
+    assert summary_call.kwargs["node_name_filter_operator"] == "AND"
 
 
 @pytest.mark.asyncio
@@ -581,6 +587,50 @@ async def test_final_raw_chunk_gets_paired_summary_text():
         retrieved = await retriever.get_retrieved_objects(query="q")
 
     assert retrieved["chunk_summaries"] == {str(chunk_id): "Paired summary"}
+
+
+@pytest.mark.asyncio
+async def test_paired_summary_text_respects_nodeset_filter():
+    chunk_id = uuid4()
+    summary_id = uuid5(chunk_id, "TextSummary")
+    vector = MagicMock()
+    vector.search = _vector_search(
+        chunks=[
+            _result(
+                str(chunk_id),
+                {"id": str(chunk_id), "text": "Raw chunk", "belongs_to_set": ["KEEP"]},
+            )
+        ]
+    )
+
+    async def retrieve(collection_name, ids):
+        if collection_name == "TextSummary_text":
+            assert ids == [str(summary_id)]
+            return [
+                _result(
+                    str(summary_id),
+                    {"id": str(summary_id), "text": "Out of scope", "belongs_to_set": ["DROP"]},
+                )
+            ]
+        return []
+
+    vector.retrieve = AsyncMock(side_effect=retrieve)
+    retriever = HybridRetriever(chunks_top_k=1, node_name=["KEEP"])
+
+    with (
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.get_unified_engine",
+            new_callable=AsyncMock,
+            return_value=_unified(vector=vector),
+        ),
+        patch(
+            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            return_value=MagicMock(get_retrieved_objects=AsyncMock(return_value=[])),
+        ),
+    ):
+        retrieved = await retriever.get_retrieved_objects(query="q")
+
+    assert retrieved["chunk_summaries"] == {}
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
+++ b/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
@@ -156,6 +156,8 @@ async def test_hybrid_completion_retriever_receives_config():
             "max_edges_per_entity": 3,
             "include_global_context_index": True,
             "global_context_index_top_k": 2,
+            "text_summaries_top_k": 0,
+            "use_importance_weight": False,
         },
     )
 
@@ -168,6 +170,8 @@ async def test_hybrid_completion_retriever_receives_config():
     assert retriever_instance.session_id == "session-1"
     assert retriever_instance.include_global_context_index is True
     assert retriever_instance.global_context_index_top_k == 2
+    assert retriever_instance.text_summaries_top_k == 0
+    assert retriever_instance.use_importance_weight is False
 
 
 @pytest.mark.asyncio
@@ -183,6 +187,8 @@ async def test_hybrid_completion_uses_top_k_for_default_channel_limits():
     assert isinstance(retriever_instance, HybridRetriever)
     assert retriever_instance.chunks_top_k == 11
     assert retriever_instance.entities_top_k == 11
+    assert retriever_instance.text_summaries_top_k is None
+    assert retriever_instance.use_importance_weight is True
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
+++ b/cognee/tests/unit/modules/search/test_get_search_type_retriever_instance.py
@@ -241,7 +241,7 @@ async def test_hybrid_completion_get_retriever_output_smoke():
             return_value=unified,
         ),
         patch(
-            "cognee.modules.retrieval.hybrid_retriever.BM25ChunksRetriever",
+            "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
             return_value=bm25_retriever,
         ),
         patch(

--- a/cognee/tests/unit/tasks/summarization/test_summarize_text.py
+++ b/cognee/tests/unit/tasks/summarization/test_summarize_text.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.modules.chunking.models import DocumentChunk
+from cognee.modules.data.processing.document_types import DltRowDocument, TextDocument
+from cognee.tasks.summarization.summarize_text import summarize_text
+
+
+def _document():
+    return TextDocument(
+        name="notes.txt",
+        raw_data_location="/tmp/notes.txt",
+        external_metadata="",
+        mime_type="text/plain",
+    )
+
+
+def _chunk(text="Chunk text", document=None):
+    return DocumentChunk(
+        text=text,
+        chunk_size=len(text.split()),
+        chunk_index=0,
+        cut_type="sentence_end",
+        is_part_of=document or _document(),
+        contains=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_summarize_text_sets_source_chunk_id():
+    chunk = _chunk()
+
+    with patch(
+        "cognee.tasks.summarization.summarize_text.extract_summary",
+        new=AsyncMock(return_value=SimpleNamespace(summary="Short summary")),
+    ):
+        summaries = await summarize_text([chunk], summarization_model=object)
+
+    assert len(summaries) == 1
+    assert summaries[0].source_chunk_id == chunk.id
+    assert summaries[0].made_from == chunk
+
+
+@pytest.mark.asyncio
+async def test_summarize_text_leaves_dlt_row_chunks_unchanged():
+    document = DltRowDocument(
+        name="row",
+        raw_data_location="/tmp/row.txt",
+        external_metadata="",
+        mime_type="application/x-dlt-row",
+    )
+    chunk = _chunk("Structured row", document=document)
+
+    result = await summarize_text([chunk], summarization_model=object)
+
+    assert result == [chunk]

--- a/cognee/tests/unit/tasks/summarization/test_summarize_text.py
+++ b/cognee/tests/unit/tasks/summarization/test_summarize_text.py
@@ -1,3 +1,4 @@
+import importlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -5,7 +6,8 @@ import pytest
 
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.modules.data.processing.document_types import DltRowDocument, TextDocument
-from cognee.tasks.summarization.summarize_text import summarize_text
+
+summarize_text_module = importlib.import_module("cognee.tasks.summarization.summarize_text")
 
 
 def _document():
@@ -33,11 +35,12 @@ def _chunk(text="Chunk text", document=None, belongs_to_set=None):
 async def test_summarize_text_sets_source_chunk_reference_fields():
     chunk = _chunk(belongs_to_set=["KEEP"])
 
-    with patch(
-        "cognee.tasks.summarization.summarize_text.extract_summary",
+    with patch.object(
+        summarize_text_module,
+        "extract_summary",
         new=AsyncMock(return_value=SimpleNamespace(summary="Short summary")),
     ):
-        summaries = await summarize_text([chunk], summarization_model=object)
+        summaries = await summarize_text_module.summarize_text([chunk], summarization_model=object)
 
     assert len(summaries) == 1
     assert summaries[0].source_chunk_id == str(chunk.id)
@@ -55,6 +58,6 @@ async def test_summarize_text_leaves_dlt_row_chunks_unchanged():
     )
     chunk = _chunk("Structured row", document=document)
 
-    result = await summarize_text([chunk], summarization_model=object)
+    result = await summarize_text_module.summarize_text([chunk], summarization_model=object)
 
     assert result == [chunk]

--- a/cognee/tests/unit/tasks/summarization/test_summarize_text.py
+++ b/cognee/tests/unit/tasks/summarization/test_summarize_text.py
@@ -40,7 +40,7 @@ async def test_summarize_text_sets_source_chunk_reference_fields():
         summaries = await summarize_text([chunk], summarization_model=object)
 
     assert len(summaries) == 1
-    assert summaries[0].source_chunk_id == chunk.id
+    assert summaries[0].source_chunk_id == str(chunk.id)
     assert summaries[0].belongs_to_set == ["KEEP"]
     assert summaries[0].made_from == chunk
 

--- a/cognee/tests/unit/tasks/summarization/test_summarize_text.py
+++ b/cognee/tests/unit/tasks/summarization/test_summarize_text.py
@@ -17,7 +17,7 @@ def _document():
     )
 
 
-def _chunk(text="Chunk text", document=None):
+def _chunk(text="Chunk text", document=None, belongs_to_set=None):
     return DocumentChunk(
         text=text,
         chunk_size=len(text.split()),
@@ -25,12 +25,13 @@ def _chunk(text="Chunk text", document=None):
         cut_type="sentence_end",
         is_part_of=document or _document(),
         contains=[],
+        belongs_to_set=belongs_to_set,
     )
 
 
 @pytest.mark.asyncio
-async def test_summarize_text_sets_source_chunk_id():
-    chunk = _chunk()
+async def test_summarize_text_sets_source_chunk_reference_fields():
+    chunk = _chunk(belongs_to_set=["KEEP"])
 
     with patch(
         "cognee.tasks.summarization.summarize_text.extract_summary",
@@ -40,6 +41,7 @@ async def test_summarize_text_sets_source_chunk_id():
 
     assert len(summaries) == 1
     assert summaries[0].source_chunk_id == chunk.id
+    assert summaries[0].belongs_to_set == ["KEEP"]
     assert summaries[0].made_from == chunk
 
 

--- a/cognee/tests/utils/extract_summary.py
+++ b/cognee/tests/utils/extract_summary.py
@@ -9,4 +9,6 @@ def extract_summary(document_chunk: DocumentChunk, summary=SummarizedContent) ->
         id=uuid5(document_chunk.id, "TextSummary"),
         text=summary.summary,
         made_from=document_chunk,
+        source_chunk_id=document_chunk.id,
+        belongs_to_set=document_chunk.belongs_to_set,
     )

--- a/cognee/tests/utils/extract_summary.py
+++ b/cognee/tests/utils/extract_summary.py
@@ -9,6 +9,6 @@ def extract_summary(document_chunk: DocumentChunk, summary=SummarizedContent) ->
         id=uuid5(document_chunk.id, "TextSummary"),
         text=summary.summary,
         made_from=document_chunk,
-        source_chunk_id=document_chunk.id,
+        source_chunk_id=str(document_chunk.id),
         belongs_to_set=document_chunk.belongs_to_set,
     )

--- a/examples/demos/hybrid_context_only_demo.py
+++ b/examples/demos/hybrid_context_only_demo.py
@@ -1,0 +1,165 @@
+"""Local playground for inspecting HybridRetriever retrieval, context, and completion.
+
+This demo ingests a tiny Northstar Labs corpus, manually calls HybridRetriever
+for retrieved objects, builds context from those objects, then runs completion
+from that context. It prints each stage so retrieval behavior is visible.
+
+Run from the `cognee/` directory:
+
+    uv run python examples/demos/hybrid_context_only_demo.py
+
+After the first run, reuse the local demo store without re-ingesting:
+
+    uv run python examples/demos/hybrid_context_only_demo.py --skip-ingest
+"""
+
+import argparse
+import asyncio
+import pathlib
+from typing import Any
+
+import cognee
+from cognee.modules.retrieval.hybrid_retriever import HybridRetriever
+
+
+DATASET = "hybrid_context_only_demo"
+TOP_K = 6
+
+DOCUMENTS = [
+    "Northstar Labs runs the Berlin office, the Lisbon office, the Toronto office, and the Singapore office; each office owns one logistics intelligence project.",
+    "The Berlin office owns RoutePulse, a project that predicts delivery delays for European freight operators.",
+    "The Lisbon office owns HarborLens, a project that monitors port congestion and recommends alternate unloading windows.",
+    "The Toronto office owns FrostLine, a project that helps cold-chain teams track temperature risk during winter shipments.",
+    "The Singapore office owns SkyBridge, a project that coordinates air-cargo handoffs between regional carriers.",
+    "RoutePulse uses traffic feeds, weather alerts, and customs delay reports to estimate arrival risk.",
+    "HarborLens uses vessel schedules, berth availability, and labor notices to forecast port bottlenecks.",
+    "FrostLine uses sensor readings, weather forecasts, and route duration to warn about spoiled-goods risk.",
+    "SkyBridge uses flight status, warehouse capacity, and customs clearance events to recommend cargo transfer plans.",
+    "Northstar Labs asks customer-facing teams to explain project details in concise operational language.",
+]
+
+QUERIES = [
+    "Which office owns HarborLens, and what signals does HarborLens use?",
+    "Which projects help with shipment risk, and what kind of risk do they monitor?",
+]
+
+
+def _configure_demo_storage() -> None:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    cognee.config.system_root_directory(str(repo_root / ".cognee_system/hybrid_context_demo"))
+    cognee.config.data_root_directory(str(repo_root / ".data_storage/hybrid_context_demo"))
+
+
+async def _ingest_demo_data() -> None:
+    print("Resetting isolated demo store...")
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    print(f"Ingesting {len(DOCUMENTS)} Northstar Labs snippets...")
+    await cognee.add(DOCUMENTS, dataset_name=DATASET)
+
+    print("Cognifying demo dataset...")
+    await cognee.cognify(DATASET)
+
+
+def _payload(result: Any) -> dict:
+    if isinstance(result, dict):
+        return result
+    payload = getattr(result, "payload", None)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _result_id(result: Any) -> str:
+    payload = _payload(result)
+    return str(payload.get("id") or getattr(result, "id", "") or "")
+
+
+def _short(text: Any, limit: int = 260) -> str:
+    if text is None:
+        return ""
+    value = " ".join(str(text).split())
+    return value if len(value) <= limit else value[: limit - 3] + "..."
+
+
+def _print_retrieved_objects(retrieved_objects: dict) -> None:
+    chunks = retrieved_objects.get("chunks", [])
+    summaries = retrieved_objects.get("chunk_summaries", {})
+    entities = retrieved_objects.get("entities", [])
+
+    print("\nRETRIEVED CHUNKS")
+    if not chunks:
+        print("  [none]")
+    for index, chunk in enumerate(chunks, start=1):
+        payload = _payload(chunk)
+        chunk_id = _result_id(chunk)
+        print(f"  {index}. id={chunk_id or '[missing]'}")
+        if chunk_id in summaries:
+            print(f"     summary: {_short(summaries[chunk_id])}")
+        print(f"     text: {_short(payload.get('text'))}")
+
+    print("\nRETRIEVED ENTITIES")
+    if not entities:
+        print("  [none]")
+    for index, entity in enumerate(entities, start=1):
+        print(f"  {index}. {entity.get('name') or entity.get('id')}")
+        for edge in entity.get("edges", [])[:3]:
+            print(f"     - {_short(edge.get('text'), limit=180)}")
+
+
+async def _run_manual_hybrid_flow(query: str, skip_completion: bool) -> None:
+    retriever = HybridRetriever(
+        chunks_top_k=TOP_K,
+        entities_top_k=TOP_K,
+        max_edges_per_entity=6,
+    )
+
+    retrieved_objects = await retriever.get_retrieved_objects(query=query)
+    _print_retrieved_objects(retrieved_objects)
+
+    context = await retriever.get_context_from_objects(
+        query=query,
+        retrieved_objects=retrieved_objects,
+    )
+    print("\nCONTEXT")
+    print(context or "[empty context]")
+
+    if skip_completion:
+        return
+
+    completion = await retriever.get_completion_from_context(
+        query=query,
+        retrieved_objects=retrieved_objects,
+        context=context,
+    )
+    print("\nCOMPLETION")
+    for item in completion:
+        print(item)
+
+
+async def main(skip_ingest: bool, skip_completion: bool) -> None:
+    _configure_demo_storage()
+    if not skip_ingest:
+        await _ingest_demo_data()
+
+    for query in QUERIES:
+        print("\n" + "=" * 88)
+        print(f"QUERY: {query}")
+        print("-" * 88)
+        await _run_manual_hybrid_flow(query, skip_completion=skip_completion)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-ingest",
+        action="store_true",
+        help="Reuse the existing isolated demo store instead of pruning and ingesting again.",
+    )
+    parser.add_argument(
+        "--skip-completion",
+        action="store_true",
+        help="Print retrieved objects and context without calling the completion LLM.",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main(skip_ingest=args.skip_ingest, skip_completion=args.skip_completion))


### PR DESCRIPTION
## Description

- Adds summary-aware ranking to the hybrid retriever by combining BM25 chunks, vector chunks, and text-summary hits with RRF.
- Makes summary retrieval the default hybrid behavior, with `text_summaries_top_k=0` available to opt out.
- Persists summary-to-source chunk metadata across supported vector/hybrid adapters.
- Splits hybrid retrieval helpers into focused modules for ranking, pairing, context formatting, entities, and result handling.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.