### PR TITLE
[codex] Persist graph trace for context-only retrieval

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -56,6 +56,7 @@ class RecallKwargs(TypedDict, total=False):
     wide_search_top_k: int
     triplet_distance_penalty: float
     feedback_influence: float
+    persist_trace: bool
     verbose: bool
     retriever_specific_config: dict
     user: object
@@ -73,7 +74,9 @@ async def _resolve_user_id(user: str | None) -> str | None:
     return str(user.id) if hasattr(user, "id") else None
 
 
-async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | None) -> str | None:
+async def _resolve_session_cache_user_id(
+    session_id: str, caller_user_id: str | None
+) -> str | None:
     """Resolve the user_id to use when querying the session cache.
 
     Session-cache entries are keyed by the session's OWNER, not by the
@@ -114,7 +117,9 @@ async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | 
 
         permitted_ids: list[UUID] = []
         try:
-            permitted = await get_specific_user_permission_datasets(caller_uuid, "read", None)
+            permitted = await get_specific_user_permission_datasets(
+                caller_uuid, "read", None
+            )
             permitted_ids = [ds.id for ds in permitted] if permitted else []
         except Exception:
             permitted_ids = []
@@ -239,7 +244,9 @@ async def _search_trace(
     if not sm.is_available:
         return []
 
-    entries = await sm.get_agent_trace_session(user_id=cache_user_id, session_id=session_id)
+    entries = await sm.get_agent_trace_session(
+        user_id=cache_user_id, session_id=session_id
+    )
 
     if not entries:
         return []
@@ -331,6 +338,7 @@ async def recall(
     wide_search_top_k: int | None = 100,
     triplet_distance_penalty: float | None = 6.5,
     feedback_influence: float = 0.0,
+    persist_trace: bool = False,
     verbose: bool = False,
     retriever_specific_config: dict | None = None,
     neighborhood_depth: int | None = None,
@@ -414,8 +422,11 @@ async def recall(
             "search_type": str(query_type.value) if query_type else "auto",
             "session_id": session_id or "",
             "datasets": ",".join(datasets) if datasets else "",
-            "dataset_ids": ",".join(str(dataset_id) for dataset_id in dataset_ids or []),
+            "dataset_ids": ",".join(
+                str(dataset_id) for dataset_id in dataset_ids or []
+            ),
             "include_references": include_references,
+            "persist_trace": persist_trace,
             "cognee_version": cognee_version,
         },
     )
@@ -441,6 +452,7 @@ async def recall(
                 system_prompt=system_prompt,
                 node_name=node_name,
                 only_context=only_context,
+                persist_trace=persist_trace,
                 session_id=session_id,
                 verbose=verbose,
                 include_references=include_references,
@@ -506,7 +518,10 @@ async def recall(
             local_query_type = query_type
             if local_query_type is not None:
                 if auto_route:
-                    from cognee.api.v1.recall.query_router import record_override, route_query
+                    from cognee.api.v1.recall.query_router import (
+                        record_override,
+                        route_query,
+                    )
 
                     result = route_query(query_text)
                     routed_type = result.search_type
@@ -530,7 +545,9 @@ async def recall(
             if search_dataset_ids is None and datasets is not None:
                 search_dataset_ids = [
                     dataset.id
-                    for dataset in await get_authorized_existing_datasets(datasets, "read", user)
+                    for dataset in await get_authorized_existing_datasets(
+                        datasets, "read", user
+                    )
                 ]
                 if not search_dataset_ids:
                     raise DatasetNotFoundError(message="No datasets found.")
@@ -550,6 +567,7 @@ async def recall(
                 wide_search_top_k=wide_search_top_k,
                 triplet_distance_penalty=triplet_distance_penalty,
                 feedback_influence=feedback_influence,
+                persist_trace=persist_trace,
                 retriever_specific_config=retriever_specific_config,
                 neighborhood_depth=neighborhood_depth,
                 neighborhood_seed_top_k=neighborhood_seed_top_k,
@@ -562,7 +580,10 @@ async def recall(
             for r in graph_results:
                 items: list[SearchResultItem] = normalize_search_payload(r)
                 tagged.extend(
-                    [ResponseGraphEntry(**item.model_dump(), source="graph") for item in items]
+                    [
+                        ResponseGraphEntry(**item.model_dump(), source="graph")
+                        for item in items
+                    ]
                 )
             return tagged
 

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -14,7 +14,10 @@ from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
 from cognee.modules.search.operations import get_history
 from cognee.modules.search.types import SearchResult, SearchType
-from cognee.modules.users.exceptions.exceptions import PermissionDeniedError, UserNotFoundError
+from cognee.modules.users.exceptions.exceptions import (
+    PermissionDeniedError,
+    UserNotFoundError,
+)
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
@@ -63,6 +66,7 @@ class RecallPayloadDTO(InDTO):
     )
     top_k: Optional[int] = Field(default=15)
     only_context: bool = Field(default=False)
+    persist_trace: bool = Field(default=False)
     verbose: bool = Field(default=False)
     include_references: bool = Field(
         default=False,
@@ -103,7 +107,10 @@ def get_recall_router() -> APIRouter:
         send_telemetry(
             "Recall API Endpoint Invoked",
             user.id,
-            additional_properties={"endpoint": "GET /v1/recall", "cognee_version": cognee_version},
+            additional_properties={
+                "endpoint": "GET /v1/recall",
+                "cognee_version": cognee_version,
+            },
         )
 
         try:
@@ -119,7 +126,9 @@ def get_recall_router() -> APIRouter:
 
     @router.post("", response_model=list[RecallResponse])
     @log_usage(function_name="POST /v1/recall", log_type="api_endpoint")
-    async def recall(payload: RecallPayloadDTO, user: User = Depends(get_authenticated_user)):
+    async def recall(
+        payload: RecallPayloadDTO, user: User = Depends(get_authenticated_user)
+    ):
         """
         Recall information from the knowledge graph.
 
