### PR TITLE
fix(lancedb): automatically prefix windows paths to resolve OS Error 3 for long paths (fixes #2941)

### DIFF
--- a/cognee/infrastructure/databases/vector/config.py
+++ b/cognee/infrastructure/databases/vector/config.py
@@ -83,6 +83,11 @@ class VectorConfig(BaseSettings):
             databases_directory_path = os.path.join(base_config.system_root_directory, "databases")
             self.vector_db_url = os.path.join(databases_directory_path, "cognee.lancedb")
 
+        import sys
+        if sys.platform == "win32" and self.vector_db_url and "://" not in self.vector_db_url:
+            if os.path.isabs(self.vector_db_url) and not self.vector_db_url.startswith("\\\\?\\"):
+                self.vector_db_url = "\\\\?\\" + os.path.normpath(self.vector_db_url)
+
         return self
 
     def to_dict(self) -> dict:


### PR DESCRIPTION
Closes #2941

This PR automatically normalizes and prefixes absolute Windows paths for the vector_db_url when using local filesystem storage. This resolves OS Error 3 triggered by LanceDB subprocesses when generating long file paths for persisting vector data on Windows.