### PR TITLE
fix(graph): implement close() method in Neo4jAdapter to prevent connection pool leaks on cache eviction

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -98,6 +98,13 @@ class Neo4jAdapter(GraphDBInterface):
             keep_alive=True,
         )
 
+    async def close(self) -> None:
+        """
+        Close the underlying Neo4j driver connection pool.
+        """
+        if hasattr(self, "driver") and self.driver is not None:
+            await self.driver.close()
+
     async def initialize(self) -> None:
         """
         Initializes the database: adds uniqueness constraint on id and performs indexing

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_adapter_close.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_adapter_close.py
@@ -1,0 +1,91 @@
+import sys
+import gc
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+# Ensure neo4j and related modules are mocked if they are not installed in the environment
+try:
+    import neo4j
+except ModuleNotFoundError:
+    sys.modules["neo4j"] = MagicMock()
+    sys.modules["neo4j.exceptions"] = MagicMock()
+
+from cognee.infrastructure.databases.graph.neo4j_driver.adapter import Neo4jAdapter
+from cognee.infrastructure.databases.utils.closing_lru_cache import ClosingLRUCache
+
+@pytest.mark.asyncio
+async def test_neo4j_adapter_close():
+    # Arrange: Create a mock driver with an async close method
+    mock_driver = MagicMock()
+    mock_driver.close = AsyncMock()
+
+    # Instantiate the Neo4jAdapter using the mock driver
+    adapter = Neo4jAdapter(
+        graph_database_url="bolt://localhost:7687",
+        graph_database_username="neo4j",
+        graph_database_password="password",
+        driver=mock_driver,
+    )
+
+    # Act: Call close()
+    await adapter.close()
+
+    # Assert: Verify that self.driver.close was called and awaited
+    mock_driver.close.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_neo4j_adapter_close_none_driver():
+    # Arrange: Instantiate with no driver (it would normally call AsyncGraphDatabase.driver)
+    mock_driver = MagicMock()
+    mock_driver.close = AsyncMock()
+
+    with patch("cognee.infrastructure.databases.graph.neo4j_driver.adapter.AsyncGraphDatabase") as mock_db:
+        mock_db.driver.return_value = mock_driver
+        adapter = Neo4jAdapter(
+            graph_database_url="bolt://localhost:7687",
+            graph_database_username="neo4j",
+            graph_database_password="password",
+        )
+
+        # Act: Call close()
+        await adapter.close()
+
+        # Assert: Verify that driver.close was called and awaited
+        mock_driver.close.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_closing_lru_cache_evicts_neo4j_adapter():
+    # Arrange: Create cache with maxsize=1 so adding a second item triggers eviction
+    cache = ClosingLRUCache(maxsize=1)
+    mock_driver = MagicMock()
+    mock_driver.close = AsyncMock()
+
+    adapter = Neo4jAdapter(
+        graph_database_url="bolt://localhost:7687",
+        graph_database_username="neo4j",
+        graph_database_password="password",
+        driver=mock_driver,
+    )
+
+    # Put the adapter in cache
+    proxy = cache.get_or_create("neo4j_key", lambda: adapter)
+    
+    # Verify the proxy wraps our adapter
+    assert proxy.__wrapped__ is adapter
+    
+    # Act: evict by putting a new item in the cache
+    cache.get_or_create("another_key", lambda: MagicMock())
+    
+    # At this point, the proxy is still held in 'proxy' variable, so it shouldn't close yet
+    assert mock_driver.close.call_count == 0
+
+    # Release the lease
+    del proxy
+    gc.collect()
+
+    # Allow any pending async close tasks to complete
+    await asyncio.sleep(0.1)
+
+    # Assert: driver should be closed
+    mock_driver.close.assert_awaited_once()


### PR DESCRIPTION
## Description
Fixes #3193

While analyzing the codebase for consistency issues, I noticed that 
`Neo4jAdapter` in `cognee/infrastructure/databases/graph/neo4j_driver/adapter.py` is missing a `close()` method — unlike every other database adapter in the codebase (`PGVectorAdapter`, `LanceDBAdapter`, `PostgresAdapter`).

Cognee's `closing_lru_cache` calls `close()` on evicted adapters to release resources. Since `Neo4jAdapter` lacked this method, `hasattr(value, "close")` returned `False` and cleanup was silently skipped — leaving the Neo4j driver connection pool open indefinitely.

The fix adds a 3-line `async def close()` method that mirrors the pattern already used by all other adapters in the codebase.

## Acceptance Criteria
- `Neo4jAdapter.close()` calls `await self.driver.close()` on eviction 
- Handles missing/None driver gracefully 
- `closing_lru_cache` now correctly cleans up Neo4j connections on eviction 
- 3 unit tests pass verifying all scenarios 
- Existing Neo4j tests pass without regression 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1236" height="195" alt="neo4jBugFix" src="https://github.com/user-attachments/assets/64cc4391-d6ba-4374-978f-2029cfc1a648" />

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.