### PR TITLE
fix(files): decode s3 uri paths

### DIFF
--- a/cognee/infrastructure/files/utils/get_data_file_path.py
+++ b/cognee/infrastructure/files/utils/get_data_file_path.py
@@ -42,7 +42,7 @@ def get_data_file_path(file_path: str) -> str:
         if not parsed.path or parsed.path == "/":
             return f"s3://{parsed.netloc}{parsed.path}"
 
-        normalized_path = posixpath.normpath(parsed.path).lstrip("/")
+        normalized_path = posixpath.normpath(unquote(parsed.path)).lstrip("/")
 
         return f"s3://{parsed.netloc}/{normalized_path}"
 

--- a/cognee/tests/unit/modules/data/test_get_data_file_path.py
+++ b/cognee/tests/unit/modules/data/test_get_data_file_path.py
@@ -1,0 +1,15 @@
+from cognee.infrastructure.files.utils.get_data_file_path import get_data_file_path
+
+
+def test_get_data_file_path_decodes_s3_key_paths():
+    assert (
+        get_data_file_path("s3://bucket/folder/my%20file%2Bv1.txt")
+        == "s3://bucket/folder/my file+v1.txt"
+    )
+
+
+def test_get_data_file_path_normalizes_decoded_s3_paths():
+    assert (
+        get_data_file_path("s3://bucket/folder%20name/../other%20folder/file.txt")
+        == "s3://bucket/other folder/file.txt"
+    )


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

Decode percent-encoded S3 key paths before normalizing them.
## Changes
- Apply `unquote()` to parsed S3 paths in `get_data_file_path()`.
- Add unit coverage for encoded spaces, plus signs, and normalized decoded paths.

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `/tmp/cognee-round2-venv/bin/python -m pytest cognee/tests/unit/modules/data/test_get_data_file_path.py cognee/tests/unit/modules/data/test_open_data_file.py -q`
- `/tmp/cognee-round2-venv/bin/python -m ruff check cognee/infrastructure/files/utils/get_data_file_path.py cognee/tests/unit/modules/data/test_get_data_file_path.py`
- `/tmp/cognee-round2-venv/bin/python -m ruff format --check cognee/infrastructure/files/utils/get_data_file_path.py cognee/tests/unit/modules/data/test_get_data_file_path.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
