### PR TITLE
docs: remove stray colon in README translations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Cognee is the open-source AI memory platform that gives AI agents persistent lon
 
   <p align="center">
   🌐 This README is also available in:
-  :
   <!-- Keep these links. Translations will automatically update with the README. -->
   <a href="https://www.readme-i18n.com/topoteretes/cognee?lang=de">Deutsch</a> |
   <a href="https://www.readme-i18n.com/topoteretes/cognee?lang=es">Español</a> |


### PR DESCRIPTION
#Description
I noticed an extra colon after the line "This README is also available in:" in the README file. It looked like a typo, so I removed it.
The stray ":" character is removed from the README.

Submitted as part of "The Hangover Part AI: Where's My Context" hackathon by WeMakeDevs.

## Type of Change
- [x] Code refactoring

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive message
