### PR TITLE
fix(graph): correct reversed connected-components metrics in NeptuneGraphDB

### DIFF
--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -764,7 +764,7 @@ class NeptuneGraphDB(GraphDBInterface):
             - Dict[str, Any]: A dictionary containing graph metrics and statistics.
         """
         num_nodes, num_edges = await self._get_model_independent_graph_data()
-        num_cluster, list_clsuter_size = await self._get_connected_components_stat()
+        list_clsuter_size, num_cluster = await self._get_connected_components_stat()
 
         mandatory_metrics = {
             "num_nodes": num_nodes,

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neptune_graph_metrics.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neptune_graph_metrics.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.neptune_driver.adapter import NeptuneGraphDB
+
+
+@pytest.mark.asyncio
+async def test_get_graph_metrics_connected_components_mapping():
+    """Regression test for the reversed connected-components unpacking.
+
+    ``_get_connected_components_stat`` returns ``(sizes_list, count)`` (see its
+    docstring and return statement). The bug unpacked it as
+    ``num_cluster, list_clsuter_size`` and then put the list into
+    ``num_connected_components`` and the int into
+    ``sizes_of_connected_components`` — both metrics were inverted.
+
+    Called as an unbound method with a stub ``self`` so we don't have to
+    instantiate the (abstract) adapter.
+    """
+    stub = SimpleNamespace(
+        _get_model_independent_graph_data=AsyncMock(return_value=(5, 4)),
+        # helper returns (sizes_list, count)
+        _get_connected_components_stat=AsyncMock(return_value=([3, 2], 2)),
+    )
+
+    metrics = await NeptuneGraphDB.get_graph_metrics(stub, include_optional=False)
+
+    assert metrics["num_connected_components"] == 2
+    assert metrics["sizes_of_connected_components"] == [3, 2]
+    assert isinstance(metrics["num_connected_components"], int)
+    assert isinstance(metrics["sizes_of_connected_components"], list)


### PR DESCRIPTION
## Description
`NeptuneGraphDB.get_graph_metrics` unpacks the connected-components helper in
the wrong order:

```python
num_cluster, list_clsuter_size = await self._get_connected_components_stat()
...
"num_connected_components": num_cluster,            # gets the LIST
"sizes_of_connected_components": list_clsuter_size, # gets the INT
```

But `_get_connected_components_stat` returns `(sizes_list, count)` — its
docstring says "A list of sizes for each connected component ... The total
number of connected components", and it ends with
`return (size_connected_components, num_connected_components)`.

So the two metrics end up inverted: `num_connected_components` is assigned the
list of sizes, and `sizes_of_connected_components` is assigned the integer
count — the opposite of what every other backend produces
(ladybug/postgres/neo4j all put an int in `num_connected_components` and a list
in `sizes_of_connected_components`).

Fix: swap the unpacking to `list_clsuter_size, num_cluster` so each value maps
to the correct metric key.

## Acceptance Criteria
- `num_connected_components` is the integer count.
- `sizes_of_connected_components` is the list of component sizes.

Added a regression test (the metric helpers are mocked; the method is invoked
unbound so no live Neptune is required). It fails on the old code and passes
with the fix. See screenshot.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1550" height="830" alt="image" src="https://github.com/user-attachments/assets/c449e183-c628-4c30-bb09-f8ac5dffcf7e" />

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
