### PR TITLE
fix(llm): pass fallback endpoint to openai adapter

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -184,7 +184,7 @@ class OpenAIAdapter(GenericAPIAdapter):
                             },
                         ],
                         api_key=self.fallback_api_key,
-                        # api_base=self.fallback_endpoint,
+                        api_base=self.fallback_endpoint,
                         response_model=response_model,
                         max_retries=self.MAX_RETRIES,
                         **merged_kwargs,

--- a/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
+++ b/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict
 
 import pytest
+from pydantic import BaseModel
 
 from cognee.infrastructure.llm.config import LLMConfig
 from cognee.infrastructure.llm.exceptions import LLMAPIKeyNotSetError
@@ -162,3 +163,45 @@ def test_openai_adapter_honors_explicit_instructor_mode_for_non_gpt5_models(monk
 
     assert calls[-2][1]["mode"].value == "json_mode"
     assert calls[-1][1]["mode"].value == "json_mode"
+
+
+@pytest.mark.asyncio
+async def test_openai_adapter_passes_fallback_endpoint_on_policy_fallback(monkeypatch):
+    class PolicyFallbackTrigger(Exception):
+        pass
+
+    calls = []
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise PolicyFallbackTrigger("blocked")
+            return "fallback-response"
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeClient:
+        chat = FakeChat()
+
+    monkeypatch.setattr(openai_adapter, "ContentFilterFinishReasonError", PolicyFallbackTrigger)
+    monkeypatch.setattr(generic_adapter.instructor, "from_litellm", lambda *args, **kwargs: object())
+    monkeypatch.setattr(openai_adapter.instructor, "from_litellm", lambda *args, **kwargs: object())
+
+    adapter = OpenAIAdapter(
+        api_key="primary-key",
+        model="openai/gpt-5-mini",
+        endpoint="https://primary.example.test",
+        max_completion_tokens=1024,
+        fallback_api_key="fallback-key",
+        fallback_endpoint="https://fallback.example.test",
+        fallback_model="openai/gpt-5-mini-fallback",
+    )
+    adapter.aclient = FakeClient()
+
+    result = await adapter.acreate_structured_output("input", "system", BaseModel)
+
+    assert result == "fallback-response"
+    assert calls[0]["api_base"] == "https://primary.example.test"
+    assert calls[1]["api_base"] == "https://fallback.example.test"


### PR DESCRIPTION
Related to #2842

## Description

OpenAI-compatible providers can be configured through `LLM_ENDPOINT`, and the primary OpenAI adapter call already forwards that endpoint to LiteLLM. The policy fallback path still omitted `fallback_endpoint`, so fallback structured-output calls could route to LiteLLM's default OpenAI endpoint instead of the configured compatible endpoint.

## Acceptance Criteria

- Fallback structured-output calls pass `fallback_endpoint` as LiteLLM `api_base`
- Primary endpoint forwarding remains unchanged
- Regression coverage verifies both primary and fallback `api_base` values

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend adapter change. Local checks:

- `python -m pytest cognee/tests/unit/infrastructure/llm/test_get_llm_client.py -q`
- `python -m ruff check cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py cognee/tests/unit/infrastructure/llm/test_get_llm_client.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
