### PR TITLE
fix(data): resolve shared dataset names via ACL permissions

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra docs --extra huggingface --extra monitoring
 
       - name: Ruff check
         run: uv run ruff check .

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -20,14 +20,39 @@ env:
   ENV: 'dev'
 
 jobs:
+  fork-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork_pr: ${{ steps.check.outputs.is_fork_pr }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  fork-pr-test-status:
+    name: Test Completion Status
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Fork PR: skipping secret-dependent Test Suites."
+          echo "Community Tests (No Secrets) provides CI for external contributions."
+
   # ── Build pre-baked CI container ──────────────────────────────────────
   build-ci-env:
     name: Build CI Environment
+    needs: [fork-check]
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
+      needs.fork-check.outputs.is_fork_pr != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository))
     outputs:
       ci-image: ${{ steps.set-image.outputs.image }}
     steps:
@@ -86,13 +111,15 @@ jobs:
 
   pre-test:
     name: basic checks
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/pre_test.yml
 
   basic-tests:
     name: Basic Tests
     uses: ./.github/workflows/basic_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -100,8 +127,8 @@ jobs:
   e2e-tests:
     name: End-to-End Tests
     uses: ./.github/workflows/e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -109,8 +136,8 @@ jobs:
   cli-tests:
     name: CLI Tests
     uses: ./.github/workflows/cli_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -118,16 +145,16 @@ jobs:
   slow-e2e-tests:
     name: Slow End-to-End Tests
     uses: ./.github/workflows/slow_e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
 
   graph-db-tests:
     name: Graph Database Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/graph_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -135,8 +162,8 @@ jobs:
 
   vector-db-tests:
     name: Vector DB Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/vector_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -144,8 +171,8 @@ jobs:
 
   example-tests:
     name: Example Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -153,8 +180,8 @@ jobs:
 
   notebook-tests:
     name: Notebook Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/notebooks_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -162,6 +189,8 @@ jobs:
 
   different-os-tests-basic:
     name: OS and Python Tests Ubuntu
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"]'
@@ -173,6 +202,8 @@ jobs:
 
   different-os-tests-extended:
     name: OS and Python Tests Extended
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.13.x"]'
@@ -181,8 +212,8 @@ jobs:
 
   llm-tests:
     name: LLM Test Suite
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_llms.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -190,8 +221,8 @@ jobs:
 
   s3-file-storage-test:
     name: S3 File Storage Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_s3_file_storage.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -199,8 +230,8 @@ jobs:
 
   integration-tests:
     name: Run Integration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/integration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -208,23 +239,29 @@ jobs:
 
   mcp-test:
     name: MCP Tests
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_mcp.yml
     secrets: inherit
 
   docker-compose-test:
     name: Docker Compose Test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/docker_compose.yml
     secrets: inherit
 
   docker-ci-test:
     name: Docker CI test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
   temporal-graph-tests:
     name: Temporal Graph Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/temporal_graph_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -232,8 +269,8 @@ jobs:
 
   search-db-tests:
     name: Search Test on Different DBs
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/search_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -241,8 +278,8 @@ jobs:
 
   relational-db-migration-tests:
     name: Relational DB Migration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/relational_db_migration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -253,8 +290,8 @@ jobs:
   # merges. (`continue-on-error` is not allowed on a reusable-workflow job.)
   distributed-tests:
     name: Distributed Cognee Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/distributed_test.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -262,8 +299,8 @@ jobs:
 
   db-examples-tests:
     name: DB Examples Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/db_examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -272,6 +309,7 @@ jobs:
   notify:
     name: Test Completion Status
     needs: [
+      fork-check,
       pre-test,
       basic-tests,
       e2e-tests,
@@ -295,7 +333,7 @@ jobs:
       db-examples-tests,
     ]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     steps:
       - name: Check Status
         run: |

--- a/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
+++ b/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 # /Users/vasa/Projects/cognee/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
 
