### PR TITLE
fix(storage): prevent shallow-copy mutation in index_data_points

### DIFF
--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -36,7 +36,7 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
         data_point_type = type(data_point)
         type_name = data_point_type.__name__
 
-        for field_name in data_point.metadata["index_fields"]:
+        for field_name in list(data_point.metadata["index_fields"]):
             if getattr(data_point, field_name, None) is None:
                 continue
 
@@ -48,6 +48,7 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
                 data_points_by_type[type_name][field_name] = []
 
             indexed_data_point = data_point.model_copy()
+            indexed_data_point.metadata = dict(data_point.metadata)
             indexed_data_point.metadata["index_fields"] = [field_name]
             data_points_by_type[type_name][field_name].append(indexed_data_point)
 

--- a/cognee/tests/unit/tasks/storage/test_index_data_points.py
+++ b/cognee/tests/unit/tasks/storage/test_index_data_points.py
@@ -1,0 +1,28 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from cognee.infrastructure.engine import DataPoint
+from cognee.tasks.storage.index_data_points import index_data_points
+
+
+class MultiFieldPoint(DataPoint):
+    problem: str = ""
+    conclusion: str = ""
+    metadata: dict = {"index_fields": ["problem", "conclusion"]}
+
+
+@pytest.mark.asyncio
+async def test_index_data_points_indexes_every_field_without_mutating_original():
+    point = MultiFieldPoint(problem="PROBLEM_AAA", conclusion="CONCLUSION_BBB")
+    vector_engine = MagicMock()
+    vector_engine.create_vector_index = AsyncMock()
+    vector_engine.index_data_points = AsyncMock()
+    vector_engine.embedding_engine.get_batch_size.return_value = 10
+
+    await index_data_points([point], vector_engine=vector_engine)
+
+    indexed_field_names = {
+        call.args[1] for call in vector_engine.index_data_points.await_args_list
+    }
+    assert indexed_field_names == {"problem", "conclusion"}
+    assert point.metadata["index_fields"] == ["problem", "conclusion"]


### PR DESCRIPTION
## Summary
- `index_data_points` truncates a custom `DataPoint`'s embedded fields to just the first `index_fields` entry, because `model_copy()` performs a shallow copy and the per-field metadata mutation writes through to the original dict shared by all copies.
- Iterates over a `list(...)` snapshot of `index_fields` (instead of the live reference) and assigns a fresh `dict(...)` copy of `metadata` to each per-field clone before mutating it.

## Root cause
`indexed_data_point.metadata` and `data_point.metadata` pointed to the same dict object after `model_copy()`. Setting `indexed_data_point.metadata["index_fields"] = [field_name]` mutated the original's `index_fields` list in place, which also broke the `for field_name in data_point.metadata["index_fields"]` loop mid-iteration since it was iterating over the same list being shortened.

## Test plan
- [x] Added `test_index_data_points_indexes_every_field_without_mutating_original`, which fails on `main` (only the first field gets indexed and the original's `index_fields` is mutated) and passes with this fix.
- [x] `pytest cognee/tests/unit/tasks/storage/test_index_data_points.py cognee/tests/unit/tasks/storage/test_add_data_points.py`
- [x] `ruff check` / `ruff format` clean

Fixes #2529
