### PR TITLE
fix(chromadb): store belongs_to_set as native array with migration

### DIFF
--- a/cognee/infrastructure/databases/vector/__init__.py
+++ b/cognee/infrastructure/databases/vector/__init__.py
@@ -4,3 +4,8 @@ from .vector_db_interface import VectorDBInterface
 from .config import get_vectordb_config
 from .get_vector_engine import get_vector_engine
 from .use_vector_adapter import use_vector_adapter
+
+try:
+    from cognee.infrastructure.databases.vector import adapters as _vector_adapters  # noqa: F401
+except ImportError:
+    pass

--- a/cognee/infrastructure/databases/vector/adapters/__init__.py
+++ b/cognee/infrastructure/databases/vector/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Optional community vector adapters bundled for registration via use_vector_adapter."""
+
+try:
+    from cognee.infrastructure.databases.vector.adapters import chromadb as _chromadb  # noqa: F401
+except ImportError:
+    pass

--- a/cognee/infrastructure/databases/vector/adapters/chromadb/ChromaDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/adapters/chromadb/ChromaDBAdapter.py
@@ -1,0 +1,497 @@
+import json
+import asyncio
+from uuid import UUID
+from typing import Any, List, Literal, Optional
+
+from pydantic import BaseModel
+
+from cognee.shared.logging_utils import get_logger
+from cognee.modules.storage.utils import get_own_properties
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.engine.utils import parse_id
+from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
+
+from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
+from cognee.infrastructure.databases.vector.vector_db_interface import VectorDBInterface
+
+try:
+    from chromadb import AsyncHttpClient, Settings
+except ImportError:  # pragma: no cover - optional extra
+    AsyncHttpClient = Any  # type: ignore[misc, assignment]
+    Settings = Any  # type: ignore[misc, assignment]
+
+logger = get_logger("ChromaDBAdapter")
+
+BELONGS_TO_SET_KEY = "belongs_to_set"
+LEGACY_BELONGS_TO_SET_LIST_KEY = f"{BELONGS_TO_SET_KEY}__list"
+LEGACY_BELONGS_TO_SET_MEMBER_PREFIX = f"{BELONGS_TO_SET_KEY}::"
+MAX_NODE_NAME_LENGTH = 256
+
+
+class IndexSchema(DataPoint):
+    text: str
+    metadata: dict = {"index_fields": ["text"]}
+
+    def model_dump(self):
+        data = super().model_dump()
+        return process_data_for_chroma(data)
+
+
+def _normalize_belongs_to_set_tags(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        tags = value
+    elif isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            tags = parsed if isinstance(parsed, list) else [value]
+        except json.JSONDecodeError:
+            tags = [value]
+    else:
+        return []
+    cleaned: list[str] = []
+    for tag in tags:
+        if isinstance(tag, str):
+            stripped = tag.strip()
+            if stripped and len(stripped) <= MAX_NODE_NAME_LENGTH:
+                cleaned.append(stripped)
+    return cleaned
+
+
+def process_data_for_chroma(data: dict) -> dict:
+    """Serialize metadata for ChromaDB, storing belongs_to_set as a native string array."""
+    processed_data: dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, UUID):
+            processed_data[key] = str(value)
+        elif isinstance(value, dict):
+            processed_data[f"{key}__dict"] = json.dumps(value)
+        elif isinstance(value, list):
+            if key == BELONGS_TO_SET_KEY:
+                processed_data[key] = _normalize_belongs_to_set_tags(value)
+            else:
+                processed_data[f"{key}__list"] = json.dumps(value)
+        elif isinstance(value, (str, int, float, bool)):
+            processed_data[key] = value
+        else:
+            processed_data[key] = str(value)
+    return processed_data
+
+
+def restore_data_from_chroma(data: dict) -> dict:
+    """Restore metadata from ChromaDB storage, including legacy belongs_to_set formats."""
+    restored_data: dict[str, Any] = {}
+    dict_keys: list[str] = []
+    list_keys: list[str] = []
+
+    for key, value in data.items():
+        if key.endswith("__dict"):
+            dict_keys.append(key)
+        elif key.endswith("__list"):
+            list_keys.append(key)
+        elif key.startswith(LEGACY_BELONGS_TO_SET_MEMBER_PREFIX):
+            continue
+        else:
+            restored_data[key] = value
+
+    for key in dict_keys:
+        original_key = key[:-6]
+        try:
+            restored_data[original_key] = json.loads(data[key])
+        except json.JSONDecodeError as exc:
+            logger.debug("Error restoring dictionary from JSON: %s", exc)
+            restored_data[key] = data[key]
+
+    for key in list_keys:
+        original_key = key[:-6]
+        if original_key == BELONGS_TO_SET_KEY and isinstance(restored_data.get(BELONGS_TO_SET_KEY), list):
+            continue
+        try:
+            restored_data[original_key] = json.loads(data[key])
+        except json.JSONDecodeError as exc:
+            logger.debug("Error restoring list from JSON: %s", exc)
+            restored_data[key] = data[key]
+
+    if BELONGS_TO_SET_KEY not in restored_data and LEGACY_BELONGS_TO_SET_LIST_KEY in data:
+        restored_data[BELONGS_TO_SET_KEY] = _normalize_belongs_to_set_tags(
+            data[LEGACY_BELONGS_TO_SET_LIST_KEY]
+        )
+
+    if BELONGS_TO_SET_KEY in restored_data:
+        restored_data[BELONGS_TO_SET_KEY] = _normalize_belongs_to_set_tags(
+            restored_data[BELONGS_TO_SET_KEY]
+        )
+
+    return restored_data
+
+
+def metadata_needs_belongs_to_set_migration(metadata: dict) -> bool:
+    if not metadata:
+        return False
+    if LEGACY_BELONGS_TO_SET_LIST_KEY in metadata:
+        return True
+    if any(key.startswith(LEGACY_BELONGS_TO_SET_MEMBER_PREFIX) for key in metadata):
+        return True
+    current = metadata.get(BELONGS_TO_SET_KEY)
+    return isinstance(current, str)
+
+
+def migrate_belongs_to_set_metadata(metadata: dict) -> dict:
+    """Convert legacy belongs_to_set storage to native array metadata."""
+    migrated = dict(metadata)
+    tags = _normalize_belongs_to_set_tags(migrated.get(BELONGS_TO_SET_KEY))
+
+    if LEGACY_BELONGS_TO_SET_LIST_KEY in migrated:
+        tags = _normalize_belongs_to_set_tags(migrated.pop(LEGACY_BELONGS_TO_SET_LIST_KEY)) or tags
+
+    for key, value in list(migrated.items()):
+        if key.startswith(LEGACY_BELONGS_TO_SET_MEMBER_PREFIX) and value is True:
+            tag = key[len(LEGACY_BELONGS_TO_SET_MEMBER_PREFIX) :]
+            if tag and tag not in tags:
+                tags.append(tag)
+            migrated.pop(key, None)
+
+    migrated[BELONGS_TO_SET_KEY] = tags
+    return migrated
+
+
+def sanitize_node_names(node_name: Optional[List[str]]) -> Optional[List[str]]:
+    if not node_name:
+        return None
+    cleaned: list[str] = []
+    for raw in node_name:
+        if not isinstance(raw, str):
+            continue
+        name = raw.strip()
+        if not name or len(name) > MAX_NODE_NAME_LENGTH:
+            continue
+        cleaned.append(name)
+    return cleaned or None
+
+
+class ChromaDBAdapter(VectorDBInterface):
+    """Community-registered ChromaDB vector adapter with native belongs_to_set arrays."""
+
+    name = "ChromaDB"
+    url: str
+    api_key: str
+    connection: AsyncHttpClient = None
+
+    def __init__(
+        self, url: Optional[str], api_key: Optional[str], embedding_engine: EmbeddingEngine
+    ):
+        self.embedding_engine = embedding_engine
+        self.url = url
+        self.api_key = api_key
+        self.VECTOR_DB_LOCK = asyncio.Lock()
+
+    async def get_connection(self) -> AsyncHttpClient:
+        if self.connection is None:
+            settings = Settings(
+                chroma_client_auth_provider="token",
+                chroma_client_auth_credentials=self.api_key or "",
+            )
+            self.connection = await AsyncHttpClient(host=self.url, settings=settings)
+        return self.connection
+
+    async def embed_data(self, data: list[str]) -> list[list[float]]:
+        return await self.embedding_engine.embed_text(data)
+
+    async def has_collection(self, collection_name: str) -> bool:
+        collections = await self.get_collection_names()
+        return collection_name in collections
+
+    async def create_collection(self, collection_name: str, payload_schema=None):
+        async with self.VECTOR_DB_LOCK:
+            client = await self.get_connection()
+            if not await self.has_collection(collection_name):
+                await client.create_collection(
+                    name=collection_name, metadata={"hnsw:space": "cosine"}
+                )
+
+    async def get_collection(self, collection_name: str):
+        if not await self.has_collection(collection_name):
+            raise CollectionNotFoundError(f"Collection '{collection_name}' not found!")
+        client = await self.get_connection()
+        return await client.get_collection(collection_name)
+
+    async def create_data_points(self, collection_name: str, data_points: list[DataPoint]):
+        await self.create_collection(collection_name)
+        collection = await self.get_collection(collection_name)
+
+        texts = [DataPoint.get_embeddable_data(data_point) for data_point in data_points]
+        embeddings = await self.embed_data(texts)
+        ids = [str(data_point.id) for data_point in data_points]
+        metadatas = [
+            process_data_for_chroma(get_own_properties(data_point)) for data_point in data_points
+        ]
+
+        await collection.upsert(
+            ids=ids, embeddings=embeddings, metadatas=metadatas, documents=texts
+        )
+
+    async def create_vector_index(self, index_name: str, index_property_name: str):
+        await self.create_collection(f"{index_name}_{index_property_name}")
+
+    async def index_data_points(
+        self, index_name: str, index_property_name: str, data_points: list[DataPoint]
+    ):
+        await self.create_data_points(
+            f"{index_name}_{index_property_name}",
+            [
+                IndexSchema(
+                    id=data_point.id,
+                    text=getattr(data_point, data_point.metadata["index_fields"][0]),
+                )
+                for data_point in data_points
+            ],
+        )
+
+    async def retrieve(self, collection_name: str, data_point_ids: list[str]):
+        try:
+            collection = await self.get_collection(collection_name)
+        except CollectionNotFoundError:
+            return []
+
+        results = await collection.get(ids=data_point_ids, include=["metadatas"])
+        return [
+            ScoredResult(
+                id=parse_id(record_id),
+                payload=restore_data_from_chroma(metadata),
+                score=0,
+            )
+            for record_id, metadata in zip(results["ids"], results["metadatas"])
+        ]
+
+    @staticmethod
+    def _build_where_filter(
+        node_name: Optional[List[str]],
+        node_name_filter_operator: Literal["OR", "AND"],
+    ) -> Optional[dict]:
+        sanitized = sanitize_node_names(node_name)
+        if node_name_filter_operator not in ("OR", "AND"):
+            raise ValueError(
+                f"Unsupported node_name_filter_operator: {node_name_filter_operator!r}. "
+                "Expected 'OR' or 'AND'."
+            )
+        if not sanitized:
+            return None
+
+        def _contains_clause(name: str) -> dict:
+            return {BELONGS_TO_SET_KEY: {"$contains": name}}
+
+        if len(sanitized) == 1:
+            return _contains_clause(sanitized[0])
+        operator_key = "$and" if node_name_filter_operator == "AND" else "$or"
+        return {operator_key: [_contains_clause(name) for name in sanitized]}
+
+    @staticmethod
+    def _build_include_list(include_payload: bool, with_vector: bool) -> List[str]:
+        include = ["distances"]
+        if include_payload:
+            include.append("metadatas")
+        if with_vector:
+            include.append("embeddings")
+        return include
+
+    async def search(
+        self,
+        collection_name: str,
+        query_text: str = None,
+        query_vector: List[float] = None,
+        limit: Optional[int] = 15,
+        with_vector: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: Literal["OR", "AND"] = "OR",
+    ):
+        if query_text is None and query_vector is None:
+            raise MissingQueryParameterError()
+
+        if query_text and not query_vector:
+            query_vector = (await self.embedding_engine.embed_text([query_text]))[0]
+
+        try:
+            collection = await self.get_collection(collection_name)
+            if limit is None:
+                limit = await collection.count()
+            if limit <= 0:
+                return []
+
+            where_filter = self._build_where_filter(node_name, node_name_filter_operator)
+            include_list = self._build_include_list(include_payload, with_vector)
+            query_kwargs = {
+                "query_embeddings": [query_vector],
+                "include": include_list,
+                "n_results": limit,
+            }
+            if where_filter is not None:
+                query_kwargs["where"] = where_filter
+
+            results = await collection.query(**query_kwargs)
+            vector_list = []
+            metadatas = results.get("metadatas")
+            for index, (record_id, distance) in enumerate(
+                zip(results["ids"][0], results["distances"][0])
+            ):
+                payload = None
+                if include_payload and metadatas:
+                    payload = restore_data_from_chroma(metadatas[0][index])
+                vector_list.append(
+                    {
+                        "id": parse_id(record_id),
+                        "payload": payload,
+                        "score": float(distance),
+                        "vector": results["embeddings"][0][index]
+                        if with_vector and "embeddings" in results
+                        else None,
+                    }
+                )
+
+            return [
+                ScoredResult(
+                    id=row["id"],
+                    payload=row["payload"],
+                    score=row["score"],
+                    vector=row["vector"],
+                )
+                for row in vector_list
+            ]
+        except Exception as exc:
+            logger.warning("Error in ChromaDB search: %s", exc)
+            return []
+
+    async def batch_search(
+        self,
+        collection_name: str,
+        query_texts: List[str],
+        limit: int = 5,
+        with_vectors: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: Literal["OR", "AND"] = "OR",
+    ):
+        query_vectors = await self.embed_data(query_texts)
+        collection = await self.get_collection(collection_name)
+        where_filter = self._build_where_filter(node_name, node_name_filter_operator)
+        include_list = self._build_include_list(include_payload, with_vectors)
+
+        query_kwargs = {
+            "query_embeddings": query_vectors,
+            "include": include_list,
+            "n_results": limit,
+        }
+        if where_filter is not None:
+            query_kwargs["where"] = where_filter
+
+        results = await collection.query(**query_kwargs)
+        all_results = []
+        metadatas = results.get("metadatas")
+        for query_index in range(len(query_texts)):
+            query_results = []
+            for record_index, (record_id, distance) in enumerate(
+                zip(results["ids"][query_index], results["distances"][query_index])
+            ):
+                payload = None
+                if include_payload and metadatas:
+                    payload = restore_data_from_chroma(metadatas[query_index][record_index])
+                result = ScoredResult(
+                    id=parse_id(record_id),
+                    payload=payload,
+                    score=float(distance),
+                )
+                if with_vectors and "embeddings" in results:
+                    result.vector = results["embeddings"][query_index][record_index]
+                query_results.append(result)
+            all_results.append(query_results)
+        return all_results
+
+    async def delete_data_points(self, collection_name: str, data_point_ids: list[str]):
+        if not await self.has_collection(collection_name):
+            return True
+        collection = await self.get_collection(collection_name)
+        await collection.delete(ids=data_point_ids)
+        return True
+
+    async def prune(self):
+        client = await self.get_connection()
+        collections = await client.list_collections()
+        for collection_name in collections:
+            await client.delete_collection(collection_name)
+        return True
+
+    async def get_collection_names(self):
+        client = await self.get_connection()
+        return await client.list_collections()
+
+    async def run_migrations(self) -> dict[str, int]:
+        """Migrate legacy belongs_to_set JSON/boolean metadata to native arrays."""
+        summary = {"checked_collections": 0, "migrated_records": 0}
+        try:
+            collection_names = await self.get_collection_names()
+        except Exception as exc:
+            logger.warning("ChromaDB migration skipped: %s", exc)
+            return summary
+
+        for collection_name in collection_names:
+            summary["checked_collections"] += 1
+            try:
+                collection = await self.get_collection(collection_name)
+                records = await collection.get(include=["metadatas", "embeddings", "documents"])
+            except Exception as exc:
+                logger.warning(
+                    "ChromaDB migration failed while reading '%s': %s", collection_name, exc
+                )
+                continue
+
+            ids = records.get("ids") or []
+            metadatas = records.get("metadatas") or []
+            embeddings = records.get("embeddings") or []
+            documents = records.get("documents") or []
+
+            migrated_ids: list[str] = []
+            migrated_metadatas: list[dict] = []
+            migrated_embeddings: list[list[float]] = []
+            migrated_documents: list[str] = []
+
+            for index, record_id in enumerate(ids):
+                metadata = metadatas[index] if index < len(metadatas) else {}
+                if not metadata_needs_belongs_to_set_migration(metadata):
+                    continue
+                migrated_ids.append(record_id)
+                migrated_metadatas.append(migrate_belongs_to_set_metadata(metadata))
+                if embeddings:
+                    migrated_embeddings.append(embeddings[index])
+                if documents:
+                    migrated_documents.append(documents[index])
+
+            if not migrated_ids:
+                continue
+
+            upsert_kwargs = {
+                "ids": migrated_ids,
+                "metadatas": migrated_metadatas,
+            }
+            if migrated_embeddings:
+                upsert_kwargs["embeddings"] = migrated_embeddings
+            if migrated_documents:
+                upsert_kwargs["documents"] = migrated_documents
+
+            try:
+                await collection.upsert(**upsert_kwargs)
+                summary["migrated_records"] += len(migrated_ids)
+            except Exception as exc:
+                logger.warning(
+                    "ChromaDB migration upsert failed for '%s': %s", collection_name, exc
+                )
+
+        if summary["migrated_records"]:
+            logger.info(
+                "ChromaDB belongs_to_set migration complete: %s records across %s collections",
+                summary["migrated_records"],
+                summary["checked_collections"],
+            )
+        return summary

--- a/cognee/infrastructure/databases/vector/adapters/chromadb/__init__.py
+++ b/cognee/infrastructure/databases/vector/adapters/chromadb/__init__.py
@@ -1,0 +1,12 @@
+"""ChromaDB vector adapter (community registration)."""
+
+from cognee.infrastructure.databases.vector.use_vector_adapter import use_vector_adapter
+
+try:
+    from .ChromaDBAdapter import ChromaDBAdapter
+
+    use_vector_adapter("chromadb", ChromaDBAdapter)
+except ImportError:
+    ChromaDBAdapter = None  # type: ignore[misc, assignment]
+
+__all__ = ["ChromaDBAdapter"]

--- a/cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py
@@ -1,0 +1,71 @@
+"""Unit tests for ChromaDBAdapter search filtering."""
+
+import pytest
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+chromadb = pytest.importorskip("chromadb", reason="ChromaDB tests require cognee[chromadb]")
+
+from cognee.infrastructure.databases.vector.adapters.chromadb.ChromaDBAdapter import (  # noqa: E402
+    BELONGS_TO_SET_KEY,
+    ChromaDBAdapter,
+)
+
+
+def _make_chroma_result(ids, distances, metadatas=None):
+    result = {"ids": [ids], "distances": [distances]}
+    if metadatas is not None:
+        result["metadatas"] = [metadatas]
+    return result
+
+
+def _make_adapter():
+    adapter = ChromaDBAdapter.__new__(ChromaDBAdapter)
+    adapter.embedding_engine = AsyncMock()
+    adapter.embedding_engine.embed_text = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    mock_collection = AsyncMock()
+    mock_collection.count = AsyncMock(return_value=10)
+    adapter.get_collection = AsyncMock(return_value=mock_collection)
+    adapter.embed_data = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    return adapter, mock_collection
+
+
+@pytest.mark.asyncio
+async def test_search_node_name_applies_contains_filter():
+    adapter, collection = _make_adapter()
+    collection.query = AsyncMock(return_value=_make_chroma_result(ids=[], distances=[]))
+
+    await adapter.search(
+        collection_name="test_col",
+        query_text="hello",
+        limit=5,
+        include_payload=False,
+        node_name=["Alice"],
+    )
+
+    where = collection.query.call_args[1]["where"]
+    assert where == {BELONGS_TO_SET_KEY: {"$contains": "Alice"}}
+
+
+@pytest.mark.asyncio
+async def test_search_include_payload_true_fetches_metadatas():
+    adapter, collection = _make_adapter()
+    node_id = str(uuid4())
+    collection.query = AsyncMock(
+        return_value=_make_chroma_result(
+            ids=[node_id],
+            distances=[0.2],
+            metadatas=[{"text": "Alice", "id": node_id, "belongs_to_set": ["Alice"]}],
+        )
+    )
+
+    results = await adapter.search(
+        collection_name="test_col",
+        query_text="hello",
+        limit=5,
+        include_payload=True,
+    )
+
+    assert len(results) == 1
+    assert results[0].payload is not None
+    assert "metadatas" in collection.query.call_args[1]["include"]

--- a/cognee/tests/unit/infrastructure/databases/vector/test_chromadb_metadata.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_chromadb_metadata.py
@@ -1,0 +1,74 @@
+import pytest
+
+from cognee.infrastructure.databases.vector.adapters.chromadb.ChromaDBAdapter import (
+    BELONGS_TO_SET_KEY,
+    LEGACY_BELONGS_TO_SET_LIST_KEY,
+    LEGACY_BELONGS_TO_SET_MEMBER_PREFIX,
+    ChromaDBAdapter,
+    metadata_needs_belongs_to_set_migration,
+    migrate_belongs_to_set_metadata,
+    process_data_for_chroma,
+    restore_data_from_chroma,
+    sanitize_node_names,
+)
+
+
+def test_process_data_for_chroma_stores_native_belongs_to_set_array():
+    processed = process_data_for_chroma({"belongs_to_set": ["alpha", "beta"]})
+    assert processed["belongs_to_set"] == ["alpha", "beta"]
+    assert LEGACY_BELONGS_TO_SET_LIST_KEY not in processed
+
+
+def test_process_data_for_chroma_still_json_encodes_other_lists():
+    processed = process_data_for_chroma({"tags": ["x"]})
+    assert "tags__list" in processed
+
+
+def test_restore_data_from_chroma_reads_native_array():
+    restored = restore_data_from_chroma({"belongs_to_set": ["alpha"]})
+    assert restored["belongs_to_set"] == ["alpha"]
+
+
+def test_restore_data_from_chroma_reads_legacy_json_list():
+    restored = restore_data_from_chroma(
+        {LEGACY_BELONGS_TO_SET_LIST_KEY: '["legacy-tag"]'}
+    )
+    assert restored["belongs_to_set"] == ["legacy-tag"]
+
+
+def test_migrate_belongs_to_set_metadata_converts_legacy_keys():
+    metadata = {
+        LEGACY_BELONGS_TO_SET_LIST_KEY: '["a"]',
+        f"{LEGACY_BELONGS_TO_SET_MEMBER_PREFIX}b": True,
+    }
+    migrated = migrate_belongs_to_set_metadata(metadata)
+    assert migrated[BELONGS_TO_SET_KEY] == ["a", "b"]
+    assert LEGACY_BELONGS_TO_SET_LIST_KEY not in migrated
+    assert not any(key.startswith(LEGACY_BELONGS_TO_SET_MEMBER_PREFIX) for key in migrated)
+
+
+def test_metadata_needs_belongs_to_set_migration_detects_legacy_formats():
+    assert metadata_needs_belongs_to_set_migration({LEGACY_BELONGS_TO_SET_LIST_KEY: "[]"})
+    assert metadata_needs_belongs_to_set_migration(
+        {f"{LEGACY_BELONGS_TO_SET_MEMBER_PREFIX}tag": True}
+    )
+    assert not metadata_needs_belongs_to_set_migration({"belongs_to_set": ["native"]})
+
+
+def test_build_where_filter_uses_contains_operator():
+    where = ChromaDBAdapter._build_where_filter(["alpha"], "OR")
+    assert where == {"belongs_to_set": {"$contains": "alpha"}}
+
+
+def test_build_where_filter_and_semantics():
+    where = ChromaDBAdapter._build_where_filter(["alpha", "beta"], "AND")
+    assert where == {
+        "$and": [
+            {"belongs_to_set": {"$contains": "alpha"}},
+            {"belongs_to_set": {"$contains": "beta"}},
+        ]
+    }
+
+
+def test_sanitize_node_names_rejects_blank_and_overlong_values():
+    assert sanitize_node_names([" valid ", "", "x" * 300]) == ["valid"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,10 @@ dev = [
 debug = ["debugpy>=1.8.9,<2.0.0"]
 redis = ["redis>=5.0.3,<6.0.0"]
 
+chromadb = [
+    "chromadb>=1.5.0,<2",
+]
+
 tracing = [
     "opentelemetry-api>=1.20.0,<2",
     "opentelemetry-sdk>=1.20.0,<2",


### PR DESCRIPTION
Closes #2947

## Summary

- Re-add ChromaDB as a community vector adapter registered via `use_vector_adapter`
- Store `belongs_to_set` as a native string array and filter with ChromaDB `$contains`
- Migrate legacy `belongs_to_set__list` JSON and `belongs_to_set::<tag>` boolean metadata on startup

## Test plan

- [x] `pytest cognee/tests/unit/infrastructure/databases/vector/test_chromadb_metadata.py`
- [x] `pytest cognee/tests/unit/infrastructure/databases/vector/test_chromadb_adapter_search.py` (with `cognee[chromadb]`)

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.