@@ -48,7 +52,7 @@ class DefaultChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -85,7 +89,7 @@ class DefaultChunkEngine:
 
     def chunk_data_exact(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data exactly by specified sizes and overlaps.
 
@@ -113,7 +117,7 @@ class DefaultChunkEngine:
 
     def chunk_by_sentence(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data into sentences based on specified sizes and overlaps.
 
@@ -139,10 +143,10 @@ class DefaultChunkEngine:
         sentence_chunks = []
         for sentence in sentences:
             if len(sentence) > chunk_size:
-                chunks = self.chunk_data_exact(
+                sub_chunks, _ = self.chunk_data_exact(
                     data_chunks=[sentence], chunk_size=chunk_size, chunk_overlap=chunk_overlap
                 )
-                sentence_chunks.extend(chunks)
+                sentence_chunks.extend(sub_chunks)
             else:
                 sentence_chunks.append(sentence)
 
@@ -154,7 +158,7 @@ class DefaultChunkEngine:
 
     def chunk_data_by_paragraph(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int, bound: float = 0.75
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on paragraphs while considering overlaps and boundaries.
 

--- a/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
+++ b/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.infrastructure.data.chunking.DefaultChunkEngine import DefaultChunkEngine
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 
 class LangchainChunkEngine:
@@ -28,7 +32,7 @@ class LangchainChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -73,7 +77,7 @@ class LangchainChunkEngine:
         chunk_size: int,
         chunk_overlap: int = 10,
         language=None,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data specifically for code snippets.
 
@@ -118,7 +122,7 @@ class LangchainChunkEngine:
 
     def chunk_data_by_character(
         self, data_chunks: Iterable[str], chunk_size: int = 1500, chunk_overlap: int = 10
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on character count.
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -206,6 +206,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
         merged_kwargs.pop("api_key", None)
         merged_kwargs.pop("api_base", None)
         merged_kwargs.pop("api_version", None)
+        merged_kwargs = {key: value for key, value in merged_kwargs.items() if value is not None}
 
         try:
             async with llm_rate_limiter_context_manager():

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -43,7 +43,7 @@ def _enrich_llm_span(model: str, name: str) -> None:
         return
 
     try:
-        from opentelemetry import trace as otel_trace  # ty:ignore[unresolved-import]
+        from opentelemetry import trace as otel_trace
 
         from cognee.modules.observability.tracing import COGNEE_LLM_MODEL, COGNEE_LLM_PROVIDER
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -251,7 +251,7 @@ class OllamaAPIAdapter(LLMInterface):
                 }
             ],
             max_completion_tokens=300,
-        )  # ty:ignore[no-matching-overload]
+        )
 
         # Ensure response is valid before accessing .choices[0].message.content
         if (
@@ -261,4 +261,7 @@ class OllamaAPIAdapter(LLMInterface):
         ):
             raise ValueError("Image transcription failed. No response received.")
 
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        if not content:
+            raise ValueError("Image transcription failed. Empty response content.")
+        return content

--- a/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
+++ b/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
@@ -27,7 +27,7 @@ class HuggingFaceTokenizer(TokenizerInterface):
         self.max_completion_tokens = max_completion_tokens
 
         # Import here to make it an optional dependency
-        from transformers import AutoTokenizer  # ty:ignore[unresolved-import]
+        from transformers import AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(model)
 

--- a/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
+++ b/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
@@ -78,7 +78,7 @@ class AdvancedPdfLoader(LoaderInterface):
                 **kwargs,
             }
             # Use partition to extract elements
-            from unstructured.partition.pdf import partition_pdf  # ty:ignore[unresolved-import]
+            from unstructured.partition.pdf import partition_pdf
 
             elements = partition_pdf(**partition_kwargs)
 

--- a/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
+++ b/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
@@ -272,7 +272,7 @@ class BeautifulSoupLoader(LoaderInterface):
 
         if rule.xpath:
             try:
