### PR TITLE
fix(ladybug): retry LOAD EXTENSION with INSTALL on the live connection

### DIFF
--- a/cognee/tests/unit/infrastructure/databases/test_kuzu_worker_load_extension.py
+++ b/cognee/tests/unit/infrastructure/databases/test_kuzu_worker_load_extension.py
@@ -1,0 +1,75 @@
+"""Unit tests for the Kuzu worker's LOAD EXTENSION retry-with-install path.
+
+The warm-up ``INSTALL JSON`` on a throwaway database is best-effort and can
+fail silently (e.g. a transient network error downloading the extension on a
+fresh CI runner). ``_load_extension`` must then install on the live
+connection and retry, instead of surfacing Ladybug's
+"Extension: json ... has not been installed" binder error.
+
+Pure tests: fake connection/registry, no ladybug, no subprocess.
+"""
+
+import pytest
+
+from cognee_db_workers.harness import Request
+from cognee_db_workers.kuzu_protocol import OP_LOAD_EXTENSION
+from cognee_db_workers.kuzu_worker import _load_extension
+
+
+class FakeConnection:
+    def __init__(self, installed: bool):
+        self.installed = installed
+        self.executed = []
+
+    def execute(self, query: str):
+        self.executed.append(query)
+        if query.startswith("LOAD EXTENSION") and not self.installed:
+            raise RuntimeError(
+                "Binder exception: Extension: json is an official extension and has "
+                "not been installed.\nYou can install it by: install json."
+            )
+        if query.startswith("INSTALL"):
+            self.installed = True
+
+
+class FakeRegistry:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def get(self, hid):
+        return self._conn
+
+
+def _request():
+    return Request(op=OP_LOAD_EXTENSION, handle_id=1, args=("JSON",))
+
+
+def test_load_succeeds_directly_when_installed():
+    conn = FakeConnection(installed=True)
+    _load_extension(FakeRegistry(conn), _request())
+    assert conn.executed == ["LOAD EXTENSION JSON;"]
+
+
+def test_load_installs_and_retries_when_not_installed():
+    conn = FakeConnection(installed=False)
+    _load_extension(FakeRegistry(conn), _request())
+    assert conn.executed == [
+        "LOAD EXTENSION JSON;",
+        "INSTALL JSON;",
+        "LOAD EXTENSION JSON;",
+    ]
+
+
+def test_unrelated_load_errors_propagate_without_install():
+    class BrokenConnection:
+        def __init__(self):
+            self.executed = []
+
+        def execute(self, query: str):
+            self.executed.append(query)
+            raise RuntimeError("IO exception: database is locked")
+
+    conn = BrokenConnection()
+    with pytest.raises(RuntimeError, match="database is locked"):
+        _load_extension(FakeRegistry(conn), _request())
+    assert conn.executed == ["LOAD EXTENSION JSON;"]

--- a/cognee_db_workers/_kuzu_helpers.py
+++ b/cognee_db_workers/_kuzu_helpers.py
@@ -16,6 +16,7 @@ avoids surprising contributors.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from typing import Optional
 
@@ -66,12 +67,22 @@ def install_json_extension_local(
             conn = ladybug.Connection(tmp_db)
             try:
                 conn.execute("INSTALL JSON;")
-            except Exception:
-                pass
-        except Exception:
+            except Exception as error:
+                # Still best-effort (LOAD EXTENSION retries the install on
+                # the live connection), but say why it failed — a silent
+                # swallow here made "has not been installed" errors at LOAD
+                # time impossible to diagnose from CI logs.
+                print(
+                    f"[ladybug worker] warm-up INSTALL JSON failed: {error!r}",
+                    file=sys.stderr,
+                )
+        except Exception as error:
             # Best-effort install: missing/incompatible JSON extension and
             # init failures all surface here. The cleanup below still runs.
-            pass
+            print(
+                f"[ladybug worker] warm-up JSON install setup failed: {error!r}",
+                file=sys.stderr,
+            )
         finally:
             _safe_close(conn)
             _safe_close(tmp_db)

--- a/cognee_db_workers/kuzu_worker.py
+++ b/cognee_db_workers/kuzu_worker.py
@@ -139,7 +139,17 @@ def _install_json(registry: HandleRegistry, req: Request) -> None:
 def _load_extension(registry: HandleRegistry, req: Request) -> None:
     conn = registry.get(req.handle_id)
     extension_name = req.args[0]
-    conn.execute(f"LOAD EXTENSION {extension_name};")
+    try:
+        conn.execute(f"LOAD EXTENSION {extension_name};")
+    except RuntimeError as error:
+        if "not been installed" not in str(error):
+            raise
+        # The warm-up INSTALL on the throwaway database is best-effort and
+        # can fail silently (e.g. a transient network error downloading the
+        # extension on a fresh machine). Install on the live connection and
+        # retry once; if INSTALL fails here it raises with the real cause.
+        conn.execute(f"INSTALL {extension_name};")
+        conn.execute(f"LOAD EXTENSION {extension_name};")
     return None
 
 


### PR DESCRIPTION
## What

Fixes the CI failure where `cognee.add()` dies during graph-engine init with:

```
RuntimeError: Binder exception: Extension: json is an official extension and has not been installed.
You can install it by: install json.
```

## Why it happens

`LadybugAdapter.create_subprocess` warms up the JSON extension via `install_json_extension_local`, which runs `INSTALL JSON;` on a throwaway database and **swallows every failure** (by design — already-installed and offline cases both surface as raises there). When the install fails for a real reason — e.g. a transient network error downloading the extension on a fresh CI runner with an empty extension cache — the warm-up silently does nothing, and the subsequent `LOAD EXTENSION JSON;` in the worker hard-fails with the binder error above. Because the swallow is silent, the root cause never appears in logs.

## Fix

- `cognee_db_workers/kuzu_worker.py::_load_extension`: catch exactly the "has not been installed" binder error, run `INSTALL <ext>;` on the **live** connection, and retry the LOAD once. Unrelated load errors propagate unchanged. If the install genuinely can't succeed (e.g. no network at all), the INSTALL now raises with the real cause instead of the confusing downstream error.
- `cognee_db_workers/_kuzu_helpers.py`: the warm-up remains best-effort, but the swallowed exception is now printed to stderr so CI logs show *why* the warm-up failed.

## Testing

- 3 new pure unit tests (`test_kuzu_worker_load_extension.py`): direct load when installed, install-and-retry when not, unrelated errors propagate without an install attempt — no ladybug, no subprocess.
- Full `tests/unit/infrastructure/databases/` suite passes, including the worker import-hygiene allowlist test (no new imports in the worker).
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)