### PR TITLE
fix: avoid duplicate PipelineRunStarted events emission when pipeline re-runs

### DIFF
--- a/cognee/modules/pipelines/operations/pipeline.py
+++ b/cognee/modules/pipelines/operations/pipeline.py
@@ -95,14 +95,7 @@ async def run_pipeline_per_dataset(
             # If pipeline caching is enabled we do not proceed with re-processing
             yield process_pipeline_status
             return
-        else:
-            # If pipeline caching is disabled we always return pipeline started information and proceed with re-processing
-            yield PipelineRunStarted(
-                pipeline_run_id=process_pipeline_status.pipeline_run_id,
-                dataset_id=dataset.id,
-                dataset_name=dataset.name,
-                payload=data,
-            )
+            # run_tasks() will emit PipelineRunStarted for the new run
 
     pipeline_run = run_tasks(
         tasks,

--- a/cognee/tests/unit/pipelines/test_pipeline.py
+++ b/cognee/tests/unit/pipelines/test_pipeline.py
@@ -1,0 +1,78 @@
+from uuid import uuid4
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.modules.pipelines.operations.pipeline import (
+    run_pipeline_per_dataset,
+)
+
+from cognee.modules.pipelines.models.PipelineRunInfo import (
+    PipelineRunStarted,
+    PipelineRunCompleted,
+)
+
+DATASET_ID = uuid4()
+
+class FakeDataset:
+    id = DATASET_ID
+    name = "test_dataset"
+
+class FakeUser:
+    id = uuid4()
+
+async def fake_run_tasks(*args, **kwargs):
+    yield PipelineRunStarted(
+        pipeline_run_id=uuid4(),
+        dataset_id=DATASET_ID,
+        dataset_name="test_dataset",
+        payload=[],
+    )
+
+    yield PipelineRunCompleted(
+        pipeline_run_id=uuid4(),
+        dataset_id=DATASET_ID,
+        dataset_name="test_dataset",
+    )
+
+@pytest.mark.asyncio
+async def test_pipeline_emits_single_start_event_when_cache_disabled():
+
+    with (
+        patch(
+            "cognee.modules.pipelines.operations.pipeline.get_dataset_data",
+            AsyncMock(return_value=["dummy"]),
+        ),
+        patch(
+            "cognee.modules.pipelines.operations.pipeline.check_pipeline_run_qualification",
+            AsyncMock(
+                return_value=PipelineRunStarted(
+                    pipeline_run_id=uuid4(),
+                    dataset_id=DATASET_ID,
+                    dataset_name="test_dataset",
+                    payload=[],
+                )
+            ),
+        ),
+        patch(
+            "cognee.modules.pipelines.operations.pipeline.run_tasks",
+            fake_run_tasks,
+        ),
+    ):
+
+        events = []
+
+        async for event in run_pipeline_per_dataset(
+            dataset=FakeDataset(),
+            user=FakeUser(),
+            tasks=[],
+            data=[],
+            use_pipeline_cache=False,
+        ):
+            events.append(type(event).__name__)
+
+        assert events.count("PipelineRunStarted") == 1
+        assert events == [
+            "PipelineRunStarted",
+            "PipelineRunCompleted",
+        ]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Closes #3228 

This PR fixes duplicate `PipelineRunStarted `events being emitted when a pipeline is re-run with `use_pipeline_cache=False.`
observed that `run_pipeline_per_dataset()` emitted `PipelineRunStarted` before continuing execution into `run_tasks()`, which emitted another PipelineRunStarted. This resulted in duplicate start events for a single pipeline execution.
This change removes the duplicate emission path and keeps event emission consistent during pipeline execution.
 

## Acceptance Criteria

1. Only one `PipelineRunStarted `event is emitted per pipeline execution
2. Existing cache-enabled behavior remains unchanged
3. Added a test covering duplicate event prevention

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<img width="900" height="174" alt="Screenshot 2026-06-21 164054" src="https://github.com/user-attachments/assets/2fdd85b9-166e-4db0-8aee-051bb557f26f" />
<img width="900" height="144" alt="Screenshot 2026-06-21 164142" src="https://github.com/user-attachments/assets/9c43bac8-fb12-477d-8a24-f70a8ab4cfaf" />

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
