### PR TITLE
fix(llm): add opt-in timeout and hang diagnostics for local models

### DIFF
--- a/cognee/infrastructure/llm/call_timeout.py
+++ b/cognee/infrastructure/llm/call_timeout.py
@@ -1,0 +1,85 @@
+"""Opt-in LLM call timeouts and slow-call diagnostics for local inference (#2902)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import suppress
+from typing import Awaitable, TypeVar
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+class LLMCallTimeoutError(TimeoutError):
+    """Raised when an opt-in LLM call timeout is exceeded."""
+
+
+def build_llm_call_label(*, provider: str, model: str, endpoint: str | None) -> str:
+    endpoint_display = endpoint or "<default>"
+    return f"provider={provider} model={model} endpoint={endpoint_display}"
+
+
+async def run_with_llm_call_limits(
+    coro: Awaitable[T],
+    *,
+    label: str,
+    timeout_seconds: int,
+    slow_warning_seconds: int,
+) -> T:
+    """
+    Execute an LLM request with optional diagnostics.
+
+    - ``timeout_seconds=0`` disables wall-clock abort (default, unlike #3126).
+    - ``slow_warning_seconds`` logs a warning if the call is still running after N seconds.
+    """
+    start = time.monotonic()
+    logger.info("LLM call started (%s)", label)
+    warn_task: asyncio.Task | None = None
+
+    async def _log_slow_call_warning() -> None:
+        await asyncio.sleep(slow_warning_seconds)
+        logger.warning(
+            "LLM call still running after %ss (%s). "
+            "For local inference hangs, set LLM_CALL_TIMEOUT_SECONDS to fail fast.",
+            slow_warning_seconds,
+            label,
+        )
+
+    try:
+        if slow_warning_seconds > 0:
+            warn_task = asyncio.create_task(_log_slow_call_warning())
+
+        if timeout_seconds > 0:
+            try:
+                result = await asyncio.wait_for(coro, timeout=timeout_seconds)
+            except asyncio.TimeoutError as error:
+                raise LLMCallTimeoutError(
+                    f"LLM call exceeded LLM_CALL_TIMEOUT_SECONDS={timeout_seconds} ({label}). "
+                    "Increase the timeout or set LLM_CALL_TIMEOUT_SECONDS=0 to disable opt-in limits."
+                ) from error
+        else:
+            result = await coro
+
+        elapsed = time.monotonic() - start
+        if slow_warning_seconds > 0 and elapsed >= slow_warning_seconds:
+            logger.warning("LLM call completed slowly in %.2fs (%s)", elapsed, label)
+        else:
+            logger.info("LLM call finished in %.2fs (%s)", elapsed, label)
+        return result
+    except Exception:
+        logger.error(
+            "LLM call failed after %.2fs (%s)",
+            time.monotonic() - start,
+            label,
+            exc_info=True,
+        )
+        raise
+    finally:
+        if warn_task is not None:
+            warn_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await warn_task

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -49,6 +49,8 @@ class LLMConfig(BaseSettings):
     llm_temperature: float = 0.0
     llm_streaming: bool = False
     llm_max_completion_tokens: int = 16384
+    llm_call_timeout_seconds: int = 0
+    llm_slow_call_warning_seconds: int = 60
 
     baml_llm_provider: str = "openai"
     baml_llm_model: str = "gpt-5-mini"
@@ -241,6 +243,8 @@ class LLMConfig(BaseSettings):
             "temperature": self.llm_temperature,
             "streaming": self.llm_streaming,
             "max_completion_tokens": self.llm_max_completion_tokens,
+            "llm_call_timeout_seconds": self.llm_call_timeout_seconds,
+            "llm_slow_call_warning_seconds": self.llm_slow_call_warning_seconds,
             "transcription_model": self.transcription_model,
             "graph_prompt_path": self.graph_prompt_path,
             "rate_limit_enabled": self.llm_rate_limit_enabled,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -19,6 +19,8 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
+from cognee.infrastructure.llm.call_timeout import build_llm_call_label, run_with_llm_call_limits
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.llm.exceptions import ContentPolicyFilterError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
@@ -151,25 +153,36 @@ class GenericAPIAdapter(LLMInterface):
         """
 
         merged_kwargs = {**self.llm_args, **kwargs}
+        llm_config = get_llm_context_config()
+        call_label = build_llm_call_label(
+            provider=llm_config.llm_provider,
+            model=self.model,
+            endpoint=self.endpoint,
+        )
         try:
             async with llm_rate_limiter_context_manager():
-                result = await self.aclient.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": system_prompt,
-                        },
-                        {
-                            "role": "user",
-                            "content": f"""{text_input}""",
-                        },
-                    ],
-                    max_retries=2,
-                    api_key=self.api_key,
-                    api_base=self.endpoint,
-                    response_model=response_model,
-                    **merged_kwargs,
+                result = await run_with_llm_call_limits(
+                    self.aclient.chat.completions.create(
+                        model=self.model,
+                        messages=[
+                            {
+                                "role": "system",
+                                "content": system_prompt,
+                            },
+                            {
+                                "role": "user",
+                                "content": f"""{text_input}""",
+                            },
+                        ],
+                        max_retries=2,
+                        api_key=self.api_key,
+                        api_base=self.endpoint,
+                        response_model=response_model,
+                        **merged_kwargs,
+                    ),
+                    label=call_label,
+                    timeout_seconds=llm_config.llm_call_timeout_seconds,
+                    slow_warning_seconds=llm_config.llm_slow_call_warning_seconds,
                 )
                 _enrich_llm_span(self.model, self.name)
                 return result
