### PR TITLE
fix(chunking): split long sentence chunks correctly

### DIFF
--- a/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
+++ b/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
@@ -139,7 +139,7 @@ class DefaultChunkEngine:
         sentence_chunks = []
         for sentence in sentences:
             if len(sentence) > chunk_size:
-                chunks = self.chunk_data_exact(
+                chunks, _ = self.chunk_data_exact(
                     data_chunks=[sentence], chunk_size=chunk_size, chunk_overlap=chunk_overlap
                 )
                 sentence_chunks.extend(chunks)

--- a/cognee/tests/unit/infrastructure/test_default_chunk_engine.py
+++ b/cognee/tests/unit/infrastructure/test_default_chunk_engine.py
@@ -1,0 +1,13 @@
+from cognee.infrastructure.data.chunking.DefaultChunkEngine import DefaultChunkEngine
+from cognee.shared.data_models import ChunkStrategy
+
+
+def test_sentence_chunking_splits_long_sentences_into_strings():
+    engine = DefaultChunkEngine(ChunkStrategy.SENTENCE, chunk_size=10, chunk_overlap=0)
+
+    chunks, numbered_chunks = engine.chunk_by_sentence(
+        ["abcdefghijklmnop."], chunk_size=10, chunk_overlap=0
+    )
+
+    assert chunks == ["abcdefghij", "klmnop."]
+    assert numbered_chunks == [[1, "abcdefghij"], [2, "klmnop."]]


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- unpack exact chunks when sentence chunking splits an oversized sentence
- keep `chunk_by_sentence()` output as plain chunk strings
- add regression coverage for long sentence chunking

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/infrastructure/test_default_chunk_engine.py -q`
- `python -m pytest cognee/tests/unit/processing/chunks/chunk_by_paragraph_test.py -q`
- `python -m ruff check cognee/infrastructure/data/chunking/DefaultChunkEngine.py cognee/tests/unit/infrastructure/test_default_chunk_engine.py`
- `python -m ruff format --check cognee/infrastructure/data/chunking/DefaultChunkEngine.py cognee/tests/unit/infrastructure/test_default_chunk_engine.py`
## Issue
TODO: link issue after opening, if we decide to open one before the PR.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
