### PR TITLE
fix: initialize content_hash to avoid UnboundLocalError on seek failure

### DIFF
--- a/cognee/infrastructure/files/utils/get_file_metadata.py
+++ b/cognee/infrastructure/files/utils/get_file_metadata.py
@@ -47,6 +47,7 @@ async def get_file_metadata(file: BinaryIO, name: str | None = None) -> FileMeta
         - FileMetadata: A dictionary containing the file's name, path, MIME type, file
           extension, and content hash.
     """
+    content_hash = ""
     try:
         file.seek(0)
         content_hash = await get_file_content_hash(file)


### PR DESCRIPTION
## Bug

`get_file_metadata` raises `UnboundLocalError: cannot access local variable 'content_hash' before assignment` when the file object does not support `seek()`.

### Root cause

`content_hash` is assigned only inside the `try` block. When `file.seek(0)` raises `io.UnsupportedOperation`, the `except` block logs the error but never sets `content_hash`. The variable is then referenced unconditionally at the `return` statement.

```python
try:
    file.seek(0)
    content_hash = await get_file_content_hash(file)  # never reached
    file.seek(0)
except io.UnsupportedOperation as error:
    logger.error(...)  # content_hash still unbound

return FileMetadata(
    ...
    content_hash=content_hash,  # UnboundLocalError
)
```

## Fix

Initialize `content_hash = ""` before the `try` block so the return statement always has a valid value regardless of whether the hash computation succeeds.

## Test scenario

Any seekable wrapper (e.g. `io.RawIOBase` subclass without `seek`) or a network stream passed as `file` will trigger the crash. Initializing to `""` is consistent with the `FileMetadata` type which declares `content_hash: str`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)