### PR TITLE
fix(mcp): pass user object to cognee.recall to resolve NoneType error (fixes #2855)

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -552,7 +552,9 @@ class CogneeClient:
             return response.json()
         else:
             with redirect_stdout(sys.stderr):
-                kwargs = {"top_k": top_k, "auto_route": True}
+                from cognee.modules.users.methods import get_default_user
+
+                kwargs = {"top_k": top_k, "auto_route": True, "user": await get_default_user()}
                 if search_type:
                     from cognee.modules.search.types import SearchType
 


### PR DESCRIPTION
Closes #2855

This PR fixes an AttributeError that occurs when using the MCP ecall tool without specifying a user. It imports get_default_user() and provides it explicitly to self.cognee.recall.