### PR TITLE
fix(pipelines): bound run_info data to prevent unbounded pipeline_runs growth

### DIFF
--- a/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
@@ -1,19 +1,15 @@
 from uuid import UUID
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.modules.data.models import Data
 from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
 from typing import Any
+
+from cognee.modules.pipelines.utils import summarize_run_info_data
 
 
 async def log_pipeline_run_complete(
     pipeline_run_id: UUID, pipeline_id: UUID, pipeline_name: str, dataset_id: UUID, data: Any
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    data_info = summarize_run_info_data(data)
 
     pipeline_run = PipelineRun(
         pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/pipelines/operations/log_pipeline_run_error.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_error.py
@@ -1,8 +1,9 @@
 from uuid import UUID
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.modules.data.models import Data
 from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
 from typing import Any
+
+from cognee.modules.pipelines.utils import summarize_run_info_data
 
 
 async def log_pipeline_run_error(
@@ -13,12 +14,7 @@ async def log_pipeline_run_error(
     data: Any,
     e: Exception,
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    data_info = summarize_run_info_data(data)
 
     pipeline_run = PipelineRun(
         pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/pipelines/operations/log_pipeline_run_start.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_start.py
@@ -1,21 +1,15 @@
 from uuid import UUID
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.modules.data.models import Data
 from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
 from typing import Any
 
-from cognee.modules.pipelines.utils import generate_pipeline_run_id
+from cognee.modules.pipelines.utils import generate_pipeline_run_id, summarize_run_info_data
 
 
 async def log_pipeline_run_start(
     pipeline_id: UUID, pipeline_name: str, dataset_id: UUID, data: Any
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    data_info = summarize_run_info_data(data)
 
     pipeline_run_id = generate_pipeline_run_id(pipeline_id, dataset_id)
 

--- a/cognee/modules/pipelines/utils/__init__.py
+++ b/cognee/modules/pipelines/utils/__init__.py
@@ -1,2 +1,3 @@
 from .generate_pipeline_id import generate_pipeline_id
 from .generate_pipeline_run_id import generate_pipeline_run_id
+from .summarize_run_info_data import summarize_run_info_data

--- a/cognee/modules/pipelines/utils/summarize_run_info_data.py
+++ b/cognee/modules/pipelines/utils/summarize_run_info_data.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from cognee.modules.data.models import Data
+
+# ``run_info["data"]`` is audit-only metadata that is never read back from the
+# database. Persisting the full stringified payload makes the ``pipeline_runs``
+# table grow without bound, because large inputs (e.g. raw text passed to
+# ``add``/``cognify``) are stored verbatim on every run. Keep a bounded preview
+# instead so a single run cannot balloon the table.
+MAX_RUN_INFO_DATA_CHARS = 512
+
+
+def summarize_run_info_data(data: Any):
+    """Return a compact, size-bounded description of pipeline-run input data.
+
+    Lists of ``Data`` records are reduced to their ids; any other payload is
+    stringified and truncated so a single pipeline run cannot persist an
+    arbitrarily large ``run_info`` blob.
+    """
+    if not data:
+        return "None"
+    if isinstance(data, list) and all(isinstance(item, Data) for item in data):
+        return [str(item.id) for item in data]
+
+    text = str(data)
+    if len(text) > MAX_RUN_INFO_DATA_CHARS:
+        return f"{text[:MAX_RUN_INFO_DATA_CHARS]}... [truncated, {len(text)} chars total]"
+    return text

--- a/cognee/tests/unit/modules/pipelines/test_summarize_run_info_data.py
+++ b/cognee/tests/unit/modules/pipelines/test_summarize_run_info_data.py
@@ -1,0 +1,41 @@
+"""Tests for ``summarize_run_info_data``.
+
+Guards against unbounded growth of the ``pipeline_runs`` table: large
+payloads passed to ``add``/``cognify`` used to be stored verbatim in
+``run_info["data"]`` on every run, with no reader and no size limit. The
+helper now bounds that payload while preserving the existing behaviour for
+empty input and lists of ``Data`` records.
+"""
+
+from uuid import uuid4
+
+from cognee.modules.data.models import Data
+from cognee.modules.pipelines.utils import summarize_run_info_data
+from cognee.modules.pipelines.utils.summarize_run_info_data import MAX_RUN_INFO_DATA_CHARS
+
+
+def test_empty_data_is_summarized_as_none():
+    assert summarize_run_info_data(None) == "None"
+    assert summarize_run_info_data("") == "None"
+    assert summarize_run_info_data([]) == "None"
+
+
+def test_list_of_data_records_is_reduced_to_ids():
+    records = [Data(id=uuid4(), name="a"), Data(id=uuid4(), name="b")]
+    result = summarize_run_info_data(records)
+    assert result == [str(records[0].id), str(records[1].id)]
+
+
+def test_small_payload_is_preserved_verbatim():
+    text = "Session trace: a small amount of text"
+    assert summarize_run_info_data(text) == text
+
+
+def test_large_payload_is_truncated_and_bounded():
+    payload = "x" * (MAX_RUN_INFO_DATA_CHARS * 100)
+    result = summarize_run_info_data(payload)
+
+    assert result.startswith("x" * MAX_RUN_INFO_DATA_CHARS)
+    assert f"[truncated, {len(payload)} chars total]" in result
+    # The stored value must stay close to the cap, not scale with the input.
+    assert len(result) < MAX_RUN_INFO_DATA_CHARS + 64


### PR DESCRIPTION
## Description

While debugging a local out-of-memory I traced it to the `pipeline_runs` table in the SQLite store growing to several GB (~23k rows, ~280 KB each). Every pipeline run logs a `run_info` row, and `log_pipeline_run_start` / `complete` / `error` store the input payload via the `str(data)` fallback whenever `data` is not a list of `Data` records. In my case raw text passed to `add` / `remember` was being stored verbatim on every run.

That column is never read back from the database anywhere (the apparent readers operate on the in-memory `PipelineRunInfo` returned by `cognify()` and only use `.status` / `.pipeline_run_id`), so it is write-only audit data that grows without limit, and opening the store pulls it into process memory.

This is the same failure mode #2549 fixed for the `queries` / `results` search-history tables; `pipeline_runs` was not covered there.

The fix extracts the shared branch into `summarize_run_info_data()` and caps the stringified payload at 512 chars with a truncation marker that records the original length. Empty input still maps to `"None"`, and lists of `Data` records still reduce to their ids, so existing behaviour is unchanged for those cases.

Closes #3074.

## Acceptance Criteria

* `run_info["data"]` no longer stores unbounded payloads: large inputs are truncated to 512 chars followed by a `[truncated, N chars total]` marker.
* Existing behaviour preserved for empty input (`"None"`) and lists of `Data` (list of ids).
* New unit test covers empty / Data-list / small / large payloads.

Local test run:

```
cognee/tests/unit/modules/pipelines/test_summarize_run_info_data.py ....   [4 passed]
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
