### PR TITLE
fix(temporal): read data through storage helper

### DIFF
--- a/cognee/tasks/temporal_awareness/build_graph_with_temporal_awareness.py
+++ b/cognee/tasks/temporal_awareness/build_graph_with_temporal_awareness.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from graphiti_core import Graphiti
 from graphiti_core.nodes import EpisodeType
 
-from cognee.infrastructure.files.storage import get_file_storage
+from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.modules.data.models import Data
 
 logger = logging.getLogger(__name__)
@@ -16,10 +16,7 @@ async def build_graph_with_temporal_awareness(data: List[Data]):
     text_list: List[str] = []
 
     for text_data in data:
-        file_dir = os.path.dirname(text_data.raw_data_location)
-        file_name = os.path.basename(text_data.raw_data_location)
-        file_storage = get_file_storage(file_dir)
-        async with file_storage.open(file_name, "r") as file:
+        async with open_data_file(text_data.raw_data_location, "r") as file:
             text_list.append(file.read())
 
     url = os.getenv("GRAPH_DATABASE_URL", "")

--- a/cognee/tests/unit/tasks/temporal_awareness/test_build_graph_with_temporal_awareness.py
+++ b/cognee/tests/unit/tasks/temporal_awareness/test_build_graph_with_temporal_awareness.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+class FakeEpisodeType:
+    text = "text"
+
+
+class FakeGraphiti:
+    def __init__(self, url, user, password):
+        self.url = url
+        self.user = user
+        self.password = password
+        self.episodes = []
+
+    async def build_indices_and_constraints(self):
+        self.indices_built = True
+
+    async def add_episode(self, **kwargs):
+        self.episodes.append(kwargs)
+
+
+def load_temporal_module(monkeypatch):
+    graphiti_module = types.ModuleType("graphiti_core")
+    graphiti_module.Graphiti = FakeGraphiti
+    nodes_module = types.ModuleType("graphiti_core.nodes")
+    nodes_module.EpisodeType = FakeEpisodeType
+    monkeypatch.setitem(sys.modules, "graphiti_core", graphiti_module)
+    monkeypatch.setitem(sys.modules, "graphiti_core.nodes", nodes_module)
+    sys.modules.pop("cognee.tasks.temporal_awareness", None)
+    sys.modules.pop("cognee.tasks.temporal_awareness.build_graph_with_temporal_awareness", None)
+    return importlib.import_module(
+        "cognee.tasks.temporal_awareness.build_graph_with_temporal_awareness"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_graph_with_temporal_awareness_reads_file_uris(monkeypatch, tmp_path):
+    module = load_temporal_module(monkeypatch)
+    file_path = tmp_path / "temporal notes.txt"
+    file_path.write_text("remember this", encoding="utf-8")
+    data = [SimpleNamespace(raw_data_location=file_path.as_uri())]
+
+    graphiti = await module.build_graph_with_temporal_awareness(data)
+
+    assert graphiti.indices_built is True
+    assert graphiti.episodes[0]["episode_body"] == "remember this"
+    assert graphiti.episodes[0]["source"] == "text"


### PR DESCRIPTION
## Description

No upstream issue was open for this specific failure case.

Read temporal-awareness input files through the shared `open_data_file()` helper.
## Changes
- Replace manual `dirname`/`basename` storage access with `open_data_file()`.
- Add a unit test that stubs Graphiti and reads a `file://` URI with an encoded space.

## Acceptance Criteria

- The affected code path handles the reproduced failure case
- Focused regression coverage exercises the fixed behavior
- Existing supported inputs keep their current behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Not applicable; this is a backend change. Local checks:

- `/tmp/cognee-round2-venv/bin/python -m pytest cognee/tests/unit/tasks/temporal_awareness/test_build_graph_with_temporal_awareness.py -q`
- `/tmp/cognee-round2-venv/bin/python -m ruff check cognee/tasks/temporal_awareness/build_graph_with_temporal_awareness.py cognee/tests/unit/tasks/temporal_awareness/test_build_graph_with_temporal_awareness.py`
- `/tmp/cognee-round2-venv/bin/python -m ruff format --check cognee/tasks/temporal_awareness/build_graph_with_temporal_awareness.py cognee/tests/unit/tasks/temporal_awareness/test_build_graph_with_temporal_awareness.py`

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description, when one exists
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
