### PR TITLE
ci: mirror pgvector image to GHCR to fix flaky Docker Hub pulls

### DIFF
--- a/.github/workflows/adapter_caching_tests.yml
+++ b/.github/workflows/adapter_caching_tests.yml
@@ -113,7 +113,10 @@ jobs:
     if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'ladybug/pgvector/postgres') }}
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -163,7 +166,10 @@ jobs:
     if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'neo4j/pgvector/postgres') }}
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee

--- a/.github/workflows/db_examples_tests.yml
+++ b/.github/workflows/db_examples_tests.yml
@@ -120,7 +120,10 @@ jobs:
     if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'postgres') }}
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -132,7 +132,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -726,7 +729,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -821,7 +827,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -887,7 +896,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -942,7 +954,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -1033,7 +1048,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -1563,7 +1581,10 @@ jobs:
 
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -1689,7 +1710,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee

--- a/.github/workflows/examples_tests.yml
+++ b/.github/workflows/examples_tests.yml
@@ -300,7 +300,10 @@ jobs:
         shell: bash
     services:
       postgres: # Using postgres to avoid storing and using SQLite from S3
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee

--- a/.github/workflows/graph_db_tests.yml
+++ b/.github/workflows/graph_db_tests.yml
@@ -78,7 +78,10 @@ jobs:
     if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'postgres') }}
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,0 +1,54 @@
+name: Mirror external images to GHCR
+
+# Copies the pinned third-party images CI depends on (pgvector) into GHCR, so the
+# PR / test hot path never pulls from Docker Hub — which is rate-limited and flaky
+# from GitHub Actions (intermittent `registry-1.docker.io ... timeout` on service
+# container setup). The test workflows reference ghcr.io/<owner>/pgvector:pg17.
+#
+# Runs weekly for freshness and on-demand. IMPORTANT: run this once (Actions ->
+# "Mirror external images to GHCR" -> Run workflow) BEFORE the GHCR references go
+# live, so the image exists. Ensure the resulting GHCR package is accessible to
+# this repo (public, or repo-linked) so service pulls with GITHUB_TOKEN succeed.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - pgvector/pgvector:pg17
+    steps:
+      - name: Log in to Docker Hub (authenticated source pulls)
+        uses: docker/login-action@v3
+        continue-on-error: true   # best-effort: fall back to anonymous if unset
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror ${{ matrix.image }} -> GHCR
+        run: |
+          set -euo pipefail
+          SRC="${{ matrix.image }}"
+          DST="ghcr.io/${{ github.repository_owner }}/${SRC##*/}"
+          echo "Mirroring $SRC -> $DST"
+          docker pull "$SRC"
+          docker tag  "$SRC" "$DST"
+          docker push "$DST"
+          echo "Done: $DST"

--- a/.github/workflows/performance_report.yml
+++ b/.github/workflows/performance_report.yml
@@ -168,7 +168,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee

--- a/.github/workflows/relational_db_migration_tests.yml
+++ b/.github/workflows/relational_db_migration_tests.yml
@@ -44,7 +44,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -109,7 +112,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee
@@ -175,7 +181,10 @@ jobs:
         shell: bash
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee

--- a/.github/workflows/search_db_tests.yml
+++ b/.github/workflows/search_db_tests.yml
@@ -122,7 +122,10 @@ jobs:
         fail-fast: false
       services:
         postgres:
-          image: pgvector/pgvector:pg17
+          image: ghcr.io/topoteretes/pgvector:pg17
+          credentials:
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
           env:
             POSTGRES_USER: cognee
             POSTGRES_PASSWORD: cognee
@@ -181,7 +184,10 @@ jobs:
       fail-fast: false
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee

--- a/.github/workflows/temporal_graph_tests.yml
+++ b/.github/workflows/temporal_graph_tests.yml
@@ -105,7 +105,10 @@ jobs:
       container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
       services:
         postgres:
-          image: pgvector/pgvector:pg17
+          image: ghcr.io/topoteretes/pgvector:pg17
+          credentials:
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
           env:
             POSTGRES_USER: cognee
             POSTGRES_PASSWORD: cognee
@@ -172,7 +175,10 @@ jobs:
           --health-timeout=5s
           --health-retries=5
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: cognee

--- a/.github/workflows/vector_db_tests.yml
+++ b/.github/workflows/vector_db_tests.yml
@@ -28,7 +28,10 @@ jobs:
     if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'postgres') }}
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
@@ -74,7 +77,10 @@ jobs:
     if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'postgres') }}
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: ghcr.io/topoteretes/pgvector:pg17
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: cognee
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}


### PR DESCRIPTION
## Problem
`pgvector/pgvector:pg17` is used as a GitHub Actions **`services:` container** in **23 blocks across 10 workflows**. Service images are pulled **anonymously from Docker Hub during job setup, before any step runs**, so they hit Docker Hub rate-limits / network timeouts from Actions' shared IPs:

```
/usr/bin/docker pull pgvector/pgvector:pg17
Error response from daemon: Get "https://registry-1.docker.io/v2/": ... timeout
```

A `docker/login-action` **step cannot fix this** (the pull already happened before steps).

## Fix — mirror to GHCR (removes Docker Hub from the PR/test hot path)
- **`mirror-images.yml`**: copies `pgvector:pg17` into `ghcr.io/<owner>/pgvector` (weekly + on-demand), with authenticated Docker Hub source pulls. The only Docker Hub pull now lives in this off-hot-path job; if it hiccups, the existing GHCR image stays and you re-run it.
- **All 23 service blocks** switched to `ghcr.io/topoteretes/pgvector:pg17` with `github.actor` / `GITHUB_TOKEN` credentials — matching the repo's existing GHCR pull for the CI `container:` image. GHCR is co-located with Actions: fast, no Docker Hub rate limits.

## ⚠️ Bootstrap (do before merge)
1. Run **Actions → "Mirror external images to GHCR" → Run workflow** once so `ghcr.io/topoteretes/pgvector:pg17` exists. (I've triggered it on this branch; verify it succeeded.)
2. Ensure the GHCR package is accessible to this repo (public, or repo-linked). Same-repo Actions pulls with `GITHUB_TOKEN` should work since the package is pushed from this repo; if a pull 403s, set the package public or grant repo read.

## On making this a required PR gate
Don't enforce the gate until CI is reliably green for several runs. Gating on infra flakiness blocks contributors on Docker Hub noise and trains them to re-run red blindly — fix the flakiness first (this PR), verify stability, then enforce.