### PR TITLE
fix(storage): write nonseekable s3 streams

### DIFF
--- a/cognee/infrastructure/files/storage/S3FileStorage.py
+++ b/cognee/infrastructure/files/storage/S3FileStorage.py
@@ -90,7 +90,10 @@ class S3FileStorage(Storage):
                 else:
                     with self.s3.open(full_file_path, mode="wb") as file:
                         if hasattr(data, "read"):
-                            data.seek(0)
+                            try:
+                                data.seek(0)
+                            except (AttributeError, OSError):
+                                pass
                             file.write(data.read())
                         else:
                             file.write(data)

--- a/cognee/tests/unit/infrastructure/files/test_s3_file_storage.py
+++ b/cognee/tests/unit/infrastructure/files/test_s3_file_storage.py
@@ -1,0 +1,67 @@
+import io
+
+import pytest
+
+from cognee.infrastructure.files.storage.S3FileStorage import S3FileStorage
+
+
+class FakeS3File:
+    def __init__(self, storage, path):
+        self.storage = storage
+        self.path = path
+        self.data = b""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.storage.files[self.path] = self.data
+
+    def write(self, data):
+        self.data += data
+
+
+class FakeS3:
+    def __init__(self):
+        self.files = {}
+
+    def exists(self, path):
+        return path in self.files
+
+    def open(self, path, mode, **kwargs):
+        return FakeS3File(self, path)
+
+
+class NonSeekableBytesIO(io.BytesIO):
+    def seek(self, *args, **kwargs):
+        raise io.UnsupportedOperation("seek")
+
+
+def make_storage(fake_s3):
+    storage = object.__new__(S3FileStorage)
+    storage.storage_path = "s3://bucket/root"
+    storage.s3 = fake_s3
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_store_rewinds_seekable_stream():
+    fake_s3 = FakeS3()
+    storage = make_storage(fake_s3)
+    stream = io.BytesIO(b"abcdef")
+    stream.read(3)
+
+    await storage.store("seekable.bin", stream, overwrite=True)
+
+    assert fake_s3.files["bucket/root/seekable.bin"] == b"abcdef"
+
+
+@pytest.mark.asyncio
+async def test_store_writes_nonseekable_stream():
+    fake_s3 = FakeS3()
+    storage = make_storage(fake_s3)
+    stream = NonSeekableBytesIO(b"abcdef")
+
+    await storage.store("nonseekable.bin", stream, overwrite=True)
+
+    assert fake_s3.files["bucket/root/nonseekable.bin"] == b"abcdef"


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

Fix `S3FileStorage.store()` so it handles binary streams that support `read()` but not `seek()`.
## Changes
- Keep rewinding seekable streams before upload.
- Skip the rewind when a stream raises an unsupported seek error.
- Add fake-S3 unit coverage for seekable and non-seekable streams.

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `/tmp/cognee-round2-venv/bin/python -m pytest cognee/tests/unit/infrastructure/files/test_s3_file_storage.py -q`
- `/tmp/cognee-round2-venv/bin/python -m ruff check cognee/infrastructure/files/storage/S3FileStorage.py cognee/tests/unit/infrastructure/files/test_s3_file_storage.py`
- `/tmp/cognee-round2-venv/bin/python -m ruff format --check cognee/infrastructure/files/storage/S3FileStorage.py cognee/tests/unit/infrastructure/files/test_s3_file_storage.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
