### PR TITLE
ci: stabilize flaky tests before the merge gate

### DIFF
--- a/.github/workflows/basic_tests.yml
+++ b/.github/workflows/basic_tests.yml
@@ -66,7 +66,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Run Unit Tests
-        run: uv run pytest cognee/tests/unit/
+        run: uv run pytest cognee/tests/unit/ --timeout=300 --timeout-method=thread
 
   simple-examples:
     name: Run Simple Examples

--- a/.github/workflows/test_different_operating_systems.yml
+++ b/.github/workflows/test_different_operating_systems.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run unit tests
         shell: bash
-        run: uv run pytest cognee/tests/unit/
+        run: uv run pytest cognee/tests/unit/ --timeout=300 --timeout-method=thread
         env:
           PYTHONUTF8: 1
           LLM_PROVIDER: openai

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -245,6 +245,9 @@ jobs:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
 
+  # NOTE: intentionally excluded from the `notify` aggregator below — this is
+  # external infra (Modal + Azure secrets), informational only; it must not gate
+  # merges. (`continue-on-error` is not allowed on a reusable-workflow job.)
   distributed-tests:
     name: Distributed Cognee Test
     needs: [ build-ci-env ]
@@ -286,7 +289,6 @@ jobs:
       temporal-graph-tests,
       search-db-tests,
       relational-db-migration-tests,
-      distributed-tests,
       db-examples-tests,
     ]
     runs-on: ubuntu-latest
@@ -314,7 +316,6 @@ jobs:
                 "${{ needs.temporal-graph-tests.result }}" == "success" &&
                 "${{ needs.search-db-tests.result }}" == "success" &&
                 "${{ needs.relational-db-migration-tests.result }}" == "success" &&
-                "${{ needs.distributed-tests.result }}" == "success" &&
                 "${{ needs.db-examples-tests.result }}" == "success" ]]; then
             echo "All test suites completed successfully!"
           else

--- a/cognee/tests/unit/modules/agents/conftest.py
+++ b/cognee/tests/unit/modules/agents/conftest.py
@@ -17,3 +17,13 @@ def _setup_db():
             await run_startup_migrations()
 
     asyncio.run(_run())
+    # The relational engine built during the migration above is process-global
+    # (@lru_cache) and is now bound to the event loop asyncio.run() just closed.
+    # Drop the cache so per-test event loops get a fresh engine — otherwise later
+    # async tests that share this cache hit "Event loop is closed" (GeneratorExit
+    # on Linux/macOS, a hang on Windows).
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+
+    create_relational_engine.cache_clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ dev = [
     "pytest>=7.4.0,<8",
     "pytest-cov>=6.1.1,<7.0.0",
     "pytest-asyncio>=0.21.1,<0.22",
+    "pytest-timeout>=2.3.1,<3",
     "pytest-split>=0.11.0,<0.12",
     "coverage>=7.3.2,<8",
     "pre-commit>=4.0.1,<5",
@@ -282,6 +283,7 @@ dev = [
     "httpx>=0.28.1",
     "pytest>=7.4.4",
     "pytest-asyncio>=0.21.2",
+    "pytest-timeout>=2.3.1",
     "pytest-split>=0.11.0,<0.12",
     "ruff>=0.13.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1279,6 +1279,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-split" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "tweepy" },
     { name = "ty" },
@@ -1399,6 +1400,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-split" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -1501,6 +1503,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.1,<0.22" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1,<7.0.0" },
     { name = "pytest-split", marker = "extra == 'dev'", specifier = ">=0.11.0,<0.12" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.1,<3" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2.0.0" },
     { name = "python-magic-bin", marker = "sys_platform == 'win32'", specifier = "<0.5" },
     { name = "python-multipart", specifier = ">=0.0.22,<1.0.0" },
@@ -1538,6 +1541,7 @@ dev = [
     { name = "pytest", specifier = ">=7.4.4" },
     { name = "pytest-asyncio", specifier = ">=0.21.2" },
     { name = "pytest-split", specifier = ">=0.11.0,<0.12" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "ruff", specifier = ">=0.13.1" },
 ]
 
@@ -8877,6 +8881,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stabilizes the suite so the upcoming "failing tests block merge" gate isn't held hostage by hangs/flakes. Three independent fixes:

### 1. `pytest-timeout` — kill hangs fast
No per-test timeout existed, so one hung test consumed the whole 60-min job budget (live example: the Windows 3.13 unit job hung **45+ min** on an unrelated PR). Adds the dep + `--timeout=300 --timeout-method=thread` (the `thread` method is required on Windows) to the two unit-test commands. A hang now fails in ≤5 min.

### 2. Async event-loop flake (`GeneratorExit` / Windows hang)
`cognee/tests/unit/modules/agents/conftest.py` built the process-global `@lru_cache`'d relational engine inside `asyncio.run()`, which closes that loop — leaving the cached engine bound to a dead loop. Later async tests sharing the cache hit `Event loop is closed` → `GeneratorExit` (Linux/macOS) or a hang (Windows); order-dependent ⇒ flaky. Fix: clear the engine cache after setup so per-test loops get a fresh engine. (conftest-only; no production code touched.)

### 3. Modal distributed test no longer gates merges
Removed `distributed-tests` from the `notify` aggregator — it's external infra (Modal + Azure secrets), informational only, and shouldn't red `Test Completion Status`. (`continue-on-error` isn't allowed on a reusable-workflow job, so exclusion from the aggregator is the mechanism.)

**Verified locally:** `uv run pytest cognee/tests/unit/modules/agents cognee/tests/unit/modules/memify_tasks/... --timeout=300 --timeout-method=thread` → **52 passed**.

After this merges, the merge gate (require `Test Completion Status` on `dev`+`main`) gets enabled.