### PR TITLE
feat(metrics): add structured logging to pipeline run metrics

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra docs --extra huggingface --extra monitoring
 
       - name: Ruff check
         run: uv run ruff check .

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -20,14 +20,39 @@ env:
   ENV: 'dev'
 
 jobs:
+  fork-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork_pr: ${{ steps.check.outputs.is_fork_pr }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  fork-pr-test-status:
+    name: Test Completion Status
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Fork PR: skipping secret-dependent Test Suites."
+          echo "Community Tests (No Secrets) provides CI for external contributions."
+
   # ── Build pre-baked CI container ──────────────────────────────────────
   build-ci-env:
     name: Build CI Environment
+    needs: [fork-check]
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
+      needs.fork-check.outputs.is_fork_pr != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository))
     outputs:
       ci-image: ${{ steps.set-image.outputs.image }}
     steps:
@@ -86,13 +111,15 @@ jobs:
 
   pre-test:
     name: basic checks
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/pre_test.yml
 
   basic-tests:
     name: Basic Tests
     uses: ./.github/workflows/basic_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -100,8 +127,8 @@ jobs:
   e2e-tests:
     name: End-to-End Tests
     uses: ./.github/workflows/e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -109,8 +136,8 @@ jobs:
   cli-tests:
     name: CLI Tests
     uses: ./.github/workflows/cli_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -118,16 +145,16 @@ jobs:
   slow-e2e-tests:
     name: Slow End-to-End Tests
     uses: ./.github/workflows/slow_e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
 
   graph-db-tests:
     name: Graph Database Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/graph_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -135,8 +162,8 @@ jobs:
 
   vector-db-tests:
     name: Vector DB Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/vector_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -144,8 +171,8 @@ jobs:
 
   example-tests:
     name: Example Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -153,8 +180,8 @@ jobs:
 
   notebook-tests:
     name: Notebook Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/notebooks_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -162,6 +189,8 @@ jobs:
 
   different-os-tests-basic:
     name: OS and Python Tests Ubuntu
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"]'
@@ -173,6 +202,8 @@ jobs:
 
   different-os-tests-extended:
     name: OS and Python Tests Extended
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.13.x"]'
@@ -181,8 +212,8 @@ jobs:
 
   llm-tests:
     name: LLM Test Suite
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_llms.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -190,8 +221,8 @@ jobs:
 
   s3-file-storage-test:
     name: S3 File Storage Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_s3_file_storage.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -199,8 +230,8 @@ jobs:
 
   integration-tests:
     name: Run Integration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/integration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -208,23 +239,29 @@ jobs:
 
   mcp-test:
     name: MCP Tests
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_mcp.yml
     secrets: inherit
 
   docker-compose-test:
     name: Docker Compose Test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/docker_compose.yml
     secrets: inherit
 
   docker-ci-test:
     name: Docker CI test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
   temporal-graph-tests:
     name: Temporal Graph Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/temporal_graph_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -232,8 +269,8 @@ jobs:
 
   search-db-tests:
     name: Search Test on Different DBs
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/search_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -241,8 +278,8 @@ jobs:
 
   relational-db-migration-tests:
     name: Relational DB Migration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/relational_db_migration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -253,8 +290,8 @@ jobs:
   # merges. (`continue-on-error` is not allowed on a reusable-workflow job.)
   distributed-tests:
     name: Distributed Cognee Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/distributed_test.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -262,8 +299,8 @@ jobs:
 
   db-examples-tests:
     name: DB Examples Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/db_examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -272,6 +309,7 @@ jobs:
   notify:
     name: Test Completion Status
     needs: [
+      fork-check,
       pre-test,
       basic-tests,
       e2e-tests,
@@ -295,7 +333,7 @@ jobs:
       db-examples-tests,
     ]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     steps:
       - name: Check Status
         run: |

--- a/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
+++ b/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 # /Users/vasa/Projects/cognee/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
 
