### PR TITLE
Fix Cognify WebSocket auth

### DIFF
--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -9,9 +9,15 @@ from fastapi import APIRouter, WebSocket, Depends, WebSocketDisconnect, status
 from starlette.status import WS_1000_NORMAL_CLOSURE, WS_1008_POLICY_VIOLATION
 
 from cognee.api.DTO import InDTO
+from cognee.modules.data.methods import get_authorized_dataset
 from cognee.modules.pipelines.methods import get_pipeline_run
 from cognee.modules.users.models import User
-from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.methods import (
+    REQUIRE_AUTHENTICATION,
+    get_authenticated_user,
+    get_default_user,
+    get_user,
+)
 from cognee.modules.users.get_user_db import get_user_db_context
 from cognee.modules.graph.methods import get_formatted_graph_data
 from cognee.modules.users.get_user_manager import get_user_manager_context
@@ -114,6 +120,65 @@ class CognifyPayloadDTO(InDTO):
         examples=[20],
         description="Maximum number of data items to process concurrently within a dataset.",
     )
+
+
+def _get_websocket_access_token(websocket: WebSocket) -> Optional[str]:
+    authorization_header = websocket.headers.get("authorization")
+    if authorization_header:
+        scheme, _, token = authorization_header.partition(" ")
+        if scheme.lower() == "bearer" and token.strip():
+            return token.strip()
+
+    return websocket.cookies.get(os.getenv("AUTH_TOKEN_COOKIE_NAME", "auth_token"))
+
+
+async def _read_websocket_jwt_user(token: Optional[str]) -> Optional[User]:
+    if not token:
+        return None
+
+    secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+    lifetime_seconds = int(os.getenv("JWT_LIFETIME_SECONDS", "3600"))
+    strategy = DefaultJWTStrategy(secret, lifetime_seconds=lifetime_seconds)
+
+    db_engine = get_relational_engine()
+
+    async with db_engine.get_async_session() as session:
+        async with get_user_db_context(session) as user_db:
+            async with get_user_manager_context(user_db) as user_manager:
+                return await strategy.read_token(token, user_manager)
+
+
+async def _get_websocket_authenticated_user(websocket: WebSocket) -> Optional[User]:
+    token = _get_websocket_access_token(websocket)
+    user = await _read_websocket_jwt_user(token)
+
+    if user is None:
+        if REQUIRE_AUTHENTICATION:
+            return None
+
+        return await get_default_user()
+
+    if not user.is_active:
+        return None
+
+    return await get_user(user.id)
+
+
+async def _get_authorized_cognify_pipeline_run(pipeline_run_id: str, user: User):
+    try:
+        parsed_pipeline_run_id = UUID(pipeline_run_id)
+    except ValueError:
+        return None
+
+    pipeline_run = await get_pipeline_run(parsed_pipeline_run_id)
+    if not pipeline_run or not pipeline_run.dataset_id:
+        return None
+
+    dataset = await get_authorized_dataset(user, pipeline_run.dataset_id, "read")
+    if not dataset:
+        return None
+
+    return pipeline_run
 
 
 def get_cognify_router() -> APIRouter:
@@ -288,32 +353,29 @@ def get_cognify_router() -> APIRouter:
     async def subscribe_to_cognify_info(websocket: WebSocket, pipeline_run_id: str):
         await websocket.accept()
 
-        access_token = websocket.cookies.get(os.getenv("AUTH_TOKEN_COOKIE_NAME", "auth_token"))
-
         try:
-            secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
-
-            strategy = DefaultJWTStrategy(secret, lifetime_seconds=3600)
-
-            db_engine = get_relational_engine()
-
-            async with db_engine.get_async_session() as session:
-                async with get_user_db_context(session) as user_db:
-                    async with get_user_manager_context(user_db) as user_manager:
-                        user = await get_authenticated_user(
-                            cookie=access_token,
-                            strategy_cookie=strategy,
-                            user_manager=user_manager,
-                            bearer=None,
-                        )
+            user = await _get_websocket_authenticated_user(websocket)
         except Exception as error:
             logger.error(f"Authentication failed: {str(error)}")
             await websocket.close(code=WS_1008_POLICY_VIOLATION, reason="Unauthorized")
             return
 
