### PR TITLE
feat(retrieval): implement missing context and LLM completion for CypherSearch and NaturalLanguage retrievers

### DIFF
--- a/cognee/modules/retrieval/cypher_search_retriever.py
+++ b/cognee/modules/retrieval/cypher_search_retriever.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Optional
 from fastapi.encoders import jsonable_encoder
 
@@ -76,9 +77,10 @@ class CypherSearchRetriever(BaseRetriever):
 
             - Any: The result of the cypher query execution.
         """
-        # TODO: Do we want to return a string response here?
-        # return jsonable_encoder(retrieved_objects)
-        return None
+        if not retrieved_objects:
+            return None
+        serialized_objects = jsonable_encoder(retrieved_objects)
+        return json.dumps(serialized_objects, indent=2)
 
     async def get_completion_from_context(
         self, query: str, retrieved_objects: Any, context: Optional[Any] = None
@@ -101,5 +103,12 @@ class CypherSearchRetriever(BaseRetriever):
 
             - Any: The context, either provided or retrieved.
         """
-        # TODO: Do we want to generate a completion using LLM here?
-        return None
+        if not context:
+            return None
+        completion = await generate_completion(
+            query=query,
+            context=context,
+            user_prompt_path=self.user_prompt_path,
+            system_prompt_path=self.system_prompt_path,
+        )
+        return [completion]

--- a/cognee/modules/retrieval/natural_language_retriever.py
+++ b/cognee/modules/retrieval/natural_language_retriever.py
@@ -1,5 +1,8 @@
+import json
 from typing import Any, Optional
+from fastapi.encoders import jsonable_encoder
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
 from cognee.infrastructure.llm.prompts import render_prompt
@@ -145,8 +148,10 @@ class NaturalLanguageRetriever(BaseRetriever):
             - Optional[Any]: Returns the context retrieved from the graph database based on the
               query.
         """
-        # TODO: Do we want to process retrieved_objects into a context string?
-        return retrieved_objects
+        if not retrieved_objects:
+            return None
+        serialized_objects = jsonable_encoder(retrieved_objects)
+        return json.dumps(serialized_objects, indent=2)
 
     async def get_completion_from_context(
         self, query: str, retrieved_objects: Any, context: Optional[Any] = None
@@ -172,5 +177,12 @@ class NaturalLanguageRetriever(BaseRetriever):
 
             - Any: Returns the completion derived from the given query and context.
         """
-        # TODO: Do we want to generate a completion using LLM here?
-        return context
+        if not context:
+            return None
+        completion = await generate_completion(
+            query=query,
+            context=context,
+            user_prompt_path="context_for_question.txt",
+            system_prompt_path="answer_simple_question.txt",
+        )
+        return [completion]

--- a/cognee/tests/unit/modules/retrieval/test_cypher_search_retriever.py
+++ b/cognee/tests/unit/modules/retrieval/test_cypher_search_retriever.py
@@ -1,0 +1,46 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, patch
+from cognee.modules.retrieval.cypher_search_retriever import CypherSearchRetriever
+
+@pytest.mark.asyncio
+async def test_cypher_search_retriever_get_context():
+    retriever = CypherSearchRetriever()
+    
+    # Test with empty retrieved objects
+    assert await retriever.get_context_from_objects("query", None) is None
+    assert await retriever.get_context_from_objects("query", []) is None
+
+    # Test with valid retrieved objects
+    objects = [{"node_id": "1", "name": "Node1"}, {"node_id": "2", "name": "Node2"}]
+    context = await retriever.get_context_from_objects("query", objects)
+    assert context is not None
+    loaded = json.loads(context)
+    assert loaded == objects
+
+@pytest.mark.asyncio
+async def test_cypher_search_retriever_get_completion():
+    retriever = CypherSearchRetriever(
+        user_prompt_path="custom_user.txt",
+        system_prompt_path="custom_system.txt"
+    )
+
+    # Test with empty context
+    assert await retriever.get_completion_from_context("query", None, None) is None
+    assert await retriever.get_completion_from_context("query", None, "") is None
+
+    # Test with valid context and mock generate_completion
+    with patch(
+        "cognee.modules.retrieval.cypher_search_retriever.generate_completion",
+        new_callable=AsyncMock
+    ) as mock_generate:
+        mock_generate.return_value = "Completion result"
+        completion = await retriever.get_completion_from_context("query", None, "some context")
+        
+        assert completion == ["Completion result"]
+        mock_generate.assert_awaited_once_with(
+            query="query",
+            context="some context",
+            user_prompt_path="custom_user.txt",
+            system_prompt_path="custom_system.txt"
+        )

