### PR TITLE
fix(ingestion): persist data_size on re-ingest update

### DIFF
--- a/cognee/tasks/ingestion/ingest_data.py
+++ b/cognee/tasks/ingestion/ingest_data.py
@@ -183,7 +183,7 @@ async def ingest_data(
                 data_point.owner_id = user.id
                 data_point.content_hash = new_content_hash
                 data_point.raw_content_hash = storage_file_metadata["content_hash"]
-                data_point.file_size = original_file_metadata["file_size"]
+                data_point.data_size = original_file_metadata["file_size"]
                 data_point.external_metadata = ext_metadata
                 data_point.node_set = json.dumps(node_set) if node_set else None
                 data_point.tenant_id = user.tenant_id if user.tenant_id else None

--- a/cognee/tests/unit/tasks/ingestion/test_ingest_update_data_size.py
+++ b/cognee/tests/unit/tasks/ingestion/test_ingest_update_data_size.py
@@ -1,0 +1,150 @@
+"""Regression test for the re-ingestion `data_size` update path.
+
+When an already-ingested file is added again with a different size, the update
+branch of ``store_data_to_dataset`` (in ``cognee/tasks/ingestion/ingest_data.py``)
+must write the new size to the ``Data.data_size`` column. A prior version wrote
+to ``data_point.file_size`` — an attribute the ``Data`` model does not declare —
+so SQLAlchemy's unit-of-work never flushed it and the persisted ``data_size``
+stayed stale.
+
+This test drives the real ``ingest_data`` update branch against an in-memory
+SQLite relational engine and asserts the persisted ``data_size`` reflects the
+new value. It fails before the fix and passes after it.
+"""
+
+import importlib
+import os
+import tempfile
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import uuid4
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+    SQLAlchemyAdapter,
+)
+from cognee.modules.data.models import Data, Dataset
+
+# Import the module object explicitly: `cognee.tasks.ingestion.__init__` re-exports
+# `ingest_data` (the function), which shadows the submodule of the same name, so
+# `import ... as ingest_module` would bind the function and break patch.object.
+ingest_module = importlib.import_module("cognee.tasks.ingestion.ingest_data")
+
+USER = SimpleNamespace(id=uuid4(), tenant_id=None)
+DATASET_ID = uuid4()
+DATA_ID = uuid4()
+
+OLD_SIZE = 100
+NEW_SIZE = 200
+
+
+def _metadata():
+    """Metadata returned by the loader for the re-ingested file (new size)."""
+    return {
+        "name": "doc.txt",
+        "file_path": "/tmp/doc.txt",
+        "extension": "txt",
+        "mime_type": "text/plain",
+        "content_hash": "new-hash",
+        "file_size": NEW_SIZE,
+    }
+
+
+@asynccontextmanager
+async def _fake_open_data_file(_path):
+    yield object()
+
+
+async def _make_engine():
+    """Create a throwaway SQLite-backed relational engine and seed one existing
+    Data row whose data_size is OLD_SIZE."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    engine = SQLAlchemyAdapter(f"sqlite+aiosqlite:///{tmp.name}")
+    await engine.create_database()
+
+    async with engine.get_async_session() as session:
+        session.add(
+            Data(
+                id=DATA_ID,
+                name="doc.txt",
+                content_hash="old-hash",
+                data_size=OLD_SIZE,
+            )
+        )
+        await session.commit()
+
+    return engine, tmp.name
+
+
+def _install_mocks(stack, engine):
+    """Patch ingest_data's collaborators so the update branch runs without real
+    storage, loaders, or dataset/permission machinery — only the relational
+    engine is real."""
+    meta = _metadata()
+    classified = SimpleNamespace(get_metadata=lambda: meta)
+    # A real (transient) mapped Dataset: store_data_to_dataset does `dataset in
+    # session` / session.add / session.merge, which require a mapped instance.
+    dataset = Dataset(id=DATASET_ID, name="ds", owner_id=USER.id)
+
+    stack.enter_context(patch.object(ingest_module, "get_relational_engine", lambda: engine))
+    stack.enter_context(
+        patch.object(
+            ingest_module, "save_data_item_to_storage", AsyncMock(return_value="/tmp/doc.txt")
+        )
+    )
+    stack.enter_context(patch.object(ingest_module, "get_data_file_path", lambda p: p))
+    stack.enter_context(patch.object(ingest_module, "open_data_file", _fake_open_data_file))
+    stack.enter_context(
+        patch.object(
+            ingest_module,
+            "data_item_to_text_file",
+            AsyncMock(return_value=("/tmp/doc.txt", SimpleNamespace(loader_name="text_loader"))),
+        )
+    )
+    stack.enter_context(patch.object(ingest_module.ingestion, "classify", lambda _f: classified))
+    stack.enter_context(
+        patch.object(ingest_module.ingestion, "identify", AsyncMock(return_value=DATA_ID))
+    )
+    # Dataset resolution: return the seeded dataset and report DATA_ID as already
+    # belonging to it, so the existing-record UPDATE branch (not CREATE) runs.
+    stack.enter_context(
+        patch.object(ingest_module, "get_authorized_existing_datasets", AsyncMock(return_value=[]))
+    )
+    stack.enter_context(
+        patch.object(ingest_module, "load_or_create_datasets", AsyncMock(return_value=dataset))
+    )
+    stack.enter_context(
+        patch.object(
+            ingest_module,
+            "get_dataset_data",
+            AsyncMock(return_value=[SimpleNamespace(id=DATA_ID)]),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_reingest_updates_persisted_data_size():
+    from contextlib import ExitStack
+
+    engine, db_path = await _make_engine()
+    try:
+        with ExitStack() as stack:
+            _install_mocks(stack, engine)
+            await ingest_module.ingest_data(
+                data="hello world",
+                dataset_name="ds",
+                user=USER,
+            )
+
+        async with engine.get_async_session() as session:
+            refreshed = await session.get(Data, DATA_ID)
+            assert refreshed.data_size == NEW_SIZE, (
+                f"persisted data_size should be {NEW_SIZE} after re-ingestion, "
+                f"got {refreshed.data_size}"
+            )
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)


### PR DESCRIPTION
Closes #3160

## Description
While looking through store_data_to_dataset in cognee/tasks/ingestion/ingest_data.py, I noticed a small typo in the update path that's used when an existing file is ingested again.

Right now it updates the file size like this:

```python
data_point.file_size = original_file_metadata["file_size"]
```

The problem is that the Data model doesn't actually have a file_size column. The mapped column is called data_size (cognee/modules/data/models/Data.py). Interestingly, the create path just a few lines below already uses the correct field:

```python
data_size=original_file_metadata["file_size"]
```

Since file_size isn't a mapped SQLAlchemy column, assigning to it only creates a regular Python attribute on the object. SQLAlchemy doesn't track or persist that attribute, so when the session is flushed, the updated file size is never written to the database. As a result, if a file is re-ingested after its size changes, the stored data_size remains outdated without raising any error.

The fix is simply to change the attribute from file_size to data_size so the update is applied to the actual database column.

## Acceptance Criteria
- Re-ingesting an existing `Data` record with a new size updates the persisted `data_size` column.
- Added a regression test that drives the real `ingest_data` update path against an in-memory SQLite relational engine and asserts the stored `data_size` reflects the new value. It fails before the change and passes after it.

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
`uv run pytest cognee/tests/unit/tasks/ingestion/ -q`
<img width="947" height="104" alt="image" src="https://github.com/user-attachments/assets/5f794efa-d561-498f-a06f-3627680ab9f2" />


Without the fix the same test fails:
<img width="824" height="119" alt="image" src="https://github.com/user-attachments/assets/15e67869-dcee-40b8-ab48-e2240da7e26c" />

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
