### PR TITLE
fix(vector/lancedb): return [] from retrieve() for an empty id list

### DIFF
--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -906,6 +906,10 @@ class LanceDBAdapter(VectorDBInterface):
 
     async def retrieve(self, collection_name: str, data_point_ids: list[str]):
         """Return rows from `collection_name` whose id is in `data_point_ids`."""
+        if not data_point_ids:
+            # No ids requested. Avoid building an "id IN ()" filter, which lance
+            # rejects as a parse error; pgvector/chromadb return [] here too.
+            return []
         try:
             collection = await self.get_collection(collection_name)
         except CollectionNotFoundError:

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_lifecycle.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_lifecycle.py
@@ -114,6 +114,39 @@ async def test_close_is_idempotent(tmp_path):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_retrieve_empty_ids_returns_empty(monkeypatch, tmp_path):
+    """retrieve() with no ids must return [] rather than build an ``id IN ()``
+    filter, which lance rejects as a parse error (parity with pgvector/chromadb;
+    e.g. has_new_chunks() passes an empty id list when data_chunks is empty)."""
+
+    class _FakeQuery:
+        def where(self, *_args, **_kwargs):
+            return self
+
+        async def to_list(self):
+            # Rows the filter path would surface; the empty-id guard must
+            # short-circuit before we ever reach here.
+            return [{"id": "00000000-0000-0000-0000-000000000000", "payload": {"text": "x"}}]
+
+    class _FakeCollection:
+        def query(self):
+            return _FakeQuery()
+
+    async def _fake_get_collection(_name):
+        return _FakeCollection()
+
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "lance_db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+    monkeypatch.setattr(adapter, "get_collection", _fake_get_collection)
+
+    assert await adapter.retrieve("any_collection", []) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
 async def test_concurrent_first_get_connection_returns_same_object(monkeypatch, tmp_path):
     """Two coroutines reaching the lazy-create path simultaneously must
     end up returning the SAME ``self.connection`` object. Without the


### PR DESCRIPTION
## What

`LanceDBAdapter.retrieve()` builds an `id IN (...)` filter from `data_point_ids`. For an empty list that becomes `id IN ()`, which lance rejects:

```
RuntimeError: lance error: Invalid user input: Error parsing statement: ... WHERE id IN ()
```

This guards the empty case and returns `[]` before building the filter — matching the existing `len == 1` special-case that already works around lance's single-element-tuple SQL quirk.

## Why this is the correct behavior (validated against sibling adapters)

- **pgvector** — `range(0, len(ids), BATCH)` is `range(0, 0)` → no iterations → returns `[]`.
- Several other adapters guard explicitly (`opengauss`, `singlestore`: `if not data_point_ids: return []`) or loop over ids (empty loop → `[]`).
- `has_new_chunks()` reaches this path with an empty id list when `data_chunks` is empty.

lancedb was the outlier that crashed.

## Re-apply note

This re-applies #3077, which was merged to `main` and then reverted by #3082. It now lands on `dev`, the correct base branch per the repo branching policy.

## Test

Adds `test_retrieve_empty_ids_returns_empty` asserting `retrieve(collection, [])` returns `[]` and short-circuits before the filter path. Full `test_lancedb_lifecycle.py` suite: 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)