### PR TITLE
feat(eval): add retrieval-quality benchmark utilities

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra docs --extra huggingface --extra monitoring
 
       - name: Ruff check
         run: uv run ruff check .

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -20,14 +20,39 @@ env:
   ENV: 'dev'
 
 jobs:
+  fork-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork_pr: ${{ steps.check.outputs.is_fork_pr }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  fork-pr-test-status:
+    name: Test Completion Status
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Fork PR: skipping secret-dependent Test Suites."
+          echo "Community Tests (No Secrets) provides CI for external contributions."
+
   # ── Build pre-baked CI container ──────────────────────────────────────
   build-ci-env:
     name: Build CI Environment
+    needs: [fork-check]
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
+      needs.fork-check.outputs.is_fork_pr != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository))
     outputs:
       ci-image: ${{ steps.set-image.outputs.image }}
     steps:
@@ -86,13 +111,15 @@ jobs:
 
   pre-test:
     name: basic checks
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/pre_test.yml
 
   basic-tests:
     name: Basic Tests
     uses: ./.github/workflows/basic_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -100,8 +127,8 @@ jobs:
   e2e-tests:
     name: End-to-End Tests
     uses: ./.github/workflows/e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -109,8 +136,8 @@ jobs:
   cli-tests:
     name: CLI Tests
     uses: ./.github/workflows/cli_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -118,16 +145,16 @@ jobs:
   slow-e2e-tests:
     name: Slow End-to-End Tests
     uses: ./.github/workflows/slow_e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
 
   graph-db-tests:
     name: Graph Database Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/graph_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -135,8 +162,8 @@ jobs:
 
   vector-db-tests:
     name: Vector DB Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/vector_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -144,8 +171,8 @@ jobs:
 
   example-tests:
     name: Example Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -153,8 +180,8 @@ jobs:
 
   notebook-tests:
     name: Notebook Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/notebooks_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -162,6 +189,8 @@ jobs:
 
   different-os-tests-basic:
     name: OS and Python Tests Ubuntu
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"]'
@@ -173,6 +202,8 @@ jobs:
 
   different-os-tests-extended:
     name: OS and Python Tests Extended
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.13.x"]'
@@ -181,8 +212,8 @@ jobs:
 
   llm-tests:
     name: LLM Test Suite
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_llms.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -190,8 +221,8 @@ jobs:
 
   s3-file-storage-test:
     name: S3 File Storage Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_s3_file_storage.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -199,8 +230,8 @@ jobs:
 
   integration-tests:
     name: Run Integration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/integration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -208,23 +239,29 @@ jobs:
 
   mcp-test:
     name: MCP Tests
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_mcp.yml
     secrets: inherit
 
   docker-compose-test:
     name: Docker Compose Test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/docker_compose.yml
     secrets: inherit
 
   docker-ci-test:
     name: Docker CI test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
   temporal-graph-tests:
     name: Temporal Graph Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/temporal_graph_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -232,8 +269,8 @@ jobs:
 
   search-db-tests:
     name: Search Test on Different DBs
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/search_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -241,8 +278,8 @@ jobs:
 
   relational-db-migration-tests:
     name: Relational DB Migration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/relational_db_migration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -253,8 +290,8 @@ jobs:
   # merges. (`continue-on-error` is not allowed on a reusable-workflow job.)
   distributed-tests:
     name: Distributed Cognee Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/distributed_test.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -262,8 +299,8 @@ jobs:
 
   db-examples-tests:
     name: DB Examples Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/db_examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -272,6 +309,7 @@ jobs:
   notify:
     name: Test Completion Status
     needs: [
+      fork-check,
       pre-test,
       basic-tests,
       e2e-tests,
@@ -295,7 +333,7 @@ jobs:
       db-examples-tests,
     ]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     steps:
       - name: Check Status
         run: |

--- a/cognee/eval_framework/retrieval_benchmark/__init__.py
+++ b/cognee/eval_framework/retrieval_benchmark/__init__.py
@@ -1,0 +1,15 @@
+"""Retrieval-quality benchmarks for Cognee search modes."""
+
+from cognee.eval_framework.retrieval_benchmark.metrics import (
+    context_overlap_f1,
+    context_recall,
+    normalize_context_text,
+)
+from cognee.eval_framework.retrieval_benchmark.runner import RetrievalBenchmarkRunner
+
+__all__ = [
+    "RetrievalBenchmarkRunner",
+    "context_overlap_f1",
+    "context_recall",
+    "normalize_context_text",
+]