--- a/cognee/tests/unit/modules/retrieval/test_natural_language_retriever.py
+++ b/cognee/tests/unit/modules/retrieval/test_natural_language_retriever.py
@@ -1,0 +1,43 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, patch
+from cognee.modules.retrieval.natural_language_retriever import NaturalLanguageRetriever
+
+@pytest.mark.asyncio
+async def test_natural_language_retriever_get_context():
+    retriever = NaturalLanguageRetriever()
+    
+    # Test with empty retrieved objects
+    assert await retriever.get_context_from_objects("query", None) is None
+    assert await retriever.get_context_from_objects("query", []) is None
+
+    # Test with valid retrieved objects
+    objects = [{"node_id": "1", "name": "Node1"}, {"node_id": "2", "name": "Node2"}]
+    context = await retriever.get_context_from_objects("query", objects)
+    assert context is not None
+    loaded = json.loads(context)
+    assert loaded == objects
+
+@pytest.mark.asyncio
+async def test_natural_language_retriever_get_completion():
+    retriever = NaturalLanguageRetriever()
+
+    # Test with empty context
+    assert await retriever.get_completion_from_context("query", None, None) is None
+    assert await retriever.get_completion_from_context("query", None, "") is None
+
+    # Test with valid context and mock generate_completion
+    with patch(
+        "cognee.modules.retrieval.natural_language_retriever.generate_completion",
+        new_callable=AsyncMock
+    ) as mock_generate:
+        mock_generate.return_value = "Completion result"
+        completion = await retriever.get_completion_from_context("query", None, "some context")
+        
+        assert completion == ["Completion result"]
+        mock_generate.assert_awaited_once_with(
+            query="query",
+            context="some context",
+            user_prompt_path="context_for_question.txt",
+            system_prompt_path="answer_simple_question.txt"
+        )


### PR DESCRIPTION
## Description
Fixes #3178

This PR implements the missing pipeline stages for `CypherSearchRetriever` and `NaturalLanguageRetriever`. Previously, these retrievers only had the stage 1 retrieval implemented, leaving TODO stubs for stage 2 (`get_context_from_objects`) and stage 3 (`get_completion_from_context`). 

Specifically, this PR updates:
1. `get_context_from_objects`: Serializes the retrieved database objects to a formatted JSON context string.
2. `get_completion_from_context`: Generates answers using the `generate_completion` utility to invoke the LLM with relevant query prompts.

These changes bring the retrievers into alignment with the behavior of `CompletionRetriever`.

## Acceptance Criteria
* `CypherSearchRetriever` successfully parses search outputs into a structured context and generates a final completion utilizing the prompt parameters.
* `NaturalLanguageRetriever` successfully converts retrieval results to context strings and generates completion responses using the simple question prompt paths.
* Unit tests mock the LLM gate/completion generation and confirm serialization logic is correct and handles empty inputs cleanly.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
Run command:
`uv run pytest cognee/tests/unit/modules/retrieval/test_cypher_search_retriever.py cognee/tests/unit/modules/retrieval/test_natural_language_retriever.py -v`

<img width="1162" height="221" alt="nat_cy_iss3178" src="https://github.com/user-attachments/assets/1e749c05-2796-4805-941a-e8bd33524a0e" />