### PR TITLE
fix(graph): default edge_label to None in Neptune get_predecessors/get_successors

### DIFF
--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -940,7 +940,7 @@ class NeptuneGraphDB(GraphDBInterface):
         results = await self.query(query)
         return results[0]["ids"] if len(results) > 0 else []
 
-    async def get_predecessors(self, node_id: str, edge_label: str = "") -> list[str]:
+    async def get_predecessors(self, node_id: str, edge_label: str = None) -> list[str]:
         """
         Retrieve the predecessor nodes of a specified node based on an optional edge label.
 
@@ -967,7 +967,7 @@ class NeptuneGraphDB(GraphDBInterface):
 
         return [result["predecessor"] for result in results]
 
-    async def get_successors(self, node_id: str, edge_label: str = "") -> list[str]:
+    async def get_successors(self, node_id: str, edge_label: str = None) -> list[str]:
         """
         Retrieve the successor nodes of a specified node based on an optional edge label.
 
@@ -985,7 +985,7 @@ class NeptuneGraphDB(GraphDBInterface):
 
         edge_label = f" :{edge_label}" if edge_label is not None else ""
         query = f"""
-        MATCH (node)-[r {edge_label}]->(successor)
+        MATCH (node)-[r{edge_label}]->(successor)
         WHERE node.id = $node_id
         RETURN successor
         """

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neptune_edge_label_default.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neptune_edge_label_default.py
@@ -1,0 +1,57 @@
+"""Regression test: Neptune get_predecessors/get_successors default edge label.
+
+Both methods accept an optional ``edge_label`` and guard it with
+``f" :{edge_label}" if edge_label is not None else ""``. The default used to be
+the empty string ``""`` instead of ``None``. Since ``"" is not None`` is True,
+calling either method without an edge label still took the "label" branch and
+produced an invalid openCypher pattern (``<-[r :]-`` / ``-[r :]->``), which
+Neptune rejects at query time. The Neo4j sibling defaults to ``None`` and works.
+
+The methods are exercised unbound with a stub ``self`` (the adapter needs live
+AWS config to instantiate), inspecting the generated query and return value.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.neptune_driver.adapter import NeptuneGraphDB
+
+
+@pytest.mark.asyncio
+async def test_get_predecessors_without_edge_label_is_valid_opencypher():
+    stub = SimpleNamespace(query=AsyncMock(return_value=[{"predecessor": "p1"}]))
+
+    result = await NeptuneGraphDB.get_predecessors(stub, "n1")
+
+    query = stub.query.call_args.args[0]
+    # No label requested -> bare relationship, never the malformed "[r :]".
+    assert "[r]" in query
+    assert "[r :]" not in query
+    assert result == ["p1"]
+
+
+@pytest.mark.asyncio
+async def test_get_successors_without_edge_label_is_valid_opencypher():
+    stub = SimpleNamespace(query=AsyncMock(return_value=[{"successor": "s1"}]))
+
+    result = await NeptuneGraphDB.get_successors(stub, "n1")
+
+    query = stub.query.call_args.args[0]
+    assert "[r]" in query
+    assert "[r :]" not in query
+    assert result == ["s1"]
+
+
+@pytest.mark.asyncio
+async def test_edge_label_still_applied_when_provided():
+    stub = SimpleNamespace(query=AsyncMock(return_value=[]))
+
+    await NeptuneGraphDB.get_predecessors(stub, "n1", edge_label="KNOWS")
+    pred_query = stub.query.call_args.args[0]
+    assert ":KNOWS" in pred_query
+
+    await NeptuneGraphDB.get_successors(stub, "n1", edge_label="KNOWS")
+    succ_query = stub.query.call_args.args[0]
+    assert ":KNOWS" in succ_query


### PR DESCRIPTION
## Description

`NeptuneGraphDB.get_predecessors` and `get_successors` take an optional `edge_label` and build the relationship filter like this:

```python
edge_label = f" :{edge_label}" if edge_label is not None else ""
query = f"MATCH (node)<-[r{edge_label}]-(predecessor) ..."
```

The signatures defaulted `edge_label` to the empty string `""`. Because `"" is not None` is `True`, calling either method **without** an edge label still takes the label branch, producing invalid openCypher:

- `get_predecessors`: `MATCH (node)<-[r :]-(predecessor)`
- `get_successors`: `MATCH (node)-[r :]->(successor)`

Neptune rejects `[r :]` at query time. The Neo4j sibling (`Neo4jAdapter.get_predecessors/get_successors`) defaults `edge_label` to `None` and works correctly, and the Neptune docstrings already document the default as `None`.

The fix defaults `edge_label` to `None` so the no-label path emits a bare `[r]`. I also removed a stray extra space in the `get_successors` pattern (`[r {edge_label}]` → `[r{edge_label}]`) so it matches `get_predecessors` and yields a clean `[r]` rather than `[r ]`.

## Acceptance Criteria

- Calling `get_predecessors`/`get_successors` without an `edge_label` produces valid openCypher (bare relationship, no `[r :]`).
- Passing an explicit `edge_label` still scopes the relationship (`[r :LABEL]`).

Regression tests (the no-label cases fail on `dev`, all pass with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_neptune_edge_label_default.py::test_get_predecessors_without_edge_label_is_valid_opencypher
  - AssertionError: '[r]' not in 'MATCH (node)<-[r :]-(predecessor) ...'
FAILED ...test_neptune_edge_label_default.py::test_get_successors_without_edge_label_is_valid_opencypher
2 failed, 1 passed in 0.79s

--- AFTER: fix applied ---
3 passed in 0.36s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="742" height="498" alt="image" src="https://github.com/user-attachments/assets/55726e5c-ee07-4db6-b21d-8551959c1e26" />


## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
