### PR TITLE
feat(eval): add retrieval-quality benchmark utilities

### DIFF
--- a/cognee/eval_framework/retrieval_benchmark/__init__.py
+++ b/cognee/eval_framework/retrieval_benchmark/__init__.py
@@ -1,0 +1,15 @@
+"""Retrieval-quality benchmarks for Cognee search modes."""
+
+from cognee.eval_framework.retrieval_benchmark.metrics import (
+    context_overlap_f1,
+    context_recall,
+    normalize_context_text,
+)
+from cognee.eval_framework.retrieval_benchmark.runner import RetrievalBenchmarkRunner
+
+__all__ = [
+    "RetrievalBenchmarkRunner",
+    "context_overlap_f1",
+    "context_recall",
+    "normalize_context_text",
+]

--- a/cognee/eval_framework/retrieval_benchmark/metrics.py
+++ b/cognee/eval_framework/retrieval_benchmark/metrics.py
@@ -1,0 +1,80 @@
+"""Retrieval-quality metrics comparing returned context to golden supporting text."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Union
+
+
+def normalize_context_text(text: Union[str, list, None]) -> str:
+    """Flatten search context payloads into comparable plain text."""
+    if text is None:
+        return ""
+    if isinstance(text, list):
+        parts = [normalize_context_text(item) for item in text]
+        return "\n".join(part for part in parts if part)
+    if isinstance(text, dict):
+        for key in ("text", "content", "context", "payload"):
+            if key in text and text[key]:
+                return normalize_context_text(text[key])
+        return " ".join(str(value) for value in text.values())
+    return re.sub(r"\s+", " ", str(text)).strip().lower()
+
+
+def _token_set(text: str) -> set[str]:
+    return {token for token in re.findall(r"[a-z0-9]+", text) if token}
+
+
+def context_recall(retrieved: Union[str, list, None], golden: Union[str, list, None]) -> float:
+    """Fraction of golden lines (or sentences) found in retrieved context."""
+    golden_text = normalize_context_text(golden)
+    retrieved_text = normalize_context_text(retrieved)
+    if not golden_text:
+        return 0.0
+
+    units = _split_golden_units(golden_text)
+    if not units:
+        return 0.0
+
+    hits = sum(1 for unit in units if unit in retrieved_text)
+    return hits / len(units)
+
+
+def context_overlap_f1(retrieved: Union[str, list, None], golden: Union[str, list, None]) -> float:
+    """Token-level F1 between retrieved and golden context."""
+    retrieved_tokens = _token_set(normalize_context_text(retrieved))
+    golden_tokens = _token_set(normalize_context_text(golden))
+    if not retrieved_tokens and not golden_tokens:
+        return 0.0
+    if not retrieved_tokens or not golden_tokens:
+        return 0.0
+
+    overlap = retrieved_tokens & golden_tokens
+    precision = len(overlap) / len(retrieved_tokens)
+    recall = len(overlap) / len(golden_tokens)
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _split_golden_units(golden_text: str) -> list[str]:
+    lines = [line.strip() for line in golden_text.splitlines() if line.strip()]
+    if len(lines) > 1:
+        return [line.lower() for line in lines]
+
+    sentences = re.split(r"(?<=[.!?])\s+", golden_text)
+    sentences = [sentence.strip().lower() for sentence in sentences if sentence.strip()]
+    return sentences or [golden_text]
+
+
+def aggregate_metric(values: Iterable[float]) -> dict[str, float]:
+    """Return mean/min/max for a metric series."""
+    series = list(values)
+    if not series:
+        return {"mean": 0.0, "min": 0.0, "max": 0.0, "count": 0.0}
+    return {
+        "mean": sum(series) / len(series),
+        "min": min(series),
+        "max": max(series),
+        "count": float(len(series)),
+    }

--- a/cognee/eval_framework/retrieval_benchmark/runner.py
+++ b/cognee/eval_framework/retrieval_benchmark/runner.py
@@ -1,0 +1,112 @@
+"""Run retrieval-only benchmarks across Cognee search modes."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from cognee.eval_framework.retrieval_benchmark.metrics import (
+    aggregate_metric,
+    context_overlap_f1,
+    context_recall,
+    normalize_context_text,
+)
+from cognee.modules.search.types import SearchType
+
+
+DEFAULT_SEARCH_TYPES = (
+    SearchType.CHUNKS,
+    SearchType.SUMMARIES,
+    SearchType.GRAPH_COMPLETION,
+)
+
+
+class RetrievalBenchmarkRunner:
+    """Evaluate retrieval quality without LLM answer generation."""
+
+    def __init__(
+        self,
+        search_types: Optional[list[SearchType]] = None,
+        top_k: int = 10,
+    ):
+        self.search_types = list(search_types or DEFAULT_SEARCH_TYPES)
+        self.top_k = top_k
+
+    async def run_instance(
+        self,
+        *,
+        question: str,
+        golden_context: str,
+        search_fn,
+        datasets: Optional[list[str]] = None,
+    ) -> list[dict[str, Any]]:
+        """Run retrieval metrics for one QA instance across configured search types."""
+        results: list[dict[str, Any]] = []
+        for search_type in self.search_types:
+            payload = await search_fn(
+                query_text=question,
+                query_type=search_type,
+                datasets=datasets,
+                top_k=self.top_k,
+                only_context=True,
+            )
+            retrieved_context = self._extract_context(payload)
+            results.append(
+                {
+                    "question": question,
+                    "search_type": search_type.value,
+                    "context_recall": context_recall(retrieved_context, golden_context),
+                    "context_f1": context_overlap_f1(retrieved_context, golden_context),
+                    "retrieved_context": normalize_context_text(retrieved_context),
+                    "golden_context": normalize_context_text(golden_context),
+                }
+            )
+        return results
+
+    async def run_instances(
+        self,
+        instances: list[dict[str, str]],
+        search_fn,
+        datasets: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Run retrieval metrics for many instances and aggregate per search type."""
+        per_type: dict[str, list[dict[str, Any]]] = {
+            search_type.value: [] for search_type in self.search_types
+        }
+
+        for instance in instances:
+            question = instance["question"]
+            golden_context = instance.get("golden_context", "")
+            rows = await self.run_instance(
+                question=question,
+                golden_context=golden_context,
+                search_fn=search_fn,
+                datasets=datasets,
+            )
+            for row in rows:
+                per_type[row["search_type"]].append(row)
+
+        summary: dict[str, Any] = {"per_search_type": {}, "instances": []}
+        for search_type, rows in per_type.items():
+            summary["per_search_type"][search_type] = {
+                "context_recall": aggregate_metric(row["context_recall"] for row in rows),
+                "context_f1": aggregate_metric(row["context_f1"] for row in rows),
+            }
+            summary["instances"].extend(rows)
+        return summary
+
+    @staticmethod
+    def _extract_context(payload: Any) -> Any:
+        if payload is None:
+            return ""
+        if isinstance(payload, list) and payload:
+            first = payload[0]
+            if isinstance(first, dict):
+                for key in ("context_result", "context", "search_result", "result"):
+                    if key in first and first[key] is not None:
+                        return first[key]
+            return payload
+        if isinstance(payload, dict):
+            for key in ("context_result", "context", "search_result", "result"):
+                if key in payload and payload[key] is not None:
+                    return payload[key]
+        return payload

--- a/cognee/tests/unit/eval_framework/test_retrieval_benchmark_metrics.py
+++ b/cognee/tests/unit/eval_framework/test_retrieval_benchmark_metrics.py
@@ -1,0 +1,41 @@
+import pytest
+
+from cognee.eval_framework.retrieval_benchmark.metrics import (
+    aggregate_metric,
+    context_overlap_f1,
+    context_recall,
+    normalize_context_text,
+)
+
+
+def test_normalize_context_text_flattens_lists_and_dicts():
+    assert normalize_context_text(["Alpha", {"text": "Beta"}]) == "alpha\nbeta"
+
+
+def test_context_recall_counts_golden_lines_found():
+    golden = "Paris is the capital.\nFrance is in Europe."
+    retrieved = "Background: Paris is the capital. More text."
+    assert context_recall(retrieved, golden) == 0.5
+
+
+def test_context_recall_returns_zero_for_empty_golden():
+    assert context_recall("anything", "") == 0.0
+
+
+def test_context_overlap_f1_token_match():
+    golden = "quantum computer uses superposition"
+    retrieved = "a quantum computer leverages superposition and entanglement"
+    score = context_overlap_f1(retrieved, golden)
+    assert 0.4 < score < 1.0
+
+
+def test_aggregate_metric_handles_empty_series():
+    assert aggregate_metric([])["count"] == 0.0
+
+
+def test_aggregate_metric_summarizes_values():
+    summary = aggregate_metric([0.2, 0.8])
+    assert summary["mean"] == pytest.approx(0.5)
+    assert summary["min"] == pytest.approx(0.2)
+    assert summary["max"] == pytest.approx(0.8)
+    assert summary["count"] == 2.0

--- a/cognee/tests/unit/eval_framework/test_retrieval_benchmark_runner.py
+++ b/cognee/tests/unit/eval_framework/test_retrieval_benchmark_runner.py
@@ -1,0 +1,29 @@
+import pytest
+
+from cognee.eval_framework.retrieval_benchmark.runner import RetrievalBenchmarkRunner
+from cognee.modules.search.types import SearchType
+
+
+@pytest.mark.asyncio
+async def test_runner_aggregates_per_search_type():
+    runner = RetrievalBenchmarkRunner(search_types=[SearchType.CHUNKS, SearchType.SUMMARIES])
+
+    async def fake_search(**kwargs):
+        if kwargs["query_type"] == SearchType.CHUNKS:
+            return [{"context_result": "alpha beta"}]
+        return [{"context_result": "alpha"}]
+
+    summary = await runner.run_instances(
+        instances=[
+            {
+                "question": "What is alpha?",
+                "golden_context": "alpha beta",
+            }
+        ],
+        search_fn=fake_search,
+    )
+
+    assert "CHUNKS" in summary["per_search_type"]
+    assert "SUMMARIES" in summary["per_search_type"]
+    assert summary["per_search_type"]["CHUNKS"]["context_recall"]["mean"] == 1.0
+    assert summary["per_search_type"]["SUMMARIES"]["context_recall"]["mean"] < 1.0


### PR DESCRIPTION
Closes #2913

## Summary

- Add `context_recall` and token-level `context_overlap_f1` metrics for comparing retrieved context to golden supporting text
- Add `RetrievalBenchmarkRunner` to score retrieval-only search modes (`only_context=True`) across CHUNKS, SUMMARIES, and GRAPH_COMPLETION
- Include unit tests for metrics normalization, aggregation, and per-search-type summaries

## Test plan

- [x] `pytest cognee/tests/unit/eval_framework/test_retrieval_benchmark_metrics.py`
- [x] `pytest cognee/tests/unit/eval_framework/test_retrieval_benchmark_runner.py`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.