### PR TITLE
fix(storage): fall back to boto3 credential chain in S3FileStorage when AWS creds are absent

### DIFF
--- a/cognee/infrastructure/files/storage/S3FileStorage.py
+++ b/cognee/infrastructure/files/storage/S3FileStorage.py
@@ -49,7 +49,16 @@ class S3FileStorage(Storage):
                 client_kwargs={"region_name": s3_config.aws_region},
             )
         else:
-            raise ValueError("S3 credentials are not set in the configuration.")
+            # No static credentials configured: fall back to boto3's default
+            # credential chain (ECS task role, EC2 instance metadata, environment
+            # variables, ~/.aws/credentials) by omitting key/secret. This lets
+            # S3 storage work on AWS-managed compute (ECS Fargate/EC2/Lambda)
+            # where credentials come from IAM roles. s3fs resolves them lazily.
+            self.s3 = s3fs.S3FileSystem(
+                anon=False,
+                endpoint_url=s3_config.aws_endpoint_url,
+                client_kwargs={"region_name": s3_config.aws_region},
+            )
 
     async def store(self, file_path: str, data: BinaryIO | str, overwrite: bool = False) -> str:
         """

--- a/cognee/tests/unit/infrastructure/files/storage/test_s3_credential_chain.py
+++ b/cognee/tests/unit/infrastructure/files/storage/test_s3_credential_chain.py
@@ -1,0 +1,98 @@
+"""Unit tests for S3FileStorage credential handling.
+
+Covers the IAM-role fallback (issue #3086): when no static AWS credentials are
+configured, S3FileStorage must construct s3fs.S3FileSystem without key/secret so
+boto3's default credential chain (ECS task role, EC2 instance metadata,
+environment variables, ~/.aws/credentials) resolves them, instead of raising
+ValueError. This is what makes S3 storage usable on ECS Fargate / EC2 / Lambda.
+
+No real AWS credentials or network access are required: s3fs.S3FileSystem is
+replaced with a recording stand-in.
+"""
+
+import pytest
+import s3fs
+
+import cognee.infrastructure.files.storage.S3FileStorage as s3_storage_module
+from cognee.infrastructure.files.storage.S3FileStorage import S3FileStorage
+from cognee.infrastructure.files.storage.s3_config import S3Config
+
+
+class _RecordingS3FileSystem:
+    """Stand-in for s3fs.S3FileSystem that records how it was constructed."""
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _RecordingS3FileSystem.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def _reset_recorder():
+    _RecordingS3FileSystem.instances.clear()
+    yield
+    _RecordingS3FileSystem.instances.clear()
+
+
+def _clear_aws_credential_env(monkeypatch):
+    """Make the no-credentials case deterministic on hosts that have AWS env set."""
+    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_falls_back_to_boto3_credential_chain_when_no_static_credentials(monkeypatch):
+    """With no key/secret configured, S3FileStorage must not raise and must let
+    boto3 resolve credentials by omitting key/secret from s3fs.S3FileSystem."""
+    _clear_aws_credential_env(monkeypatch)
+    monkeypatch.setattr(
+        s3_storage_module,
+        "get_s3_config",
+        lambda: S3Config(
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+        ),
+    )
+    monkeypatch.setattr(s3fs, "S3FileSystem", _RecordingS3FileSystem)
+
+    # Must not raise: IAM-role deployments (ECS/EC2/Lambda) depend on this path.
+    storage = S3FileStorage("test-bucket")
+
+    assert len(_RecordingS3FileSystem.instances) == 1
+    used_kwargs = _RecordingS3FileSystem.instances[0].kwargs
+
+    # Omitting key/secret is what lets boto3's credential chain run.
+    assert "key" not in used_kwargs
+    assert "secret" not in used_kwargs
+    # anon must stay False: we want real credentials, not anonymous access.
+    assert used_kwargs["anon"] is False
+    # Connection settings from the explicit-credentials path are preserved.
+    assert "endpoint_url" in used_kwargs
+    assert "client_kwargs" in used_kwargs
+    assert storage.storage_path == "test-bucket"
+
+
+def test_uses_explicit_credentials_when_configured(monkeypatch):
+    """The explicit-credentials path keeps passing key/secret/token through."""
+    monkeypatch.setattr(
+        s3_storage_module,
+        "get_s3_config",
+        lambda: S3Config(
+            aws_access_key_id="KEYID",
+            aws_secret_access_key="SECRET",
+            aws_session_token="TOKEN",
+            aws_region="us-east-1",
+            aws_endpoint_url="https://example",
+        ),
+    )
+    monkeypatch.setattr(s3fs, "S3FileSystem", _RecordingS3FileSystem)
+
+    S3FileStorage("test-bucket")
+
+    assert len(_RecordingS3FileSystem.instances) == 1
+    used_kwargs = _RecordingS3FileSystem.instances[0].kwargs
+    assert used_kwargs["key"] == "KEYID"
+    assert used_kwargs["secret"] == "SECRET"
+    assert used_kwargs["token"] == "TOKEN"
+    assert used_kwargs["anon"] is False


### PR DESCRIPTION
Hi, this addresses #3086.

When `aws_access_key_id` and `aws_secret_access_key` aren't set, `S3FileStorage.__init__` raises `ValueError` instead of letting boto3 resolve credentials on its own. That breaks S3 storage anywhere credentials come from an IAM role rather than static keys, like ECS Fargate, EC2, and Lambda.

The change is small. In the no-credentials branch, instead of raising, I construct `s3fs.S3FileSystem` without `key`/`secret` (keeping `anon=False`, `endpoint_url`, and `region`). s3fs already knows how to discover credentials through boto3's default chain when those aren't passed, so IAM task roles, instance metadata, environment variables, and `~/.aws/credentials` all work. The existing explicit-credentials path is untouched.

I added a unit test under `cognee/tests/unit/infrastructure/files/storage/` that mocks `s3fs.S3FileSystem`, so it needs no real AWS credentials or network. It covers both branches: the fallback path no longer raises and does not pass `key`/`secret`, and the explicit path still forwards `key`/`secret`/`token`. The community unit suite passes locally.

Happy to adjust anything if you'd prefer a different approach or placement.

Closes #3086

---

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin
