### PR TITLE
fix(mcp): harden cognify batch file-path ingestion

### DIFF
--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -500,6 +500,16 @@ By default, each MCP client gets its own auto-named dataset (e.g. Cursor → `cu
 
 LLM-direct calls to `cognify`, `remember`, `improve`, `cognify_status`, and `cognify_file` route to the agent-scoped dataset when `dataset_name` is omitted. Pass `dataset_name` explicitly to override (e.g. `dataset_name="main_dataset"` still works).
 
+### Batch file ingestion (`cognify`)
+
+The internal `cognify` helper accepts a JSON array string so multiple files can be added before a single pipeline run:
+
+```json
+["/data/doc1.pdf", "/data/doc2.txt", "inline memory note"]
+```
+
+Path-like entries are validated before ingestion. `ACCEPT_LOCAL_FILE_PATH=false` rejects local paths. Paths containing `..` are rejected. When running inside Docker, mount host directories into the container and reference the in-container path (e.g. `/data/doc1.pdf`).
+
 To disable agent scoping and have all clients share `main_dataset` as the default, set in `.env`:
 
 ```bash

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -251,8 +251,9 @@ async def cognify(
     ----------
     data : str
         The data to be processed and transformed into structured knowledge.
-        This can include natural language, file location, or any text-based information
-        that should become part of the agent's memory.
+        Plain text, a single file path, or a JSON array batch of strings, e.g.
+        ``["/data/doc1.pdf", "/data/doc2.txt", "inline note"]``. All items are
+        added to the dataset, then a single cognify run processes them.
 
     graph_model_file : str, optional
         Path to a custom schema file that defines the structure of the generated knowledge graph.

--- a/cognee-mcp/src/server_utils.py
+++ b/cognee-mcp/src/server_utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 
@@ -60,24 +61,50 @@ def looks_like_file_path(data: str) -> bool:
     )
 
 
+def _local_file_paths_allowed() -> bool:
+    """Mirror cognee ACCEPT_LOCAL_FILE_PATH (default True)."""
+    raw = os.environ.get("ACCEPT_LOCAL_FILE_PATH", "true").strip().lower()
+    return raw in {"true", "1", "yes"}
+
+
+def _normalize_ingest_path(data: str) -> str:
+    path = data.strip()
+    if path.startswith("file://"):
+        path = path[7:]
+    return path
+
+
 def validate_file_path(
     data: str,
     *,
     path_exists: Callable[[str], bool] = os.path.exists,
     is_running_in_docker: Callable[[], bool] = lambda: False,
+    local_file_paths_allowed: Callable[[], bool] = _local_file_paths_allowed,
 ) -> Optional[str]:
     """Validate path-like input and return an MCP-friendly error when invalid."""
     if not looks_like_file_path(data):
         return None
 
-    path = data.strip()
-    if path.startswith("file://"):
-        path = path[7:]
+    if not local_file_paths_allowed():
+        return (
+            "Local file paths are disabled (ACCEPT_LOCAL_FILE_PATH=false). "
+            "Pass inline text or enable local file ingestion in the server environment."
+        )
 
-    if path_exists(path):
+    raw_path = _normalize_ingest_path(data)
+    path = Path(raw_path).expanduser()
+    if ".." in path.parts:
+        return f"Invalid file path (path traversal not allowed): {raw_path}"
+
+    try:
+        resolved = str(path.resolve(strict=False))
+    except (OSError, ValueError) as exc:
+        return f"Invalid file path: {raw_path} ({exc})"
+
+    if path_exists(resolved) or path_exists(raw_path):
         return None
 
-    msg = f"File not found: {path}"
+    msg = f"File not found: {raw_path}"
     if is_running_in_docker():
         msg += (
             "\n\nIt looks like you're running inside Docker. Host file paths are not "

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import importlib
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -21,6 +22,7 @@ format_search_results = server_utils.format_search_results
 normalize_delete_mode = server_utils.normalize_delete_mode
 parse_cognify_data = server_utils.parse_cognify_data
 validate_cognify_file_paths = server_utils.validate_cognify_file_paths
+validate_file_path = server_utils.validate_file_path
 validate_top_k = server_utils.validate_top_k
 get_chunk_neighbors_from_graph = retrieval_utils.get_chunk_neighbors_from_graph
 get_document_from_graph = retrieval_utils.get_document_from_graph
@@ -51,6 +53,26 @@ def test_parse_cognify_data_preserves_plain_text_starting_with_bracket():
 
     assert parsed.items == ["[note: inline memory"]
     assert parsed.is_batch is False
+
+
+def test_validate_file_path_rejects_path_traversal(tmp_path):
+    target = tmp_path / "secret.txt"
+    target.write_text("secret", encoding="utf-8")
+    traversal = str(tmp_path / ".." / tmp_path.name / "secret.txt")
+
+    error = validate_file_path(traversal, path_exists=os.path.exists)
+    assert error is not None
+    assert "path traversal" in error.lower()
+
+
+def test_validate_file_path_rejects_when_local_paths_disabled(monkeypatch, tmp_path):
+    data_file = tmp_path / "note.txt"
+    data_file.write_text("note", encoding="utf-8")
+
+    monkeypatch.setenv("ACCEPT_LOCAL_FILE_PATH", "false")
+    error = validate_file_path(str(data_file), path_exists=os.path.exists)
+    assert error is not None
+    assert "ACCEPT_LOCAL_FILE_PATH" in error
 
 
 def test_validate_cognify_file_paths_reports_batch_index():


### PR DESCRIPTION
Closes #2624

## Summary

- Reject `..` path traversal and unresolved paths before cognify batch ingestion
- Honor `ACCEPT_LOCAL_FILE_PATH=false` the same way the core API does
- Document the JSON array batch format for the internal cognify helper

## Test plan

- [x] `pytest cognee-mcp/tests/test_mcp_server_hardening.py -k "parse_cognify or validate_file_path or validate_cognify"`
- [x] Manual checks for traversal, disabled local paths, and valid file paths

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.