### PR TITLE
fix(llm): add opt-in timeout and hang diagnostics for local models

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra docs --extra huggingface --extra monitoring
 
       - name: Ruff check
         run: uv run ruff check .

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -20,14 +20,39 @@ env:
   ENV: 'dev'
 
 jobs:
+  fork-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork_pr: ${{ steps.check.outputs.is_fork_pr }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  fork-pr-test-status:
+    name: Test Completion Status
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Fork PR: skipping secret-dependent Test Suites."
+          echo "Community Tests (No Secrets) provides CI for external contributions."
+
   # ── Build pre-baked CI container ──────────────────────────────────────
   build-ci-env:
     name: Build CI Environment
+    needs: [fork-check]
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
+      needs.fork-check.outputs.is_fork_pr != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository))
     outputs:
       ci-image: ${{ steps.set-image.outputs.image }}
     steps:
@@ -86,13 +111,15 @@ jobs:
 
   pre-test:
     name: basic checks
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/pre_test.yml
 
   basic-tests:
     name: Basic Tests
     uses: ./.github/workflows/basic_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -100,8 +127,8 @@ jobs:
   e2e-tests:
     name: End-to-End Tests
     uses: ./.github/workflows/e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -109,8 +136,8 @@ jobs:
   cli-tests:
     name: CLI Tests
     uses: ./.github/workflows/cli_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
@@ -118,16 +145,16 @@ jobs:
   slow-e2e-tests:
     name: Slow End-to-End Tests
     uses: ./.github/workflows/slow_e2e_tests.yml
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
     secrets: inherit
 
   graph-db-tests:
     name: Graph Database Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/graph_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -135,8 +162,8 @@ jobs:
 
   vector-db-tests:
     name: Vector DB Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/vector_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -144,8 +171,8 @@ jobs:
 
   example-tests:
     name: Example Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -153,8 +180,8 @@ jobs:
 
   notebook-tests:
     name: Notebook Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/notebooks_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -162,6 +189,8 @@ jobs:
 
   different-os-tests-basic:
     name: OS and Python Tests Ubuntu
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"]'
@@ -173,6 +202,8 @@ jobs:
 
   different-os-tests-extended:
     name: OS and Python Tests Extended
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_different_operating_systems.yml
     with:
       python-versions: '["3.13.x"]'
@@ -181,8 +212,8 @@ jobs:
 
   llm-tests:
     name: LLM Test Suite
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_llms.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -190,8 +221,8 @@ jobs:
 
   s3-file-storage-test:
     name: S3 File Storage Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/test_s3_file_storage.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -199,8 +230,8 @@ jobs:
 
   integration-tests:
     name: Run Integration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/integration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -208,23 +239,29 @@ jobs:
 
   mcp-test:
     name: MCP Tests
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/test_mcp.yml
     secrets: inherit
 
   docker-compose-test:
     name: Docker Compose Test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/docker_compose.yml
     secrets: inherit
 
   docker-ci-test:
     name: Docker CI test
+    needs: [fork-check]
+    if: needs.fork-check.outputs.is_fork_pr != 'true'
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
   temporal-graph-tests:
     name: Temporal Graph Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/temporal_graph_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -232,8 +269,8 @@ jobs:
 
   search-db-tests:
     name: Search Test on Different DBs
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/search_db_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -241,8 +278,8 @@ jobs:
 
   relational-db-migration-tests:
     name: Relational DB Migration Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/relational_db_migration_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -253,8 +290,8 @@ jobs:
   # merges. (`continue-on-error` is not allowed on a reusable-workflow job.)
   distributed-tests:
     name: Distributed Cognee Test
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/distributed_test.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -262,8 +299,8 @@ jobs:
 
   db-examples-tests:
     name: DB Examples Tests
-    needs: [ build-ci-env ]
-    if: ${{ !cancelled() }}
+    needs: [fork-check, build-ci-env]
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     uses: ./.github/workflows/db_examples_tests.yml
     with:
       ci-image: ${{ needs.build-ci-env.outputs.ci-image || '' }}
