### PR TITLE
feat(metrics): add structured logging to pipeline run metrics

### DIFF
--- a/cognee/modules/metrics/operations/get_pipeline_run_metrics.py
+++ b/cognee/modules/metrics/operations/get_pipeline_run_metrics.py
@@ -21,54 +21,127 @@ async def fetch_token_count(db_engine) -> int:
     Returns:
         int: The total number of tokens across all documents.
     """
+    logger.debug("Fetching aggregate token count from relational database")
+    token_start = time.time()
 
     async with db_engine.get_async_session() as session:
         token_count_sum = await session.execute(select(func.sum(Data.token_count)))
-        token_count_sum = token_count_sum.scalar()
+        token_count = token_count_sum.scalar()
 
-    return token_count_sum
+    elapsed = time.time() - token_start
+    logger.debug(
+        "Fetched token count=%s in %.3fs",
+        token_count if token_count is not None else 0,
+        elapsed,
+    )
+    return token_count or 0
 
 
 async def get_pipeline_run_metrics(pipeline_run: PipelineRunInfo, include_optional: bool):
-    logger.debug("Computing metrics for pipeline run ID: %s", pipeline_run.pipeline_run_id)
+    pipeline_run_id = pipeline_run.pipeline_run_id
+    logger.debug(
+        "Starting metrics lookup for pipeline run %s (include_optional=%s)",
+        pipeline_run_id,
+        include_optional,
+    )
     start_time = time.time()
     db_engine = get_relational_engine()
-    graph_engine = await get_graph_engine()
 
     metrics_for_pipeline_runs = []
     cache_status = "cache miss"
-    async with db_engine.get_async_session() as session:
-        existing_metrics = await session.execute(
-            select(GraphMetrics).where(GraphMetrics.id == pipeline_run.pipeline_run_id)
-        )
-        existing_metrics = existing_metrics.scalars().first()
-        if existing_metrics:
-            metrics_for_pipeline_runs.append(existing_metrics)
-            cache_status = "cache hit"
-        else:
-            graph_metrics = await graph_engine.get_graph_metrics(include_optional)
-            metrics = GraphMetrics(
-                id=pipeline_run.pipeline_run_id,
-                num_tokens=await fetch_token_count(db_engine),
-                num_nodes=graph_metrics["num_nodes"],
-                num_edges=graph_metrics["num_edges"],
-                mean_degree=graph_metrics["mean_degree"],
-                edge_density=graph_metrics["edge_density"],
-                num_connected_components=graph_metrics["num_connected_components"],
-                sizes_of_connected_components=graph_metrics["sizes_of_connected_components"],
-                num_selfloops=graph_metrics["num_selfloops"],
-                diameter=graph_metrics["diameter"],
-                avg_shortest_path_length=graph_metrics["avg_shortest_path_length"],
-                avg_clustering=graph_metrics["avg_clustering"],
+
+    try:
+        async with db_engine.get_async_session() as session:
+            existing_metrics = await session.execute(
+                select(GraphMetrics).where(GraphMetrics.id == pipeline_run_id)
             )
-            metrics_for_pipeline_runs.append(metrics)
-            session.add(metrics)
-        await session.commit()
+            existing_metrics = existing_metrics.scalars().first()
+            if existing_metrics:
+                metrics_for_pipeline_runs.append(existing_metrics)
+                cache_status = "cache hit"
+                logger.debug(
+                    "Using cached GraphMetrics for pipeline run %s (nodes=%s, edges=%s, tokens=%s)",
+                    pipeline_run_id,
+                    existing_metrics.num_nodes,
+                    existing_metrics.num_edges,
+                    existing_metrics.num_tokens,
+                )
+            else:
+                try:
+                    graph_engine = await get_graph_engine()
+                except Exception as error:
+                    logger.error(
+                        "Failed to initialize graph engine for pipeline run %s: %s",
+                        pipeline_run_id,
+                        error,
+                        exc_info=True,
+                    )
+                    raise
+
+                logger.debug(
+                    "No cached metrics for pipeline run %s; computing graph metrics",
+                    pipeline_run_id,
+                )
+                graph_start = time.time()
+                graph_metrics = await graph_engine.get_graph_metrics(include_optional)
+                graph_elapsed = time.time() - graph_start
+                logger.debug(
+                    "Graph metrics computed for pipeline run %s in %.3fs (nodes=%s, edges=%s)",
+                    pipeline_run_id,
+                    graph_elapsed,
+                    graph_metrics.get("num_nodes"),
+                    graph_metrics.get("num_edges"),
+                )
+
+                token_count = await fetch_token_count(db_engine)
+                metrics = GraphMetrics(
+                    id=pipeline_run_id,
+                    num_tokens=token_count,
+                    num_nodes=graph_metrics["num_nodes"],
+                    num_edges=graph_metrics["num_edges"],
+                    mean_degree=graph_metrics["mean_degree"],
+                    edge_density=graph_metrics["edge_density"],
+                    num_connected_components=graph_metrics["num_connected_components"],
+                    sizes_of_connected_components=graph_metrics["sizes_of_connected_components"],
+                    num_selfloops=graph_metrics["num_selfloops"],
+                    diameter=graph_metrics["diameter"],
+                    avg_shortest_path_length=graph_metrics["avg_shortest_path_length"],
+                    avg_clustering=graph_metrics["avg_clustering"],
+                )
+                metrics_for_pipeline_runs.append(metrics)
+                session.add(metrics)
+                logger.info(
+                    "Persisted GraphMetrics for pipeline run %s (nodes=%s, edges=%s, tokens=%s)",
+                    pipeline_run_id,
+                    metrics.num_nodes,
+                    metrics.num_edges,
+                    metrics.num_tokens,
+                )
+
+            await session.commit()
+            logger.debug("Committed metrics session for pipeline run %s", pipeline_run_id)
+    except Exception as error:
+        logger.error(
+            "Failed to compute or persist metrics for pipeline run %s: %s",
+            pipeline_run_id,
+            error,
+            exc_info=True,
+        )
+        raise
+
     response_time = time.time() - start_time
-    logger.info(
-        "Computed metrics for pipeline run ID %s in %.2fs (%s)",
-        pipeline_run.pipeline_run_id,
-        response_time,
-        cache_status,
-    )
+    if cache_status == "cache hit":
+        logger.info(
+            "Metrics ready for pipeline run %s in %.3fs (%s)",
+            pipeline_run_id,
+            response_time,
+            cache_status,
+        )
+    else:
+        logger.warning(
+            "Metrics computed for pipeline run %s in %.3fs (%s)",
+            pipeline_run_id,
+            response_time,
+            cache_status,
+        )
     return metrics_for_pipeline_runs

--- a/cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py
+++ b/cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py
@@ -1,0 +1,195 @@
+import importlib
+import types
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.data.models import GraphMetrics
+
+metrics_mod = importlib.import_module(
+    "cognee.modules.metrics.operations.get_pipeline_run_metrics"
+)
+
+
+def _make_pipeline_run():
+    return types.SimpleNamespace(pipeline_run_id=uuid4())
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_run_metrics_returns_cached_metrics(monkeypatch, caplog):
+    pipeline_run = _make_pipeline_run()
+    cached = GraphMetrics(
+        id=pipeline_run.pipeline_run_id,
+        num_tokens=10,
+        num_nodes=3,
+        num_edges=2,
+        mean_degree=1.0,
+        edge_density=0.5,
+        num_connected_components=1,
+        sizes_of_connected_components=[3],
+        num_selfloops=0,
+        diameter=2,
+        avg_shortest_path_length=1.0,
+        avg_clustering=0.0,
+    )
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, _query):
+            result = types.SimpleNamespace()
+            result.scalars = lambda: types.SimpleNamespace(first=lambda: cached)
+            return result
+
+        async def commit(self):
+            return None
+
+        def add(self, _metrics):
+            return None
+
+    class DummyEngine:
+        def get_async_session(self):
+            return DummySession()
+
+    async def fake_get_graph_engine():
+        raise AssertionError("graph engine should not be queried on cache hit")
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_relational_engine",
+        lambda: DummyEngine(),
+    )
+    monkeypatch.setattr(metrics_mod, "get_graph_engine", fake_get_graph_engine)
+
+    with caplog.at_level("INFO"):
+        result = await metrics_mod.get_pipeline_run_metrics(
+            pipeline_run, include_optional=False
+        )
+
+    assert result == [cached]
+    assert any("cache hit" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_run_metrics_computes_and_persists_on_cache_miss(monkeypatch, caplog):
+    pipeline_run = _make_pipeline_run()
+    added = []
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, _query):
+            result = types.SimpleNamespace()
+            result.scalars = lambda: types.SimpleNamespace(first=lambda: None)
+            return result
+
+        async def commit(self):
+            return None
+
+        def add(self, metrics):
+            added.append(metrics)
+
+    class DummyEngine:
+        def get_async_session(self):
+            return DummySession()
+
+    class DummyGraphEngine:
+        async def get_graph_metrics(self, include_optional):
+            assert include_optional is True
+            return {
+                "num_nodes": 4,
+                "num_edges": 5,
+                "mean_degree": 2.0,
+                "edge_density": 0.4,
+                "num_connected_components": 1,
+                "sizes_of_connected_components": [4],
+                "num_selfloops": 0,
+                "diameter": 3,
+                "avg_shortest_path_length": 1.5,
+                "avg_clustering": 0.1,
+            }
+
+    async def fake_fetch_token_count(_engine):
+        return 42
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_relational_engine",
+        lambda: DummyEngine(),
+    )
+    async def fake_get_graph_engine():
+        return DummyGraphEngine()
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_graph_engine",
+        fake_get_graph_engine,
+    )
+    monkeypatch.setattr(
+        metrics_mod,
+        "fetch_token_count",
+        fake_fetch_token_count,
+    )
+
+    with caplog.at_level("WARNING"):
+        result = await metrics_mod.get_pipeline_run_metrics(
+            pipeline_run, include_optional=True
+        )
+
+    assert len(result) == 1
+    assert result[0].num_tokens == 42
+    assert result[0].num_nodes == 4
+    assert len(added) == 1
+    assert any("cache miss" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_run_metrics_logs_and_reraises_graph_engine_errors(
+    monkeypatch, caplog
+):
+    pipeline_run = _make_pipeline_run()
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, _query):
+            result = types.SimpleNamespace()
+            result.scalars = lambda: types.SimpleNamespace(first=lambda: None)
+            return result
+
+        async def commit(self):
+            return None
+
+    async def failing_get_graph_engine():
+        raise RuntimeError("graph unavailable")
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_relational_engine",
+        lambda: types.SimpleNamespace(get_async_session=lambda: DummySession()),
+    )
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_graph_engine",
+        failing_get_graph_engine,
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(RuntimeError, match="graph unavailable"):
+            await metrics_mod.get_pipeline_run_metrics(
+                pipeline_run, include_optional=False
+            )
+
+    assert any(record.levelname == "ERROR" for record in caplog.records)


### PR DESCRIPTION
Closes #2039

## Summary

Add debug/info/warning/error logging across pipeline run metrics: cache hits/misses, graph metric computation timing, token count fetch, persistence, and failures. Skip graph engine initialization on cache hits.

## Test plan

- [x] `uv run pytest cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py -v`
- [x] `uv run ruff check` on changed files

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.