### PR TITLE
fix(ladybug): retry INSTALL through transient extension-download failures

### DIFF
--- a/cognee/tests/unit/infrastructure/databases/test_kuzu_worker_load_extension.py
+++ b/cognee/tests/unit/infrastructure/databases/test_kuzu_worker_load_extension.py
@@ -73,3 +73,61 @@ def test_unrelated_load_errors_propagate_without_install():
     with pytest.raises(RuntimeError, match="database is locked"):
         _load_extension(FakeRegistry(conn), _request())
     assert conn.executed == ["LOAD EXTENSION JSON;"]
+
+
+def test_install_retries_through_transient_failures(monkeypatch):
+    """A transient network failure during INSTALL must not kill the load."""
+    import cognee_db_workers.kuzu_worker as worker
+
+    monkeypatch.setattr(worker.time, "sleep", lambda seconds: None)
+
+    class FlakyConnection:
+        def __init__(self, install_failures: int):
+            self.install_failures = install_failures
+            self.installed = False
+            self.executed = []
+
+        def execute(self, query: str):
+            self.executed.append(query)
+            if query.startswith("LOAD EXTENSION") and not self.installed:
+                raise RuntimeError(
+                    "Binder exception: Extension: json is an official extension and "
+                    "has not been installed."
+                )
+            if query.startswith("INSTALL"):
+                if self.install_failures > 0:
+                    self.install_failures -= 1
+                    raise RuntimeError("IO exception: download failed")
+                self.installed = True
+
+    conn = FlakyConnection(install_failures=2)
+    _load_extension(FakeRegistry(conn), _request())
+    assert conn.executed == [
+        "LOAD EXTENSION JSON;",
+        "INSTALL JSON;",
+        "INSTALL JSON;",
+        "INSTALL JSON;",
+        "LOAD EXTENSION JSON;",
+    ]
+
+
+def test_install_gives_up_after_max_attempts(monkeypatch):
+    import cognee_db_workers.kuzu_worker as worker
+
+    monkeypatch.setattr(worker.time, "sleep", lambda seconds: None)
+
+    class AlwaysFailingConnection:
+        def __init__(self):
+            self.install_attempts = 0
+
+        def execute(self, query: str):
+            if query.startswith("LOAD EXTENSION"):
+                raise RuntimeError("Extension: json ... has not been installed.")
+            if query.startswith("INSTALL"):
+                self.install_attempts += 1
+                raise RuntimeError("IO exception: download failed")
+
+    conn = AlwaysFailingConnection()
+    with pytest.raises(RuntimeError, match="download failed"):
+        _load_extension(FakeRegistry(conn), _request())
+    assert conn.install_attempts == worker.INSTALL_ATTEMPTS

--- a/cognee_db_workers/kuzu_worker.py
+++ b/cognee_db_workers/kuzu_worker.py
@@ -9,6 +9,9 @@ working without churn.
 
 from __future__ import annotations
 
+import sys
+import time
+
 from ._kuzu_helpers import install_json_extension_local
 from .harness import (
     DEFAULT_DISPATCH,
@@ -136,6 +139,12 @@ def _install_json(registry: HandleRegistry, req: Request) -> None:
     return None
 
 
+# INSTALL downloads the extension from the network; ride out transient
+# failures (observed as intermittent CI flakes) with a few short retries.
+INSTALL_ATTEMPTS = 3
+INSTALL_RETRY_DELAY_SECONDS = 2.0
+
+
 def _load_extension(registry: HandleRegistry, req: Request) -> None:
     conn = registry.get(req.handle_id)
     extension_name = req.args[0]
@@ -146,9 +155,22 @@ def _load_extension(registry: HandleRegistry, req: Request) -> None:
             raise
         # The warm-up INSTALL on the throwaway database is best-effort and
         # can fail silently (e.g. a transient network error downloading the
-        # extension on a fresh machine). Install on the live connection and
-        # retry once; if INSTALL fails here it raises with the real cause.
-        conn.execute(f"INSTALL {extension_name};")
+        # extension on a fresh machine). Install on the live connection —
+        # retrying through transient download failures — then retry the
+        # LOAD once; if INSTALL keeps failing it raises with the real cause.
+        for attempt in range(1, INSTALL_ATTEMPTS + 1):
+            try:
+                conn.execute(f"INSTALL {extension_name};")
+                break
+            except Exception as install_error:
+                if attempt == INSTALL_ATTEMPTS:
+                    raise
+                print(
+                    f"[ladybug worker] INSTALL {extension_name} attempt {attempt} "
+                    f"failed ({install_error!r}); retrying...",
+                    file=sys.stderr,
+                )
+                time.sleep(INSTALL_RETRY_DELAY_SECONDS)
         conn.execute(f"LOAD EXTENSION {extension_name};")
     return None
 


### PR DESCRIPTION
## What

Follow-up to #3057 (this commit was pushed moments after that PR merged).

Analysis of dev run [27425923988](https://github.com/topoteretes/cognee/actions/runs/27425923988) (S3 File Storage job) shows the JSON-extension failure is **intermittent**: the same job was green at 12:22 and 12:55 and failed at 15:35 on identical code — no infra changes in the commit range, ladybug 0.17.1 stable since Jun 2. That points to transient network failures downloading the extension.

#3057's install-at-LOAD-time fallback makes a *single* attempt, which can hit the same network blip. This retries the INSTALL up to 3 times with a 2s delay, logging each failed attempt to stderr, before giving up with the real error.

## Testing

- 2 new pure unit tests: install succeeds after transient failures (asserting the exact execute sequence), and gives up with the real error after max attempts; `time.sleep` monkeypatched.
- All 8 extension tests + worker import-hygiene test pass (sys/time are stdlib — no new worker deps); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)