### PR TITLE
fix(ingestion): expand local file URI directories

### DIFF
--- a/cognee/tasks/ingestion/resolve_data_directories.py
+++ b/cognee/tasks/ingestion/resolve_data_directories.py
@@ -4,6 +4,7 @@ from typing import List, Union, BinaryIO
 
 from cognee.tasks.ingestion.exceptions import S3FileSystemNotFoundError
 from cognee.exceptions import CogneeSystemError
+from cognee.infrastructure.files.utils.get_data_file_path import get_data_file_path
 from cognee.infrastructure.files.storage.s3_config import get_s3_config
 
 
@@ -40,8 +41,11 @@ async def resolve_data_directories(
 
     for item in data:
         if isinstance(item, str):  # Check if the item is a path
+            parsed_url = urlparse(item)
+            item_path = get_data_file_path(item) if parsed_url.scheme == "file" else item
+
             # S3
-            if urlparse(item).scheme == "s3":
+            if parsed_url.scheme == "s3":
                 if fs is not None:
                     if include_subdirectories:
                         base_path = item if item.endswith("/") else item + "/"
@@ -63,18 +67,18 @@ async def resolve_data_directories(
                 else:
                     raise S3FileSystemNotFoundError()
 
-            elif os.path.isdir(item):  # If it's a directory
+            elif os.path.isdir(item_path):  # If it's a directory
                 if include_subdirectories:
                     # Recursively add all files in the directory and subdirectories
-                    for root, _, files in os.walk(item):
+                    for root, _, files in os.walk(item_path):
                         resolved_data.extend([os.path.join(root, f) for f in files])
                 else:
                     # Add all files (not subdirectories) in the directory
                     resolved_data.extend(
                         [
-                            os.path.join(item, f)
-                            for f in os.listdir(item)
-                            if os.path.isfile(os.path.join(item, f))
+                            os.path.join(item_path, f)
+                            for f in os.listdir(item_path)
+                            if os.path.isfile(os.path.join(item_path, f))
                         ]
                     )
             else:  # If it's a file or text add it directly

--- a/cognee/tests/unit/tasks/ingestion/test_resolve_data_directories.py
+++ b/cognee/tests/unit/tasks/ingestion/test_resolve_data_directories.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+from cognee.tasks.ingestion.resolve_data_directories import resolve_data_directories
+
+
+@pytest.mark.asyncio
+async def test_resolve_data_directories_expands_file_uri_directory(tmp_path):
+    root = tmp_path / "docs"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    first_file = root / "a.txt"
+    second_file = nested / "b.txt"
+    first_file.write_text("a", encoding="utf-8")
+    second_file.write_text("b", encoding="utf-8")
+
+    result = await resolve_data_directories(root.as_uri())
+
+    assert sorted(Path(item).name for item in result) == ["a.txt", "b.txt"]
+    assert all(not item.startswith("file://") for item in result)
+
+
+@pytest.mark.asyncio
+async def test_resolve_data_directories_expands_file_uri_directory_non_recursive(tmp_path):
+    root = tmp_path / "docs"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    first_file = root / "a.txt"
+    second_file = nested / "b.txt"
+    first_file.write_text("a", encoding="utf-8")
+    second_file.write_text("b", encoding="utf-8")
+
+    result = await resolve_data_directories(root.as_uri(), include_subdirectories=False)
+
+    assert [Path(item).name for item in result] == ["a.txt"]


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- normalize `file://` inputs before local directory detection in `resolve_data_directories()`
- keep existing local directory expansion behavior for recursive and non-recursive modes
- add regression tests for file URI directory ingestion

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/tasks/ingestion/test_resolve_data_directories.py -q`
- `python -m ruff check cognee/tasks/ingestion/resolve_data_directories.py cognee/tests/unit/tasks/ingestion/test_resolve_data_directories.py`
- `python -m ruff format --check cognee/tasks/ingestion/resolve_data_directories.py cognee/tests/unit/tasks/ingestion/test_resolve_data_directories.py`
## Issue
TODO: link issue after opening, if we decide to open one before the PR.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
