### PR TITLE
ci: add NMZivkovic to core-team (live test of Claude PR review)

### DIFF
--- a/.github/core-team.txt
+++ b/.github/core-team.txt
@@ -8,3 +8,4 @@ lxobr
 pazone
 siillee
 vasilije1990
+NMZivkovic

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -328,9 +328,7 @@ jobs:
   # logic. Runs only after the suite is green (needs: notify), core-team PRs only, advisory.
   claude-review:
     name: Claude Code Review
-    # TEMP(self-test only): 'needs: [ notify ]' removed so this runs immediately to
-    # validate the skill-load fix without waiting on the (flaky) full suite. The dev
-    # PR restores 'needs: [ notify ]'.
+    needs: [ notify ]
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -328,7 +328,9 @@ jobs:
   # logic. Runs only after the suite is green (needs: notify), core-team PRs only, advisory.
   claude-review:
     name: Claude Code Review
-    needs: [ notify ]
+    # TEMP(self-test only): 'needs: [ notify ]' removed so this runs immediately to
+    # validate the skill-load fix without waiting on the (flaky) full suite. The dev
+    # PR restores 'needs: [ notify ]'.
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -373,11 +375,17 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: .ci-private
 
-      - name: Stage skill into the workspace
+      - name: Stage skill into the user skills dir
         if: ${{ steps.gate.outputs.run == 'true' }}
         run: |
-          mkdir -p .claude/skills
-          cp -r .ci-private/.claude/skills/pr-review .claude/skills/
+          # Stage into the USER skills dir ($HOME/.claude), NOT the repo's .claude/.
+          # claude-code-action sanitizes the repo .claude for untrusted PR heads
+          # (it moves the working-tree .claude to .claude-pr/ and restores a clean
+          # .claude from the base branch), which wipes the staged private skill and
+          # leaves /pr-review unresolved -> 0 turns, nothing posted. $HOME/.claude is
+          # untouched by that sanitization and is loaded via settingSources: [user,...].
+          mkdir -p "$HOME/.claude/skills"
+          cp -r .ci-private/.claude/skills/pr-review "$HOME/.claude/skills/"
 
       - name: Claude Code review
         if: ${{ steps.gate.outputs.run == 'true' }}


### PR DESCRIPTION
Adds the `NMZivkovic` to `.github/core-team.txt`.

It also doubles as the **first live end-to-end test** of the advisory Claude review wired up in #3058. Since the `claude-review` job reads `core-team.txt` from the PR's checkout, this PR self-enables.

**Expected once CI is green** (the job is `needs: [notify]`, so it waits for the full suite):
- the `Claude Code Review` job runs (not skipped),
- it posts inline comments + one summary comment starting `<!-- claude-pr-review:summary -->` (opening roast → verdict → findings),
- and DMs me on Slack.