### PR TITLE
feat(release): richer, clearer AI release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
           echo "Tag to create: ${TAG}"
 
-          git config user.name "github-actions[bot]"
+          git config user.name "Cognee Team"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
@@ -73,6 +73,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.create_tag.outputs.tag }}
+          name: ${{ steps.generate_notes.outputs.RELEASE_TITLE }}
           body: ${{ steps.generate_notes.outputs.RELEASE_NOTES }}
           prerelease: ${{ github.ref_name == 'dev' }}
         env:

--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -99,6 +99,93 @@ def get_pr_list(base_ref: str, target_ref: str) -> str:
     return ", ".join(f"#{pr}" for pr in sorted(pr_numbers))
 
 
+def _parse_dependencies(pyproject_text: str) -> dict[str, str]:
+    """Parse direct project dependencies into a {package: specifier} map.
+
+    Uses tomllib when available (Python 3.11+), falling back to a line-based
+    regex parse so the script also works on Python 3.10.
+    """
+    deps: dict[str, str] = {}
+
+    def _split(req: str) -> tuple[str, str]:
+        # Strip environment markers (after ';') and extras ('pkg[extra]').
+        req = req.split(";")[0].strip()
+        match = re.match(r"^([A-Za-z0-9._-]+)\s*(?:\[[^\]]*\])?\s*(.*)$", req)
+        if not match:
+            return req, ""
+        return match.group(1).lower(), match.group(2).strip()
+
+    try:
+        import tomllib  # type: ignore[import-not-found]
+
+        data = tomllib.loads(pyproject_text)
+        for req in data.get("project", {}).get("dependencies", []):
+            name, spec = _split(req)
+            if name:
+                deps[name] = spec
+        return deps
+    except Exception:
+        pass
+
+    # Fallback: extract the [project].dependencies = [ ... ] array textually.
+    match = re.search(r"^dependencies\s*=\s*\[(.*?)\]", pyproject_text, re.DOTALL | re.MULTILINE)
+    if not match:
+        return deps
+    for raw in re.findall(r"""["']([^"']+)["']""", match.group(1)):
+        name, spec = _split(raw)
+        if name:
+            deps[name] = spec
+    return deps
+
+
+def get_dependency_changes(base_ref: str, target_ref: str) -> dict[str, list[str]]:
+    """Compare direct dependencies in pyproject.toml between two refs."""
+    changes: dict[str, list[str]] = {"added": [], "removed": [], "changed": []}
+    try:
+        base_text = run_git_command(["git", "show", f"{base_ref}:pyproject.toml"])
+        target_text = run_git_command(["git", "show", f"{target_ref}:pyproject.toml"])
+    except SystemExit:
+        return changes
+    except Exception:
+        return changes
+
+    base_deps = _parse_dependencies(base_text)
+    target_deps = _parse_dependencies(target_text)
+
+    for name, spec in sorted(target_deps.items()):
+        if name not in base_deps:
+            changes["added"].append(f"{name} {spec}".strip())
+        elif base_deps[name] != spec:
+            changes["changed"].append(f"{name}: {base_deps[name] or '*'} → {spec or '*'}")
+    for name, spec in sorted(base_deps.items()):
+        if name not in target_deps:
+            changes["removed"].append(f"{name} {spec}".strip())
+    return changes
+
+
+def get_compatibility_info(target_ref: str) -> dict[str, str]:
+    """Read compatibility-relevant metadata from pyproject.toml at the target ref."""
+    info: dict[str, str] = {}
+    try:
+        text = run_git_command(["git", "show", f"{target_ref}:pyproject.toml"])
+    except Exception:
+        try:
+            text = (Path(__file__).parent.parent / "pyproject.toml").read_text()
+        except Exception:
+            return info
+
+    py_match = re.search(r'^requires-python\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
+    if py_match:
+        info["python"] = py_match.group(1)
+
+    # Surface a few core runtime dependencies users commonly pin against.
+    deps = _parse_dependencies(text)
+    for pkg in ("pydantic", "litellm", "fastapi", "sqlalchemy", "lancedb", "ladybug"):
+        if pkg in deps:
+            info[pkg] = deps[pkg] or "*"
+    return info
+
+
 async def generate_release_notes_with_llm(
     diff: str,
     commits: str,
@@ -134,11 +221,39 @@ async def generate_release_notes_with_llm(
     class ReleaseNotes(BaseModel):
         """Structured release notes."""
 
+        title: str = Field(
+            description=(
+                "A short, descriptive release title naming the single most important theme "
+                "of this release, formatted as 'v{version} — {Theme}' "
+                "(e.g. 'v0.1.9 — Memory Graph Improvements'). "
+                "If no single theme dominates, summarize the largest change area. "
+                "Keep it under 60 characters and never leave it empty."
+            )
+        )
         summary: str = Field(description="A brief, engaging summary of the release (2-3 sentences)")
         highlights: list[str] = Field(description="3-5 key highlights that users care about most")
-        features: list[str] = Field(description="New features added in this release")
+        features: list[str] = Field(
+            description=(
+                "New features added in this release. Each entry must be understandable to a "
+                "first-time reader: name the feature, say in plain words what it does, and why "
+                "it matters. Do not use undefined jargon."
+            )
+        )
         improvements: list[str] = Field(
             description="Enhancements and improvements to existing functionality"
+        )
+        performance: list[str] = Field(
+            description=(
+                "Performance changes: speedups, reduced memory/latency, throughput gains. "
+                "State the practical impact (e.g. 'faster ingestion of large files')."
+            )
+        )
+        security: list[str] = Field(
+            description=(
+                "Security-relevant changes: hardening, auth fixes, vulnerability patches. "
+                "Do NOT invent CVE identifiers — only mention a CVE if it appears in the diff "
+                "or commit messages."
+            )
         )
         bug_fixes: list[str] = Field(description="Bug fixes and issue resolutions")
         breaking_changes: list[str] = Field(description="Breaking changes that require user action")
@@ -155,15 +270,25 @@ async def generate_release_notes_with_llm(
 
 Analyze the git diff and commit history to create clear, user-friendly release notes.
 
-Guidelines:
-- Focus on user-facing changes and their benefits
-- Group related changes together
-- Use clear, non-technical language where possible
-- Highlight breaking changes prominently
-- Organize by impact: features > improvements > bug fixes > technical changes
-- Be concise but informative
-- Emphasize the "why" and "what it means" for users, not just "what changed"
-- Mention specific file names only if critical to understanding
+WRITING FOR A FIRST-TIME READER (most important rule):
+- Assume the reader has never seen this feature before and does not know Cognee's internal vocabulary.
+- Every entry must answer, in plain words: WHAT it is, WHAT it does, and WHY it matters.
+- Do NOT use undefined jargon. If a term like "summary layer", "dataset", "graph completion",
+  or "semantic bucket" is unavoidable, explain it in the same sentence the first time it appears.
+- Bad: "An optional summary layer that builds dataset-level orientation through semantic buckets."
+  Good: "A new optional index that groups a dataset (a collection of documents you've added) into
+  topic clusters and a short overview, so search has broader context and returns better answers."
+- Prefer concrete outcomes ("search returns more relevant results") over abstract descriptions.
+
+Other guidelines:
+- Choose ONE dominant theme for the title; if none dominates, name the largest change area.
+- Focus on user-facing changes and their benefits.
+- Group related changes together and categorize each change correctly
+  (feature / improvement / performance / security / bug fix / breaking change / technical).
+- Highlight breaking changes prominently.
+- Be concise but informative; emphasize the "why" and "what it means", not just "what changed".
+- Mention specific file names only if critical to understanding.
+- Never invent CVE numbers, deprecation dates, or version-support promises that are not in the input.
 """
 
     text_input = f"""Generate release notes for Cognee version {version or "TBD"}.
@@ -207,10 +332,13 @@ def generate_fallback_notes(
 
     @dataclass
     class FallbackNotes:
+        title: str = ""
         summary: str = ""
         highlights: list[str] = field(default_factory=list)
         features: list[str] = field(default_factory=list)
         improvements: list[str] = field(default_factory=list)
+        performance: list[str] = field(default_factory=list)
+        security: list[str] = field(default_factory=list)
         bug_fixes: list[str] = field(default_factory=list)
         breaking_changes: list[str] = field(default_factory=list)
         technical_changes: list[str] = field(default_factory=list)
@@ -228,6 +356,10 @@ def generate_fallback_notes(
             notes.features.append(msg)
         elif lower.startswith("fix"):
             notes.bug_fixes.append(msg)
+        elif lower.startswith("perf"):
+            notes.performance.append(msg)
+        elif lower.startswith(("security", "sec(")):
+            notes.security.append(msg)
         elif lower.startswith("breaking"):
             notes.breaking_changes.append(msg)
         elif any(lower.startswith(p) for p in ("refactor", "chore", "ci", "build", "test")):
@@ -235,19 +367,39 @@ def generate_fallback_notes(
         else:
             notes.improvements.append(msg)
 
+    notes.title = f"v{version} — {len(notes.features)} features, {len(notes.bug_fixes)} fixes"
     notes.summary = f"Cognee v{version} includes {len(notes.features)} new features, {len(notes.bug_fixes)} bug fixes, and {len(notes.improvements)} improvements."
     notes.highlights = (notes.features + notes.improvements)[:5]
 
     return notes
 
 
+def get_release_title(notes: Any, version: str) -> str:
+    """Resolve the release title, guaranteeing a non-empty, version-prefixed value."""
+    # Collapse any whitespace/newlines so the title is safe as a single-line
+    # GitHub Actions output (RELEASE_TITLE=...).
+    title = " ".join((getattr(notes, "title", "") or "").split())
+    if not title:
+        return f"v{version}"
+    # Ensure the version prefix is present so releases sort/scan consistently.
+    if not re.match(rf"^v?{re.escape(version)}\b", title):
+        return f"v{version} — {title}"
+    return title if title.startswith("v") else f"v{title}"
+
+
 def format_release_notes(
-    notes: Any, version: str, base_ref: str, target_ref: str, pr_list: str
+    notes: Any,
+    version: str,
+    base_ref: str,
+    target_ref: str,
+    pr_list: str,
+    dep_changes: dict[str, list[str]] | None = None,
+    compat_info: dict[str, str] | None = None,
 ) -> str:
     """Format structured release notes into markdown."""
     date_str = datetime.now().strftime("%Y-%m-%d")
 
-    md = f"# Release Notes - v{version}\n\n"
+    md = f"# {get_release_title(notes, version)}\n\n"
     md += f"**Release Date:** {date_str}\n"
     md += f"**Changes:** {base_ref} → {target_ref}\n\n"
 
@@ -266,44 +418,58 @@ def format_release_notes(
             md += f"- {highlight}\n"
         md += "\n"
 
-    # Breaking Changes (if any)
-    if notes.breaking_changes:
-        md += "## Breaking Changes\n\n"
-        for change in notes.breaking_changes:
-            md += f"- {change}\n"
-        md += "\n"
+    def _section(heading: str, items: list[str]) -> str:
+        if not items:
+            return ""
+        block = f"## {heading}\n\n"
+        for item in items:
+            block += f"- {item}\n"
+        return block + "\n"
 
-    # Features
-    if notes.features:
-        md += "## New Features\n\n"
-        for feature in notes.features:
-            md += f"- {feature}\n"
-        md += "\n"
+    # Ordered by impact.
+    md += _section("Breaking Changes", notes.breaking_changes)
+    md += _section("New Features", notes.features)
+    md += _section("Improvements", notes.improvements)
+    md += _section("Performance", getattr(notes, "performance", []))
+    md += _section("Security", getattr(notes, "security", []))
+    md += _section("Bug Fixes", notes.bug_fixes)
+    md += _section("Technical Changes", notes.technical_changes)
 
-    # Improvements
-    if notes.improvements:
-        md += "## Improvements\n\n"
-        for improvement in notes.improvements:
-            md += f"- {improvement}\n"
-        md += "\n"
+    # Dependency updates (deterministic, parsed from pyproject.toml diff).
+    if dep_changes and any(dep_changes.values()):
+        md += "## Dependency Updates\n\n"
+        if dep_changes.get("added"):
+            md += "**Added:**\n"
+            for dep in dep_changes["added"]:
+                md += f"- {dep}\n"
+            md += "\n"
+        if dep_changes.get("changed"):
+            md += "**Updated:**\n"
+            for dep in dep_changes["changed"]:
+                md += f"- {dep}\n"
+            md += "\n"
+        if dep_changes.get("removed"):
+            md += "**Removed:**\n"
+            for dep in dep_changes["removed"]:
+                md += f"- {dep}\n"
+            md += "\n"
 
-    # Bug Fixes
-    if notes.bug_fixes:
-        md += "## Bug Fixes\n\n"
-        for fix in notes.bug_fixes:
-            md += f"- {fix}\n"
-        md += "\n"
-
-    # Technical Changes
-    if notes.technical_changes:
-        md += "## Technical Changes\n\n"
-        for change in notes.technical_changes:
-            md += f"- {change}\n"
+    # Compatibility matrix (deterministic, read from pyproject.toml).
+    if compat_info:
+        md += "## Compatibility\n\n"
+        md += "| Component | Supported / Required |\n"
+        md += "| --- | --- |\n"
+        if compat_info.get("python"):
+            md += f"| Python | `{compat_info['python']}` |\n"
+        for pkg, spec in compat_info.items():
+            if pkg == "python":
+                continue
+            md += f"| {pkg} | `{spec}` |\n"
         md += "\n"
 
     # Footer
     md += "---\n\n"
-    md += f"*Generated by Cognee Release Notes Generator on {date_str}*\n"
+    md += f"*— The Cognee Team · {date_str}*\n"
 
     return md
 
@@ -377,6 +543,8 @@ async def main():
     diff = get_git_diff(base_ref, target_ref)
     commits = get_commit_history(base_ref, target_ref)
     pr_list = get_pr_list(base_ref, target_ref)
+    dep_changes = get_dependency_changes(base_ref, target_ref)
+    compat_info = get_compatibility_info(target_ref)
 
     # Generate release notes with LLM, fall back to commit-based notes
     notes = await generate_release_notes_with_llm(diff, commits, base_ref, target_ref, version)
@@ -386,13 +554,17 @@ async def main():
         notes = generate_fallback_notes(commits, version)
 
     # Format as markdown
-    markdown = format_release_notes(notes, version, base_ref, target_ref, pr_list)
+    title = get_release_title(notes, version)
+    markdown = format_release_notes(
+        notes, version, base_ref, target_ref, pr_list, dep_changes, compat_info
+    )
 
     # Output results
     if args.github_output:
         # GitHub Actions multi-line output
         delimiter = "EOF"
         output_var = f"RELEASE_NOTES<<{delimiter}\n{markdown}\n{delimiter}\n"
+        output_var += f"RELEASE_TITLE={title}\n"
 
         # Write to GITHUB_OUTPUT file
         github_output = os.environ.get("GITHUB_OUTPUT")


### PR DESCRIPTION
## Summary

Improves how GitHub release notes are generated, based on team feedback. All changes live in two files: `tools/generate_release_notes.py` and `.github/workflows/release.yml`.

## What changed

**Clarity & structure**
- **Descriptive title** — the LLM picks a dominant theme (`v0.1.9 — Memory Graph Improvements`); guaranteed non-empty, version-prefixed fallback. Used as the GitHub release `name`.
- **First-time-reader prompt rework** — bans undefined jargon; every entry must state *what it is / what it does / why it matters*. Addresses the "feature descriptions don't make sense" feedback (e.g. the Global Context Index example).
- **New Performance & Security categories** — AI categorizes each change; explicitly forbidden from inventing CVE identifiers.

**Deterministic sections (no LLM)**
- **Dependency Updates** — parsed from the `pyproject.toml` diff between tags (added / updated / removed). Uses `tomllib` with a regex fallback for Python 3.10.
- **Compatibility matrix** — `requires-python` + key runtime deps.

**Authorship**
- Git tag author → `Cognee Team`.
- Notes signed `— The Cognee Team`.
- Note: the GitHub release *author badge* is the `GH_RELEASE_TOKEN` owner and cannot be changed from code — a dedicated account / GitHub App would be needed for that.

## Deferred (need team decision, not code)
- CVE scanning — left to pip-audit / Dependabot as source of truth.
- Deprecation deadlines and LTS / Stability labels — require a team policy first.

## Testing
Ran the generator (fallback path) and `--github-output` path against real tags `v1.1.3 → v1.2.0`: title, Dependency Updates, Compatibility matrix, footer, and the `RELEASE_TITLE` output all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)