### PR TITLE
fix(files): hash local file URIs

### DIFF
--- a/cognee/infrastructure/files/utils/get_file_content_hash.py
+++ b/cognee/infrastructure/files/utils/get_file_content_hash.py
@@ -2,9 +2,11 @@ import hashlib
 import os
 from os import path
 from typing import BinaryIO, Union
+from urllib.parse import urlparse
 
 from ..exceptions import FileContentHashingError
 from ..storage import get_file_storage
+from .get_data_file_path import get_data_file_path
 
 
 async def get_file_content_hash(file_obj: str | BinaryIO) -> str:
@@ -12,8 +14,10 @@ async def get_file_content_hash(file_obj: str | BinaryIO) -> str:
 
     try:
         if isinstance(file_obj, str):
-            # Normalize path separators to handle mixed separators on Windows
-            normalized_path = os.path.normpath(file_obj)
+            parsed_url = urlparse(file_obj)
+            normalized_path = get_data_file_path(file_obj)
+            if parsed_url.scheme != "s3":
+                normalized_path = os.path.normpath(normalized_path)
 
             file_dir_path = path.dirname(normalized_path)
             file_name = path.basename(normalized_path)

--- a/cognee/tests/unit/processing/utils/utils_test.py
+++ b/cognee/tests/unit/processing/utils/utils_test.py
@@ -46,6 +46,24 @@ async def test_get_file_content_hash_file():
 
 
 @pytest.mark.asyncio
+async def test_get_file_content_hash_file_uri():
+    text_content = "Test content with file URI"
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt", encoding="utf-8") as f:
+        f.write(text_content)
+        temp_file_path = f.name
+
+    import hashlib
+
+    try:
+        expected_hash = hashlib.md5(text_content.encode("utf-8")).hexdigest()
+        result = await get_file_content_hash(Path(temp_file_path).as_uri())
+        assert result == expected_hash
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
 async def test_get_file_content_hash_stream():
     stream = BytesIO(b"test_data")
     import hashlib


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- normalize string inputs in `get_file_content_hash()` through the existing URI-aware path helper
- preserve S3 URI shape before storage dispatch
- add regression coverage for hashing a local file via `Path(...).as_uri()`

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/processing/utils/utils_test.py -q`
- `python -m ruff check cognee/infrastructure/files/utils/get_file_content_hash.py cognee/tests/unit/processing/utils/utils_test.py`
- `python -m ruff format --check cognee/infrastructure/files/utils/get_file_content_hash.py cognee/tests/unit/processing/utils/utils_test.py`
## Issue
TODO: link issue after opening, if we decide to open one before the PR.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
