### PR TITLE
fix(remember): materialize uploads before background ingestion (closed-file)

### DIFF
--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -1063,6 +1063,35 @@ async def _remember_inner(
             await improve(**improve_kwargs)
 
     if run_in_background:
+        import os
+        import tempfile
+        from pathlib import Path as _Path
+
+        # The request closes UploadFile / file-like inputs as soon as it returns,
+        # but the background task reads them afterwards -> "I/O operation on closed
+        # file" and the upload silently ingests nothing. Materialize file-like
+        # uploads to on-disk temp copies NOW (still inside the request) so the
+        # background task ingests stable files; clean them up once it finishes.
+        _bg_tmp_dir: Optional[tempfile.TemporaryDirectory] = None
+        _items = data if isinstance(data, list) else [data]
+        if any(not isinstance(it, (str, _Path)) and hasattr(it, "read") for it in _items):
+            _bg_tmp_dir = tempfile.TemporaryDirectory(prefix="cognee-remember-")
+            _root = _Path(_bg_tmp_dir.name)
+            _materialized = []
+            for it in _items:
+                if not isinstance(it, (str, _Path)) and hasattr(it, "read"):
+                    _raw = it.read()
+                    _content = await _raw if hasattr(_raw, "__await__") else _raw
+                    if isinstance(_content, str):
+                        _content = _content.encode("utf-8")
+                    _name = getattr(it, "filename", None) or getattr(it, "name", None) or "upload"
+                    _safe = os.path.basename(_Path(str(_name)).as_posix()) or "upload"
+                    _dest = _root / _safe
+                    _dest.write_bytes(_content or b"")
+                    _materialized.append(str(_dest))
+                else:
+                    _materialized.append(it)
+            data = _materialized if isinstance(data, list) else _materialized[0]
 
         async def _remember_background():
             try:
@@ -1070,6 +1099,9 @@ async def _remember_inner(
             except Exception as exc:
                 result._fail(exc)
                 logger.exception("Background remember failed")
+            finally:
+                if _bg_tmp_dir is not None:
+                    _bg_tmp_dir.cleanup()
 
         result._task = asyncio.create_task(_remember_background())
         return result


### PR DESCRIPTION
## Problem

`remember(..., run_in_background=True)` with a file / `UploadFile` input **silently ingests nothing**. The HTTP request closes the upload stream as soon as it returns, but the background task reads it afterwards:

```
Item 0 failed: I/O operation on closed file.
PipelineRunFailedError: Pipeline run failed. Data item could not be processed. (422)
```

No data is added and no graph is built — and because the caller already received its "running" result, the failure is only visible in logs. This is what breaks "upload a file" in a hosted/API setting where `run_in_background=True` is the norm.

## Fix

Before scheduling the background task (i.e. **still inside the request**, while the streams are open), materialize any file-like / `UploadFile` items to on-disk temp copies, preserving the original filename, and hand those stable paths to `add`/`cognify`. The temp dir is cleaned up when the task finishes. This mirrors the existing `content_type="skills"` materialization in this same module.

Blocking mode (`run_in_background=False`) is untouched — the streams are still open there.

## Repro

`POST /api/v1/remember` with a file upload + `run_in_background=true`:
- **Before:** background log shows `I/O operation on closed file` → `422`; dataset `data` stays empty.
- **After:** the upload is materialized in-request, so the background `add`/`cognify` ingests the file normally.

Independent of (and complementary to) the detached-user background fix in #3092.