### PR TITLE
fix(api): return 404 (not 500) for missing dataset in data endpoints

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -370,10 +370,12 @@ def get_datasets_router() -> APIRouter:
         # Verify user has permission to read dataset
         dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
 
-        if dataset is None:
+        if not dataset:
             return JSONResponse(
                 status_code=404,
-                content=ErrorResponseDTO(f"Dataset ({str(dataset_id)}) not found."),
+                content=ErrorResponseDTO(
+                    message=f"Dataset ({str(dataset_id)}) not found."
+                ).model_dump(),
             )
 
         dataset_id = dataset[0].id
@@ -525,7 +527,7 @@ def get_datasets_router() -> APIRouter:
         # Verify user has permission to read dataset
         dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
 
-        if dataset is None:
+        if not dataset:
             return JSONResponse(
                 status_code=404, content={"detail": f"Dataset ({dataset_id}) not found."}
             )

--- a/cognee/tests/unit/api/test_datasets_missing_dataset_404.py
+++ b/cognee/tests/unit/api/test_datasets_missing_dataset_404.py
@@ -1,0 +1,88 @@
+"""Regression test: dataset data endpoints return 404 for missing/unauthorized datasets.
+
+``GET /datasets/{id}/data`` and ``GET /datasets/{id}/data/{data_id}/raw`` guard
+with ``if dataset is None`` and then index ``dataset[0].id``. But
+``get_authorized_existing_datasets`` always returns a *list* (``[]`` when the
+dataset is missing or the user lacks permission), never ``None`` — so the guard
+was dead code and ``dataset[0].id`` raised ``IndexError`` (HTTP 500) instead of a
+clean 404. (``GET .../data`` additionally built ``ErrorResponseDTO`` with a
+positional arg, which Pydantic v2 rejects, so even the dead branch would have
+500'd.) The guards now use ``if not dataset``.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cognee.modules.users.methods import get_authenticated_user
+
+
+@pytest.fixture(scope="module")
+def test_client():
+    from cognee.api.v1.datasets.routers.get_datasets_router import get_datasets_router
+
+    app = FastAPI()
+    app.include_router(get_datasets_router(), prefix="/api/v1/datasets")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def client(test_client):
+    async def override_get_authenticated_user():
+        return SimpleNamespace(
+            id=str(uuid.uuid4()),
+            email="default@example.com",
+            is_active=True,
+            tenant_id=str(uuid.uuid4()),
+        )
+
+    import importlib
+
+    datasets_router_module = importlib.import_module(
+        "cognee.api.v1.datasets.routers.get_datasets_router"
+    )
+    datasets_router_module.send_telemetry = lambda *args, **kwargs: None
+
+    test_client.app.dependency_overrides[get_authenticated_user] = override_get_authenticated_user
+    yield test_client
+    test_client.app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+def _no_authorized_datasets(monkeypatch):
+    """Simulate a missing/unauthorized dataset: an empty list, as the real helper returns."""
+    import importlib
+
+    datasets_router_module = importlib.import_module(
+        "cognee.api.v1.datasets.routers.get_datasets_router"
+    )
+    monkeypatch.setattr(
+        datasets_router_module,
+        "get_authorized_existing_datasets",
+        AsyncMock(return_value=[]),
+    )
+
+
+def test_get_dataset_data_missing_dataset_returns_404(client, monkeypatch):
+    _no_authorized_datasets(monkeypatch)
+    dataset_id = uuid.uuid4()
+
+    response = client.get(f"/api/v1/datasets/{dataset_id}/data")
+
+    assert response.status_code == 404
+    assert "not found" in response.text.lower()
+
+
+def test_get_raw_data_missing_dataset_returns_404(client, monkeypatch):
+    _no_authorized_datasets(monkeypatch)
+    dataset_id = uuid.uuid4()
+    data_id = uuid.uuid4()
+
+    response = client.get(f"/api/v1/datasets/{dataset_id}/data/{data_id}/raw")
+
+    assert response.status_code == 404
+    assert "not found" in response.text.lower()


### PR DESCRIPTION
## Description

`GET /v1/datasets/{dataset_id}/data` and `GET /v1/datasets/{dataset_id}/data/{data_id}/raw` authorize the request like this:

```python
dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
if dataset is None:
    return JSONResponse(status_code=404, ...)
dataset_id = dataset[0].id   # or dataset[0].id below
```

`get_authorized_existing_datasets` always returns a **list** — `[]` when the dataset doesn't exist or the user lacks permission — and never `None`. So `if dataset is None` is dead code, and `dataset[0].id` raises `IndexError: list index out of range`, surfacing as an **HTTP 500** instead of a clean **404** for a missing/unauthorized dataset.

The `.../data` endpoint had a second defect in that same dead branch: `ErrorResponseDTO(f"...")` passes a positional argument, which Pydantic v2 rejects, and the model instance was handed straight to `JSONResponse(content=...)` without `model_dump()` — so even if the branch were reached it could not produce a valid response.

The fix guards with `if not dataset` and returns `ErrorResponseDTO(message=...).model_dump()`.

## Acceptance Criteria

- Requesting a non-existent or unauthorized dataset on either endpoint returns **404** with a "not found" message, not a 500.

Regression tests (both 500 on `dev`, 404 with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_datasets_missing_dataset_404.py::test_get_dataset_data_missing_dataset_returns_404
  - IndexError: list index out of range  (get_datasets_router.py:533)
FAILED ...test_datasets_missing_dataset_404.py::test_get_raw_data_missing_dataset_returns_404
2 failed in 1.01s

--- AFTER: fix applied ---
2 passed in 0.11s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="702" height="432" alt="image" src="https://github.com/user-attachments/assets/747cbf75-44c7-454b-b8ed-b68e14843764" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