@@ -272,6 +309,7 @@ jobs:
   notify:
     name: Test Completion Status
     needs: [
+      fork-check,
       pre-test,
       basic-tests,
       e2e-tests,
@@ -295,7 +333,7 @@ jobs:
       db-examples-tests,
     ]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.fork-check.outputs.is_fork_pr != 'true' }}
     steps:
       - name: Check Status
         run: |

--- a/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
+++ b/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 # /Users/vasa/Projects/cognee/cognee/infrastructure/data/chunking/DefaultChunkEngine.py
 
@@ -48,7 +52,7 @@ class DefaultChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -85,7 +89,7 @@ class DefaultChunkEngine:
 
     def chunk_data_exact(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data exactly by specified sizes and overlaps.
 
@@ -113,7 +117,7 @@ class DefaultChunkEngine:
 
     def chunk_by_sentence(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data into sentences based on specified sizes and overlaps.
 
@@ -139,10 +143,10 @@ class DefaultChunkEngine:
         sentence_chunks = []
         for sentence in sentences:
             if len(sentence) > chunk_size:
-                chunks = self.chunk_data_exact(
+                sub_chunks, _ = self.chunk_data_exact(
                     data_chunks=[sentence], chunk_size=chunk_size, chunk_overlap=chunk_overlap
                 )
-                sentence_chunks.extend(chunks)
+                sentence_chunks.extend(sub_chunks)
             else:
                 sentence_chunks.append(sentence)
 
@@ -154,7 +158,7 @@ class DefaultChunkEngine:
 
     def chunk_data_by_paragraph(
         self, data_chunks: Iterable[str], chunk_size: int, chunk_overlap: int, bound: float = 0.75
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on paragraphs while considering overlaps and boundaries.
 

--- a/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
+++ b/cognee/infrastructure/data/chunking/LangchainChunkingEngine.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import Any
 
 from cognee.infrastructure.data.chunking.DefaultChunkEngine import DefaultChunkEngine
 from cognee.shared.data_models import ChunkStrategy
+
+ChunkNumbering = list[Any]
+ChunkResult = tuple[list[str], ChunkNumbering]
 
 
 class LangchainChunkEngine:
@@ -28,7 +32,7 @@ class LangchainChunkEngine:
         source_data: Iterable[str],
         chunk_size: int,
         chunk_overlap: int,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on the specified strategy.
 
@@ -73,7 +77,7 @@ class LangchainChunkEngine:
         chunk_size: int,
         chunk_overlap: int = 10,
         language=None,
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data specifically for code snippets.
 
@@ -118,7 +122,7 @@ class LangchainChunkEngine:
 
     def chunk_data_by_character(
         self, data_chunks: Iterable[str], chunk_size: int = 1500, chunk_overlap: int = 10
-    ) -> tuple[list[str], list[int]]:
+    ) -> ChunkResult:
         """
         Chunk data based on character count.
 

--- a/cognee/infrastructure/llm/call_timeout.py
+++ b/cognee/infrastructure/llm/call_timeout.py
@@ -1,0 +1,85 @@
+"""Opt-in LLM call timeouts and slow-call diagnostics for local inference (#2902)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import suppress
+from typing import Awaitable, TypeVar
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+class LLMCallTimeoutError(TimeoutError):
+    """Raised when an opt-in LLM call timeout is exceeded."""
+
+
+def build_llm_call_label(*, provider: str, model: str, endpoint: str | None) -> str:
+    endpoint_display = endpoint or "<default>"
+    return f"provider={provider} model={model} endpoint={endpoint_display}"
+
+
+async def run_with_llm_call_limits(
+    coro: Awaitable[T],
+    *,
+    label: str,
+    timeout_seconds: int,
+    slow_warning_seconds: int,
+) -> T:
+    """
+    Execute an LLM request with optional diagnostics.
+
+    - ``timeout_seconds=0`` disables wall-clock abort (default, unlike #3126).
+    - ``slow_warning_seconds`` logs a warning if the call is still running after N seconds.
+    """
+    start = time.monotonic()
+    logger.debug("LLM call started (%s)", label)
+    warn_task: asyncio.Task | None = None
+
+    async def _log_slow_call_warning() -> None:
+        await asyncio.sleep(slow_warning_seconds)
+        logger.warning(
+            "LLM call still running after %ss (%s). "
+            "For local inference hangs, set LLM_CALL_TIMEOUT_SECONDS to fail fast.",
+            slow_warning_seconds,
+            label,
+        )
+
+    try:
+        if slow_warning_seconds > 0:
+            warn_task = asyncio.create_task(_log_slow_call_warning())
+
+        if timeout_seconds > 0:
+            try:
+                result = await asyncio.wait_for(coro, timeout=timeout_seconds)
+            except asyncio.TimeoutError as error:
+                raise LLMCallTimeoutError(
+                    f"LLM call exceeded LLM_CALL_TIMEOUT_SECONDS={timeout_seconds} ({label}). "
+                    "Increase the timeout or set LLM_CALL_TIMEOUT_SECONDS=0 to disable opt-in limits."
+                ) from error
+        else:
+            result = await coro
+
+        elapsed = time.monotonic() - start
+        if slow_warning_seconds > 0 and elapsed >= slow_warning_seconds:
+            logger.warning("LLM call completed slowly in %.2fs (%s)", elapsed, label)
+        else:
+            logger.debug("LLM call finished in %.2fs (%s)", elapsed, label)
+        return result
+    except Exception:
+        logger.error(
+            "LLM call failed after %.2fs (%s)",
+            time.monotonic() - start,
+            label,
+            exc_info=True,
+        )
+        raise
+    finally:
+        if warn_task is not None:
+            warn_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await warn_task

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -49,6 +49,8 @@ class LLMConfig(BaseSettings):
     llm_temperature: float = 0.0
     llm_streaming: bool = False
     llm_max_completion_tokens: int = 16384
+    llm_call_timeout_seconds: int = 0
+    llm_slow_call_warning_seconds: int = 60
 
     baml_llm_provider: str = "openai"
     baml_llm_model: str = "gpt-5-mini"
@@ -241,6 +243,8 @@ class LLMConfig(BaseSettings):
             "temperature": self.llm_temperature,
             "streaming": self.llm_streaming,
             "max_completion_tokens": self.llm_max_completion_tokens,
+            "llm_call_timeout_seconds": self.llm_call_timeout_seconds,
+            "llm_slow_call_warning_seconds": self.llm_slow_call_warning_seconds,
             "transcription_model": self.transcription_model,
             "graph_prompt_path": self.graph_prompt_path,
             "rate_limit_enabled": self.llm_rate_limit_enabled,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -206,6 +206,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
         merged_kwargs.pop("api_key", None)
         merged_kwargs.pop("api_base", None)
         merged_kwargs.pop("api_version", None)
+        merged_kwargs = {key: value for key, value in merged_kwargs.items() if value is not None}
 
         try:
             async with llm_rate_limiter_context_manager():

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -45,7 +45,7 @@ def _enrich_llm_span(model: str, name: str) -> None:
         return
 
     try:
-        from opentelemetry import trace as otel_trace  # ty:ignore[unresolved-import]
+        from opentelemetry import trace as otel_trace
 
         from cognee.modules.observability.tracing import COGNEE_LLM_MODEL, COGNEE_LLM_PROVIDER
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -19,6 +19,8 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
+from cognee.infrastructure.llm.call_timeout import build_llm_call_label, run_with_llm_call_limits
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.llm.exceptions import ContentPolicyFilterError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
@@ -177,25 +179,36 @@ class GenericAPIAdapter(LLMInterface):
         if response_model is str:
             return await self.acreate_str_output(text_input, system_prompt, **merged_kwargs)
 
+        llm_config = get_llm_context_config()
+        call_label = build_llm_call_label(
+            provider=llm_config.llm_provider,
+            model=self.model,
+            endpoint=self.endpoint,
+        )
         try:
             async with llm_rate_limiter_context_manager():
-                result = await self.aclient.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": system_prompt,
-                        },
-                        {
-                            "role": "user",
-                            "content": f"""{text_input}""",
-                        },
-                    ],
-                    max_retries=1,
-                    api_key=self.api_key,
-                    api_base=self.endpoint,
-                    response_model=response_model,
-                    **merged_kwargs,
+                result = await run_with_llm_call_limits(
+                    self.aclient.chat.completions.create(
+                        model=self.model,
+                        messages=[
+                            {
+                                "role": "system",
+                                "content": system_prompt,
+                            },
+                            {
+                                "role": "user",
+                                "content": f"""{text_input}""",
+                            },
+                        ],
+                        max_retries=1,
+                        api_key=self.api_key,
+                        api_base=self.endpoint,
+                        response_model=response_model,
+                        **merged_kwargs,
+                    ),
+                    label=call_label,
+                    timeout_seconds=llm_config.llm_call_timeout_seconds,
+                    slow_warning_seconds=llm_config.llm_slow_call_warning_seconds,
                 )
                 _enrich_llm_span(self.model, self.name)
                 return result
@@ -220,23 +233,28 @@ class GenericAPIAdapter(LLMInterface):
 
             try:
                 async with llm_rate_limiter_context_manager():
-                    return await self.aclient.chat.completions.create(
-                        model=fallback_model,
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": system_prompt,
-                            },
-                            {
-                                "role": "user",
-                                "content": f"""{text_input}""",
-                            },
-                        ],
-                        max_retries=1,
-                        api_key=self.fallback_api_key,
-                        api_base=self.fallback_endpoint,
-                        response_model=response_model,
-                        **fallback_llm_args,
+                    return await run_with_llm_call_limits(
+                        self.aclient.chat.completions.create(
+                            model=fallback_model,
+                            messages=[
+                                {
+                                    "role": "system",
+                                    "content": system_prompt,
+                                },
+                                {
+                                    "role": "user",
+                                    "content": f"""{text_input}""",
+                                },
+                            ],
+                            max_retries=1,
+                            api_key=self.fallback_api_key,
+                            api_base=self.fallback_endpoint,
+                            response_model=response_model,
+                            **fallback_llm_args,
+                        ),
+                        label=f"{call_label} fallback={fallback_model}",
+                        timeout_seconds=llm_config.llm_call_timeout_seconds,
+                        slow_warning_seconds=llm_config.llm_slow_call_warning_seconds,
                     )
             except (
                 ContentFilterFinishReasonError,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -264,7 +264,7 @@ class OllamaAPIAdapter(LLMInterface):
                 }
             ],
             max_completion_tokens=300,
