### PR TITLE
docs(env): document Docker/MCP runtime variables in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -491,6 +491,57 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET="change_me_in_production"
 
 
+################################################################################
+#  Docker / MCP Runtime
+#  Configure the cognee API image (cognee/cognee) and the MCP image
+#  (cognee/cognee-mcp) when running `docker run` / `docker compose`.
+#  Unless noted "read by the app", these are consumed by the container
+#  entrypoints/compose and have defaults baked into the images — set them only
+#  to override. (docker-compose.yml already sets sensible values for most.)
+################################################################################
+
+# -- API server (cognee/cognee image) ----------------------------------------
+# CORS allow-list for the FastAPI server: comma-separated origins. Read by the
+# app (cognee/api/client.py). Default '*' (all origins) — set explicit domains
+# in production.
+#CORS_ALLOWED_ORIGINS="https://yourdomain.com,https://another.com"
+# Server bind/port inside the container (entrypoint defaults shown).
+#HTTP_PORT=8000
+#BIND_ADDRESS=0.0.0.0
+# HOST is set by docker-compose for the API service; BIND_ADDRESS is the value
+# the entrypoint actually binds to (see standardization note in the docs).
+#HOST=0.0.0.0
+
+# -- MCP server (cognee/cognee-mcp image) -------------------------------------
+# Transport the MCP container serves. The Docker image reads TRANSPORT_MODE;
+# the direct `cognee-mcp` CLI uses --transport instead.
+#TRANSPORT_MODE=stdio          # stdio | sse | http
+# Comma-separated optional extras to pip-install at container startup.
+#EXTRAS=aws,postgres
+# MCP "API mode": point the MCP server at an already-running cognee API server.
+#API_URL=http://localhost:8000
+#API_TOKEN=""
+# MCP "Cloud mode": point the MCP server at a managed Cognee Cloud instance.
+# NOTE: distinct from COGNEE_CLOUD_API_URL / COGNEE_CLOUD_AUTH_TOKEN above
+# (those drive the SDK `sync` feature). Read by cognee-mcp/src/server.py.
+#COGNEE_SERVICE_URL=""
+#COGNEE_API_KEY=""
+# MCP log level (image default: DEBUG).
+#MCP_LOG_LEVEL=INFO
+
+# -- Debug (both images) ------------------------------------------------------
+# DEBUG=true together with ENVIRONMENT in {dev,local} starts the container
+# under debugpy, listening on DEBUG_PORT.
+# NOTE: the container entrypoints read ENVIRONMENT, while the application reads
+# ENV (see the Dev/Debug section above). They are separate variables today.
+#DEBUG=false
+#ENVIRONMENT=local             # dev | local | prod (container entrypoint only)
+#DEBUG_PORT=5678
+
+# -- Frontend (cognee-frontend image / compose `ui` profile) ------------------
+#NEXT_PUBLIC_BACKEND_API_URL=http://localhost:8000
+
+
 ###############################################################################
 # TIER 4 — EXAMPLE PROVIDER OVERRIDES (commented out)
 # Uncomment + fill values to switch providers.

--- a/.env.template
+++ b/.env.template
@@ -508,9 +508,6 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # Server bind/port inside the container (entrypoint defaults shown).
 #HTTP_PORT=8000
 #BIND_ADDRESS=0.0.0.0
-# HOST is set by docker-compose for the API service; BIND_ADDRESS is the value
-# the entrypoint actually binds to (see standardization note in the docs).
-#HOST=0.0.0.0
 
 # -- MCP server (cognee/cognee-mcp image) -------------------------------------
 # Transport the MCP container serves. The Docker image reads TRANSPORT_MODE;
@@ -522,20 +519,18 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #API_URL=http://localhost:8000
 #API_TOKEN=""
 # MCP "Cloud mode": point the MCP server at a managed Cognee Cloud instance.
-# NOTE: distinct from COGNEE_CLOUD_API_URL / COGNEE_CLOUD_AUTH_TOKEN above
-# (those drive the SDK `sync` feature). Read by cognee-mcp/src/server.py.
+# These are the canonical cloud-connection variables, shared across serve(),
+# push(), the MCP server, and sync. COGNEE_CLOUD_API_URL / COGNEE_CLOUD_AUTH_TOKEN
+# (above) remain as deprecated fallbacks.
 #COGNEE_SERVICE_URL=""
 #COGNEE_API_KEY=""
-# MCP log level (image default: DEBUG).
-#MCP_LOG_LEVEL=INFO
 
 # -- Debug (both images) ------------------------------------------------------
-# DEBUG=true together with ENVIRONMENT in {dev,local} starts the container
-# under debugpy, listening on DEBUG_PORT.
-# NOTE: the container entrypoints read ENVIRONMENT, while the application reads
-# ENV (see the Dev/Debug section above). They are separate variables today.
+# DEBUG=true together with ENV in {dev,local} starts the container under
+# debugpy, listening on DEBUG_PORT. ENV is the canonical environment variable
+# (set it in the Dev/Debug section above); ENVIRONMENT is a deprecated alias
+# still accepted by the container entrypoints.
 #DEBUG=false
-#ENVIRONMENT=local             # dev | local | prod (container entrypoint only)
 #DEBUG_PORT=5678
 
 # -- Frontend (cognee-frontend image / compose `ui` profile) ------------------


### PR DESCRIPTION
## Summary
Follow-up to #3245. `.env.template` documented 100+ application config vars but **none of the Docker/MCP runtime knobs** read by the container entrypoints and `docker-compose.yml`. This adds a `Docker / MCP Runtime` section (all commented, defaults shown) so users running the prebuilt images via `--env-file` can discover them.

## Added (verified against code/entrypoints)
- **API image (`cognee/cognee`):** `CORS_ALLOWED_ORIGINS` (read by `cognee/api/client.py:125`), `HTTP_PORT`, `BIND_ADDRESS`, `HOST`
- **MCP image (`cognee/cognee-mcp`):** `TRANSPORT_MODE`, `EXTRAS`, `API_URL`, `API_TOKEN`, `COGNEE_SERVICE_URL` / `COGNEE_API_KEY` (read by `cognee-mcp/src/server.py:1949-1950`), `MCP_LOG_LEVEL`
- **Debug (both):** `DEBUG`, `ENVIRONMENT`, `DEBUG_PORT`
- **Frontend:** `NEXT_PUBLIC_BACKEND_API_URL`

## Inconsistencies flagged inline (for a separate standardization PR)
1. **`ENV` vs `ENVIRONMENT`** — the app reads `ENV` (`cognee/shared/utils.py:242`); the container entrypoints read `ENVIRONMENT`. Two names for "what environment am I in".
2. **`COGNEE_CLOUD_API_URL`/`COGNEE_CLOUD_AUTH_TOKEN` (SDK sync, `cognee/api/v1/sync/sync.py:560-565`) vs `COGNEE_SERVICE_URL`/`COGNEE_API_KEY` (MCP cloud mode)** — two variable pairs pointing at a Cognee Cloud instance + token.

Doc-only; no behavior change. A standardization plan for the two overlaps will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)