### PR TITLE
fix(ontology): try multiple RDF formats for file-object ontology input

### DIFF
--- a/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
+++ b/cognee/modules/ontology/rdf_xml/RDFLibOntologyResolver.py
@@ -57,11 +57,31 @@ class RDFLibOntologyResolver(BaseOntologyResolver):
                     for file_obj in file_objects:
                         try:
                             content = file_obj.read()
-                            self.graph.parse(data=content, format="xml")
-                            loaded_objects.append(file_obj)
-                            logger.info("Ontology loaded successfully from file object")
                         except Exception as e:
-                            logger.warning("Failed to parse ontology file object: %s", str(e))
+                            logger.warning("Failed to read ontology file object: %s", str(e))
+                            continue
+
+                        parsed = False
+                        for rdf_format in ("xml", "turtle", "n3", "json-ld"):
+                            try:
+                                candidate_graph = Graph()
+                                candidate_graph.parse(data=content, format=rdf_format)
+                            except Exception:
+                                continue
+                            self.graph += candidate_graph
+                            parsed = True
+                            logger.info(
+                                "Ontology loaded successfully from file object (format=%s)",
+                                rdf_format,
+                            )
+                            break
+
+                        if parsed:
+                            loaded_objects.append(file_obj)
+                        else:
+                            logger.warning(
+                                "Failed to parse ontology file object with any supported format (xml, turtle, n3, json-ld)"
+                            )
 
                     if not loaded_objects:
                         logger.info(

--- a/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
+++ b/cognee/tests/unit/modules/ontology/test_ontology_adapter.py
@@ -1,3 +1,5 @@
+from io import StringIO
+
 import pytest
 from rdflib import Graph, Namespace, RDF, OWL, RDFS
 from cognee.modules.ontology.rdf_xml.RDFLibOntologyResolver import RDFLibOntologyResolver
@@ -18,6 +20,24 @@ def test_ontology_adapter_initialization_file_not_found():
     """Test OntologyAdapter initialization with nonexistent file."""
     adapter = RDFLibOntologyResolver(ontology_file="nonexistent.owl")
     assert adapter.graph is None
+
+
+def test_ontology_adapter_loads_turtle_file_object():
+    """Turtle-serialized file objects should not be silently dropped (issue #2907)."""
+    turtle_content = """
+    @prefix : <http://example.org/test#> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+    :Car a owl:Class .
+    :Audi a :Car .
+    """
+
+    adapter = RDFLibOntologyResolver(ontology_file=StringIO(turtle_content))
+
+    assert adapter.graph is not None
+    assert "car" in adapter.lookup["classes"]
+    assert "audi" in adapter.lookup["individuals"]
 
 
 def test_build_lookup():


### PR DESCRIPTION
## Summary
- `RDFLibOntologyResolver` hardcoded `format="xml"` when parsing file-like ontology objects. Any non-RDF/XML serialization (Turtle, N3, JSON-LD) failed to parse; the exception was swallowed and the resolver silently ended up with an empty graph (cognify "succeeds" but every node is `ontology_valid: false`).
- Now tries `xml`, `turtle`, `n3`, `json-ld` in order for each file object and keeps the first format that parses successfully. Each attempt parses into a scratch graph first, so a failed attempt never leaves partial triples in `self.graph`.

## Test plan
- [x] Added `test_ontology_adapter_loads_turtle_file_object`, which fails on `main` (graph stays empty) and passes with this fix.
- [x] `pytest cognee/tests/unit/modules/ontology/test_ontology_adapter.py`
- [x] `ruff check` / `ruff format` clean

Fixes #2907
