### PR TITLE
docs(env): document managed config vars in .env.template + fix two ignored knob names

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -52,7 +52,7 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 #LLM_INSTRUCTOR_MODE=""
 
 # Cognee uses this to determine optimal chunk size (not forwarded in LLM calls).
-#LLM_MAX_TOKENS="16384"
+#LLM_MAX_COMPLETION_TOKENS="16384"
 
 # LLM API version (needed for Azure OpenAI)
 #LLM_API_VERSION=""
@@ -73,7 +73,7 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 
 #EMBEDDING_ENDPOINT=""
 #EMBEDDING_API_VERSION=""
-#EMBEDDING_MAX_TOKENS=8191
+#EMBEDDING_MAX_COMPLETION_TOKENS=8191
 #EMBEDDING_BATCH_SIZE=36
 # If not provided, LLM_API_KEY is used for embeddings too.
 #EMBEDDING_API_KEY="your_api_key"
@@ -397,6 +397,100 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # CACHE_PURGE_INTERVAL_SECONDS=900
 
 
+################################################################################
+#  ADDITIONAL MANAGED SETTINGS (previously undocumented)
+#  These are all read by Cognee's config classes (pydantic BaseSettings) but
+#  were missing from this template. Defaults shown; uncomment to override.
+################################################################################
+
+# -- LLM tuning ---------------------------------------------------------------
+#LLM_TEMPERATURE=0.0
+#LLM_STREAMING=false
+# Optional fallback model used when the primary completion fails.
+#FALLBACK_MODEL=""
+#FALLBACK_API_KEY=""
+#FALLBACK_ENDPOINT=""
+# Audio transcription model.
+#TRANSCRIPTION_MODEL="whisper-1"
+
+# -- Embedding rate limiting (mirrors the LLM_RATE_LIMIT_* knobs) -------------
+#EMBEDDING_RATE_LIMIT_ENABLED=false
+#EMBEDDING_RATE_LIMIT_REQUESTS=60
+#EMBEDDING_RATE_LIMIT_INTERVAL=60
+#EMBEDDING_RATE_LIMIT_TOKENS=0
+# Token-based LLM limit (0 = disabled; requests/interval already documented above).
+#LLM_RATE_LIMIT_TOKENS=0
+
+# -- Chunking -----------------------------------------------------------------
+#CHUNK_SIZE=1500
+#CHUNK_OVERLAP=10
+#CHUNK_STRATEGY="paragraph"
+
+# -- Triplet embedding (extra triplet-level vectors during cognify) -----------
+#TRIPLET_EMBEDDING=false
+
+# -- Session cache (Redis backend + session/usage tuning) ---------------------
+# Used when CACHE_BACKEND=redis; also the host/port for a remote cache.
+#CACHE_HOST="localhost"
+#CACHE_PORT=6379
+#CACHE_USERNAME=""
+#CACHE_PASSWORD=""
+# Session lifetime in the cache (default 7 days) and per-turn context cap.
+#SESSION_TTL_SECONDS=604800
+#MAX_SESSION_CONTEXT_CHARS=
+# Self-improvement: absorb per-turn feedback/guidance automatically (default on).
+#AUTO_FEEDBACK=true
+# Per-process LLM usage logging into the cache.
+#USAGE_LOGGING=false
+#USAGE_LOGGING_TTL=604800
+# Cross-process locks for file-based embedded graph backends.
+#SHARED_KUZU_LOCK=false
+#SHARED_LADYBUG_LOCK=false
+
+# -- Graph database — advanced connection / Kuzu tuning -----------------------
+#GRAPH_DATABASE_HOST=""
+#GRAPH_DATABASE_PORT=
+#GRAPH_DATABASE_KEY=""
+#GRAPH_DATABASE_ALLOW_ANONYMOUS=false
+# Run the embedded graph engine (Kuzu/Ladybug) in a worker subprocess.
+#GRAPH_DATABASE_SUBPROCESS_ENABLED=true
+# Kuzu performance tuning (0/auto by default).
+#KUZU_NUM_THREADS=0
+#KUZU_BUFFER_POOL_SIZE=
+#KUZU_MAX_DB_SIZE=
+
+# -- Vector database — advanced connection ------------------------------------
+#VECTOR_DB_HOST=""
+#VECTOR_DB_PORT=1234
+#VECTOR_DB_NAME=""
+#VECTOR_DB_USERNAME=""
+#VECTOR_DB_PASSWORD=""
+#VECTOR_DB_SUBPROCESS_ENABLED=true
+
+# -- Observability (Langfuse) -------------------------------------------------
+# Set MONITORING_TOOL=langfuse and provide keys to enable LLM tracing.
+#MONITORING_TOOL="langfuse"
+#LANGFUSE_PUBLIC_KEY=""
+#LANGFUSE_SECRET_KEY=""
+#LANGFUSE_HOST=""
+
+# -- AWS / Bedrock extras (in addition to the AWS section above) --------------
+#AWS_PROFILE_NAME=""
+#AWS_BEDROCK_RUNTIME_ENDPOINT=""
+
+# -- Local llama.cpp provider -------------------------------------------------
+#LLAMA_CPP_MODEL_PATH=""
+#LLAMA_CPP_N_CTX=2048
+#LLAMA_CPP_N_GPU_LAYERS=0
+#LLAMA_CPP_CHAT_FORMAT="chatml"
+
+# -- Security: additional auth-token secrets ----------------------------------
+# Like FASTAPI_USERS_JWT_SECRET above, these default to the INSECURE value
+# "super_secret". Override BOTH with long random strings in production.
+#FASTAPI_USERS_VERIFICATION_TOKEN_SECRET="change_me_in_production"
+#FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET="change_me_in_production"
+
+
 ###############################################################################
 # TIER 4 — EXAMPLE PROVIDER OVERRIDES (commented out)
 # Uncomment + fill values to switch providers.
