### PR TITLE
fix(search): serialize response_model completions for SearchResultPayload

### DIFF
--- a/cognee/modules/search/methods/get_retriever_output.py
+++ b/cognee/modules/search/methods/get_retriever_output.py
@@ -1,4 +1,7 @@
 from inspect import Parameter, signature
+from typing import Any, List
+
+from pydantic import BaseModel
 
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.modules.observability import (
@@ -16,6 +19,17 @@ from cognee.modules.search.types import SearchType
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
+
+
+def _normalize_completion_value(value: Any) -> Any:
+    """Make completion JSON-serializable for SearchResultPayload."""
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    if isinstance(value, list):
+        return [_normalize_completion_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _normalize_completion_value(val) for key, val in value.items()}
+    return value
 
 
 def _method_accepts_kwarg(method, name: str) -> bool:
@@ -104,6 +118,7 @@ async def get_retriever_output(
             if _method_accepts_kwarg(completion_method, "turn_preparation"):
                 completion_kwargs["turn_preparation"] = turn_preparation
             completion = await completion_method(**completion_kwargs)
+            completion = _normalize_completion_value(completion)
             if isinstance(completion, str):
                 span.set_attribute("cognee.retrieval.completion_length", len(completion))
             span.set_attribute(

--- a/cognee/tests/unit/modules/search/test_get_retriever_output.py
+++ b/cognee/tests/unit/modules/search/test_get_retriever_output.py
@@ -2,10 +2,12 @@ import importlib
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pydantic import BaseModel
 
 from cognee.infrastructure.session.session_manager import SessionTurnPreparation
 from cognee.modules.search.methods.get_retriever_output import (
     _count_retrieved_objects,
+    _normalize_completion_value,
     get_retriever_output,
 )
 from cognee.modules.search.types import SearchType
@@ -77,6 +79,25 @@ class _NoAnswerRetriever:
         raise AssertionError("retrieval should be skipped")
 
 
+class SampleAnswer(BaseModel):
+    answer: str
+    confidence: float
+
+
+class _StructuredCompletionRetriever:
+    async def prepare_session_turn_for_retrieval(self, query):
+        return SessionTurnPreparation(should_answer=True, effective_query=query)
+
+    async def get_retrieved_objects(self, query):
+        return []
+
+    async def get_context_from_objects(self, query, retrieved_objects):
+        return "context"
+
+    async def get_completion_from_context(self, query, retrieved_objects, context):
+        return SampleAnswer(answer="structured", confidence=0.75)
+
+
 @pytest.mark.asyncio
 async def test_get_retriever_output_uses_effective_query_before_retrieval():
     retriever = _EffectiveQueryRetriever()
@@ -133,6 +154,27 @@ async def test_get_retriever_output_skips_retrieval_for_no_answer_turn():
     assert result.completion == ["Thanks, I noted that."]
 
 
+@pytest.mark.asyncio
+async def test_get_retriever_output_normalizes_structured_response_model_completion():
+    with (
+        patch.object(
+            get_retriever_output_module,
+            "get_graph_engine",
+            new_callable=AsyncMock,
+            return_value=_FakeGraphEngine(),
+        ),
+        patch.object(
+            get_retriever_output_module,
+            "get_search_type_retriever_instance",
+            new_callable=AsyncMock,
+            return_value=_StructuredCompletionRetriever(),
+        ),
+    ):
+        result = await get_retriever_output(SearchType.GRAPH_COMPLETION, "structured query")
+
+    assert result.completion == {"answer": "structured", "confidence": 0.75}
+
+
 def test_count_retrieved_objects_counts_structured_lists():
     assert _count_retrieved_objects({"chunks": [1, 2], "entities": [3]}) == 3
 
@@ -143,3 +185,35 @@ def test_count_retrieved_objects_preserves_existing_shapes():
     assert _count_retrieved_objects({"triplets": []}) == 0
     assert _count_retrieved_objects({"metadata": "value"}) == 1
     assert _count_retrieved_objects("answer") == 1
+
+
+def test_normalize_completion_value_serializes_base_model():
+    model = SampleAnswer(answer="42", confidence=0.9)
+    assert _normalize_completion_value(model) == {
+        "answer": "42",
+        "confidence": 0.9,
+    }
+
+
+def test_normalize_completion_value_handles_nested_structures():
+    model = SampleAnswer(answer="yes", confidence=1.0)
+    assert _normalize_completion_value([model, "plain"]) == [
+        {"answer": "yes", "confidence": 1.0},
+        "plain",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_result_payload_accepts_normalized_response_model_completion():
+    """SearchResultPayload must accept structured completions after normalization (#3048)."""
+    from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
+
+    model = SampleAnswer(answer="structured", confidence=0.75)
+    payload = SearchResultPayload(
+        result_object=None,
+        context=None,
+        completion=_normalize_completion_value(model),
+        search_type=SearchType.GRAPH_COMPLETION,
+    )
+
+    assert payload.completion == {"answer": "structured", "confidence": 0.75}


### PR DESCRIPTION
Closes #3048

## Summary

`cognee.search(..., retriever_specific_config={"response_model": MyModel})` failed after retrieval succeeded because `SearchResultPayload.completion` does not accept Pydantic `BaseModel` instances. That triggered a `ValidationError` when building the payload (and could hang error logging per #3048).

Normalize structured completions with `model_dump()` before constructing `SearchResultPayload`.

## Test plan

- [x] `uv run pytest cognee/tests/unit/modules/search/test_get_retriever_output.py -v`
- [x] `uv run ruff check` on changed files
- [x] Structured `response_model` without ValidationError — `test_get_retriever_output_normalizes_structured_response_model_completion` and `test_search_result_payload_accepts_normalized_response_model_completion`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.