@@ -179,6 +188,7 @@ def get_recall_router() -> APIRouter:
                 top_k=payload.top_k,
                 verbose=payload.verbose,
                 only_context=payload.only_context,
+                persist_trace=payload.persist_trace,
                 session_id=payload.session_id,
                 scope=payload.scope,
                 include_references=payload.include_references,

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -13,7 +13,10 @@ from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
 from cognee.modules.search.operations import get_history
 from cognee.modules.search.types import SearchResult, SearchType
-from cognee.modules.users.exceptions.exceptions import PermissionDeniedError, UserNotFoundError
+from cognee.modules.users.exceptions.exceptions import (
+    PermissionDeniedError,
+    UserNotFoundError,
+)
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
 from cognee.shared.usage_logger import log_usage
@@ -61,6 +64,13 @@ class SearchPayloadDTO(InDTO):
     )
     top_k: Optional[int] = Field(default=15)
     only_context: bool = Field(default=False)
+    persist_trace: bool = Field(
+        default=False,
+        description=(
+            "When used with only_context, persist the retrieved graph element trace"
+            " in the session cache without generating an LLM answer."
+        ),
+    )
     verbose: bool = Field(
         default=False,
         description=(
@@ -135,7 +145,10 @@ def get_search_router() -> APIRouter:
         send_telemetry(
             "Search API Endpoint Invoked",
             user.id,
-            additional_properties={"endpoint": "GET /v1/search", "cognee_version": cognee_version},
+            additional_properties={
+                "endpoint": "GET /v1/search",
+                "cognee_version": cognee_version,
+            },
         )
 
         try:
@@ -161,7 +174,9 @@ def get_search_router() -> APIRouter:
         },
     )
     @log_usage(function_name="POST /v1/search", log_type="api_endpoint")
