### PR TITLE
fix(remember): store session text from file-upload payloads (#2888)

### DIFF
--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import time
 from uuid import UUID
 from typing import Union, BinaryIO, List, Optional, Any, Literal
@@ -106,35 +107,70 @@ def _estimate_data_size(data) -> int:
     return 0
 
 
-def _data_to_text(data) -> str:
-    """Convert ingested data to its full text representation."""
+async def _coerce_session_text(data) -> str:
+    """Extract chat-shaped text from remember() input for session storage.
+
+    Session memory stores chat-shaped content (prompts, assistant answers,
+    Q&A turns). The ``/api/v1/remember`` endpoint and the cognee-mcp client
+    always transport the payload as a multipart file upload — even when the
+    caller passed a plain string — so the real session text arrives here as a
+    file-like object. Read its content as UTF-8 text instead of dropping it.
+
+    Binary (non-UTF-8) or empty payloads decode to an empty string and are
+    skipped by the caller, so genuinely non-text uploads never pollute the
+    session cache.
+    """
     if isinstance(data, str):
         return data
-    if isinstance(data, list):
+    if isinstance(data, bytes):
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+    if isinstance(data, (list, tuple)):
         parts = []
         for item in data:
-            if isinstance(item, str):
-                parts.append(item)
-            elif hasattr(item, "name"):
-                parts.append(f"[file: {item.name}]")
-            else:
-                parts.append(f"[{type(item).__name__}]")
+            text = await _coerce_session_text(item)
+            if text and text.strip():
+                parts.append(text)
         return "\n\n".join(parts)
-    if hasattr(data, "name"):
-        return f"[file: {data.name}]"
-    return f"[{type(data).__name__}]"
 
-
-_SESSION_PLACEHOLDER_PREFIXES = ("[UploadFile]", "[file:", "[BinaryIO", "[SpooledTemporaryFile")
+    reader = getattr(data, "read", None)
+    if reader is None:
+        return ""
+    try:
+        raw = reader()
+        if inspect.isawaitable(raw):
+            raw = await raw
+    except Exception:
+        return ""
+    # Restore the stream position so the payload can still be read downstream.
+    seeker = getattr(data, "seek", None)
+    if seeker is not None:
+        try:
+            position = seeker(0)
+            if inspect.isawaitable(position):
+                await position
+        except Exception:
+            pass
+    if isinstance(raw, bytes):
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+    if isinstance(raw, str):
+        return raw
+    return ""
 
 
 async def _add_to_session(session_id: str, data, user):
     """Add a Q&A entry to the session cache.
 
-    Sessions store chat-shaped content (prompts, assistant answers,
-    Q&A turns). File-upload data coerces to placeholder strings like
-    ``[UploadFile]`` / ``[file: name]`` — those are useless in the
-    session cache and pollute recall results, so they're skipped.
+    Session memory stores chat-shaped content (prompts, assistant answers,
+    Q&A turns). The remember HTTP endpoint and the cognee-mcp client transport
+    the payload as a multipart file upload, so the text is read from the
+    uploaded file here (see ``_coerce_session_text``). Binary or empty payloads
+    yield no text and are skipped.
     """
     from cognee.infrastructure.session.get_session_manager import get_session_manager
 
@@ -147,15 +183,9 @@ async def _add_to_session(session_id: str, data, user):
     if not user_id:
         return
 
-    text = _data_to_text(data)
-    stripped = text.strip()
-    if not stripped:
-        return
-    if any(stripped.startswith(prefix) for prefix in _SESSION_PLACEHOLDER_PREFIXES):
-        logger.debug(
-            "remember: skipping session write for placeholder-only payload (%.40s…)",
-            stripped,
-        )
+    text = await _coerce_session_text(data)
+    if not text.strip():
+        logger.debug("remember: skipping session write for empty/non-text payload")
         return
 
     await sm.add_qa(

--- a/cognee/tests/unit/api/test_remember_session_text.py
+++ b/cognee/tests/unit/api/test_remember_session_text.py
@@ -1,0 +1,111 @@
+"""Regression tests for #2888.
+
+`remember(session_id=...)` over HTTP/MCP silently no-op'd: the client wraps the
+payload as a multipart file upload, and the session-storage path used to coerce
+file uploads to a placeholder string and skip the write. These tests pin that a
+file-upload payload is now read as text and stored in the session cache.
+"""
+
+import io
+
+import pytest
+
+from cognee.api.v1.remember.remember import _add_to_session, _coerce_session_text
+
+
+class _AsyncUpload:
+    """Minimal stand-in for starlette ``UploadFile`` (async read/seek)."""
+
+    def __init__(self, content: bytes, name: str = "upload.txt"):
+        self._buffer = io.BytesIO(content)
+        self.name = name
+
+    async def read(self, *args):
+        return self._buffer.read()
+
+    async def seek(self, position):
+        return self._buffer.seek(position)
+
+
+class _FakeSessionManager:
+    def __init__(self):
+        self.is_available = True
+        self.calls = []
+
+    async def add_qa(self, **kwargs):
+        self.calls.append(kwargs)
+        return "qa-id"
+
+
+class _User:
+    id = "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.mark.asyncio
+async def test_coerce_plain_string():
+    assert await _coerce_session_text("hello world") == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_coerce_bytes():
+    assert await _coerce_session_text(b"hi there") == "hi there"
+
+
+@pytest.mark.asyncio
+async def test_coerce_sync_file_like_restores_position():
+    file_like = io.BytesIO(b"session text content")
+    assert await _coerce_session_text(file_like) == "session text content"
+    # The stream position is restored so downstream readers see the full content.
+    assert file_like.tell() == 0
+
+
+@pytest.mark.asyncio
+async def test_coerce_async_upload_file():
+    upload = _AsyncUpload(b"uploaded session text")
+    assert await _coerce_session_text(upload) == "uploaded session text"
+
+
+@pytest.mark.asyncio
+async def test_coerce_list_of_uploads():
+    uploads = [_AsyncUpload(b"alpha"), _AsyncUpload(b"beta")]
+    assert await _coerce_session_text(uploads) == "alpha\n\nbeta"
+
+
+@pytest.mark.asyncio
+async def test_coerce_binary_payload_yields_empty():
+    # Non-UTF-8 bytes are treated as non-text; caller skips the write.
+    assert await _coerce_session_text(io.BytesIO(b"\xff\xfe\x00\x01")) == ""
+
+
+@pytest.mark.asyncio
+async def test_add_to_session_stores_uploaded_file_text(monkeypatch):
+    """The core #2888 regression: a file-upload payload must be stored."""
+    import sys
+    import cognee.infrastructure.session.get_session_manager  # noqa: F401  (ensure loaded)
+
+    module = sys.modules["cognee.infrastructure.session.get_session_manager"]
+    fake_sm = _FakeSessionManager()
+    monkeypatch.setattr(module, "get_session_manager", lambda: fake_sm)
+
+    upload = _AsyncUpload(b"remember this for the session")
+    await _add_to_session("sess-123", upload, _User())
+
+    assert len(fake_sm.calls) == 1
+    stored = fake_sm.calls[0]
+    assert stored["session_id"] == "sess-123"
+    assert stored["answer"] == "remember this for the session"
+    assert stored["user_id"] == _User.id
+
+
+@pytest.mark.asyncio
+async def test_add_to_session_skips_empty_payload(monkeypatch):
+    import sys
+    import cognee.infrastructure.session.get_session_manager  # noqa: F401  (ensure loaded)
+
+    module = sys.modules["cognee.infrastructure.session.get_session_manager"]
+    fake_sm = _FakeSessionManager()
+    monkeypatch.setattr(module, "get_session_manager", lambda: fake_sm)
+
+    await _add_to_session("sess-123", io.BytesIO(b""), _User())
+
+    assert fake_sm.calls == []


### PR DESCRIPTION
### Summary

Fixes #2888. `remember(session_id=...)` via HTTP/MCP returned `status="session_stored"` but wrote nothing to the session cache.

### Root cause

The cognee-mcp client and `POST /api/v1/remember` always transport the payload as a multipart **file upload** — even when the caller passed a plain string. The session-storage path (`_add_to_session`) coerced file uploads to a placeholder string (`[file: name]`) via `_data_to_text` and then skipped the write, so the documented `remember → recall → improve` workflow was broken through every HTTP path. Direct Python `cognee.remember(...)` calls were unaffected, which isolated the defect to the transport layer.

### Fix

`_add_to_session` now reads the uploaded file's content as UTF-8 text for the session entry (via a new `_coerce_session_text` helper) instead of dropping it:

- Handles `str`, `bytes`, file-like (sync **and** async `read`/`seek`, i.e. starlette `UploadFile`), and lists of these.
- Binary (non-UTF-8) or empty payloads decode to an empty string and are still skipped — genuinely non-text uploads never pollute the session cache.
- The stream position is restored after reading.
- The fix is contained to the session branch, whose only consumer of `data` is `_add_to_session` (the graph bridge runs via `improve(session_ids=...)`), so nothing downstream is affected.

### Tests

New `cognee/tests/unit/api/test_remember_session_text.py` covers `str`/`bytes`/sync-file/async-upload/list inputs, the binary-skip path, stream-position restoration, and the end-to-end `_add_to_session` regression (file upload → stored).

### Verification

- `uv run python -m pytest cognee/tests/unit/api/` → **209 passed** (incl. 8 new)
- `uv run ruff check .` / `ruff format --check .` → pass
- `uv run ty check .` → exit 0

Fixes #2888.
