### PR TITLE
fix(graph): await async query in Neo4jAdapter.has_node

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -176,7 +176,7 @@ class Neo4jAdapter(GraphDBInterface):
 
             - bool: True if the node exists, otherwise False.
         """
-        results = self.query(
+        results = await self.query(
             f"""
                 MATCH (n:`{BASE_LABEL}`)
                 WHERE n.id = $node_id

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_has_node.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_has_node.py
@@ -1,0 +1,28 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.neo4j_driver.adapter import Neo4jAdapter
+
+
+@pytest.mark.asyncio
+async def test_has_node_awaits_query_and_returns_true():
+    """Regression test: has_node must await the async query().
+
+    The bug called ``self.query(...)`` without ``await``, so ``results`` was a
+    coroutine and ``len(results)`` raised ``TypeError`` — has_node could never
+    return a value (and leaked an un-awaited coroutine).
+    """
+    adapter = object.__new__(Neo4jAdapter)
+    adapter.query = AsyncMock(return_value=[{"node_exists": True}])
+
+    assert await adapter.has_node("node-1") is True
+    adapter.query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_has_node_returns_false_when_no_results():
+    adapter = object.__new__(Neo4jAdapter)
+    adapter.query = AsyncMock(return_value=[])
+
+    assert await adapter.has_node("missing") is False


### PR DESCRIPTION
## Description
`Neo4jAdapter.has_node` calls the async `query` method without awaiting it:

```python
async def has_node(self, node_id: str) -> bool:
    results = self.query(            # <-- query is async, not awaited
        f"""
            MATCH (n:`{BASE_LABEL}`)
            WHERE n.id = $node_id
            RETURN COUNT(n) > 0 AS node_exists
        """,
        {"node_id": node_id},
    )
    return results[0]["node_exists"] if len(results) > 0 else False
```

`query` is an `async def`, so `self.query(...)` returns a coroutine. The next
line then does `len(results)` / `results[0]` on that coroutine, which raises
`TypeError: object of type 'coroutine' has no len()` — `has_node` can never
return a value, and the coroutine is left un-awaited.

Every other call site in this adapter awaits `query`; `has_node` was the only
one that didn't. The fix is a missing `await`.

## Acceptance Criteria
- `has_node` returns a bool instead of raising `TypeError`.
- Returns `True`/`False` based on the query result.

Added a unit test (with a mocked async `query`) that fails on the old code
(`TypeError`: coroutine has no `len()`) and passes with the fix. See screenshot.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1550" height="830" alt="image" src="https://github.com/user-attachments/assets/c56d1877-55d6-4d8e-b27c-3b02eafd1ce2" />



## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
