### PR TITLE
fix(pipelines): isolate per-item failures in run_tasks batch

### DIFF
--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -127,8 +127,14 @@ async def run_tasks(
                         incremental_loading,
                     )
 
+            # return_exceptions=True so a single failing data item does not abort
+            # the whole batch: every item runs to completion and per-item failures
+            # are collected below as PipelineRunErrored results. Without it, the
+            # first exception propagates straight out of gather() and the
+            # success/error aggregation that follows never runs.
             gathered = await asyncio.gather(
                 *[asyncio.create_task(_run_item(item)) for item in data],
+                return_exceptions=True,
             )
 
             # Separate successes from unhandled exceptions

--- a/cognee/tests/unit/modules/pipelines/test_run_tasks_per_item_error_isolation.py
+++ b/cognee/tests/unit/modules/pipelines/test_run_tasks_per_item_error_isolation.py
@@ -1,0 +1,117 @@
+"""Regression test: per-item error isolation in run_tasks.
+
+run_tasks schedules every data item with ``asyncio.gather`` and then walks the
+gathered values, turning any ``BaseException`` into a ``PipelineRunErrored`` and
+keeping the successful results, before raising a single ``PipelineRunFailedError``
+if anything failed.
+
+That aggregation only works if ``gather`` is called with
+``return_exceptions=True``. Without it, the first item to raise propagates
+straight out of ``gather`` *before* the results list is even built, so the whole
+``isinstance(result, BaseException)`` branch is dead code: the raw exception is
+re-raised out of the generator and any successful items' results are discarded.
+
+This test drives run_tasks with one succeeding and one failing item and asserts
+the failure is aggregated (no raw raise; a PipelineRunFailedError; both items'
+results preserved). On the un-fixed code the raw ValueError escapes instead.
+"""
+
+from contextlib import asynccontextmanager
+import importlib
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.pipelines.exceptions import PipelineRunFailedError
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunErrored, PipelineRunStarted
+from cognee.modules.pipelines.tasks.task import Task
+
+run_tasks_module = importlib.import_module("cognee.modules.pipelines.operations.run_tasks")
+
+
+class _FakeSession:
+    def __init__(self, dataset):
+        self._dataset = dataset
+
+    async def get(self, _model, _dataset_id):
+        return self._dataset
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self, dataset):
+        self._dataset = dataset
+
+    def get_async_session(self):
+        return _FakeSession(self._dataset)
+
+
+@asynccontextmanager
+async def _no_op_context(*_args, **_kwargs):
+    yield
+
+
+@pytest.mark.asyncio
+async def test_failing_item_is_aggregated_not_raised_raw(monkeypatch):
+    dataset_id = uuid4()
+    pipeline_run_id = uuid4()
+    dataset = SimpleNamespace(id=dataset_id, name="dataset-1", owner_id=uuid4())
+    user = SimpleNamespace(id=uuid4(), tenant_id=uuid4())
+
+    ok_item = SimpleNamespace(id=uuid4(), kind="ok")
+    bad_item = SimpleNamespace(id=uuid4(), kind="bad")
+
+    async def _run_item(data_item, *_args, **_kwargs):
+        if data_item.kind == "bad":
+            raise ValueError("boom")
+        return {"run_info": SimpleNamespace(status="PipelineRunCompleted")}
+
+    rollback_calls = []
+
+    async def _rollback_handler(**kwargs):
+        rollback_calls.append(kwargs)
+
+    async def _log_start(*_args, **_kwargs):
+        return SimpleNamespace(pipeline_run_id=pipeline_run_id)
+
+    async def _log_error(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(run_tasks_module, "get_relational_engine", lambda: _FakeEngine(dataset))
+    monkeypatch.setattr(run_tasks_module, "generate_pipeline_id", lambda *_args: uuid4())
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_start", _log_start)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_error", _log_error)
+    monkeypatch.setattr(run_tasks_module, "set_database_global_context_variables", _no_op_context)
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", _run_item)
+
+    yielded = []
+    # On the un-fixed code this raises ValueError("boom") instead of yielding.
+    async for item in run_tasks_module.run_tasks(
+        tasks=[Task(lambda x: x)],
+        dataset_id=dataset_id,
+        data=[ok_item, bad_item],
+        user=user,
+        pipeline_name="cognify_pipeline",
+        rollback_handler=_rollback_handler,
+    ):
+        yielded.append(item)
+
+    # The run is reported as errored, not crashed with the raw exception.
+    assert isinstance(yielded[0], PipelineRunStarted)
+    assert isinstance(yielded[-1], PipelineRunErrored)
+
+    # Rollback receives the aggregated per-item results and a PipelineRunFailedError.
+    assert len(rollback_calls) == 1
+    info = rollback_calls[0]["data_ingestion_info"]
+    assert isinstance(rollback_calls[0]["error"], PipelineRunFailedError)
+    assert info is not None
+    # Both items are represented: one success result and one per-item error.
+    statuses = [entry["run_info"].status for entry in info]
+    assert "PipelineRunErrored" in statuses
+    assert "PipelineRunCompleted" in statuses


### PR DESCRIPTION
## Description

`run_tasks` processes a batch of data items concurrently and is written to isolate per-item failures: it gathers all items, walks the gathered values turning any `BaseException` into a `PipelineRunErrored`, keeps the successful results, and finally raises a single `PipelineRunFailedError` if anything failed:

```python
gathered = await asyncio.gather(
    *[asyncio.create_task(_run_item(item)) for item in data],
)   # <-- no return_exceptions=True

results = []
for i, result in enumerate(gathered):
    if isinstance(result, BaseException):   # never true
        ... PipelineRunErrored ...
    elif result:
        results.append(result)
```

But `asyncio.gather` without `return_exceptions=True` re-raises the first exception immediately, *before* `results` is built. So the entire `isinstance(result, BaseException)` aggregation branch is dead code. In practice:

- the first failing item aborts the whole batch instead of letting the others finish being recorded,
- the raw exception (not a `PipelineRunFailedError`) is re-raised out of the generator, and
- successful items' results are discarded (`locals().get("results")` is `None` in the `except` block).

The fix passes `return_exceptions=True` so each item runs to completion and per-item failures are aggregated exactly as the surrounding code already intends.

## Acceptance Criteria

- A single failing data item is reported as a `PipelineRunErrored` and surfaces as a `PipelineRunFailedError`, rather than the raw exception escaping the generator.
- Successful items in the same batch still have their results preserved (passed to the rollback handler / yielded run info).
- Existing `run_tasks` tests (`test_run_tasks_rollback.py`, `run_tasks_test.py`, `run_tasks_with_context_test.py`) still pass.

Regression test (one succeeding + one failing item; fails on `dev`, passes with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED cognee/tests/unit/modules/pipelines/test_run_tasks_per_item_error_isolation.py::test_failing_item_is_aggregated_not_raised_raw
  - ValueError: boom   (raw exception escapes run_tasks.py:130 gather)
1 failed in 0.53s

--- AFTER: fix applied ---
1 passed in 0.10s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="702" height="418" alt="image" src="https://github.com/user-attachments/assets/62ae29f4-eb7a-43c7-ac8d-99a7349f383d" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
