### PR TITLE
fix(retrieval): align triplet context results with their entities

### DIFF
--- a/cognee/modules/retrieval/context_providers/TripletSearchContextProvider.py
+++ b/cognee/modules/retrieval/context_providers/TripletSearchContextProvider.py
@@ -43,20 +43,31 @@ class TripletSearchContextProvider(BaseContextProvider):
         entities: List[DataPoint],
         query: str,
         memory_fragment: CogneeGraph,
-    ) -> List:
-        """Creates search tasks for valid entities."""
-        tasks = [
-            brute_force_triplet_search(
-                query=f"{entity_text} {query}",
-                top_k=self.top_k,
-                collections=self.collections,
-                properties_to_project=self.properties_to_project,
-                memory_fragment=memory_fragment,
+    ) -> tuple[List[DataPoint], List]:
+        """Creates search tasks for the entities that have searchable text.
+
+        Returns the surviving entities alongside their tasks so callers can keep
+        the two lists aligned — entities without text are skipped, so zipping the
+        original ``entities`` list against the results would misalign every
+        subsequent entity.
+        """
+        valid_entities = []
+        tasks = []
+        for entity in entities:
+            entity_text = self._get_entity_text(entity)
+            if entity_text is None:
+                continue
+            valid_entities.append(entity)
+            tasks.append(
+                brute_force_triplet_search(
+                    query=f"{entity_text} {query}",
+                    top_k=self.top_k,
+                    collections=self.collections,
+                    properties_to_project=self.properties_to_project,
+                    memory_fragment=memory_fragment,
+                )
             )
-            for entity in entities
-            if (entity_text := self._get_entity_text(entity)) is not None
-        ]
-        return tasks
+        return valid_entities, tasks
 
     async def _format_triplets(self, triplets: List, entity_name: str) -> str:
         """Format triplets into readable text."""
@@ -83,10 +94,10 @@ class TripletSearchContextProvider(BaseContextProvider):
             return "No entities provided for context search."
 
         memory_fragment = await get_memory_fragment(self.properties_to_project)
-        search_tasks = self._get_search_tasks(entities, query, memory_fragment)
+        valid_entities, search_tasks = self._get_search_tasks(entities, query, memory_fragment)
 
         if not search_tasks:
             return "No valid entities found for context search."
 
         results = await asyncio.gather(*search_tasks)
-        return await self._results_to_context(entities, results)
+        return await self._results_to_context(valid_entities, results)

--- a/cognee/tests/unit/modules/retrieval/test_triplet_context_provider_alignment.py
+++ b/cognee/tests/unit/modules/retrieval/test_triplet_context_provider_alignment.py
@@ -1,0 +1,51 @@
+"""Guards entity/result alignment in TripletSearchContextProvider.
+
+``_get_search_tasks`` skips entities that have no searchable text, so the list
+of search results is shorter than the original ``entities`` list whenever any
+entity is text-less. ``get_context`` used to zip the *full* ``entities`` list
+against those results, which mislabels every entity after the skipped one (and
+silently drops the trailing entities via ``zip``). The provider now returns the
+surviving entities alongside their tasks and zips those instead.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from cognee.modules.retrieval.context_providers import TripletSearchContextProvider as mod
+from cognee.modules.retrieval.context_providers.TripletSearchContextProvider import (
+    TripletSearchContextProvider,
+)
+
+
+@pytest.mark.asyncio
+async def test_context_pairs_each_entity_with_its_own_result(monkeypatch):
+    # A text-less entity sits between two entities that do have text. On the
+    # buggy code this shifts results so "Gamma" is dropped and pairs the empty
+    # entity with Gamma's result.
+    entities = [
+        SimpleNamespace(name="Alpha"),
+        SimpleNamespace(name=""),  # no searchable text -> skipped by _get_search_tasks
+        SimpleNamespace(name="Gamma"),
+    ]
+
+    async def fake_triplet_search(query, **kwargs):
+        # Echo the query (which embeds the entity text) so we can verify which
+        # entity each result belongs to.
+        return f"RESULT::{query}"
+
+    async def fake_get_memory_fragment(_properties):
+        return None
+
+    monkeypatch.setattr(mod, "brute_force_triplet_search", fake_triplet_search)
+    monkeypatch.setattr(mod, "get_memory_fragment", fake_get_memory_fragment)
+    monkeypatch.setattr(mod, "format_triplets", lambda triplets: triplets)
+
+    provider = TripletSearchContextProvider()
+    context = await provider.get_context(entities, query="Q")
+
+    # Each entity must be paired with the result derived from its OWN text.
+    assert "Context for Alpha:\nRESULT::Alpha Q" in context
+    assert "Context for Gamma:\nRESULT::Gamma Q" in context
+    # Gamma must not be dropped, and its result must not leak onto another entity.
+    assert "Context for Gamma:\nRESULT::Alpha Q" not in context


### PR DESCRIPTION
## Description

`TripletSearchContextProvider` runs a brute-force triplet search per entity and then labels each set of results with the entity it came from. `_get_search_tasks` builds the tasks with a *filtering* comprehension — it skips any entity whose concatenated text (`name`/`description`/`text`) is empty:

```python
tasks = [
    brute_force_triplet_search(query=f"{entity_text} {query}", ...)
    for entity in entities
    if (entity_text := self._get_entity_text(entity)) is not None
]
```

So when any entity is text-less, the gathered `results` list is shorter than `entities`. But `_results_to_context` re-zipped against the **full** `entities` list:

```python
for entity, entity_triplets in zip(entities, results):
```

`zip` then pairs each result with the wrong entity from the first skipped one onward, and silently drops the trailing entities. The triplet context handed to the LLM ends up attributed to the wrong entity (and some entities disappear), degrading retrieval quality whenever at least one entity lacks text.

The fix makes `_get_search_tasks` return the surviving entities alongside their tasks, and `get_context` zips those — so every result is paired with the entity it was actually searched for.

## Acceptance Criteria

- Each entity's triplet results are labeled with that same entity, even when an earlier entity was skipped for having no text.
- Entities with searchable text are never dropped.

Regression test (text-less entity between two valid ones; fails on `dev`, passes with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED cognee/tests/unit/modules/retrieval/test_triplet_context_provider_alignment.py::test_context_pairs_each_entity_with_its_own_result
  - AssertionError: 'Context for Gamma:\nRESULT::Gamma Q' not found (Gamma was dropped / misaligned)
1 failed in 0.47s

--- AFTER: fix applied ---
1 passed in 0.06s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="718" height="426" alt="image" src="https://github.com/user-attachments/assets/e14244d3-dc61-460a-aec3-9860119c5fb8" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