@@ -200,23 +213,28 @@ class GenericAPIAdapter(LLMInterface):
 
             try:
                 async with llm_rate_limiter_context_manager():
-                    return await self.aclient.chat.completions.create(
-                        model=fallback_model,
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": system_prompt,
-                            },
-                            {
-                                "role": "user",
-                                "content": f"""{text_input}""",
-                            },
-                        ],
-                        max_retries=2,
-                        api_key=self.fallback_api_key,
-                        api_base=self.fallback_endpoint,
-                        response_model=response_model,
-                        **fallback_llm_args,
+                    return await run_with_llm_call_limits(
+                        self.aclient.chat.completions.create(
+                            model=fallback_model,
+                            messages=[
+                                {
+                                    "role": "system",
+                                    "content": system_prompt,
+                                },
+                                {
+                                    "role": "user",
+                                    "content": f"""{text_input}""",
+                                },
+                            ],
+                            max_retries=2,
+                            api_key=self.fallback_api_key,
+                            api_base=self.fallback_endpoint,
+                            response_model=response_model,
+                            **fallback_llm_args,
+                        ),
+                        label=f"{call_label} fallback={fallback_model}",
+                        timeout_seconds=llm_config.llm_call_timeout_seconds,
+                        slow_warning_seconds=llm_config.llm_slow_call_warning_seconds,
                     )
             except (
                 ContentFilterFinishReasonError,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -16,6 +16,8 @@ from tenacity import (
 )
 
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
+from cognee.infrastructure.llm.call_timeout import build_llm_call_label, run_with_llm_call_limits
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
 )
