### PR TITLE
fix(ingestion): correct data_size attribute when updating existing data points (fixes #3160)

### DIFF
--- a/cognee/tasks/ingestion/ingest_data.py
+++ b/cognee/tasks/ingestion/ingest_data.py
@@ -183,7 +183,7 @@ async def ingest_data(
                 data_point.owner_id = user.id
                 data_point.content_hash = new_content_hash
                 data_point.raw_content_hash = storage_file_metadata["content_hash"]
-                data_point.file_size = original_file_metadata["file_size"]
+                data_point.data_size = original_file_metadata["file_size"]
                 data_point.external_metadata = ext_metadata
                 data_point.node_set = json.dumps(node_set) if node_set else None
                 data_point.tenant_id = user.tenant_id if user.tenant_id else None


### PR DESCRIPTION
Fixes #3160 by replacing the incorrect file_size attribute with the correct data_size attribute when updating existing data points in the ingestion pipeline.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.