### PR TITLE
fix: narrow CLI user resolution exception handling

### DIFF
--- a/cognee/cli/user_resolution.py
+++ b/cognee/cli/user_resolution.py
@@ -4,6 +4,7 @@ from typing import Optional
 from uuid import UUID
 
 import cognee.cli.echo as fmt
+from cognee.infrastructure.databases.exceptions import EntityNotFoundError
 
 
 async def resolve_cli_user(user_id: Optional[str] = None, strict: bool = False):
@@ -33,7 +34,7 @@ async def resolve_cli_user(user_id: Optional[str] = None, strict: bool = False):
 
     try:
         return await get_user(uid)
-    except Exception:
+    except EntityNotFoundError:
         if strict:
             raise ValueError(
                 f"--user-id {uid} does not exist.  Refusing to fall back to the default "

--- a/cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from cognee.cli.user_resolution import resolve_cli_user, scoped_session_id
+from cognee.infrastructure.databases.exceptions import EntityNotFoundError
 
 
 class TestScopedSessionId:
@@ -59,7 +60,7 @@ class TestResolveCliUser:
     def test_valid_uuid_unknown_user_warns_and_falls_back(self):
         uid = "550e8400-e29b-41d4-a716-446655440000"
         default_user = MagicMock()
-        mock_get_user = AsyncMock(side_effect=Exception("not found"))
+        mock_get_user = AsyncMock(side_effect=EntityNotFoundError(message="not found"))
         mock_get_default = AsyncMock(return_value=default_user)
 
         with patch("cognee.modules.users.methods.get_user", mock_get_user):
@@ -69,3 +70,11 @@ class TestResolveCliUser:
                     assert result is default_user
                     mock_warn.assert_called_once()
                     assert "falling back" in mock_warn.call_args[0][0].lower()
+
+    def test_unexpected_lookup_error_propagates(self):
+        uid = "550e8400-e29b-41d4-a716-446655440000"
+        mock_get_user = AsyncMock(side_effect=RuntimeError("db offline"))
+
+        with patch("cognee.modules.users.methods.get_user", mock_get_user):
+            with pytest.raises(RuntimeError, match="db offline"):
+                asyncio.run(resolve_cli_user(uid))

--- a/cognee/tests/unit/test_agents_sdk_cli.py
+++ b/cognee/tests/unit/test_agents_sdk_cli.py
@@ -18,6 +18,8 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from cognee.infrastructure.databases.exceptions import EntityNotFoundError
+
 agents_sdk = pytest.importorskip(
     "cognee.api.v1.agents.agents",
     reason="agents SDK namespace not yet available",
@@ -509,7 +511,7 @@ async def test_resolve_cli_user_strict_unknown_uuid_raises(monkeypatch):
     from cognee.cli import user_resolution
 
     async def fake_get_user(uid):
-        raise Exception("user not found")
+        raise EntityNotFoundError(message="user not found")
 
     async def fake_get_default_user():
         raise AssertionError("strict mode must not fall back to the default user")
@@ -532,7 +534,7 @@ async def test_resolve_cli_user_non_strict_falls_back(monkeypatch):
     sentinel = _make_user()
 
     async def fake_get_user(uid):
-        raise Exception("user not found")
+        raise EntityNotFoundError(message="user not found")
 
     async def fake_get_default_user():
         return sentinel


### PR DESCRIPTION
## Description

This PR fixes the broad exception handling in `cognee/cli/user_resolution.py`.

Before this change, `resolve_cli_user()` caught `Exception` around `get_user()`, which could swallow unrelated database or ORM failures and treat them as missing-user cases.

This change narrows the fallback path to `EntityNotFoundError` only, so genuine infrastructure or lookup failures propagate normally.

This PR intentionally addresses only the CLI user-resolution bug described in #3276. It does not change telemetry or privacy behavior.

## Acceptance Criteria

- `resolve_cli_user()` only falls back for the expected missing-user case
- unrelated lookup failures are no longer swallowed
- existing `strict=True`, non-strict fallback, and invalid UUID behavior are preserved
- regression coverage proves the new propagation behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Passing local checks were run on branch `fix-3276-narrow-cli-user-resolution` based on `origin/dev`.

`uv sync --extra dev`

`uv run pytest cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py -v --tb=short`
- Result: `10 passed`

`uv run pytest cognee/tests/unit/test_agents_sdk_cli.py -v --tb=short`
- Result: `16 passed`

`pre-commit run --files cognee/cli/user_resolution.py cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py cognee/tests/unit/test_agents_sdk_cli.py`
- Result: all hooks passed

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
