### PR TITLE
fix(retrieval): apply vector scores in TEMPORAL event ranking

### DIFF
--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -106,12 +106,15 @@ class TemporalRetriever(GraphCompletionRetriever):
         return time_from, time_to
 
     async def filter_top_k_events(self, relevant_events, scored_results):
-        # Build a score lookup from vector search results
-        score_lookup = {res.id: res.score for res in scored_results}
+        # Build a score lookup from vector search results. ScoredResult.id is a
+        # UUID, while event["id"] coming from the graph is a string, so the keys
+        # must be normalized to str — otherwise every lookup misses, all events
+        # tie at inf, and the vector ranking is silently ignored.
+        score_lookup = {str(res.id): res.score for res in scored_results}
 
         events_with_scores = []
         for event in relevant_events[0]["events"]:
-            score = score_lookup.get(event["id"], float("inf"))
+            score = score_lookup.get(str(event["id"]), float("inf"))
             events_with_scores.append({**event, "score": score})
 
         events_with_scores.sort(key=itemgetter("score"))

--- a/cognee/tests/unit/modules/retrieval/test_temporal_filter_top_k_events.py
+++ b/cognee/tests/unit/modules/retrieval/test_temporal_filter_top_k_events.py
@@ -1,0 +1,68 @@
+"""Regression test: TEMPORAL event ranking must apply the vector scores.
+
+``TemporalRetriever.filter_top_k_events`` ranks the time-filtered events by the
+similarity score of the ``Event_name`` vector search. It built the score lookup
+keyed by ``ScoredResult.id`` (a ``uuid.UUID``) but looked it up with
+``event["id"]`` (a plain string from the graph). ``UUID(x) != str(x)`` and they
+hash differently, so every lookup returned the ``inf`` default — all events tied,
+the sort was a no-op, and the events came back in arbitrary graph order with the
+vector ranking discarded. Keys are now normalized to ``str``.
+"""
+
+import uuid
+
+import pytest
+
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.modules.retrieval.temporal_retriever import TemporalRetriever
+
+
+@pytest.mark.asyncio
+async def test_events_are_ranked_by_vector_score():
+    id_a = uuid.uuid4()
+    id_b = uuid.uuid4()
+    id_c = uuid.uuid4()
+
+    # Graph events carry string ids and are returned in a non-score order.
+    relevant_events = [
+        {
+            "events": [
+                {"id": str(id_a), "name": "A", "description": "a"},
+                {"id": str(id_b), "name": "B", "description": "b"},
+                {"id": str(id_c), "name": "C", "description": "c"},
+            ]
+        }
+    ]
+    # Lower score is better; B is most relevant, then C, then A.
+    scored_results = [
+        ScoredResult(id=id_a, score=0.9, payload={}),
+        ScoredResult(id=id_b, score=0.1, payload={}),
+        ScoredResult(id=id_c, score=0.5, payload={}),
+    ]
+
+    retriever = TemporalRetriever(top_k=3)
+    top = await retriever.filter_top_k_events(relevant_events, scored_results)
+
+    # The scores must actually be applied (not the inf fallback)...
+    assert [e["score"] for e in top] == [0.1, 0.5, 0.9]
+    # ...and the events ordered by relevance.
+    assert [e["name"] for e in top] == ["B", "C", "A"]
+
+
+@pytest.mark.asyncio
+async def test_top_k_truncates_to_best_matches():
+    ids = [uuid.uuid4() for _ in range(3)]
+    relevant_events = [
+        {"events": [{"id": str(i), "name": n} for i, n in zip(ids, ["A", "B", "C"])]}
+    ]
+    scored_results = [
+        ScoredResult(id=ids[0], score=0.9, payload={}),
+        ScoredResult(id=ids[1], score=0.1, payload={}),
+        ScoredResult(id=ids[2], score=0.5, payload={}),
+    ]
+
+    retriever = TemporalRetriever(top_k=2)
+    top = await retriever.filter_top_k_events(relevant_events, scored_results)
+
+    # The two best (lowest score) events, in order.
+    assert [e["name"] for e in top] == ["B", "C"]


### PR DESCRIPTION
## Description

`TemporalRetriever.filter_top_k_events` ranks the time-filtered events by the similarity score of the `Event_name` vector search:

```python
score_lookup = {res.id: res.score for res in scored_results}
...
score = score_lookup.get(event["id"], float("inf"))
```

`scored_results` are `ScoredResult` objects whose `.id` is a `uuid.UUID` (every vector adapter builds them via `parse_id(...)`, and the model field is typed `id: UUID`). `event["id"]` comes from the graph (`collect_events` → `node["id"]`) and is a **plain string**. In Python `UUID(x) != str(x)` and the two hash differently, so `score_lookup.get(event["id"], inf)` returns `inf` for **every** event.

The consequence: all events tie at `inf`, `sort(key=itemgetter("score"))` is a no-op, and `[: top_k]` just returns the first `top_k` events in arbitrary graph-traversal order. The entire `Event_name` vector ranking that this method exists to apply is silently discarded — TEMPORAL search returns time-filtered events with no relevance ordering.

The fix normalizes both sides of the lookup to `str`.

## Acceptance Criteria

- Events are ordered by their vector score (lower distance = better), and `top_k` returns the best matches.

Regression tests (events come back unranked on `dev`, correctly ordered with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_temporal_filter_top_k_events.py::test_events_are_ranked_by_vector_score
  - assert [inf, inf, inf] == [0.1, 0.5, 0.9]
FAILED ...test_temporal_filter_top_k_events.py::test_top_k_truncates_to_best_matches
2 failed in 0.62s

--- AFTER: fix applied ---
2 passed in 0.08s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="717" height="415" alt="image" src="https://github.com/user-attachments/assets/30718ce0-565a-4baa-af5c-43d195d7ef5c" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
