### PR TITLE
fix(graph): correct Neo4jAdapter.has_edge query alias and return value

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -460,9 +460,9 @@ class Neo4jAdapter(GraphDBInterface):
             - bool: True if the edge exists, otherwise False.
         """
         query = f"""
-            MATCH (from_node: `{BASE_LABEL}`)-[:`{edge_label}`]->(to_node: `{BASE_LABEL}`)
+            MATCH (from_node: `{BASE_LABEL}`)-[r:`{edge_label}`]->(to_node: `{BASE_LABEL}`)
             WHERE from_node.id = $from_node_id AND to_node.id = $to_node_id
-            RETURN COUNT(relationship) > 0 AS edge_exists
+            RETURN COUNT(r) > 0 AS edge_exists
         """
 
         params = {
@@ -470,8 +470,8 @@ class Neo4jAdapter(GraphDBInterface):
             "to_node_id": str(to_node),
         }
 
-        edge_exists = await self.query(query, params)
-        return edge_exists
+        results = await self.query(query, params)
+        return results[0]["edge_exists"] if len(results) > 0 else False
 
     async def has_edges(self, edges):
         """

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_has_edge.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_has_edge.py
@@ -1,0 +1,31 @@
+from uuid import uuid4
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.neo4j_driver.adapter import Neo4jAdapter
+
+
+@pytest.mark.asyncio
+async def test_has_edge_returns_bool_true():
+    """Regression test: has_edge must return a bool, not the raw query result.
+
+    The bug returned the query result list directly (always truthy when
+    non-empty) instead of the ``edge_exists`` value, and its Cypher referenced
+    an unbound ``relationship`` identifier (the relationship had no alias).
+    """
+    adapter = object.__new__(Neo4jAdapter)
+    adapter.query = AsyncMock(return_value=[{"edge_exists": True}])
+
+    result = await adapter.has_edge(uuid4(), uuid4(), "KNOWS")
+
+    assert result is True
+    adapter.query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_has_edge_returns_false_when_no_results():
+    adapter = object.__new__(Neo4jAdapter)
+    adapter.query = AsyncMock(return_value=[])
+
+    assert await adapter.has_edge(uuid4(), uuid4(), "KNOWS") is False


### PR DESCRIPTION
## Description
`Neo4jAdapter.has_edge` has two defects:

```python
query = f"""
    MATCH (from_node: `{BASE_LABEL}`)-[:`{edge_label}`]->(to_node: `{BASE_LABEL}`)
    WHERE from_node.id = $from_node_id AND to_node.id = $to_node_id
    RETURN COUNT(relationship) > 0 AS edge_exists      # 'relationship' is unbound
"""
...
edge_exists = await self.query(query, params)
return edge_exists                                      # returns a list, not a bool
```

1. The relationship in the `MATCH` pattern has no alias (`-[:`label`]->`), but
   the `RETURN` does `COUNT(relationship)` — `relationship` is an undefined
   identifier, so Neo4j errors on the query.
2. `self.query(...)` returns a list of records; returning it directly means
   `has_edge` returns a list (always truthy when non-empty) instead of the
   declared `bool`.

The sibling `has_edges` already aliases the relationship as `r` and uses
`count(r)`, and `has_node` returns `results[0][...]`. This change makes
`has_edge` consistent: alias `r`, `COUNT(r)`, and return
`results[0]["edge_exists"]` (or `False` when empty).

## Acceptance Criteria
- The Cypher references a bound relationship (`r`).
- `has_edge` returns a `bool`.

Added a regression test (mocked async query) that fails on the old code
(returns the list, not a bool) and passes with the fix. See screenshot.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1550" height="830" alt="image" src="https://github.com/user-attachments/assets/1e508396-277d-418c-b3cd-4bdbf2e43a3e" />

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
