### PR TITLE
feat(search): enrich CHUNKS results with document context

### DIFF
--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -60,6 +60,15 @@ class SearchPayloadDTO(InDTO):
         ),
     )
     top_k: Optional[int] = Field(default=15)
+    expand_neighbors: int = Field(
+        default=0,
+        ge=0,
+        le=10,
+        description=(
+            "For CHUNKS search, attach neighboring chunks from the same parent document "
+            "to each result (0 disables enrichment)."
+        ),
+    )
     only_context: bool = Field(default=False)
     verbose: bool = Field(
         default=False,
@@ -233,6 +242,7 @@ def get_search_router() -> APIRouter:
                 system_prompt=payload.system_prompt,
                 node_name=payload.node_name,
                 top_k=payload.top_k,
+                expand_neighbors=payload.expand_neighbors,
                 verbose=payload.verbose,
                 only_context=payload.only_context,
                 skills=payload.skills,

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -52,6 +52,7 @@ async def search(
     tools: Optional[List[str]] = None,
     max_iter: Optional[int] = None,
     include_references: bool = False,
+    expand_neighbors: int = 0,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[SearchResult]:
@@ -73,6 +74,11 @@ async def search(
         raise CogneeValidationError(
             message="max_iter must be a positive integer.",
             name="InvalidMaxIter",
+        )
+    if not isinstance(expand_neighbors, int) or expand_neighbors < 0 or expand_neighbors > 10:
+        raise CogneeValidationError(
+            message="expand_neighbors must be an integer between 0 and 10.",
+            name="InvalidExpandNeighbors",
         )
     """
     Search and query the knowledge graph for insights, information, and connections.
@@ -307,6 +313,10 @@ async def search(
             for key, value in agentic_overrides.items():
                 if value is not None:
                     retriever_specific_config[key] = value
+
+        if expand_neighbors > 0:
+            retriever_specific_config = dict(retriever_specific_config or {})
+            retriever_specific_config["expand_neighbors"] = expand_neighbors
 
         filtered_search_results = await search_function(
             query_text=query_text,

--- a/cognee/infrastructure/databases/graph/utils.py
+++ b/cognee/infrastructure/databases/graph/utils.py
@@ -1,0 +1,16 @@
+"""Utility functions for graph database operations."""
+
+from typing import Any, List, Dict
+
+
+def normalize_graph_result(result: List[Any], columns: List[str]) -> List[Dict[str, Any]]:
+    """
+    Normalize graph query results to a consistent dict format.
+
+    Ladybug/Kuzu returns List[Tuple], while Neo4j and Neptune return List[Dict[str, Any]].
+    """
+    if not result:
+        return []
+    if isinstance(result[0], tuple):
+        return [dict(zip(columns, row)) for row in result]
+    return result

--- a/cognee/modules/retrieval/chunk_context_enrichment.py
+++ b/cognee/modules/retrieval/chunk_context_enrichment.py
@@ -1,0 +1,223 @@
+"""Graph-backed enrichment for chunk search results (parent document + neighbors)."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from uuid import UUID
+
+from cognee.infrastructure.databases.graph.utils import normalize_graph_result
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("ChunkContextEnrichment")
+
+MAX_EXPAND_NEIGHBORS = 10
+
+
+def _safe_chunk_id(raw_id: Any) -> Optional[str]:
+    """Validate chunk IDs before graph queries to avoid injection via malformed IDs."""
+    if raw_id is None:
+        return None
+    try:
+        return str(UUID(str(raw_id).strip()))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def extract_chunk_ids(found_chunks: list[Any]) -> tuple[list[str], dict[str, Any]]:
+    chunk_ids: list[str] = []
+    chunk_id_map: dict[str, Any] = {}
+
+    for chunk in found_chunks:
+        chunk_id = None
+        if hasattr(chunk, "id"):
+            chunk_id = _safe_chunk_id(chunk.id)
+        elif hasattr(chunk, "payload") and isinstance(chunk.payload, dict):
+            chunk_id = _safe_chunk_id(chunk.payload.get("id"))
+        elif isinstance(chunk, dict):
+            if "id" in chunk:
+                chunk_id = _safe_chunk_id(chunk["id"])
+            elif isinstance(chunk.get("payload"), dict):
+                chunk_id = _safe_chunk_id(chunk["payload"].get("id"))
+
+        if chunk_id:
+            chunk_ids.append(chunk_id)
+            chunk_id_map[chunk_id] = chunk
+
+    return chunk_ids, chunk_id_map
+
+
+def _build_parent_info(row: dict[str, Any]) -> dict[str, str]:
+    parent_info = {
+        "id": str(row.get("doc_id", "")),
+        "name": row.get("doc_name") or "Unknown",
+    }
+    if row.get("doc_type"):
+        parent_info["type"] = str(row["doc_type"])
+    return parent_info
+
+
+async def fetch_parent_documents(graph_engine: Any, chunk_ids: list[str]) -> dict[str, dict]:
+    parent_map: dict[str, dict] = {}
+    if not chunk_ids:
+        return parent_map
+
+    try:
+        query = """
+        MATCH (chunk:DocumentChunk)-[:is_part_of]->(doc:Document)
+        WHERE chunk.id IN $chunk_ids
+        RETURN chunk.id as chunk_id, doc.id as doc_id, doc.name as doc_name, doc.type as doc_type
+        """
+        result = await graph_engine.query(query, params={"chunk_ids": chunk_ids})
+        result = normalize_graph_result(result, ["chunk_id", "doc_id", "doc_name", "doc_type"])
+        for row in result:
+            chunk_id = _safe_chunk_id(row.get("chunk_id"))
+            if chunk_id:
+                parent_map[chunk_id] = _build_parent_info(row)
+    except Exception as error:
+        logger.warning("Batched parent-document lookup failed: %s", error)
+
+    missing = [chunk_id for chunk_id in chunk_ids if chunk_id not in parent_map]
+    for chunk_id in missing:
+        try:
+            query = """
+            MATCH (chunk:DocumentChunk {id: $chunk_id})-[:is_part_of]->(doc:Document)
+            RETURN doc.id as doc_id, doc.name as doc_name, doc.type as doc_type
+            LIMIT 1
+            """
+            result = await graph_engine.query(query, params={"chunk_id": chunk_id})
+            result = normalize_graph_result(result, ["doc_id", "doc_name", "doc_type"])
+            if result:
+                parent_map[chunk_id] = _build_parent_info(result[0])
+        except Exception as error:
+            logger.debug("Individual parent lookup failed for %s: %s", chunk_id, error)
+
+    return parent_map
+
+
+async def fetch_neighbor_chunks(
+    graph_engine: Any,
+    chunk_ids: list[str],
+    *,
+    neighbor_count: int,
+) -> dict[str, list[dict[str, Any]]]:
+    if neighbor_count <= 0 or not chunk_ids:
+        return {}
+
+    neighbor_count = min(max(neighbor_count, 1), MAX_EXPAND_NEIGHBORS)
+    neighbors_by_chunk: dict[str, list[dict[str, Any]]] = {chunk_id: [] for chunk_id in chunk_ids}
+
+    try:
+        query = """
+        MATCH (target:DocumentChunk)-[:is_part_of]->(doc:Document)
+        WHERE target.id IN $chunk_ids
+        MATCH (doc)<-[:is_part_of]-(sibling:DocumentChunk)
+        RETURN target.id as chunk_id, target.chunk_index as target_index,
+               sibling.id as sibling_id, sibling.chunk_index as sibling_index,
+               sibling.text as sibling_text
+        """
+        result = await graph_engine.query(query, params={"chunk_ids": chunk_ids})
+        result = normalize_graph_result(
+            result,
+            ["chunk_id", "target_index", "sibling_id", "sibling_index", "sibling_text"],
+        )
+    except Exception as error:
+        logger.warning("Neighbor chunk lookup failed: %s", error)
+        return neighbors_by_chunk
+
+    for row in result:
+        chunk_id = _safe_chunk_id(row.get("chunk_id"))
+        sibling_id = _safe_chunk_id(row.get("sibling_id"))
+        target_index = row.get("target_index")
+        sibling_index = row.get("sibling_index")
+        if (
+            chunk_id is None
+            or sibling_id is None
+            or target_index is None
+            or sibling_index is None
+        ):
+            continue
+        if chunk_id not in neighbors_by_chunk:
+            continue
+        if abs(int(sibling_index) - int(target_index)) > neighbor_count:
+            continue
+        if sibling_id == chunk_id:
+            continue
+        neighbors_by_chunk[chunk_id].append(
+            {
+                "chunk_id": sibling_id,
+                "chunk_index": int(sibling_index),
+                "text": row.get("sibling_text") or "",
+            }
+        )
+
+    for chunk_id, neighbors in neighbors_by_chunk.items():
+        neighbors.sort(key=lambda item: item.get("chunk_index", 0))
+
+    return neighbors_by_chunk
+
+
+def _attach_to_payload(chunk: Any, key: str, value: Any) -> None:
+    if hasattr(chunk, "payload") and isinstance(chunk.payload, dict):
+        chunk.payload[key] = value
+    elif isinstance(chunk, dict):
+        if isinstance(chunk.get("payload"), dict):
+            chunk["payload"][key] = value
+        else:
+            chunk[key] = value
+
+
+async def enrich_chunk_results(
+    graph_engine: Any,
+    found_chunks: list[Any],
+    *,
+    expand_neighbors: int = 0,
+    strict_enrichment: bool = False,
+) -> list[Any]:
+    if not found_chunks:
+        return found_chunks
+
+    chunk_ids, chunk_id_map = extract_chunk_ids(found_chunks)
+    if not chunk_ids:
+        if strict_enrichment:
+            raise ValueError("No valid chunk IDs found for enrichment")
+        logger.warning("No valid chunk IDs found, skipping enrichment")
+        return found_chunks
+
+    parent_map = await fetch_parent_documents(graph_engine, chunk_ids)
+    neighbor_map = await fetch_neighbor_chunks(
+        graph_engine, chunk_ids, neighbor_count=expand_neighbors
+    )
+
+    enriched_count = 0
+    for chunk_id, chunk in chunk_id_map.items():
+        parent_info = parent_map.get(chunk_id)
+        if parent_info:
+            _attach_to_payload(chunk, "parent_document", parent_info)
+            _attach_to_payload(
+                chunk,
+                "is_part_of",
+                {
+                    "id": parent_info["id"],
+                    "name": parent_info.get("name"),
+                    "type": parent_info.get("type"),
+                },
+            )
+            enriched_count += 1
+        elif strict_enrichment:
+            raise ValueError(f"No parent document found for chunk {chunk_id}")
+
+        if expand_neighbors > 0:
+            neighbors = neighbor_map.get(chunk_id, [])
+            if neighbors:
+                _attach_to_payload(chunk, "neighboring_chunks", neighbors)
+
+    if found_chunks:
+        success_rate = enriched_count / len(found_chunks) * 100
+        logger.info(
+            "Enriched %s/%s chunks with parent document metadata (%.1f%%)",
+            enriched_count,
+            len(found_chunks),
+            success_rate,
+        )
+
+    return found_chunks

--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -1,7 +1,9 @@
 from typing import Any, Optional, List, Union
+
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.retrieval.base_retriever import BaseRetriever
+from cognee.modules.retrieval.chunk_context_enrichment import enrich_chunk_results
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
 
@@ -25,6 +27,8 @@ class ChunksRetriever(BaseRetriever):
         top_k: Optional[int] = 5,
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
+        expand_neighbors: int = 0,
+        strict_enrichment: bool = False,
     ):
         """
         Initializes the chunk retriever.
@@ -39,10 +43,16 @@ class ChunksRetriever(BaseRetriever):
               node set filtering.
             - node_name_filter_operator (str): Logical operator used when applying
               multiple node_name filters, such as "OR" or "AND". Defaults to "OR".
+            - expand_neighbors (int): When > 0, attach neighboring chunks from the
+              same parent document to each result (max 10).
+            - strict_enrichment (bool): Raise when graph enrichment cannot resolve
+              parent documents for retrieved chunks.
         """
         self.top_k = top_k
         self.node_name = node_name
         self.node_name_filter_operator = node_name_filter_operator
+        self.expand_neighbors = max(0, min(int(expand_neighbors or 0), 10))
+        self.strict_enrichment = strict_enrichment
 
     async def get_completion_from_context(
         self, query: str, retrieved_objects: Any, context: Any
@@ -122,9 +132,31 @@ class ChunksRetriever(BaseRetriever):
                 node_name_filter_operator=self.node_name_filter_operator,
             )
             logger.info(f"Found {len(found_chunks)} chunks from vector search")
-
-            return found_chunks
-
         except CollectionNotFoundError as error:
             logger.error("DocumentChunk_text collection not found in vector database")
             raise NoDataError("No data found in the system, please add data first.") from error
+
+        if not found_chunks:
+            return found_chunks
+
+        try:
+            graph_engine = unified.graph
+        except Exception as error:
+            message = f"Graph engine unavailable: {error}"
+            if self.strict_enrichment:
+                raise NoDataError(message) from error
+            logger.warning("%s, skipping enrichment", message)
+            return found_chunks
+
+        try:
+            return await enrich_chunk_results(
+                graph_engine,
+                found_chunks,
+                expand_neighbors=self.expand_neighbors,
+                strict_enrichment=self.strict_enrichment,
+            )
+        except ValueError as error:
+            if self.strict_enrichment:
+                raise NoDataError(str(error)) from error
+            logger.warning("Chunk enrichment skipped: %s", error)
+            return found_chunks

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -80,6 +80,8 @@ async def get_search_type_retriever_instance(
                 "top_k": top_k,
                 "node_name": node_name,
                 "node_name_filter_operator": node_name_filter_operator,
+                "expand_neighbors": retriever_specific_config.get("expand_neighbors", 0),
+                "strict_enrichment": retriever_specific_config.get("strict_enrichment", False),
             },
         ),
         SearchType.RAG_COMPLETION: (

--- a/cognee/tests/unit/modules/retrieval/test_chunk_context_enrichment.py
+++ b/cognee/tests/unit/modules/retrieval/test_chunk_context_enrichment.py
@@ -1,0 +1,126 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from cognee.modules.retrieval.chunk_context_enrichment import (
+    enrich_chunk_results,
+    extract_chunk_ids,
+    fetch_neighbor_chunks,
+    fetch_parent_documents,
+)
+from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
+from cognee.modules.retrieval.exceptions.exceptions import NoDataError
+
+
+def test_extract_chunk_ids_validates_uuid_format():
+    valid_id = str(uuid4())
+    chunk = SimpleNamespace(id=valid_id, payload={"text": "hello"})
+    chunk_ids, chunk_map = extract_chunk_ids([chunk])
+    assert chunk_ids == [valid_id]
+    assert chunk_map[valid_id] is chunk
+
+    invalid_ids, _ = extract_chunk_ids([SimpleNamespace(id="not-a-uuid", payload={})])
+    assert invalid_ids == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_parent_documents_batched_lookup():
+    graph = AsyncMock()
+    chunk_id = str(uuid4())
+    doc_id = str(uuid4())
+    graph.query = AsyncMock(
+        return_value=[(chunk_id, doc_id, "report.pdf", "PdfDocument")]
+    )
+
+    parent_map = await fetch_parent_documents(graph, [chunk_id])
+    assert parent_map[chunk_id]["id"] == doc_id
+    assert parent_map[chunk_id]["name"] == "report.pdf"
+
+
+@pytest.mark.asyncio
+async def test_fetch_neighbor_chunks_filters_by_index_window():
+    graph = AsyncMock()
+    chunk_id = str(uuid4())
+    neighbor_id = str(uuid4())
+    graph.query = AsyncMock(
+        return_value=[
+            (chunk_id, 2, neighbor_id, 3, "neighbor text"),
+            (chunk_id, 2, chunk_id, 2, "target text"),
+        ]
+    )
+
+    neighbors = await fetch_neighbor_chunks(graph, [chunk_id], neighbor_count=1)
+    assert len(neighbors[chunk_id]) == 1
+    assert neighbors[chunk_id][0]["chunk_id"] == neighbor_id
+
+
+@pytest.mark.asyncio
+async def test_enrich_chunk_results_attaches_parent_and_neighbors():
+    graph = AsyncMock()
+    chunk_id = str(uuid4())
+    doc_id = str(uuid4())
+    neighbor_id = str(uuid4())
+
+    async def _query_side_effect(query, params=None):
+        if "sibling" in query:
+            return [(chunk_id, 1, neighbor_id, 2, "next")]
+        return [(chunk_id, doc_id, "Doc", "TextDocument")]
+
+    graph.query = AsyncMock(side_effect=_query_side_effect)
+    chunk = SimpleNamespace(id=chunk_id, payload={"id": chunk_id, "text": "hit"})
+
+    enriched = await enrich_chunk_results(
+        graph, [chunk], expand_neighbors=1, strict_enrichment=True
+    )
+
+    assert enriched[0].payload["parent_document"]["id"] == doc_id
+    assert enriched[0].payload["is_part_of"]["id"] == doc_id
+    assert enriched[0].payload["neighboring_chunks"][0]["chunk_id"] == neighbor_id
+
+
+@pytest.mark.asyncio
+async def test_chunks_retriever_enriches_results():
+    chunk_id = str(uuid4())
+    doc_id = str(uuid4())
+    mock_result = SimpleNamespace(id=chunk_id, payload={"id": chunk_id, "text": "alpha"})
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.search = AsyncMock(return_value=[mock_result])
+
+    graph = AsyncMock()
+    graph.query = AsyncMock(return_value=[(chunk_id, doc_id, "Doc", "TextDocument")])
+
+    unified = AsyncMock()
+    unified.vector = mock_vector_engine
+    unified.graph = graph
+
+    retriever = ChunksRetriever(top_k=1)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
+        return_value=unified,
+    ):
+        objects = await retriever.get_retrieved_objects("alpha")
+
+    assert objects[0].payload["parent_document"]["id"] == doc_id
+
+
+@pytest.mark.asyncio
+async def test_chunks_retriever_skips_enrichment_when_graph_unavailable():
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.search = AsyncMock(
+        return_value=[SimpleNamespace(id=str(uuid4()), payload={"text": "x"})]
+    )
+    unified = AsyncMock()
+    unified.vector = mock_vector_engine
+    type(unified).graph = property(lambda self: (_ for _ in ()).throw(RuntimeError("no graph")))
+
+    retriever = ChunksRetriever(strict_enrichment=False)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
+        return_value=unified,
+    ):
+        objects = await retriever.get_retrieved_objects("alpha")
+
+    assert len(objects) == 1


### PR DESCRIPTION
Closes #2090

## Summary

- After vector chunk retrieval, look up parent documents via graph `is_part_of` and attach `parent_document` + `is_part_of` on each CHUNKS result
- Add optional `expand_neighbors` (0–10) on the search API to include sibling chunks from the same document
- No new MCP tools — enrichment is exposed through CHUNKS search / SDK / API only

## Test plan

- [x] `pytest cognee/tests/unit/modules/retrieval/test_chunk_context_enrichment.py`
- [x] `pytest cognee/tests/unit/modules/retrieval/chunks_retriever_test.py`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.