### PR TITLE
fix(storage): use deep copy when copying data points metadata (fixes #2529)

### DIFF
--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -47,7 +47,7 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
                 await vector_engine.create_vector_index(type_name, field_name)
                 data_points_by_type[type_name][field_name] = []
 
-            indexed_data_point = data_point.model_copy()
+            indexed_data_point = data_point.model_copy(deep=True)
             indexed_data_point.metadata["index_fields"] = [field_name]
             data_points_by_type[type_name][field_name].append(indexed_data_point)
 

--- a/cognee/tasks/temporal_awareness/index_graphiti_objects.py
+++ b/cognee/tasks/temporal_awareness/index_graphiti_objects.py
@@ -62,7 +62,7 @@ async def index_and_transform_graphiti_nodes_and_edges():
                 index_points[index_name] = []
 
             if getattr(graphiti_node, field_name, None) is not None:
-                indexed_data_point = graphiti_node.model_copy()
+                indexed_data_point = graphiti_node.model_copy(deep=True)
                 indexed_data_point.metadata["index_fields"] = [field_name]
                 index_points[index_name].append(indexed_data_point)
 
@@ -89,7 +89,7 @@ async def index_and_transform_graphiti_nodes_and_edges():
             if index_name not in index_points:
                 index_points[index_name] = []
 
-            indexed_data_point = edge.model_copy()
+            indexed_data_point = edge.model_copy(deep=True)
             indexed_data_point.metadata["index_fields"] = [field_name]
             index_points[index_name].append(indexed_data_point)
 


### PR DESCRIPTION
This PR resolves issue #2529. It updates model_copy() calls to model_copy(deep=True) in index_data_points.py and index_graphiti_objects.py. This ensures that the metadata dictionary of Pydantic models is deep-copied, preventing shared dictionary references and avoiding unexpected mutations during indexing.