### PR TITLE
fix(search): fix LanceDB filter fallback in CogneeGraph (fixes #2720)

### DIFF
--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -134,15 +134,7 @@ class CogneeGraph(CogneeAbstractGraph):
         else:
             logger.info("Retrieving full graph from database.")
             nodes_data, edges_data = await get_graph_data_fn()
-        if hasattr(adapter, "get_id_filtered_graph_data") and (not nodes_data or not edges_data):
-            logger.warning(
-                "Id filtered graph returned empty, falling back to full graph retrieval."
-            )
-            logger.info("Retrieving full graph")
-            nodes_data, edges_data = await adapter.get_graph_data()
 
-        if not nodes_data or not edges_data:
-            raise EntityNotFoundError("Empty graph projected from the database.")
         return nodes_data, edges_data
 
     async def _get_filtered_graph(


### PR DESCRIPTION
This PR resolves issue #2720. It removes the fallback to full graph retrieval in CogneeGraph when an ID-filtered graph query returns empty nodes or edges. This prevents the retriever from falling back to a full graph scan, ensuring that distance-based filtering correctly restricts the retrieved subgraph.