### PR TITLE
fix(storage): await file_exists in LocalFileStorage.get_size

### DIFF
--- a/cognee/infrastructure/files/storage/LocalFileStorage.py
+++ b/cognee/infrastructure/files/storage/LocalFileStorage.py
@@ -204,7 +204,7 @@ class LocalFileStorage(Storage):
 
         return (
             os.path.getsize(os.path.join(parsed_storage_path, file_path))
-            if self.file_exists(file_path)
+            if await self.file_exists(file_path)
             else 0
         )
 

--- a/cognee/tests/unit/infrastructure/test_local_file_storage_get_size.py
+++ b/cognee/tests/unit/infrastructure/test_local_file_storage_get_size.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+
+import pytest
+
+from cognee.infrastructure.files.storage.LocalFileStorage import LocalFileStorage
+
+
+@pytest.mark.asyncio
+async def test_get_size_returns_zero_for_missing_file():
+    """Regression test for the get_size() missing-await bug.
+
+    file_exists() is async, so calling it without await left the coroutine
+    (always truthy), made the ``else 0`` branch unreachable, and raised
+    FileNotFoundError for a missing file instead of returning 0.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = LocalFileStorage(tmp)
+        assert await storage.get_size("does_not_exist.txt") == 0
+
+
+@pytest.mark.asyncio
+async def test_get_size_returns_actual_size_for_existing_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = LocalFileStorage(tmp)
+        with open(os.path.join(tmp, "file.txt"), "wb") as handle:
+            handle.write(b"hello")
+        assert await storage.get_size("file.txt") == 5


### PR DESCRIPTION
## Description
While reading through the local file storage adapter I noticed `get_size`
calls `file_exists` without awaiting it:

```python
async def get_size(self, file_path: str) -> int:
    parsed_storage_path = get_parsed_path(self.storage_path)
    return (
        os.path.getsize(os.path.join(parsed_storage_path, file_path))
        if self.file_exists(file_path)   # <-- file_exists is async, not awaited
        else 0
    )
```

`file_exists` is an `async def`, so `self.file_exists(file_path)` returns a
coroutine object. A coroutine is always truthy, so the `if` is always true:
the `else 0` branch is dead and `os.path.getsize(...)` runs unconditionally.
For a path that doesn't exist this raises `FileNotFoundError` instead of
returning `0`, and Python also emits a "coroutine was never awaited" warning.

Everywhere else in the codebase `file_exists` is awaited (e.g. in
`S3FileStorage.store`, `SqlAlchemyAdapter`, `StorageManager`), so this is just
a missing `await`. The fix is one word.

## Acceptance Criteria
- `get_size` returns `0` for a missing file (instead of raising).
- `get_size` still returns the real size for an existing file.
- No "coroutine was never awaited" warning.

Verified locally (before the fix `get_size("missing")` raised
`FileNotFoundError`; after it returns `0`), and added a unit test that covers
both the missing-file and existing-file cases. See screenshot.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1550" height="830" alt="image" src="https://github.com/user-attachments/assets/f5cd8175-9791-404a-ba46-3d0852f1c4f7" />


## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
