### PR TITLE
fix: initialize database before CLI user lookup

### DIFF
--- a/cognee/cli/user_resolution.py
+++ b/cognee/cli/user_resolution.py
@@ -6,6 +6,20 @@ from uuid import UUID
 import cognee.cli.echo as fmt
 
 
+async def _ensure_database_ready() -> None:
+    """Initialize storage before CLI commands resolve users.
+
+    SDK entry points such as ``cognee.add`` call setup internally, but the CLI
+    resolves the acting user before delegating to those entry points.  On a fresh
+    Postgres database that means the first ``get_default_user`` query can run
+    before the ``principals`` table exists.  Running setup here keeps user
+    resolution safe for every in-process CLI command.
+    """
+    from cognee.modules.engine.operations.setup import setup
+
+    await setup()
+
+
 async def resolve_cli_user(user_id: Optional[str] = None, strict: bool = False):
     """Return the User for the given --user-id, or the default user when omitted.
 
@@ -19,6 +33,7 @@ async def resolve_cli_user(user_id: Optional[str] = None, strict: bool = False):
     from cognee.modules.users.methods import get_default_user
 
     if not user_id:
+        await _ensure_database_ready()
         return await get_default_user()
 
     try:
@@ -28,6 +43,8 @@ async def resolve_cli_user(user_id: Optional[str] = None, strict: bool = False):
             f"Invalid --user-id: '{user_id}' is not a valid UUID.  "
             f"Example: --user-id 550e8400-e29b-41d4-a716-446655440000"
         )
+
+    await _ensure_database_ready()
 
     from cognee.modules.users.methods import get_user
 

--- a/cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py
@@ -16,7 +16,10 @@ class TestScopedSessionId:
 
     def test_custom_session(self):
         uid = UUID("550e8400-e29b-41d4-a716-446655440000")
-        assert scoped_session_id(uid, "chat-1") == "550e8400-e29b-41d4-a716-446655440000:chat-1"
+        assert (
+            scoped_session_id(uid, "chat-1")
+            == "550e8400-e29b-41d4-a716-446655440000:chat-1"
+        )
 
     def test_none_session_uses_default(self):
         uid = uuid4()
@@ -30,42 +33,76 @@ class TestScopedSessionId:
 
 
 class TestResolveCliUser:
-    def test_none_returns_default_user(self):
+    @pytest.fixture(autouse=True)
+    def mock_database_setup(self):
+        with patch(
+            "cognee.modules.engine.operations.setup.setup", new_callable=AsyncMock
+        ) as mock_setup:
+            yield mock_setup
+
+    def test_none_returns_default_user(self, mock_database_setup):
         mock_user = MagicMock()
         mock_get_default = AsyncMock(return_value=mock_user)
         with patch("cognee.modules.users.methods.get_default_user", mock_get_default):
             result = asyncio.run(resolve_cli_user(None))
             assert result is mock_user
+            mock_database_setup.assert_awaited_once()
 
-    def test_empty_string_returns_default_user(self):
+    def test_empty_string_returns_default_user(self, mock_database_setup):
         mock_user = MagicMock()
         mock_get_default = AsyncMock(return_value=mock_user)
         with patch("cognee.modules.users.methods.get_default_user", mock_get_default):
             result = asyncio.run(resolve_cli_user(""))
             assert result is mock_user
+            mock_database_setup.assert_awaited_once()
 
-    def test_invalid_uuid_raises_value_error(self):
+    def test_invalid_uuid_raises_value_error(self, mock_database_setup):
         with pytest.raises(ValueError, match="not a valid UUID"):
             asyncio.run(resolve_cli_user("not-a-uuid"))
+        mock_database_setup.assert_not_awaited()
 
-    def test_valid_uuid_existing_user(self):
+    def test_valid_uuid_existing_user(self, mock_database_setup):
         uid = "550e8400-e29b-41d4-a716-446655440000"
         mock_user = MagicMock()
         mock_get_user = AsyncMock(return_value=mock_user)
         with patch("cognee.modules.users.methods.get_user", mock_get_user):
             result = asyncio.run(resolve_cli_user(uid))
             assert result is mock_user
+            mock_database_setup.assert_awaited_once()
 
-    def test_valid_uuid_unknown_user_warns_and_falls_back(self):
+    def test_database_setup_happens_before_default_user_lookup(
+        self, mock_database_setup
+    ):
+        calls = []
+
+        async def setup_side_effect():
+            calls.append("setup")
+
+        async def get_default_side_effect():
+            calls.append("get_default_user")
+            return MagicMock()
+
+        mock_database_setup.side_effect = setup_side_effect
+        mock_get_default = AsyncMock(side_effect=get_default_side_effect)
+
+        with patch("cognee.modules.users.methods.get_default_user", mock_get_default):
+            asyncio.run(resolve_cli_user(None))
+
+        assert calls == ["setup", "get_default_user"]
+
+    def test_valid_uuid_unknown_user_warns_and_falls_back(self, mock_database_setup):
         uid = "550e8400-e29b-41d4-a716-446655440000"
         default_user = MagicMock()
         mock_get_user = AsyncMock(side_effect=Exception("not found"))
         mock_get_default = AsyncMock(return_value=default_user)
 
         with patch("cognee.modules.users.methods.get_user", mock_get_user):
-            with patch("cognee.modules.users.methods.get_default_user", mock_get_default):
+            with patch(
+                "cognee.modules.users.methods.get_default_user", mock_get_default
+            ):
                 with patch("cognee.cli.echo.warning") as mock_warn:
                     result = asyncio.run(resolve_cli_user(uid))
                     assert result is default_user
+                    mock_database_setup.assert_awaited_once()
                     mock_warn.assert_called_once()
                     assert "falling back" in mock_warn.call_args[0][0].lower()


### PR DESCRIPTION
## Summary

Initialize Cognee storage before CLI commands resolve the acting user, so a fresh Postgres database has its relational/vector schemas created before `get_default_user()` queries tables such as `principals`.

## Changes

- Added a CLI user-resolution setup step that calls the existing engine `setup()` before default or explicit user lookup.
- Preserved invalid UUID validation without touching the database.
- Updated CLI user-resolution unit tests to assert setup happens first and remains skipped for invalid UUIDs.

## Testing

- `uv run pytest cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py`
- `uv run pytest cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py cognee/tests/cli_tests/cli_unit_tests/test_cli_edge_cases.py`
- `uv run black cognee/cli/user_resolution.py cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py`
- `uv run ruff check cognee/cli/user_resolution.py cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py`

Fixes topoteretes/cognee#3267