-        )  # ty:ignore[no-matching-overload]
+        )
 
         # Ensure response is valid before accessing .choices[0].message.content
         if (
@@ -274,4 +274,7 @@ class OllamaAPIAdapter(LLMInterface):
         ):
             raise ValueError("Image transcription failed. No response received.")
 
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        if not content:
+            raise ValueError("Image transcription failed. Empty response content.")
+        return content

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -16,6 +16,8 @@ from tenacity import (
 )
 
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
+from cognee.infrastructure.llm.call_timeout import build_llm_call_label, run_with_llm_call_limits
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
 )
@@ -134,22 +136,33 @@ class OllamaAPIAdapter(LLMInterface):
                 )
             return response.choices[0].message.content or ""
 
+        llm_config = get_llm_context_config()
+        call_label = build_llm_call_label(
+            provider=llm_config.llm_provider,
+            model=self.model,
+            endpoint=self.endpoint,
+        )
         async with llm_rate_limiter_context_manager():
-            response = await self.aclient.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": system_prompt,
-                    },
-                    {
-                        "role": "user",
-                        "content": f"{text_input}",
-                    },
-                ],
-                max_retries=2,
-                response_model=response_model,
-                **merged_kwargs,
+            response = await run_with_llm_call_limits(
+                self.aclient.chat.completions.create(
+                    model=self.model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": system_prompt,
+                        },
+                        {
+                            "role": "user",
+                            "content": f"{text_input}",
+                        },
+                    ],
+                    max_retries=2,
+                    response_model=response_model,
+                    **merged_kwargs,
+                ),
+                label=call_label,
+                timeout_seconds=llm_config.llm_call_timeout_seconds,
+                slow_warning_seconds=llm_config.llm_slow_call_warning_seconds,
             )
 
         return response

