### PR TITLE
chore(types): enable ty for already-clean modules (#2681)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,12 @@ include = [
     "cognee/infrastructure/locks",
     "cognee/infrastructure/session",
     "cognee/infrastructure/utils",
-    "cognee/shared"
+    "cognee/shared",
+    "cognee/modules/metrics",
+    "cognee/modules/cloud",
+    "cognee/modules/settings",
+    "cognee/modules/recall",
+    "cognee/tasks/completion"
 ]
 # Exclude generated files
 exclude = ["cognee/infrastructure/llm/structured_output_framework/baml/baml_client/"]


### PR DESCRIPTION
## Description

This continues the gradual `ty` type-checking rollout from #2681.

While fixing types in another module I checked the rest of the codebase and found that several modules outside the current `[tool.ty.src].include` set already pass `ty` cleanly, with no changes required. Rather than leave that coverage un-enforced (where it can silently regress), this PR turns type checking on for them now.

No source changes are needed — these modules are already type-clean — so the diff is limited to `pyproject.toml`. Modules enabled: `metrics`, `cloud`, `settings`, `recall`, and `tasks/completion`.

## Acceptance Criteria

- The newly included modules pass `ty` with no errors.
- `uv run ty check .` still passes overall (exit 0).

Verified locally:

```
uv run ty check .          # passes (exit 0)
uv run ruff check .        # passes
uv run ruff format --check .  # passes
```

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [x] Other: enable type checking for already-clean modules (CI coverage)

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works (N/A — `ty check` is the proof)
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Part of #2681.
