### PR TITLE
fix(search): support response_model in SearchResultPayload + safe exception hook

### DIFF
--- a/cognee/modules/search/models/SearchResultPayload.py
+++ b/cognee/modules/search/models/SearchResultPayload.py
@@ -16,7 +16,9 @@ class SearchResultPayload(BaseModel):
 
     result_object: Any = None
     context: Optional[Union[str, List[str]]] = None
-    completion: Optional[Union[str, List[str], List[dict], BaseModel, List[BaseModel]]] = None
+    # NOTE: dict must precede BaseModel in the union so a plain dict validates
+    # as-is instead of being coerced into an empty bare BaseModel.
+    completion: Optional[Union[str, List[str], List[dict], dict, BaseModel, List[BaseModel]]] = None
 
     # TODO: Add return_type info
     search_type: SearchType

--- a/cognee/modules/search/models/SearchResultPayload.py
+++ b/cognee/modules/search/models/SearchResultPayload.py
@@ -16,7 +16,7 @@ class SearchResultPayload(BaseModel):
 
     result_object: Any = None
     context: Optional[Union[str, List[str]]] = None
-    completion: Optional[Union[str, List[str], List[dict]]] = None
+    completion: Optional[Union[str, List[str], List[dict], BaseModel, List[BaseModel]]] = None
 
     # TODO: Add return_type info
     search_type: SearchType
@@ -52,6 +52,17 @@ class SearchResultPayload(BaseModel):
         else:
             # Fallback for the object itself
             return v if is_simple(v) else str(v)
+
+    @field_serializer("completion")
+    def serialize_completion(self, v: Any):
+        """Serialize completion field. Supports str, list, dict, and Pydantic BaseModel."""
+        if v is None:
+            return None
+        if isinstance(v, BaseModel):
+            return v.model_dump()
+        if isinstance(v, list):
+            return [item.model_dump() if isinstance(item, BaseModel) else item for item in v]
+        return v
 
     @property
     def result(self) -> Any:

--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -458,6 +458,10 @@ def setup_logging(log_level=None, name=None) -> bool:
         # Normal path - hand back to original hook
         sys.__excepthook__(exc_type, exc_value, tb)
 
