### PR TITLE
fix: make KnowledgeGraph node description optional (fixes nightly llama-cpp flake)

### DIFF
--- a/cognee/modules/engine/models/Entity.py
+++ b/cognee/modules/engine/models/Entity.py
@@ -7,7 +7,7 @@ from cognee.modules.engine.models.EntityType import EntityType
 class Entity(DataPoint):
     name: str
     is_a: Optional[EntityType] = None
-    description: str
+    description: Optional[str] = None
     relations: List[tuple] = []
     # identity_fields makes the id deterministic and namespaced by class
     # (``Entity:<name>``) when constructed without an explicit id — the same

--- a/cognee/modules/graph/utils/expand_with_nodes_and_edges.py
+++ b/cognee/modules/graph/utils/expand_with_nodes_and_edges.py
@@ -168,7 +168,7 @@ def _create_type_node(
 def _create_entity_node(
     node_id: str,
     node_name: str,
-    node_description: str,
+    node_description: str | None,
     type_node: EntityType,
     ontology_resolver: RDFLibOntologyResolver,
     added_nodes_map: dict,

--- a/cognee/shared/data_models.py
+++ b/cognee/shared/data_models.py
@@ -23,7 +23,10 @@ if get_llm_config().llm_provider.lower() == "gemini":
         id: str
         name: str
         type: str
-        description: str
+        description: str | None = Field(
+            None,
+            description="Concise one-sentence description of the entity, using its name.",
+        )
         label: str
 
     class Edge(BaseModel):
@@ -52,7 +55,10 @@ else:
         id: str
         name: str = ""
         type: str
-        description: str
+        description: str | None = Field(
+            None,
+            description="Concise one-sentence description of the entity, using its name.",
+        )
 
         def __init__(self, **data: Any) -> None:
             if not data.get("name"):


### PR DESCRIPTION
## What

Make the per-node `description` in `KnowledgeGraph` **optional** (nullable), mirroring the existing `Edge.description` pattern, and add the schema hint the model was missing.

## Why — this is *not* an instructor/code regression

The nightly **Llama-cpp** job fails on `InstructorRetryException` → `3 validation errors for KnowledgeGraph` (`nodes.N.description Field required`). The 4-bit Phi-3-mini sometimes omits the node `description`. Investigation of the last-green (Jun 15) → first-red (Jun 16) window shows **nothing in the code path changed**:

- **instructor was `1.15.1` at *both* the green and red commits** — it did not change, so downgrading wouldn't help.
- The forward-compat fix (#3080) only wraps bare *primitives*; a `BaseModel` like `KnowledgeGraph` passes through untouched.
- The GGUF model is **SHA-pinned** (`sha256sum -c`) — no model drift; the release didn't bump any inference lib.

So the job is **structurally flaky**: `Node.description` was a *required* field with **no schema guidance**, while `Edge.description` right next to it is already `str | None` *with* a description — which is exactly why edges never fail but nodes do. Jun 15 was the last lucky sampling draw.

## Change

- `shared/data_models.py` — both `Node` variants (gemini + non-gemini): `description: str | None = Field(None, description=…)`
- `modules/engine/models/Entity.py` — `description: Optional[str] = None` so the omitted case flows end-to-end (entities are indexed on `name`, not `description`)
- `expand_with_nodes_and_edges.py` — honest `node_description: str | None` hint

`EntityType.description` is unaffected (it receives `node_name`, not `node.description`).

## Verification

- `description` no longer in `Node`/`Entity` `required` sets; `KnowledgeGraph` and `Entity(description=None)` both validate
- `cognee/tests/unit/modules/graph` (97) and `cognee/tests/unit/tasks/graph` (8) green