--- a/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
+++ b/cognee/infrastructure/llm/tokenizer/HuggingFace/adapter.py
@@ -27,7 +27,7 @@ class HuggingFaceTokenizer(TokenizerInterface):
         self.max_completion_tokens = max_completion_tokens
 
         # Import here to make it an optional dependency
-        from transformers import AutoTokenizer  # ty:ignore[unresolved-import]
+        from transformers import AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(model)
 

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -96,7 +96,9 @@ async def test_llm_connection() -> None:
         msg = (
             f"LLM connection test timed out after {CONNECTION_TEST_TIMEOUT_SECONDS}s. "
             "Check that your LLM endpoint is reachable and responding. "
-            "Set COGNEE_SKIP_CONNECTION_TEST=true to bypass this check."
+            "For slow local inference (omlx/vLLM/custom), increase patience or set "
+            "COGNEE_SKIP_CONNECTION_TEST=true. "
+            "To abort long-running LLM calls after startup, set LLM_CALL_TIMEOUT_SECONDS."
         )
         logger.error(msg)
         raise TimeoutError(msg)

--- a/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
+++ b/cognee/infrastructure/loaders/external/advanced_pdf_loader.py
@@ -78,7 +78,7 @@ class AdvancedPdfLoader(LoaderInterface):
                 **kwargs,
             }
             # Use partition to extract elements
