### PR TITLE
fix: allow S3FileStorage to fall back to boto3 credential chain for IAM roles

### DIFF
--- a/cognee/infrastructure/files/storage/S3FileStorage.py
+++ b/cognee/infrastructure/files/storage/S3FileStorage.py
@@ -49,7 +49,12 @@ class S3FileStorage(Storage):
                 client_kwargs={"region_name": s3_config.aws_region},
             )
         else:
-            raise ValueError("S3 credentials are not set in the configuration.")
+            # No credentials provided, let s3fs discover them via the IAM Role/Chain
+         self.s3 = s3fs.S3FileSystem(
+         anon=False,
+         endpoint_url=s3_config.aws_endpoint_url,
+         client_kwargs={"region_name": s3_config.aws_region},
+    )
 
     async def store(self, file_path: str, data: BinaryIO | str, overwrite: bool = False) -> str:
         """


### PR DESCRIPTION
closes #3086 

### Description
This PR fixes an issue where `S3FileStorage` completely fails in AWS-managed environments (ECS Fargate, EC2, Lambda) that use IAM Roles for authentication. 

Previously, `S3FileStorage.__init__` unconditionally raised a `ValueError` if `aws_access_key_id` or `aws_secret_access_key` were not explicitly provided. This broke deployments relying on IAM roles, returning the following health check error:
`"details": "Storage test failed: S3 credentials are not set in the configuration."`

### Changes Made
* Added an `else` branch to the initialization logic in `cognee/infrastructure/files/storage/S3FileStorage.py`.
* When explicit keys are missing, the storage now falls back to `s3fs.S3FileSystem(anon=False)` without passing `key` and `secret`. 
* This one-line change in logic delegates credential discovery to the underlying `boto3` standard credential chain (fetching from the ECS task metadata endpoint, EC2 IMDS, `~/.aws/credentials`, etc.).

### Impact
* **Backward Compatibility:** Existing setups using explicit keys remain 100% unaffected.
* **New Capability:** Cognee can now be deployed natively on AWS ECS/EC2 without hardcoding sensitive access keys, relying securely on IAM task roles instead.

### Steps to Test
1. Deploy Cognee to AWS ECS Fargate with `STORAGE_BACKEND=s3`.
2. Attach an IAM task role with S3 permissions.
3. Ensure `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are **not** set.
4. Call the `/health` endpoint. The file storage will now report as healthy instead of throwing a `ValueError`.