### PR TITLE
fix(files): support relative file URLs

### DIFF
--- a/cognee/infrastructure/files/storage/LocalFileStorage.py
+++ b/cognee/infrastructure/files/storage/LocalFileStorage.py
@@ -57,6 +57,10 @@ def get_parsed_path(file_path: str) -> str:
         return os.path.normpath(file_path)
 
 
+def get_file_uri(file_path: str) -> str:
+    return Path(os.path.abspath(file_path)).as_uri()
+
+
 class LocalFileStorage(Storage):
     """
     Manage local file storage operations such as storing, retrieving, and managing files on
@@ -103,7 +107,7 @@ class LocalFileStorage(Storage):
 
                 file.close()
 
-        return Path(full_file_path).as_uri()
+        return get_file_uri(full_file_path)
 
     @asynccontextmanager
     async def open(
@@ -156,7 +160,7 @@ class LocalFileStorage(Storage):
                 )
 
         with open(full_file_path, mode=mode, *args, **kwargs) as file:
-            file = FileBufferedReader(file, name=Path(full_file_path).as_uri())
+            file = FileBufferedReader(file, name=get_file_uri(full_file_path))
 
             try:
                 yield file

--- a/cognee/infrastructure/files/utils/get_data_file_path.py
+++ b/cognee/infrastructure/files/utils/get_data_file_path.py
@@ -15,14 +15,19 @@ def get_data_file_path(file_path: str) -> str:
         # file:///path/to/file -> /path/to/file
         fs_path = unquote(parsed.path)
 
-        if os.name == "nt" and parsed.netloc:
-            # Distinguish drive letter (file://D:/path) from UNC (file://server/share)
-            if len(parsed.netloc) == 2 and parsed.netloc[1] == ":" and parsed.netloc[0].isalpha():
-                # Drive letter in netloc from malformed file://D:/path URLs
-                fs_path = parsed.netloc + fs_path
-            else:
-                # Handle UNC paths (file://server/share/...)
-                fs_path = f"//{parsed.netloc}{fs_path}"
+        if parsed.netloc:
+            netloc = unquote(parsed.netloc)
+
+            if os.name == "nt":
+                # Distinguish drive letter (file://D:/path) from UNC (file://server/share)
+                if len(netloc) == 2 and netloc[1] == ":" and netloc[0].isalpha():
+                    # Drive letter in netloc from malformed file://D:/path URLs
+                    fs_path = netloc + fs_path
+                else:
+                    # Handle UNC paths (file://server/share/...)
+                    fs_path = f"//{netloc}{fs_path}"
+            elif netloc.lower() != "localhost":
+                fs_path = os.path.join(netloc, fs_path.lstrip("/"))
 
         # Normalize the file URI for Windows - handle drive letters correctly
         if os.name == "nt":  # Windows

--- a/cognee/tests/unit/modules/data/test_open_data_file.py
+++ b/cognee/tests/unit/modules/data/test_open_data_file.py
@@ -3,11 +3,22 @@ import tempfile
 import pytest
 from pathlib import Path
 
+from cognee.infrastructure.files.utils.get_data_file_path import get_data_file_path
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 
 
 class TestOpenDataFile:
     """Test cases for open_data_file function with file:// URL handling."""
+
+    def test_relative_file_url_path(self):
+        assert get_data_file_path("file://relative/path.txt") == os.path.normpath(
+            "relative/path.txt"
+        )
+
+    def test_localhost_file_url_path(self):
+        assert get_data_file_path("file://localhost/tmp/path.txt") == os.path.normpath(
+            "/tmp/path.txt"
+        )
 
     @pytest.mark.asyncio
     async def test_regular_file_path(self):
@@ -40,6 +51,19 @@ class TestOpenDataFile:
                 assert content == test_content
         finally:
             os.unlink(temp_file_path)
+
+    @pytest.mark.asyncio
+    async def test_relative_file_url_text_mode(self, tmp_path, monkeypatch):
+        test_content = "Test content for relative file:// URL handling"
+        relative_dir = tmp_path / "relative"
+        relative_dir.mkdir()
+        (relative_dir / "path.txt").write_text(test_content)
+
+        monkeypatch.chdir(tmp_path)
+
+        async with open_data_file("file://relative/path.txt", mode="r") as f:
+            content = f.read()
+            assert content == test_content
 
     @pytest.mark.asyncio
     async def test_file_url_binary_mode(self):


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- keep non-localhost `file://...` netlocs as the leading path segment on Unix-like systems so documented inputs like `file://relative/path.txt` resolve to `relative/path.txt`
- build `LocalFileStorage` file metadata URIs from absolute paths so relative storage paths do not crash after a file opens
- add regression coverage for relative file URL normalization and `open_data_file()`

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/modules/data/test_open_data_file.py -q`
- `python -m pytest cognee/tests/unit/api/test_get_raw_data_endpoint.py -q`
- `python -m ruff check cognee/infrastructure/files/utils/get_data_file_path.py cognee/infrastructure/files/storage/LocalFileStorage.py cognee/tests/unit/modules/data/test_open_data_file.py`
## Issue
TODO: link issue after opening, if we decide to open one before the PR.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
