### PR TITLE
fix(api): align router DTO types with core function signatures

### DIFF
--- a/cognee/api/dto_types.py
+++ b/cognee/api/dto_types.py
@@ -1,0 +1,50 @@
+"""Shared API DTO field types aligned with core function signatures."""
+
+from typing import Annotated, Any, Optional, Union
+from uuid import UUID
+
+from pydantic import BeforeValidator
+
+
+def _coerce_optional_str_list(value: Any) -> Optional[list[str]]:
+    """Accept a single string or list of strings; normalize to list or None."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return None if stripped == "" else [value]
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    raise ValueError(f"Expected str, list[str], or null; got {type(value).__name__}")
+
+
+def _coerce_optional_uuid_list(value: Any) -> Optional[list[UUID]]:
+    """Accept a single UUID or list of UUIDs; normalize to list or None."""
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        return [value]
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        return [UUID(stripped)]
+    if isinstance(value, (list, tuple)):
+        return [item if isinstance(item, UUID) else UUID(str(item)) for item in value]
+    raise ValueError(f"Expected UUID, list[UUID], or null; got {type(value).__name__}")
+
+
+OptionalStringList = Annotated[
+    Optional[list[str]],
+    BeforeValidator(_coerce_optional_str_list),
+]
+
+OptionalUUIDList = Annotated[
+    Optional[list[UUID]],
+    BeforeValidator(_coerce_optional_uuid_list),
+]
+
+# Type aliases for annotations that also document accepted wire formats.
+DatasetNamesInput = Union[str, list[str], None]
+DatasetIdsInput = Union[UUID, list[UUID], None]
+NodeNamesInput = Union[str, list[str], None]

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -37,7 +37,7 @@ def get_add_router() -> APIRouter:
     )
     @log_usage(function_name="POST /v1/add", log_type="api_endpoint")
     async def add(
-        data: List[UploadFile] = File(default=None),
+        data: Optional[List[UploadFile]] = File(default=None),
         datasetName: Optional[str] = Form(default=None),
         # Note: Literal is needed for Swagger use
         datasetId: Union[UUID, Literal[""], None] = Form(default=None, examples=[""]),

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -3,6 +3,8 @@ import asyncio
 from uuid import UUID
 from pydantic import Field
 from typing import List, Optional
+
+from cognee.api.dto_types import OptionalStringList, OptionalUUIDList
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from fastapi import APIRouter, WebSocket, Depends, WebSocketDisconnect, status
@@ -42,18 +44,19 @@ class CognifyPayloadDTO(InDTO):
     # Examples double as the Swagger try-it-out prefill, which is SUBMITTED
     # as-is on Execute — keep them behavior-neutral (empty/None) for every
     # field where a value changes processing.
-    datasets: Optional[List[str]] = Field(
+    datasets: OptionalStringList = Field(
         default=None,
-        examples=[["default_dataset"]],
+        examples=["default_dataset", ["default_dataset"]],
         description=(
-            "Dataset names to process; resolved against datasets owned by the authenticated user."
+            "Dataset name or list of names to process; resolved against datasets owned "
+            "by the authenticated user."
         ),
     )
-    dataset_ids: Optional[List[UUID]] = Field(
+    dataset_ids: OptionalUUIDList = Field(
         default=None,
-        examples=[[]],
+        examples=["a1b2c3d4-e5f6-7890-abcd-ef1234567890", []],
         description=(
-            "Dataset UUIDs to process (required for datasets shared with you). "
+            "Dataset UUID or list of UUIDs to process (required for datasets shared with you). "
             "Takes precedence over the datasets name list when both are provided."
         ),
     )

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -9,6 +9,7 @@ from pydantic import Field
 
 from cognee import __version__ as cognee_version
 from cognee.api.DTO import InDTO, OutDTO
+from cognee.api.dto_types import OptionalStringList, OptionalUUIDList
 from cognee.api.v1.recall.recall import RecallResponse
 from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
@@ -33,32 +34,32 @@ class RecallPayloadDTO(InDTO):
             "Pass null to let cognee auto-route the query to the best strategy."
         ),
     )
-    datasets: Optional[list[str]] = Field(
+    datasets: OptionalStringList = Field(
         default=None,
-        examples=[["main_dataset"]],
+        examples=["main_dataset", ["main_dataset"]],
         description=(
-            "Dataset names to search within. Omit (null) to search all datasets "
-            "you have read access to."
+            "Dataset name or list of names to search within. Omit (null) to search all "
+            "datasets you have read access to."
         ),
     )
-    dataset_ids: Optional[list[UUID]] = Field(
+    dataset_ids: OptionalUUIDList = Field(
         default=None,
         examples=[[]],
         description=(
-            "Dataset UUIDs to search within; takes precedence over 'datasets' names "
-            "when both are provided. Leave empty to resolve by name."
+            "Dataset UUID or list of UUIDs to search within; takes precedence over "
+            "'datasets' names when both are provided. Leave empty to resolve by name."
         ),
     )
     query: str = Field(default="What is in the document?")
     system_prompt: Optional[str] = Field(
         default="Answer the question using the provided context. Be as brief as possible."
     )
-    node_name: Optional[list[str]] = Field(
+    node_name: OptionalStringList = Field(
         default=None,
-        examples=[["tech_docs"]],
+        examples=["tech_docs", ["tech_docs"]],
         description=(
-            "Restrict results to these node sets (the node_set values passed to "
-            "/v1/add or /v1/remember). Omit to search all nodes."
+            "Node set name or list of names to restrict results "
+            "(the node_set values passed to /v1/add or /v1/remember). Omit to search all nodes."
         ),
     )
     top_k: Optional[int] = Field(default=15)

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -9,6 +9,7 @@ from pydantic import Field
 
 from cognee import __version__ as cognee_version
 from cognee.api.DTO import ErrorResponse, InDTO, OutDTO
+from cognee.api.dto_types import OptionalStringList, OptionalUUIDList
 from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
 from cognee.modules.search.operations import get_history
@@ -31,32 +32,35 @@ class SearchPayloadDTO(InDTO):
             " AGENTIC_COMPLETION (enables skills/tools/max_iter)."
         ),
     )
-    datasets: Optional[list[str]] = Field(
+    datasets: OptionalStringList = Field(
         default=None,
-        examples=[["main_dataset"]],
+        examples=["main_dataset", ["main_dataset"]],
         description=(
-            "Dataset names to search. Names only resolve to datasets owned by the caller;"
-            " use dataset_ids for datasets shared with you."
+            "Dataset name or list of names to search. Names only resolve to datasets owned "
+            "by the caller; use dataset_ids for datasets shared with you."
         ),
     )
-    dataset_ids: Optional[list[UUID]] = Field(
+    dataset_ids: OptionalUUIDList = Field(
         default=None,
-        examples=[["a1b2c3d4-5678-40ab-8cde-1234567890ab"]],
+        examples=[
+            "a1b2c3d4-5678-40ab-8cde-1234567890ab",
+            ["a1b2c3d4-5678-40ab-8cde-1234567890ab"],
+        ],
         description=(
-            "Dataset UUIDs to search (required for datasets shared with you)."
-            " When provided, the datasets name list is ignored."
+            "Dataset UUID or list of UUIDs to search (required for datasets shared with you). "
+            "When provided, the datasets name list is ignored."
         ),
     )
     query: str = Field(default="What is in the document?")
     system_prompt: Optional[str] = Field(
         default="Answer the question using the provided context. Be as brief as possible."
     )
-    node_name: Optional[list[str]] = Field(
+    node_name: OptionalStringList = Field(
         default=None,
-        examples=[["tech_docs"]],
+        examples=["tech_docs", ["tech_docs"]],
         description=(
-            "Restrict results to nodes in these node_sets"
-            " (the node_set values used during add/remember)."
+            "Node set name or list of names to restrict results "
+            "(the node_set values used during add/remember)."
         ),
     )
     top_k: Optional[int] = Field(default=15)

--- a/cognee/api/v1/update/routers/get_update_router.py
+++ b/cognee/api/v1/update/routers/get_update_router.py
@@ -1,9 +1,8 @@
 from fastapi.responses import JSONResponse
 from fastapi import File, UploadFile as UF, Depends, Form, Query, status
-from typing import Optional, Annotated
+from typing import Annotated, List, Optional
 from fastapi import APIRouter
 from fastapi.encoders import jsonable_encoder
-from typing import List
 from uuid import UUID
 from pydantic import WithJsonSchema
 from cognee.shared.logging_utils import get_logger
@@ -49,7 +48,7 @@ def get_update_router() -> APIRouter:
             description="UUID of the dataset containing the document to update.",
             examples=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
         ),
-        data: List[UploadFile] = File(
+        data: Optional[List[UploadFile]] = File(
             default=None,
             description=(
                 "New version of the document that replaces the existing one. The existing "

--- a/cognee/tests/unit/api/test_dto_type_normalization.py
+++ b/cognee/tests/unit/api/test_dto_type_normalization.py
@@ -1,0 +1,92 @@
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from cognee.api.dto_types import (
+    _coerce_optional_str_list,
+    _coerce_optional_uuid_list,
+)
+from cognee.api.v1.cognify.routers.get_cognify_router import CognifyPayloadDTO
+from cognee.api.v1.recall.routers.get_recall_router import RecallPayloadDTO
+from cognee.api.v1.search.routers.get_search_router import SearchPayloadDTO
+
+
+class TestCoercionHelpers:
+    def test_coerce_optional_str_list_single_string(self):
+        assert _coerce_optional_str_list("alpha") == ["alpha"]
+
+    def test_coerce_optional_str_list_list(self):
+        assert _coerce_optional_str_list(["a", "b"]) == ["a", "b"]
+
+    def test_coerce_optional_str_list_none_and_empty(self):
+        assert _coerce_optional_str_list(None) is None
+        assert _coerce_optional_str_list("") is None
+        assert _coerce_optional_str_list("   ") is None
+
+    def test_coerce_optional_str_list_rejects_invalid_type(self):
+        with pytest.raises(ValueError):
+            _coerce_optional_str_list(42)
+
+    def test_coerce_optional_uuid_list_single_uuid(self):
+        value = uuid4()
+        assert _coerce_optional_uuid_list(value) == [value]
+
+    def test_coerce_optional_uuid_list_string_uuid(self):
+        value = uuid4()
+        assert _coerce_optional_uuid_list(str(value)) == [value]
+
+    def test_coerce_optional_uuid_list_list(self):
+        first = uuid4()
+        second = uuid4()
+        assert _coerce_optional_uuid_list([first, second]) == [first, second]
+
+
+class TestCognifyPayloadDTO:
+    def test_accepts_single_dataset_name(self):
+        payload = CognifyPayloadDTO(datasets="shared_dataset")
+        assert payload.datasets == ["shared_dataset"]
+        assert payload.dataset_ids is None
+
+    def test_accepts_single_dataset_id(self):
+        dataset_id = uuid4()
+        payload = CognifyPayloadDTO(dataset_ids=dataset_id)
+        assert payload.dataset_ids == [dataset_id]
+
+    def test_accepts_dataset_name_list(self):
+        payload = CognifyPayloadDTO(datasets=["a", "b"])
+        assert payload.datasets == ["a", "b"]
+
+
+class TestSearchPayloadDTO:
+    def test_accepts_single_dataset_and_node_name(self):
+        payload = SearchPayloadDTO(
+            query="q",
+            datasets="main_dataset",
+            node_name="tech_docs",
+        )
+        assert payload.datasets == ["main_dataset"]
+        assert payload.node_name == ["tech_docs"]
+
+    def test_accepts_single_dataset_id(self):
+        dataset_id = uuid4()
+        payload = SearchPayloadDTO(query="q", dataset_ids=dataset_id)
+        assert payload.dataset_ids == [dataset_id]
+
+
+class TestRecallPayloadDTO:
+    def test_accepts_single_values(self):
+        dataset_id = uuid4()
+        payload = RecallPayloadDTO(
+            query="q",
+            datasets="main_dataset",
+            dataset_ids=dataset_id,
+            node_name="memories",
+        )
+        assert payload.datasets == ["main_dataset"]
+        assert payload.dataset_ids == [dataset_id]
+        assert payload.node_name == ["memories"]
+
+    def test_rejects_invalid_dataset_id_type(self):
+        with pytest.raises(ValidationError):
+            RecallPayloadDTO(query="q", dataset_ids=12345)


### PR DESCRIPTION
Closes #2049

## Summary

API routers now accept the same flexible input shapes as the Python SDK. Shared `OptionalStringList` / `OptionalUUIDList` coercions normalize single values to lists for cognify, search, and recall. Add/update upload fields are typed as `Optional[List[UploadFile]]` for accurate OpenAPI docs.

## Test plan

- [x] `uv run pytest cognee/tests/unit/api/test_dto_type_normalization.py -v`
- [x] `uv run ruff check` on changed files

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.