### PR TITLE
fix(chunking): validate exact chunk overlap

### DIFF
--- a/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
+++ b/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
@@ -101,6 +101,13 @@ class DefaultChunkEngine:
 
             Returns the created chunks and their numbered indices.
         """
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be greater than 0")
+        if chunk_overlap < 0:
+            raise ValueError("chunk_overlap must be greater than or equal to 0")
+        if chunk_overlap >= chunk_size:
+            raise ValueError("chunk_overlap must be smaller than chunk_size")
+
         data = "".join(data_chunks)
         chunks = []
         for i in range(0, len(data), chunk_size - chunk_overlap):

--- a/cognee/tests/unit/infrastructure/test_default_chunk_engine_overlap.py
+++ b/cognee/tests/unit/infrastructure/test_default_chunk_engine_overlap.py
@@ -1,0 +1,28 @@
+import pytest
+
+from cognee.infrastructure.data.chunking.DefaultChunkEngine import DefaultChunkEngine
+from cognee.shared.data_models import ChunkStrategy
+
+
+@pytest.mark.parametrize("chunk_overlap", [5, 6])
+def test_chunk_data_exact_rejects_overlap_at_or_above_chunk_size(chunk_overlap):
+    engine = DefaultChunkEngine(ChunkStrategy.EXACT, chunk_size=5, chunk_overlap=chunk_overlap)
+
+    with pytest.raises(ValueError, match="chunk_overlap must be smaller than chunk_size"):
+        engine.chunk_data_exact(["abcdef"], chunk_size=5, chunk_overlap=chunk_overlap)
+
+
+@pytest.mark.parametrize(
+    ("chunk_size", "chunk_overlap", "message"),
+    [
+        (0, 0, "chunk_size must be greater than 0"),
+        (5, -1, "chunk_overlap must be greater than or equal to 0"),
+    ],
+)
+def test_chunk_data_exact_rejects_invalid_chunk_options(chunk_size, chunk_overlap, message):
+    engine = DefaultChunkEngine(
+        ChunkStrategy.EXACT, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+    )
+
+    with pytest.raises(ValueError, match=message):
+        engine.chunk_data_exact(["abcdef"], chunk_size=chunk_size, chunk_overlap=chunk_overlap)


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

Add explicit validation for exact chunking options before computing the chunk step.
## Changes
- Reject non-positive `chunk_size`.
- Reject negative `chunk_overlap`.
- Reject `chunk_overlap` values greater than or equal to `chunk_size`.
- Add regression coverage for the invalid option cases.

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `/tmp/cognee-round2-venv/bin/python -m pytest cognee/tests/unit/infrastructure/test_default_chunk_engine_overlap.py cognee/tests/unit/processing/chunks/chunk_by_paragraph_test.py cognee/tests/unit/processing/chunks/chunk_by_sentence_test.py -q`
- `/tmp/cognee-round2-venv/bin/python -m ruff check cognee/infrastructure/data/chunking/DefaultChunkEngine.py cognee/tests/unit/infrastructure/test_default_chunk_engine_overlap.py`
- `/tmp/cognee-round2-venv/bin/python -m ruff format --check cognee/infrastructure/data/chunking/DefaultChunkEngine.py cognee/tests/unit/infrastructure/test_default_chunk_engine_overlap.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
