### PR TITLE
fix(chunking): propagate document importance_weight in overlap and CSV chunkers

### DIFF
--- a/cognee/modules/chunking/CsvChunker.py
+++ b/cognee/modules/chunking/CsvChunker.py
@@ -29,6 +29,7 @@ class CsvChunker(Chunker):
                         contains=[],
                         document_id=document_id,
                         document_name=document_name,
+                        importance_weight=self.document.importance_weight,
                         metadata={
                             "index_fields": ["text"],
                         },

--- a/cognee/modules/chunking/text_chunker_with_overlap.py
+++ b/cognee/modules/chunking/text_chunker_with_overlap.py
@@ -80,6 +80,7 @@ class TextChunkerWithOverlap(Chunker):
                 contains=[],
                 document_id=str(self.document.id),
                 document_name=self.document_name,
+                importance_weight=self.document.importance_weight,
                 metadata={"index_fields": ["text"]},
             )
         except Exception as e:

--- a/cognee/tests/unit/modules/chunking/test_chunker_importance_weight.py
+++ b/cognee/tests/unit/modules/chunking/test_chunker_importance_weight.py
@@ -1,0 +1,74 @@
+"""Regression test: chunkers must propagate the document's importance_weight.
+
+A ``DocumentChunk`` carries the ``importance_weight`` that later flows into every
+``Entity``/``EntityType`` extracted from it (node weighting in the graph).
+``TextChunker`` forwards ``self.document.importance_weight`` into each chunk, but
+``TextChunkerWithOverlap`` and ``CsvChunker`` omitted it, so every chunk they
+produced silently fell back to the ``DocumentChunk`` default (0.5) regardless of
+the document's real weight. These chunkers now forward it like ``TextChunker``.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.chunking.CsvChunker import CsvChunker
+from cognee.modules.chunking.text_chunker_with_overlap import TextChunkerWithOverlap
+from cognee.modules.data.processing.document_types import Document
+
+
+def _make_text_generator(*texts):
+    async def gen():
+        for text in texts:
+            yield text
+
+    return gen
+
+
+def _document(importance_weight):
+    return Document(
+        id=uuid4(),
+        name="weighted_document",
+        raw_data_location="/test/path.csv",
+        external_metadata=None,
+        mime_type="text/plain",
+        importance_weight=importance_weight,
+    )
+
+
+@pytest.mark.asyncio
+async def test_overlap_chunker_propagates_importance_weight():
+    document = _document(0.9)
+
+    def controlled_chunk_data(_text):
+        return [
+            {"text": "alpha", "chunk_size": 5, "cut_type": "sentence", "chunk_id": uuid4()},
+            {"text": "beta", "chunk_size": 4, "cut_type": "sentence", "chunk_id": uuid4()},
+        ]
+
+    chunker = TextChunkerWithOverlap(
+        document,
+        _make_text_generator("dummy"),
+        max_chunk_size=20,
+        get_chunk_data=controlled_chunk_data,
+    )
+
+    chunks = [chunk async for chunk in chunker.read()]
+
+    assert chunks  # sanity: the chunker produced output
+    assert all(chunk.importance_weight == 0.9 for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_csv_chunker_propagates_importance_weight():
+    document = _document(0.9)
+    chunker = CsvChunker(
+        document,
+        _make_text_generator("col_a,col_b\n1,2\n3,4\n"),
+        max_chunk_size=4096,
+    )
+
+    chunks = [chunk async for chunk in chunker.read()]
+
+    assert chunks
+    assert all(chunk.importance_weight == 0.9 for chunk in chunks)


### PR DESCRIPTION
## Description

A `DocumentChunk` carries an `importance_weight` that propagates from the chunk into every `Entity`/`EntityType` created from it in `expand_with_nodes_and_edges` (node weighting in the knowledge graph). `TextChunker` forwards `self.document.importance_weight` into each `DocumentChunk` it yields:

```python
# TextChunker.py
yield DocumentChunk(..., importance_weight=self.document.importance_weight, ...)
```

But `TextChunkerWithOverlap._create_chunk` and `CsvChunker.read` build their `DocumentChunk`s **without** `importance_weight`, so every chunk they emit silently falls back to the `DocumentChunk` default (`0.5`) regardless of the document's actual weight. With the overlap chunker or the CSV/DLT ingestion path, all extracted entities therefore get a flat `0.5` importance instead of inheriting the document's weight — silently wrong node weighting across the graph for those paths.

The fix forwards `self.document.importance_weight` in both chunkers, matching `TextChunker`.

## Acceptance Criteria

- Chunks produced by `TextChunkerWithOverlap` and `CsvChunker` carry the document's `importance_weight`, not the default.

Regression tests (chunks come out at `0.5` on `dev`, inherit `0.9` with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_chunker_importance_weight.py::test_overlap_chunker_propagates_importance_weight
  - assert all(chunk.importance_weight == 0.9 ...)  ->  chunks were 0.5
FAILED ...test_chunker_importance_weight.py::test_csv_chunker_propagates_importance_weight
2 failed

--- AFTER: fix applied ---
2 passed in 0.12s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="742" height="438" alt="image" src="https://github.com/user-attachments/assets/b5a8ecc6-2bfa-4bd1-b465-204b118177b2" />


## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
