### PR TITLE
fix(ingestion): read s3 files as bytes

### DIFF
--- a/cognee/tasks/ingestion/data_item_to_text_file.py
+++ b/cognee/tasks/ingestion/data_item_to_text_file.py
@@ -25,7 +25,7 @@ settings = SaveDataSettings()
 
 
 async def pull_from_s3(file_path, destination_file) -> None:
-    async with open_data_file(file_path) as file:
+    async with open_data_file(file_path, mode="rb") as file:
         while True:
             chunk = file.read(8192)
             if not chunk:

--- a/cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py
+++ b/cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py
@@ -1,0 +1,25 @@
+from contextlib import asynccontextmanager
+from io import BytesIO
+
+import pytest
+
+import cognee.tasks.ingestion.data_item_to_text_file as data_item_to_text_file_module
+from cognee.tasks.ingestion.data_item_to_text_file import pull_from_s3
+
+
+@pytest.mark.asyncio
+async def test_pull_from_s3_reads_source_in_binary_mode(monkeypatch):
+    open_modes = []
+    destination = BytesIO()
+
+    @asynccontextmanager
+    async def fake_open_data_file(file_path, mode="r", **kwargs):
+        open_modes.append(mode)
+        yield BytesIO(b"\x00\xffcontent")
+
+    monkeypatch.setattr(data_item_to_text_file_module, "open_data_file", fake_open_data_file)
+
+    await pull_from_s3("s3://bucket/file.pdf", destination)
+
+    assert open_modes == ["rb"]
+    assert destination.getvalue() == b"\x00\xffcontent"


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- open S3 sources in binary mode when copying them into loader temp files
- keep the temp-file handoff byte-compatible for binary loaders
- add a regression test that verifies the S3 source is opened with `rb`

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py -q`
- `python -m ruff check cognee/tasks/ingestion/data_item_to_text_file.py cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py`
- `python -m ruff format --check cognee/tasks/ingestion/data_item_to_text_file.py cognee/tests/unit/tasks/ingestion/test_data_item_to_text_file.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
