### PR TITLE
docs: fix broken simple example path in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,27 +112,12 @@ Copy `.env.template` to `.env` and provide your OPENAI_API_KEY as LLM_API_KEY
 Make sure to run ```shell uv sync ``` in the root cloned folder or set up a virtual environment to run cognee
 
 ```shell
-python examples/python/simple_example.py
+python examples/demos/simple_cognee_example.py
 ```
 or
 
 ```shell
-uv run python examples/python/simple_example.py
-```
-
-### Running Simple Example
-
-Copy `.env.template` to `.env` and provide your OPENAI_API_KEY as LLM_API_KEY
-
-Make sure to run ```shell uv sync ``` in the root cloned folder or set up a virtual environment to run cognee
-
-```shell
-python cognee/cognee/examples/python/simple_example.py
-```
-or
-
-```shell
-uv run python cognee/cognee/examples/python/simple_example.py
+uv run python examples/demos/simple_cognee_example.py
 ```
 
 ## 4. 📤 Submitting Changes


### PR DESCRIPTION
## Description
While following CONTRIBUTING.md to set the project up, the "Running Simple
Example" step failed for me. It tells you to run:

    python examples/python/simple_example.py

but that file doesn't exist in the repo, so you get a "can't open file" error
on your very first run. The section was also duplicated, and the second copy
pointed at another path that doesn't exist either
(cognee/cognee/examples/python/simple_example.py).

The simple example that actually exists — and the one CI runs in
.github/workflows/basic_tests.yml — is examples/demos/simple_cognee_example.py.
This PR points both commands at that file and removes the duplicated block.

## Acceptance Criteria
- The command documented in CONTRIBUTING.md exists and runs.
- Verified locally: `python examples/demos/simple_cognee_example.py` completes
  the full add -> cognify -> search flow and returns a result (exit code 0).

## Type of Change
- [x] Other: documentation fix

## Screenshots
<!-- screenshot of the example running successfully (exit code 0) -->
<img width="980" height="680" alt="image" src="https://github.com/user-attachments/assets/165eb500-7ebf-4e61-8cae-fe1c2508a124" />

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective (n/a — docs only)
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass (n/a — docs only)
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
