### PR TITLE
fix: add universal timeout for generic API adapter (fixes 2995)

### DIFF
--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -49,6 +49,7 @@ class LLMConfig(BaseSettings):
     llm_temperature: float = 0.0
     llm_streaming: bool = False
     llm_max_completion_tokens: int = 16384
+    llm_timeout: int = 120
 
     baml_llm_provider: str = "openai"
     baml_llm_model: str = "gpt-5-mini"

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -1,5 +1,6 @@
 """Adapter for Generic API LLM provider API"""
 
+import asyncio
 import base64
 import logging
 import mimetypes
@@ -86,6 +87,7 @@ class GenericAPIAdapter(LLMInterface):
         fallback_api_key: str | None = None,
         fallback_endpoint: str | None = None,
         llm_args: dict[str, Any] | None = None,
+        timeout: int | None = None,
     ) -> None:
         self.name = name
         self.model = model
@@ -100,6 +102,7 @@ class GenericAPIAdapter(LLMInterface):
         self.fallback_endpoint = fallback_endpoint
         self._base_llm_args: dict[str, Any] = llm_args or {}
         self.llm_args = self._base_llm_args
+        self.timeout = timeout
 
         self.instructor_mode = instructor_mode if instructor_mode else self.default_instructor_mode
 
@@ -153,23 +156,27 @@ class GenericAPIAdapter(LLMInterface):
         merged_kwargs = {**self.llm_args, **kwargs}
         try:
             async with llm_rate_limiter_context_manager():
-                result = await self.aclient.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": system_prompt,
-                        },
-                        {
-                            "role": "user",
-                            "content": f"""{text_input}""",
-                        },
-                    ],
-                    max_retries=2,
-                    api_key=self.api_key,
-                    api_base=self.endpoint,
-                    response_model=response_model,
-                    **merged_kwargs,
+                timeout_val = self.timeout if self.timeout else None
+                result = await asyncio.wait_for(
+                    self.aclient.chat.completions.create(
+                        model=self.model,
+                        messages=[
+                            {
+                                "role": "system",
+                                "content": system_prompt,
+                            },
+                            {
+                                "role": "user",
+                                "content": f"""{text_input}""",
+                            },
+                        ],
+                        max_retries=2,
+                        api_key=self.api_key,
+                        api_base=self.endpoint,
+                        response_model=response_model,
+                        **merged_kwargs,
+                    ),
+                    timeout=timeout_val,
                 )
                 _enrich_llm_span(self.model, self.name)
                 return result
@@ -200,23 +207,27 @@ class GenericAPIAdapter(LLMInterface):
 
             try:
                 async with llm_rate_limiter_context_manager():
-                    return await self.aclient.chat.completions.create(
-                        model=fallback_model,
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": system_prompt,
-                            },
-                            {
-                                "role": "user",
-                                "content": f"""{text_input}""",
-                            },
-                        ],
-                        max_retries=2,
-                        api_key=self.fallback_api_key,
-                        api_base=self.fallback_endpoint,
-                        response_model=response_model,
-                        **fallback_llm_args,
+                    timeout_val = self.timeout if self.timeout else None
+                    return await asyncio.wait_for(
+                        self.aclient.chat.completions.create(
+                            model=fallback_model,
+                            messages=[
+                                {
+                                    "role": "system",
+                                    "content": system_prompt,
+                                },
+                                {
+                                    "role": "user",
+                                    "content": f"""{text_input}""",
+                                },
+                            ],
+                            max_retries=2,
+                            api_key=self.fallback_api_key,
+                            api_base=self.fallback_endpoint,
+                            response_model=response_model,
+                            **fallback_llm_args,
+                        ),
+                        timeout=timeout_val,
                     )
             except (
                 ContentFilterFinishReasonError,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -64,6 +64,7 @@ class _LLMClientCacheKey:
     llama_cpp_n_ctx: int
     llama_cpp_n_gpu_layers: int
     llama_cpp_chat_format: str
+    timeout: int
 
 
 # Define an Enum for LLM Providers
@@ -178,6 +179,7 @@ def _build_llm_client_cache_key(llm_config, max_completion_tokens: int) -> _LLMC
         llama_cpp_n_ctx=llm_config.llama_cpp_n_ctx,
         llama_cpp_n_gpu_layers=llm_config.llama_cpp_n_gpu_layers,
         llama_cpp_chat_format=llm_config.llama_cpp_chat_format,
+        timeout=llm_config.llm_timeout,
     )
 
 
@@ -289,6 +291,7 @@ def _get_llm_client_cached(cache_key: _LLMClientCacheKey) -> LLMInterface:
             fallback_endpoint=cache_key.fallback_endpoint,
             fallback_model=cache_key.fallback_model,
             llm_args=llm_args,
+            timeout=cache_key.timeout,
         )
 
     elif provider == LLMProvider.GEMINI:


### PR DESCRIPTION
Closes #2995.

This PR introduces a universal asyncio.wait_for timeout in GenericAPIAdapter and threads the setting through LLMConfig to ensure endpoints do not hang infinitely.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin