### PR TITLE
fix(pipeline): truncate pipeline run_info payload to prevent unbounded DB growth

### DIFF
--- a/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
@@ -8,12 +8,9 @@ from typing import Any
 async def log_pipeline_run_complete(
     pipeline_run_id: UUID, pipeline_id: UUID, pipeline_name: str, dataset_id: UUID, data: Any
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    from cognee.modules.pipelines.utils.format_data_info import format_data_info
+
+    data_info = format_data_info(data)
 
     pipeline_run = PipelineRun(
         pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/pipelines/operations/log_pipeline_run_error.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_error.py
@@ -13,12 +13,9 @@ async def log_pipeline_run_error(
     data: Any,
     e: Exception,
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    from cognee.modules.pipelines.utils.format_data_info import format_data_info
+
+    data_info = format_data_info(data)
 
     pipeline_run = PipelineRun(
         pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/pipelines/operations/log_pipeline_run_start.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_start.py
@@ -10,12 +10,9 @@ from cognee.modules.pipelines.utils import generate_pipeline_run_id
 async def log_pipeline_run_start(
     pipeline_id: UUID, pipeline_name: str, dataset_id: UUID, data: Any
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    from cognee.modules.pipelines.utils.format_data_info import format_data_info
+
+    data_info = format_data_info(data)
 
     pipeline_run_id = generate_pipeline_run_id(pipeline_id, dataset_id)
 

--- a/cognee/modules/pipelines/utils/__init__.py
+++ b/cognee/modules/pipelines/utils/__init__.py
@@ -1,2 +1,3 @@
 from .generate_pipeline_id import generate_pipeline_id
 from .generate_pipeline_run_id import generate_pipeline_run_id
+from .format_data_info import format_data_info

--- a/cognee/modules/pipelines/utils/format_data_info.py
+++ b/cognee/modules/pipelines/utils/format_data_info.py
@@ -1,0 +1,14 @@
+from typing import Any
+from cognee.modules.data.models import Data
+
+
+def format_data_info(data: Any) -> str | list[str]:
+    if not data:
+        return "None"
+    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
+        return [str(item.id) for item in data]
+    else:
+        stringified_data = str(data)
+        if len(stringified_data) > 500:
+            return f"{stringified_data[:500]}... [truncated {len(stringified_data)} chars]"
+        return stringified_data

--- a/cognee/tests/unit/modules/pipelines/utils/test_format_data_info.py
+++ b/cognee/tests/unit/modules/pipelines/utils/test_format_data_info.py
@@ -1,0 +1,26 @@
+import unittest
+from uuid import uuid4
+from cognee.modules.data.models import Data
+from cognee.modules.pipelines.utils.format_data_info import format_data_info
+
+
+class TestFormatDataInfo(unittest.TestCase):
+    def test_format_data_info_none(self):
+        self.assertEqual(format_data_info(None), "None")
+        self.assertEqual(format_data_info(""), "None")
+        self.assertEqual(format_data_info([]), "None")
+
+    def test_format_data_info_data_list(self):
+        data_list = [Data(id=uuid4()), Data(id=uuid4())]
+        expected = [str(item.id) for item in data_list]
+        self.assertEqual(format_data_info(data_list), expected)
+
+    def test_format_data_info_short_string(self):
+        self.assertEqual(format_data_info("short text"), "short text")
+
+    def test_format_data_info_long_string(self):
+        long_text = "a" * 1000
+        result = format_data_info(long_text)
+        self.assertTrue(result.startswith("a" * 500))
+        self.assertTrue(result.endswith("... [truncated 1000 chars]"))
+        self.assertEqual(len(result), 500 + len("... [truncated 1000 chars]"))


### PR DESCRIPTION
Closes #3074

When input data to pipelines isn't a list of Data items, the raw stringified payload could cause unbounded growth in the SQLite pipeline_runs table. This PR extracts the serialization logic into a reusable format_data_info helper that caps stringified payloads at 500 characters.