### PR TITLE
fix(pdf): skip empty extracted pages

### DIFF
--- a/cognee/infrastructure/loaders/external/pypdf_loader.py
+++ b/cognee/infrastructure/loaders/external/pypdf_loader.py
@@ -72,7 +72,7 @@ class PyPdfLoader(LoaderInterface):
                 for page_num, page in enumerate(reader.pages, 1):
                     try:
                         page_text = page.extract_text()
-                        if page_text.strip():  # Only add non-empty pages
+                        if page_text and page_text.strip():  # Only add non-empty pages
                             page_texts.append(page_text)
                             content_parts.append(f"Page {page_num}:\n{page_text}\n")
                     except Exception as e:

--- a/cognee/modules/data/processing/document_types/PdfDocument.py
+++ b/cognee/modules/data/processing/document_types/PdfDocument.py
@@ -21,7 +21,8 @@ class PdfDocument(Document):
             async def get_text():
                 for page in file.pages:
                     page_text = page.extract_text()
-                    yield page_text
+                    if page_text and page_text.strip():
+                        yield page_text
 
             chunker = chunker_cls(self, get_text=get_text, max_chunk_size=max_chunk_size)
 

--- a/cognee/tests/unit/documents/test_pdf_empty_pages.py
+++ b/cognee/tests/unit/documents/test_pdf_empty_pages.py
@@ -1,0 +1,70 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.loaders.external import pypdf_loader
+from cognee.infrastructure.loaders.external.pypdf_loader import PyPdfLoader
+from cognee.modules.data.processing.document_types.PdfDocument import PdfDocument
+
+pdf_document_module = importlib.import_module(
+    "cognee.modules.data.processing.document_types.PdfDocument"
+)
+
+
+class FakePage:
+    def __init__(self, text):
+        self.text = text
+
+    def extract_text(self):
+        return self.text
+
+
+class FakePdfReader:
+    def __init__(self, *_args, **_kwargs):
+        self.pages = [FakePage(None), FakePage("   "), FakePage("page text")]
+
+
+class CollectingChunker:
+    def __init__(self, _document, get_text, max_chunk_size):
+        self.get_text = get_text
+
+    async def read(self):
+        async for text in self.get_text():
+            yield text
+
+
+@pytest.mark.asyncio
+async def test_pdf_document_skips_empty_pages(monkeypatch, tmp_path):
+    monkeypatch.setattr(pdf_document_module, "PdfReader", FakePdfReader)
+    file_path = tmp_path / "empty-pages.pdf"
+    file_path.write_bytes(b"pdf")
+    document = PdfDocument(
+        id=uuid4(),
+        name="empty-pages.pdf",
+        raw_data_location=str(file_path),
+        external_metadata="",
+        mime_type="application/pdf",
+    )
+
+    texts = [text async for text in document.read(CollectingChunker, max_chunk_size=100)]
+
+    assert texts == ["page text"]
+
+
+@pytest.mark.asyncio
+async def test_pypdf_loader_skips_empty_pages(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "pypdf", SimpleNamespace(PdfReader=FakePdfReader))
+
+    async def fake_get_file_metadata(_file):
+        return {"content_hash": "abc123"}
+
+    monkeypatch.setattr(pypdf_loader, "get_file_metadata", fake_get_file_metadata)
+    file_path = tmp_path / "empty-pages.pdf"
+    file_path.write_bytes(b"pdf")
+
+    content = await PyPdfLoader().load(str(file_path), persist=False)
+
+    assert content == "Page 3:\npage text\n"


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

Skip PDF pages where `extract_text()` returns `None` or whitespace-only text.
## Changes
- Guard `PdfDocument.read()` before yielding page text to chunkers.
- Guard `PyPdfLoader` before calling `.strip()` and adding page content.
- Add unit coverage for both PDF paths with `None`, whitespace-only, and valid text pages.

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `/tmp/cognee-round2-venv/bin/python -m pytest cognee/tests/unit/documents/test_pdf_empty_pages.py -q`
- `/tmp/cognee-round2-venv/bin/python -m ruff check cognee/modules/data/processing/document_types/PdfDocument.py cognee/infrastructure/loaders/external/pypdf_loader.py cognee/tests/unit/documents/test_pdf_empty_pages.py`
- `/tmp/cognee-round2-venv/bin/python -m ruff format --check cognee/modules/data/processing/document_types/PdfDocument.py cognee/infrastructure/loaders/external/pypdf_loader.py cognee/tests/unit/documents/test_pdf_empty_pages.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