-    async def search(payload: SearchPayloadDTO, user: User = Depends(get_authenticated_user)):
+    async def search(
+        payload: SearchPayloadDTO, user: User = Depends(get_authenticated_user)
+    ):
         """
         Search for nodes in the graph database.
 
@@ -204,12 +219,15 @@ def get_search_router() -> APIRouter:
                 "endpoint": "POST /v1/search",
                 "search_type": str(payload.search_type),
                 "datasets": payload.datasets,
-                "dataset_ids": [str(dataset_id) for dataset_id in payload.dataset_ids or []],
+                "dataset_ids": [
+                    str(dataset_id) for dataset_id in payload.dataset_ids or []
+                ],
                 "query": payload.query,
                 "system_prompt": payload.system_prompt,
                 "node_name": payload.node_name,
                 "top_k": payload.top_k,
                 "only_context": payload.only_context,
+                "persist_trace": payload.persist_trace,
                 "verbose": payload.verbose,
                 "skills": payload.skills,
                 "tools": payload.tools,
@@ -226,15 +244,16 @@ def get_search_router() -> APIRouter:
                 query_text=payload.query,
                 query_type=payload.search_type,
                 user=user,
-                datasets=payload.datasets
-                if not payload.dataset_ids
-                else None,  # If dataset_ids are provided, ignore datasets by name to avoid confusion and potential mismatches.
+                datasets=(
+                    payload.datasets if not payload.dataset_ids else None
+                ),  # If dataset_ids are provided, ignore datasets by name to avoid confusion and potential mismatches.
                 dataset_ids=payload.dataset_ids,
                 system_prompt=payload.system_prompt,
                 node_name=payload.node_name,
                 top_k=payload.top_k,
                 verbose=payload.verbose,
                 only_context=payload.only_context,
+                persist_trace=payload.persist_trace,
                 skills=payload.skills,
                 tools=payload.tools,
                 max_iter=payload.max_iter,
@@ -251,7 +270,9 @@ def get_search_router() -> APIRouter:
                 ).model_dump(),
             )
         except (DatabaseNotCreatedError, UserNotFoundError, CogneeValidationError) as e:
-            status_code = getattr(e, "status_code", status.HTTP_422_UNPROCESSABLE_CONTENT)
+            status_code = getattr(
+                e, "status_code", status.HTTP_422_UNPROCESSABLE_CONTENT
+            )
             return JSONResponse(
                 status_code=status_code,
                 content=ErrorResponse(

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -44,6 +44,7 @@ async def search(
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
     feedback_influence: float = 0.0,
+    persist_trace: bool = False,
     verbose: bool = False,
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
@@ -239,9 +240,14 @@ async def search(
             top_k=top_k,
             node_name=node_name,
             only_context=only_context,
+            persist_trace=persist_trace,
             verbose=verbose,
             include_references=include_references,
-            **{key: value for key, value in agentic_overrides.items() if value is not None},
+            **{
+                key: value
+                for key, value in agentic_overrides.items()
+                if value is not None
+            },
         )
 
     with new_span("cognee.api.search") as span:
@@ -262,7 +268,9 @@ async def search(
             )
 
         allowed_node_name_operators = {"AND", "OR"}
-        normalized_node_name_filter_operator = (node_name_filter_operator or "").strip().upper()
+        normalized_node_name_filter_operator = (
+            (node_name_filter_operator or "").strip().upper()
+        )
 
         if normalized_node_name_filter_operator not in allowed_node_name_operators:
             raise CogneeValidationError(
@@ -286,7 +294,9 @@ async def search(
         await set_session_user_context_variable(user)
 
         # Transform string based datasets to UUID - String based datasets can only be found for current user
-        if datasets is not None and [all(isinstance(dataset, str) for dataset in datasets)]:
+        if datasets is not None and [
+            all(isinstance(dataset, str) for dataset in datasets)
+        ]:
             datasets = await get_authorized_existing_datasets(datasets, "read", user)
             datasets = [dataset.id for dataset in datasets]
             if not datasets:
@@ -324,6 +334,7 @@ async def search(
             wide_search_top_k=wide_search_top_k,
             triplet_distance_penalty=triplet_distance_penalty,
             feedback_influence=feedback_influence,
+            persist_trace=persist_trace,
             verbose=verbose,
             retriever_specific_config=retriever_specific_config,
             neighborhood_depth=neighborhood_depth,

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -46,7 +46,9 @@ class CloudClient:
 
     # ----- V2 Operations -----
 
-    async def remember(self, data: Any, dataset_name: str = "main_dataset", **kwargs) -> dict:
+    async def remember(
+        self, data: Any, dataset_name: str = "main_dataset", **kwargs
+    ) -> dict:
         """POST /api/v1/remember — ingest data and build knowledge graph."""
         session = await self._get_session()
 
@@ -90,7 +92,9 @@ class CloudClient:
             name = getattr(data, "name", "upload")
             form.add_field("data", data, filename=name)
 
-        async with session.post(f"{self.service_url}/api/v1/remember", data=form) as resp:
+        async with session.post(
+            f"{self.service_url}/api/v1/remember", data=form
+        ) as resp:
             if resp.status >= 400:
                 body = await resp.text()
                 raise RuntimeError(f"Remote remember failed ({resp.status}): {body}")
@@ -125,18 +129,26 @@ class CloudClient:
         ) as resp:
             if resp.status >= 400:
                 body = await resp.text()
-                raise RuntimeError(f"Remote remember_entry failed ({resp.status}): {body}")
+                raise RuntimeError(
+                    f"Remote remember_entry failed ({resp.status}): {body}"
+                )
             return await resp.json()
 
-    async def recall(self, query_text: str, query_type: Optional[str] = None, **kwargs) -> list:
+    async def recall(
+        self, query_text: str, query_type: Optional[str] = None, **kwargs
+    ) -> list:
         """POST /api/v1/recall — query the knowledge graph and/or session cache."""
         session = await self._get_session()
 
         payload: dict = {"query": query_text}
         if query_type:
-            payload["search_type"] = query_type if isinstance(query_type, str) else query_type.value
+            payload["search_type"] = (
+                query_type if isinstance(query_type, str) else query_type.value
+            )
         if kwargs.get("dataset_ids"):
-            payload["dataset_ids"] = [str(dataset_id) for dataset_id in kwargs["dataset_ids"]]
+            payload["dataset_ids"] = [
+                str(dataset_id) for dataset_id in kwargs["dataset_ids"]
+            ]
         elif kwargs.get("datasets"):
             payload["datasets"] = kwargs["datasets"]
         if kwargs.get("top_k"):
@@ -147,6 +159,8 @@ class CloudClient:
             payload["node_name"] = kwargs["node_name"]
         if kwargs.get("only_context"):
             payload["only_context"] = kwargs["only_context"]
+        if kwargs.get("persist_trace") is not None:
+            payload["persist_trace"] = kwargs["persist_trace"]
         if kwargs.get("verbose"):
             payload["verbose"] = kwargs["verbose"]
         if kwargs.get("session_id"):
@@ -190,7 +204,9 @@ class CloudClient:
 
     # ----- V1 Operations (add / cognify / search) -----
 
-    async def add(self, data: Any, dataset_name: str = "main_dataset", **kwargs) -> dict:
+    async def add(
+        self, data: Any, dataset_name: str = "main_dataset", **kwargs
+    ) -> dict:
         """POST /api/v1/add — ingest data into a dataset."""
         session = await self._get_session()
 
@@ -233,7 +249,9 @@ class CloudClient:
         payload: dict = {}
         if datasets:
             payload["datasets"] = (
-                [str(d) for d in datasets] if isinstance(datasets, list) else [str(datasets)]
+                [str(d) for d in datasets]
+                if isinstance(datasets, list)
+                else [str(datasets)]
             )
         if kwargs.get("run_in_background"):
             payload["run_in_background"] = True
@@ -276,11 +294,14 @@ class CloudClient:
             payload["nodeName"] = kwargs["node_name"]
         if kwargs.get("only_context") is not None:
             payload["onlyContext"] = kwargs["only_context"]
+        if kwargs.get("persist_trace") is not None:
+            payload["persistTrace"] = kwargs["persist_trace"]
         if kwargs.get("verbose") is not None:
             payload["verbose"] = kwargs["verbose"]
         if kwargs.get("skills") is not None:
             payload["skills"] = [
-                skill.name if hasattr(skill, "name") else str(skill) for skill in kwargs["skills"]
+                skill.name if hasattr(skill, "name") else str(skill)
+                for skill in kwargs["skills"]
             ]
         if kwargs.get("tools") is not None:
             payload["tools"] = kwargs["tools"]

--- a/cognee/modules/retrieval/graph_completion_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_retriever.py
@@ -7,7 +7,9 @@ from cognee.modules.retrieval.utils.validate_queries import validate_retriever_i
 from cognee.modules.graph.utils import resolve_edges_to_text
 from cognee.modules.graph.utils.convert_node_to_data_point import get_all_subclasses
 from cognee.modules.retrieval.base_retriever import BaseRetriever
-from cognee.modules.retrieval.utils.brute_force_triplet_search import brute_force_triplet_search
+from cognee.modules.retrieval.utils.brute_force_triplet_search import (
+    brute_force_triplet_search,
+)
 from cognee.modules.retrieval.utils.global_context import (
     format_global_context_prelude,
     load_root_text,
@@ -128,7 +130,9 @@ class GraphCompletionRetriever(BaseRetriever):
         triplets = await self.get_triplets(query, query_batch)
 
         # Check if all triplets are empty, in case of batch queries
-        if query_batch and all(len(batched_triplets) == 0 for batched_triplets in triplets):
+        if query_batch and all(
+            len(batched_triplets) == 0 for batched_triplets in triplets
+        ):
             logger.warning("Empty context was provided to the completion")
             return []
 
@@ -237,12 +241,17 @@ class GraphCompletionRetriever(BaseRetriever):
 
         if query_batch:
             # Check if all triplets are empty, in case of batch queries
-            if not triplets or all(len(batched_triplets) == 0 for batched_triplets in triplets):
+            if not triplets or all(
+                len(batched_triplets) == 0 for batched_triplets in triplets
+            ):
                 logger.warning("Empty context was provided to the completion")
                 return ["" for _ in query_batch]
 
             return await asyncio.gather(
-                *[self.resolve_edges_to_text(batched_triplets) for batched_triplets in triplets]
+                *[
+                    self.resolve_edges_to_text(batched_triplets)
+                    for batched_triplets in triplets
+                ]
             )
 
         graph_context = await self.resolve_edges_to_text(triplets) if triplets else ""
@@ -274,7 +283,9 @@ class GraphCompletionRetriever(BaseRetriever):
         )
         return format_global_context_prelude(root_text, top_summaries)
 
-    def _extract_context_object_ids(self, retrieved_objects: Any) -> Optional[Dict[str, List[str]]]:
+    def _extract_context_object_ids(
+        self, retrieved_objects: Any
+    ) -> Optional[Dict[str, List[str]]]:
         """Extract node_ids and edge_ids from list of Edge. Only used for single-query session path."""
         if not isinstance(retrieved_objects, list) or not retrieved_objects:
             return None
@@ -373,6 +384,38 @@ class GraphCompletionRetriever(BaseRetriever):
         # cites chunks that share nothing with it.
         return await self._append_graph_evidence(completions)
 
+    async def persist_context_trace(
+        self,
+        query: Optional[str] = None,
+        retrieved_objects: Optional[List[Edge]] = None,
+        context: str = None,
+    ) -> Optional[str]:
+        """Persist retrieval trace for context-only calls without generating an LLM answer."""
+        if not self._use_session_cache():
+            return None
+
+        used_graph_element_ids = self._extract_context_object_ids(retrieved_objects)
+        if used_graph_element_ids is None:
+            return None
+
+        user = session_user.get()
+        user_id = getattr(user, "id", None)
+        if user_id is None:
+            return None
+
+        if isinstance(context, list):
+            context = "\n".join(str(item) for item in context)
+
+        sm = get_session_manager()
+        return await sm.add_qa(
+            user_id=str(user_id),
+            session_id=self.session_id,
+            question=query or "",
+            context=context or "",
+            answer="",
+            used_graph_element_ids=used_graph_element_ids,
+        )
+
     async def get_completion(
         self, query: Optional[str] = None, query_batch: Optional[List[str]] = None
     ) -> List[Any]:
@@ -388,7 +431,9 @@ class GraphCompletionRetriever(BaseRetriever):
         """
         validate_retriever_input(query, query_batch)
 
