### PR TITLE
fix(types): make run_custom_pipeline type-clean and enforce ty checks (#2681)

### DIFF
--- a/cognee/modules/run_custom_pipeline/run_custom_pipeline.py
+++ b/cognee/modules/run_custom_pipeline/run_custom_pipeline.py
@@ -12,10 +12,10 @@ logger = get_logger()
 
 
 async def run_custom_pipeline(
-    tasks: Union[List[Task], List[str]] = None,
+    tasks: Optional[Union[List[Task], List[str]]] = None,
     data: Any = None,
     dataset: Union[str, UUID] = "main_dataset",
-    user: User = None,
+    user: Optional[User] = None,
     vector_db_config: Optional[dict] = None,
     graph_db_config: Optional[dict] = None,
     use_pipeline_cache: bool = False,
@@ -54,7 +54,7 @@ async def run_custom_pipeline(
     """
 
     custom_tasks = [
-        *tasks,
+        *(tasks or []),
     ]
 
     # By calling get pipeline executor we get a function that will have the run_pipeline run in the background or a function that we will need to wait for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,8 @@ include = [
     "cognee/infrastructure/locks",
     "cognee/infrastructure/session",
     "cognee/infrastructure/utils",
-    "cognee/shared"
+    "cognee/shared",
+    "cognee/modules/run_custom_pipeline"
 ]
 # Exclude generated files
 exclude = ["cognee/infrastructure/llm/structured_output_framework/baml/baml_client/"]


### PR DESCRIPTION
### Summary

Continues the gradual `ty` type-checking rollout tracked in #2681 by making `cognee/modules/run_custom_pipeline` type-clean and adding it to the enforced `[tool.ty.src].include` set.

### Changes

- **Fix `invalid-parameter-default` errors**: `tasks` and `user` were annotated as non-optional but defaulted to `None`. Wrapped both in `Optional[...]` to match the actual default.
- **Fix a latent runtime bug**: with the default `tasks=None`, `[*tasks]` would raise `TypeError: argument of type 'NoneType' is not iterable`. Guarding with `*(tasks or [])` preserves behavior for valid inputs and makes the documented `None` default safe.
- **Enable type checking**: added `cognee/modules/run_custom_pipeline` to `[tool.ty.src].include`.

### Verification

- `uv run ty check .` → passes (exit 0)
- `uv run ruff check .` → passes
- `uv run ruff format --check .` → passes

Relates to #2681.
