### PR TITLE
fix(graph): implement is_empty in NeptuneGraphDB

### DIFF
--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -751,6 +751,15 @@ class NeptuneGraphDB(GraphDBInterface):
             logger.error(f"Failed to get neighborhood: {error_msg}")
             raise Exception(f"Failed to get neighborhood: {error_msg}") from e
 
+    async def is_empty(self) -> bool:
+        """Return True if the graph contains no nodes."""
+        query = f"""
+            MATCH (n:{self._GRAPH_NODE_LABEL})
+            RETURN count(n) AS node_count
+        """
+        result = await self.query(query)
+        return result[0]["node_count"] == 0
+
     async def get_graph_metrics(self, include_optional: bool = False) -> Dict[str, Any]:
         """
         Fetch metrics and statistics of the graph, possibly including optional details.

--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -757,8 +757,13 @@ class NeptuneGraphDB(GraphDBInterface):
             MATCH (n:{self._GRAPH_NODE_LABEL})
             RETURN count(n) AS node_count
         """
-        result = await self.query(query)
-        return result[0]["node_count"] == 0
+        try:
+            result = await self.query(query)
+            return not result or result[0]["node_count"] == 0
+        except Exception as e:
+            error_msg = format_neptune_error(e)
+            logger.error(f"Failed to check if graph is empty: {error_msg}")
+            raise Exception(f"Failed to check if graph is empty: {error_msg}") from e
 
     async def get_graph_metrics(self, include_optional: bool = False) -> Dict[str, Any]:
         """

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neptune_is_empty.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neptune_is_empty.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.neptune_driver.adapter import NeptuneGraphDB
+
+
+def test_neptune_adapter_implements_is_empty():
+    """Regression test: NeptuneGraphDB must implement the abstract is_empty.
+
+    GraphDBInterface declares is_empty as an @abstractmethod, and ladybug,
+    neo4j and postgres implement it. Neptune did not, so it stayed abstract
+    and could not be instantiated at all
+    (``TypeError: Can't instantiate abstract class NeptuneGraphDB``).
+    """
+    assert "is_empty" not in NeptuneGraphDB.__abstractmethods__
+
+
+@pytest.mark.asyncio
+async def test_is_empty_true_when_no_nodes():
+    stub = SimpleNamespace(
+        _GRAPH_NODE_LABEL="COGNEE_NODE",
+        query=AsyncMock(return_value=[{"node_count": 0}]),
+    )
+    assert await NeptuneGraphDB.is_empty(stub) is True
+
+
+@pytest.mark.asyncio
+async def test_is_empty_false_when_nodes_exist():
+    stub = SimpleNamespace(
+        _GRAPH_NODE_LABEL="COGNEE_NODE",
+        query=AsyncMock(return_value=[{"node_count": 7}]),
+    )
+    assert await NeptuneGraphDB.is_empty(stub) is False

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neptune_is_empty.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neptune_is_empty.py
@@ -33,3 +33,24 @@ async def test_is_empty_false_when_nodes_exist():
         query=AsyncMock(return_value=[{"node_count": 7}]),
     )
     assert await NeptuneGraphDB.is_empty(stub) is False
+
+
+@pytest.mark.asyncio
+async def test_is_empty_true_when_result_empty():
+    """A query returning no rows must not raise IndexError; treat as empty."""
+    stub = SimpleNamespace(
+        _GRAPH_NODE_LABEL="COGNEE_NODE",
+        query=AsyncMock(return_value=[]),
+    )
+    assert await NeptuneGraphDB.is_empty(stub) is True
+
+
+@pytest.mark.asyncio
+async def test_is_empty_wraps_query_error():
+    """A failing query is reported instead of bubbling up the raw driver error."""
+    stub = SimpleNamespace(
+        _GRAPH_NODE_LABEL="COGNEE_NODE",
+        query=AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    with pytest.raises(Exception, match="Failed to check if graph is empty"):
+        await NeptuneGraphDB.is_empty(stub)


### PR DESCRIPTION
## Description
`NeptuneGraphDB` does not implement `is_empty`, which `GraphDBInterface`
declares as an `@abstractmethod`:

```python
# graph_db_interface.py
@abstractmethod
async def is_empty(self) -> bool:
    """Return True when the graph contains no nodes."""
    logger.warning("is_empty() is not implemented")
    return True
```

`ladybug`, `neo4j` and `postgres` all implement it; Neptune does not. Because
the abstract method is left unimplemented, `NeptuneGraphDB.__abstractmethods__`
is `{'is_empty'}`, so the class can't be instantiated at all:

```
TypeError: Can't instantiate abstract class NeptuneGraphDB without an
implementation for abstract method 'is_empty'
```

i.e. the Neptune graph backend is unusable. (And even ignoring the abstract
check, the interface's fallback body just logs a warning and returns `True`, so
it would report every graph as empty.)

This PR implements `is_empty` with a simple node-count query scoped to the
graph's node label, returning `True` only when there are no nodes — consistent
with the neo4j/ladybug/postgres implementations.

## Acceptance Criteria
- `NeptuneGraphDB` is no longer abstract (can be instantiated).
- `is_empty()` returns `True` for an empty graph and `False` otherwise.

Added a regression test that asserts `is_empty` is no longer in
`__abstractmethods__` and that the method returns the correct value (query
mocked; no live Neptune needed). It fails on the old code and passes with the
fix. See screenshot.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1550" height="830" alt="image" src="https://github.com/user-attachments/assets/3efe95f6-f70c-48c6-aeed-9d82a2c33b21" />

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
