### PR TITLE
chore: standardize overlapping Docker/MCP environment variables

### DIFF
--- a/.github/workflows/docker_compose.yml
+++ b/.github/workflows/docker_compose.yml
@@ -19,14 +19,12 @@ jobs:
 
     - name: Build Docker images
       env:
-        ENVIRONMENT: dev
         ENV: dev
       run: |
         docker compose -f docker-compose.yml build
 
     - name: Run Docker Compose
       env:
-        ENVIRONMENT: dev
         ENV: dev
       run: |
         docker compose -f docker-compose.yml up -d

--- a/cognee-mcp/Dockerfile
+++ b/cognee-mcp/Dockerfile
@@ -80,7 +80,6 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 # Set environment variables for MCP server
 ENV PYTHONUNBUFFERED=1
-ENV MCP_LOG_LEVEL=DEBUG
 ENV PYTHONPATH=/app
 # Give the non-root user a stable, writable HOME so Kuzu/Ladybug caches its
 # downloaded extensions in a consistent location across build and runtime.

--- a/cognee-mcp/entrypoint.sh
+++ b/cognee-mcp/entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 set -e  # Exit on error
-echo "Environment: $ENVIRONMENT"
+# ENV is the canonical environment variable (matches what the app reads).
+# ENVIRONMENT is accepted as a deprecated fallback for older deployments.
+ENV="${ENV:-${ENVIRONMENT:-}}"
+echo "Environment: $ENV"
 
 # Install optional dependencies if EXTRAS is set
 if [ -n "$EXTRAS" ]; then
@@ -127,7 +130,7 @@ fi
 
 echo "calling cognee-mcp" "${ARGS[@]}"
 
-if [ "$DEBUG" = "true" ] && { [ "$ENVIRONMENT" = "dev" ] || [ "$ENVIRONMENT" = "local" ]; }; then
+if [ "$DEBUG" = "true" ] && { [ "$ENV" = "dev" ] || [ "$ENV" = "local" ]; }; then
     DEBUG_PORT=${DEBUG_PORT:-5678}
     echo "Running in debug mode"
     echo "Debug port: $DEBUG_PORT"

--- a/cognee/api/v1/sync/sync.py
+++ b/cognee/api/v1/sync/sync.py
@@ -564,13 +564,29 @@ async def _get_file_size(file_path: str) -> int:
 
 
 async def _get_cloud_base_url() -> str:
-    """Get Cognee Cloud API base URL."""
-    return os.getenv("COGNEE_CLOUD_API_URL", "http://localhost:8001")
+    """Get Cognee Cloud API base URL.
+
+    Canonical: COGNEE_SERVICE_URL (shared with serve()/push()/MCP).
+    COGNEE_CLOUD_API_URL is accepted as a deprecated fallback.
+    """
+    return (
+        os.getenv("COGNEE_SERVICE_URL")
+        or os.getenv("COGNEE_CLOUD_API_URL")
+        or "http://localhost:8001"
+    )
 
 
 async def _get_cloud_auth_token(user: User) -> str:
