### PR TITLE
fix(llm): enforce universal call timeout

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -57,6 +57,10 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 # LLM API version (needed for Azure OpenAI)
 #LLM_API_VERSION=""
 
+# Total wall-clock budget for one LLM operation, including provider and adapter retries.
+# Increase this for slow local models or providers. Must be greater than zero.
+#LLM_CALL_TIMEOUT_SECONDS=120
+
 # Extra kwargs passed to every LLM completion call (JSON string).
 # Examples: LLM_ARGS='{"max_tokens": 16384, "temperature": 0.7}'
 #LLM_ARGS='{}'

--- a/cognee/eval_framework/evaluation/metrics/rubric.py
+++ b/cognee/eval_framework/evaluation/metrics/rubric.py
@@ -10,17 +10,11 @@ Unlike DeepEval's GEval, this metric:
   - Does not require deepeval's GEval infrastructure
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
-
-
-def _get_llm_client():
-    from cognee.infrastructure.llm.get_llm_client import get_llm_client
-
-    return get_llm_client()
 
 
 _JUDGE_SYSTEM_PROMPT = """You are an evaluation judge. You will be given:
@@ -81,7 +75,7 @@ class RubricMetric:
             import concurrent.futures
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                result = pool.submit(asyncio.run, self.a_measure(test_case)).result()
+                result = cast(float, pool.submit(asyncio.run, self.a_measure(test_case)).result())
         else:
             result = asyncio.run(self.a_measure(test_case))
 
@@ -102,9 +96,9 @@ class RubricMetric:
             self._verdicts = []
             return self.score
 
-        llm_client = _get_llm_client()
+        from cognee.infrastructure.llm.LLMGateway import LLMGateway
 
-        verdicts = []
+        verdicts: List[Dict[str, Any]] = []
         satisfied = 0
 
         for criterion in rubric:
@@ -115,7 +109,7 @@ class RubricMetric:
             )
 
             try:
-                judge_response = await llm_client.acreate_structured_output(
+                judge_response = await LLMGateway.acreate_structured_output(
                     text_input=prompt,
                     system_prompt=_JUDGE_SYSTEM_PROMPT,
                     response_model=str,

--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -3,7 +3,8 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
-from cognee.infrastructure.llm import get_llm_config
+from cognee.infrastructure.llm.call_timeout import run_with_timeout
+from cognee.infrastructure.llm.config import get_llm_config, get_llm_context_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
 )
@@ -89,7 +90,12 @@ class LLMGateway:
 
         # Wrap so usage is recorded against any active session tracker.
         # No-op when no tracker is installed.
-        return _record_session_usage_after(inner, text_input=text_input)
+        bounded = run_with_timeout(
+            inner,
+            timeout_seconds=get_llm_context_config().llm_call_timeout_seconds,
+            operation="structured output generation",
+        )
+        return _record_session_usage_after(bounded, text_input=text_input)
 
     @staticmethod
     def create_transcript(input) -> Coroutine[Any, Any, TranscriptionReturnType | None]:
@@ -98,7 +104,12 @@ class LLMGateway:
         )
 
         llm_client = get_llm_client()
-        return llm_client.create_transcript(input=input)
+        llm_config = get_llm_context_config()
+        return run_with_timeout(
+            llm_client.create_transcript(input=input),
+            timeout_seconds=llm_config.llm_call_timeout_seconds,
+            operation="audio transcription",
+        )
 
     @staticmethod
     def transcribe_image(input: str) -> Coroutine[Any, Any, Any]:
@@ -107,4 +118,9 @@ class LLMGateway:
         )
 
         llm_client = get_llm_client()
-        return llm_client.transcribe_image(input=input)
+        llm_config = get_llm_context_config()
+        return run_with_timeout(
+            llm_client.transcribe_image(input=input),
+            timeout_seconds=llm_config.llm_call_timeout_seconds,
+            operation="image transcription",
+        )

--- a/cognee/infrastructure/llm/call_timeout.py
+++ b/cognee/infrastructure/llm/call_timeout.py
@@ -1,0 +1,41 @@
+import asyncio
+from collections.abc import Awaitable
+from typing import TypeVar
+
+from cognee.infrastructure.llm.exceptions import LLMCallTimeoutError
+
+T = TypeVar("T")
+
+
+def _consume_task_exception(task: asyncio.Future) -> None:
+    """Retrieve a detached task's exception so asyncio does not log it as unhandled."""
+    if task.cancelled():
+        return
+    try:
+        task.exception()
+    except asyncio.CancelledError:
+        pass
+
+
+async def run_with_timeout(awaitable: Awaitable[T], *, timeout_seconds: float, operation: str) -> T:
+    """Run an LLM operation with a hard deadline for the awaiting caller.
+
+    ``asyncio.wait_for`` waits for cancellation cleanup before raising. Some SDK retry
+    layers delay or suppress that cleanup, allowing a nominal timeout to overrun by
+    minutes. This race cancels the provider task at the deadline but does not wait for
+    it to acknowledge cancellation.
+    """
+    task = asyncio.ensure_future(awaitable)
+    try:
+        done, _ = await asyncio.wait((task,), timeout=timeout_seconds)
+    except asyncio.CancelledError:
+        task.cancel()
+        task.add_done_callback(_consume_task_exception)
+        raise
+
+    if task in done:
+        return task.result()
+
+    task.cancel()
+    task.add_done_callback(_consume_task_exception)
+    raise LLMCallTimeoutError(operation=operation, timeout_seconds=timeout_seconds)

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -3,7 +3,7 @@ import os
 from functools import lru_cache
 from typing import Any, ClassVar
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 try:
@@ -49,6 +49,7 @@ class LLMConfig(BaseSettings):
     llm_temperature: float = 0.0
     llm_streaming: bool = False
     llm_max_completion_tokens: int = 16384
