### PR TITLE
fix(users): check user/role existence before dereferencing in add_user_to_role

### DIFF
--- a/cognee/modules/users/roles/methods/add_user_to_role.py
+++ b/cognee/modules/users/roles/methods/add_user_to_role.py
@@ -35,7 +35,13 @@ async def add_user_to_role(user_id: UUID, role_id: UUID, owner_id: UUID):
     db_engine = get_relational_engine()
     async with db_engine.get_async_session() as session:
         user = (await session.execute(select(User).where(User.id == user_id))).scalars().first()
+        if not user:
+            raise UserNotFoundError
+
         role = (await session.execute(select(Role).where(Role.id == role_id))).scalars().first()
+        if not role:
+            raise RoleNotFoundError
+
         tenant = (
             (await session.execute(select(Tenant).where(Tenant.id == role.tenant_id)))
             .scalars()
@@ -44,11 +50,7 @@ async def add_user_to_role(user_id: UUID, role_id: UUID, owner_id: UUID):
 
         user_tenants = await user.awaitable_attrs.tenants
 
-        if not user:
-            raise UserNotFoundError
-        elif not role:
-            raise RoleNotFoundError
-        elif role.tenant_id not in [tenant.id for tenant in user_tenants]:
+        if role.tenant_id not in [tenant.id for tenant in user_tenants]:
             raise TenantNotFoundError(
                 message="User tenant does not match role tenant. User cannot be added to role."
             )

--- a/cognee/tests/unit/modules/users/test_add_user_to_role_guard_order.py
+++ b/cognee/tests/unit/modules/users/test_add_user_to_role_guard_order.py
@@ -1,0 +1,94 @@
+"""Regression test: add_user_to_role must check existence before dereferencing.
+
+add_user_to_role fetches ``user``, ``role`` and ``role``'s ``tenant`` and then
+checks ``if not user`` / ``elif not role``. The fetch order used to dereference
+``role.tenant_id`` (to look up the tenant) and ``user.awaitable_attrs`` *before*
+those guards ran, so a non-existent role/user raised ``AttributeError`` (HTTP 500
+through the permissions router) instead of the intended ``RoleNotFoundError`` /
+``UserNotFoundError`` (HTTP 404). The guards are now evaluated right after each
+fetch, before any attribute access.
+"""
+
+import importlib
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.users.exceptions import RoleNotFoundError, UserNotFoundError
+
+add_user_to_role_module = importlib.import_module(
+    "cognee.modules.users.roles.methods.add_user_to_role"
+)
+
+
+class _Result:
+    def __init__(self, value):
+        self._value = value
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._value
+
+
+class _FakeSession:
+    """Returns the queued results in execute() call order (user, role, tenant)."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self._i = 0
+
+    async def execute(self, _stmt):
+        result = _Result(self._results[self._i])
+        self._i += 1
+        return result
+
+    async def commit(self):
+        return None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self, results):
+        self._results = results
+
+    def get_async_session(self):
+        return _FakeSession(self._results)
+
+
+@pytest.mark.asyncio
+async def test_missing_user_raises_user_not_found(monkeypatch):
+    # user -> None; role/tenant rows present so the buggy code would still reach
+    # user.awaitable_attrs (and raise AttributeError) instead of UserNotFoundError.
+    role_row = SimpleNamespace(tenant_id=uuid4())
+    tenant_row = SimpleNamespace(id=uuid4(), owner_id=uuid4())
+    monkeypatch.setattr(
+        add_user_to_role_module,
+        "get_relational_engine",
+        lambda: _FakeEngine([None, role_row, tenant_row]),
+    )
+
+    with pytest.raises(UserNotFoundError):
+        await add_user_to_role_module.add_user_to_role(uuid4(), uuid4(), uuid4())
+
+
+@pytest.mark.asyncio
+async def test_missing_role_raises_role_not_found(monkeypatch):
+    # user present, role -> None; the buggy code dereferences role.tenant_id first.
+    user_row = SimpleNamespace(id=uuid4())
+    tenant_row = SimpleNamespace(id=uuid4(), owner_id=uuid4())
+    monkeypatch.setattr(
+        add_user_to_role_module,
+        "get_relational_engine",
+        lambda: _FakeEngine([user_row, None, tenant_row]),
+    )
+
+    with pytest.raises(RoleNotFoundError):
+        await add_user_to_role_module.add_user_to_role(uuid4(), uuid4(), uuid4())


### PR DESCRIPTION
## Description

`add_user_to_role(user_id, role_id, owner_id)` is reached from the permissions router (`POST .../roles/{role_id}/users`) with client-supplied IDs and no prior existence check. It fetched `user`, `role`, and `role`'s `tenant`, and only afterwards validated existence:

```python
user = (... User.id == user_id ...).first()
role = (... Role.id == role_id ...).first()
tenant = (... Tenant.id == role.tenant_id ...).first()   # role may be None
user_tenants = await user.awaitable_attrs.tenants         # user may be None
if not user:
    raise UserNotFoundError
elif not role:
    raise RoleNotFoundError
...
```

Looking up the tenant dereferences `role.tenant_id`, and the membership check reads `user.awaitable_attrs.tenants` — both **before** the `if not user` / `elif not role` guards. So a non-existent `role_id` raises `AttributeError: 'NoneType' object has no attribute 'tenant_id'`, and a non-existent `user_id` raises `AttributeError: ... 'awaitable_attrs'`. Either way the client gets an unhandled HTTP 500 instead of the 404 the `UserNotFoundError`/`RoleNotFoundError` branches are meant to produce (those branches are dead code for the missing case).

The fix evaluates each existence guard immediately after its fetch, before any attribute access.

## Acceptance Criteria

- A non-existent `user_id` raises `UserNotFoundError` (404), not `AttributeError` (500).
- A non-existent `role_id` raises `RoleNotFoundError` (404), not `AttributeError` (500).

Regression tests (both raise `AttributeError` on `dev`, pass with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_add_user_to_role_guard_order.py::test_missing_user_raises_user_not_found
  - AttributeError: 'NoneType' object has no attribute 'awaitable_attrs'
FAILED ...test_add_user_to_role_guard_order.py::test_missing_role_raises_role_not_found
  - AttributeError: 'NoneType' object has no attribute 'tenant_id'
2 failed in 0.93s

--- AFTER: fix applied ---
2 passed in 0.15s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="692" height="402" alt="image" src="https://github.com/user-attachments/assets/eee14630-8ba5-4617-a518-99030a9e9a6a" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
