### PR TITLE
fix(files): skip empty extracted pdf pages

### DIFF
--- a/cognee/infrastructure/files/utils/extract_text_from_file.py
+++ b/cognee/infrastructure/files/utils/extract_text_from_file.py
@@ -28,7 +28,16 @@ def extract_text_from_file(file: BinaryIO, file_type: filetype.Type) -> str | No
     if file_type.extension == "pdf":
         reader = PdfReader(stream=file)
         pages = list(reader.pages[:3])
-        return "\n".join([page.extract_text().strip() for page in pages])
+        page_texts = []
+
+        for page in pages:
+            page_text = page.extract_text()
+            if page_text:
+                stripped_page_text = page_text.strip()
+                if stripped_page_text:
+                    page_texts.append(stripped_page_text)
+
+        return "\n".join(page_texts)
 
     if file_type.extension == "txt":
         return file.read().decode("utf-8")

--- a/cognee/tests/unit/infrastructure/files/test_extract_text_from_file.py
+++ b/cognee/tests/unit/infrastructure/files/test_extract_text_from_file.py
@@ -1,0 +1,26 @@
+from io import BytesIO
+from types import SimpleNamespace
+
+import cognee.infrastructure.files.utils.extract_text_from_file as extract_text_module
+from cognee.infrastructure.files.utils.extract_text_from_file import extract_text_from_file
+
+
+class FakePage:
+    def __init__(self, text):
+        self.text = text
+
+    def extract_text(self):
+        return self.text
+
+
+class FakePdfReader:
+    def __init__(self, stream):
+        self.pages = [FakePage(None), FakePage("  extracted text  ")]
+
+
+def test_extract_text_from_pdf_skips_pages_without_text(monkeypatch):
+    monkeypatch.setattr(extract_text_module, "PdfReader", FakePdfReader)
+
+    text = extract_text_from_file(BytesIO(b"pdf"), SimpleNamespace(extension="pdf"))
+
+    assert text == "extracted text"


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- skip PDF pages whose `extract_text()` result is empty
- preserve the existing behavior of joining non-empty page text
- add a focused regression test for the `None` page-text case

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/infrastructure/files/test_extract_text_from_file.py -q`
- `python -m ruff check cognee/infrastructure/files/utils/extract_text_from_file.py cognee/tests/unit/infrastructure/files/test_extract_text_from_file.py`
- `python -m ruff format --check cognee/infrastructure/files/utils/extract_text_from_file.py cognee/tests/unit/infrastructure/files/test_extract_text_from_file.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
