### PR TITLE
fix(search): preserve empty completion results

### DIFF
--- a/cognee/modules/search/models/SearchResultPayload.py
+++ b/cognee/modules/search/models/SearchResultPayload.py
@@ -72,9 +72,9 @@ class SearchResultPayload(BaseModel):
         Return context if only_context is True, else return completion if it exists, else return result_object."""
         if self.only_context:
             return self.context
-        elif self.completion:
+        elif self.completion is not None:
             return self.completion
-        elif self.context:
+        elif self.context is not None:
             return self.context
         else:
             return self.result_object

--- a/cognee/tests/unit/search/test_search_result_payload.py
+++ b/cognee/tests/unit/search/test_search_result_payload.py
@@ -64,3 +64,26 @@ def test_search_result_payload_model_json_round_trip():
     payload = SearchResultPayload(completion=deal, search_type=SearchType.GRAPH_COMPLETION)
     dumped = json.loads(payload.model_dump_json())
     assert dumped["completion"] == {"deal_name": "Acme Corp", "health": "Good"}
+
+
+@pytest.mark.parametrize("completion", ["", [], {}])
+def test_search_result_payload_returns_empty_completion(completion):
+    payload = SearchResultPayload(
+        completion=completion,
+        context="fallback context",
+        result_object="fallback result",
+        search_type=SearchType.GRAPH_COMPLETION,
+    )
+
+    assert payload.result == completion
+
+
+def test_search_result_payload_returns_empty_context_without_completion():
+    payload = SearchResultPayload(
+        completion=None,
+        context="",
+        result_object="fallback result",
+        search_type=SearchType.GRAPH_COMPLETION,
+    )
+
+    assert payload.result == ""


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

- preserve empty completion values in `SearchResultPayload.result`
- preserve empty context values when no completion is set
- add regression tests for empty string, list, dict, and context results

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `python -m pytest cognee/tests/unit/search/test_search_result_payload.py -q`
- `python -m ruff check cognee/modules/search/models/SearchResultPayload.py cognee/tests/unit/search/test_search_result_payload.py`
- `python -m ruff format --check cognee/modules/search/models/SearchResultPayload.py cognee/tests/unit/search/test_search_result_payload.py`
## Issue
TODO: link issue after opening, if we decide to open one before the PR.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
