### PR TITLE
fix(permissions): resolve user against a live session (fixes DetachedInstanceError in background remember/cognify/memify)

### DIFF
--- a/cognee/modules/users/permissions/methods/get_all_user_permission_datasets.py
+++ b/cognee/modules/users/permissions/methods/get_all_user_permission_datasets.py
@@ -18,18 +18,28 @@ async def get_all_user_permission_datasets(user: User, permission_type: str) -> 
     Returns:
         list[Dataset]: List of datasets user has permission for
     """
+    # Re-resolve the user within this call so `tenants`/`roles` are eager-loaded
+    # against a live session. Callers may pass a User that's detached from its
+    # original session — e.g. the asyncio background tasks spawned by
+    # remember/cognify/memify(run_in_background=True) — where lazy-loading
+    # `awaitable_attrs.tenants` would raise DetachedInstanceError. get_user()
+    # selectinloads roles + tenants, so the reads below need no live session.
+    from cognee.modules.users.methods.get_user import get_user
+
+    resolved_user = await get_user(user.id) or user
+
     datasets = list()
     # Get all datasets User has explicit access to
-    datasets.extend(await get_principal_datasets(user, permission_type))
+    datasets.extend(await get_principal_datasets(resolved_user, permission_type))
 
     # Get all tenants user is a part of
-    tenants = await user.awaitable_attrs.tenants
+    tenants = await resolved_user.awaitable_attrs.tenants
     for tenant in tenants:
         # Get all datasets all tenant members have access to
         datasets.extend(await get_principal_datasets(tenant, permission_type))
 
         # Get all datasets accessible by roles user is a part of
-        roles = await user.awaitable_attrs.roles
+        roles = await resolved_user.awaitable_attrs.roles
         for role in roles:
             datasets.extend(await get_principal_datasets(role, permission_type))
 
@@ -42,7 +52,7 @@ async def get_all_user_permission_datasets(user: User, permission_type: str) -> 
     # Filter out dataset that aren't part of the selected user's tenant
     filtered_datasets = []
     for dataset in list(unique.values()):
-        if dataset.tenant_id == user.tenant_id:
+        if dataset.tenant_id == resolved_user.tenant_id:
             filtered_datasets.append(dataset)
 
     return filtered_datasets


### PR DESCRIPTION
## Problem

`get_all_user_permission_datasets` lazy-loads `user.tenants` / `user.roles` via `awaitable_attrs` off the **passed-in** `User`. When that `User` is **detached** from its DB session, this raises:

```
DetachedInstanceError: <User> is not bound to a Session; lazy load of 'tenants' cannot proceed
```

This happens on every `run_in_background=True` ingestion under access control: the request session that loaded `user` is closed by the time the `asyncio` background task runs the permission check. The background task aborts and the failure is silent (the caller already received its "running" result), so the operation appears to do nothing.

It is **not** remember-specific — this helper is reached by `get_authorized_existing_datasets` / `get_specific_user_permission_datasets`, so `cognify(run_in_background=True)` and `memify(run_in_background=True)` hit it too.

## Fix (at the source)

Re-resolve the user inside the helper via `get_user(user.id)` — which `selectinload`s `roles` + `tenants` — and read tenants/roles from that. The reads then need no live session, so the helper is correct whether or not the caller's `User` is attached. `get_principal_datasets` only needs `principal.id`, so it's unaffected.

This replaces the earlier remember-only approach (reloading the user inside `_remember_background`) with a single fix at the shared permission layer, so all callers benefit.

## Scope / relationship

- Independent of #3095 (closed-file). For background `remember` of a **file** under multi-tenant, both are needed: #3095 keeps the upload stream readable, this PR keeps the permission check from crashing on a detached user.

## Verification

The equivalent reload (verified earlier in a multi-tenant deployment) eliminates the `DetachedInstanceError`; this moves that same resolution into the shared helper.