### PR TITLE
fix(settings): require superuser to save global settings and fully mask API keys (fixes #3084)

### DIFF
--- a/cognee/api/v1/settings/routers/get_settings_router.py
+++ b/cognee/api/v1/settings/routers/get_settings_router.py
@@ -90,9 +90,16 @@ def get_settings_router() -> APIRouter:
 
         ## Error Codes
         - **400 Bad Request**: Invalid settings provided
+        - **403 Forbidden**: Only superusers can modify global settings
         - **500 Internal Server Error**: Error saving settings
         """
         from cognee.modules.settings import save_llm_config, save_vector_db_config
+        from fastapi import HTTPException
+
+        if not user.is_superuser:
+            raise HTTPException(
+                status_code=403, detail="Only superusers can modify global settings"
+            )
 
         if new_settings.llm is not None:
             await save_llm_config(new_settings.llm)

--- a/cognee/modules/settings/get_settings.py
+++ b/cognee/modules/settings/get_settings.py
@@ -91,9 +91,7 @@ def get_settings() -> SettingsDict:
                 "model": llm_config.llm_model,
                 "endpoint": llm_config.llm_endpoint,
                 "api_version": llm_config.llm_api_version,
-                "api_key": (llm_config.llm_api_key[0:10] + "*" * (len(llm_config.llm_api_key) - 10))
-                if llm_config.llm_api_key
-                else None,
+                "api_key": ("*" * len(llm_config.llm_api_key)) if llm_config.llm_api_key else None,
                 "providers": llm_providers,
                 "models": {
                     "openai": [
@@ -181,10 +179,7 @@ def get_settings() -> SettingsDict:
             vector_db={
                 "provider": vector_config.vector_db_provider,
                 "url": vector_config.vector_db_url,
-                "api_key": (
-                    vector_config.vector_db_key[0:10]
-                    + "*" * (len(vector_config.vector_db_key) - 10)
-                ),
+                "api_key": ("*" * len(vector_config.vector_db_key)),
                 "providers": vector_dbs,
             },
         )


### PR DESCRIPTION
Fixes #3084 by adding a strict superuser permission check to the POST settings endpoint to prevent global configuration takeover. Also updates the GET settings endpoint to fully mask the LLM and VectorDB API keys to prevent unauthorized prefix leaking.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.