### PR TITLE
fix(pipelines): truncate stringified payloads in pipeline runs to prevent unbounded memory growth (fixes #3074)

### DIFF
--- a/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
@@ -8,12 +8,8 @@ from typing import Any
 async def log_pipeline_run_complete(
     pipeline_run_id: UUID, pipeline_id: UUID, pipeline_name: str, dataset_id: UUID, data: Any
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    from cognee.modules.pipelines.utils.extract_data_info import extract_data_info
+    data_info = extract_data_info(data)
 
     pipeline_run = PipelineRun(
         pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/pipelines/operations/log_pipeline_run_error.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_error.py
@@ -13,12 +13,8 @@ async def log_pipeline_run_error(
     data: Any,
     e: Exception,
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    from cognee.modules.pipelines.utils.extract_data_info import extract_data_info
+    data_info = extract_data_info(data)
 
     pipeline_run = PipelineRun(
         pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/pipelines/operations/log_pipeline_run_start.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_start.py
@@ -10,12 +10,8 @@ from cognee.modules.pipelines.utils import generate_pipeline_run_id
 async def log_pipeline_run_start(
     pipeline_id: UUID, pipeline_name: str, dataset_id: UUID, data: Any
 ):
-    if not data:
-        data_info = "None"
-    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        data_info = [str(item.id) for item in data]
-    else:
-        data_info = str(data)
+    from cognee.modules.pipelines.utils.extract_data_info import extract_data_info
+    data_info = extract_data_info(data)
 
     pipeline_run_id = generate_pipeline_run_id(pipeline_id, dataset_id)
 

--- a/cognee/modules/pipelines/utils/extract_data_info.py
+++ b/cognee/modules/pipelines/utils/extract_data_info.py
@@ -1,0 +1,16 @@
+from typing import Any
+from cognee.modules.data.models import Data
+
+def extract_data_info(data: Any) -> Any:
+    if not data:
+        return "None"
+    elif isinstance(data, list) and all(isinstance(item, Data) for item in data):
+        return [str(item.id) for item in data]
+    else:
+        # Cap stringified payload to prevent unbounded pipeline_runs growth
+        data_str = str(data)
+        max_len = 250
+        if len(data_str) > max_len:
+            return f"{data_str[:max_len]}... (truncated from {len(data_str)} chars)"
+        return data_str
+


### PR DESCRIPTION
Closes #3074

This PR truncates long stringified payloads logged in the pipeline_runs table when the input is not a list of Data objects. This prevents unbounded database growth and Out-Of-Memory errors when large text payloads are stored verbatim on every pipeline run.