### PR TITLE
fix(api): surface real pipeline error in cognify/memify 500 responses

### DIFF
--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -255,7 +255,12 @@ def get_cognify_router() -> APIRouter:
                 )
                 detail = None
                 if first_err is not None:
-                    detail = getattr(first_err, "error", None) or str(first_err)
+                    # The failing task's error is carried on ``payload`` (set to
+                    # ``repr(error)`` by the pipeline runner); PipelineRunErrored
+                    # has no ``error`` attribute. Surface it so the client gets an
+                    # actionable message instead of the model's repr.
+                    payload = first_err.payload if isinstance(first_err.payload, str) else None
+                    detail = payload or str(first_err)
 
                 return JSONResponse(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/cognee/api/v1/memify/routers/get_memify_router.py
+++ b/cognee/api/v1/memify/routers/get_memify_router.py
@@ -111,7 +111,12 @@ def get_memify_router() -> APIRouter:
             )
 
             if isinstance(memify_run, PipelineRunErrored):
-                detail = getattr(memify_run, "error", None) or str(memify_run)
+                # The failing task's error is carried on ``payload`` (set to
+                # ``repr(error)`` by the pipeline runner); PipelineRunErrored has
+                # no ``error`` attribute. Surface it so the client gets an
+                # actionable message instead of the model's repr.
+                payload = memify_run.payload if isinstance(memify_run.payload, str) else None
+                detail = payload or str(memify_run)
 
                 return JSONResponse(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/cognee/tests/unit/api/test_cognify_memify_error_detail.py
+++ b/cognee/tests/unit/api/test_cognify_memify_error_detail.py
@@ -1,0 +1,89 @@
+"""Regression test: cognify/memify error responses surface the real error.
+
+When a cognify/memify pipeline run errors, the routers build the 500 response
+``detail`` from ``getattr(run, "error", None) or str(run)``. ``PipelineRunErrored``
+has no ``error`` attribute — the failing task's message is carried on ``payload``
+(set to ``repr(error)`` by the pipeline runner; the add router reads it
+correctly). So ``getattr(..., "error", None)`` was always ``None`` and the detail
+fell back to the model's ``str()`` repr instead of the actionable message. The
+routers now read ``payload`` like the add router does.
+"""
+
+import importlib
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunErrored
+from cognee.modules.users.methods import get_authenticated_user
+
+cognify_router_module = importlib.import_module("cognee.api.v1.cognify.routers.get_cognify_router")
+memify_router_module = importlib.import_module("cognee.api.v1.memify.routers.get_memify_router")
+
+
+def _errored(payload_message):
+    return PipelineRunErrored(
+        pipeline_run_id=uuid.uuid4(),
+        dataset_id=uuid.uuid4(),
+        dataset_name="ds",
+        payload=payload_message,
+    )
+
+
+@pytest.fixture(scope="module")
+def test_client():
+    app = FastAPI()
+    app.include_router(cognify_router_module.get_cognify_router(), prefix="/api/v1/cognify")
+    app.include_router(memify_router_module.get_memify_router(), prefix="/api/v1/memify")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def client(test_client):
+    async def override_get_authenticated_user():
+        return SimpleNamespace(
+            id=str(uuid.uuid4()), email="default@example.com", is_active=True, tenant_id=None
+        )
+
+    cognify_router_module.send_telemetry = lambda *a, **k: None
+    memify_router_module.send_telemetry = lambda *a, **k: None
+    test_client.app.dependency_overrides[get_authenticated_user] = override_get_authenticated_user
+    yield test_client
+    test_client.app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+def test_cognify_error_detail_is_the_task_message(client, monkeypatch):
+    message = "LLM_API_KEY is missing"
+
+    import cognee.api.v1.cognify as cognify_pkg
+
+    async def fake_cognify(*_args, **_kwargs):
+        return {"ds": _errored(message)}
+
+    monkeypatch.setattr(cognify_pkg, "cognify", fake_cognify)
+
+    response = client.post("/api/v1/cognify", json={"datasets": ["ds"]})
+
+    assert response.status_code == 500
+    # The clean task message, not the PipelineRunErrored repr.
+    assert response.json()["detail"] == message
+
+
+def test_memify_error_detail_is_the_task_message(client, monkeypatch):
+    message = "enrichment task blew up"
+
+    import cognee.modules.memify as memify_pkg
+
+    async def fake_memify(*_args, **_kwargs):
+        return _errored(message)
+
+    monkeypatch.setattr(memify_pkg, "memify", fake_memify)
+
+    response = client.post("/api/v1/memify", json={"dataset_name": "ds"})
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == message


### PR DESCRIPTION
## Description

When a cognify or memify pipeline run errors, both routers build the HTTP 500 response `detail` like this:

```python
detail = getattr(first_err, "error", None) or str(first_err)   # cognify
detail = getattr(memify_run, "error", None) or str(memify_run) # memify
```

`PipelineRunErrored` (see `PipelineRunInfo.py`) has **no `error` attribute** — the failing task's message is carried on `payload`, which the pipeline runner sets to `repr(error)`. The add router already reads it correctly (`add_run.payload`). So `getattr(..., "error", None)` is always `None`, and `detail` falls back to `str(first_err)` — the model's repr (e.g. `status='PipelineRunErrored' pipeline_run_id=UUID('...') dataset_name='ds' payload='LLM_API_KEY is missing' ...`) instead of the clean, actionable message.

The fix reads `payload` (guarded to `str`) like the add router, in both routers.

## Acceptance Criteria

- A failed cognify/memify run returns a 500 whose `detail` is the failing task's message (e.g. `LLM_API_KEY is missing`), not the `PipelineRunErrored` repr.

Regression tests (detail is the model repr on `dev`, the clean message with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_cognify_memify_error_detail.py::test_cognify_error_detail_is_the_task_message
  - assert "status='PipelineRunErrored' ... payload='LLM_API_KEY is missing' ..." == 'LLM_API_KEY is missing'
1 failed, 1 passed in 0.49s

--- AFTER: fix applied ---
2 passed in 0.10s
```

(In the screenshot the BEFORE run only toggles the cognify router back to `dev`, so the memify test already passes; both fail when run against unmodified `dev`.)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="715" height="453" alt="image" src="https://github.com/user-attachments/assets/576e2413-71de-4c4b-a218-32dffc0f0800" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
