### PR TITLE
fix(datasets): pass User object (not user.id) to get_authorized_dataset in has_data

### DIFF
--- a/cognee/api/v1/datasets/datasets.py
+++ b/cognee/api/v1/datasets/datasets.py
@@ -71,7 +71,7 @@ class datasets:
         if not user:
             user = await get_default_user()
 
-        dataset = await get_authorized_dataset(user.id, dataset_id)
+        dataset = await get_authorized_dataset(user, dataset_id)
 
         return await has_dataset_data(dataset.id)
 

--- a/cognee/tests/unit/api/test_datasets_has_data.py
+++ b/cognee/tests/unit/api/test_datasets_has_data.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.api.v1.datasets.datasets import datasets
+
+
+@pytest.mark.asyncio
+async def test_has_data_passes_user_object_to_authorization():
+    """Regression test: datasets.has_data must pass the User object, not user.id.
+
+    The bug passed ``user.id`` (a UUID) to ``get_authorized_dataset``, whose
+    first parameter is a ``User``. Downstream ``get_authorized_existing_datasets``
+    dereferences ``user.id``, so a UUID raised ``AttributeError`` and the public
+    ``has_data`` API was broken. All sibling methods (list_data, empty_dataset,
+    delete_data) correctly pass the user object.
+    """
+    user = SimpleNamespace(id=uuid4())
+    dataset_id = uuid4()
+    fake_dataset = SimpleNamespace(id=dataset_id)
+
+    with (
+        patch(
+            "cognee.api.v1.datasets.datasets.get_authorized_dataset",
+            new=AsyncMock(return_value=fake_dataset),
+        ) as mock_get_authorized_dataset,
+        patch(
+            "cognee.api.v1.datasets.datasets.has_dataset_data",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        result = await datasets.has_data(dataset_id, user=user)
+
+    assert result is True
+    # First positional arg must be the User object itself, not user.id.
+    first_arg = mock_get_authorized_dataset.call_args.args[0]
+    assert first_arg is user


### PR DESCRIPTION
## Description
While reading the dataset management code I found `datasets.has_data` passes
the wrong argument to the authorization helper:

```python
@staticmethod
async def has_data(dataset_id: str, user: Optional[User] = None) -> bool:
    if not user:
        user = await get_default_user()
    dataset = await get_authorized_dataset(user.id, dataset_id)   # <-- passes user.id
    return await has_dataset_data(dataset.id)
```

`get_authorized_dataset(user, dataset_id, ...)` takes a **User object** as its
first parameter (it forwards to `get_authorized_existing_datasets`, which then
dereferences `user.id`). Passing `user.id` (a `UUID`) means the helper does
`UUID.id`, which raises `AttributeError: 'UUID' object has no attribute 'id'`.
So the public `has_data` API fails for every caller.

Every sibling method in the same class passes the object, not the id:
- `list_data`   -> `get_authorized_dataset(user, dataset_id)`
- `empty_dataset` -> `get_authorized_dataset(user, dataset_id, "delete")`
- `delete_data` -> `get_authorized_dataset(user, dataset_id, "delete")`

This was clearly a copy-paste slip in just the `has_data` branch. The fix is to
pass `user`.

## Acceptance Criteria
- `has_data` forwards the `User` object (not `user.id`) to `get_authorized_dataset`.
- Added a regression test that fails on the old code (UUID passed) and passes
  with the fix (User object passed).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1550" height="830" alt="image" src="https://github.com/user-attachments/assets/ef4e0218-ddde-4dad-b0bf-58f43da78065" />

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
