### PR TITLE
fix(pipelines): anchor background tasks in set to prevent GC (fixes #3183)

### DIFF
--- a/cognee/api/v1/sync/sync.py
+++ b/cognee/api/v1/sync/sync.py
@@ -3,6 +3,8 @@ import os
 import uuid
 import asyncio
 import aiohttp
+
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
 from pydantic import BaseModel
 from typing import List, Optional
 from datetime import datetime, timezone
@@ -150,7 +152,9 @@ async def sync(
         # Continue without database tracking if record creation fails
 
     # Start the sync operation in the background
-    asyncio.create_task(_perform_background_sync(run_id, datasets, user))
+    task = asyncio.create_task(_perform_background_sync(run_id, datasets, user))
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
 
     # Return immediately with run_id
     return SyncResponse(

--- a/cognee/modules/pipelines/layers/pipeline_execution_mode.py
+++ b/cognee/modules/pipelines/layers/pipeline_execution_mode.py
@@ -2,6 +2,8 @@ import asyncio
 from typing import Any, AsyncIterable, AsyncGenerator, Callable, Dict, Union, Awaitable
 from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunCompleted, PipelineRunErrored
 from cognee.modules.pipelines.queues.pipeline_run_info_queues import push_to_queue
+
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
 from cognee.modules.users.methods.get_default_user import get_default_user
 from cognee.modules.data.methods.get_authorized_existing_datasets import (
     get_authorized_existing_datasets,
@@ -113,7 +115,9 @@ async def run_pipeline_as_background_process(
         pipeline_list.append(pipeline_run)
 
     # Send all started pipelines to execute one by one in background
-    asyncio.create_task(handle_rest_of_the_run(pipeline_list=pipeline_list))
+    task = asyncio.create_task(handle_rest_of_the_run(pipeline_list=pipeline_list))
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
 
     return pipeline_run_started_info
 


### PR DESCRIPTION
This PR resolves issue #3183. It adds a module-level set named _BACKGROUND_TASKS to anchor the asyncio Tasks created for background execution in pipeline_execution_mode.py and sync.py. This prevents the tasks from being garbage collected mid-run by Python's garbage collector.