@@ -408,7 +502,7 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #LLM_ENDPOINT="https://YOUR-RESOURCE.openai.azure.com"
 #LLM_API_KEY="your-azure-api-key"
 #LLM_API_VERSION="2024-12-01-preview"
-#LLM_MAX_TOKENS="16384"
+#LLM_MAX_COMPLETION_TOKENS="16384"
 
 ########## Azure OpenAI (managed identity / DefaultAzureCredential) ###########
 # Uses DefaultAzureCredential - no API key needed (for Azure VMs, App Service, etc.)
@@ -424,7 +518,7 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #EMBEDDING_API_KEY="your-azure-api-key"
 #EMBEDDING_API_VERSION="2024-12-01-preview"
 #EMBEDDING_DIMENSIONS=3072
-#EMBEDDING_MAX_TOKENS=8191
+#EMBEDDING_MAX_COMPLETION_TOKENS=8191
 
 ########## Local LLM via Ollama ###############################################
 #LLM_API_KEY ="ollama"
@@ -454,4 +548,4 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #EMBEDDING_ENDPOINT=""
 #EMBEDDING_API_VERSION=""
 #EMBEDDING_DIMENSIONS=3072
-#EMBEDDING_MAX_TOKENS=8191
+#EMBEDDING_MAX_COMPLETION_TOKENS=8191


### PR DESCRIPTION
## What
Closes the gap between Cognee's actual configuration surface and `.env.template` (the **A points** from a config-coverage audit), and fixes two documented-but-ignored variable names.

`.env.template` documented ~118 vars, but ~80 user-facing settings read by the pydantic `BaseSettings` config classes were undocumented, so users couldn't discover them.

## Fixes (real bugs — documented knobs that did nothing)
The template documented names the code never reads:
- `LLM_MAX_TOKENS` → **`LLM_MAX_COMPLETION_TOKENS`** (actual field in `infrastructure/llm/config.py`)
- `EMBEDDING_MAX_TOKENS` → **`EMBEDDING_MAX_COMPLETION_TOKENS`** (actual field in `embeddings/config.py`)

## Adds (new "Additional managed settings" section)
All commented-out, with defaults pulled from the config classes:
- **LLM tuning:** `LLM_TEMPERATURE`, `LLM_STREAMING`, `FALLBACK_MODEL/API_KEY/ENDPOINT`, `TRANSCRIPTION_MODEL`
- **Rate limits:** `EMBEDDING_RATE_LIMIT_*`, `LLM_RATE_LIMIT_TOKENS`
- **Chunking:** `CHUNK_SIZE`, `CHUNK_OVERLAP`, `CHUNK_STRATEGY`; `TRIPLET_EMBEDDING`
- **Session cache:** `CACHE_HOST/PORT/USERNAME/PASSWORD`, `SESSION_TTL_SECONDS`, `MAX_SESSION_CONTEXT_CHARS`, `AUTO_FEEDBACK`, `USAGE_LOGGING(_TTL)`, `SHARED_KUZU_LOCK`, `SHARED_LADYBUG_LOCK`
- **Graph DB advanced:** `GRAPH_DATABASE_HOST/PORT/KEY/ALLOW_ANONYMOUS/SUBPROCESS_ENABLED`, `KUZU_NUM_THREADS/BUFFER_POOL_SIZE/MAX_DB_SIZE`
- **Vector DB advanced:** `VECTOR_DB_HOST/PORT/NAME/USERNAME/PASSWORD/SUBPROCESS_ENABLED`
- **Observability:** `MONITORING_TOOL`, `LANGFUSE_PUBLIC_KEY/SECRET_KEY/HOST`
- **AWS/Bedrock:** `AWS_PROFILE_NAME`, `AWS_BEDROCK_RUNTIME_ENDPOINT`
- **llama.cpp:** `LLAMA_CPP_*`
- **Security:** `FASTAPI_USERS_VERIFICATION_TOKEN_SECRET` and `FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET` — like the JWT secret, these default to the insecure `"super_secret"` and should be overridden in production.

Eval-framework-internal vars (`BENCHMARK`, `DASHBOARD`, `QA_ENGINE`, …) are intentionally omitted from the user template.

## Scope / follow-ups (not in this PR)
- **Docs-only**: no behavior change; every addition is commented out.
- The insecure `"super_secret"` / `NEO4J_ENCRYPTION_KEY="test_key"` *defaults* are now documented but **not yet hardened** — a follow-up should make them fail-fast/warn (tracked separately).
- Translation config reads generic unprefixed env names (`BATCH_SIZE`, `MAX_RETRIES`, `TIMEOUT_SECONDS`) while the template documents `TRANSLATION_*` — left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)