-    """Get authentication token for Cognee Cloud API."""
-    return os.getenv("COGNEE_CLOUD_AUTH_TOKEN", "your-auth-token")
+    """Get authentication token for Cognee Cloud API.
+
+    Canonical: COGNEE_API_KEY (shared with serve()/push()/MCP).
+    COGNEE_CLOUD_AUTH_TOKEN is accepted as a deprecated fallback.
+    """
+    return (
+        os.getenv("COGNEE_API_KEY")
+        or os.getenv("COGNEE_CLOUD_AUTH_TOKEN")
+        or "your-auth-token"
+    )
 
 
 async def _check_hashes_diff(

--- a/cognee/api/v1/sync/sync.py
+++ b/cognee/api/v1/sync/sync.py
@@ -582,11 +582,7 @@ async def _get_cloud_auth_token(user: User) -> str:
     Canonical: COGNEE_API_KEY (shared with serve()/push()/MCP).
     COGNEE_CLOUD_AUTH_TOKEN is accepted as a deprecated fallback.
     """
-    return (
-        os.getenv("COGNEE_API_KEY")
-        or os.getenv("COGNEE_CLOUD_AUTH_TOKEN")
-        or "your-auth-token"
-    )
+    return os.getenv("COGNEE_API_KEY") or os.getenv("COGNEE_CLOUD_AUTH_TOKEN") or "your-auth-token"
 
 
 async def _check_hashes_diff(

--- a/deployment/helm/docker-compose-helm.yml
+++ b/deployment/helm/docker-compose-helm.yml
@@ -11,8 +11,7 @@ services:
       - .:/app
       - /app/cognee-frontend/ # Ignore frontend code
     environment:
-      - HOST=0.0.0.0
-      - ENVIRONMENT=local
+      - ENV=local
       - PYTHONPATH=.
     ports:
       - 8000:8000

--- a/deployment/helm/templates/cognee_deployment.yaml
+++ b/deployment/helm/templates/cognee_deployment.yaml
@@ -22,10 +22,8 @@ spec:
           env:
             - name: ENABLE_BACKEND_ACCESS_CONTROL
               value: "false"
-            - name: HOST
-              value: {{ .Values.cognee.env.HOST }}
-            - name: ENVIRONMENT
-              value: {{ .Values.cognee.env.ENVIRONMENT }}
+            - name: ENV
+              value: {{ .Values.cognee.env.ENV }}
             - name: PYTHONPATH
               value: {{ .Values.cognee.env.PYTHONPATH }}
             - name: VECTOR_DB_PROVIDER

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -4,8 +4,7 @@ cognee:
   image: "cognee/cognee:main"
   port: 8000
   env:
-    HOST: "0.0.0.0"
-    ENVIRONMENT: "local"
+    ENV: "local"
     PYTHONPATH: "."
     LLM_MODEL: "openai/gpt-4o-mini"
     LLM_PROVIDER: "openai"

--- a/distributed/deploy/render.yaml
+++ b/distributed/deploy/render.yaml
@@ -17,9 +17,7 @@ services:
         value: openai/gpt-4o-mini
       - key: LLM_PROVIDER
         value: openai
-      - key: HOST
-        value: 0.0.0.0
-      - key: ENVIRONMENT
+      - key: ENV
         value: prod
       - key: DB_PROVIDER
         value: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       # - /path/to/your/data:/data
     environment:
       - DEBUG=false # Change to true if debugging
-      - HOST=0.0.0.0
-      - ENVIRONMENT=local
+      - ENV=local
       - LOG_LEVEL=INFO
       # CAUTION: Default '*' allows all origins. Override with specific domains in production.
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-*}
@@ -55,7 +54,7 @@ services:
       # - /path/to/your/data:/data
     environment:
       - DEBUG=false # Change to true if debugging
-      - ENVIRONMENT=local
+      - ENV=local
       - LOG_LEVEL=INFO
       - TRANSPORT_MODE=sse
       # Database configuration - should match the main cognee service
@@ -66,7 +65,6 @@ services:
       - DB_USERNAME=${DB_USERNAME:-cognee}
       - DB_PASSWORD=${DB_PASSWORD:-cognee}
       # MCP specific configuration
-      - MCP_LOG_LEVEL=INFO
       - PYTHONUNBUFFERED=1
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 set -e  # Exit on error
+# ENV is the canonical environment variable (matches what the app reads).
+# ENVIRONMENT is accepted as a deprecated fallback for older deployments.
+ENV="${ENV:-${ENVIRONMENT:-}}"
 echo "Debug mode: $DEBUG"
-echo "Environment: $ENVIRONMENT"
+echo "Environment: $ENV"
 
 # Set default ports and bind address if not specified
 DEBUG_PORT=${DEBUG_PORT:-5678}
@@ -42,7 +45,7 @@ echo "Starting server..."
 sleep 2
 
 # Modified Gunicorn startup with error handling
-if [ "$ENVIRONMENT" = "dev" ] || [ "$ENVIRONMENT" = "local" ]; then
+if [ "$ENV" = "dev" ] || [ "$ENV" = "local" ]; then
     if [ "$DEBUG" = "true" ]; then
         echo "Waiting for the debugger to attach..."
         exec debugpy --wait-for-client --listen $BIND_ADDRESS:$DEBUG_PORT -m gunicorn -w 1 -k uvicorn.workers.UvicornWorker -t 30000 --bind=$BIND_ADDRESS:$HTTP_PORT --log-level debug --reload --access-logfile - --error-logfile - cognee.api.client:app


### PR DESCRIPTION
## Summary
Follow-up to #3245 / #3258. Unifies the four env-var overlaps found while documenting the Docker/MCP runtime config. **Every change keeps the legacy name working via fallback**, so no existing `.env` or compose/helm override breaks.

| # | Overlap | Canonical | Legacy (still works) |
|---|---|---|---|
| 1 | `ENV` vs `ENVIRONMENT` | `ENV` | `ENVIRONMENT` (entrypoint fallback) |
| 2 | cloud URL/token | `COGNEE_SERVICE_URL` / `COGNEE_API_KEY` | `COGNEE_CLOUD_API_URL` / `COGNEE_CLOUD_AUTH_TOKEN` (sync fallback) |
| 3 | `HOST` | — (removed; bind via `BIND_ADDRESS`) | n/a (was dead) |
| 4 | `MCP_LOG_LEVEL` | `LOG_LEVEL` / `--log-level` | n/a (was dead) |

### 1. `ENV` vs `ENVIRONMENT`
The app reads `ENV` (`cognee/api/client.py`, `cognee/shared/utils.py`, etc.); the two container entrypoints read `ENVIRONMENT`. Now both entrypoints resolve `ENV="${ENV:-${ENVIRONMENT:-}}"` (ENVIRONMENT honored as deprecated fallback), and `docker-compose.yml`, helm, `render.yaml`, and the CI workflow set `ENV`.
**Behavior note:** dockerized dev/local/CI containers now report their real environment to the app instead of defaulting to `prod`. Practical impact is minimal — Sentry only initializes when the `monitoring` extra + DSN are present, and `ENV=local` still emits telemetry.

### 2. Cloud connection vars
`cognee/api/v1/sync/sync.py` was the only consumer of `COGNEE_CLOUD_API_URL` / `COGNEE_CLOUD_AUTH_TOKEN`. Everything else (`serve()`, `push()`, MCP server, CLI, tests) uses `COGNEE_SERVICE_URL` / `COGNEE_API_KEY`. `sync.py` now reads the canonical names first, falling back to `COGNEE_CLOUD_*`. Default base URL (`http://localhost:8001`) preserved.

### 3. `HOST`
Set by compose/helm/render but read by no code (entrypoints bind via `BIND_ADDRESS`, which already defaults to `0.0.0.0`). Removed the dead entries.

### 4. `MCP_LOG_LEVEL`
Set in the MCP `Dockerfile` (`ENV MCP_LOG_LEVEL=DEBUG`) and compose, but read by no code — MCP log level comes from the `--log-level` flag / `mcp.settings.log_level`. Removed; `LOG_LEVEL` is the canonical knob.

## Verification
- `bash -n` on both entrypoints ✅; `ENV` fallback + precedence simulated ✅
- All edited YAML parses (compose, helm, render, CI) ✅
- `ruff check cognee/api/v1/sync/sync.py` clean ✅
- Only residual `ENVIRONMENT` refs are the intentional fallback lines ✅

## Follow-up
The `.env.template` notes added in #3258 ("ENV vs ENVIRONMENT are separate today", "COGNEE_SERVICE_URL distinct from COGNEE_CLOUD_*") will be refreshed to describe this unified behavior once both land. (Unrelated: `deployment/helm/values.yaml` still has a stale `LLM_MODEL: "openai/gpt-4o-mini"` default — left out of this scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)