### PR TITLE
fix(ui): make MCP Docker launch work on Colima

### DIFF
--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -21,6 +21,48 @@ from .npm_utils import run_npm_command
 logger = get_logger()
 
 
+def _mcp_docker_api_url(backend_port: int) -> str:
+    """Backend URL reachable from inside the MCP container (Docker Desktop / Colima)."""
+    return f"http://host.docker.internal:{backend_port}"
+
+
+def build_mcp_docker_command(
+    *,
+    container_name: str,
+    mcp_port: int,
+    image: str,
+    backend_port: Optional[int] = None,
+    env_file: Optional[str] = None,
+) -> list[str]:
+    """Build the docker run argv for launching the MCP server container."""
+    docker_cmd = [
+        "docker",
+        "run",
+        "--name",
+        container_name,
+        "-p",
+        f"{mcp_port}:8000",
+        "--rm",
+        "--add-host",
+        "host.docker.internal:host-gateway",
+        "-e",
+        "TRANSPORT_MODE=sse",
+    ]
+
+    if backend_port is not None:
+        docker_cmd.extend(
+            [
+                "-e",
+                f"API_URL={_mcp_docker_api_url(backend_port)}",
+            ]
+        )
+    elif env_file:
+        docker_cmd.extend(["--env-file", env_file])
+
+    docker_cmd.append(image)
+    return docker_cmd
+
+
 def _check_docker_available() -> Tuple[bool, str]:
     """
     Check if the Docker daemon is reachable by running `docker info`.
@@ -532,35 +574,26 @@ def start_ui(
 
             container_name = f"cognee-mcp-{uuid.uuid4().hex[:8]}"
 
-            docker_cmd = [
-                "docker",
-                "run",
-                "--name",
-                container_name,
-                "-p",
-                f"{mcp_port}:8000",
-                "--rm",
-                "-e",
-                "TRANSPORT_MODE=sse",
-            ]
+            env_file = None
+            backend_port_for_mcp = backend_port if start_backend else None
+            if not start_backend:
+                env_file = os.path.join(os.getcwd(), ".env")
+
+            docker_cmd = build_mcp_docker_command(
+                container_name=container_name,
+                mcp_port=mcp_port,
+                image=image,
+                backend_port=backend_port_for_mcp,
+                env_file=env_file,
+            )
 
             if start_backend:
-                docker_cmd.extend(
-                    [
-                        "-e",
-                        f"API_URL=http://localhost:{backend_port}",
-                    ]
-                )
                 logger.info(
-                    f"Configuring MCP to connect to backend API at http://localhost:{backend_port}"
+                    f"Configuring MCP to connect to backend API at "
+                    f"{_mcp_docker_api_url(backend_port)}"
                 )
-                logger.info("(localhost will be auto-converted to host.docker.internal)")
-            else:
-                cwd = os.getcwd()
-                env_file = os.path.join(cwd, ".env")
-                docker_cmd.extend(["--env-file", env_file])
-
-            docker_cmd.append(image)
+            elif env_file:
+                logger.info(f"Configuring MCP with env file: {env_file}")
 
             mcp_process = subprocess.Popen(
                 docker_cmd,

--- a/cognee/tests/unit/api/v1/ui/test_mcp_docker_command.py
+++ b/cognee/tests/unit/api/v1/ui/test_mcp_docker_command.py
@@ -1,0 +1,29 @@
+from cognee.api.v1.ui.ui import build_mcp_docker_command
+
+
+def test_build_mcp_docker_command_uses_host_gateway_and_host_docker_internal():
+    cmd = build_mcp_docker_command(
+        container_name="cognee-mcp-test",
+        mcp_port=8001,
+        image="cognee/cognee-mcp:main",
+        backend_port=8000,
+    )
+
+    assert cmd[:2] == ["docker", "run"]
+    assert "--add-host" in cmd
+    assert "host.docker.internal:host-gateway" in cmd
+    assert "API_URL=http://host.docker.internal:8000" in cmd
+    assert cmd[-1] == "cognee/cognee-mcp:main"
+
+
+def test_build_mcp_docker_command_direct_mode_uses_env_file():
+    cmd = build_mcp_docker_command(
+        container_name="cognee-mcp-test",
+        mcp_port=8001,
+        image="cognee/cognee-mcp:main",
+        env_file="/tmp/.env",
+    )
+
+    assert "--env-file" in cmd
+    assert "/tmp/.env" in cmd
+    assert "API_URL=" not in " ".join(cmd)


### PR DESCRIPTION
Closes #2744

## Summary

- Extract `build_mcp_docker_command()` so MCP container launch is testable
- Add `--add-host host.docker.internal:host-gateway` for Docker Desktop and Colima
- Set `API_URL` to `http://host.docker.internal:<port>` instead of `localhost` from inside the container

## Test plan

- [x] `pytest cognee/tests/unit/api/v1/ui/test_mcp_docker_command.py`