-        retrieved_objects = await self.get_retrieved_objects(query=query, query_batch=query_batch)
+        retrieved_objects = await self.get_retrieved_objects(
+            query=query, query_batch=query_batch
+        )
         context = await self.get_context_from_objects(
             query=query, query_batch=query_batch, retrieved_objects=retrieved_objects
         )

--- a/cognee/modules/search/methods/get_retriever_output.py
+++ b/cognee/modules/search/methods/get_retriever_output.py
@@ -35,7 +35,9 @@ async def get_retriever_output(
     with new_span("cognee.retrieval.get_objects") as span:
         span.set_attribute("cognee.retrieval.retriever", retriever_class)
         span.set_attribute(COGNEE_SEARCH_TYPE, query_type.value)
-        retrieved_objects = await retriever_instance.get_retrieved_objects(query=query_text)
+        retrieved_objects = await retriever_instance.get_retrieved_objects(
+            query=query_text
+        )
         obj_count = _count_retrieved_objects(retrieved_objects)
         span.set_attribute(COGNEE_RESULT_COUNT, obj_count)
         span.set_attribute(
@@ -71,11 +73,28 @@ async def get_retriever_output(
                 context=context,
             )
             if isinstance(completion, str):
-                span.set_attribute("cognee.retrieval.completion_length", len(completion))
+                span.set_attribute(
+                    "cognee.retrieval.completion_length", len(completion)
+                )
             span.set_attribute(
                 COGNEE_RESULT_SUMMARY,
                 f"{retriever_class} generated completion",
             )
+    elif kwargs.get("persist_trace", False):
+        persist_context_trace = getattr(
+            retriever_instance, "persist_context_trace", None
+        )
+        if persist_context_trace is not None:
+            with new_span("cognee.retrieval.persist_context_trace") as span:
+                span.set_attribute("cognee.retrieval.retriever", retriever_class)
+                qa_id = await persist_context_trace(
+                    query=query_text,
+                    retrieved_objects=retrieved_objects,
+                    context=context,
+                )
+                span.set_attribute(
+                    "cognee.retrieval.trace_persisted", qa_id is not None
+                )
 
     search_result = SearchResultPayload(
         result_object=retrieved_objects,
@@ -85,7 +104,9 @@ async def get_retriever_output(
         only_context=kwargs.get("only_context", False),
         dataset_name=kwargs.get("dataset").name if kwargs.get("dataset") else None,
         dataset_id=kwargs.get("dataset").id if kwargs.get("dataset") else None,
-        dataset_tenant_id=kwargs.get("dataset").tenant_id if kwargs.get("dataset") else None,
+        dataset_tenant_id=(
+            kwargs.get("dataset").tenant_id if kwargs.get("dataset") else None
+        ),
     )
 
     return search_result
@@ -98,7 +119,9 @@ def _count_retrieved_objects(retrieved_objects) -> int:
         return len(retrieved_objects)
     if isinstance(retrieved_objects, dict):
         list_counts = [
-            len(value) for value in retrieved_objects.values() if isinstance(value, list)
+            len(value)
+            for value in retrieved_objects.values()
+            if isinstance(value, list)
         ]
         if list_counts:
             return sum(list_counts)

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -52,6 +52,7 @@ async def search(
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
     feedback_influence: float = 0.0,
+    persist_trace: bool = False,
     verbose=False,
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
@@ -81,8 +82,11 @@ async def search(
         user.id,
         additional_properties={
             "cognee_version": cognee_version,
-            "tenant_id": str(user.tenant_id) if user.tenant_id else "Single User Tenant",
+            "tenant_id": (
+                str(user.tenant_id) if user.tenant_id else "Single User Tenant"
+            ),
             "include_references": include_references,
+            "persist_trace": persist_trace,
         },
     )
 
@@ -111,6 +115,7 @@ async def search(
             wide_search_top_k=wide_search_top_k,
             triplet_distance_penalty=triplet_distance_penalty,
             feedback_influence=feedback_influence,
+            persist_trace=persist_trace,
             retriever_specific_config=retriever_specific_config,
             neighborhood_depth=neighborhood_depth,
             neighborhood_seed_top_k=neighborhood_seed_top_k,
@@ -126,7 +131,9 @@ async def search(
         user.id,
         additional_properties={
             "cognee_version": cognee_version,
-            "tenant_id": str(user.tenant_id) if user.tenant_id else "Single User Tenant",
+            "tenant_id": (
+                str(user.tenant_id) if user.tenant_id else "Single User Tenant"
+            ),
         },
     )
 
@@ -165,6 +172,7 @@ async def authorized_search(
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
     feedback_influence: float = 0.0,
+    persist_trace: bool = False,
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
@@ -198,6 +206,7 @@ async def authorized_search(
         wide_search_top_k=wide_search_top_k,
         triplet_distance_penalty=triplet_distance_penalty,
         feedback_influence=feedback_influence,
+        persist_trace=persist_trace,
         retriever_specific_config=retriever_specific_config,
         neighborhood_depth=neighborhood_depth,
         neighborhood_seed_top_k=neighborhood_seed_top_k,
@@ -225,6 +234,7 @@ async def search_in_datasets_context(
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
     feedback_influence: float = 0.0,
+    persist_trace: bool = False,
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
@@ -252,6 +262,7 @@ async def search_in_datasets_context(
         wide_search_top_k: Optional[int] = 100,
         triplet_distance_penalty: Optional[float] = 6.5,
         feedback_influence: float = 0.0,
+        persist_trace: bool = False,
         retriever_specific_config: Optional[dict] = None,
         neighborhood_depth: Optional[int] = None,
         neighborhood_seed_top_k: Optional[int] = None,
@@ -305,6 +316,7 @@ async def search_in_datasets_context(
                     wide_search_top_k=wide_search_top_k,
                     triplet_distance_penalty=triplet_distance_penalty,
                     feedback_influence=feedback_influence,
+                    persist_trace=persist_trace,
                     retriever_specific_config=retriever_specific_config,
                     neighborhood_depth=neighborhood_depth,
                     neighborhood_seed_top_k=neighborhood_seed_top_k,
@@ -331,6 +343,7 @@ async def search_in_datasets_context(
                     wide_search_top_k=wide_search_top_k,
                     triplet_distance_penalty=triplet_distance_penalty,
                     feedback_influence=feedback_influence,
+                    persist_trace=persist_trace,
                     retriever_specific_config=retriever_specific_config,
                     neighborhood_depth=neighborhood_depth,
                     neighborhood_seed_top_k=neighborhood_seed_top_k,
@@ -357,6 +370,7 @@ async def search_in_datasets_context(
             wide_search_top_k=wide_search_top_k,
             triplet_distance_penalty=triplet_distance_penalty,
             feedback_influence=feedback_influence,
+            persist_trace=persist_trace,
             retriever_specific_config=retriever_specific_config,
             neighborhood_depth=neighborhood_depth,
             neighborhood_seed_top_k=neighborhood_seed_top_k,

--- a/cognee/tests/unit/modules/retrieval/graph_completion_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/graph_completion_retriever_test.py
@@ -117,7 +117,9 @@ async def test_get_context_empty_results():
         ),
     ):
         mock_get_unified.return_value = _make_unified_mock(mock_graph_engine)
-        context = await retriever.get_context_from_objects(query="test query", retrieved_objects=[])
+        context = await retriever.get_context_from_objects(
+            query="test query", retrieved_objects=[]
+        )
 
     assert context == ""
 
@@ -135,7 +137,9 @@ async def test_get_context_empty_graph():
         new_callable=AsyncMock,
     ) as mock_get_unified:
         mock_get_unified.return_value = _make_unified_mock(mock_graph_engine)
-        context = await retriever.get_context_from_objects(query="test query", retrieved_objects=[])
+        context = await retriever.get_context_from_objects(
+            query="test query", retrieved_objects=[]
+        )
 
     assert context == ""
 
@@ -330,7 +334,9 @@ async def test_get_completion_with_session(mock_edge):
         mock_cache_config.return_value = mock_config
         mock_session_user.get.return_value = mock_user
         mock_sm = MagicMock()
-        mock_sm.generate_completion_with_session = AsyncMock(return_value="Generated answer")
+        mock_sm.generate_completion_with_session = AsyncMock(
+            return_value="Generated answer"
+        )
         mock_get_sm.return_value = mock_sm
 
         completion = await retriever.get_completion_from_context(
@@ -382,7 +388,9 @@ async def test_get_completion_with_session_passes_used_graph_element_ids(mock_ed
         mock_cache_config.return_value = mock_config
         mock_session_user.get.return_value = mock_user
         mock_sm = MagicMock()
-        mock_sm.generate_completion_with_session = AsyncMock(return_value="Generated answer")
+        mock_sm.generate_completion_with_session = AsyncMock(
+            return_value="Generated answer"
+        )
         mock_get_sm.return_value = mock_sm
 
         await retriever.get_completion_from_context(
@@ -400,6 +408,60 @@ async def test_get_completion_with_session_passes_used_graph_element_ids(mock_ed
     assert "node-1" in ids.get("node_ids", [])
     assert "node-2" in ids.get("node_ids", [])
     assert "edge-1" in ids.get("edge_ids", [])
+
+
+@pytest.mark.asyncio
+async def test_persist_context_trace_adds_session_qa_without_completion(mock_edge):
+    """Context-only trace persistence stores used graph IDs without calling the LLM path."""
+    mock_node1 = MagicMock()
+    mock_node1.id = "node-1"
+    mock_node2 = MagicMock()
+    mock_node2.id = "node-2"
+    mock_edge.node1 = mock_node1
+    mock_edge.node2 = mock_node2
+    mock_edge.attributes = {"edge_object_id": "edge-1"}
+
+    retriever = GraphCompletionRetriever(session_id="test_session")
+    mock_user = MagicMock()
+    mock_user.id = "test-user-id"
+
+    with (
+        patch(
+            "cognee.modules.retrieval.graph_completion_retriever.get_session_manager",
+        ) as mock_get_sm,
+        patch(
+            "cognee.modules.retrieval.graph_completion_retriever.CacheConfig"
+        ) as mock_cache_config,
+        patch(
+            "cognee.modules.retrieval.graph_completion_retriever.session_user"
+        ) as mock_session_user,
+    ):
+        mock_config = MagicMock()
+        mock_config.caching = True
+        mock_cache_config.return_value = mock_config
+        mock_session_user.get.return_value = mock_user
+        mock_sm = MagicMock()
+        mock_sm.add_qa = AsyncMock(return_value="qa-id")
+        mock_get_sm.return_value = mock_sm
+
+        qa_id = await retriever.persist_context_trace(
+            query="test query",
+            retrieved_objects=[mock_edge],
+            context="Resolved context",
+        )
+
+    assert qa_id == "qa-id"
+    mock_sm.add_qa.assert_awaited_once()
+    call_kw = mock_sm.add_qa.call_args.kwargs
+    assert call_kw["user_id"] == "test-user-id"
+    assert call_kw["session_id"] == "test_session"
+    assert call_kw["question"] == "test query"
+    assert call_kw["context"] == "Resolved context"
+    assert call_kw["answer"] == ""
+    assert call_kw["used_graph_element_ids"] == {
+        "node_ids": ["node-1", "node-2"],
+        "edge_ids": ["edge-1"],
+    }
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/search/test_get_retriever_output.py
+++ b/cognee/tests/unit/modules/search/test_get_retriever_output.py
@@ -1,4 +1,10 @@
+import importlib
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from cognee.modules.search.methods.get_retriever_output import _count_retrieved_objects
+from cognee.modules.search.types import SearchType
 
 
 def test_count_retrieved_objects_counts_structured_lists():
@@ -11,3 +17,50 @@ def test_count_retrieved_objects_preserves_existing_shapes():
     assert _count_retrieved_objects({"triplets": []}) == 0
     assert _count_retrieved_objects({"metadata": "value"}) == 1
     assert _count_retrieved_objects("answer") == 1
+
+
+@pytest.mark.asyncio
+async def test_only_context_persist_trace_skips_completion(monkeypatch):
+    retriever_output_module = importlib.import_module(
+        "cognee.modules.search.methods.get_retriever_output"
+    )
+
+    graph_engine = MagicMock()
+    graph_engine.is_empty = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        retriever_output_module,
+        "get_graph_engine",
+        AsyncMock(return_value=graph_engine),
+    )
+    monkeypatch.setattr(
+        retriever_output_module,
+        "update_node_access_timestamps",
+        AsyncMock(),
+    )
+
+    retriever = MagicMock()
+    retriever.get_retrieved_objects = AsyncMock(return_value=["edge"])
+    retriever.get_context_from_objects = AsyncMock(return_value="resolved context")
+    retriever.get_completion_from_context = AsyncMock(return_value=["answer"])
+    retriever.persist_context_trace = AsyncMock(return_value="qa-id")
+    monkeypatch.setattr(
+        retriever_output_module,
+        "get_search_type_retriever_instance",
+        AsyncMock(return_value=retriever),
+    )
+
+    result = await retriever_output_module.get_retriever_output(
+        query_type=SearchType.GRAPH_COMPLETION,
+        query_text="test query",
+        only_context=True,
+        persist_trace=True,
+    )
+
+    assert result.context == "resolved context"
+    assert result.completion is None
+    retriever.get_completion_from_context.assert_not_awaited()
+    retriever.persist_context_trace.assert_awaited_once_with(
+        query="test query",
+        retrieved_objects=["edge"],
+        context="resolved context",
+    )


### PR DESCRIPTION
﻿## Summary
- add an opt-in `persist_trace` flag for context-only search and recall calls
- persist retrieved graph element IDs to the session cache without generating an LLM completion
- wire the flag through SDK/API/cloud-client paths and add focused unit coverage

## Why
When `only_context=True`, Cognee skips completion generation. That also meant graph trace metadata was not saved, so later feedback/improve flows could not know which graph elements were used for the returned context.

## Validation
- `.\.venv\Scripts\python -m pytest cognee\tests\unit\modules\retrieval\graph_completion_retriever_test.py cognee\tests\unit\modules\search\test_get_retriever_output.py -q`
- `.\.venv\Scripts\python -m py_compile cognee\modules\retrieval\graph_completion_retriever.py cognee\modules\search\methods\get_retriever_output.py cognee\modules\search\methods\search.py cognee\api\v1\search\search.py cognee\api\v1\search\routers\get_search_router.py cognee\api\v1\recall\recall.py cognee\api\v1\recall\routers\get_recall_router.py cognee\api\v1\serve\cloud_client.py cognee\tests\unit\modules\retrieval\graph_completion_retriever_test.py cognee\tests\unit\modules\search\test_get_retriever_output.py`
- `git diff --check`

Fixes #2910
