### PR TITLE
fix: fallback to boto3 credential chain in S3FileStorage (fixes 3086)

### DIFF
--- a/cognee/infrastructure/files/storage/S3FileStorage.py
+++ b/cognee/infrastructure/files/storage/S3FileStorage.py
@@ -49,7 +49,11 @@ class S3FileStorage(Storage):
                 client_kwargs={"region_name": s3_config.aws_region},
             )
         else:
-            raise ValueError("S3 credentials are not set in the configuration.")
+            self.s3 = s3fs.S3FileSystem(
+                anon=False,
+                endpoint_url=s3_config.aws_endpoint_url,
+                client_kwargs={"region_name": s3_config.aws_region} if s3_config.aws_region else None,
+            )
 
     async def store(self, file_path: str, data: BinaryIO | str, overwrite: bool = False) -> str:
         """


### PR DESCRIPTION
Closes #3086.

When credentials are not explicitly set in the S3 configuration, this gracefully falls back to the boto3 configuration chain to resolve AWS credentials, instead of raising an error.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin