### PR TITLE
fix(llm/ollama): offload blocking sync client calls off the event loop

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -115,7 +115,12 @@ class OllamaAPIAdapter(LLMInterface):
         """
         merged_kwargs = {**self.llm_args, **kwargs}
         async with llm_rate_limiter_context_manager():
-            response = self.aclient.chat.completions.create(
+            # ``self.aclient`` wraps a *synchronous* ``OpenAI`` client, so calling
+            # ``.create()`` directly blocks the event loop for the full duration of
+            # the LLM request. Offload it to a worker thread so concurrent async
+            # callers are not serialized behind it.
+            response = await asyncio.to_thread(
+                self.aclient.chat.completions.create,
                 model=self.model,
                 messages=[
                     {
@@ -168,7 +173,9 @@ class OllamaAPIAdapter(LLMInterface):
         """
 
         async with open_data_file(input, mode="rb") as audio_file:
-            transcription = self.aclient.audio.transcriptions.create(
+            # Synchronous client call -- offload so it does not block the loop.
+            transcription = await asyncio.to_thread(
+                self.aclient.audio.transcriptions.create,
                 model="whisper-1",  # Ensure the correct model for transcription
                 file=audio_file,
                 language="en",
@@ -216,7 +223,9 @@ class OllamaAPIAdapter(LLMInterface):
         async with open_data_file(input, mode="rb") as image_file:
             encoded_image = base64.b64encode(image_file.read()).decode("utf-8")
 
-        response = self.aclient.chat.completions.create(
+        # Synchronous client call -- offload so it does not block the loop.
+        response = await asyncio.to_thread(
+            self.aclient.chat.completions.create,
             model=self.model,
             messages=[
                 {

--- a/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
@@ -1,0 +1,60 @@
+"""OllamaAPIAdapter must not block the event loop on its synchronous client.
+
+The adapter wraps a synchronous ``OpenAI`` client (``instructor.from_openai``),
+so calling ``.create()`` directly from an ``async def`` blocks the event loop for
+the full LLM round-trip. The calls must be offloaded with ``asyncio.to_thread``.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.ollama.adapter import (
+    OllamaAPIAdapter,
+)
+
+_MODULE = (
+    "cognee.infrastructure.llm.structured_output_framework."
+    "litellm_instructor.llm.ollama.adapter"
+)
+
+
+class _Resp(BaseModel):
+    value: str
+
+
+@asynccontextmanager
+async def _null_rate_limiter():
+    yield
+
+
+@pytest.mark.asyncio
+async def test_acreate_structured_output_offloads_blocking_client_call():
+    adapter = OllamaAPIAdapter(
+        endpoint="http://localhost:11434/v1",
+        api_key="ollama",
+        model="llama3",
+        name="ollama",
+        max_completion_tokens=128,
+    )
+
+    sentinel = _Resp(value="ok")
+    # The production client is synchronous; replace it with a sync mock so a
+    # missing offload would run inline on the event loop.
+    adapter.aclient = Mock()
+    adapter.aclient.chat.completions.create = Mock(return_value=sentinel)
+
+    with (
+        patch(f"{_MODULE}.llm_rate_limiter_context_manager", _null_rate_limiter),
+        patch(f"{_MODULE}.asyncio.to_thread", wraps=asyncio.to_thread) as to_thread_spy,
+    ):
+        result = await adapter.acreate_structured_output("hello", "system prompt", _Resp)
+
+    # The blocking synchronous call is offloaded to a worker thread...
+    assert to_thread_spy.called, "client call was not offloaded via asyncio.to_thread"
+    assert to_thread_spy.call_args.args[0] is adapter.aclient.chat.completions.create
+    # ...and its result is returned unchanged.
+    assert result is sentinel


### PR DESCRIPTION
## What

`OllamaAPIAdapter` wraps a **synchronous** `OpenAI` client (`instructor.from_openai(OpenAI(...))`), but its `async def` methods call `.create()` directly — so each LLM round-trip blocks the event loop, serializing any concurrent async callers behind it.

Every other adapter is already non-blocking: `generic_llm_api` / `openai` use `instructor.from_litellm(litellm.acompletion)` with `await`, and the sibling `llama_cpp` adapter uses `AsyncOpenAI`. Ollama was the lone synchronous outlier.

## Change

Offload the three blocking client calls — `acreate_structured_output`, `create_transcript`, `transcribe_image` — via `asyncio.to_thread` (a pattern already used across cognee, e.g. `tasks/ingestion`, `shared/cache`). This keeps the existing synchronous Ollama client but moves the blocking call off the event loop; no other behavior change.

## Test

Adds `cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py`, which spies on `asyncio.to_thread` and asserts `acreate_structured_output` dispatches the (synchronous) client call through it. Reverting the offload fails the test.

`pytest cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py` → **1 passed**.

(Happy to switch to `AsyncOpenAI` + `await` to mirror the `llama_cpp` adapter instead, if you prefer the true-async client over the thread offload.)