### PR TITLE
fix(ingestion): load local file URIs

### DIFF
--- a/cognee/tasks/ingestion/data_item_to_text_file.py
+++ b/cognee/tasks/ingestion/data_item_to_text_file.py
@@ -8,6 +8,7 @@ from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface
 from cognee.modules.ingestion.exceptions import IngestionError
 from cognee.infrastructure.loaders import get_loader_engine
 from cognee.shared.logging_utils import get_logger
+from cognee.infrastructure.files.utils.get_data_file_path import get_data_file_path
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -56,9 +57,10 @@ async def data_item_to_text_file(
         # data is local file path
         elif parsed_url.scheme == "file":
             if settings.accept_local_file_path:
+                file_path = get_data_file_path(data_item_path)
                 loader = get_loader_engine()
-                return await loader.load_file(data_item_path, preferred_loaders), loader.get_loader(
-                    data_item_path, preferred_loaders
+                return await loader.load_file(file_path, preferred_loaders), loader.get_loader(
+                    file_path, preferred_loaders
                 )
             else:
                 raise IngestionError(message="Local files are not accepted.")

--- a/cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py
+++ b/cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import pytest
+
+from cognee.tasks.ingestion.data_item_to_text_file import data_item_to_text_file
+
+
+@pytest.mark.asyncio
+async def test_file_uri_loads_local_text_file(tmp_path):
+    file_path = tmp_path / "example.txt"
+    file_path.write_text("hello text")
+
+    content, loader = await data_item_to_text_file(
+        Path(file_path).as_uri(),
+        preferred_loaders={"text_loader": {"persist": False}},
+    )
+
+    assert content == "hello text"
+    assert loader.loader_name == "text_loader"


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- normalize `file://` inputs to filesystem paths before passing them to loader detection and loading
- add a regression test that loads a local text file via `Path(...).as_uri()`

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py -q`
- `python -m ruff check cognee/tasks/ingestion/data_item_to_text_file.py cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py`
- `python -m ruff format --check cognee/tasks/ingestion/data_item_to_text_file.py cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py`
## Issue
TODO: link issue after opening, if we decide to open one before the PR.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
