### PR TITLE
fix: fix datasets UUID filtering bug (fixes 3140)

### DIFF
--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -286,7 +286,7 @@ async def search(
         await set_session_user_context_variable(user)
 
         # Transform string based datasets to UUID - String based datasets can only be found for current user
-        if datasets is not None and [all(isinstance(dataset, str) for dataset in datasets)]:
+        if datasets is not None and all(isinstance(dataset, str) for dataset in datasets):
             datasets = await get_authorized_existing_datasets(datasets, "read", user)
             datasets = [dataset.id for dataset in datasets]
             if not datasets:

--- a/cognee/infrastructure/databases/vector/config.py
+++ b/cognee/infrastructure/databases/vector/config.py
@@ -84,6 +84,7 @@ class VectorConfig(BaseSettings):
             self.vector_db_url = os.path.join(databases_directory_path, "cognee.lancedb")
 
         import sys
+
         if sys.platform == "win32" and self.vector_db_url and "://" not in self.vector_db_url:
             if os.path.isabs(self.vector_db_url) and not self.vector_db_url.startswith("\\\\?\\"):
                 self.vector_db_url = "\\\\?\\" + os.path.normpath(self.vector_db_url)

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -1248,7 +1248,9 @@ class LanceDBAdapter(VectorDBInterface):
             await collection.delete("id IS NOT NULL")
             await connection.drop_table(collection_name)
 
-        if self.url and not self.url.startswith(("db://", "http://", "https://", "s3://", "gs://", "az://")):
+        if self.url and not self.url.startswith(
+            ("db://", "http://", "https://", "s3://", "gs://", "az://")
+        ):
             db_dir_path = path.dirname(self.url)
             db_file_name = path.basename(self.url)
             await get_file_storage(db_dir_path).remove_all(db_file_name)

--- a/cognee/infrastructure/files/storage/S3FileStorage.py
+++ b/cognee/infrastructure/files/storage/S3FileStorage.py
@@ -50,11 +50,11 @@ class S3FileStorage(Storage):
             )
         else:
             # No credentials provided, let s3fs discover them via the IAM Role/Chain
-         self.s3 = s3fs.S3FileSystem(
-         anon=False,
-         endpoint_url=s3_config.aws_endpoint_url,
-         client_kwargs={"region_name": s3_config.aws_region},
-    )
+            self.s3 = s3fs.S3FileSystem(
+                anon=False,
+                endpoint_url=s3_config.aws_endpoint_url,
+                client_kwargs={"region_name": s3_config.aws_region},
+            )
 
     async def store(self, file_path: str, data: BinaryIO | str, overwrite: bool = False) -> str:
         """

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_lifecycle.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_lifecycle.py
@@ -255,4 +255,3 @@ async def test_prune_removes_local_db_directory(tmp_path):
     assert db_path.exists() is True
     await adapter.prune()
     assert db_path.exists() is False
-

--- a/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
+++ b/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
@@ -186,7 +186,9 @@ async def test_openai_adapter_passes_fallback_endpoint_on_policy_fallback(monkey
         chat = FakeChat()
 
     monkeypatch.setattr(openai_adapter, "ContentFilterFinishReasonError", PolicyFallbackTrigger)
-    monkeypatch.setattr(generic_adapter.instructor, "from_litellm", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        generic_adapter.instructor, "from_litellm", lambda *args, **kwargs: object()
+    )
     monkeypatch.setattr(openai_adapter.instructor, "from_litellm", lambda *args, **kwargs: object())
 
     adapter = OpenAIAdapter(

--- a/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
@@ -17,8 +17,7 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
 )
 
 _MODULE = (
-    "cognee.infrastructure.llm.structured_output_framework."
-    "litellm_instructor.llm.ollama.adapter"
+    "cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.ollama.adapter"
 )
 
 

--- a/cognee/tests/unit/modules/chunking/test_langchain_chunker.py
+++ b/cognee/tests/unit/modules/chunking/test_langchain_chunker.py
@@ -15,6 +15,8 @@ import uuid
 
 import pytest
 
+pytest.importorskip("langchain_text_splitters")
+
 from cognee.modules.chunking.LangchainChunker import LangchainChunker
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.modules.data.processing.document_types.TextDocument import TextDocument


### PR DESCRIPTION
Closes #3140.

Removed the brackets around the all() condition which caused the check to always evaluate to True when UUIDs were passed instead of strings, triggering a false DatasetNotFoundError.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin