### PR TITLE
fix: add early returns for md/json/xml/yaml in guess_file_type

### DIFF
--- a/cognee/infrastructure/files/utils/guess_file_type.py
+++ b/cognee/infrastructure/files/utils/guess_file_type.py
@@ -57,16 +57,24 @@ def guess_file_type(file: BinaryIO, name: str | None = None) -> filetype.Type:
         return file_type
 
     if ext in [".csv"]:
-        file_type = Type("text/csv", "csv")
-        return file_type
+        return Type("text/csv", "csv")
+
+    if ext in [".md", ".markdown"]:
+        return Type("text/markdown", "md")
+
+    if ext in [".json"]:
+        return Type("application/json", "json")
+
+    if ext in [".xml"]:
+        return Type("application/xml", "xml")
+
+    if ext in [".yaml", ".yml"]:
+        return Type("application/yaml", "yaml")
 
     file_type = filetype.guess(file)
 
     # If file type could not be determined consider it a plain text file as they don't have magic number encoding
     if file_type is None:
         file_type = Type("text/plain", "txt")
-
-    if file_type is None:
-        raise FileTypeException(f"Unknown file detected: {file.name}.")
 
     return file_type


### PR DESCRIPTION
## Bug

`guess_file_type` returns `text/plain` for `.md`, `.json`, `.xml`, `.yaml`, and `.yml` files instead of their correct MIME types.

### Root cause

`filetype.guess()` uses magic-byte signatures and returns `None` for text-based formats that have no binary header. The function already handled `.txt`, `.text`, and `.csv` with extension-based early returns, but left the rest to fall through:

```python
file_type = filetype.guess(file)  # returns None for .json, .md, .yaml, .xml

if file_type is None:
    file_type = Type("text/plain", "txt")  # wrong for all of them
```

This means a JSON file ingested by cognee is tagged as `text/plain` with extension `txt`, which breaks downstream pipeline steps that branch on MIME type.

A secondary dead-code issue: after the unconditional assignment above, the following check can never be True and was removed:

```python
if file_type is None:  # unreachable
    raise FileTypeException(...)
```

## Fix

Add extension-based early returns for the missing text formats, consistent with the existing `.txt`/`.csv` pattern:

| Extension | MIME type |
|-----------|-----------|
| `.md`, `.markdown` | `text/markdown` |
| `.json` | `application/json` |
| `.xml` | `application/xml` |
| `.yaml`, `.yml` | `application/yaml` |

Remove the unreachable `raise FileTypeException` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)