### PR TITLE
fix(files): handle non-seekable metadata streams

### DIFF
--- a/cognee/infrastructure/files/utils/get_file_metadata.py
+++ b/cognee/infrastructure/files/utils/get_file_metadata.py
@@ -28,6 +28,27 @@ class FileMetadata(TypedDict):
     file_size: int
 
 
+def _get_file_size(file: BinaryIO) -> int:
+    try:
+        return os.fstat(file.fileno()).st_size
+    except (AttributeError, io.UnsupportedOperation, OSError):
+        pass
+
+    try:
+        return len(file.getbuffer())
+    except (AttributeError, BufferError, TypeError, ValueError):
+        pass
+
+    try:
+        pos = file.tell()
+        file.seek(0, os.SEEK_END)
+        file_size = file.tell()
+        file.seek(pos)
+        return file_size
+    except (AttributeError, io.UnsupportedOperation, OSError):
+        return 0
+
+
 async def get_file_metadata(file: BinaryIO, name: str | None = None) -> FileMetadata:
     """
     Retrieve metadata from a file object.
@@ -53,7 +74,8 @@ async def get_file_metadata(file: BinaryIO, name: str | None = None) -> FileMeta
         content_hash = await get_file_content_hash(file)
         file.seek(0)
     except io.UnsupportedOperation as error:
-        logger.error(f"Error retrieving content hash for file: {file.name} \n{str(error)}\n\n")
+        file_name = getattr(file, "name", name or "<unknown>")
+        logger.error(f"Error retrieving content hash for file: {file_name} \n{str(error)}\n\n")
 
     file_type = guess_file_type(file, name)
 
@@ -65,17 +87,11 @@ async def get_file_metadata(file: BinaryIO, name: str | None = None) -> FileMeta
         # In case file_path does not exist or is a integer return None
         file_name = None
 
-    # Get file size
-    pos = file.tell()  # remember current pointer
-    file.seek(0, os.SEEK_END)  # jump to end
-    file_size = file.tell()  # byte count
-    file.seek(pos)
-
     return FileMetadata(
         name=file_name,
         file_path=file_path,
         mime_type=file_type.mime,
         extension=file_type.extension,
         content_hash=content_hash,
-        file_size=file_size,
+        file_size=_get_file_size(file),
     )

--- a/cognee/infrastructure/files/utils/get_file_metadata.py
+++ b/cognee/infrastructure/files/utils/get_file_metadata.py
@@ -3,6 +3,7 @@ import os.path
 from pathlib import Path
 from typing import BinaryIO, TypedDict
 
+from cognee.infrastructure.files.exceptions import FileContentHashingError
 from cognee.infrastructure.files.utils.get_file_content_hash import get_file_content_hash
 from cognee.shared.logging_utils import get_logger
 
@@ -73,7 +74,7 @@ async def get_file_metadata(file: BinaryIO, name: str | None = None) -> FileMeta
         file.seek(0)
         content_hash = await get_file_content_hash(file)
         file.seek(0)
-    except io.UnsupportedOperation as error:
+    except (AttributeError, FileContentHashingError, io.UnsupportedOperation, OSError) as error:
         file_name = getattr(file, "name", name or "<unknown>")
         logger.error(f"Error retrieving content hash for file: {file_name} \n{str(error)}\n\n")
 

--- a/cognee/tests/unit/processing/utils/test_get_file_metadata.py
+++ b/cognee/tests/unit/processing/utils/test_get_file_metadata.py
@@ -1,0 +1,29 @@
+import io
+
+import pytest
+
+from cognee.infrastructure.files.utils.get_file_metadata import get_file_metadata
+
+
+class NonSeekableBytesIO(io.BytesIO):
+    name = "stream.txt"
+
+    def seekable(self):
+        return False
+
+    def seek(self, *args):
+        raise io.UnsupportedOperation("seek")
+
+    def tell(self):
+        raise io.UnsupportedOperation("tell")
+
+
+@pytest.mark.asyncio
+async def test_get_file_metadata_handles_non_seekable_stream():
+    metadata = await get_file_metadata(NonSeekableBytesIO(b"hello"), name="stream.txt")
+
+    assert metadata["name"] == "stream"
+    assert metadata["mime_type"] == "text/plain"
+    assert metadata["extension"] == "txt"
+    assert metadata["content_hash"] == ""
+    assert metadata["file_size"] == len(b"hello")

--- a/cognee/tests/unit/processing/utils/test_get_file_metadata.py
+++ b/cognee/tests/unit/processing/utils/test_get_file_metadata.py
@@ -18,11 +18,27 @@ class NonSeekableBytesIO(io.BytesIO):
         raise io.UnsupportedOperation("tell")
 
 
+class OSErrorSeekBytesIO(io.BytesIO):
+    def seek(self, *args):
+        raise OSError("cannot seek")
+
+
 @pytest.mark.asyncio
 async def test_get_file_metadata_handles_non_seekable_stream():
     metadata = await get_file_metadata(NonSeekableBytesIO(b"hello"), name="stream.txt")
 
     assert metadata["name"] == "stream"
+    assert metadata["mime_type"] == "text/plain"
+    assert metadata["extension"] == "txt"
+    assert metadata["content_hash"] == ""
+    assert metadata["file_size"] == len(b"hello")
+
+
+@pytest.mark.asyncio
+async def test_get_file_metadata_handles_seek_oserror_without_stream_name():
+    metadata = await get_file_metadata(OSErrorSeekBytesIO(b"hello"), name="stream.txt")
+
+    assert metadata["name"] is None
     assert metadata["mime_type"] == "text/plain"
     assert metadata["extension"] == "txt"
     assert metadata["content_hash"] == ""


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- make file-size detection tolerant of streams that do not support `seek()`/`tell()`
- use `fileno()` or `getbuffer()` when available before falling back to seek-based sizing
- add regression coverage for a non-seekable binary stream

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/processing/utils/test_get_file_metadata.py cognee/tests/unit/processing/utils/utils_test.py -q`
- `python -m ruff check cognee/infrastructure/files/utils/get_file_metadata.py cognee/tests/unit/processing/utils/test_get_file_metadata.py`
- `python -m ruff format --check cognee/infrastructure/files/utils/get_file_metadata.py cognee/tests/unit/processing/utils/test_get_file_metadata.py`
## Issue
TODO: link issue after opening, if we decide to open one before the PR.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