-        pipeline_run_id = UUID(pipeline_run_id)
+        if user is None:
+            await websocket.close(code=WS_1008_POLICY_VIOLATION, reason="Unauthorized")
+            return
 
-        pipeline_run = await get_pipeline_run(pipeline_run_id)
+        try:
+            pipeline_run = await _get_authorized_cognify_pipeline_run(pipeline_run_id, user)
+        except Exception as error:
+            logger.error(f"Authorization failed: {str(error)}")
+            await websocket.close(code=WS_1008_POLICY_VIOLATION, reason="Unauthorized")
+            return
+
+        if pipeline_run is None:
+            await websocket.close(code=WS_1008_POLICY_VIOLATION, reason="Unauthorized")
+            return
+
+        pipeline_run_id = pipeline_run.pipeline_run_id
 
         initialize_queue(pipeline_run_id)
 

--- a/cognee/tests/unit/api/test_cognify_websocket_auth.py
+++ b/cognee/tests/unit/api/test_cognify_websocket_auth.py
@@ -1,0 +1,136 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from starlette.datastructures import Headers
+
+router_module = importlib.import_module("cognee.api.v1.cognify.routers.get_cognify_router")
+
+
+class WebSocketStub:
+    def __init__(self, *, headers=None, cookies=None):
+        self.headers = Headers(headers or {})
+        self.cookies = cookies or {}
+
+
+def test_websocket_access_token_prefers_bearer_header():
+    websocket = WebSocketStub(
+        headers={"Authorization": "Bearer header-token"},
+        cookies={"auth_token": "cookie-token"},
+    )
+
+    assert router_module._get_websocket_access_token(websocket) == "header-token"
+
+
+def test_websocket_access_token_falls_back_to_cookie():
+    websocket = WebSocketStub(
+        headers={"Authorization": "Basic ignored"},
+        cookies={"auth_token": "cookie-token"},
+    )
+
+    assert router_module._get_websocket_access_token(websocket) == "cookie-token"
+
+
+@pytest.mark.asyncio
+async def test_websocket_auth_fetches_active_user_from_jwt(monkeypatch):
+    token_user = SimpleNamespace(id=uuid4(), is_active=True)
+    hydrated_user = SimpleNamespace(id=token_user.id, is_active=True)
+    read_user = AsyncMock(return_value=token_user)
+    get_user = AsyncMock(return_value=hydrated_user)
+    get_default_user = AsyncMock()
+
+    monkeypatch.setattr(router_module, "REQUIRE_AUTHENTICATION", True)
+    monkeypatch.setattr(router_module, "_read_websocket_jwt_user", read_user)
+    monkeypatch.setattr(router_module, "get_user", get_user)
+    monkeypatch.setattr(router_module, "get_default_user", get_default_user)
+
+    websocket = WebSocketStub(headers={"Authorization": "Bearer jwt-token"})
+    user = await router_module._get_websocket_authenticated_user(websocket)
+
+    assert user is hydrated_user
+    read_user.assert_awaited_once_with("jwt-token")
+    get_user.assert_awaited_once_with(token_user.id)
+    get_default_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_websocket_auth_rejects_inactive_user(monkeypatch):
+    token_user = SimpleNamespace(id=uuid4(), is_active=False)
+    read_user = AsyncMock(return_value=token_user)
+    get_user = AsyncMock()
+
+    monkeypatch.setattr(router_module, "REQUIRE_AUTHENTICATION", True)
+    monkeypatch.setattr(router_module, "_read_websocket_jwt_user", read_user)
+    monkeypatch.setattr(router_module, "get_user", get_user)
+
+    websocket = WebSocketStub(headers={"Authorization": "Bearer jwt-token"})
+    user = await router_module._get_websocket_authenticated_user(websocket)
+
+    assert user is None
+    get_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_websocket_auth_uses_default_user_if_auth_disabled(monkeypatch):
+    default_user = SimpleNamespace(id=uuid4(), is_active=True)
+    read_user = AsyncMock(return_value=None)
+    get_default_user = AsyncMock(return_value=default_user)
+
+    monkeypatch.setattr(router_module, "REQUIRE_AUTHENTICATION", False)
+    monkeypatch.setattr(router_module, "_read_websocket_jwt_user", read_user)
+    monkeypatch.setattr(router_module, "get_default_user", get_default_user)
+
+    user = await router_module._get_websocket_authenticated_user(WebSocketStub())
+
+    assert user is default_user
+    read_user.assert_awaited_once_with(None)
+    get_default_user.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_authorized_cognify_pipeline_run_requires_dataset_read(monkeypatch):
+    dataset_id = uuid4()
+    pipeline_run_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    pipeline_run = SimpleNamespace(pipeline_run_id=pipeline_run_id, dataset_id=dataset_id)
+    get_pipeline_run = AsyncMock(return_value=pipeline_run)
+    get_authorized_dataset = AsyncMock(return_value=SimpleNamespace(id=dataset_id))
+
+    monkeypatch.setattr(router_module, "get_pipeline_run", get_pipeline_run)
+    monkeypatch.setattr(router_module, "get_authorized_dataset", get_authorized_dataset)
+
+    result = await router_module._get_authorized_cognify_pipeline_run(str(pipeline_run_id), user)
+
+    assert result is pipeline_run
+    get_pipeline_run.assert_awaited_once_with(pipeline_run_id)
+    get_authorized_dataset.assert_awaited_once_with(user, dataset_id, "read")
+
+
+@pytest.mark.asyncio
+async def test_authorized_cognify_pipeline_run_rejects_missing_read_access(monkeypatch):
+    dataset_id = uuid4()
+    pipeline_run_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    pipeline_run = SimpleNamespace(pipeline_run_id=pipeline_run_id, dataset_id=dataset_id)
+
+    monkeypatch.setattr(router_module, "get_pipeline_run", AsyncMock(return_value=pipeline_run))
+    monkeypatch.setattr(router_module, "get_authorized_dataset", AsyncMock(return_value=None))
+
+    result = await router_module._get_authorized_cognify_pipeline_run(str(pipeline_run_id), user)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_authorized_cognify_pipeline_run_rejects_invalid_run_id(monkeypatch):
+    get_pipeline_run = AsyncMock()
+    monkeypatch.setattr(router_module, "get_pipeline_run", get_pipeline_run)
+
+    result = await router_module._get_authorized_cognify_pipeline_run(
+        "not-a-uuid", SimpleNamespace(id=uuid4())
+    )
+
+    assert result is None
+    get_pipeline_run.assert_not_awaited()


### PR DESCRIPTION
## Summary
- replace the Cognify subscription direct dependency call with a WebSocket-specific JWT auth helper
- accept bearer headers or auth cookies, hydrate active users, and preserve default-user fallback when auth is disabled
- verify read access to the pipeline run dataset before queue subscription and graph streaming

## Root cause
The WebSocket path manually called `get_authenticated_user(cookie=..., strategy_cookie=..., user_manager=..., bearer=None)`, but the current helper only accepts dependency-injected users. That raises during subscription auth and closes clients as unauthorized.

## Validation
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest cognee/tests/unit/api/test_cognify_websocket_auth.py -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest cognee/tests/unit/api/test_api_error_responses.py -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check cognee/api/v1/cognify/routers/get_cognify_router.py cognee/tests/unit/api/test_cognify_websocket_auth.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff format --check cognee/api/v1/cognify/routers/get_cognify_router.py cognee/tests/unit/api/test_cognify_websocket_auth.py`