### PR TITLE
fix(storage): write nonseekable streams

### DIFF
--- a/cognee/infrastructure/files/storage/LocalFileStorage.py
+++ b/cognee/infrastructure/files/storage/LocalFileStorage.py
@@ -96,7 +96,10 @@ class LocalFileStorage(Storage):
             else:
                 with open(full_file_path, mode="wb") as file:
                     if hasattr(data, "read"):
-                        data.seek(0)
+                        try:
+                            data.seek(0)
+                        except (AttributeError, OSError):
+                            pass
                         file.write(data.read())
                     else:
                         file.write(data)

--- a/cognee/tests/unit/infrastructure/files/test_local_file_storage.py
+++ b/cognee/tests/unit/infrastructure/files/test_local_file_storage.py
@@ -1,0 +1,31 @@
+import io
+
+import pytest
+
+from cognee.infrastructure.files.storage.LocalFileStorage import LocalFileStorage
+
+
+class NonSeekableBytesIO(io.BytesIO):
+    def seek(self, *args, **kwargs):
+        raise io.UnsupportedOperation("seek")
+
+
+@pytest.mark.asyncio
+async def test_store_rewinds_seekable_stream(tmp_path):
+    storage = LocalFileStorage(str(tmp_path))
+    stream = io.BytesIO(b"abcdef")
+    stream.read(3)
+
+    await storage.store("seekable.bin", stream, overwrite=True)
+
+    assert (tmp_path / "seekable.bin").read_bytes() == b"abcdef"
+
+
+@pytest.mark.asyncio
+async def test_store_writes_nonseekable_stream(tmp_path):
+    storage = LocalFileStorage(str(tmp_path))
+    stream = NonSeekableBytesIO(b"abcdef")
+
+    await storage.store("nonseekable.bin", stream, overwrite=True)
+
+    assert (tmp_path / "nonseekable.bin").read_bytes() == b"abcdef"


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

Fix `LocalFileStorage.store()` so it handles binary streams that support `read()` but not `seek()`.
## Changes
- Keep rewinding seekable streams before writing.
- Skip the rewind when a stream raises an unsupported seek error.
- Add unit coverage for seekable and non-seekable streams.

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `/tmp/cognee-round2-venv/bin/python -m pytest cognee/tests/unit/infrastructure/files/test_local_file_storage.py -q`
- `/tmp/cognee-round2-venv/bin/python -m ruff check cognee/infrastructure/files/storage/LocalFileStorage.py cognee/tests/unit/infrastructure/files/test_local_file_storage.py`
- `/tmp/cognee-round2-venv/bin/python -m ruff format --check cognee/infrastructure/files/storage/LocalFileStorage.py cognee/tests/unit/infrastructure/files/test_local_file_storage.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
