### PR TITLE
fix: stop graph dots flying off on click and keep stage labels visible

### DIFF
--- a/cognee/modules/visualization/views/story_view.js
+++ b/cognee/modules/visualization/views/story_view.js
@@ -1205,20 +1205,27 @@ var isDragging=false,dragNode=null,isPanning=false;
 // doing so unpinned the clicked node and let repulsion push it off into
 // space (the layout anchors are much weaker than the charge force).
 var dragStarted=false;
-var DRAG_THRESHOLD=3;
+// 6px: trackpad clicks routinely jitter 3-5px, and treating that as a
+// drag reheated the simulation — a plain click sent the dot (and, in
+// Force mode, the whole layout) flying.
+var DRAG_THRESHOLD=6;
 var lastMx=0,lastMy=0,downMx=0,downMy=0;
 
 function releaseDragNode(){
   if(!dragNode)return;
   if(layoutMode==="story"){
     // Story pins every node into its lane; snap the dragged node back so
-    // interaction can never degrade the deterministic grid.
-    dragNode.fx=(typeof dragNode._targetX==="number")?dragNode._targetX:null;
-    dragNode.fy=(typeof dragNode._targetY==="number")?dragNode._targetY:null;
+    // interaction can never degrade the deterministic grid. The sim is
+    // not running in story drags, so restore x/y directly too.
+    if(typeof dragNode._targetX==="number"){dragNode.fx=dragNode._targetX;dragNode.x=dragNode._targetX}
+    else{dragNode.fx=null}
+    if(typeof dragNode._targetY==="number"){dragNode.fy=dragNode._targetY;dragNode.y=dragNode._targetY}
+    else{dragNode.fy=null}
+    if(dragStarted){rebuildQuadtree();draw()}
   }else{
     dragNode.fx=null;dragNode.fy=null;
+    if(dragStarted)simulation.alphaTarget(0);
   }
-  if(dragStarted)simulation.alphaTarget(0);
 }
 
 canvas.addEventListener("mousedown",function(ev){
@@ -1241,10 +1248,18 @@ canvas.addEventListener("mousemove",function(ev){
       var dx=mx-downMx,dy=my-downMy;
       if(dx*dx+dy*dy<DRAG_THRESHOLD*DRAG_THRESHOLD){lastMx=mx;lastMy=my;return}
       dragStarted=true;
-      simulation.alphaTarget(0.3).restart();
+      // Story is a fully pinned grid — reheating the simulation only
+      // agitates it (and a hot sim is what made clicked dots shoot off).
+      // Drive the node directly instead; other layouts use the standard
+      // d3 drag reheat so neighbors respond to the drag.
+      if(layoutMode!=="story")simulation.alphaTarget(0.3).restart();
     }
     var w=screenToWorld(mx,my);
     dragNode.fx=w.x;dragNode.fy=w.y;
+    if(layoutMode==="story"){
+      dragNode.x=w.x;dragNode.y=w.y;
+      draw();
+    }
   }else if(isPanning){
     tx+=mx-lastMx;ty+=my-lastMy;
     draw();
@@ -1491,6 +1506,20 @@ function drawRankColumns(vp,_light){
       ctx.lineWidth=1/scale;
       ctx.stroke();
     }
+  });
+  ctx.restore();
+}
+
+// Stage label pills are drawn in a SEPARATE pass at the END of draw() —
+// after edges, nodes and node labels — so a dense graph panned toward
+// the top of the viewport can never paint over them.
+function drawRankColumnLabels(vp,_light){
+  if((layoutMode!=="ranked"&&layoutMode!=="story")||rankColumns.length<2)return;
+  ctx.save();
+  var topY=vp.y1+TOP_CHROME_PAD/scale;
+  rankColumns.forEach(function(column){
+    var half=rankColumnGap/2;
+    if(column.x+half<vp.x1||column.x-half>vp.x2)return;
 
     if(scale>0.12){
       // Pill-style stage header drawn below the tab bar
@@ -1930,6 +1959,9 @@ function draw(){
       ctx.fillText(label2,hn.x,hn.y+yOff2);
     }
   }
+
+  // Stage label pills last — always readable above the node mass.
+  drawRankColumnLabels(vp,_light);
 
   ctx.restore();
 


### PR DESCRIPTION
## Summary

Fixes two interaction/rendering bugs in the story-view graph canvas (`cognee/modules/visualization/views/story_view.js`):

### 1. Clicking a dot made it move rapidly away
- The click-vs-drag threshold was **3px**, but a normal click (especially on a trackpad) routinely jitters 3–5px, so plain clicks were treated as drags.
- A "drag" reheated the entire force simulation (`alphaTarget(0.3).restart()`); in a settled layout this wakes repulsion forces and shoves the clicked dot (and in Force mode, the whole graph) away.

**Fix:**
- Raised the threshold to **6px**.
- In Story mode (a fully pinned grid) drags now move the node directly and redraw — the simulation is never reheated. On release the node snaps back to its lane slot and the hit-test quadtree is rebuilt so hover/click targeting stays accurate.
- Flow/Force modes keep the standard d3 drag reheat, now only on deliberate drags.

### 2. The graph's mid-section obscured the stage labels at the top
- The "Documents / Chunks / Entities…" pills were painted at the *start* of `draw()`, before edges, nodes, and node labels, so the dense middle of the graph painted over them whenever it reached the top band of the viewport.

**Fix:** split the rendering — column separator gridlines stay underneath the graph, while the label pills are drawn in a final pass (`drawRankColumnLabels`, called last in `draw()`), so they always stay readable above the node mass.

## Test plan
- `node --check` passes on the modified JS.
- All 35 visualization unit tests pass (`uv run pytest cognee/tests/unit/modules/visualization/ -q`).
- Manual: regenerate a visualization HTML, click dots in Story/Flow/Force modes (no fly-away), pan a dense graph toward the top (stage pills stay on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)