### PR TITLE
fix(pipeline): preserve item exceptions in run results

### DIFF
--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -129,6 +129,7 @@ async def run_tasks(
 
             gathered = await asyncio.gather(
                 *[asyncio.create_task(_run_item(item)) for item in data],
+                return_exceptions=True,
             )
 
             # Separate successes from unhandled exceptions

--- a/cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py
+++ b/cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py
@@ -105,3 +105,56 @@ async def test_run_tasks_calls_custom_rollback_on_pipeline_failure(monkeypatch):
     assert rollback_payload["data"] == [data_item]
     assert isinstance(rollback_payload["error"], Exception)
     assert rollback_payload["data_ingestion_info"][0]["run_info"].status == "PipelineRunErrored"
+
+
+@pytest.mark.asyncio
+async def test_run_tasks_converts_unhandled_item_exceptions_to_run_errors(monkeypatch):
+    dataset_id = uuid4()
+    user_id = uuid4()
+    owner_id = uuid4()
+    pipeline_run_id = uuid4()
+
+    dataset = SimpleNamespace(id=dataset_id, name="dataset-1", owner_id=owner_id)
+    user = SimpleNamespace(id=user_id, tenant_id=uuid4())
+    data_item = SimpleNamespace(id=uuid4())
+
+    async def _raising_item(*_args, **_kwargs):
+        raise RuntimeError("item exploded")
+
+    rollback_calls = []
+
+    async def _rollback_handler(**kwargs):
+        rollback_calls.append(kwargs)
+
+    monkeypatch.setattr(run_tasks_module, "get_relational_engine", lambda: _FakeEngine(dataset))
+    monkeypatch.setattr(run_tasks_module, "generate_pipeline_id", lambda *_args: uuid4())
+
+    async def _log_start(*_args, **_kwargs):
+        return SimpleNamespace(pipeline_run_id=pipeline_run_id)
+
+    async def _log_error(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_start", _log_start)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_error", _log_error)
+    monkeypatch.setattr(run_tasks_module, "set_database_global_context_variables", _no_op_context)
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", _raising_item)
+
+    yielded = []
+    async for item in run_tasks_module.run_tasks(
+        tasks=[Task(lambda x: x)],
+        dataset_id=dataset_id,
+        data=[data_item],
+        user=user,
+        pipeline_name="cognify_pipeline",
+        rollback_handler=_rollback_handler,
+    ):
+        yielded.append(item)
+
+    assert len(yielded) == 2
+    assert isinstance(yielded[0], PipelineRunStarted)
+    assert isinstance(yielded[1], PipelineRunErrored)
+    assert yielded[1].data_ingestion_info[0]["run_info"].payload == "RuntimeError('item exploded')"
+    assert rollback_calls[0]["data_ingestion_info"][0]["run_info"].payload == (
+        "RuntimeError('item exploded')"
+    )


### PR DESCRIPTION
Related to #3079

## Description

`run_tasks()` already has logic to convert per-item `BaseException` results into `PipelineRunErrored`, but `asyncio.gather()` was not called with `return_exceptions=True`. That meant an unhandled item exception could abort the gather before the existing error-normalization path ran.

This change lets the existing normalization path handle item-level failures and preserve the exception payload in the pipeline result.

## Acceptance Criteria

- Per-item task exceptions are collected instead of aborting the gather immediately
- The existing `PipelineRunErrored` path receives the exception payload
- Regression coverage verifies an item task raising `RuntimeError` becomes a `PipelineRunErrored` result

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend pipeline change. Local checks:

- `python -m pytest cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py -q`
- `python -m ruff check cognee/modules/pipelines/operations/run_tasks.py cognee/tests/unit/modules/pipelines/test_run_tasks_rollback.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