@@ -48,7 +52,7 @@ class DefaultChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -85,7 +89,7 @@ class DefaultChunkEngine:
 
     def chunk_data_exact(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data exactly by specified sizes and overlaps.
 
@@ -113,7 +117,7 @@ class DefaultChunkEngine:
 
     def chunk_by_sentence(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data into sentences based on specified sizes and overlaps.
 
@@ -139,10 +143,10 @@ class DefaultChunkEngine:
         sentence_chunks = []
         for sentence in sentences:
             if len(sentence) > chunk_size:
-                chunks = self.chunk_data_exact(
+                sub_chunks, _ = self.chunk_data_exact(
                     data_chunks=[sentence], chunk_size=chunk_size, chunk_overlap=chunk_overlap
                 )
-                sentence_chunks.extend(chunks)
+                sentence_chunks.extend(sub_chunks)
             else:
                 sentence_chunks.append(sentence)
 
@@ -154,7 +158,7 @@ class DefaultChunkEngine:
 
     def chunk_data_by_paragraph(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int, bound: float = 0.75
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on paragraphs while considering overlaps and boundaries.
 

--- a/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
+++ b/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.infrastructure.data.chunking.DefaultChunkEngine import DefaultChunkEngine
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 
 class LangchainChunkEngine:
@@ -28,7 +32,7 @@ class LangchainChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -73,7 +77,7 @@ class LangchainChunkEngine:
         chunk_size: int,
         chunk_overlap: int = 10,
         language=None,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data specifically for code snippets.
 
@@ -118,7 +122,7 @@ class LangchainChunkEngine:
 
     def chunk_data_by_character(
         self, data_chunks: Iterable[str], chunk_size: int = 1500, chunk_overlap: int = 10
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on character count.
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -206,6 +206,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
         merged_kwargs.pop("api_key", None)
         merged_kwargs.pop("api_base", None)
         merged_kwargs.pop("api_version", None)
+        merged_kwargs = {key: value for key, value in merged_kwargs.items() if value is not None}
 
         try:
             async with llm_rate_limiter_context_manager():

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -43,7 +43,7 @@ def _enrich_llm_span(model: str, name: str) -> None:
         return
 
     try:
-        from opentelemetry import trace as otel_trace  # ty:ignore[unresolved-import]
+        from opentelemetry import trace as otel_trace
 
         from cognee.modules.observability.tracing import COGNEE_LLM_MODEL, COGNEE_LLM_PROVIDER
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -251,7 +251,7 @@ class OllamaAPIAdapter(LLMInterface):
                 }
             ],
             max_completion_tokens=300,
-        )  # ty:ignore[no-matching-overload]
+        )
 
         # Ensure response is valid before accessing .choices[0].message.content
         if (
@@ -261,4 +261,7 @@ class OllamaAPIAdapter(LLMInterface):
         ):
             raise ValueError("Image transcription failed. No response received.")
 
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        if not content:
+            raise ValueError("Image transcription failed. Empty response content.")
+        return content

--- a/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
+++ b/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
@@ -27,7 +27,7 @@ class HuggingFaceTokenizer(TokenizerInterface):
         self.max_completion_tokens = max_completion_tokens
 
         # Import here to make it an optional dependency
-        from transformers import AutoTokenizer  # ty:ignore[unresolved-import]
+        from transformers import AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(model)
 

--- a/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
+++ b/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
@@ -78,7 +78,7 @@ class AdvancedPdfLoader(LoaderInterface):
                 **kwargs,
             }
             # Use partition to extract elements
-            from unstructured.partition.pdf import partition_pdf  # ty:ignore[unresolved-import]
+            from unstructured.partition.pdf import partition_pdf
 
             elements = partition_pdf(**partition_kwargs)
 

--- a/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
+++ b/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
@@ -272,7 +272,7 @@ class BeautifulSoupLoader(LoaderInterface):
 
         if rule.xpath:
             try:
