### PR TITLE
fix(mcp): cognify_status works in API mode via REST endpoint

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -366,8 +366,13 @@ class CogneeClient:
             Status information keyed by dataset ID
         """
         if self.use_api:
-            # Note: This would need a custom endpoint on the API side
-            raise NotImplementedError("Pipeline status is not available via API")
+            # API mode: query the server's dataset-status endpoint, which
+            # reports the pipeline run state keyed by dataset id.
+            endpoint = f"{self.api_url}/api/v1/datasets/status"
+            params = [("dataset", str(d)) for d in dataset_ids]
+            response = await self.client.get(endpoint, params=params, headers=self._get_headers())
+            response.raise_for_status()
+            return response.json()
         else:
             # Direct mode: Call cognee directly
             from cognee.modules.pipelines.operations.get_pipeline_status import get_pipeline_status

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1300,24 +1300,33 @@ async def cognify_status(
     - Use `pipelines` to restrict to specific pipeline names
     - Status information includes job progress, execution time, and completion status
     - The status is returned in string format for easy reading
-    - This operation is not available in API mode
+    - In API mode the dataset id is resolved over HTTP and status is read
+      from the server's `GET /api/v1/datasets/status` endpoint
     """
     dataset_name = dataset_name or _agent_scoped_default_dataset()
     with redirect_stdout(sys.stderr):
         try:
             if cognee_client.use_api:
-                return [
-                    types.TextContent(
-                        type="text",
-                        text="❌ Pipeline status is not available in API mode",
-                    )
-                ]
+                # API mode: resolve the dataset id over HTTP (no local cognee
+                # instance exists in this process) before querying status.
+                datasets = await cognee_client.list_datasets()
+                dataset_id = next(
+                    (d["id"] for d in datasets if d.get("name") == dataset_name), None
+                )
+                if dataset_id is None:
+                    return [
+                        types.TextContent(
+                            type="text",
+                            text=f"❌ Dataset '{dataset_name}' not found via API",
+                        )
+                    ]
+            else:
+                from cognee.modules.data.methods.get_unique_dataset_id import get_unique_dataset_id
+                from cognee.modules.users.methods import get_default_user
 
-            from cognee.modules.data.methods.get_unique_dataset_id import get_unique_dataset_id
-            from cognee.modules.users.methods import get_default_user
+                user = await get_default_user()
+                dataset_id = await get_unique_dataset_id(dataset_name, user)
 
-            user = await get_default_user()
-            dataset_id = await get_unique_dataset_id(dataset_name, user)
             requested_pipelines = list(dict.fromkeys(pipelines or ["cognify_pipeline"]))
 
             if len(requested_pipelines) == 1:


### PR DESCRIPTION
## Summary

Makes the MCP `cognify_status` tool work in **API mode** (`cognee-mcp --api-url ...`, remote backend). Today it is non-functional there:

- On `main`: returns `❌ Pipeline status is not available in API mode`.
- On released 0.5.4: crashes with `sqlite3.OperationalError: unable to open database file`.

Fixes #3067.

## Root cause

`cognify_status` depended on a local cognee install even in API mode:

- `server.py` resolved the dataset via `get_default_user()` / `get_unique_dataset_id()` (local SQLite, absent in the MCP process).
- `cognee_client.get_pipeline_status()` hard-stopped in API mode with `raise NotImplementedError("Pipeline status is not available via API")`.

The endpoint the original `NotImplementedError` comment asked for already exists: `GET /api/v1/datasets/status?dataset=<id>` → `{dataset_id: PipelineRunStatus}`.

## Changes

- **`cognee-mcp/src/cognee_client.py`** — `get_pipeline_status()`: in API mode, call `GET /api/v1/datasets/status` (one `dataset` query param per id) and return the parsed `{dataset_id: status}` map instead of raising.
- **`cognee-mcp/src/server.py`** — `cognify_status()`: in API mode, resolve the dataset id via `list_datasets()` (HTTP), then fall through to the existing single-/multi-pipeline status logic. Returns a clear "dataset not found" message when the name is unknown. Direct mode is unchanged.

## History

This re-lands #2418 (`fix(mcp): cognify_status works in API mode via REST endpoint`), which was closed unmerged and was **not** carried by the superseding #2459 (that PR added the dataset/`pipelines` parameters but left the API-mode path raising). The fix is rebased onto the current `main` handler, so it preserves the `pipelines` selection and agent-scoped default dataset behavior.

## Testing

Verified end-to-end against a live cognee 1.x server: the patched MCP boots in API mode and `cognify_status` returns real status (`{"<dataset-id>": "DATASET_PROCESSING_STARTED"}`, `isError: false`) where upstream returned the "not available" message.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
