### PR TITLE
fix(llm): return instructor result directly in Mistral structured output

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
@@ -119,22 +119,17 @@ class MistralAdapter(GenericAPIAdapter):
             merged_kwargs = {**self.llm_args, **kwargs}
             try:
                 async with llm_rate_limiter_context_manager():
-                    response = await self.aclient.chat.completions.create(
+                    # self.aclient is an instructor client, so create() returns the
+                    # validated `response_model` instance directly (not a raw
+                    # ChatCompletion). Return it as-is, like the other adapters;
+                    # reaching into `.choices` would raise AttributeError.
+                    return await self.aclient.chat.completions.create(
                         model=self.model,
                         max_retries=2,
                         messages=messages,
                         response_model=response_model,
                         **merged_kwargs,
                     )
-                if (
-                    response.choices
-                    and response.choices[0].message is not None
-                    and response.choices[0].message.content
-                ):
-                    content = response.choices[0].message.content
-                    return response_model.model_validate_json(content)
-                else:
-                    raise ValueError("Failed to get valid response after retries")
             except litellm.exceptions.BadRequestError as e:
                 logger.error(f"Bad request error: {str(e)}")
                 raise ValueError(f"Invalid request: {str(e)}")

--- a/cognee/tests/unit/infrastructure/llm/test_mistral_structured_output.py
+++ b/cognee/tests/unit/infrastructure/llm/test_mistral_structured_output.py
@@ -1,0 +1,62 @@
+"""Regression test: MistralAdapter returns the instructor result directly.
+
+``self.aclient`` is an ``instructor.from_litellm(...)`` client, so calling
+``chat.completions.create(..., response_model=...)`` returns the *validated
+response_model instance*, not a raw ``ChatCompletion``. The adapter used to do
+``response.choices[0].message.content`` on that instance, which has no
+``choices`` attribute -> ``AttributeError`` (retried by tenacity, then reraised),
+making structured output completely broken under ``LLM_PROVIDER="mistral"``.
+Every sibling adapter (OpenAI, Gemini, Anthropic, Generic) returns the result
+directly. This test drives the method with a stubbed instructor client.
+"""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import BaseModel
+
+# The mistral adapter imports `mistralai` at module load; skip when the optional
+# `mistral` extra isn't installed (e.g. default CI) rather than erroring on collect.
+pytest.importorskip("mistralai")
+
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mistral import (  # noqa: E402
+    adapter as mistral_adapter_module,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mistral.adapter import (  # noqa: E402
+    MistralAdapter,
+)
+
+
+class _Answer(BaseModel):
+    value: str
+
+
+@pytest.mark.asyncio
+async def test_returns_validated_model_from_instructor(monkeypatch):
+    @asynccontextmanager
+    async def _noop_rate_limiter(*_args, **_kwargs):
+        yield
+
+    monkeypatch.setattr(
+        mistral_adapter_module, "llm_rate_limiter_context_manager", _noop_rate_limiter
+    )
+
+    expected = _Answer(value="ok")
+    create = AsyncMock(return_value=expected)
+    # Stub self: an instructor client returns the validated model instance.
+    stub = SimpleNamespace(
+        llm_args={},
+        model="mistral/mistral-small-latest",
+        aclient=SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create))),
+    )
+
+    result = await MistralAdapter.acreate_structured_output(
+        stub, text_input="hello", system_prompt="sys", response_model=_Answer
+    )
+
+    # The instructor result is returned as-is (no .choices dereference).
+    assert result is expected
+    create.assert_awaited_once()
+    assert create.await_args.kwargs["response_model"] is _Answer


### PR DESCRIPTION
## Description

`MistralAdapter.acreate_structured_output` calls:

```python
response = await self.aclient.chat.completions.create(
    model=self.model, messages=messages, response_model=response_model, ...
)
if response.choices and response.choices[0].message ...:
    content = response.choices[0].message.content
    return response_model.model_validate_json(content)
```

`self.aclient` is built with `instructor.from_litellm(...)`, so calling `create(..., response_model=...)` returns the **validated `response_model` instance**, not a raw `ChatCompletion`. That instance has no `.choices` attribute, so `response.choices` raises `AttributeError`. The error isn't in the `retry_if_not_exception_type(...)` exclusion list, so tenacity retries three times and reraises — making structured output **completely broken** for `LLM_PROVIDER="mistral"` (every cognify/search/extraction call fails with `AttributeError: '<YourModel>' object has no attribute 'choices'`).

Every sibling adapter (OpenAI, Gemini, Anthropic, Generic) returns the instructor result directly. The fix does the same here.

## Acceptance Criteria

- `acreate_structured_output` returns the validated `response_model` instance produced by the instructor client, without dereferencing `.choices`.

Regression test (drives the method with a stubbed instructor client; skipped when the optional `mistral` extra is absent):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_mistral_structured_output.py::test_returns_validated_model_from_instructor
  - AttributeError: '_Answer' object has no attribute 'choices' (retried 3x, then reraised)
1 failed in 25.77s

--- AFTER: fix applied ---
1 passed in 0.08s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="773" height="517" alt="image" src="https://github.com/user-attachments/assets/56877232-7d82-4634-a5a6-26379371a169" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
