### PR TITLE
fix: use dataset context for graph visualization

### DIFF
--- a/cognee/api/v1/users/routers/get_visualize_router.py
+++ b/cognee/api/v1/users/routers/get_visualize_router.py
@@ -68,7 +68,7 @@ def get_visualize_router() -> APIRouter:
             # Will only be used if ENABLE_BACKEND_ACCESS_CONTROL is set to True
             await set_database_global_context_variables(dataset[0].id, dataset[0].owner_id)
 
-            html_visualization = await visualize_graph()
+            html_visualization = await visualize_graph(datasets=[dataset[0].id], user=user)
             return HTMLResponse(html_visualization)
 
         except Exception as error:

--- a/cognee/api/v1/visualize/visualize.py
+++ b/cognee/api/v1/visualize/visualize.py
@@ -1,10 +1,15 @@
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple, Union
+from uuid import UUID
 
 from cognee.modules.visualization.cognee_network_visualization import (
     cognee_network_visualization,
     aggregate_multi_user_graphs,
 )
 from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger, setup_logging, ERROR
 
 
@@ -14,7 +19,23 @@ import asyncio
 logger = get_logger()
 
 
-async def visualize_graph(destination_file_path: str = None) -> str:
+async def visualize_graph(
+    destination_file_path: str = None,
+    datasets: Optional[Union[str, UUID, List[Union[str, UUID]]]] = None,
+    user: Optional[User] = None,
+) -> str:
+    if isinstance(datasets, (str, UUID)):
+        datasets = [datasets]
+
+    if user is None:
+        user = await get_default_user()
+
+    authorized_datasets = await get_authorized_existing_datasets(datasets, "read", user)
+
+    if authorized_datasets:
+        dataset = authorized_datasets[0]
+        await set_database_global_context_variables(dataset.id, dataset.owner_id)
+
     graph_engine = await get_graph_engine()
     graph_data = await graph_engine.get_graph_data()
 

--- a/cognee/tests/unit/modules/visualization/test_visualize_graph.py
+++ b/cognee/tests/unit/modules/visualization/test_visualize_graph.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import importlib
+
+import pytest
+
+visualize_module = importlib.import_module("cognee.api.v1.visualize.visualize")
+
+
+@pytest.mark.asyncio
+async def test_visualize_graph_uses_dataset_context(monkeypatch):
+    dataset = SimpleNamespace(id="dataset-id", owner_id="owner-id")
+    graph_engine = SimpleNamespace(get_graph_data=AsyncMock(return_value=([], [])))
+    set_context = AsyncMock()
+    monkeypatch.setattr(visualize_module, "get_default_user", AsyncMock(return_value=object()))
+    monkeypatch.setattr(visualize_module, "get_authorized_existing_datasets", AsyncMock(return_value=[dataset]))
+    monkeypatch.setattr(visualize_module, "set_database_global_context_variables", set_context)
+    monkeypatch.setattr(visualize_module, "get_graph_engine", AsyncMock(return_value=graph_engine))
+    monkeypatch.setattr(visualize_module, "cognee_network_visualization", AsyncMock(return_value="<html></html>"))
+
+    assert await visualize_module.visualize_graph(datasets="NLP") == "<html></html>"
+    set_context.assert_awaited_once_with(dataset.id, dataset.owner_id)


### PR DESCRIPTION
## Description
Fixes dataset routing for `visualize_graph()` by resolving the requested/default readable dataset and setting the graph database context before loading graph data. The visualize API endpoint now passes the authorized dataset and user into the shared helper.

Fixes #3007

## Acceptance Criteria
* `visualize_graph()` can resolve a dataset name/id and load graph data from that dataset context.
* The API visualize endpoint continues to authorize the dataset and now reuses that context in the helper.
* Added a unit test covering dataset context setup before graph data loading.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
N/A — local test output:

```text
PYTHONPATH=. uv run pytest cognee/tests/unit/modules/visualization -q
2 passed, 8 warnings

uv run ruff check cognee/api/v1/visualize/visualize.py cognee/api/v1/users/routers/get_visualize_router.py cognee/tests/unit/modules/visualization/test_visualize_graph.py
All checks passed!
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
