### PR TITLE
fix(api/ontologies): offload blocking filesystem IO off the event loop

### DIFF
--- a/cognee/api/v1/ontologies/routers/get_ontology_router.py
+++ b/cognee/api/v1/ontologies/routers/get_ontology_router.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, File, Form, Path, UploadFile, Depends, Request
 from fastapi.responses import JSONResponse
 from typing import Optional, List
@@ -132,7 +134,11 @@ def get_ontology_router() -> APIRouter:
         )
 
         try:
-            ontology_service.delete_ontology(ontology_key=ontology_key, user=user)
+            # delete_ontology performs blocking filesystem IO (stat/unlink); run
+            # it off the event loop so this async route does not block.
+            await asyncio.to_thread(
+                ontology_service.delete_ontology, ontology_key=ontology_key, user=user
+            )
             return {"status": "success", "ontology_key": ontology_key}
         except ValueError as e:
             return JSONResponse(status_code=400, content={"error": str(e)})
@@ -160,7 +166,8 @@ def get_ontology_router() -> APIRouter:
         )
 
         try:
-            metadata = ontology_service.list_ontologies(user)
+            # list_ontologies reads metadata from disk; run it off the event loop.
+            metadata = await asyncio.to_thread(ontology_service.list_ontologies, user)
             return metadata
         except Exception as e:
             return JSONResponse(status_code=500, content={"error": str(e)})

--- a/cognee/tests/unit/api/test_ontology_router_offload.py
+++ b/cognee/tests/unit/api/test_ontology_router_offload.py
@@ -1,0 +1,61 @@
+"""Ontology routes must not block the event loop on synchronous file IO.
+
+`OntologyService.delete_ontology` / `list_ontologies` do blocking filesystem IO
+(stat / unlink / metadata read). The async routes must dispatch them via
+`asyncio.to_thread` rather than calling them inline on the event loop.
+"""
+
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cognee.api.v1.ontologies.ontologies import OntologyService
+from cognee.api.v1.ontologies.routers.get_ontology_router import get_ontology_router
+
+_MODULE = "cognee.api.v1.ontologies.routers.get_ontology_router"
+
+
+def _endpoint_for(method: str):
+    router = get_ontology_router()
+    for route in router.routes:
+        if method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError(f"no {method} route found on the ontology router")
+
+
+@pytest.mark.asyncio
+async def test_delete_ontology_route_offloads_blocking_io():
+    delete_route = _endpoint_for("DELETE")
+    user = Mock()
+    user.id = "u1"
+
+    with (
+        patch.object(OntologyService, "delete_ontology", return_value=None) as mock_delete,
+        patch(f"{_MODULE}.send_telemetry"),
+        patch(f"{_MODULE}.asyncio.to_thread", wraps=asyncio.to_thread) as to_thread_spy,
+    ):
+        result = await delete_route(ontology_key="k", user=user)
+
+    assert to_thread_spy.called, "delete route did not offload via asyncio.to_thread"
+    mock_delete.assert_called_once()
+    assert result == {"status": "success", "ontology_key": "k"}
+
+
+@pytest.mark.asyncio
+async def test_list_ontologies_route_offloads_blocking_io():
+    list_route = _endpoint_for("GET")
+    user = Mock()
+    user.id = "u1"
+    sentinel = {"k": {"filename": "k.owl"}}
+
+    with (
+        patch.object(OntologyService, "list_ontologies", return_value=sentinel) as mock_list,
+        patch(f"{_MODULE}.send_telemetry"),
+        patch(f"{_MODULE}.asyncio.to_thread", wraps=asyncio.to_thread) as to_thread_spy,
+    ):
+        result = await list_route(user=user)
+
+    assert to_thread_spy.called, "list route did not offload via asyncio.to_thread"
+    mock_list.assert_called_once()
+    assert result == sentinel


### PR DESCRIPTION
## What

The `delete_ontology` and `list_ontologies` ontology routes are `async def`, but call the **synchronous** `OntologyService` methods directly:

```python
@router.delete("/{ontology_key}")
async def delete_ontology(...):
    ontology_service.delete_ontology(...)   # blocking stat/unlink on the event loop

@router.get("")
async def list_ontologies(...):
    ontology_service.list_ontologies(user)  # blocking metadata read on the event loop
```

Both service methods do blocking filesystem IO (`Path.exists`/`resolve`/`unlink`, metadata read), so they stall the event loop for the duration. The sibling `upload_ontology` route already `await`s its async service method — these two were the inconsistent blocking paths.

## Change

Dispatch the two synchronous calls via `asyncio.to_thread`. The service methods stay synchronous on purpose — their existing unit tests (`tests/unit/api/test_delete_ontology.py`) call them directly — so only the async routes change.

## Test

Adds `tests/unit/api/test_ontology_router_offload.py`: extracts each route handler and asserts the blocking call is dispatched through `asyncio.to_thread`. Reverting either offload fails the corresponding test.

`pytest tests/unit/api/test_ontology_router_offload.py tests/unit/api/test_delete_ontology.py` → **10 passed**; `ruff` clean.