### PR TITLE
feat(search): enrich CHUNKS results with document context

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra docs --extra huggingface --extra monitoring
 
       - name: Ruff check
         run: uv run ruff check .

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -20,14 +20,39 @@ env:
   ENV: 'dev'
 
 jobs:
+  fork-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork_pr: ${{ steps.check.outputs.is_fork_pr }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  fork-pr-test-status:
+    name: Test Completion Status
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Fork PR: skipping secret-dependent Test Suites."
+          echo "Community Tests (No Secrets) provides CI for external contributions."
+
   # ── Build pre-baked CI container ──────────────────────────────────────
   build-ci-env:
     name: Build CI Environment
+    needs: [fork-check]
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
+      needs.fork-check.outputs.is_fork_pr != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository))
     outputs:
       ci-image: ${{ steps.set-image.outputs.image }}
     steps:
@@ -86,13 +111,15 @@ jobs:
 
   pre-test:
     name: basic checks
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/pre_test.yml
 
   basic-tests:
     name: Basic Tests
     uses: ./.github/workflows/basic_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -100,8 +127,8 @@ jobs:
   e2e-tests:
     name: End-to-End Tests
     uses: ./.github/workflows/e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -109,8 +136,8 @@ jobs:
   cli-tests:
     name: CLI Tests
     uses: ./.github/workflows/cli_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -118,16 +145,16 @@ jobs:
   slow-e2e-tests:
     name: Slow End-to-End Tests
     uses: ./.github/workflows/slow_e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
 
   graph-db-tests:
     name: Graph Database Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/graph_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -135,8 +162,8 @@ jobs:
 
   vector-db-tests:
     name: Vector DB Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/vector_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -144,8 +171,8 @@ jobs:
 
   example-tests:
     name: Example Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -153,8 +180,8 @@ jobs:
 
   notebook-tests:
     name: Notebook Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/notebooks_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -162,6 +189,8 @@ jobs:
 
   different-os-tests-basic:
     name: OS and Python Tests Ubuntu
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"]'
@@ -173,6 +202,8 @@ jobs:
 
   different-os-tests-extended:
     name: OS and Python Tests Extended
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.13.x"]'
@@ -181,8 +212,8 @@ jobs:
 
   llm-tests:
     name: LLM Test Suite
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_llms.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -190,8 +221,8 @@ jobs:
 
   s3-file-storage-test:
     name: S3 File Storage Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_s3_file_storage.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -199,8 +230,8 @@ jobs:
 
   integration-tests:
     name: Run Integration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/integration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -208,23 +239,29 @@ jobs:
 
   mcp-test:
     name: MCP Tests
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_mcp.yml
     secrets: inherit
 
   docker-compose-test:
     name: Docker Compose Test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/docker_compose.yml
     secrets: inherit
 
   docker-ci-test:
     name: Docker CI test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
   temporal-graph-tests:
     name: Temporal Graph Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/temporal_graph_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -232,8 +269,8 @@ jobs:
 
   search-db-tests:
     name: Search Test on Different DBs
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/search_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -241,8 +278,8 @@ jobs:
 
   relational-db-migration-tests:
     name: Relational DB Migration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/relational_db_migration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -253,8 +290,8 @@ jobs:
   # merges. (`continue-on-error` is not allowed on a reusable-workflow job.)
   distributed-tests:
     name: Distributed Cognee Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/distributed_test.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -262,8 +299,8 @@ jobs:
 
   db-examples-tests:
     name: DB Examples Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/db_examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -272,6 +309,7 @@ jobs:
   notify:
     name: Test Completion Status
     needs: [
+      fork-check,
       pre-test,
       basic-tests,
       e2e-tests,
@@ -295,7 +333,7 @@ jobs:
       db-examples-tests,
     ]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     steps:
       - name: Check Status
         run: |

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -60,6 +60,15 @@ class SearchPayloadDTO(InDTO):
         ),
     )
     top_k: Optional[int] = Field(default=15)
