### PR TITLE
fix(search): fix ValidationError on search with response_model and structlog deadlock (#3048)

### DIFF
--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 from typing import Any, List, Optional, Tuple, Type, Union
 from uuid import UUID
+from pydantic import BaseModel
 
 from cognee import __version__ as cognee_version
 from cognee.context_global_variables import (
@@ -121,6 +122,15 @@ async def search(
         },
     )
 
+    def to_json_serializable(val: Any) -> Any:
+        if isinstance(val, BaseModel):
+            return val.model_dump()
+        if isinstance(val, list):
+            return [to_json_serializable(item) for item in val]
+        if isinstance(val, dict):
+            return {k: to_json_serializable(v) for k, v in val.items()}
+        return val
+
     # Log only the completion text (what the user sees), not the full
     # serialized graph payload. The raw result_objects can be 50-100 KB
     # each and cause unbounded DB growth in long-running deployments.
@@ -128,9 +138,9 @@ async def search(
     for item in search_results:
         payload = item[0] if isinstance(item, tuple) else item
         if hasattr(payload, "completion") and payload.completion:
-            completions.append(payload.completion)
+            completions.append(to_json_serializable(payload.completion))
         elif hasattr(payload, "context") and payload.context:
-            completions.append(payload.context)
+            completions.append(to_json_serializable(payload.context))
     await log_result(
         query.id,
         json.dumps(completions) if completions else "[]",

--- a/cognee/modules/search/models/SearchResultPayload.py
+++ b/cognee/modules/search/models/SearchResultPayload.py
@@ -16,7 +16,7 @@ class SearchResultPayload(BaseModel):
 
     result_object: Any = None
     context: Optional[Union[str, List[str]]] = None
-    completion: Optional[Union[str, List[str], List[dict]]] = None
+    completion: Optional[Union[str, List[str], List[dict], BaseModel]] = None
 
     # TODO: Add return_type info
     search_type: SearchType

--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -409,7 +409,7 @@ def setup_logging(log_level=None, name=None) -> bool:
             else:
                 exc_type, exc_value, tb = sys.exc_info()
 
-            if exc_type and hasattr(exc_type, __name__):
+            if exc_type and hasattr(exc_type, "__name__"):
                 event_dict["exception_type"] = exc_type.__name__
             event_dict["exception_message"] = str(exc_value)
             event_dict["traceback"] = True
@@ -459,6 +459,7 @@ def setup_logging(log_level=None, name=None) -> bool:
         processor=structlog.dev.ConsoleRenderer(
             colors=True,
             force_colors=True,
+            exception_formatter=structlog.dev.RichTracebackFormatter(show_locals=False),
             level_styles={
                 "critical": structlog.dev.RED,
                 "exception": structlog.dev.RED,

--- a/cognee/tests/unit/modules/search/test_search.py
+++ b/cognee/tests/unit/modules/search/test_search.py
@@ -208,3 +208,69 @@ async def test_search_passes_retriever_specific_config_to_authorized_search(
     )
 
     assert out
+
+
+from pydantic import BaseModel
+
+class DummyModel(BaseModel):
+    message: str
+
+def test_search_result_payload_accepts_basemodel():
+    model_instance = DummyModel(message="hello")
+    payload = SearchResultPayload(
+        result_object="object",
+        context="ctx",
+        completion=model_instance,
+        search_type=SearchType.GRAPH_COMPLETION,
+    )
+    assert payload.completion == model_instance
+    assert payload.result == model_instance
+
+
+@pytest.mark.asyncio
+async def test_search_serializes_basemodel_completions(monkeypatch, search_mod):
+    user = _make_user()
+    ds = _make_dataset(name="ds1", tenant_id="t1")
+    model_instance = DummyModel(message="hello_search")
+
+    async def dummy_authorized_search(**_kwargs):
+        return [
+            SearchResultPayload(
+                result_object="object",
+                context="ctx",
+                completion=model_instance,
+                search_type=SearchType.GRAPH_COMPLETION,
+                dataset_name=ds.name,
+                dataset_id=ds.id,
+                dataset_tenant_id=ds.tenant_id,
+            )
+        ]
+
+    logged_result_value = None
+
+    async def dummy_log_result(_query_id, result_str, _user_id):
+        nonlocal logged_result_value
+        logged_result_value = result_str
+
+    monkeypatch.setattr(search_mod, "backend_access_control_enabled", lambda: True)
+    monkeypatch.setattr(search_mod, "authorized_search", dummy_authorized_search)
+    monkeypatch.setattr(search_mod, "log_result", dummy_log_result)
+
+    out = await search_mod.search(
+        query_text="q",
+        query_type=SearchType.GRAPH_COMPLETION,
+        dataset_ids=[ds.id],
+        user=user,
+        verbose=False,
+    )
+
+    assert out == [
+        {
+            "search_result": model_instance,
+            "dataset_id": ds.id,
+            "dataset_name": "ds1",
+            "dataset_tenant_id": uuid5(NAMESPACE_OID, "t1"),
+        }
+    ]
+    assert logged_result_value == '[{"message": "hello_search"}]'
+


### PR DESCRIPTION
Closes topoteretes/cognee#3048

### Description of Changes
- Widened `SearchResultPayload.completion` type to accept Pydantic `BaseModel` instances.
- Added `to_json_serializable` helper to recursively serialize Pydantic models when logging search results.
- Configured structlog console renderer traceback formatter with `show_locals=False` to prevent infinite recursion/deadlocks during `rich` formatting of `ValidationError` exceptions.
- Corrected typo `hasattr(exc_type, __name__)` -> `hasattr(exc_type, "__name__")` in standard exception logger.

### How to test locally
uv run pytest cognee/tests/unit/modules/search/ -v
