### PR TITLE
fix(storage): fallback to anon=False boto3 chain in S3FileStorage when credentials are not explicitly set (fixes #3086)

### DIFF
--- a/cognee/infrastructure/files/storage/S3FileStorage.py
+++ b/cognee/infrastructure/files/storage/S3FileStorage.py
@@ -49,7 +49,11 @@ class S3FileStorage(Storage):
                 client_kwargs={"region_name": s3_config.aws_region},
             )
         else:
-            raise ValueError("S3 credentials are not set in the configuration.")
+            self.s3 = s3fs.S3FileSystem(
+                anon=False,
+                endpoint_url=s3_config.aws_endpoint_url,
+                client_kwargs={"region_name": s3_config.aws_region},
+            )
 
     async def store(self, file_path: str, data: BinaryIO | str, overwrite: bool = False) -> str:
         """


### PR DESCRIPTION
Closes #3086

This PR removes the ValueError raised by S3FileStorage when credentials are not explicitly provided. Instead, it allows s3fs to use the standard boto3 credential chain (e.g. IAM roles, aws config files, env vars) with anon=False.