### PR TITLE
fix(storage): fix metadata dict shared reference across model_copy() in index_data_points

### DIFF
--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -48,7 +48,7 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
                 data_points_by_type[type_name][field_name] = []
 
             indexed_data_point = data_point.model_copy()
-            indexed_data_point.metadata["index_fields"] = [field_name]
+            indexed_data_point.metadata = {**data_point.metadata, "index_fields": [field_name]}
             data_points_by_type[type_name][field_name].append(indexed_data_point)
 
     batch_size = vector_engine.embedding_engine.get_batch_size()

--- a/cognee/tests/unit/infrastructure/databases/test_index_data_points_leak.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_data_points_leak.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from cognee.tasks.storage.index_data_points import index_data_points
+from cognee.infrastructure.engine import DataPoint
+
+class MultiFieldDataPoint(DataPoint):
+    name: str = "Test Entity"
+    description: str = "Test Description"
+    metadata: dict = {"index_fields": ["name", "description"]}
+
+@pytest.mark.asyncio
+async def test_index_data_points_does_not_overwrite_metadata():
+    data_point = MultiFieldDataPoint()
+    data_points = [data_point]
+
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.embedding_engine.get_batch_size = MagicMock(return_value=100)
+
+    # Patch get_vector_engine to return our mock
+    with patch(
+        "cognee.tasks.storage.index_data_points.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        await index_data_points(data_points)
+
+    # Assert that the original object's metadata was not corrupted/mutated
+    assert data_point.metadata["index_fields"] == ["name", "description"], (
+        f"Original metadata index_fields was mutated to: {data_point.metadata['index_fields']}"
+    )
+
+    # Verify that the vector indexer calls index_data_points for both fields with correct copied points
+    # Let's inspect the calls to vector_engine.index_data_points.
+    # index_data_points signature: index_data_points(type_name, field_name, batch)
+    calls = mock_vector_engine.index_data_points.call_args_list
+    assert len(calls) == 2, f"Expected 2 index calls, got {len(calls)}"
+
+    first_call_field = calls[0][0][1]
+    first_call_batch = calls[0][0][2]
+    second_call_field = calls[1][0][1]
+    second_call_batch = calls[1][0][2]
+
+    # Verify field names and their copied data point metadata
+    assert first_call_field == "name"
+    assert first_call_batch[0].metadata["index_fields"] == ["name"], (
+        f"Expected first batch data points to have index_fields=['name'], got {first_call_batch[0].metadata['index_fields']}"
+    )
+
+    assert second_call_field == "description"
+    assert second_call_batch[0].metadata["index_fields"] == ["description"], (
+        f"Expected second batch data points to have index_fields=['description'], got {second_call_batch[0].metadata['index_fields']}"
+    )


### PR DESCRIPTION
## Description
Fixes #3254 

While reading through the vector indexing pipeline, I noticed that `index_data_points` calls `data_point.model_copy()` to create per-field copies of each `DataPoint` before batching them for embedding. 
The problem is that `model_copy()` does a shallow copy — the `metadata` dict is shared between the original and every copy.

The loop then does `indexed_data_point.metadata["index_fields"] = [field_name]`, which mutates the shared dict in place. By the time the second field is processed, the first copy's `metadata["index_fields"]` has already been 
overwritten. 
Every batch ends up with the last field's name, so the `name` index silently stores embeddings of the `description` value.

The fix is straightforward — instead of mutating the shared dict, create a new one:
```python
indexed_data_point.metadata = {**data_point.metadata, "index_fields": [field_name]}
```

## Acceptance Criteria
- Each field's copied DataPoint has its own isolated metadata dict 
- Original DataPoint metadata remains unmutated after indexing 
- `name` index correctly embeds name values, not description values 
- Unit test added proving isolation across all copied instances 

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
**After fix — verified locally on Windows 10:**
<img width="1002" height="262" alt="shallowCopyFix" src="https://github.com/user-attachments/assets/21de3db6-673c-4cda-bc25-412a409b3fd1" />

**Unit test:**
<img width="1270" height="247" alt="unitTest" src="https://github.com/user-attachments/assets/8e95fc4b-1669-4e3c-b506-11351e4a1020" />


## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.