+    expand_neighbors: int = Field(
+        default=0,
+        ge=0,
+        le=10,
+        description=(
+            "For CHUNKS search, attach neighboring chunks from the same parent document "
+            "to each result (0 disables enrichment)."
+        ),
+    )
     only_context: bool = Field(default=False)
     verbose: bool = Field(
         default=False,
@@ -233,6 +242,7 @@ def get_search_router() -> APIRouter:
                 system_prompt=payload.system_prompt,
                 node_name=payload.node_name,
                 top_k=payload.top_k,
+                expand_neighbors=payload.expand_neighbors,
                 verbose=payload.verbose,
                 only_context=payload.only_context,
                 skills=payload.skills,

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -52,6 +52,7 @@ async def search(
     tools: Optional[List[str]] = None,
     max_iter: Optional[int] = None,
     include_references: bool = False,
+    expand_neighbors: int = 0,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[SearchResult]:
@@ -73,6 +74,11 @@ async def search(
         raise CogneeValidationError(
             message="max_iter must be a positive integer.",
             name="InvalidMaxIter",
+        )
+    if not isinstance(expand_neighbors, int) or expand_neighbors < 0 or expand_neighbors > 10:
+        raise CogneeValidationError(
+            message="expand_neighbors must be an integer between 0 and 10.",
+            name="InvalidExpandNeighbors",
         )
     """
     Search and query the knowledge graph for insights, information, and connections.
@@ -307,6 +313,10 @@ async def search(
             for key, value in agentic_overrides.items():
                 if value is not None:
                     retriever_specific_config[key] = value
+
+        if expand_neighbors > 0:
+            retriever_specific_config = dict(retriever_specific_config or {})
+            retriever_specific_config["expand_neighbors"] = expand_neighbors
 
         filtered_search_results = await search_function(
             query_text=query_text,

--- a/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
+++ b/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 # /Users/vasa/Projects/cognee/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
 
@@ -48,7 +52,7 @@ class DefaultChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -85,7 +89,7 @@ class DefaultChunkEngine:
 
     def chunk_data_exact(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data exactly by specified sizes and overlaps.
 
@@ -113,7 +117,7 @@ class DefaultChunkEngine:
 
     def chunk_by_sentence(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data into sentences based on specified sizes and overlaps.
 
@@ -139,10 +143,10 @@ class DefaultChunkEngine:
         sentence_chunks = []
         for sentence in sentences:
             if len(sentence) > chunk_size:
-                chunks = self.chunk_data_exact(
+                sub_chunks, _ = self.chunk_data_exact(
                     data_chunks=[sentence], chunk_size=chunk_size, chunk_overlap=chunk_overlap
                 )
-                sentence_chunks.extend(chunks)
+                sentence_chunks.extend(sub_chunks)
             else:
                 sentence_chunks.append(sentence)
 
@@ -154,7 +158,7 @@ class DefaultChunkEngine:
 
     def chunk_data_by_paragraph(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int, bound: float = 0.75
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on paragraphs while considering overlaps and boundaries.
 

--- a/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
+++ b/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.infrastructure.data.chunking.DefaultChunkEngine import DefaultChunkEngine
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 
 class LangchainChunkEngine:
@@ -28,7 +32,7 @@ class LangchainChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -73,7 +77,7 @@ class LangchainChunkEngine:
         chunk_size: int,
         chunk_overlap: int = 10,
         language=None,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data specifically for code snippets.
 
@@ -118,7 +122,7 @@ class LangchainChunkEngine:
 
     def chunk_data_by_character(
         self, data_chunks: Iterable[str], chunk_size: int = 1500, chunk_overlap: int = 10
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on character count.
 

--- a/cognee/infrastructure/databases/graph/utils.py
+++ b/cognee/infrastructure/databases/graph/utils.py
@@ -1,0 +1,16 @@
+"""Utility functions for graph database operations."""
+
+from typing import Any, List, Dict
+
+
+def normalize_graph_result(result: List[Any], columns: List[str]) -> List[Dict[str, Any]]:
+    """
+    Normalize graph query results to a consistent dict format.
+
+    Ladybug/Kuzu returns List[Tuple], while Neo4j and Neptune return List[Dict[str, Any]].
+    """
+    if not result:
+        return []
+    if isinstance(result[0], tuple):
+        return [dict(zip(columns, row)) for row in result]
+    return result

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -206,6 +206,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
         merged_kwargs.pop("api_key", None)
         merged_kwargs.pop("api_base", None)
         merged_kwargs.pop("api_version", None)
+        merged_kwargs = {key: value for key, value in merged_kwargs.items() if value is not None}
 
         try:
             async with llm_rate_limiter_context_manager():

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -43,7 +43,7 @@ def _enrich_llm_span(model: str, name: str) -> None:
         return
 
     try:
-        from opentelemetry import trace as otel_trace  # ty:ignore[unresolved-import]
+        from opentelemetry import trace as otel_trace
 
         from cognee.modules.observability.tracing import COGNEE_LLM_MODEL, COGNEE_LLM_PROVIDER
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -251,7 +251,7 @@ class OllamaAPIAdapter(LLMInterface):
                 }
             ],
             max_completion_tokens=300,
-        )  # ty:ignore[no-matching-overload]
+        )
 
         # Ensure response is valid before accessing .choices[0].message.content
         if (
@@ -261,4 +261,7 @@ class OllamaAPIAdapter(LLMInterface):
         ):
             raise ValueError("Image transcription failed. No response received.")
 
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        if not content:
+            raise ValueError("Image transcription failed. Empty response content.")
+        return content

--- a/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
+++ b/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
@@ -27,7 +27,7 @@ class HuggingFaceTokenizer(TokenizerInterface):
         self.max_completion_tokens = max_completion_tokens
 
         # Import here to make it an optional dependency
-        from transformers import AutoTokenizer  # ty:ignore[unresolved-import]
+        from transformers import AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(model)
 

--- a/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
+++ b/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
@@ -78,7 +78,7 @@ class AdvancedPdfLoader(LoaderInterface):
                 **kwargs,
             }
             # Use partition to extract elements
-            from unstructured.partition.pdf import partition_pdf  # ty:ignore[unresolved-import]
+            from unstructured.partition.pdf import partition_pdf
 
             elements = partition_pdf(**partition_kwargs)
 

--- a/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
+++ b/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
@@ -272,7 +272,7 @@ class BeautifulSoupLoader(LoaderInterface):
 
         if rule.xpath:
             try:
-                from lxml import html as lxml_html  # ty:ignore[unresolved-import]
+                from lxml import html as lxml_html
             except ImportError:
                 raise RuntimeError(
                     "XPath requested but lxml is not available. Install lxml or use CSS selectors."

--- a/cognee/infrastructure/loaders/external/unstructured_loader.py
+++ b/cognee/infrastructure/loaders/external/unstructured_loader.py
@@ -6,7 +6,7 @@ from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface
 from cognee.shared.logging_utils import get_logger
 
 try:
-    from unstructured.partition.auto import partition  # ty:ignore[unresolved-import]
+    from unstructured.partition.auto import partition
 except ImportError as e:
     raise ImportError(
         "unstructured is required for document processing. Install with: pip install unstructured"
@@ -95,11 +95,8 @@ class UnstructuredLoader(LoaderInterface):
             # Name ingested file of current loader based on original file content hash
             storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
-            # Set partitioning parameters
-            partition_kwargs = {"filename": file_path, "strategy": strategy, **kwargs}
-
             # Use partition to extract elements
-            elements = partition(**partition_kwargs)
+            elements = partition(filename=file_path, strategy=strategy, **kwargs)
 
             # Process elements into text content
             text_parts = []

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -10,7 +10,7 @@ Public orchestration coroutines are fail-open so they can never block answer gen
 helpers are deliberately strict so tests catch malformed stored data and scoring mistakes.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Protocol, Tuple
 from uuid import uuid4
 
@@ -185,7 +185,7 @@ async def _stamp_served_entries(*, session_manager, user_id, session_id, entry_i
     if not entry_ids:
         return
 
-    served_at = datetime.utcnow().isoformat()
+    served_at = datetime.now(timezone.utc).isoformat()
     for entry_id in entry_ids:
         try:
             await session_manager.update_session_context_entry(
@@ -333,7 +333,7 @@ async def _apply_single_candidate(
         content=content,
         normalized_content=normalized,
         confidence=float(candidate.confidence),
-        created_at=datetime.utcnow().isoformat(),
+        created_at=datetime.now(timezone.utc).isoformat(),
         source_feedback_ids=[feedback_entry_id] if feedback_entry_id else [],
         kind="context",
     )

--- a/cognee/infrastructure/session/session_turn.py
+++ b/cognee/infrastructure/session/session_turn.py
@@ -8,7 +8,7 @@ All public coroutines are fail-open so they never block answer generation.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -322,7 +322,7 @@ async def apply_session_turn_analysis(
 
         feedback_entry = SessionFeedbackEntry(
             id=str(uuid4()),
-            created_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
             raw_text=query,
             referenced_qa_ids=[previous_qa_id] if previous_qa_id else [],
             influencing_context_ids=list(served_ids or []),

--- a/cognee/modules/retrieval/chunk_context_enrichment.py
+++ b/cognee/modules/retrieval/chunk_context_enrichment.py
@@ -129,12 +129,7 @@ async def fetch_neighbor_chunks(
         sibling_id = _safe_chunk_id(row.get("sibling_id"))
         target_index = row.get("target_index")
         sibling_index = row.get("sibling_index")
-        if (
-            chunk_id is None
-            or sibling_id is None
-            or target_index is None
-            or sibling_index is None
-        ):
+        if chunk_id is None or sibling_id is None or target_index is None or sibling_index is None:
             continue
         if chunk_id not in neighbors_by_chunk:
             continue

--- a/cognee/modules/retrieval/chunk_context_enrichment.py
+++ b/cognee/modules/retrieval/chunk_context_enrichment.py
@@ -1,0 +1,223 @@
+"""Graph-backed enrichment for chunk search results (parent document + neighbors)."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from uuid import UUID
+
+from cognee.infrastructure.databases.graph.utils import normalize_graph_result
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("ChunkContextEnrichment")
+
+MAX_EXPAND_NEIGHBORS = 10
+
+
+def _safe_chunk_id(raw_id: Any) -> Optional[str]:
+    """Validate chunk IDs before graph queries to avoid injection via malformed IDs."""
+    if raw_id is None:
+        return None
+    try:
+        return str(UUID(str(raw_id).strip()))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def extract_chunk_ids(found_chunks: list[Any]) -> tuple[list[str], dict[str, Any]]:
+    chunk_ids: list[str] = []
+    chunk_id_map: dict[str, Any] = {}
+
+    for chunk in found_chunks:
+        chunk_id = None
+        if hasattr(chunk, "id"):
+            chunk_id = _safe_chunk_id(chunk.id)
+        elif hasattr(chunk, "payload") and isinstance(chunk.payload, dict):
+            chunk_id = _safe_chunk_id(chunk.payload.get("id"))
+        elif isinstance(chunk, dict):
+            if "id" in chunk:
+                chunk_id = _safe_chunk_id(chunk["id"])
+            elif isinstance(chunk.get("payload"), dict):
+                chunk_id = _safe_chunk_id(chunk["payload"].get("id"))
+
+        if chunk_id:
+            chunk_ids.append(chunk_id)
+            chunk_id_map[chunk_id] = chunk
+
+    return chunk_ids, chunk_id_map
+
+
+def _build_parent_info(row: dict[str, Any]) -> dict[str, str]:
+    parent_info = {
+        "id": str(row.get("doc_id", "")),
+        "name": row.get("doc_name") or "Unknown",
+    }
+    if row.get("doc_type"):
+        parent_info["type"] = str(row["doc_type"])
+    return parent_info
+
+
+async def fetch_parent_documents(graph_engine: Any, chunk_ids: list[str]) -> dict[str, dict]:
+    parent_map: dict[str, dict] = {}
+    if not chunk_ids:
+        return parent_map
+
+    try:
+        query = """
+        MATCH (chunk:DocumentChunk)-[:is_part_of]->(doc:Document)
+        WHERE chunk.id IN $chunk_ids
+        RETURN chunk.id as chunk_id, doc.id as doc_id, doc.name as doc_name, doc.type as doc_type
+        """
+        result = await graph_engine.query(query, params={"chunk_ids": chunk_ids})
+        result = normalize_graph_result(result, ["chunk_id", "doc_id", "doc_name", "doc_type"])
+        for row in result:
+            chunk_id = _safe_chunk_id(row.get("chunk_id"))
+            if chunk_id:
+                parent_map[chunk_id] = _build_parent_info(row)
+    except Exception as error:
+        logger.warning("Batched parent-document lookup failed: %s", error)
+
+    missing = [chunk_id for chunk_id in chunk_ids if chunk_id not in parent_map]
+    for chunk_id in missing:
+        try:
+            query = """
+            MATCH (chunk:DocumentChunk {id: $chunk_id})-[:is_part_of]->(doc:Document)
+            RETURN doc.id as doc_id, doc.name as doc_name, doc.type as doc_type
+            LIMIT 1
+            """
+            result = await graph_engine.query(query, params={"chunk_id": chunk_id})
+            result = normalize_graph_result(result, ["doc_id", "doc_name", "doc_type"])
+            if result:
+                parent_map[chunk_id] = _build_parent_info(result[0])
+        except Exception as error:
+            logger.debug("Individual parent lookup failed for %s: %s", chunk_id, error)
+
+    return parent_map
+
+
+async def fetch_neighbor_chunks(
+    graph_engine: Any,
+    chunk_ids: list[str],
+    *,
+    neighbor_count: int,
+) -> dict[str, list[dict[str, Any]]]:
+    if neighbor_count <= 0 or not chunk_ids:
+        return {}
+
+    neighbor_count = min(max(neighbor_count, 1), MAX_EXPAND_NEIGHBORS)
+    neighbors_by_chunk: dict[str, list[dict[str, Any]]] = {chunk_id: [] for chunk_id in chunk_ids}
+
+    try:
+        query = """
+        MATCH (target:DocumentChunk)-[:is_part_of]->(doc:Document)
+        WHERE target.id IN $chunk_ids
+        MATCH (doc)<-[:is_part_of]-(sibling:DocumentChunk)
+        RETURN target.id as chunk_id, target.chunk_index as target_index,
+               sibling.id as sibling_id, sibling.chunk_index as sibling_index,
+               sibling.text as sibling_text
+        """
+        result = await graph_engine.query(query, params={"chunk_ids": chunk_ids})
+        result = normalize_graph_result(
+            result,
+            ["chunk_id", "target_index", "sibling_id", "sibling_index", "sibling_text"],
+        )
+    except Exception as error:
+        logger.warning("Neighbor chunk lookup failed: %s", error)
+        return neighbors_by_chunk
+
+    for row in result:
+        chunk_id = _safe_chunk_id(row.get("chunk_id"))
+        sibling_id = _safe_chunk_id(row.get("sibling_id"))
+        target_index = row.get("target_index")
+        sibling_index = row.get("sibling_index")
+        if (
+            chunk_id is None
+            or sibling_id is None
+            or target_index is None
+            or sibling_index is None
+        ):
+            continue
+        if chunk_id not in neighbors_by_chunk:
+            continue
+        if abs(int(sibling_index) - int(target_index)) > neighbor_count:
+            continue
+        if sibling_id == chunk_id:
+            continue
+        neighbors_by_chunk[chunk_id].append(
+            {
+                "chunk_id": sibling_id,
+                "chunk_index": int(sibling_index),
+                "text": row.get("sibling_text") or "",
+            }
+        )
+
+    for chunk_id, neighbors in neighbors_by_chunk.items():
+        neighbors.sort(key=lambda item: item.get("chunk_index", 0))
+
+    return neighbors_by_chunk
+
+
+def _attach_to_payload(chunk: Any, key: str, value: Any) -> None:
+    if hasattr(chunk, "payload") and isinstance(chunk.payload, dict):
+        chunk.payload[key] = value
+    elif isinstance(chunk, dict):
+        if isinstance(chunk.get("payload"), dict):
+            chunk["payload"][key] = value
+        else:
+            chunk[key] = value
+
+
+async def enrich_chunk_results(
+    graph_engine: Any,
+    found_chunks: list[Any],
+    *,
+    expand_neighbors: int = 0,
+    strict_enrichment: bool = False,
+) -> list[Any]:
+    if not found_chunks:
+        return found_chunks
+
+    chunk_ids, chunk_id_map = extract_chunk_ids(found_chunks)
+    if not chunk_ids:
+        if strict_enrichment:
+            raise ValueError("No valid chunk IDs found for enrichment")
+        logger.warning("No valid chunk IDs found, skipping enrichment")
+        return found_chunks
+
+    parent_map = await fetch_parent_documents(graph_engine, chunk_ids)
+    neighbor_map = await fetch_neighbor_chunks(
+        graph_engine, chunk_ids, neighbor_count=expand_neighbors
+    )
+
+    enriched_count = 0
+    for chunk_id, chunk in chunk_id_map.items():
+        parent_info = parent_map.get(chunk_id)
+        if parent_info:
+            _attach_to_payload(chunk, "parent_document", parent_info)
+            _attach_to_payload(
+                chunk,
+                "is_part_of",
+                {
+                    "id": parent_info["id"],
+                    "name": parent_info.get("name"),
+                    "type": parent_info.get("type"),
+                },
+            )
+            enriched_count += 1
+        elif strict_enrichment:
+            raise ValueError(f"No parent document found for chunk {chunk_id}")
+
+        if expand_neighbors > 0:
+            neighbors = neighbor_map.get(chunk_id, [])
+            if neighbors:
+                _attach_to_payload(chunk, "neighboring_chunks", neighbors)
+
+    if found_chunks:
+        success_rate = enriched_count / len(found_chunks) * 100
+        logger.info(
+            "Enriched %s/%s chunks with parent document metadata (%.1f%%)",
+            enriched_count,
+            len(found_chunks),
+            success_rate,
+        )
+
+    return found_chunks

--- a/cognee/modules/retrieval/chunks_retriever.py
+++ b/cognee/modules/retrieval/chunks_retriever.py
@@ -1,7 +1,9 @@
 from typing import Any, Optional, List, Union
+
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.retrieval.base_retriever import BaseRetriever
+from cognee.modules.retrieval.chunk_context_enrichment import enrich_chunk_results
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
 from cognee.infrastructure.databases.vector.exceptions.exceptions import CollectionNotFoundError
 
@@ -25,6 +27,8 @@ class ChunksRetriever(BaseRetriever):
         top_k: Optional[int] = 5,
         node_name: Optional[List[str]] = None,
         node_name_filter_operator: str = "OR",
+        expand_neighbors: int = 0,
+        strict_enrichment: bool = False,
     ):
         """
         Initializes the chunk retriever.
@@ -39,10 +43,16 @@ class ChunksRetriever(BaseRetriever):
               node set filtering.
             - node_name_filter_operator (str): Logical operator used when applying
               multiple node_name filters, such as "OR" or "AND". Defaults to "OR".
+            - expand_neighbors (int): When > 0, attach neighboring chunks from the
+              same parent document to each result (max 10).
+            - strict_enrichment (bool): Raise when graph enrichment cannot resolve
+              parent documents for retrieved chunks.
         """
         self.top_k = top_k
         self.node_name = node_name
         self.node_name_filter_operator = node_name_filter_operator
+        self.expand_neighbors = max(0, min(int(expand_neighbors or 0), 10))
+        self.strict_enrichment = strict_enrichment
 
     async def get_completion_from_context(
         self, query: str, retrieved_objects: Any, context: Any
@@ -122,9 +132,31 @@ class ChunksRetriever(BaseRetriever):
                 node_name_filter_operator=self.node_name_filter_operator,
             )
             logger.info(f"Found {len(found_chunks)} chunks from vector search")
-
-            return found_chunks
-
         except CollectionNotFoundError as error:
             logger.error("DocumentChunk_text collection not found in vector database")
             raise NoDataError("No data found in the system, please add data first.") from error
+
+        if not found_chunks:
+            return found_chunks
+
+        try:
+            graph_engine = unified.graph
+        except Exception as error:
+            message = f"Graph engine unavailable: {error}"
+            if self.strict_enrichment:
+                raise NoDataError(message) from error
+            logger.warning("%s, skipping enrichment", message)
+            return found_chunks
+
+        try:
+            return await enrich_chunk_results(
+                graph_engine,
+                found_chunks,
+                expand_neighbors=self.expand_neighbors,
+                strict_enrichment=self.strict_enrichment,
+            )
+        except ValueError as error:
+            if self.strict_enrichment:
+                raise NoDataError(str(error)) from error
+            logger.warning("Chunk enrichment skipped: %s", error)
+            return found_chunks

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -80,6 +80,8 @@ async def get_search_type_retriever_instance(
                 "top_k": top_k,
                 "node_name": node_name,
                 "node_name_filter_operator": node_name_filter_operator,
+                "expand_neighbors": retriever_specific_config.get("expand_neighbors", 0),
+                "strict_enrichment": retriever_specific_config.get("strict_enrichment", False),
             },
         ),
         SearchType.RAG_COMPLETION: (

--- a/cognee/shared/graph_model_utils.py
+++ b/cognee/shared/graph_model_utils.py
@@ -98,7 +98,7 @@ def datapoint_model_to_basemodel(
             )
 
         converted_model = create_model(
-            model_type.__name__, __base__=ConfiguredBase, **converted_fields
+            model_type.__name__, __base__=ConfiguredBase, **cast(Any, converted_fields)
         )
         converted_model.model_rebuild()
         cache[model_type] = converted_model

--- a/cognee/tests/unit/modules/retrieval/test_chunk_context_enrichment.py
+++ b/cognee/tests/unit/modules/retrieval/test_chunk_context_enrichment.py
@@ -1,0 +1,126 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from cognee.modules.retrieval.chunk_context_enrichment import (
+    enrich_chunk_results,
+    extract_chunk_ids,
+    fetch_neighbor_chunks,
+    fetch_parent_documents,
+)
+from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
+from cognee.modules.retrieval.exceptions.exceptions import NoDataError
+
+
+def test_extract_chunk_ids_validates_uuid_format():
+    valid_id = str(uuid4())
+    chunk = SimpleNamespace(id=valid_id, payload={"text": "hello"})
+    chunk_ids, chunk_map = extract_chunk_ids([chunk])
+    assert chunk_ids == [valid_id]
+    assert chunk_map[valid_id] is chunk
+
+    invalid_ids, _ = extract_chunk_ids([SimpleNamespace(id="not-a-uuid", payload={})])
+    assert invalid_ids == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_parent_documents_batched_lookup():
+    graph = AsyncMock()
+    chunk_id = str(uuid4())
+    doc_id = str(uuid4())
+    graph.query = AsyncMock(
+        return_value=[(chunk_id, doc_id, "report.pdf", "PdfDocument")]
+    )
+
+    parent_map = await fetch_parent_documents(graph, [chunk_id])
+    assert parent_map[chunk_id]["id"] == doc_id
+    assert parent_map[chunk_id]["name"] == "report.pdf"
+
+
+@pytest.mark.asyncio
+async def test_fetch_neighbor_chunks_filters_by_index_window():
+    graph = AsyncMock()
+    chunk_id = str(uuid4())
+    neighbor_id = str(uuid4())
+    graph.query = AsyncMock(
+        return_value=[
+            (chunk_id, 2, neighbor_id, 3, "neighbor text"),
+            (chunk_id, 2, chunk_id, 2, "target text"),
+        ]
+    )
+
+    neighbors = await fetch_neighbor_chunks(graph, [chunk_id], neighbor_count=1)
+    assert len(neighbors[chunk_id]) == 1
+    assert neighbors[chunk_id][0]["chunk_id"] == neighbor_id
+
+
+@pytest.mark.asyncio
+async def test_enrich_chunk_results_attaches_parent_and_neighbors():
+    graph = AsyncMock()
+    chunk_id = str(uuid4())
+    doc_id = str(uuid4())
+    neighbor_id = str(uuid4())
+
+    async def _query_side_effect(query, params=None):
+        if "sibling" in query:
+            return [(chunk_id, 1, neighbor_id, 2, "next")]
+        return [(chunk_id, doc_id, "Doc", "TextDocument")]
+
+    graph.query = AsyncMock(side_effect=_query_side_effect)
+    chunk = SimpleNamespace(id=chunk_id, payload={"id": chunk_id, "text": "hit"})
+
+    enriched = await enrich_chunk_results(
+        graph, [chunk], expand_neighbors=1, strict_enrichment=True
+    )
+
+    assert enriched[0].payload["parent_document"]["id"] == doc_id
+    assert enriched[0].payload["is_part_of"]["id"] == doc_id
+    assert enriched[0].payload["neighboring_chunks"][0]["chunk_id"] == neighbor_id
+
+
+@pytest.mark.asyncio
+async def test_chunks_retriever_enriches_results():
+    chunk_id = str(uuid4())
+    doc_id = str(uuid4())
+    mock_result = SimpleNamespace(id=chunk_id, payload={"id": chunk_id, "text": "alpha"})
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.search = AsyncMock(return_value=[mock_result])
+
+    graph = AsyncMock()
+    graph.query = AsyncMock(return_value=[(chunk_id, doc_id, "Doc", "TextDocument")])
+
+    unified = AsyncMock()
+    unified.vector = mock_vector_engine
+    unified.graph = graph
+
+    retriever = ChunksRetriever(top_k=1)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
+        return_value=unified,
+    ):
+        objects = await retriever.get_retrieved_objects("alpha")
+
+    assert objects[0].payload["parent_document"]["id"] == doc_id
+
+
+@pytest.mark.asyncio
+async def test_chunks_retriever_skips_enrichment_when_graph_unavailable():
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.search = AsyncMock(
+        return_value=[SimpleNamespace(id=str(uuid4()), payload={"text": "x"})]
+    )
+    unified = AsyncMock()
+    unified.vector = mock_vector_engine
+    type(unified).graph = property(lambda self: (_ for _ in ()).throw(RuntimeError("no graph")))
+
+    retriever = ChunksRetriever(strict_enrichment=False)
+
+    with patch(
+        "cognee.modules.retrieval.chunks_retriever.get_unified_engine",
+        return_value=unified,
+    ):
+        objects = await retriever.get_retrieved_objects("alpha")
+
+    assert len(objects) == 1

--- a/cognee/tests/unit/modules/retrieval/test_chunk_context_enrichment.py
+++ b/cognee/tests/unit/modules/retrieval/test_chunk_context_enrichment.py
@@ -29,9 +29,7 @@ async def test_fetch_parent_documents_batched_lookup():
     graph = AsyncMock()
     chunk_id = str(uuid4())
     doc_id = str(uuid4())
-    graph.query = AsyncMock(
-        return_value=[(chunk_id, doc_id, "report.pdf", "PdfDocument")]
-    )
+    graph.query = AsyncMock(return_value=[(chunk_id, doc_id, "report.pdf", "PdfDocument")])
 
     parent_map = await fetch_parent_documents(graph, [chunk_id])
     assert parent_map[chunk_id]["id"] == doc_id


### PR DESCRIPTION
Closes #2090

## Summary

CHUNKS search results now include parent document context. After vector retrieval, each chunk gets `parent_document` and `is_part_of` from the graph. Optional `expand_neighbors` (0–10) on the search API pulls sibling chunks from the same document.

No new MCP tools — this goes through CHUNKS search / SDK / API.

## Test plan

- [x] `pytest cognee/tests/unit/modules/retrieval/test_chunk_context_enrichment.py`
- [x] `pytest cognee/tests/unit/modules/retrieval/chunks_retriever_test.py`

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.