### PR TITLE
fix(search): remove list-wrapping around all() condition for datasets…

### DIFF
--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -286,7 +286,7 @@ async def search(
         await set_session_user_context_variable(user)
 
         # Transform string based datasets to UUID - String based datasets can only be found for current user
-        if datasets is not None and [all(isinstance(dataset, str) for dataset in datasets)]:
+        if datasets is not None and all(isinstance(dataset, str) for dataset in datasets):
             datasets = await get_authorized_existing_datasets(datasets, "read", user)
             datasets = [dataset.id for dataset in datasets]
             if not datasets:


### PR DESCRIPTION
## Description
Fixes #3140

While analyzing the codebase, I found that in `cognee/api/v1/search/search.py` 
line 289, the `all()` condition was wrapped in square brackets:

```python
# Before
if datasets is not None and [all(isinstance(dataset, str) for dataset in datasets)]:

# After
if datasets is not None and all(isinstance(dataset, str) for dataset in datasets):
```

`[all(...)]` always produces a non-empty list which is always truthy in Python,
making the UUID type-check completely ineffective.

## Acceptance Criteria
- UUID datasets no longer incorrectly enter the string-resolution block
- `DatasetNotFoundError` is not falsely raised when passing UUID datasets

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
Pure Python logic bug — verified by static analysis:
```python
>>> bool([False])  # buggy: always True
True
>>> bool(False)    # fixed: correctly False
False
```

## DCO
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.