--- a/cognee/eval_framework/retrieval_benchmark/metrics.py
+++ b/cognee/eval_framework/retrieval_benchmark/metrics.py
@@ -1,0 +1,80 @@
+"""Retrieval-quality metrics comparing returned context to golden supporting text."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Union
+
+
+def normalize_context_text(text: Union[str, list, None]) -> str:
+    """Flatten search context payloads into comparable plain text."""
+    if text is None:
+        return ""
+    if isinstance(text, list):
+        parts = [normalize_context_text(item) for item in text]
+        return "\n".join(part for part in parts if part)
+    if isinstance(text, dict):
+        for key in ("text", "content", "context", "payload"):
+            if key in text and text[key]:
+                return normalize_context_text(text[key])
+        return " ".join(str(value) for value in text.values())
+    return re.sub(r"\s+", " ", str(text)).strip().lower()
+
+
+def _token_set(text: str) -> set[str]:
+    return {token for token in re.findall(r"[a-z0-9]+", text) if token}
+
+
+def context_recall(retrieved: Union[str, list, None], golden: Union[str, list, None]) -> float:
+    """Fraction of golden lines (or sentences) found in retrieved context."""
+    golden_text = normalize_context_text(golden)
+    retrieved_text = normalize_context_text(retrieved)
+    if not golden_text:
+        return 0.0
+
+    units = _split_golden_units(golden_text)
+    if not units:
+        return 0.0
+
+    hits = sum(1 for unit in units if unit in retrieved_text)
+    return hits / len(units)
+
+
+def context_overlap_f1(retrieved: Union[str, list, None], golden: Union[str, list, None]) -> float:
+    """Token-level F1 between retrieved and golden context."""
+    retrieved_tokens = _token_set(normalize_context_text(retrieved))
+    golden_tokens = _token_set(normalize_context_text(golden))
+    if not retrieved_tokens and not golden_tokens:
+        return 0.0
+    if not retrieved_tokens or not golden_tokens:
+        return 0.0
+
+    overlap = retrieved_tokens & golden_tokens
+    precision = len(overlap) / len(retrieved_tokens)
+    recall = len(overlap) / len(golden_tokens)
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _split_golden_units(golden_text: str) -> list[str]:
+    lines = [line.strip() for line in golden_text.splitlines() if line.strip()]
+    if len(lines) > 1:
+        return [line.lower() for line in lines]
+
+    sentences = re.split(r"(?<=[.!?])\s+", golden_text)
+    sentences = [sentence.strip().lower() for sentence in sentences if sentence.strip()]
+    return sentences or [golden_text]
+
+
+def aggregate_metric(values: Iterable[float]) -> dict[str, float]:
+    """Return mean/min/max for a metric series."""
+    series = list(values)
+    if not series:
+        return {"mean": 0.0, "min": 0.0, "max": 0.0, "count": 0.0}
+    return {
+        "mean": sum(series) / len(series),
+        "min": min(series),
+        "max": max(series),
+        "count": float(len(series)),
+    }

--- a/cognee/eval_framework/retrieval_benchmark/runner.py
+++ b/cognee/eval_framework/retrieval_benchmark/runner.py
@@ -1,0 +1,112 @@
+"""Run retrieval-only benchmarks across Cognee search modes."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from cognee.eval_framework.retrieval_benchmark.metrics import (
+    aggregate_metric,
+    context_overlap_f1,
+    context_recall,
+    normalize_context_text,
+)
+from cognee.modules.search.types import SearchType
+
+
+DEFAULT_SEARCH_TYPES = (
+    SearchType.CHUNKS,
+    SearchType.SUMMARIES,
+    SearchType.GRAPH_COMPLETION,
+)
+
+
+class RetrievalBenchmarkRunner:
+    """Evaluate retrieval quality without LLM answer generation."""
+
+    def __init__(
+        self,
+        search_types: Optional[list[SearchType]] = None,
+        top_k: int = 10,
+    ):
+        self.search_types = list(search_types or DEFAULT_SEARCH_TYPES)
+        self.top_k = top_k
+
+    async def run_instance(
+        self,
+        *,
+        question: str,
+        golden_context: str,
+        search_fn,
+        datasets: Optional[list[str]] = None,
+    ) -> list[dict[str, Any]]:
+        """Run retrieval metrics for one QA instance across configured search types."""
+        results: list[dict[str, Any]] = []
+        for search_type in self.search_types:
+            payload = await search_fn(
+                query_text=question,
+                query_type=search_type,
+                datasets=datasets,
+                top_k=self.top_k,
+                only_context=True,
+            )
+            retrieved_context = self._extract_context(payload)
+            results.append(
+                {
+                    "question": question,
+                    "search_type": search_type.value,
+                    "context_recall": context_recall(retrieved_context, golden_context),
+                    "context_f1": context_overlap_f1(retrieved_context, golden_context),
+                    "retrieved_context": normalize_context_text(retrieved_context),
+                    "golden_context": normalize_context_text(golden_context),
+                }
+            )
+        return results
+
+    async def run_instances(
+        self,
+        instances: list[dict[str, str]],
+        search_fn,
+        datasets: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Run retrieval metrics for many instances and aggregate per search type."""
+        per_type: dict[str, list[dict[str, Any]]] = {
+            search_type.value: [] for search_type in self.search_types
+        }
+
+        for instance in instances:
+            question = instance["question"]
+            golden_context = instance.get("golden_context", "")
+            rows = await self.run_instance(
+                question=question,
+                golden_context=golden_context,
+                search_fn=search_fn,
+                datasets=datasets,
+            )
+            for row in rows:
+                per_type[row["search_type"]].append(row)
+
+        summary: dict[str, Any] = {"per_search_type": {}, "instances": []}
+        for search_type, rows in per_type.items():
+            summary["per_search_type"][search_type] = {
+                "context_recall": aggregate_metric(row["context_recall"] for row in rows),
+                "context_f1": aggregate_metric(row["context_f1"] for row in rows),
+            }
+            summary["instances"].extend(rows)
+        return summary
+
+    @staticmethod
+    def _extract_context(payload: Any) -> Any:
+        if payload is None:
+            return ""
+        if isinstance(payload, list) and payload:
+            first = payload[0]
+            if isinstance(first, dict):
+                for key in ("context_result", "context", "search_result", "result"):
+                    if key in first and first[key] is not None:
+                        return first[key]
+            return payload
+        if isinstance(payload, dict):
+            for key in ("context_result", "context", "search_result", "result"):
+                if key in payload and payload[key] is not None:
+                    return payload[key]
+        return payload

--- a/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
+++ b/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 # /Users/vasa/Projects/cognee/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
 
@@ -48,7 +52,7 @@ class DefaultChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -85,7 +89,7 @@ class DefaultChunkEngine:
 
     def chunk_data_exact(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data exactly by specified sizes and overlaps.
 
@@ -113,7 +117,7 @@ class DefaultChunkEngine:
 
     def chunk_by_sentence(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data into sentences based on specified sizes and overlaps.
 
@@ -139,10 +143,10 @@ class DefaultChunkEngine:
         sentence_chunks = []
         for sentence in sentences:
             if len(sentence) > chunk_size:
-                chunks = self.chunk_data_exact(
+                sub_chunks, _ = self.chunk_data_exact(
                     data_chunks=[sentence], chunk_size=chunk_size, chunk_overlap=chunk_overlap
                 )
-                sentence_chunks.extend(chunks)
+                sentence_chunks.extend(sub_chunks)
             else:
                 sentence_chunks.append(sentence)
 
@@ -154,7 +158,7 @@ class DefaultChunkEngine:
 
     def chunk_data_by_paragraph(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int, bound: float = 0.75
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on paragraphs while considering overlaps and boundaries.
 

--- a/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
+++ b/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.infrastructure.data.chunking.DefaultChunkEngine import DefaultChunkEngine
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 
 class LangchainChunkEngine:
@@ -28,7 +32,7 @@ class LangchainChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -73,7 +77,7 @@ class LangchainChunkEngine:
         chunk_size: int,
         chunk_overlap: int = 10,
         language=None,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data specifically for code snippets.
 
@@ -118,7 +122,7 @@ class LangchainChunkEngine:
 
     def chunk_data_by_character(
         self, data_chunks: Iterable[str], chunk_size: int = 1500, chunk_overlap: int = 10
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on character count.
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -206,6 +206,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
         merged_kwargs.pop("api_key", None)
         merged_kwargs.pop("api_base", None)
         merged_kwargs.pop("api_version", None)
+        merged_kwargs = {key: value for key, value in merged_kwargs.items() if value is not None}
 
         try:
             async with llm_rate_limiter_context_manager():

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -43,7 +43,7 @@ def _enrich_llm_span(model: str, name: str) -> None:
         return
 
     try:
-        from opentelemetry import trace as otel_trace  # ty:ignore[unresolved-import]
+        from opentelemetry import trace as otel_trace
 
         from cognee.modules.observability.tracing import COGNEE_LLM_MODEL, COGNEE_LLM_PROVIDER
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -251,7 +251,7 @@ class OllamaAPIAdapter(LLMInterface):
                 }
             ],
             max_completion_tokens=300,
-        )  # ty:ignore[no-matching-overload]
+        )
 
         # Ensure response is valid before accessing .choices[0].message.content
         if (
@@ -261,4 +261,7 @@ class OllamaAPIAdapter(LLMInterface):
         ):
             raise ValueError("Image transcription failed. No response received.")
 
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        if not content:
+            raise ValueError("Image transcription failed. Empty response content.")
+        return content

--- a/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
+++ b/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
@@ -27,7 +27,7 @@ class HuggingFaceTokenizer(TokenizerInterface):
         self.max_completion_tokens = max_completion_tokens
 
         # Import here to make it an optional dependency
-        from transformers import AutoTokenizer  # ty:ignore[unresolved-import]
+        from transformers import AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(model)
 

--- a/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
+++ b/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
@@ -78,7 +78,7 @@ class AdvancedPdfLoader(LoaderInterface):
                 **kwargs,
             }
             # Use partition to extract elements
-            from unstructured.partition.pdf import partition_pdf  # ty:ignore[unresolved-import]
+            from unstructured.partition.pdf import partition_pdf
 
             elements = partition_pdf(**partition_kwargs)
 

--- a/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
+++ b/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
@@ -272,7 +272,7 @@ class BeautifulSoupLoader(LoaderInterface):
 
         if rule.xpath:
             try:
-                from lxml import html as lxml_html  # ty:ignore[unresolved-import]
+                from lxml import html as lxml_html
             except ImportError:
                 raise RuntimeError(
                     "XPath requested but lxml is not available. Install lxml or use CSS selectors."

--- a/cognee/infrastructure/loaders/external/unstructured_loader.py
+++ b/cognee/infrastructure/loaders/external/unstructured_loader.py
@@ -6,7 +6,7 @@ from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface
 from cognee.shared.logging_utils import get_logger
 
 try:
-    from unstructured.partition.auto import partition  # ty:ignore[unresolved-import]
+    from unstructured.partition.auto import partition
 except ImportError as e:
     raise ImportError(
         "unstructured is required for document processing. Install with: pip install unstructured"
@@ -95,11 +95,8 @@ class UnstructuredLoader(LoaderInterface):
             # Name ingested file of current loader based on original file content hash
             storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
-            # Set partitioning parameters
-            partition_kwargs = {"filename": file_path, "strategy": strategy, **kwargs}
-
             # Use partition to extract elements
-            elements = partition(**partition_kwargs)
+            elements = partition(filename=file_path, strategy=strategy, **kwargs)
 
             # Process elements into text content
             text_parts = []

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -10,7 +10,7 @@ Public orchestration coroutines are fail-open so they can never block answer gen
 helpers are deliberately strict so tests catch malformed stored data and scoring mistakes.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Protocol, Tuple
 from uuid import uuid4
 
@@ -185,7 +185,7 @@ async def _stamp_served_entries(*, session_manager, user_id, session_id, entry_i
     if not entry_ids:
         return
 
-    served_at = datetime.utcnow().isoformat()
+    served_at = datetime.now(timezone.utc).isoformat()
     for entry_id in entry_ids:
         try:
             await session_manager.update_session_context_entry(
@@ -333,7 +333,7 @@ async def _apply_single_candidate(
         content=content,
         normalized_content=normalized,
         confidence=float(candidate.confidence),
-        created_at=datetime.utcnow().isoformat(),
+        created_at=datetime.now(timezone.utc).isoformat(),
         source_feedback_ids=[feedback_entry_id] if feedback_entry_id else [],
         kind="context",
     )

--- a/cognee/infrastructure/session/session_turn.py
+++ b/cognee/infrastructure/session/session_turn.py
@@ -8,7 +8,7 @@ All public coroutines are fail-open so they never block answer generation.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -322,7 +322,7 @@ async def apply_session_turn_analysis(
 
         feedback_entry = SessionFeedbackEntry(
             id=str(uuid4()),
-            created_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
             raw_text=query,
             referenced_qa_ids=[previous_qa_id] if previous_qa_id else [],
             influencing_context_ids=list(served_ids or []),

--- a/cognee/shared/graph_model_utils.py
+++ b/cognee/shared/graph_model_utils.py
@@ -98,7 +98,7 @@ def datapoint_model_to_basemodel(
             )
 
         converted_model = create_model(
-            model_type.__name__, __base__=ConfiguredBase, **converted_fields
+            model_type.__name__, __base__=ConfiguredBase, **cast(Any, converted_fields)
         )
         converted_model.model_rebuild()
         cache[model_type] = converted_model

--- a/cognee/tests/unit/eval_framework/test_retrieval_benchmark_metrics.py
+++ b/cognee/tests/unit/eval_framework/test_retrieval_benchmark_metrics.py
@@ -1,0 +1,41 @@
+import pytest
+
+from cognee.eval_framework.retrieval_benchmark.metrics import (
+    aggregate_metric,
+    context_overlap_f1,
+    context_recall,
+    normalize_context_text,
+)
+
+
+def test_normalize_context_text_flattens_lists_and_dicts():
+    assert normalize_context_text(["Alpha", {"text": "Beta"}]) == "alpha\nbeta"
+
+
+def test_context_recall_counts_golden_lines_found():
+    golden = "Paris is the capital.\nFrance is in Europe."
+    retrieved = "Background: Paris is the capital. More text."
+    assert context_recall(retrieved, golden) == 0.5
+
+
+def test_context_recall_returns_zero_for_empty_golden():
+    assert context_recall("anything", "") == 0.0
+
+
+def test_context_overlap_f1_token_match():
+    golden = "quantum computer uses superposition"
+    retrieved = "a quantum computer leverages superposition and entanglement"
+    score = context_overlap_f1(retrieved, golden)
+    assert 0.4 < score < 1.0
+
+
+def test_aggregate_metric_handles_empty_series():
+    assert aggregate_metric([])["count"] == 0.0
+
+
+def test_aggregate_metric_summarizes_values():
+    summary = aggregate_metric([0.2, 0.8])
+    assert summary["mean"] == pytest.approx(0.5)
+    assert summary["min"] == pytest.approx(0.2)
+    assert summary["max"] == pytest.approx(0.8)
+    assert summary["count"] == 2.0

--- a/cognee/tests/unit/eval_framework/test_retrieval_benchmark_runner.py
+++ b/cognee/tests/unit/eval_framework/test_retrieval_benchmark_runner.py
@@ -1,0 +1,29 @@
+import pytest
+
+from cognee.eval_framework.retrieval_benchmark.runner import RetrievalBenchmarkRunner
+from cognee.modules.search.types import SearchType
+
+
+@pytest.mark.asyncio
+async def test_runner_aggregates_per_search_type():
+    runner = RetrievalBenchmarkRunner(search_types=[SearchType.CHUNKS, SearchType.SUMMARIES])
+
+    async def fake_search(**kwargs):
+        if kwargs["query_type"] == SearchType.CHUNKS:
+            return [{"context_result": "alpha beta"}]
+        return [{"context_result": "alpha"}]
+
+    summary = await runner.run_instances(
+        instances=[
+            {
+                "question": "What is alpha?",
+                "golden_context": "alpha beta",
+            }
+        ],
+        search_fn=fake_search,
+    )
+
+    assert "CHUNKS" in summary["per_search_type"]
+    assert "SUMMARIES" in summary["per_search_type"]
+    assert summary["per_search_type"]["CHUNKS"]["context_recall"]["mean"] == 1.0
+    assert summary["per_search_type"]["SUMMARIES"]["context_recall"]["mean"] < 1.0


### PR DESCRIPTION
Closes #2913

## Summary

Adds retrieval-quality benchmark utilities: `context_recall` and token-level `context_overlap_f1` for comparing retrieved context to golden text, plus a `RetrievalBenchmarkRunner` that scores CHUNKS, SUMMARIES, and GRAPH_COMPLETION in retrieval-only mode (`only_context=True`).

## Test plan

- [x] `pytest cognee/tests/unit/eval_framework/test_retrieval_benchmark_metrics.py`
- [x] `pytest cognee/tests/unit/eval_framework/test_retrieval_benchmark_runner.py`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.