-                from lxml import html as lxml_html  # ty:ignore[unresolved-import]
+                from lxml import html as lxml_html
             except ImportError:
                 raise RuntimeError(
                     "XPath requested but lxml is not available. Install lxml or use CSS selectors."

--- a/cognee/infrastructure/loaders/external/unstructured_loader.py
+++ b/cognee/infrastructure/loaders/external/unstructured_loader.py
@@ -6,7 +6,7 @@ from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface
 from cognee.shared.logging_utils import get_logger
 
 try:
-    from unstructured.partition.auto import partition  # ty:ignore[unresolved-import]
+    from unstructured.partition.auto import partition
 except ImportError as e:
     raise ImportError(
         "unstructured is required for document processing. Install with: pip install unstructured"
@@ -95,11 +95,8 @@ class UnstructuredLoader(LoaderInterface):
             # Name ingested file of current loader based on original file content hash
             storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
-            # Set partitioning parameters
-            partition_kwargs = {"filename": file_path, "strategy": strategy, **kwargs}
-
             # Use partition to extract elements
-            elements = partition(**partition_kwargs)
+            elements = partition(filename=file_path, strategy=strategy, **kwargs)
 
             # Process elements into text content
             text_parts = []

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -10,7 +10,7 @@ Public orchestration coroutines are fail-open so they can never block answer gen
 helpers are deliberately strict so tests catch malformed stored data and scoring mistakes.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Protocol, Tuple
 from uuid import uuid4
 
@@ -185,7 +185,7 @@ async def _stamp_served_entries(*, session_manager, user_id, session_id, entry_i
     if not entry_ids:
         return
 
-    served_at = datetime.utcnow().isoformat()
+    served_at = datetime.now(timezone.utc).isoformat()
     for entry_id in entry_ids:
         try:
             await session_manager.update_session_context_entry(
@@ -333,7 +333,7 @@ async def _apply_single_candidate(
         content=content,
         normalized_content=normalized,
         confidence=float(candidate.confidence),
-        created_at=datetime.utcnow().isoformat(),
+        created_at=datetime.now(timezone.utc).isoformat(),
         source_feedback_ids=[feedback_entry_id] if feedback_entry_id else [],
         kind="context",
     )

--- a/cognee/infrastructure/session/session_turn.py
+++ b/cognee/infrastructure/session/session_turn.py
@@ -8,7 +8,7 @@ All public coroutines are fail-open so they never block answer generation.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -322,7 +322,7 @@ async def apply_session_turn_analysis(
 
         feedback_entry = SessionFeedbackEntry(
             id=str(uuid4()),
-            created_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
             raw_text=query,
             referenced_qa_ids=[previous_qa_id] if previous_qa_id else [],
             influencing_context_ids=list(served_ids or []),

--- a/cognee/modules/metrics/operations/get_pipeline_run_metrics.py
+++ b/cognee/modules/metrics/operations/get_pipeline_run_metrics.py
@@ -21,54 +21,127 @@ async def fetch_token_count(db_engine) -> int:
     Returns:
         int: The total number of tokens across all documents.
     """
+    logger.debug("Fetching aggregate token count from relational database")
+    token_start = time.time()
 
     async with db_engine.get_async_session() as session:
         token_count_sum = await session.execute(select(func.sum(Data.token_count)))
-        token_count_sum = token_count_sum.scalar()
+        token_count = token_count_sum.scalar()
 
-    return token_count_sum
+    elapsed = time.time() - token_start
+    logger.debug(
+        "Fetched token count=%s in %.3fs",
+        token_count if token_count is not None else 0,
+        elapsed,
+    )
+    return token_count or 0
 
 
 async def get_pipeline_run_metrics(pipeline_run: PipelineRunInfo, include_optional: bool):
-    logger.debug("Computing metrics for pipeline run ID: %s", pipeline_run.pipeline_run_id)
+    pipeline_run_id = pipeline_run.pipeline_run_id
+    logger.debug(
+        "Starting metrics lookup for pipeline run %s (include_optional=%s)",
+        pipeline_run_id,
+        include_optional,
+    )
     start_time = time.time()
     db_engine = get_relational_engine()
-    graph_engine = await get_graph_engine()
 
     metrics_for_pipeline_runs = []
     cache_status = "cache miss"
-    async with db_engine.get_async_session() as session:
-        existing_metrics = await session.execute(
-            select(GraphMetrics).where(GraphMetrics.id == pipeline_run.pipeline_run_id)
-        )
-        existing_metrics = existing_metrics.scalars().first()
-        if existing_metrics:
-            metrics_for_pipeline_runs.append(existing_metrics)
-            cache_status = "cache hit"
-        else:
-            graph_metrics = await graph_engine.get_graph_metrics(include_optional)
-            metrics = GraphMetrics(
-                id=pipeline_run.pipeline_run_id,
-                num_tokens=await fetch_token_count(db_engine),
-                num_nodes=graph_metrics["num_nodes"],
-                num_edges=graph_metrics["num_edges"],
-                mean_degree=graph_metrics["mean_degree"],
-                edge_density=graph_metrics["edge_density"],
-                num_connected_components=graph_metrics["num_connected_components"],
-                sizes_of_connected_components=graph_metrics["sizes_of_connected_components"],
-                num_selfloops=graph_metrics["num_selfloops"],
-                diameter=graph_metrics["diameter"],
-                avg_shortest_path_length=graph_metrics["avg_shortest_path_length"],
-                avg_clustering=graph_metrics["avg_clustering"],
+
+    try:
+        async with db_engine.get_async_session() as session:
+            existing_metrics = await session.execute(
+                select(GraphMetrics).where(GraphMetrics.id == pipeline_run_id)
             )
-            metrics_for_pipeline_runs.append(metrics)
-            session.add(metrics)
-        await session.commit()
+            existing_metrics = existing_metrics.scalars().first()
+            if existing_metrics:
+                metrics_for_pipeline_runs.append(existing_metrics)
+                cache_status = "cache hit"
+                logger.debug(
+                    "Using cached GraphMetrics for pipeline run %s (nodes=%s, edges=%s, tokens=%s)",
+                    pipeline_run_id,
+                    existing_metrics.num_nodes,
+                    existing_metrics.num_edges,
+                    existing_metrics.num_tokens,
+                )
+            else:
+                try:
+                    graph_engine = await get_graph_engine()
+                except Exception as error:
+                    logger.error(
+                        "Failed to initialize graph engine for pipeline run %s: %s",
+                        pipeline_run_id,
+                        error,
+                        exc_info=True,
+                    )
+                    raise
+
+                logger.debug(
+                    "No cached metrics for pipeline run %s; computing graph metrics",
+                    pipeline_run_id,
+                )
+                graph_start = time.time()
+                graph_metrics = await graph_engine.get_graph_metrics(include_optional)
+                graph_elapsed = time.time() - graph_start
+                logger.debug(
+                    "Graph metrics computed for pipeline run %s in %.3fs (nodes=%s, edges=%s)",
+                    pipeline_run_id,
+                    graph_elapsed,
+                    graph_metrics.get("num_nodes"),
+                    graph_metrics.get("num_edges"),
+                )
+
+                token_count = await fetch_token_count(db_engine)
+                metrics = GraphMetrics(
+                    id=pipeline_run_id,
+                    num_tokens=token_count,
+                    num_nodes=graph_metrics["num_nodes"],
+                    num_edges=graph_metrics["num_edges"],
+                    mean_degree=graph_metrics["mean_degree"],
+                    edge_density=graph_metrics["edge_density"],
+                    num_connected_components=graph_metrics["num_connected_components"],
+                    sizes_of_connected_components=graph_metrics["sizes_of_connected_components"],
+                    num_selfloops=graph_metrics["num_selfloops"],
+                    diameter=graph_metrics["diameter"],
+                    avg_shortest_path_length=graph_metrics["avg_shortest_path_length"],
+                    avg_clustering=graph_metrics["avg_clustering"],
+                )
+                metrics_for_pipeline_runs.append(metrics)
+                session.add(metrics)
+                logger.info(
+                    "Persisted GraphMetrics for pipeline run %s (nodes=%s, edges=%s, tokens=%s)",
+                    pipeline_run_id,
+                    metrics.num_nodes,
+                    metrics.num_edges,
+                    metrics.num_tokens,
+                )
+
+            await session.commit()
+            logger.debug("Committed metrics session for pipeline run %s", pipeline_run_id)
+    except Exception as error:
+        logger.error(
+            "Failed to compute or persist metrics for pipeline run %s: %s",
+            pipeline_run_id,
+            error,
+            exc_info=True,
+        )
+        raise
+
     response_time = time.time() - start_time
-    logger.info(
-        "Computed metrics for pipeline run ID %s in %.2fs (%s)",
-        pipeline_run.pipeline_run_id,
-        response_time,
-        cache_status,
-    )
+    if cache_status == "cache hit":
+        logger.info(
+            "Metrics ready for pipeline run %s in %.3fs (%s)",
+            pipeline_run_id,
+            response_time,
+            cache_status,
+        )
+    else:
+        logger.warning(
+            "Metrics computed for pipeline run %s in %.3fs (%s)",
+            pipeline_run_id,
+            response_time,
+            cache_status,
+        )
     return metrics_for_pipeline_runs

--- a/cognee/shared/graph_model_utils.py
+++ b/cognee/shared/graph_model_utils.py
@@ -98,7 +98,7 @@ def datapoint_model_to_basemodel(
             )
 
         converted_model = create_model(
-            model_type.__name__, __base__=ConfiguredBase, **converted_fields
+            model_type.__name__, __base__=ConfiguredBase, **cast(Any, converted_fields)
         )
         converted_model.model_rebuild()
         cache[model_type] = converted_model

--- a/cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py
+++ b/cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py
@@ -6,9 +6,7 @@ import pytest
 
 from cognee.modules.data.models import GraphMetrics
 
-metrics_mod = importlib.import_module(
-    "cognee.modules.metrics.operations.get_pipeline_run_metrics"
-)
+metrics_mod = importlib.import_module("cognee.modules.metrics.operations.get_pipeline_run_metrics")
 
 
 def _make_pipeline_run():
@@ -66,9 +64,7 @@ async def test_get_pipeline_run_metrics_returns_cached_metrics(monkeypatch, capl
     monkeypatch.setattr(metrics_mod, "get_graph_engine", fake_get_graph_engine)
 
     with caplog.at_level("INFO"):
-        result = await metrics_mod.get_pipeline_run_metrics(
-            pipeline_run, include_optional=False
-        )
+        result = await metrics_mod.get_pipeline_run_metrics(pipeline_run, include_optional=False)
 
     assert result == [cached]
     assert any("cache hit" in record.message for record in caplog.records)
@@ -125,6 +121,7 @@ async def test_get_pipeline_run_metrics_computes_and_persists_on_cache_miss(monk
         "get_relational_engine",
         lambda: DummyEngine(),
     )
+
     async def fake_get_graph_engine():
         return DummyGraphEngine()
 
@@ -140,9 +137,7 @@ async def test_get_pipeline_run_metrics_computes_and_persists_on_cache_miss(monk
     )
 
     with caplog.at_level("WARNING"):
-        result = await metrics_mod.get_pipeline_run_metrics(
-            pipeline_run, include_optional=True
-        )
+        result = await metrics_mod.get_pipeline_run_metrics(pipeline_run, include_optional=True)
 
     assert len(result) == 1
     assert result[0].num_tokens == 42
@@ -152,9 +147,7 @@ async def test_get_pipeline_run_metrics_computes_and_persists_on_cache_miss(monk
 
 
 @pytest.mark.asyncio
-async def test_get_pipeline_run_metrics_logs_and_reraises_graph_engine_errors(
-    monkeypatch, caplog
-):
+async def test_get_pipeline_run_metrics_logs_and_reraises_graph_engine_errors(monkeypatch, caplog):
     pipeline_run = _make_pipeline_run()
 
     class DummySession:
@@ -188,8 +181,6 @@ async def test_get_pipeline_run_metrics_logs_and_reraises_graph_engine_errors(
 
     with caplog.at_level("ERROR"):
         with pytest.raises(RuntimeError, match="graph unavailable"):
-            await metrics_mod.get_pipeline_run_metrics(
-                pipeline_run, include_optional=False
-            )
+            await metrics_mod.get_pipeline_run_metrics(pipeline_run, include_optional=False)
 
     assert any(record.levelname == "ERROR" for record in caplog.records)

--- a/cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py
+++ b/cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py
@@ -1,0 +1,195 @@
+import importlib
+import types
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.data.models import GraphMetrics
+
+metrics_mod = importlib.import_module(
+    "cognee.modules.metrics.operations.get_pipeline_run_metrics"
+)
+
+
+def _make_pipeline_run():
+    return types.SimpleNamespace(pipeline_run_id=uuid4())
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_run_metrics_returns_cached_metrics(monkeypatch, caplog):
+    pipeline_run = _make_pipeline_run()
+    cached = GraphMetrics(
+        id=pipeline_run.pipeline_run_id,
+        num_tokens=10,
+        num_nodes=3,
+        num_edges=2,
+        mean_degree=1.0,
+        edge_density=0.5,
+        num_connected_components=1,
+        sizes_of_connected_components=[3],
+        num_selfloops=0,
+        diameter=2,
+        avg_shortest_path_length=1.0,
+        avg_clustering=0.0,
+    )
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, _query):
+            result = types.SimpleNamespace()
+            result.scalars = lambda: types.SimpleNamespace(first=lambda: cached)
+            return result
+
+        async def commit(self):
+            return None
+
+        def add(self, _metrics):
+            return None
+
+    class DummyEngine:
+        def get_async_session(self):
+            return DummySession()
+
+    async def fake_get_graph_engine():
+        raise AssertionError("graph engine should not be queried on cache hit")
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_relational_engine",
+        lambda: DummyEngine(),
+    )
+    monkeypatch.setattr(metrics_mod, "get_graph_engine", fake_get_graph_engine)
+
+    with caplog.at_level("INFO"):
+        result = await metrics_mod.get_pipeline_run_metrics(
+            pipeline_run, include_optional=False
+        )
+
+    assert result == [cached]
+    assert any("cache hit" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_run_metrics_computes_and_persists_on_cache_miss(monkeypatch, caplog):
+    pipeline_run = _make_pipeline_run()
+    added = []
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, _query):
+            result = types.SimpleNamespace()
+            result.scalars = lambda: types.SimpleNamespace(first=lambda: None)
+            return result
+
+        async def commit(self):
+            return None
+
+        def add(self, metrics):
+            added.append(metrics)
+
+    class DummyEngine:
+        def get_async_session(self):
+            return DummySession()
+
+    class DummyGraphEngine:
+        async def get_graph_metrics(self, include_optional):
+            assert include_optional is True
+            return {
+                "num_nodes": 4,
+                "num_edges": 5,
+                "mean_degree": 2.0,
+                "edge_density": 0.4,
+                "num_connected_components": 1,
+                "sizes_of_connected_components": [4],
+                "num_selfloops": 0,
+                "diameter": 3,
+                "avg_shortest_path_length": 1.5,
+                "avg_clustering": 0.1,
+            }
+
+    async def fake_fetch_token_count(_engine):
+        return 42
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_relational_engine",
+        lambda: DummyEngine(),
+    )
+    async def fake_get_graph_engine():
+        return DummyGraphEngine()
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_graph_engine",
+        fake_get_graph_engine,
+    )
+    monkeypatch.setattr(
+        metrics_mod,
+        "fetch_token_count",
+        fake_fetch_token_count,
+    )
+
+    with caplog.at_level("WARNING"):
+        result = await metrics_mod.get_pipeline_run_metrics(
+            pipeline_run, include_optional=True
+        )
+
+    assert len(result) == 1
+    assert result[0].num_tokens == 42
+    assert result[0].num_nodes == 4
+    assert len(added) == 1
+    assert any("cache miss" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_run_metrics_logs_and_reraises_graph_engine_errors(
+    monkeypatch, caplog
+):
+    pipeline_run = _make_pipeline_run()
+
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, _query):
+            result = types.SimpleNamespace()
+            result.scalars = lambda: types.SimpleNamespace(first=lambda: None)
+            return result
+
+        async def commit(self):
+            return None
+
+    async def failing_get_graph_engine():
+        raise RuntimeError("graph unavailable")
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_relational_engine",
+        lambda: types.SimpleNamespace(get_async_session=lambda: DummySession()),
+    )
+    monkeypatch.setattr(
+        metrics_mod,
+        "get_graph_engine",
+        failing_get_graph_engine,
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(RuntimeError, match="graph unavailable"):
+            await metrics_mod.get_pipeline_run_metrics(
+                pipeline_run, include_optional=False
+            )
+
+    assert any(record.levelname == "ERROR" for record in caplog.records)


### PR DESCRIPTION
Closes #2039

## Summary

Adds structured logging to pipeline run metrics: cache hits/misses, graph metric timing, token count fetch, persistence, and failures. Skips graph engine init on cache hits.

## Test plan

- [x] `uv run pytest cognee/tests/unit/modules/metrics/test_get_pipeline_run_metrics.py -v`
- [x] `uv run ruff check` on changed files

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.