### PR TITLE
fix(graph): implement close() in NeptuneGraphDB to prevent resource leaks on cache eviction

### DIFF
--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -146,6 +146,21 @@ class NeptuneGraphDB(GraphDBInterface):
                 message=f"Failed to initialize Neptune Analytics client: {format_neptune_error(e)}"
             ) from e
 
+    async def close(self) -> None:
+        """
+        Release resources held by the Neptune Analytics client.
+
+        Called automatically by ``closing_lru_cache`` when this adapter is
+        evicted from ``_create_graph_engine``'s cache. The underlying boto3
+        client is cleaned up if present.
+        """
+        if hasattr(self, "_client") and self._client is not None:
+            # NeptuneAnalyticsGraph wraps a boto3 client; close it if available
+            underlying = getattr(self._client, "client", None)
+            if underlying is not None and hasattr(underlying, "close"):
+                underlying.close()
+            self._client = None
+
     @staticmethod
     def _serialize_properties(properties: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neptune_adapter_close.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neptune_adapter_close.py
@@ -1,0 +1,111 @@
+import sys
+import gc
+import asyncio
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock langchain_aws if not installed
+if "langchain_aws" not in sys.modules:
+    mock_lc = MagicMock()
+    sys.modules["langchain_aws"] = mock_lc
+
+from cognee.infrastructure.databases.graph.neptune_driver.adapter import NeptuneGraphDB
+from cognee.infrastructure.databases.utils.closing_lru_cache import ClosingLRUCache
+
+
+@pytest.mark.asyncio
+async def test_neptune_adapter_close():
+    """close() should clean up the underlying boto3 client and set _client to None."""
+    # Arrange: create a mock NeptuneAnalyticsGraph with a nested boto3 client
+    mock_boto3_client = MagicMock()
+    mock_boto3_client.close = MagicMock()
+
+    mock_neptune_graph = MagicMock()
+    mock_neptune_graph.client = mock_boto3_client
+
+    with patch(
+        "cognee.infrastructure.databases.graph.neptune_driver.adapter.NeptuneGraphDB._initialize_client",
+        return_value=mock_neptune_graph,
+    ):
+        adapter = NeptuneGraphDB(
+            graph_id="g-1234",
+            region="us-east-1",
+        )
+
+    # Act
+    await adapter.close()
+
+    # Assert: boto3 client closed, _client set to None
+    mock_boto3_client.close.assert_called_once()
+    assert adapter._client is None
+
+
+@pytest.mark.asyncio
+async def test_neptune_adapter_close_no_client():
+    """close() should be a no-op when _client is None."""
+    with patch(
+        "cognee.infrastructure.databases.graph.neptune_driver.adapter.NeptuneGraphDB._initialize_client",
+        return_value=None,
+    ), patch(
+        "cognee.infrastructure.databases.graph.neptune_driver.adapter.NeptuneGraphDB.__init__",
+        side_effect=lambda **kw: None,
+    ):
+        adapter = NeptuneGraphDB.__new__(NeptuneGraphDB)
+        adapter._client = None
+
+    # Should not raise
+    await adapter.close()
+    assert adapter._client is None
+
+
+@pytest.mark.asyncio
+async def test_neptune_adapter_close_no_underlying_client():
+    """close() should handle _client without a .client attribute gracefully."""
+    mock_neptune_graph = MagicMock(spec=[])  # no .client attribute
+
+    adapter = NeptuneGraphDB.__new__(NeptuneGraphDB)
+    adapter._client = mock_neptune_graph
+
+    # Should not raise
+    await adapter.close()
+    assert adapter._client is None
+
+
+@pytest.mark.asyncio
+async def test_closing_lru_cache_evicts_neptune_adapter():
+    """When evicted from closing_lru_cache, the adapter's close() should be called."""
+    cache = ClosingLRUCache(maxsize=1)
+
+    mock_boto3_client = MagicMock()
+    mock_boto3_client.close = MagicMock()
+
+    mock_neptune_graph = MagicMock()
+    mock_neptune_graph.client = mock_boto3_client
+
+    with patch(
+        "cognee.infrastructure.databases.graph.neptune_driver.adapter.NeptuneGraphDB._initialize_client",
+        return_value=mock_neptune_graph,
+    ):
+        adapter = NeptuneGraphDB(
+            graph_id="g-1234",
+            region="us-east-1",
+        )
+
+    proxy = cache.get_or_create("neptune_key", lambda: adapter)
+    assert proxy.__wrapped__ is adapter
+
+    # Evict by adding another entry
+    cache.get_or_create("another_key", lambda: MagicMock())
+
+    # Proxy still held, so not closed yet
+    assert mock_boto3_client.close.call_count == 0
+
+    # Release the lease
+    del proxy
+    gc.collect()
+
+    # Allow pending async close tasks to complete
+    await asyncio.sleep(0.1)
+
+    # Now the boto3 client should be closed
+    mock_boto3_client.close.assert_called_once()


### PR DESCRIPTION
## Description

Fixes the same class of bug as #3193 / #3194 (Neo4jAdapter missing `close()`).

`NeptuneGraphDB` is cached via `closing_lru_cache` but does not implement `close()`. When evicted from the cache, `_close_value()` checks `hasattr(value, "close")` and silently skips cleanup, leaving the underlying boto3 client alive.

### What changed

- **`NeptuneGraphDB.close()`**: Async method that closes the underlying boto3 client (accessed via `self._client.client`) and nullifies `self._client`. Follows the same defensive pattern as the Neo4j fix (#3194) — `hasattr` + `None` checks before accessing resources.
- **Tests**: 4 test cases covering:
  1. Normal close — boto3 client closed, `_client` set to `None`
  2. `_client is None` — no-op, no error
  3. `_client` without `.client` attribute — graceful no-op
  4. `closing_lru_cache` eviction — confirms adapter is properly closed when evicted

### Why not just `self._client.close()`?

`NeptuneAnalyticsGraph` (from `langchain_aws`) does not expose a `close()` method. The actual boto3 client is at `self._client.client`, which does have `close()`. We close that and nullify the reference.

### Consistency

This mirrors the `close()` pattern already established in:
- `PGVectorAdapter.close()` ✅
- `LanceDBAdapter.close()` ✅
- `PostgresAdapter.close()` ✅
- `Neo4jAdapter.close()` (in #3194, pending) ✅

## Test plan

- [x] `pytest cognee/tests/unit/infrastructure/databases/graph/test_neptune_adapter_close.py`
- [ ] CI passes