### PR TITLE
fix(data): serialize null tenant_id as null in Dataset.to_json (#3173)

### DIFF
--- a/cognee/modules/data/models/Dataset.py
+++ b/cognee/modules/data/models/Dataset.py
@@ -43,6 +43,6 @@ class Dataset(Base):
             "createdAt": self.created_at.isoformat(),
             "updatedAt": self.updated_at.isoformat() if self.updated_at else None,
             "ownerId": str(self.owner_id),
-            "tenantId": str(self.tenant_id),
+            "tenantId": str(self.tenant_id) if self.tenant_id else None,
             "data": [data.to_json() for data in self.data],
         }

--- a/cognee/tests/unit/modules/data/test_dataset_to_json_tenant.py
+++ b/cognee/tests/unit/modules/data/test_dataset_to_json_tenant.py
@@ -1,0 +1,35 @@
+"""Regression test: Dataset.to_json() must serialize a null tenant_id as JSON
+null, not the string "None".
+
+`tenant_id` is a nullable column, so in single-tenant deployments it is None.
+`str(None)` yields the literal "None", leaking a bogus string into the payload.
+The same method already handles the nullable `updated_at` correctly with
+`... if ... else None`; this pins tenant_id to that same convention.
+"""
+
+from datetime import datetime, timezone
+
+from cognee.modules.data.models.Dataset import Dataset
+
+
+def _make_dataset(tenant_id):
+    d = Dataset()
+    d.id = "00000000-0000-0000-0000-000000000001"
+    d.name = "ds"
+    d.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    d.updated_at = None
+    d.owner_id = "00000000-0000-0000-0000-000000000002"
+    d.tenant_id = tenant_id
+    d.data = []
+    return d
+
+
+def test_null_tenant_serializes_as_none_not_string():
+    payload = _make_dataset(None).to_json()
+    assert payload["tenantId"] is None  # was the literal string "None" before the fix
+
+
+def test_present_tenant_still_serialized_as_string():
+    tid = "00000000-0000-0000-0000-000000000003"
+    payload = _make_dataset(tid).to_json()
+    assert payload["tenantId"] == str(tid)


### PR DESCRIPTION
## Description

While reading the dataset models I noticed `Dataset.to_json()` serializes the nullable `tenant_id` column with `str(self.tenant_id)`. For any dataset without a tenant — the normal case in single-tenant / non-multi-tenant setups where `tenant_id` is `None` — `str(None)` returns the literal string `"None"`, so the payload ends up with `"tenantId": "None"` instead of `null`.

The same method already handles the nullable `updated_at` the right way (`... if ... else None`), so I applied that same pattern to `tenant_id`. `owner_id` is non-nullable, so I left it as `str(self.owner_id)`.

## Acceptance Criteria

- A dataset with `tenant_id = None` serializes `"tenantId": null`.
- A dataset with a tenant still serializes `"tenantId"` as the stringified UUID.

```python
# before:  d.to_json()["tenantId"] == "None"
# after:   d.to_json()["tenantId"] is None   (when tenant_id is None)
```

Added a unit test (`cognee/tests/unit/modules/data/test_dataset_to_json_tenant.py`) covering both cases. It fails before the change and passes after. No DB/LLM needed.

`uv run ruff check .` passes; the change adds no `ty` diagnostics.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Fixes #3173.
