### PR TITLE
fix(lancedb): fix prune() path check to support Windows and relative …

### DIFF
--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -1248,7 +1248,7 @@ class LanceDBAdapter(VectorDBInterface):
             await collection.delete("id IS NOT NULL")
             await connection.drop_table(collection_name)
 
-        if self.url.startswith("/"):
+        if self.url and not self.url.startswith(("db://", "http://", "https://", "s3://", "gs://", "az://")):
             db_dir_path = path.dirname(self.url)
             db_file_name = path.basename(self.url)
             await get_file_storage(db_dir_path).remove_all(db_file_name)

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_lifecycle.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_lifecycle.py
@@ -234,3 +234,25 @@ async def test_close_does_not_block_event_loop(monkeypatch, tmp_path):
     assert ticks >= 5, (
         f"event loop appears blocked: only {ticks} heartbeats during a 150ms shutdown"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_prune_removes_local_db_directory(tmp_path):
+    """prune() must delete the local database directory from the filesystem."""
+    from cognee.infrastructure.databases.vector.lancedb.LanceDBAdapter import IndexSchema
+
+    db_path = tmp_path / "lance_db"
+    adapter = LanceDBAdapter(
+        url=str(db_path),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+
+    # Materialize the directory by creating a collection
+    await adapter.create_collection("test_col", IndexSchema)
+
+    assert db_path.exists() is True
+    await adapter.prune()
+    assert db_path.exists() is False
+


### PR DESCRIPTION
## Description
Fixes #3145

`LanceDBAdapter.prune()` at line 1251 used a Unix-only path check:

```python
# Before
if self.url.startswith("/"):

# After 
if self.url and not self.url.startswith(("db://", "http://", "https://", "s3://", "gs://", "az://")):
```

On Windows, absolute paths start with drive letters (`C:\`), so `remove_all()` was silently never called, leaving stale database 
files on disk after every `prune()` call.

## Acceptance Criteria
- `prune()` correctly cleans up local files on Windows 
- `prune()` correctly skips cleanup for remote URLs 
- Linux/macOS behavior unchanged 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Test Results (Windows 10)
**Added regression test** in `test_lancedb_lifecycle.py` to prevent future regressions.

- Command:
```uv run pytest cognee/tests/unit/infrastructure/databases/vector/test_lancedb_lifecycle.py -k test_prune_removes_local_db_directory -v```

Output:
<img width="1206" height="171" alt="image" src="https://github.com/user-attachments/assets/2ec3bf34-a726-4c22-b299-48bbe9a5959a" />


## DCO
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.