### PR TITLE
revert: restore pghybrid code that was commented out

### DIFF
--- a/.github/workflows/graph_db_tests.yml
+++ b/.github/workflows/graph_db_tests.yml
@@ -137,40 +137,40 @@ jobs:
           EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
         run: uv run python ./cognee/tests/e2e/postgres/test_graphdb_postgres.py
 
-#      - name: Run Postgres Hybrid Adapter Tests
-#        env:
-#          ENV: 'dev'
-#          DB_PROVIDER: postgres
-#          DB_HOST: localhost
-#          DB_PORT: 5432
-#          DB_USERNAME: cognee
-#          DB_PASSWORD: cognee
-#          DB_NAME: cognee_db
-#          EMBEDDING_DIMENSIONS: 300
-#          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
-#          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
-#        run: uv run pytest cognee/tests/e2e/postgres/test_postgres_hybrid_adapter.py -v
-#
-#      - name: Run Postgres Hybrid E2E Test
-#        env:
-#          ENV: 'dev'
-#          USE_UNIFIED_PROVIDER: "pghybrid"
-#          DB_PROVIDER: postgres
-#          DB_HOST: localhost
-#          DB_PORT: 5432
-#          DB_USERNAME: cognee
-#          DB_PASSWORD: cognee
-#          DB_NAME: cognee_db
-#          ENABLE_BACKEND_ACCESS_CONTROL: 'false'
-#          LLM_MODEL: ${{ secrets.LLM_MODEL }}
-#          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
-#          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-#          LLM_ARGS: ${{ secrets.LLM_ARGS }}
-#          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
-#          EMBEDDING_DIMENSIONS: 300
-#          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
-#          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
-#        run: uv run python ./cognee/tests/e2e/postgres/test_pghybrid.py
+      - name: Run Postgres Hybrid Adapter Tests
+        env:
+          ENV: 'dev'
+          DB_PROVIDER: postgres
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_USERNAME: cognee
+          DB_PASSWORD: cognee
+          DB_NAME: cognee_db
+          EMBEDDING_DIMENSIONS: 300
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run pytest cognee/tests/e2e/postgres/test_postgres_hybrid_adapter.py -v
+
+      - name: Run Postgres Hybrid E2E Test
+        env:
+          ENV: 'dev'
+          USE_UNIFIED_PROVIDER: "pghybrid"
+          DB_PROVIDER: postgres
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_USERNAME: cognee
+          DB_PASSWORD: cognee
+          DB_NAME: cognee_db
+          ENABLE_BACKEND_ACCESS_CONTROL: 'false'
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_DIMENSIONS: 300
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run python ./cognee/tests/e2e/postgres/test_pghybrid.py
 
   run-neo4j-tests:
     name: Neo4j Tests

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -159,14 +159,14 @@ def create_graph_engine(
     kuzu_max_db_size = normalized_optional_params["kuzu_max_db_size"]
 
     # Check USE_UNIFIED_PROVIDER outside the cache so it's always re-read
-    # unified_provider = os.environ.get("USE_UNIFIED_PROVIDER", "")
-    # if unified_provider == "pghybrid":
-    #     from .postgres.adapter import PostgresAdapter
-    #     from cognee.infrastructure.databases.relational.get_relational_engine import (
-    #         get_relational_engine,
-    #     )
-    #
-    #     return PostgresAdapter(connection_string=get_relational_engine().db_uri)
+    unified_provider = os.environ.get("USE_UNIFIED_PROVIDER", "")
+    if unified_provider == "pghybrid":
+        from .postgres.adapter import PostgresAdapter
+        from cognee.infrastructure.databases.relational.get_relational_engine import (
+            get_relational_engine,
+        )
+
+        return PostgresAdapter(connection_string=get_relational_engine().db_uri)
 
     return _create_graph_engine(
         graph_database_provider,

--- a/cognee/infrastructure/databases/unified/get_unified_engine.py
+++ b/cognee/infrastructure/databases/unified/get_unified_engine.py
@@ -61,26 +61,26 @@ async def _create_hybrid_adapter(graph_config: dict, vector_config: dict):
             embedding_engine=embedding_engine,
         )
 
-    # if provider == "pghybrid":
-    #     from cognee.infrastructure.databases.hybrid.postgres.adapter import (
-    #         PostgresHybridAdapter,
-    #     )
-    #     from cognee.infrastructure.databases.graph.postgres.adapter import PostgresAdapter
-    #     from cognee.infrastructure.databases.relational.get_relational_engine import (
-    #         get_relational_engine,
-    #     )
-    #
-    #     # Graph adapter gets its own engine from the relational connection string
-    #     graph_adapter = PostgresAdapter(connection_string=get_relational_engine().db_uri)
-    #
-    #     # Vector adapter: reuse the cached PGVectorAdapter from the
-    #     # vector engine factory. This requires VECTOR_DB_PROVIDER=pgvector.
-    #     vector_adapter = get_vector_engine()
-    #
-    #     return PostgresHybridAdapter(
-    #         graph_adapter=graph_adapter,
-    #         vector_adapter=vector_adapter,
-    #     )
+    if provider == "pghybrid":
+        from cognee.infrastructure.databases.hybrid.postgres.adapter import (
+            PostgresHybridAdapter,
+        )
+        from cognee.infrastructure.databases.graph.postgres.adapter import PostgresAdapter
+        from cognee.infrastructure.databases.relational.get_relational_engine import (
+            get_relational_engine,
+        )
+
+        # Graph adapter gets its own engine from the relational connection string
+        graph_adapter = PostgresAdapter(connection_string=get_relational_engine().db_uri)
+
+        # Vector adapter: reuse the cached PGVectorAdapter from the
+        # vector engine factory. This requires VECTOR_DB_PROVIDER=pgvector.
+        vector_adapter = get_vector_engine()
+
+        return PostgresHybridAdapter(
+            graph_adapter=graph_adapter,
+            vector_adapter=vector_adapter,
+        )
 
     raise EnvironmentError(f"Unsupported hybrid provider: {provider}")
 

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -78,25 +78,25 @@ def create_vector_engine(
     vector_db_subprocess_enabled = normalized_optional_params["vector_db_subprocess_enabled"]
 
     # Check USE_UNIFIED_PROVIDER outside the cache so it's always re-read
-    # unified_provider = os.environ.get("USE_UNIFIED_PROVIDER", "")
-    # if unified_provider == "pghybrid":
-    #     from cognee.infrastructure.databases.relational import get_relational_config
-    #
-    #     embedding_engine = get_embedding_engine()
-    #     relational_config = get_relational_config()
-    #     connection_string = (
-    #         f"postgresql+asyncpg://{relational_config.db_username}:{relational_config.db_password}"
-    #         f"@{relational_config.db_host}:{relational_config.db_port}"
-    #         f"/{relational_config.db_name}"
-    #     )
-    #
-    #     from .pgvector.PGVectorAdapter import PGVectorAdapter
-    #
-    #     return PGVectorAdapter(
-    #         connection_string,
-    #         vector_db_key,
-    #         embedding_engine,
-    #     )
+    unified_provider = os.environ.get("USE_UNIFIED_PROVIDER", "")
+    if unified_provider == "pghybrid":
+        from cognee.infrastructure.databases.relational import get_relational_config
+
+        embedding_engine = get_embedding_engine()
+        relational_config = get_relational_config()
+        connection_string = (
+            f"postgresql+asyncpg://{relational_config.db_username}:{relational_config.db_password}"
+            f"@{relational_config.db_host}:{relational_config.db_port}"
+            f"/{relational_config.db_name}"
+        )
+
+        from .pgvector.PGVectorAdapter import PGVectorAdapter
+
+        return PGVectorAdapter(
+            connection_string,
+            vector_db_key,
+            embedding_engine,
+        )
 
     return _create_vector_engine(
         vector_db_provider,


### PR DESCRIPTION
Un-comments the pghybrid (PostgresHybridAdapter / USE_UNIFIED_PROVIDER) blocks in the graph, vector, and unified engine factories, plus the Postgres Hybrid CI steps in graph_db_tests.yml. The data_cache changes from the prior commit are left intact.

<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