+    # Install the exception handler so uncaught exceptions are logged
+    # through structlog before the default hook prints and exits.
+    sys.excepthook = handle_exception
+
     # Create console formatter for standard library logging
     console_formatter = structlog.stdlib.ProcessorFormatter(
         processor=structlog.dev.ConsoleRenderer(

--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -436,23 +436,27 @@ def setup_logging(log_level=None, name=None) -> bool:
     )
 
     # Set up system-wide exception handling
-    def handle_exception(exc_type, exc_value, traceback) -> None:
-        """Handle any uncaught exception."""
+    def handle_exception(exc_type, exc_value, tb) -> None:
+        """Handle any uncaught exception safely."""
         if issubclass(exc_type, KeyboardInterrupt):
             # Let KeyboardInterrupt pass through
-            sys.__excepthook__(exc_type, exc_value, traceback)
+            sys.__excepthook__(exc_type, exc_value, tb)
             return
 
-        logger = structlog.get_logger()
-        logger.error(
-            "Exception",
-            exc_info=(exc_type, exc_value, traceback),
-        )
-        # Hand back to the original hook → prints traceback and exits
-        sys.__excepthook__(exc_type, exc_value, traceback)
+        try:
+            logger = structlog.get_logger()
+            logger.error(
+                "Exception",
+                exc_info=(exc_type, exc_value, tb),
+            )
+        except Exception:
+            print("\n[Warning] Could not render rich traceback. Falling back to plain traceback.\n")
+            traceback.print_exception(exc_type, exc_value, tb)
+            sys.__excepthook__(exc_type, exc_value, tb)
+            return
 
-    # Install exception handlers
-    sys.excepthook = handle_exception
+        # Normal path - hand back to original hook
+        sys.__excepthook__(exc_type, exc_value, tb)
 
     # Create console formatter for standard library logging
     console_formatter = structlog.stdlib.ProcessorFormatter(

--- a/cognee/tests/unit/search/test_search_result_payload.py
+++ b/cognee/tests/unit/search/test_search_result_payload.py
@@ -43,3 +43,24 @@ def test_search_result_payload_only_context():
         context="Some context here", only_context=True, search_type=SearchType.GRAPH_COMPLETION
     )
     assert payload.result == "Some context here"
+
+
+def test_search_result_payload_with_plain_dict():
+    """A plain dict completion validates as a dict — it must not be coerced
+    into an empty bare BaseModel (which would silently drop every field)."""
+    payload = SearchResultPayload(
+        completion={"deal_name": "Acme Corp", "health": "Good"},
+        search_type=SearchType.GRAPH_COMPLETION,
+    )
+    assert payload.completion == {"deal_name": "Acme Corp", "health": "Good"}
+    assert payload.model_dump()["completion"] == {"deal_name": "Acme Corp", "health": "Good"}
+
+
+def test_search_result_payload_model_json_round_trip():
+    """model_dump_json must carry subclass fields, not bare-BaseModel emptiness."""
+    import json
+
+    deal = DealBrief(deal_name="Acme Corp", health="Good")
+    payload = SearchResultPayload(completion=deal, search_type=SearchType.GRAPH_COMPLETION)
+    dumped = json.loads(payload.model_dump_json())
+    assert dumped["completion"] == {"deal_name": "Acme Corp", "health": "Good"}

--- a/cognee/tests/unit/search/test_search_result_payload.py
+++ b/cognee/tests/unit/search/test_search_result_payload.py
@@ -1,0 +1,45 @@
+import pytest
+from pydantic import BaseModel
+from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
+from cognee.modules.search.types.SearchType import SearchType
+
+
+class DealBrief(BaseModel):
+    deal_name: str = ""
+    health: str = ""
+
+
+def test_search_result_payload_with_string_completion():
+    """Test that normal string completion still works."""
+    payload = SearchResultPayload(
+        completion="a normal string answer", search_type=SearchType.GRAPH_COMPLETION
+    )
+    assert payload.completion == "a normal string answer"
+
+
+def test_search_result_payload_with_pydantic_model():
+    """Test that Pydantic BaseModel is accepted (core bug fix)."""
+    deal = DealBrief(deal_name="Acme Corp", health="Good")
+    payload = SearchResultPayload(completion=deal, search_type=SearchType.GRAPH_COMPLETION)
+
+    assert isinstance(payload.completion, DealBrief)
+    assert payload.completion.deal_name == "Acme Corp"
+    assert payload.model_dump()["completion"] == {"deal_name": "Acme Corp", "health": "Good"}
+
+
+def test_search_result_payload_with_list_of_models():
+    """Test list of Pydantic models."""
+    deals = [DealBrief(deal_name="Deal 1"), DealBrief(deal_name="Deal 2")]
+    payload = SearchResultPayload(completion=deals, search_type=SearchType.GRAPH_COMPLETION)
+    assert isinstance(payload.completion, list)
+    assert len(payload.completion) == 2
+    assert isinstance(payload.completion[0], DealBrief)
+    assert payload.completion[0].deal_name == "Deal 1"
+
+
+def test_search_result_payload_only_context():
+    """Test only_context flag behavior."""
+    payload = SearchResultPayload(
+        context="Some context here", only_context=True, search_type=SearchType.GRAPH_COMPLETION
+    )
+    assert payload.result == "Some context here"

--- a/cognee/tests/unit/shared/test_logging_setup_excepthook.py
+++ b/cognee/tests/unit/shared/test_logging_setup_excepthook.py
@@ -1,0 +1,81 @@
+"""Regression tests for the uncaught-exception hook installed by setup_logging().
+
+The hook was once silently dropped during a refactor — handle_exception was
+defined but never assigned to sys.excepthook, disabling structlog handling of
+uncaught exceptions without any test noticing. These tests pin the contract.
+"""
+
+import sys
+
+from cognee.shared.logging_utils import setup_logging
+
+
+class TestExcepthookInstallation:
+    def test_setup_logging_installs_custom_excepthook(self):
+        original_hook = sys.excepthook
+        try:
+            setup_logging()
+            assert sys.excepthook is not sys.__excepthook__, (
+                "setup_logging() must install a custom sys.excepthook so uncaught "
+                "exceptions are logged through structlog."
+            )
+            assert sys.excepthook.__qualname__.endswith("handle_exception")
+        finally:
+            sys.excepthook = original_hook
+
+    def test_handler_falls_back_to_plain_traceback_when_rendering_raises(self, monkeypatch, capsys):
+        """If structlog/rich rendering raises, the handler must still print a
+        plain traceback instead of dying inside the hook."""
+        import structlog
+
+        original_hook = sys.excepthook
+        try:
+            setup_logging()
+            handler = sys.excepthook
+
+            class ExplodingLogger:
+                def error(self, *args, **kwargs):
+                    raise RuntimeError("renderer exploded")
+
+            monkeypatch.setattr(structlog, "get_logger", lambda *a, **k: ExplodingLogger())
+
+            try:
+                raise ValueError("the original error")
+            except ValueError:
+                exc_type, exc_value, tb = sys.exc_info()
+
+            handler(exc_type, exc_value, tb)
+
+            captured = capsys.readouterr()
+            combined = captured.out + captured.err
+            assert "the original error" in combined
+            assert "plain traceback" in combined.lower()
+        finally:
+            sys.excepthook = original_hook
+
+    def test_keyboard_interrupt_passes_through(self, monkeypatch):
+        """KeyboardInterrupt must go straight to the default hook, unlogged."""
+        import structlog
+
+        original_hook = sys.excepthook
+        try:
+            setup_logging()
+            handler = sys.excepthook
+
+            logged = []
+
+            class RecordingLogger:
+                def error(self, *args, **kwargs):
+                    logged.append((args, kwargs))
+
+            monkeypatch.setattr(structlog, "get_logger", lambda *a, **k: RecordingLogger())
+
+            passed_through = []
+            monkeypatch.setattr(sys, "__excepthook__", lambda *args: passed_through.append(args))
+
+            handler(KeyboardInterrupt, KeyboardInterrupt(), None)
+
+            assert logged == []
+            assert len(passed_through) == 1
+        finally:
+            sys.excepthook = original_hook


### PR DESCRIPTION
## What

Supersedes #3050 (carries @coder-jayp's commit with authorship preserved) and fixes the regression it introduced.

Fixes #3048.

### From #3050 (cherry-picked)
- `SearchResultPayload.completion` accepts Pydantic `BaseModel` / `List[BaseModel]`, so `search(..., retriever_specific_config={"response_model": MyModel})` returns structured objects instead of raising `ValidationError` at payload construction
- `field_serializer` dumps model instances via `model_dump()`, so subclass fields survive `model_dump()`/`model_dump_json()` (bare-`BaseModel` typing would otherwise serialize to `{}`)
- Plain-traceback fallback in the uncaught-exception handler when structlog/rich rendering itself raises; handler param renamed `traceback` → `tb`, fixing it shadowing the `traceback` module

### Fixed on top
- **#3050 accidentally deleted `sys.excepthook = handle_exception`** — the rewritten handler was dead code and uncaught exceptions silently lost structlog handling (verified by execution: after `import cognee`, the hook was the built-in default on that branch). Reinstalled, with regression tests pinning the contract: hook installed by `setup_logging()`, fallback path prints a plain traceback when rendering raises, `KeyboardInterrupt` passes through unlogged.
- **Plain `dict` completion**: with `BaseModel` newly in the union, a dict was coerced toward an empty bare `BaseModel` and failed at serialization with a confusing error (on `dev` it was a clean `ValidationError`). Added `dict` to the union, ordered before `BaseModel`, so it validates as-is.

### Note on the "hang" fix
The try/except fallback only helps when rich's renderer *raises* (e.g. `RecursionError`) — a slow/deep traversal is not an exception. The actual hang/OOM mitigation remains `RichTracebackFormatter(show_locals=False)` already on `dev`; the fallback is belt-and-braces on top.

## Testing
- 6 payload tests (string, model, list-of-models, plain dict, JSON round trip, only_context) + 3 excepthook regression tests; full `tests/unit/search`, `tests/unit/modules/search`, `tests/unit/shared` suites pass (70 tests)
- Verified end-to-end that `sys.excepthook` is `handle_exception` after `import cognee`
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)