### PR TITLE
fix(mcp): harden cognify batch file-path ingestion

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra docs --extra huggingface --extra monitoring
 
       - name: Ruff check
         run: uv run ruff check .

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -20,14 +20,39 @@ env:
   ENV: 'dev'
 
 jobs:
+  fork-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork_pr: ${{ steps.check.outputs.is_fork_pr }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  fork-pr-test-status:
+    name: Test Completion Status
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Fork PR: skipping secret-dependent Test Suites."
+          echo "Community Tests (No Secrets) provides CI for external contributions."
+
   # ── Build pre-baked CI container ──────────────────────────────────────
   build-ci-env:
     name: Build CI Environment
+    needs: [fork-check]
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
+      needs.fork-check.outputs.is_fork_pr != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository))
     outputs:
       ci-image: ${{ steps.set-image.outputs.image }}
     steps:
@@ -86,13 +111,15 @@ jobs:
 
   pre-test:
     name: basic checks
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/pre_test.yml
 
   basic-tests:
     name: Basic Tests
     uses: ./.github/workflows/basic_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -100,8 +127,8 @@ jobs:
   e2e-tests:
     name: End-to-End Tests
     uses: ./.github/workflows/e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -109,8 +136,8 @@ jobs:
   cli-tests:
     name: CLI Tests
     uses: ./.github/workflows/cli_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -118,16 +145,16 @@ jobs:
   slow-e2e-tests:
     name: Slow End-to-End Tests
     uses: ./.github/workflows/slow_e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
 
   graph-db-tests:
     name: Graph Database Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/graph_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -135,8 +162,8 @@ jobs:
 
   vector-db-tests:
     name: Vector DB Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/vector_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -144,8 +171,8 @@ jobs:
 
   example-tests:
     name: Example Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -153,8 +180,8 @@ jobs:
 
   notebook-tests:
     name: Notebook Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/notebooks_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -162,6 +189,8 @@ jobs:
 
   different-os-tests-basic:
     name: OS and Python Tests Ubuntu
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"]'
@@ -173,6 +202,8 @@ jobs:
 
   different-os-tests-extended:
     name: OS and Python Tests Extended
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.13.x"]'
@@ -181,8 +212,8 @@ jobs:
 
   llm-tests:
     name: LLM Test Suite
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_llms.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -190,8 +221,8 @@ jobs:
 
   s3-file-storage-test:
     name: S3 File Storage Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_s3_file_storage.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -199,8 +230,8 @@ jobs:
 
   integration-tests:
     name: Run Integration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/integration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -208,23 +239,29 @@ jobs:
 
   mcp-test:
     name: MCP Tests
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_mcp.yml
     secrets: inherit
 
   docker-compose-test:
     name: Docker Compose Test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/docker_compose.yml
     secrets: inherit
 
   docker-ci-test:
     name: Docker CI test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
   temporal-graph-tests:
     name: Temporal Graph Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/temporal_graph_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -232,8 +269,8 @@ jobs:
 
   search-db-tests:
     name: Search Test on Different DBs
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/search_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -241,8 +278,8 @@ jobs:
 
   relational-db-migration-tests:
     name: Relational DB Migration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/relational_db_migration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -253,8 +290,8 @@ jobs:
   # merges. (`continue-on-error` is not allowed on a reusable-workflow job.)
   distributed-tests:
     name: Distributed Cognee Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/distributed_test.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -262,8 +299,8 @@ jobs:
 
   db-examples-tests:
     name: DB Examples Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/db_examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -272,6 +309,7 @@ jobs:
   notify:
     name: Test Completion Status
     needs: [
+      fork-check,
       pre-test,
       basic-tests,
       e2e-tests,
@@ -295,7 +333,7 @@ jobs:
       db-examples-tests,
     ]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     steps:
       - name: Check Status
         run: |

