### PR TITLE
fix(files): infer stream file types from names

### DIFF
--- a/cognee/infrastructure/files/utils/guess_file_type.py
+++ b/cognee/infrastructure/files/utils/guess_file_type.py
@@ -51,6 +51,10 @@ def guess_file_type(file: BinaryIO, name: str | None = None) -> filetype.Type:
         ext = Path(file).suffix
     elif name is not None:
         ext = Path(name).suffix
+    else:
+        file_name = getattr(file, "name", None) or getattr(file, "full_name", None)
+        if isinstance(file_name, str):
+            ext = Path(file_name).suffix
 
     if ext in [".txt", ".text"]:
         file_type = Type("text/plain", "txt")

--- a/cognee/tests/unit/processing/utils/test_guess_file_type.py
+++ b/cognee/tests/unit/processing/utils/test_guess_file_type.py
@@ -1,0 +1,34 @@
+from io import BytesIO
+
+import pytest
+
+from cognee.infrastructure.files.utils.guess_file_type import guess_file_type
+
+
+class NamedBytesIO(BytesIO):
+    def __init__(self, value: bytes, name: str | None = None, full_name: str | None = None):
+        super().__init__(value)
+        self._name = name
+        self.full_name = full_name
+
+    @property
+    def name(self):
+        return self._name
+
+
+@pytest.mark.parametrize(
+    ("name", "full_name", "mime_type", "extension"),
+    [
+        ("s3://bucket/data.json", None, "application/json", "json"),
+        (None, "s3://bucket/notes.md", "text/markdown", "md"),
+    ],
+)
+def test_guess_file_type_uses_stream_name_when_name_is_not_passed(
+    name, full_name, mime_type, extension
+):
+    stream = NamedBytesIO(b'{"value": 1}', name=name, full_name=full_name)
+
+    file_type = guess_file_type(stream)
+
+    assert file_type.mime == mime_type
+    assert file_type.extension == extension


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

Use stream metadata when guessing file types without an explicit name argument.
## Changes
- Fall back to `file.name` or `file.full_name` in `guess_file_type()`.
- Add regression coverage for named JSON streams and `full_name` Markdown streams.

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `/tmp/cognee-round2-venv/bin/python -m pytest cognee/tests/unit/processing/utils/test_guess_file_type.py cognee/tests/unit/processing/utils/utils_test.py -q`
- `/tmp/cognee-round2-venv/bin/python -m ruff check cognee/infrastructure/files/utils/guess_file_type.py cognee/tests/unit/processing/utils/test_guess_file_type.py`
- `/tmp/cognee-round2-venv/bin/python -m ruff format --check cognee/infrastructure/files/utils/guess_file_type.py cognee/tests/unit/processing/utils/test_guess_file_type.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
