### PR TITLE
fix(pipeline): serialize sqlite data item processing

### DIFF
--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -35,6 +35,26 @@ from ..tasks.task import Task
 logger = get_logger("run_tasks(tasks: [Task], data)")
 
 
+def _relational_dialect_name(relational_engine: Any) -> Optional[str]:
+    dialect = getattr(getattr(relational_engine, "engine", None), "dialect", None)
+    name = getattr(dialect, "name", None)
+    return name.lower() if isinstance(name, str) else None
+
+
+def _effective_data_per_batch(data_per_batch: Optional[int], relational_engine: Any) -> int:
+    effective_data_per_batch = max(1, int(data_per_batch or 1))
+    if (
+        effective_data_per_batch > 1
+        and _relational_dialect_name(relational_engine) == "sqlite"
+    ):
+        logger.info(
+            "SQLite relational backend detected; serializing pipeline data items to avoid "
+            "concurrent write locks."
+        )
+        return 1
+    return effective_data_per_batch
+
+
 def override_run_tasks(new_gen):
     def decorator(original_gen):
         @wraps(original_gen)
@@ -71,7 +91,9 @@ async def run_tasks(
     if not user:
         user = await get_default_user()
 
-    async with get_relational_engine().get_async_session() as session:
+    relational_engine = get_relational_engine()
+
+    async with relational_engine.get_async_session() as session:
         from cognee.modules.data.models import Dataset
 
         dataset = await session.get(Dataset, dataset_id)
@@ -102,9 +124,15 @@ async def run_tasks(
             if incremental_loading:
                 data = await resolve_data_directories(data)
 
+            relational_engine = get_relational_engine()
+            effective_data_per_batch = _effective_data_per_batch(
+                data_per_batch,
+                relational_engine,
+            )
+
             # Semaphore-based concurrency: all items are scheduled at once,
-            # but at most data_per_batch run concurrently at any time.
-            semaphore = asyncio.Semaphore(data_per_batch)
+            # but at most effective_data_per_batch run concurrently at any time.
+            semaphore = asyncio.Semaphore(effective_data_per_batch)
 
             async def _run_item(data_item):
                 async with semaphore:
@@ -167,7 +195,6 @@ async def run_tasks(
             if hasattr(graph_engine, "push_to_s3"):
                 await graph_engine.push_to_s3()
 
-            relational_engine = get_relational_engine()
             if hasattr(relational_engine, "push_to_s3"):
                 await relational_engine.push_to_s3()
 

--- a/cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py
+++ b/cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 import importlib
 from types import SimpleNamespace
@@ -26,8 +27,9 @@ class _FakeSession:
 
 
 class _FakeEngine:
-    def __init__(self, dataset):
+    def __init__(self, dataset, dialect_name="sqlite"):
         self._dataset = dataset
+        self.engine = SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
 
     def get_async_session(self):
         return _FakeSession(self._dataset)
@@ -105,3 +107,62 @@ async def test_run_tasks_calls_custom_rollback_on_pipeline_failure(monkeypatch):
     assert rollback_payload["data"] == [data_item]
     assert isinstance(rollback_payload["error"], Exception)
     assert rollback_payload["data_ingestion_info"][0]["run_info"].status == "PipelineRunErrored"
+
+
+@pytest.mark.asyncio
+async def test_run_tasks_serializes_data_items_for_sqlite(monkeypatch):
+    dataset_id = uuid4()
+    user_id = uuid4()
+    owner_id = uuid4()
+    pipeline_run_id = uuid4()
+
+    dataset = SimpleNamespace(id=dataset_id, name="dataset-1", owner_id=owner_id)
+    user = SimpleNamespace(id=user_id, tenant_id=uuid4())
+    fake_engine = _FakeEngine(dataset, dialect_name="sqlite")
+
+    active_items = 0
+    max_active_items = 0
+
+    async def _successful_item(*_args, **_kwargs):
+        nonlocal active_items, max_active_items
+        active_items += 1
+        max_active_items = max(max_active_items, active_items)
+        await asyncio.sleep(0.01)
+        active_items -= 1
+        return {"run_info": SimpleNamespace(status="PipelineRunCompleted")}
+
+    async def _log_start(*_args, **_kwargs):
+        return SimpleNamespace(pipeline_run_id=pipeline_run_id)
+
+    async def _log_complete(*_args, **_kwargs):
+        return None
+
+    async def _log_error(*_args, **_kwargs):
+        return None
+
+    async def _get_graph_engine():
+        return SimpleNamespace()
+
+    monkeypatch.setattr(run_tasks_module, "get_relational_engine", lambda: fake_engine)
+    monkeypatch.setattr(run_tasks_module, "get_graph_engine", _get_graph_engine)
+    monkeypatch.setattr(run_tasks_module, "generate_pipeline_id", lambda *_args: uuid4())
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_start", _log_start)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_complete", _log_complete)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_error", _log_error)
+    monkeypatch.setattr(run_tasks_module, "set_database_global_context_variables", _no_op_context)
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", _successful_item)
+
+    yielded = []
+    async for item in run_tasks_module.run_tasks(
+        tasks=[Task(lambda x: x)],
+        dataset_id=dataset_id,
+        data=[object(), object(), object()],
+        user=user,
+        pipeline_name="cognify_pipeline",
+        data_per_batch=3,
+    ):
+        yielded.append(item)
+
+    assert len(yielded) == 2
+    assert isinstance(yielded[0], PipelineRunStarted)
+    assert max_active_items == 1


### PR DESCRIPTION
Closes #2717

## Description

The pipeline still fans data items out with `data_per_batch=20` by default. That is fine for server databases, but the default SQLite relational backend only supports one writer at a time. For SQLite, concurrent data-item tasks can race on `UPDATE data` and insert commits, then surface as `sqlite3.OperationalError: database is locked`.

This keeps the existing concurrent behavior for non-SQLite relational backends and caps only SQLite dataset item processing to one active item at a time.

## Acceptance Criteria

- SQLite pipeline runs process dataset items serially inside a run
- Non-SQLite relational backends keep the requested `data_per_batch`
- Regression coverage proves a fake SQLite run never has more than one active data item when `data_per_batch=3`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend pipeline change. Local checks:

- `python -m pytest cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py -q`
- `python -m ruff check cognee/modules/pipelines/operations/run_tasks.py cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