+    llm_call_timeout_seconds: float = Field(default=120.0, gt=0)
 
     baml_llm_provider: str = "openai"
     baml_llm_model: str = "gpt-5-mini"
@@ -241,6 +242,7 @@ class LLMConfig(BaseSettings):
             "temperature": self.llm_temperature,
             "streaming": self.llm_streaming,
             "max_completion_tokens": self.llm_max_completion_tokens,
+            "call_timeout_seconds": self.llm_call_timeout_seconds,
             "transcription_model": self.transcription_model,
             "graph_prompt_path": self.graph_prompt_path,
             "rate_limit_enabled": self.llm_rate_limit_enabled,

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -5,6 +5,17 @@ class ContentPolicyFilterError(CogneeValidationError):
     pass
 
 
+class LLMCallTimeoutError(TimeoutError):
+    """Raised when an LLM operation exceeds its configured wall-clock budget."""
+
+    def __init__(self, operation: str, timeout_seconds: float) -> None:
+        self.operation = operation
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"LLM {operation} exceeded the {timeout_seconds:g} second wall-clock timeout."
+        )
+
+
 class LLMAPIKeyNotSetError(CogneeValidationError):
     """
     Raised when the LLM API key is not set in the configuration.

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
@@ -15,7 +15,7 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from cognee.infrastructure.llm.config import get_llm_config
+from cognee.infrastructure.llm.config import get_llm_config, get_llm_context_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
     GenericAPIAdapter,
 )
@@ -63,6 +63,7 @@ class AnthropicAdapter(GenericAPIAdapter):
             create=anthropic.AsyncAnthropic(
                 api_key=self.api_key,
                 http_client=anthropic.DefaultAsyncHttpxClient(http2=False),
+                timeout=get_llm_context_config().llm_call_timeout_seconds,
             ).messages.create,
             mode=instructor.Mode(self.instructor_mode),
         )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -24,6 +24,7 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.exceptions import ContentPolicyFilterError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai.adapter import (
     OpenAIAdapter,
@@ -151,15 +152,18 @@ class AzureOpenAIAdapter(OpenAIAdapter):
 
         # Create native Azure OpenAI clients with managed identity token provider
         azure_endpoint = endpoint.rstrip("/")
+        timeout = get_llm_context_config().llm_call_timeout_seconds
         azure_client = AzureOpenAIClient(
             azure_endpoint=azure_endpoint,
             azure_ad_token_provider=token_provider,
             api_version=self.api_version,
+            timeout=timeout,
         )
         azure_aclient = AsyncAzureOpenAI(
             azure_endpoint=azure_endpoint,
             azure_ad_token_provider=token_provider,
             api_version=self.api_version,
+            timeout=timeout,
         )
 
         self.client = instructor.from_openai(

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -1,5 +1,6 @@
 """Adapter for Generic API LLM provider API"""
 
+import asyncio
 import base64
 import logging
 import mimetypes
@@ -119,7 +120,11 @@ class GenericAPIAdapter(LLMInterface):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(8, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
+            (
+                litellm.exceptions.NotFoundError,
+                litellm.exceptions.AuthenticationError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -238,7 +243,11 @@ class GenericAPIAdapter(LLMInterface):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(2, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
+            (
+                litellm.exceptions.NotFoundError,
+                litellm.exceptions.AuthenticationError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -296,7 +305,11 @@ class GenericAPIAdapter(LLMInterface):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(2, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
+            (
+                litellm.exceptions.NotFoundError,
+                litellm.exceptions.AuthenticationError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -54,6 +54,7 @@ class _LLMClientCacheKey:
     instructor_mode: str
     streaming: bool
     max_completion_tokens: int
+    call_timeout_seconds: float
     transcription_model: str
     fallback_api_key_cache_key: _SecretCacheKey
     fallback_endpoint: str
@@ -168,6 +169,7 @@ def _build_llm_client_cache_key(llm_config, max_completion_tokens: int) -> _LLMC
         instructor_mode=llm_config.llm_instructor_mode.lower(),
         streaming=llm_config.llm_streaming,
         max_completion_tokens=max_completion_tokens,
+        call_timeout_seconds=llm_config.llm_call_timeout_seconds,
         transcription_model=llm_config.transcription_model,
         fallback_api_key_cache_key=_secret_cache_key(llm_config.fallback_api_key),
         fallback_endpoint=llm_config.fallback_endpoint,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/llama_cpp/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/llama_cpp/adapter.py
@@ -1,5 +1,6 @@
 """Adapter for Instructor-backed Structured Output Framework for Llama CPP"""
 
+import asyncio
 import logging
 import threading
 from typing import Any, cast
@@ -16,6 +17,7 @@ from tenacity import (
     stop_after_delay,
     wait_exponential_jitter,
 )
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
 )
@@ -144,7 +146,11 @@ class LlamaCppAPIAdapter(LLMInterface):
 
         # Use instructor.from_openai() for server mode (OpenAI-compatible API)
         self.aclient = instructor.from_openai(
-            AsyncOpenAI(base_url=self.endpoint, api_key=self.api_key),
+            AsyncOpenAI(
+                base_url=self.endpoint,
+                api_key=self.api_key,
+                timeout=get_llm_context_config().llm_call_timeout_seconds,
+            ),
             mode=instructor.Mode(self.instructor_mode),
         )
 
@@ -153,7 +159,11 @@ class LlamaCppAPIAdapter(LLMInterface):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(8, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
+            (
+                litellm.exceptions.NotFoundError,
+                litellm.exceptions.AuthenticationError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
@@ -16,7 +16,7 @@ from tenacity import (
 )
 
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
-from cognee.infrastructure.llm.config import get_llm_config
+from cognee.infrastructure.llm.config import get_llm_config, get_llm_context_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
     GenericAPIAdapter,
 )
@@ -178,12 +178,13 @@ class MistralAdapter(GenericAPIAdapter):
             transcription_model = self.transcription_model.split("/")[-1]
         file_name = input.split("/")[-1]
         async with open_data_file(input, mode="rb") as f:
-            transcription_response = self.mistral_client.audio.transcriptions.complete(
+            transcription_response = await self.mistral_client.audio.transcriptions.complete_async(
                 model=transcription_model,
                 file={
                     "content": f,
                     "file_name": file_name,
                 },
+                timeout_ms=int(get_llm_context_config().llm_call_timeout_seconds * 1000),
             )
 
             return TranscriptionReturnType(transcription_response.text, transcription_response)

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -16,6 +16,7 @@ from tenacity import (
 )
 
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
 )
@@ -73,7 +74,11 @@ class OllamaAPIAdapter(LLMInterface):
         self.instructor_mode = instructor_mode if instructor_mode else self.default_instructor_mode
 
         self.aclient = instructor.from_openai(
-            OpenAI(base_url=self.endpoint, api_key=self.api_key),
+            OpenAI(
+                base_url=self.endpoint,
+                api_key=self.api_key,
+                timeout=get_llm_context_config().llm_call_timeout_seconds,
+            ),
             mode=instructor.Mode(self.instructor_mode),
         )
 
@@ -114,8 +119,9 @@ class OllamaAPIAdapter(LLMInterface):
             - BaseModel: A structured output that conforms to the specified response model.
         """
         merged_kwargs = {**self.llm_args, **kwargs}
