### PR TITLE
Fix tenant-scoped role lookups

### DIFF
--- a/cognee/modules/users/tenants/methods/get_user_roles.py
+++ b/cognee/modules/users/tenants/methods/get_user_roles.py
@@ -1,7 +1,8 @@
 from sqlalchemy import select
 from uuid import UUID
 
-from cognee.modules.users.models import User
+from cognee.modules.users.exceptions import UserNotFoundError
+from cognee.modules.users.models import Role, User, UserRole, UserTenant
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.users.permissions.methods.has_user_management_permission import (
     has_user_management_permission,
@@ -14,10 +15,21 @@ async def get_user_roles(tenant_id: UUID, user_id: UUID, user: User):
 
     db_engine = get_relational_engine()
     async with db_engine.get_async_session() as session:
-        from cognee.modules.users.models import Role
+        tenant_membership_result = await session.execute(
+            select(UserTenant).where(
+                UserTenant.user_id == user_id,
+                UserTenant.tenant_id == tenant_id,
+            )
+        )
+        tenant_membership = tenant_membership_result.scalars().first()
+
+        if tenant_membership is None:
+            raise UserNotFoundError(message="User not found in tenant.")
 
         role_results = await session.execute(
-            select(Role).join(Role.users).where(User.id == user_id)
+            select(Role)
+            .join(UserRole, Role.id == UserRole.role_id)
+            .where(UserRole.user_id == user_id, Role.tenant_id == tenant_id)
         )
         roles = role_results.scalars().all()
 

--- a/cognee/modules/users/tenants/methods/get_users_in_role.py
+++ b/cognee/modules/users/tenants/methods/get_users_in_role.py
@@ -1,7 +1,8 @@
 from sqlalchemy import select
 from uuid import UUID
 
-from cognee.modules.users.models import User
+from cognee.modules.users.exceptions import RoleNotFoundError
+from cognee.modules.users.models import Role, User, UserRole, UserTenant
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.users.permissions.methods.has_user_management_permission import (
     has_user_management_permission,
@@ -14,10 +15,22 @@ async def get_users_in_role(tenant_id: UUID, role_id: UUID, user: User):
 
     db_engine = get_relational_engine()
     async with db_engine.get_async_session() as session:
-        from cognee.modules.users.models import Role
+        role_result = await session.execute(
+            select(Role).where(Role.id == role_id, Role.tenant_id == tenant_id)
+        )
+        role = role_result.scalars().first()
+
+        if role is None:
+            raise RoleNotFoundError(message="Role not found in tenant.")
 
         user_results = await session.execute(
-            select(User).join(User.roles).where(Role.id == role_id)
+            select(User)
+            .join(UserRole, User.id == UserRole.user_id)
+            .join(UserTenant, User.id == UserTenant.user_id)
+            .where(
+                UserRole.role_id == role_id,
+                UserTenant.tenant_id == tenant_id,
+            )
         )
         users = user_results.scalars().all()
 

--- a/cognee/tests/unit/users/tenants/test_role_lookup_methods.py
+++ b/cognee/tests/unit/users/tenants/test_role_lookup_methods.py
@@ -1,0 +1,173 @@
+import importlib
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.users.exceptions import RoleNotFoundError, UserNotFoundError
+from cognee.modules.users.tenants.methods.get_user_roles import get_user_roles
+from cognee.modules.users.tenants.methods.get_users_in_role import get_users_in_role
+
+_get_users_in_role_mod = importlib.import_module(
+    "cognee.modules.users.tenants.methods.get_users_in_role"
+)
+_get_user_roles_mod = importlib.import_module("cognee.modules.users.tenants.methods.get_user_roles")
+
+
+class FakeResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self.value
+
+    def all(self):
+        return self.value
+
+
+class FakeSession:
+    def __init__(self, values):
+        self.values = list(values)
+        self.statements = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return FakeResult(self.values.pop(0))
+
+
+class FakeEngine:
+    def __init__(self, session):
+        self.session = session
+
+    def get_async_session(self):
+        return self.session
+
+
+def statement_sql(session, index):
+    return str(session.statements[index]).lower()
+
+
+@pytest.mark.asyncio
+async def test_get_users_in_role_filters_role_and_users_by_tenant(monkeypatch):
+    tenant_id = uuid4()
+    role_id = uuid4()
+    requester_id = uuid4()
+    target_user_id = uuid4()
+    target_user = SimpleNamespace(id=target_user_id, email="member@example.com")
+    session = FakeSession([SimpleNamespace(id=role_id), [target_user]])
+    permission_calls = []
+
+    async def fake_has_user_management_permission(user_id, checked_tenant_id):
+        permission_calls.append((user_id, checked_tenant_id))
+        return True
+
+    monkeypatch.setattr(
+        _get_users_in_role_mod, "get_relational_engine", lambda: FakeEngine(session)
+    )
+    monkeypatch.setattr(
+        _get_users_in_role_mod,
+        "has_user_management_permission",
+        fake_has_user_management_permission,
+    )
+
+    result = await get_users_in_role(
+        tenant_id=tenant_id, role_id=role_id, user=SimpleNamespace(id=requester_id)
+    )
+
+    assert result == [{"id": str(target_user_id), "name": "member@example.com"}]
+    assert permission_calls == [(requester_id, tenant_id)]
+    assert "roles.tenant_id" in statement_sql(session, 0)
+    assert "user_roles.role_id" in statement_sql(session, 1)
+    assert "user_tenants.tenant_id" in statement_sql(session, 1)
+
+
+@pytest.mark.asyncio
+async def test_get_users_in_role_raises_for_role_outside_tenant(monkeypatch):
+    tenant_id = uuid4()
+    role_id = uuid4()
+    session = FakeSession([None])
+
+    async def fake_has_user_management_permission(user_id, checked_tenant_id):  # noqa: ARG001
+        return True
+
+    monkeypatch.setattr(
+        _get_users_in_role_mod, "get_relational_engine", lambda: FakeEngine(session)
+    )
+    monkeypatch.setattr(
+        _get_users_in_role_mod,
+        "has_user_management_permission",
+        fake_has_user_management_permission,
+    )
+
+    with pytest.raises(RoleNotFoundError):
+        await get_users_in_role(
+            tenant_id=tenant_id, role_id=role_id, user=SimpleNamespace(id=uuid4())
+        )
+
+    assert len(session.statements) == 1
+    assert "roles.tenant_id" in statement_sql(session, 0)
+
+
+@pytest.mark.asyncio
+async def test_get_user_roles_requires_user_membership_and_filters_roles_by_tenant(monkeypatch):
+    tenant_id = uuid4()
+    requester_id = uuid4()
+    target_user_id = uuid4()
+    role_id = uuid4()
+    role = SimpleNamespace(id=role_id, name="admin")
+    session = FakeSession([SimpleNamespace(user_id=target_user_id), [role]])
+    permission_calls = []
+
+    async def fake_has_user_management_permission(user_id, checked_tenant_id):
+        permission_calls.append((user_id, checked_tenant_id))
+        return True
+
+    monkeypatch.setattr(_get_user_roles_mod, "get_relational_engine", lambda: FakeEngine(session))
+    monkeypatch.setattr(
+        _get_user_roles_mod,
+        "has_user_management_permission",
+        fake_has_user_management_permission,
+    )
+
+    result = await get_user_roles(
+        tenant_id=tenant_id, user_id=target_user_id, user=SimpleNamespace(id=requester_id)
+    )
+
+    assert result == [{"id": str(role_id), "name": "admin"}]
+    assert permission_calls == [(requester_id, tenant_id)]
+    assert "user_tenants.tenant_id" in statement_sql(session, 0)
+    assert "roles.tenant_id" in statement_sql(session, 1)
+
+
+@pytest.mark.asyncio
+async def test_get_user_roles_raises_for_user_outside_tenant(monkeypatch):
+    tenant_id = uuid4()
+    target_user_id = uuid4()
+    session = FakeSession([None])
+
+    async def fake_has_user_management_permission(user_id, checked_tenant_id):  # noqa: ARG001
+        return True
+
+    monkeypatch.setattr(_get_user_roles_mod, "get_relational_engine", lambda: FakeEngine(session))
+    monkeypatch.setattr(
+        _get_user_roles_mod,
+        "has_user_management_permission",
+        fake_has_user_management_permission,
+    )
+
+    with pytest.raises(UserNotFoundError):
+        await get_user_roles(
+            tenant_id=tenant_id, user_id=target_user_id, user=SimpleNamespace(id=uuid4())
+        )
+
+    assert len(session.statements) == 1
+    assert "user_tenants.tenant_id" in statement_sql(session, 0)


### PR DESCRIPTION
## Summary
- bind role lookup endpoints to the tenant already checked for user-management permission
- return the existing 404-style errors when the requested role or target user is not in that tenant
- add focused unit tests for tenant filtering and out-of-tenant targets

## Root cause
The permission check used the tenant id from the path, but the follow-up queries did not bind the requested role or user to that same tenant. A manager of one tenant could therefore query role/user ids from another tenant and get cross-tenant membership data.

## Validation
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest cognee/tests/unit/users/tenants/test_role_lookup_methods.py -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest cognee/tests/unit/users/roles/test_role_management_methods.py cognee/tests/unit/users/tenants/test_remove_user_from_tenant.py cognee/tests/unit/users/permissions/test_has_user_management_permission.py -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check cognee/modules/users/tenants/methods/get_users_in_role.py cognee/modules/users/tenants/methods/get_user_roles.py cognee/tests/unit/users/tenants/test_role_lookup_methods.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff format --check cognee/modules/users/tenants/methods/get_users_in_role.py cognee/modules/users/tenants/methods/get_user_roles.py cognee/tests/unit/users/tenants/test_role_lookup_methods.py`