### PR TITLE
docs: align auth env var guidance with runtime defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,7 +461,7 @@ FastAPI application with versioned routes under `cognee/api/v1/`:
 - `/search` - Query interface
 - `/memify` - Graph enrichment
 - `/datasets` - Dataset management
-- `/users` - Authentication (if `REQUIRE_AUTHENTICATION=True`)
+- `/users` - Authentication (when `REQUIRE_AUTHENTICATION` is effectively true; see auth posture below)
 - `/visualize` - Graph visualization server
 
 ## Python SDK Entry Points
@@ -483,8 +483,8 @@ Several security environment variables in `.env`:
 - `ACCEPT_LOCAL_FILE_PATH` - Allow local file paths (default: True)
 - `ALLOW_HTTP_REQUESTS` - Allow HTTP requests from Cognee (default: True)
 - `ALLOW_CYPHER_QUERY` - Allow raw Cypher queries (default: True)
-- `REQUIRE_AUTHENTICATION` - Enable API authentication (default: False)
-- `ENABLE_BACKEND_ACCESS_CONTROL` - Multi-tenant isolation (default: True)
+- `ENABLE_BACKEND_ACCESS_CONTROL` - Multi-tenant isolation (default: True). When `true`, API auth is required and per-user/dataset DB isolation is enabled. When `false`, single-user mode: shared DBs and auth off unless overridden.
+- `REQUIRE_AUTHENTICATION` - Explicit auth override. Unset (default): follows `ENABLE_BACKEND_ACCESS_CONTROL`. `false` is ignored when `ENABLE_BACKEND_ACCESS_CONTROL=true`. For a single-user deployment with auth off, set `ENABLE_BACKEND_ACCESS_CONTROL=false` (and optionally `REQUIRE_AUTHENTICATION=false`).
 
 For production deployments, review and tighten these settings.
 

--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -512,8 +512,8 @@ When disabled, the workspace UI header shows `(agent scoping off)` and no per-cl
 
 Agent scoping decides which dataset *name* a tool defaults to. Whether two datasets are actually isolated at the storage layer is governed by cognee's `ENABLE_BACKEND_ACCESS_CONTROL` flag:
 
-- **`false` (default)** — all datasets share one Kuzu graph DB and one LanceDB. The dataset filter is honored for top-level data points, but `GRAPH_COMPLETION` traversal can pull connected nodes from any dataset, and `visualize_graph_ui` reflects the full shared graph. Fastest path; fine for single-user local dev.
-- **`true`** — each `(user, dataset)` pair gets its own per-dataset Kuzu + LanceDB under `.cognee_system/databases/<dataset_uuid>/`. `visualize_graph_ui` and search become strictly per-dataset because the workspace passes `dataset_name` and the server routes the visualization through cognee's `visualize_multi_user_graph` to set the right DB context.
+- **`true` (default)** — each `(user, dataset)` pair gets its own per-dataset Kuzu + LanceDB under `.cognee_system/databases/<dataset_uuid>/`. `visualize_graph_ui` and search become strictly per-dataset because the workspace passes `dataset_name` and the server routes the visualization through cognee's `visualize_multi_user_graph` to set the right DB context.
+- **`false`** — all datasets share one Kuzu graph DB and one LanceDB. The dataset filter is honored for top-level data points, but `GRAPH_COMPLETION` traversal can pull connected nodes from any dataset, and `visualize_graph_ui` reflects the full shared graph. Use for single-user local dev; also disables the API auth requirement unless `REQUIRE_AUTHENTICATION=true` is set explicitly.
 
 **Switching modes wipes nothing automatically — but data does not migrate.** Data ingested in one mode lives at a different on-disk path than the other and won't be visible after the flip. Clean-slate when changing the flag:
 

--- a/distributed/deploy/README.md
+++ b/distributed/deploy/README.md
@@ -172,7 +172,7 @@ docker-compose --profile ui up
 
 2. **Set `CORS_ALLOWED_ORIGINS`** to your actual frontend domain instead of `*`.
 
-3. **Enable authentication**: Set `REQUIRE_AUTHENTICATION=True` and configure user management.
+3. **Enable authentication for multi-tenant deployments**: Set `ENABLE_BACKEND_ACCESS_CONTROL=true` (default) and configure user management. For a single-user internal deployment with auth off, set `ENABLE_BACKEND_ACCESS_CONTROL=false`; `REQUIRE_AUTHENTICATION=false` alone is not sufficient when multi-tenant mode is on.
 
 4. **Configure rate limiting**: Set `LLM_RATE_LIMIT_ENABLED=true` to avoid hitting provider limits.
 
@@ -196,4 +196,5 @@ docker-compose --profile ui up
 | `VECTOR_DB_PROVIDER` | No | `lancedb` | `lancedb`, `pgvector`, `chromadb` |
 | `GRAPH_DATABASE_PROVIDER` | No | `ladybug` | `ladybug`, `neo4j` |
 | `CORS_ALLOWED_ORIGINS` | No | `*` | Allowed CORS origins |
-| `REQUIRE_AUTHENTICATION` | No | `False` | Enable API auth |
+| `ENABLE_BACKEND_ACCESS_CONTROL` | No | `true` | Multi-tenant isolation; when `true`, auth is required |
+| `REQUIRE_AUTHENTICATION` | No | inherits from `ENABLE_BACKEND_ACCESS_CONTROL` | Explicit auth override (`false` ignored when multi-tenant is on) |


### PR DESCRIPTION
Closes #2808

## Summary

- Document that `ENABLE_BACKEND_ACCESS_CONTROL` defaults to `true` and controls multi-tenant isolation plus effective API auth
- Clarify `REQUIRE_AUTHENTICATION` as an explicit override that cannot disable auth when multi-tenant mode is on
- Update CLAUDE.md, MCP README, and deployment README to match `_resolve_auth_posture` behavior

## Test plan

- [x] Cross-checked against `cognee/tests/unit/modules/users/test_conditional_authentication.py`
- [x] Reviewed wording in CLAUDE.md, cognee-mcp/README.md, distributed/deploy/README.md