### PR TITLE
fix(remember): content_type=skills via CloudClient uploads file bytes, not path strings

### DIFF
--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -814,6 +814,9 @@ async def _remember_inner(
         )
 
     if content_type == "skills":
+        import tempfile
+        from pathlib import Path as _Path
+
         from cognee.context_global_variables import set_database_global_context_variables
         from cognee.modules.engine.operations.setup import setup
         from cognee.modules.tools import add_skills
@@ -831,13 +834,53 @@ async def _remember_inner(
         if owner_id is None:
             raise ValueError("Skill ingestion requires a dataset owner or user.")
 
-        async with set_database_global_context_variables(dataset.id, owner_id):
-            skills = await add_skills(
-                data,
-                node_set=skills_node_set,
-                user=user,
-                dataset=dataset,
-            )
+        # HTTP callers (CloudClient + Swagger) deliver SKILL.md content as
+        # UploadFile/file-like objects, not paths. add_skills reads paths from
+        # the local filesystem, so materialize the uploads into a tempdir
+        # under cwd (which is always allowed by _configured_skill_source_roots)
+        # before handing off. Local SDK callers continue to pass a path.
+        skill_source: Any = data
+        tmp_dir: Optional[tempfile.TemporaryDirectory] = None
+        normalized_uploads: list = []
+        if isinstance(data, list):
+            for item in data:
+                if not isinstance(item, (str, _Path)) and hasattr(item, "read"):
+                    normalized_uploads.append(item)
+        elif data is not None and not isinstance(data, (str, _Path)) and hasattr(data, "read"):
+            normalized_uploads.append(data)
+
+        if normalized_uploads:
+            tmp_dir = tempfile.TemporaryDirectory(prefix="cognee-skills-", dir=_Path.cwd())
+            tmp_root = _Path(tmp_dir.name)
+            for upload in normalized_uploads:
+                rel_name = (
+                    getattr(upload, "filename", None) or getattr(upload, "name", None) or "SKILL.md"
+                )
+                # Defensive: reject absolute paths / traversal in client-sent names.
+                safe_rel = _Path(rel_name).as_posix().lstrip("/")
+                if ".." in _Path(safe_rel).parts:
+                    raise ValueError(f"Invalid skill filename: {rel_name}")
+                dest = tmp_root / safe_rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                # UploadFile.read() is async; plain file-like .read() is sync.
+                read_result = upload.read()
+                payload = await read_result if hasattr(read_result, "__await__") else read_result
+                if isinstance(payload, str):
+                    payload = payload.encode("utf-8")
+                dest.write_bytes(payload or b"")
+            skill_source = tmp_root
+
+        try:
+            async with set_database_global_context_variables(dataset.id, owner_id):
+                skills = await add_skills(
+                    skill_source,
+                    node_set=skills_node_set,
+                    user=user,
+                    dataset=dataset,
+                )
+        finally:
+            if tmp_dir is not None:
+                tmp_dir.cleanup()
         result = RememberResult(
             status="completed",
             dataset_name=dataset.name,

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -1,6 +1,7 @@
 """Remote HTTP client that proxies V2 operations to a Cognee Cloud instance."""
 
 import io
+from pathlib import Path
 from typing import Any, Optional
 from uuid import UUID
 
@@ -63,11 +64,33 @@ class CloudClient:
             form.add_field("chunk_size", str(kwargs["chunk_size"]))
         if kwargs.get("chunks_per_batch") is not None:
             form.add_field("chunks_per_batch", str(kwargs["chunks_per_batch"]))
-        if kwargs.get("content_type") is not None:
-            form.add_field("content_type", str(kwargs["content_type"]))
+        content_type_kw = kwargs.get("content_type")
+        if content_type_kw is not None:
+            form.add_field("content_type", str(content_type_kw))
 
+        # Skills are local SKILL.md files. The server's add_skills() reads
+        # paths from its own filesystem — sending the path string verbatim
+        # would have the server look for that path on the POD, not the
+        # caller. For content_type="skills", read each SKILL.md and upload
+        # its bytes so the server can write them to a tempdir.
+        if content_type_kw == "skills" and isinstance(data, (str, Path)):
+            source = Path(data).expanduser()
+            if source.is_file():
+                skill_files = [source] if source.name == "SKILL.md" else []
+            elif source.is_dir():
+                skill_files = sorted(source.rglob("SKILL.md"))
+            else:
+                raise FileNotFoundError(f"Skills source not found: {data}")
+            if not skill_files:
+                raise ValueError(f"No SKILL.md files under {data}")
+            base = source if source.is_dir() else source.parent
+            for skill_path in skill_files:
+                # Preserve relative structure so the server can reconstruct
+                # the SKILL.md layout when writing to its tempdir.
+                rel = skill_path.relative_to(base).as_posix()
+                form.add_field("data", skill_path.open("rb"), filename=rel)
         # Handle data — string or file-like objects
-        if isinstance(data, str):
+        elif isinstance(data, str):
             form.add_field(
                 "data",
                 io.BytesIO(data.encode("utf-8")),

--- a/cognee/tests/unit/api/test_cloud_client_skills_upload.py
+++ b/cognee/tests/unit/api/test_cloud_client_skills_upload.py
@@ -1,0 +1,148 @@
+"""CloudClient.remember(content_type='skills') reads local SKILL.md files
+and uploads their contents — not the path string.
+
+Before the fix, a remote ``cognee.remember("./skills", content_type="skills")``
+sent the literal string ``"./skills"`` (10 bytes) as the form body. The pod
+then handed an UploadFile containing that string to ``add_skills`` which
+rejected it with PermissionError because no such path exists pod-side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from cognee.api.v1.serve.cloud_client import CloudClient
+
+
+class _FakeResponse:
+    status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return {"status": "completed"}
+
+    async def text(self):
+        return ""
+
+
+class _FakeSession:
+    """Minimal aiohttp.ClientSession stand-in that captures the POST body."""
+
+    def __init__(self):
+        self.last_form = None
+        self.closed = False
+
+    def post(self, _url, data=None):
+        self.last_form = data
+        return _FakeResponse()
+
+    async def close(self):
+        self.closed = True
+
+
+def _form_field_dump(form):
+    """Extract (name, filename, body_bytes) tuples from an aiohttp.FormData."""
+    out = []
+    # FormData stores fields in ._fields (list of (type_options, headers, value))
+    for type_options, _headers, value in form._fields:
+        name = type_options.get("name")
+        filename = type_options.get("filename")
+        if hasattr(value, "read"):
+            body = value.read()
+        elif isinstance(value, (bytes, bytearray)):
+            body = bytes(value)
+        else:
+            body = str(value).encode("utf-8")
+        out.append((name, filename, body))
+    return out
+
+
+def test_remember_skills_with_file_path_uploads_bytes(tmp_path):
+    skill = tmp_path / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# Demo Skill\n\nDoes the thing.\n", encoding="utf-8")
+
+    client = CloudClient(service_url="https://example.test", api_key="k")
+    fake_session = _FakeSession()
+
+    async def run():
+        with patch.object(client, "_get_session", return_value=fake_session):
+            await client.remember(
+                str(tmp_path),
+                dataset_name="ds",
+                content_type="skills",
+            )
+
+    asyncio.run(run())
+
+    fields = _form_field_dump(fake_session.last_form)
+    skill_fields = [(name, fn, body) for name, fn, body in fields if name == "data"]
+    assert skill_fields, "expected at least one 'data' field"
+    # filename preserves the relative layout under the source dir
+    assert skill_fields[0][1] == "demo/SKILL.md", skill_fields[0][1]
+    # body is the FILE contents, not the path string
+    assert skill_fields[0][2].decode("utf-8").startswith("# Demo Skill"), skill_fields[0][2]
+    # content_type=skills made it onto the form
+    ct = [(name, body.decode("utf-8")) for name, _fn, body in fields if name == "content_type"]
+    assert ct == [("content_type", "skills")], ct
+
+
+def test_remember_skills_rejects_missing_source(tmp_path):
+    client = CloudClient(service_url="https://example.test", api_key="k")
+    fake_session = _FakeSession()
+
+    async def run():
+        with patch.object(client, "_get_session", return_value=fake_session):
+            await client.remember(
+                str(tmp_path / "nope"),
+                dataset_name="ds",
+                content_type="skills",
+            )
+
+    try:
+        asyncio.run(run())
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError for missing skills source")
+
+
+def test_remember_skills_rejects_empty_folder(tmp_path):
+    client = CloudClient(service_url="https://example.test", api_key="k")
+    fake_session = _FakeSession()
+
+    async def run():
+        with patch.object(client, "_get_session", return_value=fake_session):
+            await client.remember(
+                str(tmp_path),
+                dataset_name="ds",
+                content_type="skills",
+            )
+
+    try:
+        asyncio.run(run())
+    except ValueError as e:
+        assert "No SKILL.md files" in str(e)
+        return
+    raise AssertionError("expected ValueError for empty skills folder")
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp)
+        test_remember_skills_with_file_path_uploads_bytes(p)
+        # Fresh dir for the missing-source case
+    with tempfile.TemporaryDirectory() as tmp:
+        test_remember_skills_rejects_missing_source(Path(tmp))
+    with tempfile.TemporaryDirectory() as tmp:
+        test_remember_skills_rejects_empty_folder(Path(tmp))
+    print("OK")


### PR DESCRIPTION
## Summary

- `cognee.remember(path, content_type=\"skills\")` against a remote cloud was sending the literal path string as the request body. The pod then handed an `UploadFile` containing that string to `add_skills()`, which rejected it because `_resolve_skill_source_path()` can't resolve a path that doesn't exist on the pod's filesystem.
- `CloudClient` now reads local `SKILL.md` file/folder contents and uploads bytes, preserving relative paths in part filenames so the server can reconstruct the layout.
- The pod-side skills branch of `remember()` materializes any `UploadFile`/file-like data items to a tempdir under cwd (always allowed by `_configured_skill_source_roots()`) before calling `add_skills()`, and cleans up after. Local SDK calls that pass a path string keep working unchanged — they skip the tempdir hop.

## Why this matters

Today, *any* SaaS / cloud user trying to register skills via the SDK hits a `PermissionError` from `_resolve_skill_source_path()`. Local SDK use was fine; remote SDK + the Swagger multipart upload were both broken for `content_type=\"skills\"`.

## Test plan

- [x] New unit test `cognee/tests/unit/api/test_cloud_client_skills_upload.py` — verifies CloudClient sends file bytes (not the path string), preserves relative filenames, and raises on missing / empty sources.
- [x] `ruff check` + `ruff format` clean on changed files.
- [ ] Manual: `cognee.serve(url=..., api_key=...); cognee.remember(\"./skills\", content_type=\"skills\", dataset_name=\"X\")` against a dev tenant pod, then `GET /v1/skills?dataset_id=X` to confirm nodes landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)