-            from unstructured.partition.pdf import partition_pdf  # ty:ignore[unresolved-import]
+            from unstructured.partition.pdf import partition_pdf
 
             elements = partition_pdf(**partition_kwargs)
 

--- a/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
+++ b/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
@@ -272,7 +272,7 @@ class BeautifulSoupLoader(LoaderInterface):
 
         if rule.xpath:
             try:
-                from lxml import html as lxml_html  # ty:ignore[unresolved-import]
+                from lxml import html as lxml_html
             except ImportError:
                 raise RuntimeError(
                     "XPath requested but lxml is not available. Install lxml or use CSS selectors."

--- a/cognee/infrastructure/loaders/external/unstructured_loader.py
+++ b/cognee/infrastructure/loaders/external/unstructured_loader.py
@@ -6,7 +6,7 @@ from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface
 from cognee.shared.logging_utils import get_logger
 
 try:
-    from unstructured.partition.auto import partition  # ty:ignore[unresolved-import]
+    from unstructured.partition.auto import partition
 except ImportError as e:
     raise ImportError(
         "unstructured is required for document processing. Install with: pip install unstructured"
@@ -95,11 +95,8 @@ class UnstructuredLoader(LoaderInterface):
             # Name ingested file of current loader based on original file content hash
             storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
-            # Set partitioning parameters
-            partition_kwargs = {"filename": file_path, "strategy": strategy, **kwargs}
-
             # Use partition to extract elements
-            elements = partition(**partition_kwargs)
+            elements = partition(filename=file_path, strategy=strategy, **kwargs)
 
             # Process elements into text content
             text_parts = []

--- a/cognee/infrastructure/session/session_context_builder.py
+++ b/cognee/infrastructure/session/session_context_builder.py
@@ -10,7 +10,7 @@ Public orchestration coroutines are fail-open so they can never block answer gen
 helpers are deliberately strict so tests catch malformed stored data and scoring mistakes.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Protocol, Tuple
 from uuid import uuid4
 
@@ -185,7 +185,7 @@ async def _stamp_served_entries(*, session_manager, user_id, session_id, entry_i
     if not entry_ids:
         return
 
-    served_at = datetime.utcnow().isoformat()
+    served_at = datetime.now(timezone.utc).isoformat()
     for entry_id in entry_ids:
         try:
             await session_manager.update_session_context_entry(
@@ -333,7 +333,7 @@ async def _apply_single_candidate(
         content=content,
         normalized_content=normalized,
         confidence=float(candidate.confidence),
-        created_at=datetime.utcnow().isoformat(),
+        created_at=datetime.now(timezone.utc).isoformat(),
         source_feedback_ids=[feedback_entry_id] if feedback_entry_id else [],
         kind="context",
     )

--- a/cognee/infrastructure/session/session_turn.py
+++ b/cognee/infrastructure/session/session_turn.py
@@ -8,7 +8,7 @@ All public coroutines are fail-open so they never block answer generation.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -322,7 +322,7 @@ async def apply_session_turn_analysis(
 
         feedback_entry = SessionFeedbackEntry(
             id=str(uuid4()),
-            created_at=datetime.utcnow().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
             raw_text=query,
             referenced_qa_ids=[previous_qa_id] if previous_qa_id else [],
             influencing_context_ids=list(served_ids or []),

--- a/cognee/shared/graph_model_utils.py
+++ b/cognee/shared/graph_model_utils.py
@@ -98,7 +98,7 @@ def datapoint_model_to_basemodel(
             )
 
         converted_model = create_model(
-            model_type.__name__, __base__=ConfiguredBase, **converted_fields
+            model_type.__name__, __base__=ConfiguredBase, **cast(Any, converted_fields)
         )
         converted_model.model_rebuild()
         cache[model_type] = converted_model

--- a/cognee/tests/unit/infrastructure/llm/test_llm_call_timeout.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_call_timeout.py
@@ -1,0 +1,71 @@
+import asyncio
+
+import pytest
+
+from cognee.infrastructure.llm.call_timeout import (
+    LLMCallTimeoutError,
+    build_llm_call_label,
+    run_with_llm_call_limits,
+)
+from cognee.infrastructure.llm.config import LLMConfig
+
+
+@pytest.mark.asyncio
+async def test_run_with_llm_call_limits_disabled_by_default():
+    async def fast_call():
+        await asyncio.sleep(0)
+        return "ok"
+
+    result = await run_with_llm_call_limits(
+        fast_call(),
+        label="provider=custom model=test endpoint=http://localhost:8000/v1",
+        timeout_seconds=0,
+        slow_warning_seconds=0,
+    )
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_run_with_llm_call_limits_raises_when_opt_in_timeout_exceeded():
+    async def slow_call():
+        await asyncio.sleep(0.2)
+        return "late"
+
+    with pytest.raises(LLMCallTimeoutError, match="LLM_CALL_TIMEOUT_SECONDS=0.1"):
+        await run_with_llm_call_limits(
+            slow_call(),
+            label=build_llm_call_label(
+                provider="custom",
+                model="openai/test-model",
+                endpoint="http://localhost:8000/v1",
+            ),
+            timeout_seconds=0.1,
+            slow_warning_seconds=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_with_llm_call_limits_continues_after_slow_warning_threshold():
+    async def medium_call():
+        await asyncio.sleep(0.15)
+        return "done"
+
+    result = await run_with_llm_call_limits(
+        medium_call(),
+        label="provider=custom model=test endpoint=http://localhost:8000/v1",
+        timeout_seconds=0,
+        slow_warning_seconds=0.05,
+    )
+
+    assert result == "done"
+
+
+def test_llm_config_defaults_keep_timeout_disabled():
+    config = LLMConfig(
+        llm_provider="custom",
+        llm_model="openai/test-model",
+        llm_api_key="test-key",
+        llm_endpoint="http://localhost:8000/v1",
+    )
+    assert config.llm_call_timeout_seconds == 0
+    assert config.llm_slow_call_warning_seconds == 60


### PR DESCRIPTION
Closes #2902

## Summary

Local/custom inference (omlx, vLLM, OpenAI-compatible endpoints) can hang forever on structured-output calls. This adds opt-in wall-clock limits and slow-call warnings without changing default behavior.

- `LLM_CALL_TIMEOUT_SECONDS` defaults to **0** (off)
- `LLM_SLOW_CALL_WARNING_SECONDS` defaults to **60**
- Wrapped in custom and Ollama adapters (the paths from #2902)
- Timeout errors mention the env var

Different from #3126, which adds a mandatory `llm_timeout=120` for CI hangs on #2995. Happy to rebase onto that once it lands.

## Test plan

- [x] `uv run pytest cognee/tests/unit/infrastructure/llm/test_llm_call_timeout.py -v`
- [x] `uv run ruff check` on changed files

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.