-                from lxml import html as lxml_html  # ty:ignore[unresolved-import]
+                from lxml import html as lxml_html
             except ImportError:
                 raise RuntimeError(
                     "XPath requested but lxml is not available. Install lxml or use CSS selectors."

--- a/cognee/infrastructure/loaders/external/unstructured_loader.py
+++ b/cognee/infrastructure/loaders/external/unstructured_loader.py
@@ -6,7 +6,7 @@ from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface
 from cognee.shared.logging_utils import get_logger
 
 try:
-    from unstructured.partition.auto import partition  # ty:ignore[unresolved-import]
+    from unstructured.partition.auto import partition
 except ImportError as e:
     raise ImportError(
         "unstructured is required for document processing. Install with: pip install unstructured"
@@ -95,11 +95,8 @@ class UnstructuredLoader(LoaderInterface):
             # Name ingested file of current loader based on original file content hash
             storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
-            # Set partitioning parameters
-            partition_kwargs = {"filename": file_path, "strategy": strategy, **kwargs}
-
             # Use partition to extract elements
-            elements = partition(**partition_kwargs)
+            elements = partition(filename=file_path, strategy=strategy, **kwargs)
 
             # Process elements into text content
             text_parts = []

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -10,7 +10,7 @@ Public orchestration coroutines are fail-open so they can never block answer gen
 helpers are deliberately strict so tests catch malformed stored data and scoring mistakes.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Protocol, Tuple
 from uuid import uuid4
 
@@ -185,7 +185,7 @@ async def _stamp_served_entries(*, session_manager, user_id, session_id, entry_i
     if not entry_ids:
         return
 
-    served_at = datetime.utcnow().isoformat()
+    served_at = datetime.now(timezone.utc).isoformat()
     for entry_id in entry_ids:
         try:
             await session_manager.update_session_context_entry(
@@ -333,7 +333,7 @@ async def _apply_single_candidate(
         content=content,
         normalized_content=normalized,
         confidence=float(candidate.confidence),
-        created_at=datetime.utcnow().isoformat(),
+        created_at=datetime.now(timezone.utc).isoformat(),
         source_feedback_ids=[feedback_entry_id] if feedback_entry_id else [],
         kind="context",
     )

--- a/cognee/infrastructure/session/session_turn.py
+++ b/cognee/infrastructure/session/session_turn.py
@@ -8,7 +8,7 @@ All public coroutines are fail-open so they never block answer generation.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -322,7 +322,7 @@ async def apply_session_turn_analysis(
 
         feedback_entry = SessionFeedbackEntry(
             id=str(uuid4()),
-            created_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
             raw_text=query,
             referenced_qa_ids=[previous_qa_id] if previous_qa_id else [],
             influencing_context_ids=list(served_ids or []),

--- a/cognee/modules/data/methods/get_authorized_existing_datasets.py
+++ b/cognee/modules/data/methods/get_authorized_existing_datasets.py
@@ -1,9 +1,10 @@
 from typing import Union
 from uuid import UUID
 
+from cognee.modules.data.exceptions import DatasetTypeError
 from cognee.modules.data.models import Dataset
+from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.models import User
-from cognee.modules.data.methods.get_dataset_ids import get_dataset_ids
 from cognee.modules.users.permissions.methods import get_all_user_permission_datasets
 from cognee.modules.users.permissions.methods import get_specific_user_permission_datasets
 
@@ -23,15 +24,28 @@ async def get_authorized_existing_datasets(
 
     """
     if datasets:
-        # Function handles transforming dataset input to dataset IDs (if possible)
-        dataset_ids = await get_dataset_ids(datasets, user)
-        # If dataset_ids are provided filter these datasets based on what user has permission for.
-        if dataset_ids:
+        if all(isinstance(dataset, UUID) for dataset in datasets):
             existing_datasets = await get_specific_user_permission_datasets(
-                user.id, permission_type, dataset_ids
+                user.id, permission_type, list(datasets)
             )
+        elif all(isinstance(dataset, str) for dataset in datasets):
+            # Resolve names against ACL-visible datasets, not only owner-scoped rows.
+            # Fixes shared-dataset add/search when a collaborator uses dataset_name=...
+            permitted_datasets = await get_all_user_permission_datasets(user, permission_type)
+            requested_names = set(datasets)
+            existing_datasets = [
+                dataset for dataset in permitted_datasets if dataset.name in requested_names
+            ]
+            resolved_names = {dataset.name for dataset in existing_datasets}
+            if resolved_names != requested_names:
+                raise PermissionDeniedError(
+                    f"Request owner does not have necessary permission: [{permission_type}] "
+                    "for all datasets requested."
+                )
         else:
-            existing_datasets = []
+            raise DatasetTypeError(
+                f"One or more of the provided dataset types is not handled: {datasets}"
+            )
     else:
         # If no datasets are provided, work with all existing datasets user has permission for.
         existing_datasets = await get_all_user_permission_datasets(user, permission_type)

--- a/cognee/shared/graph_model_utils.py
+++ b/cognee/shared/graph_model_utils.py
@@ -98,7 +98,7 @@ def datapoint_model_to_basemodel(
             )
 
         converted_model = create_model(
-            model_type.__name__, __base__=ConfiguredBase, **converted_fields
+            model_type.__name__, __base__=ConfiguredBase, **cast(Any, converted_fields)
         )
         converted_model.model_rebuild()
         cache[model_type] = converted_model

--- a/cognee/tests/unit/modules/data/test_get_authorized_existing_datasets.py
+++ b/cognee/tests/unit/modules/data/test_get_authorized_existing_datasets.py
@@ -143,6 +143,4 @@ async def test_denied_dataset_name_raises_permission_error(monkeypatch, datasets
     )
 
     with pytest.raises(PermissionDeniedError, match="for all datasets requested"):
-        await datasets_mod.get_authorized_existing_datasets(
-            ["allowed", "denied"], "read", user
-        )
+        await datasets_mod.get_authorized_existing_datasets(["allowed", "denied"], "read", user)

--- a/cognee/tests/unit/modules/data/test_get_authorized_existing_datasets.py
+++ b/cognee/tests/unit/modules/data/test_get_authorized_existing_datasets.py
@@ -1,0 +1,148 @@
+import types
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.data.exceptions import DatasetTypeError
+
+
+def _make_user(user_id=None, tenant_id=None):
+    return types.SimpleNamespace(
+        id=user_id or uuid4(),
+        tenant_id=tenant_id or uuid4(),
+    )
+
+
+def _make_dataset(*, name="shared_dataset", dataset_id=None, owner_id=None, tenant_id=None):
+    return types.SimpleNamespace(
+        id=dataset_id or uuid4(),
+        name=name,
+        owner_id=owner_id or uuid4(),
+        tenant_id=tenant_id,
+    )
+
+
+@pytest.fixture
+def datasets_mod():
+    import importlib
+
+    return importlib.import_module("cognee.modules.data.methods.get_authorized_existing_datasets")
+
+
+@pytest.mark.asyncio
+async def test_resolves_shared_dataset_names_via_acl(monkeypatch, datasets_mod):
+    """Non-owner collaborators can resolve dataset names granted via ACL (#2845, #2846)."""
+    user = _make_user()
+    owner_id = uuid4()
+    shared = _make_dataset(name="acme_shared", owner_id=owner_id, tenant_id=user.tenant_id)
+    owned = _make_dataset(name="bob_private", owner_id=user.id, tenant_id=user.tenant_id)
+
+    async def fake_get_all_user_permission_datasets(user_arg, permission_type):
+        assert user_arg is user
+        assert permission_type == "write"
+        return [shared, owned]
+
+    monkeypatch.setattr(
+        datasets_mod,
+        "get_all_user_permission_datasets",
+        fake_get_all_user_permission_datasets,
+    )
+
+    result = await datasets_mod.get_authorized_existing_datasets(["acme_shared"], "write", user)
+
+    assert result == [shared]
+
+
+@pytest.mark.asyncio
+async def test_resolves_multiple_shared_names(monkeypatch, datasets_mod):
+    user = _make_user()
+    ds_a = _make_dataset(name="alpha", tenant_id=user.tenant_id)
+    ds_b = _make_dataset(name="beta", tenant_id=user.tenant_id)
+    ds_other = _make_dataset(name="gamma", tenant_id=user.tenant_id)
+
+    async def fake_get_all_user_permission_datasets(_user, _permission_type):
+        return [ds_a, ds_b, ds_other]
+
+    monkeypatch.setattr(
+        datasets_mod,
+        "get_all_user_permission_datasets",
+        fake_get_all_user_permission_datasets,
+    )
+
+    result = await datasets_mod.get_authorized_existing_datasets(["beta", "alpha"], "read", user)
+
+    assert result == [ds_a, ds_b]
+
+
+@pytest.mark.asyncio
+async def test_uuid_inputs_delegate_to_specific_permission_lookup(monkeypatch, datasets_mod):
+    user = _make_user()
+    dataset_id = uuid4()
+    expected = [_make_dataset(dataset_id=dataset_id)]
+
+    async def fake_get_specific_user_permission_datasets(user_id, permission_type, dataset_ids):
+        assert user_id == user.id
+        assert permission_type == "read"
+        assert dataset_ids == [dataset_id]
+        return expected
+
+    monkeypatch.setattr(
+        datasets_mod,
+        "get_specific_user_permission_datasets",
+        fake_get_specific_user_permission_datasets,
+    )
+
+    result = await datasets_mod.get_authorized_existing_datasets([dataset_id], "read", user)
+
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_none_returns_all_permitted_datasets(monkeypatch, datasets_mod):
+    user = _make_user()
+    expected = [_make_dataset(name="only_one")]
+
+    async def fake_get_all_user_permission_datasets(_user, permission_type):
+        assert permission_type == "delete"
+        return expected
+
+    monkeypatch.setattr(
+        datasets_mod,
+        "get_all_user_permission_datasets",
+        fake_get_all_user_permission_datasets,
+    )
+
+    result = await datasets_mod.get_authorized_existing_datasets(None, "delete", user)
+
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_mixed_name_and_uuid_types_raise(monkeypatch, datasets_mod):
+    user = _make_user()
+
+    with pytest.raises(DatasetTypeError):
+        await datasets_mod.get_authorized_existing_datasets(["shared", uuid4()], "read", user)
+
+
+@pytest.mark.asyncio
+async def test_denied_dataset_name_raises_permission_error(monkeypatch, datasets_mod):
+    """Fail closed when a requested dataset name is not permitted (#2845)."""
+    from cognee.modules.users.exceptions import PermissionDeniedError
+
+    user = _make_user()
+    allowed = _make_dataset(name="allowed", tenant_id=user.tenant_id)
+
+    async def fake_get_all_user_permission_datasets(_user, _permission_type):
+        return [allowed]
+
+    monkeypatch.setattr(
+        datasets_mod,
+        "get_all_user_permission_datasets",
+        fake_get_all_user_permission_datasets,
+    )
+
+    with pytest.raises(PermissionDeniedError, match="for all datasets requested"):
+        await datasets_mod.get_authorized_existing_datasets(
+            ["allowed", "denied"], "read", user
+        )


### PR DESCRIPTION
Closes #2845, closes #2846, closes #2847

## Summary

String `dataset_name` lookups only matched datasets owned by the caller. Collaborators with ACL access on a shared dataset had to pass UUIDs. That meant `add()` could silently create a parallel owner-scoped dataset, and `search()` returned `DatasetNotFoundError` when you used the shared name.

This resolves names from `get_all_user_permission_datasets` and raises `PermissionDeniedError` when a requested name is missing, same as UUID lookups.

## Test plan

- [x] `uv run pytest cognee/tests/unit/modules/data/test_get_authorized_existing_datasets.py -v`
- [x] `uv run ruff check` on changed files
- [x] ACL collaborator resolves shared dataset name — `test_resolves_shared_dataset_names_via_acl`
- [x] Multiple shared names — `test_resolves_multiple_shared_names`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.