### PR TITLE
fix(graph): make LadybugAdapter.add_node parse and upsert on the default backend

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -927,23 +927,35 @@ class LadybugAdapter(GraphDBInterface):
 
             # Add timestamps for new node
             now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
-            fields = []
+            # Build per-property SET assignments. The map-literal form
+            # (``SET n += {{...}}``) does not parse on the Kuzu/Ladybug backend, so
+            # mirror the batch add_nodes which assigns each property individually.
+            create_assignments = []
+            match_assignments = []
             params = {}
             for key, value in core_properties.items():
-                if value is not None:
-                    param_name = f"param_{key}"
-                    fields.append(f"{key}: ${param_name}")
-                    params[param_name] = value
+                if value is None:
+                    continue
+                param_name = f"param_{key}"
+                params[param_name] = value
+                # id is the MERGE key; no need to re-assign it.
+                if key == "id":
+                    continue
+                create_assignments.append(f"n.{key} = ${param_name}")
+                match_assignments.append(f"n.{key} = ${param_name}")
 
-            # Add timestamp fields
-            fields.extend(
-                ["created_at: timestamp($created_at)", "updated_at: timestamp($updated_at)"]
-            )
             params.update({"created_at": now, "updated_at": now})
+            create_assignments.append("n.created_at = timestamp($created_at)")
+            create_assignments.append("n.updated_at = timestamp($updated_at)")
+            # ON MATCH updates the same fields but preserves the original created_at,
+            # and must be present at all — without it, re-adding an existing node
+            # silently drops the update (the batch add_nodes already does this).
+            match_assignments.append("n.updated_at = timestamp($updated_at)")
 
             merge_query = f"""
             MERGE (n:Node {{id: $param_id}})
-            ON CREATE SET n += {{{", ".join(fields)}}}
+            ON CREATE SET {", ".join(create_assignments)}
+            ON MATCH SET {", ".join(match_assignments)}
             """
             await self.query(merge_query, params)
 

--- a/cognee/tests/integration/infrastructure/graph/test_ladybug_add_node_upsert.py
+++ b/cognee/tests/integration/infrastructure/graph/test_ladybug_add_node_upsert.py
@@ -1,0 +1,59 @@
+"""Regression test: LadybugAdapter.add_node (singular) upsert on the default backend.
+
+The singular ``add_node`` built its MERGE with the map-literal form
+``ON CREATE SET n += {{...}}``, which does not parse on the Kuzu/Ladybug backend
+(``Parser exception``) — so every call crashed, breaking callers such as the web
+scraper on the default graph backend. It also had no ``ON MATCH SET`` clause, so
+even where it did run it silently dropped updates to existing nodes (the batch
+``add_nodes`` already assigns each property individually with both ON CREATE and
+ON MATCH).
+
+This test adds a node, then re-adds it with a changed name, and asserts the
+update persists — which both exercises the per-property MERGE syntax (no parser
+crash) and the ON MATCH update.
+"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
+
+
+class _Node(DataPoint):
+    name: str
+    type: str = "Entity"
+    metadata: dict = {"index_fields": ["name"]}
+
+
+@pytest_asyncio.fixture
+async def adapter(tmp_path):
+    a = LadybugAdapter(db_path=str(tmp_path / "ladybug_add_node"))
+    if hasattr(a, "initialize"):
+        await a.initialize()
+    try:
+        yield a
+    finally:
+        try:
+            await a.close()
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_add_node_creates_then_updates(adapter):
+    node_id = uuid4()
+
+    # Create — must not raise a parser exception.
+    await adapter.add_node(_Node(id=node_id, name="OLD"))
+    created = await adapter.get_node(node_id)
+    assert created is not None
+    assert created["name"] == "OLD"
+
+    # Re-add with a changed name — the update must persist (ON MATCH SET).
+    await adapter.add_node(_Node(id=node_id, name="NEW"))
+    updated = await adapter.get_node(node_id)
+    assert updated is not None
+    assert updated["name"] == "NEW"


### PR DESCRIPTION
## Description

`LadybugAdapter.add_node` (the singular variant) builds its MERGE with a Cypher **map literal**:

```python
merge_query = f"""
MERGE (n:Node {{id: $param_id}})
ON CREATE SET n += {{{", ".join(fields)}}}
"""
```

This `SET n += {{...}}` form does **not parse** on the Kuzu/Ladybug backend (the default graph backend). Every call raises:

```
RuntimeError: Parser exception: Invalid input <MERGE (n:Node {id: $param_id})
            ON CREATE SET n +>: expected rule oC_SingleQuery (line: 2, offset: 28)
```

So `add_node` is effectively unusable on the default backend, which breaks its callers — e.g. `web_scraper_task.py` calls `graph_db.add_node(scraping_job)` in three places. On top of that, the query has **no `ON MATCH SET` clause**, so even where it would run it silently drops updates to existing nodes. The batch sibling `add_nodes` does it correctly: it assigns each property individually (`SET n.name = node.name, ...`) and has both `ON CREATE SET` and `ON MATCH SET`.

The fix rewrites `add_node` to mirror `add_nodes` — per-property `SET n.key = $param` assignments with both `ON CREATE SET` and `ON MATCH SET` (`ON MATCH` preserves the original `created_at`). This fixes the parser crash **and** the dropped-update.

## Acceptance Criteria

- `add_node` succeeds on the default Ladybug/Kuzu backend (no parser exception).
- Re-adding a node with the same id updates its properties (upsert).
- Existing `add_nodes`/`get_node` behavior is unchanged (existing kuzu adapter tests still pass).

Regression test (the first `add_node` raises a parser exception on `dev`; passes with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_ladybug_add_node_upsert.py::test_add_node_creates_then_updates
  - RuntimeError: Parser exception: Invalid input <MERGE (n:Node {id: $param_id}) ON CREATE SET n +>
1 failed in 1.06s

--- AFTER: fix applied ---
1 passed in 0.26s
```

Also verified `cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py` still passes (42 passed, 4 xfailed, 2 xpassed).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="708" height="403" alt="image" src="https://github.com/user-attachments/assets/7824a361-ddc3-44f7-a64e-e7fd3cd84205" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
