### PR TITLE
fix: retry dataset data after processing completes

### DIFF
--- a/cognee-frontend/src/app/(app)/datasets/DatasetsPage.tsx
+++ b/cognee-frontend/src/app/(app)/datasets/DatasetsPage.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useCogniInstance, useTenant } from "@/modules/tenant/TenantProvider";
+import { type CogneeInstance } from "@/modules/instances/types";
 import { useFilter } from "@/ui/layout/FilterContext";
 import getDatasets from "@/modules/datasets/getDatasets";
 import getDatasetData from "@/modules/datasets/getDatasetData";
@@ -130,6 +131,18 @@ function formatDate(dateStr?: string): string {
   return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function getDatasetDataWithRetry(datasetId: string, instance: CogneeInstance, shouldRetryEmpty: boolean) {
+  const maxAttempts = shouldRetryEmpty ? 4 : 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const data = await getDatasetData(datasetId, instance);
+    if (!shouldRetryEmpty || !Array.isArray(data) || data.length > 0 || attempt === maxAttempts) return data;
+    await delay(1500);
+  }
+  return [];
+}
+
 export default function DatasetsPage() {
   const { cogniInstance, isInitializing } = useCogniInstance();
   const { tenant } = useTenant();
@@ -234,7 +247,7 @@ export default function DatasetsPage() {
       const statusData: Record<string, DatasetProcessingStatus> = statusResp?.ok ? await statusResp.json() : {};
 
       for (const ds of list) {
-        getDatasetData(ds.id, cogniInstance)
+        getDatasetDataWithRetry(ds.id, cogniInstance, statusData[ds.id] === "DATASET_PROCESSING_COMPLETED")
           .then((data) => {
             const count = Array.isArray(data) ? data.length : 0;
             setDatasets((prev) => prev.map((d) => d.id === ds.id ? { ...d, documents: count, status: mapProcessingStatus(statusData[ds.id], count) } : d));


### PR DESCRIPTION
## Summary

The Brains/Datasets page now retries the dataset data endpoint briefly when backend processing reports completion but the data list is still empty, covering the eventual-consistency window seen immediately after dashboard uploads.

## Changes

- Add a small retry helper for dataset document loads.
- Use it only for datasets with `DATASET_PROCESSING_COMPLETED` status so genuinely empty or loading datasets are not delayed unnecessarily.

## Testing

- `npm run lint` could not run initially because dependencies were not installed (`next: command not found`).
- `npm ci` could not install dependencies because the checked-in package-lock is out of sync with package.json (missing optional sharp/unrs resolver packages).

Fixes topoteretes/cognee#3234