@@ -114,22 +116,33 @@ class OllamaAPIAdapter(LLMInterface):
             - BaseModel: A structured output that conforms to the specified response model.
         """
         merged_kwargs = {**self.llm_args, **kwargs}
+        llm_config = get_llm_context_config()
+        call_label = build_llm_call_label(
+            provider=llm_config.llm_provider,
+            model=self.model,
+            endpoint=self.endpoint,
+        )
         async with llm_rate_limiter_context_manager():
-            response = self.aclient.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": system_prompt,
-                    },
-                    {
-                        "role": "user",
-                        "content": f"{text_input}",
-                    },
-                ],
-                max_retries=2,
-                response_model=response_model,
-                **merged_kwargs,
+            response = await run_with_llm_call_limits(
+                self.aclient.chat.completions.create(
+                    model=self.model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": system_prompt,
+                        },
+                        {
+                            "role": "user",
+                            "content": f"{text_input}",
+                        },
+                    ],
+                    max_retries=2,
+                    response_model=response_model,
+                    **merged_kwargs,
+                ),
+                label=call_label,
+                timeout_seconds=llm_config.llm_call_timeout_seconds,
+                slow_warning_seconds=llm_config.llm_slow_call_warning_seconds,
             )
 
         return response

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -96,7 +96,9 @@ async def test_llm_connection() -> None:
         msg = (
             f"LLM connection test timed out after {CONNECTION_TEST_TIMEOUT_SECONDS}s. "
             "Check that your LLM endpoint is reachable and responding. "
-            "Set COGNEE_SKIP_CONNECTION_TEST=true to bypass this check."
+            "For slow local inference (omlx/vLLM/custom), increase patience or set "
+            "COGNEE_SKIP_CONNECTION_TEST=true. "
+            "To abort long-running LLM calls after startup, set LLM_CALL_TIMEOUT_SECONDS."
         )
         logger.error(msg)
         raise TimeoutError(msg)

--- a/cognee/tests/unit/infrastructure/llm/test_llm_call_timeout.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_call_timeout.py
@@ -1,0 +1,71 @@
+import asyncio
+
+import pytest
+
+from cognee.infrastructure.llm.call_timeout import (
+    LLMCallTimeoutError,
+    build_llm_call_label,
+    run_with_llm_call_limits,
+)
+from cognee.infrastructure.llm.config import LLMConfig
+
+
+@pytest.mark.asyncio
+async def test_run_with_llm_call_limits_disabled_by_default():
+    async def fast_call():
+        await asyncio.sleep(0)
+        return "ok"
+
+    result = await run_with_llm_call_limits(
+        fast_call(),
+        label="provider=custom model=test endpoint=http://localhost:8000/v1",
+        timeout_seconds=0,
+        slow_warning_seconds=0,
+    )
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_run_with_llm_call_limits_raises_when_opt_in_timeout_exceeded():
+    async def slow_call():
+        await asyncio.sleep(0.2)
+        return "late"
+
+    with pytest.raises(LLMCallTimeoutError, match="LLM_CALL_TIMEOUT_SECONDS=0.1"):
+        await run_with_llm_call_limits(
+            slow_call(),
+            label=build_llm_call_label(
+                provider="custom",
+                model="openai/test-model",
+                endpoint="http://localhost:8000/v1",
+            ),
+            timeout_seconds=0.1,
+            slow_warning_seconds=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_with_llm_call_limits_continues_after_slow_warning_threshold():
+    async def medium_call():
+        await asyncio.sleep(0.15)
+        return "done"
+
+    result = await run_with_llm_call_limits(
+        medium_call(),
+        label="provider=custom model=test endpoint=http://localhost:8000/v1",
+        timeout_seconds=0,
+        slow_warning_seconds=0.05,
+    )
+
+    assert result == "done"
+
+
+def test_llm_config_defaults_keep_timeout_disabled():
+    config = LLMConfig(
+        llm_provider="custom",
+        llm_model="openai/test-model",
+        llm_api_key="test-key",
+        llm_endpoint="http://localhost:8000/v1",
+    )
+    assert config.llm_call_timeout_seconds == 0
+    assert config.llm_slow_call_warning_seconds == 60


### PR DESCRIPTION
Closes #2902

## Summary

Local/custom inference (omlx, vLLM, OpenAI-compatible endpoints) can hang indefinitely during structured-output calls. This adds opt-in wall-clock limits and slow-call diagnostics without changing default behavior.

- `LLM_CALL_TIMEOUT_SECONDS` defaults to **0** (disabled)
- `LLM_SLOW_CALL_WARNING_SECONDS` defaults to **60** (logs if a call is still running)
- Applied to **custom** and **Ollama** adapters (the local inference paths from #2902)
- Clear timeout errors mention the env var

This is intentionally different from open PR #3126, which adds a mandatory `llm_timeout=120` for #2995 CI hangs.

## Test plan

- [x] `uv run pytest cognee/tests/unit/infrastructure/llm/test_llm_call_timeout.py -v`
- [x] `uv run ruff check` on changed files

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.