### PR TITLE
fix(postgres): pass SSL connect args to maintenance, pgvector, and graph engines

### DIFF
--- a/cognee/infrastructure/databases/graph/postgres/adapter.py
+++ b/cognee/infrastructure/databases/graph/postgres/adapter.py
@@ -44,6 +44,14 @@ class PostgresAdapter(GraphDBInterface):
 
         relational_config = get_relational_config()
         pool_args: dict = dict(relational_config.pool_args) if relational_config.pool_args else {}
+        # Managed Postgres (e.g. Neon, RDS) requires SSL;
+        # reuse the relational DATABASE_CONNECT_ARGS (asyncpg `ssl`) for the graph
+        # engine too. Empty dict is a no-op for in-cluster Postgres.
+        connect_args: dict = (
+            dict(relational_config.database_connect_args)
+            if relational_config.database_connect_args
+            else {}
+        )
 
         # Serialize JSONB columns once, at execute time, with the UUID/datetime-aware
         # encoder. This lets add_nodes/add_edges pass raw property dicts straight through
@@ -53,6 +61,7 @@ class PostgresAdapter(GraphDBInterface):
         self.engine = create_async_engine(
             self.db_uri,
             json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
+            connect_args=connect_args,
             **pool_args,
         )
         self.sessionmaker = async_sessionmaker(bind=self.engine, expire_on_commit=False)

--- a/cognee/infrastructure/databases/postgres/admin.py
+++ b/cognee/infrastructure/databases/postgres/admin.py
@@ -7,6 +7,8 @@ is intentionally agnostic about which subsystem (graph, vector, dlt) the
 credentials came from.
 """
 
+import json
+import os
 from typing import Union
 
 from sqlalchemy import URL, text
@@ -16,12 +18,40 @@ from sqlalchemy.ext.asyncio import create_async_engine
 _MAINTENANCE_DB_NAME = "postgres"
 
 
+def _admin_connect_args() -> dict:
+    """SSL/connect args for the maintenance engine, from DATABASE_CONNECT_ARGS.
+
+    Managed Postgres (e.g. Neon, RDS) requires SSL,
+    but asyncpg uses ``ssl`` not ``sslmode``. Returns {} for in-cluster Postgres
+    (env unset) so this stays a no-op there.
+    """
+    raw = os.environ.get("DATABASE_CONNECT_ARGS")
+    if not raw:
+        return {}
+    try:
+        args = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    out = {}
+    if args.get("ssl") is not None:
+        out["ssl"] = args["ssl"]
+    elif args.get("sslmode") is not None:  # map libpq sslmode -> asyncpg ssl
+        out["ssl"] = args["sslmode"]
+    return out
+
+
+def _direct_host(host: str) -> str:
+    """CREATE/DROP DATABASE can't run through Neon's PgBouncer pooler — use the
+    direct endpoint. No-op for non-Neon hosts."""
+    return host.replace("-pooler.", ".") if host and "-pooler." in host else host
+
+
 def _build_maintenance_url(host: str, port: Union[int, str], username: str, password: str) -> URL:
     return URL.create(
         "postgresql+asyncpg",
         username=username,
         password=password,
-        host=host,
+        host=_direct_host(host),
         port=int(port),
         database=_MAINTENANCE_DB_NAME,
     )
@@ -42,7 +72,10 @@ async def create_pg_database_if_not_exists(
     Returns:
         True if the database was created, False if it already existed.
     """
-    engine = create_async_engine(_build_maintenance_url(host, port, username, password))
+    engine = create_async_engine(
+        _build_maintenance_url(host, port, username, password),
+        connect_args=_admin_connect_args(),
+    )
     try:
         connection = await engine.connect()
         try:
@@ -74,7 +107,10 @@ async def drop_pg_database_if_exists(
     mode, terminates every backend currently connected to ``db_name`` other
     than our own, then runs ``DROP DATABASE IF EXISTS``.
     """
-    engine = create_async_engine(_build_maintenance_url(host, port, username, password))
+    engine = create_async_engine(
+        _build_maintenance_url(host, port, username, password),
+        connect_args=_admin_connect_args(),
+    )
     try:
         connection = await engine.connect()
         try:

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -102,6 +102,15 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
                 dict(relational_config.pool_args) if relational_config.pool_args else {}
             )
 
+        # A per-dataset PGVector engine may connect to managed
+        # Postgres (Neon) which requires SSL. Reuse the relational connect_args
+        # (e.g. {"ssl": "require"} from DATABASE_CONNECT_ARGS); {} for in-cluster.
+        effective_connect_args = (
+            dict(relational_config.database_connect_args)
+            if relational_config.database_connect_args
+            else None
+        )
+
         # Reuse engine and sessionmaker if the relational engine is provided and is the same database as the one configured for pgvector
         db_name1 = make_url(relational_db.db_uri).database
         db_name2 = make_url(self.db_uri).database
@@ -109,6 +118,7 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
             # If backend access control create new instances of engine and sessionmaker
             super().__init__(
                 connection_string=self.db_uri,
+                connect_args=effective_connect_args,
                 pool_args=effective_pool_args,
             )
             self._owns_engine = True
@@ -120,6 +130,7 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
             # If not postgreSQL and not backend access control create new instances of engine and sessionmaker
             super().__init__(
                 connection_string=self.db_uri,
+                connect_args=effective_connect_args,
                 pool_args=effective_pool_args,
             )
             self._owns_engine = True


### PR DESCRIPTION
## Problem

Managed Postgres providers (Neon, RDS) require SSL. cognee already accepts `DATABASE_CONNECT_ARGS` for the main relational engine, but three other engine-creation paths ignored it, so any deployment pointing them at an SSL-required host failed to connect:

1. **`postgres/admin.py`** — the maintenance engine used for per-dataset `CREATE/DROP DATABASE`
2. **`pgvector/PGVectorAdapter.py`** — the per-dataset engines created under backend access control
3. **`graph/postgres/adapter.py`** — the graph-as-tables engine

## Fix

All three now apply the relational config's `database_connect_args` (asyncpg uses `ssl`; a libpq-style `sslmode` value is mapped in admin.py). Additionally, admin.py routes DDL to the **direct** endpoint when the host is a Neon `-pooler` address, since `CREATE DATABASE` cannot run through PgBouncer.

All changes are no-ops when `DATABASE_CONNECT_ARGS` is unset — in-cluster and local Postgres behavior is unchanged.

## Verification

Validated end-to-end in the cognee-cloud v3 tenant architecture (one Neon project per tenant, relational + pgvector + graph all external): full add → cognify → search pipeline over SSL, including per-dataset database creation/deletion via the direct endpoint and graph-as-tables writes. See topoteretes/cloud-backend branch `tenant_v3_neon_provisioning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)