### PR TITLE
fix(search): honor datasets filter when access control is disabled

### DIFF
--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -311,9 +311,11 @@ async def search_in_datasets_context(
                     include_references=include_references,
                 )
 
-    # Search every dataset async based on query and appropriate database configuration
+    # Search every dataset async based on query and appropriate database configuration.
+    # When callers pass explicit datasets, always scope search per dataset — even if
+    # backend access control is disabled (self-hosted Neo4j without per-dataset DBs).
     tasks = []
-    if backend_access_control_enabled():
+    if backend_access_control_enabled() or search_datasets:
         for dataset in search_datasets:
             tasks.append(
                 _search_in_dataset_context(
@@ -338,14 +340,12 @@ async def search_in_datasets_context(
                 )
             )
     else:
-        # Run search without setting database context in case access control is disabled
-        # Needed for low level pipelines that need to run search without dataset context.
-        dataset = search_datasets[0] if len(search_datasets) == 1 else None
+        # Low-level pipelines may run search without an explicit dataset scope.
         retriever_kwargs = dict(
             query_type=query_type,
             query_text=query_text,
             user=user,
-            dataset=dataset,
+            dataset=None,
             system_prompt_path=system_prompt_path,
             system_prompt=system_prompt,
             top_k=top_k,
@@ -364,13 +364,9 @@ async def search_in_datasets_context(
         )
 
         async def _search_without_context() -> SearchResultPayload:
-            # No dataset DB context to set when access control is disabled, but
-            # still forward any per-call LLM/embedding overrides onto the async
-            # context (set_database_global_context_variables applies these even
-            # in single-tenant mode and ignores the dataset argument).
             if llm_config is not None or embedding_config is not None:
                 async with set_database_global_context_variables(
-                    dataset.id if dataset else None,
+                    None,
                     user.id,
                     llm_config=llm_config,
                     embedding_config=embedding_config,

--- a/cognee/tests/unit/modules/search/test_search.py
+++ b/cognee/tests/unit/modules/search/test_search.py
@@ -176,6 +176,64 @@ async def test_authorized_search_delegates_to_search_in_datasets_context(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_search_in_datasets_context_scopes_each_dataset_when_access_control_disabled(
+    monkeypatch, search_mod
+):
+    """Explicit datasets must be searched per-dataset even when ACCESS_CONTROL=false (#2867)."""
+    user = _make_user()
+    ds_one = _make_dataset(name="dataset_a")
+    ds_two = _make_dataset(name="dataset_b")
+    searched_dataset_ids = []
+
+    async def fake_get_retriever_output(**kwargs):
+        dataset = kwargs.get("dataset")
+        searched_dataset_ids.append(dataset.id if dataset else None)
+        return SearchResultPayload(
+            result_object="object",
+            context="ctx",
+            completion="ok",
+            search_type=SearchType.CHUNKS,
+            dataset_name=dataset.name if dataset else None,
+            dataset_id=dataset.id if dataset else None,
+            dataset_tenant_id=dataset.tenant_id if dataset else None,
+        )
+
+    class DummyGraphEngine:
+        async def is_empty(self):
+            return False
+
+    async def fake_get_graph_engine():
+        return DummyGraphEngine()
+
+    class DummyContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(search_mod, "backend_access_control_enabled", lambda: False)
+    monkeypatch.setattr(search_mod, "get_retriever_output", fake_get_retriever_output)
+    monkeypatch.setattr(search_mod, "get_graph_engine", fake_get_graph_engine)
+    monkeypatch.setattr(
+        search_mod,
+        "set_database_global_context_variables",
+        lambda *args, **kwargs: DummyContext(),
+    )
+
+    results = await search_mod.search_in_datasets_context(
+        search_datasets=[ds_one, ds_two],
+        query_type=SearchType.CHUNKS,
+        query_text="q",
+        user=user,
+    )
+
+    assert searched_dataset_ids == [ds_one.id, ds_two.id]
+    assert len(results) == 2
+    assert {result.dataset_id for result in results} == {ds_one.id, ds_two.id}
+
+
+@pytest.mark.asyncio
 async def test_search_passes_retriever_specific_config_to_authorized_search(
     monkeypatch, search_mod
 ):


### PR DESCRIPTION
Closes #2867

## Summary

With `ENABLE_BACKEND_ACCESS_CONTROL=false`, explicit `datasets` / `dataset_ids` were ignored for `CHUNKS`, `SUMMARIES`, and `GRAPH_COMPLETION`. Search hit the global graph/vector stores instead of scoping to the requested dataset(s).

This runs search per dataset with `set_database_global_context_variables` whenever callers pass explicit datasets. Global no-context search is kept only when no dataset scope is provided.

## Test plan

- [x] `uv run pytest cognee/tests/unit/modules/search/test_search.py -v`
- [x] `uv run ruff check` on changed files
- [x] Per-dataset search with ACL disabled — `test_search_in_datasets_context_scopes_each_dataset_when_access_control_disabled`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.