-        async with llm_rate_limiter_context_manager():
-            response = self.aclient.chat.completions.create(
+
+        def _create_completion() -> BaseModel:
+            return self.aclient.chat.completions.create(
                 model=self.model,
                 messages=[
                     {
@@ -131,6 +137,9 @@ class OllamaAPIAdapter(LLMInterface):
                 response_model=response_model,
                 **merged_kwargs,
             )
+
+        async with llm_rate_limiter_context_manager():
+            response = await asyncio.to_thread(_create_completion)
 
         return response
 
@@ -168,11 +177,15 @@ class OllamaAPIAdapter(LLMInterface):
         """
 
         async with open_data_file(input, mode="rb") as audio_file:
-            transcription = self.aclient.audio.transcriptions.create(
-                model="whisper-1",  # Ensure the correct model for transcription
-                file=audio_file,
-                language="en",
-            )
+
+            def _create_transcription() -> Any:
+                return self.aclient.audio.transcriptions.create(
+                    model="whisper-1",  # Ensure the correct model for transcription
+                    file=audio_file,
+                    language="en",
+                )
+
+            transcription = await asyncio.to_thread(_create_transcription)
 
         # Ensure the response contains a valid transcript
         if not hasattr(transcription, "text"):
@@ -216,22 +229,25 @@ class OllamaAPIAdapter(LLMInterface):
         async with open_data_file(input, mode="rb") as image_file:
             encoded_image = base64.b64encode(image_file.read()).decode("utf-8")
 
-        response = self.aclient.chat.completions.create(
-            model=self.model,
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": "What's in this image?"},
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": f"data:image/jpeg;base64,{encoded_image}"},
-                        },
-                    ],
-                }
-            ],
-            max_completion_tokens=300,
-        )  # ty:ignore[no-matching-overload]
+        def _create_image_completion() -> Any:
+            return self.aclient.chat.completions.create(  # ty:ignore[no-matching-overload]
+                model=self.model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "What's in this image?"},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": f"data:image/jpeg;base64,{encoded_image}"},
+                            },
+                        ],
+                    }
+                ],
+                max_completion_tokens=300,
+            )
+
+        response = await asyncio.to_thread(_create_image_completion)
 
         # Ensure response is valid before accessing .choices[0].message.content
         if (

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any
 
@@ -16,6 +17,7 @@ from tenacity import (
 )
 
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.exceptions import (
     ContentPolicyFilterError,
 )
@@ -111,7 +113,11 @@ class OpenAIAdapter(GenericAPIAdapter):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(8, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
+            (
+                litellm.exceptions.NotFoundError,
+                litellm.exceptions.AuthenticationError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -209,7 +215,11 @@ class OpenAIAdapter(GenericAPIAdapter):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(2, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
+            (
+                litellm.exceptions.NotFoundError,
+                litellm.exceptions.AuthenticationError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -233,8 +243,9 @@ class OpenAIAdapter(GenericAPIAdapter):
             The generated transcription of the audio file.
         """
 
+        kwargs.setdefault("timeout", get_llm_context_config().llm_call_timeout_seconds)
         async with open_data_file(input, mode="rb") as audio_file:
-            transcription = litellm.transcription(
+            transcription = await litellm.atranscription(
                 model=self.transcription_model,
                 file=audio_file,
                 api_key=self.api_key,

--- a/cognee/tests/unit/infrastructure/llm/test_adapter_timeouts.py
+++ b/cognee/tests/unit/infrastructure/llm/test_adapter_timeouts.py
@@ -1,0 +1,109 @@
+import asyncio
+import inspect
+import threading
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mistral import (
+    adapter as mistral_module,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mistral.adapter import (
+    MistralAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.ollama.adapter import (
+    OllamaAPIAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai import (
+    adapter as openai_module,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai.adapter import (
+    OpenAIAdapter,
+)
+
+
+class ResponseModel(BaseModel):
+    value: str
+
+
+@pytest.mark.asyncio
+async def test_openai_transcription_uses_async_api_and_native_timeout(monkeypatch, tmp_path):
+    captured = {}
+
+    async def fake_transcription(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(text="transcript")
+
+    monkeypatch.setattr(openai_module.litellm, "atranscription", fake_transcription)
+    monkeypatch.setattr(
+        openai_module,
+        "get_llm_context_config",
+        lambda: SimpleNamespace(llm_call_timeout_seconds=17.0),
+    )
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"audio")
+
+    adapter = OpenAIAdapter.__new__(OpenAIAdapter)
+    adapter.transcription_model = "whisper-1"
+    adapter.api_key = "test-key"
+    adapter.endpoint = "https://example.test"
+    adapter.api_version = None
+
+    result = await inspect.unwrap(OpenAIAdapter.create_transcript)(adapter, str(audio_path))
+
+    assert result.text == "transcript"
+    assert captured["timeout"] == 17.0
+
+
+@pytest.mark.asyncio
+async def test_mistral_transcription_uses_async_api_and_native_timeout(monkeypatch, tmp_path):
+    captured = {}
+
+    class Transcriptions:
+        async def complete_async(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(text="transcript")
+
+    monkeypatch.setattr(
+        mistral_module,
+        "get_llm_context_config",
+        lambda: SimpleNamespace(llm_call_timeout_seconds=17.5),
+    )
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"audio")
+
+    adapter = MistralAdapter.__new__(MistralAdapter)
+    adapter.transcription_model = "mistral/voxtral-mini"
+    adapter.mistral_client = SimpleNamespace(audio=SimpleNamespace(transcriptions=Transcriptions()))
+
+    result = await inspect.unwrap(MistralAdapter.create_transcript)(adapter, str(audio_path))
+
+    assert result.text == "transcript"
+    assert captured["timeout_ms"] == 17500
+
+
+@pytest.mark.asyncio
+async def test_ollama_sync_completion_does_not_block_event_loop():
+    call_thread = None
+
+    def create(**kwargs):
+        nonlocal call_thread
+        call_thread = threading.get_ident()
+        return ResponseModel(value="done")
+
+    adapter = OllamaAPIAdapter.__new__(OllamaAPIAdapter)
+    adapter.model = "ollama/test"
+    adapter.llm_args = {}
+    adapter.aclient = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    )
+
+    event_loop_thread = threading.get_ident()
+    result = await inspect.unwrap(OllamaAPIAdapter.acreate_structured_output)(
+        adapter, "input", "system", ResponseModel
+    )
+
+    assert result == ResponseModel(value="done")
+    assert call_thread is not None
+    assert call_thread != event_loop_thread

--- a/cognee/tests/unit/infrastructure/llm/test_call_timeout.py
+++ b/cognee/tests/unit/infrastructure/llm/test_call_timeout.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import pytest
+
+from cognee.infrastructure.llm.call_timeout import run_with_timeout
+from cognee.infrastructure.llm.exceptions import LLMCallTimeoutError
+
+
+@pytest.mark.asyncio
+async def test_run_with_timeout_returns_result():
+    async def complete():
+        return "done"
+
+    assert (
+        await run_with_timeout(complete(), timeout_seconds=1, operation="test completion") == "done"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_with_timeout_preserves_provider_exception():
+    provider_error = RuntimeError("provider failed")
+
+    async def fail():
+        raise provider_error
+
+    with pytest.raises(RuntimeError) as raised:
+        await run_with_timeout(fail(), timeout_seconds=1, operation="test completion")
+
+    assert raised.value is provider_error
+
+
+@pytest.mark.asyncio
+async def test_run_with_timeout_does_not_wait_for_cancellation_cleanup():
+    cleanup_finished = asyncio.Event()
+
+    async def delay_cancellation():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.2)
+            cleanup_finished.set()
+            raise
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    with pytest.raises(LLMCallTimeoutError, match="0.02 second") as raised:
+        await run_with_timeout(
+            delay_cancellation(), timeout_seconds=0.02, operation="test completion"
+        )
+
+    assert loop.time() - started < 0.15
+    assert raised.value.operation == "test completion"
+    assert raised.value.timeout_seconds == 0.02
+    await asyncio.wait_for(cleanup_finished.wait(), timeout=1)

--- a/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
+++ b/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
@@ -60,6 +60,7 @@ def test_llm_client_cache_key_covers_adapter_configuration_fields():
         _build_llm_client_cache_key(_llm_config(llm_api_key="other-secret"), 1024),
         _build_llm_client_cache_key(_llm_config(llm_api_version="2024-02-01"), 1024),
         _build_llm_client_cache_key(_llm_config(llm_streaming=True), 1024),
+        _build_llm_client_cache_key(_llm_config(llm_call_timeout_seconds=30), 1024),
         _build_llm_client_cache_key(_llm_config(fallback_api_key="other-fallback"), 1024),
         _build_llm_client_cache_key(_llm_config(fallback_endpoint="https://other.test"), 1024),
         _build_llm_client_cache_key(_llm_config(fallback_model="other-model"), 1024),

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config.py
@@ -44,3 +44,19 @@ def test_strip_quotes_from_strings():
 
     # Strings with internal quotes ("internal\"quotes" → internal"quotes")
     assert config.baml_llm_model == 'internal"quotes'
+
+
+def test_llm_call_timeout_defaults_to_120_seconds():
+    assert LLMConfig().llm_call_timeout_seconds == 120.0
+
+
+def test_llm_call_timeout_reads_environment(monkeypatch):
+    monkeypatch.setenv("LLM_CALL_TIMEOUT_SECONDS", "45.5")
+
+    assert LLMConfig(_env_file=None).llm_call_timeout_seconds == 45.5
+
+
+@pytest.mark.parametrize("timeout", [0, -1])
+def test_llm_call_timeout_must_be_positive(timeout):
+    with pytest.raises(ValueError):
+        LLMConfig(llm_call_timeout_seconds=timeout)

--- a/cognee/tests/unit/infrastructure/llm/test_llm_gateway_timeout.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_gateway_timeout.py
@@ -1,0 +1,110 @@
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.context_global_variables import llm_config as llm_config_context
+from cognee.infrastructure.llm.config import LLMConfig
+from cognee.infrastructure.llm.exceptions import LLMCallTimeoutError
+from cognee.infrastructure.llm.LLMGateway import LLMGateway
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client import (
+    _get_llm_client_cached,
+)
+
+gateway_module = importlib.import_module("cognee.infrastructure.llm.LLMGateway")
+
+
+class ResponseModel(BaseModel):
+    value: str
+
+
+class StallingLLMClient:
+    async def acreate_structured_output(self, **kwargs):
+        await asyncio.Event().wait()
+
+    async def create_transcript(self, **kwargs):
+        await asyncio.Event().wait()
+
+    async def transcribe_image(self, **kwargs):
+        await asyncio.Event().wait()
+
+
+@pytest.fixture
+def stalling_gateway(monkeypatch):
+    config = SimpleNamespace(
+        structured_output_framework="instructor",
+        llm_call_timeout_seconds=0.02,
+        llm_model="test-model",
+    )
+    monkeypatch.setattr(gateway_module, "get_llm_context_config", lambda: config)
+
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm import (
+        get_llm_client as client_module,
+    )
+
+    monkeypatch.setattr(client_module, "get_llm_client", lambda: StallingLLMClient())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operation", "expected_name"),
+    [
+        (
+            lambda: LLMGateway.acreate_structured_output("input", "system", ResponseModel),
+            "structured output generation",
+        ),
+        (lambda: LLMGateway.create_transcript("audio.wav"), "audio transcription"),
+        (lambda: LLMGateway.transcribe_image("image.png"), "image transcription"),
+    ],
+)
+async def test_gateway_bounds_every_llm_operation(stalling_gateway, operation, expected_name):
+    with pytest.raises(LLMCallTimeoutError) as raised:
+        await operation()
+
+    assert raised.value.operation == expected_name
+
+
+@pytest.mark.asyncio
+async def test_gateway_bounds_a_stalling_litellm_http_endpoint():
+    request_received = asyncio.Event()
+    release_connection = asyncio.Event()
+
+    async def stall_response(reader, writer):
+        try:
+            await reader.readuntil(b"\r\n\r\n")
+            request_received.set()
+            await release_connection.wait()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(stall_response, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    config = LLMConfig(
+        llm_provider="custom",
+        llm_model="openai/test-model",
+        llm_endpoint=f"http://127.0.0.1:{port}/v1",
+        llm_api_key="test-key",
+        llm_call_timeout_seconds=2.0,
+        llm_args={"num_retries": 0},
+    )
+    token = llm_config_context.set(config)  # ty:ignore[invalid-argument-type]
+    _get_llm_client_cached.cache_clear()
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    try:
+        with pytest.raises(LLMCallTimeoutError):
+            await LLMGateway.acreate_structured_output("input", "system", ResponseModel)
+
+        assert request_received.is_set()
+        assert loop.time() - started < 2.4
+    finally:
+        release_connection.set()
+        server.close()
+        await server.wait_closed()
+        await asyncio.sleep(0)
+        llm_config_context.reset(token)
+        _get_llm_client_cached.cache_clear()


### PR DESCRIPTION
## Description

Fixes #2995 by applying one configurable wall-clock budget to every LLM operation routed through `LLMGateway`, including structured completion, audio transcription, and image transcription.

The timeout is configured with `LLM_CALL_TIMEOUT_SECONDS` and defaults to 120 seconds. It covers the complete operation, including Instructor, LiteLLM, provider, and adapter retry layers. At the deadline, Cognee cancels the provider task and raises `LLMCallTimeoutError` immediately without waiting indefinitely for third-party cancellation cleanup.

This change also:

- prevents Tenacity from retrying cancelled Generic, OpenAI, and llama.cpp calls;
- configures native request timeouts for Anthropic, Azure OpenAI, Ollama, and llama.cpp server clients;
- uses native asynchronous transcription APIs for OpenAI and Mistral;
- moves Ollama's synchronous SDK calls off the event loop;
- routes rubric evaluation through `LLMGateway` so it receives the same timeout protection;
- includes the timeout in the LLM client cache key so context-specific budgets cannot reuse an incompatible native client.

## Acceptance Criteria

- [x] Completion, audio transcription, and image transcription share one configurable total deadline.
- [x] A stalled LiteLLM/Instructor HTTP request raises within the configured wall-clock budget.
- [x] Cancellation is not retried by adapter-level Tenacity decorators.
- [x] Native SDK and synchronous adapter paths cannot block the event loop indefinitely.
- [x] llama.cpp local mode does not receive an unsupported `timeout` keyword argument.
- [x] Slow backends can raise the positive `LLM_CALL_TIMEOUT_SECONDS` setting.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<!-- Add screenshots of the local test results before submitting, as required by CONTRIBUTING.md. -->

Local verification results:

```text
LLM unit tests: 26 passed
Broad unit suite: 2301 passed, 16 skipped, 11 deselected
Ruff check and format: passed
Focused ty check for changed files: passed
Pre-commit (all files): passed
```

The 11 deselected tests are existing local baseline failures unrelated to this change: one Windows currency-encoding assertion and ten retrieval tests whose mocks do not cover newer internal LLM calls. The complete suite initially reported those 11 failures plus two gateway-mocking compatibility failures introduced during development; the two related failures were fixed and explicitly rerun successfully.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