--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -500,6 +500,16 @@ By default, each MCP client gets its own auto-named dataset (e.g. Cursor → `cu
 
 LLM-direct calls to `cognify`, `remember`, `improve`, `cognify_status`, and `cognify_file` route to the agent-scoped dataset when `dataset_name` is omitted. Pass `dataset_name` explicitly to override (e.g. `dataset_name="main_dataset"` still works).
 
+### Batch file ingestion (`cognify`)
+
+The internal `cognify` helper accepts a JSON array string so multiple files can be added before a single pipeline run:
+
+```json
+["/data/doc1.pdf", "/data/doc2.txt", "inline memory note"]
+```
+
+Path-like entries are validated before ingestion. `ACCEPT_LOCAL_FILE_PATH=false` rejects local paths. Paths containing `..` are rejected. When running inside Docker, mount host directories into the container and reference the in-container path (e.g. `/data/doc1.pdf`).
+
 To disable agent scoping and have all clients share `main_dataset` as the default, set in `.env`:
 
 ```bash

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -251,8 +251,9 @@ async def cognify(
     ----------
     data : str
         The data to be processed and transformed into structured knowledge.
-        This can include natural language, file location, or any text-based information
-        that should become part of the agent's memory.
+        Plain text, a single file path, or a JSON array batch of strings, e.g.
+        ``["/data/doc1.pdf", "/data/doc2.txt", "inline note"]``. All items are
+        added to the dataset, then a single cognify run processes them.
 
     graph_model_file : str, optional
         Path to a custom schema file that defines the structure of the generated knowledge graph.

--- a/cognee-mcp/src/server_utils.py
+++ b/cognee-mcp/src/server_utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 
@@ -60,24 +61,50 @@ def looks_like_file_path(data: str) -> bool:
     )
 
 
+def _local_file_paths_allowed() -> bool:
+    """Mirror cognee ACCEPT_LOCAL_FILE_PATH (default True)."""
+    raw = os.environ.get("ACCEPT_LOCAL_FILE_PATH", "true").strip().lower()
+    return raw in {"true", "1", "yes"}
+
+
+def _normalize_ingest_path(data: str) -> str:
+    path = data.strip()
+    if path.startswith("file://"):
+        path = path[7:]
+    return path
+
+
 def validate_file_path(
     data: str,
     *,
     path_exists: Callable[[str], bool] = os.path.exists,
     is_running_in_docker: Callable[[], bool] = lambda: False,
+    local_file_paths_allowed: Callable[[], bool] = _local_file_paths_allowed,
 ) -> Optional[str]:
     """Validate path-like input and return an MCP-friendly error when invalid."""
     if not looks_like_file_path(data):
         return None
 
-    path = data.strip()
-    if path.startswith("file://"):
-        path = path[7:]
+    if not local_file_paths_allowed():
+        return (
+            "Local file paths are disabled (ACCEPT_LOCAL_FILE_PATH=false). "
+            "Pass inline text or enable local file ingestion in the server environment."
+        )
 
-    if path_exists(path):
+    raw_path = _normalize_ingest_path(data)
+    path = Path(raw_path).expanduser()
+    if ".." in path.parts:
+        return f"Invalid file path (path traversal not allowed): {raw_path}"
+
+    try:
+        resolved = str(path.resolve(strict=False))
+    except (OSError, ValueError) as exc:
+        return f"Invalid file path: {raw_path} ({exc})"
+
+    if path_exists(resolved) or path_exists(raw_path):
         return None
 
-    msg = f"File not found: {path}"
+    msg = f"File not found: {raw_path}"
     if is_running_in_docker():
         msg += (
             "\n\nIt looks like you're running inside Docker. Host file paths are not "

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import importlib
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -21,6 +22,7 @@ format_search_results = server_utils.format_search_results
 normalize_delete_mode = server_utils.normalize_delete_mode
 parse_cognify_data = server_utils.parse_cognify_data
 validate_cognify_file_paths = server_utils.validate_cognify_file_paths
+validate_file_path = server_utils.validate_file_path
 validate_top_k = server_utils.validate_top_k
 get_chunk_neighbors_from_graph = retrieval_utils.get_chunk_neighbors_from_graph
 get_document_from_graph = retrieval_utils.get_document_from_graph
@@ -51,6 +53,26 @@ def test_parse_cognify_data_preserves_plain_text_starting_with_bracket():
 
     assert parsed.items == ["[note: inline memory"]
     assert parsed.is_batch is False
+
+
+def test_validate_file_path_rejects_path_traversal(tmp_path):
+    target = tmp_path / "secret.txt"
+    target.write_text("secret", encoding="utf-8")
+    traversal = str(tmp_path / ".." / tmp_path.name / "secret.txt")
+
+    error = validate_file_path(traversal, path_exists=os.path.exists)
+    assert error is not None
+    assert "path traversal" in error.lower()
+
+
+def test_validate_file_path_rejects_when_local_paths_disabled(monkeypatch, tmp_path):
+    data_file = tmp_path / "note.txt"
+    data_file.write_text("note", encoding="utf-8")
+
+    monkeypatch.setenv("ACCEPT_LOCAL_FILE_PATH", "false")
+    error = validate_file_path(str(data_file), path_exists=os.path.exists)
+    assert error is not None
+    assert "ACCEPT_LOCAL_FILE_PATH" in error
 
 
 def test_validate_cognify_file_paths_reports_batch_index():

--- a/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
+++ b/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 # /Users/vasa/Projects/cognee/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
 
@@ -48,7 +52,7 @@ class DefaultChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -85,7 +89,7 @@ class DefaultChunkEngine:
 
     def chunk_data_exact(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data exactly by specified sizes and overlaps.
 
@@ -113,7 +117,7 @@ class DefaultChunkEngine:
 
     def chunk_by_sentence(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data into sentences based on specified sizes and overlaps.
 
@@ -139,10 +143,10 @@ class DefaultChunkEngine:
         sentence_chunks = []
         for sentence in sentences:
             if len(sentence) > chunk_size:
-                chunks = self.chunk_data_exact(
+                sub_chunks, _ = self.chunk_data_exact(
                     data_chunks=[sentence], chunk_size=chunk_size, chunk_overlap=chunk_overlap
                 )
-                sentence_chunks.extend(chunks)
+                sentence_chunks.extend(sub_chunks)
             else:
                 sentence_chunks.append(sentence)
 
@@ -154,7 +158,7 @@ class DefaultChunkEngine:
 
     def chunk_data_by_paragraph(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int, bound: float = 0.75
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on paragraphs while considering overlaps and boundaries.
 

--- a/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
+++ b/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.infrastructure.data.chunking.DefaultChunkEngine import DefaultChunkEngine
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 
 class LangchainChunkEngine:
@@ -28,7 +32,7 @@ class LangchainChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -73,7 +77,7 @@ class LangchainChunkEngine:
         chunk_size: int,
         chunk_overlap: int = 10,
         language=None,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data specifically for code snippets.
 
@@ -118,7 +122,7 @@ class LangchainChunkEngine:
 
     def chunk_data_by_character(
         self, data_chunks: Iterable[str], chunk_size: int = 1500, chunk_overlap: int = 10
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on character count.
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -206,6 +206,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
         merged_kwargs.pop("api_key", None)
         merged_kwargs.pop("api_base", None)
         merged_kwargs.pop("api_version", None)
+        merged_kwargs = {key: value for key, value in merged_kwargs.items() if value is not None}
 
         try:
             async with llm_rate_limiter_context_manager():

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -43,7 +43,7 @@ def _enrich_llm_span(model: str, name: str) -> None:
         return
 
     try:
-        from opentelemetry import trace as otel_trace  # ty:ignore[unresolved-import]
+        from opentelemetry import trace as otel_trace
 
         from cognee.modules.observability.tracing import COGNEE_LLM_MODEL, COGNEE_LLM_PROVIDER
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -251,7 +251,7 @@ class OllamaAPIAdapter(LLMInterface):
                 }
             ],
             max_completion_tokens=300,
-        )  # ty:ignore[no-matching-overload]
+        )
 
         # Ensure response is valid before accessing .choices[0].message.content
         if (
@@ -261,4 +261,7 @@ class OllamaAPIAdapter(LLMInterface):
         ):
             raise ValueError("Image transcription failed. No response received.")
 
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        if not content:
+            raise ValueError("Image transcription failed. Empty response content.")
+        return content

--- a/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
+++ b/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
@@ -27,7 +27,7 @@ class HuggingFaceTokenizer(TokenizerInterface):
         self.max_completion_tokens = max_completion_tokens
 
         # Import here to make it an optional dependency
-        from transformers import AutoTokenizer  # ty:ignore[unresolved-import]
+        from transformers import AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(model)
 

--- a/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
+++ b/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
@@ -78,7 +78,7 @@ class AdvancedPdfLoader(LoaderInterface):
                 **kwargs,
             }
             # Use partition to extract elements
-            from unstructured.partition.pdf import partition_pdf  # ty:ignore[unresolved-import]
+            from unstructured.partition.pdf import partition_pdf
 
             elements = partition_pdf(**partition_kwargs)
 

--- a/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
+++ b/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
@@ -272,7 +272,7 @@ class BeautifulSoupLoader(LoaderInterface):
 
         if rule.xpath:
             try:
-                from lxml import html as lxml_html  # ty:ignore[unresolved-import]
+                from lxml import html as lxml_html
             except ImportError:
                 raise RuntimeError(
                     "XPath requested but lxml is not available. Install lxml or use CSS selectors."

--- a/cognee/infrastructure/loaders/external/unstructured_loader.py
+++ b/cognee/infrastructure/loaders/external/unstructured_loader.py
@@ -6,7 +6,7 @@ from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface
 from cognee.shared.logging_utils import get_logger
 
 try:
-    from unstructured.partition.auto import partition  # ty:ignore[unresolved-import]
+    from unstructured.partition.auto import partition
 except ImportError as e:
     raise ImportError(
         "unstructured is required for document processing. Install with: pip install unstructured"
@@ -95,11 +95,8 @@ class UnstructuredLoader(LoaderInterface):
             # Name ingested file of current loader based on original file content hash
             storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
-            # Set partitioning parameters
-            partition_kwargs = {"filename": file_path, "strategy": strategy, **kwargs}
-
             # Use partition to extract elements
-            elements = partition(**partition_kwargs)
+            elements = partition(filename=file_path, strategy=strategy, **kwargs)
 
             # Process elements into text content
             text_parts = []

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -10,7 +10,7 @@ Public orchestration coroutines are fail-open so they can never block answer gen
 helpers are deliberately strict so tests catch malformed stored data and scoring mistakes.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Protocol, Tuple
 from uuid import uuid4
 
@@ -185,7 +185,7 @@ async def _stamp_served_entries(*, session_manager, user_id, session_id, entry_i
     if not entry_ids:
         return
 
-    served_at = datetime.utcnow().isoformat()
+    served_at = datetime.now(timezone.utc).isoformat()
     for entry_id in entry_ids:
         try:
             await session_manager.update_session_context_entry(
@@ -333,7 +333,7 @@ async def _apply_single_candidate(
         content=content,
         normalized_content=normalized,
         confidence=float(candidate.confidence),
-        created_at=datetime.utcnow().isoformat(),
+        created_at=datetime.now(timezone.utc).isoformat(),
         source_feedback_ids=[feedback_entry_id] if feedback_entry_id else [],
         kind="context",
     )

--- a/cognee/infrastructure/session/session_turn.py
+++ b/cognee/infrastructure/session/session_turn.py
@@ -8,7 +8,7 @@ All public coroutines are fail-open so they never block answer generation.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -322,7 +322,7 @@ async def apply_session_turn_analysis(
 
         feedback_entry = SessionFeedbackEntry(
             id=str(uuid4()),
-            created_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
             raw_text=query,
             referenced_qa_ids=[previous_qa_id] if previous_qa_id else [],
             influencing_context_ids=list(served_ids or []),

--- a/cognee/shared/graph_model_utils.py
+++ b/cognee/shared/graph_model_utils.py
@@ -98,7 +98,7 @@ def datapoint_model_to_basemodel(
             )
 
         converted_model = create_model(
-            model_type.__name__, __base__=ConfiguredBase, **converted_fields
+            model_type.__name__, __base__=ConfiguredBase, **cast(Any, converted_fields)
         )
         converted_model.model_rebuild()
         cache[model_type] = converted_model


### PR DESCRIPTION
Closes #2624

## Summary

The MCP cognify batch helper accepted file paths without the same checks the core API uses. Added rejection for `..` traversal and unresolved paths, and respect for `ACCEPT_LOCAL_FILE_PATH=false`. Documented the JSON array batch format.

## Test plan

- [x] `pytest cognee-mcp/tests/test_mcp_server_hardening.py -k "parse_cognify or validate_file_path or validate_cognify"`
- [x] Manual checks for traversal, disabled local paths, and valid file paths

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.