### PR TITLE
fix(graph): guard null properties in LadybugAdapter.collect_events

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -2736,7 +2736,11 @@ class LadybugAdapter(GraphDBInterface):
             return [{"events": events}]
 
         for node in result[0][0]:
-            props = json.loads(node["properties"])
+            # ``properties`` is a raw JSON string that can be None/empty; guard
+            # the parse so a single Event node without properties doesn't crash
+            # the whole TEMPORAL search (every other site here guards it too).
+            raw_properties = node.get("properties")
+            props = json.loads(raw_properties) if raw_properties else {}
 
             event = {
                 "id": node["id"],

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_collect_events_null_props.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_collect_events_null_props.py
@@ -1,0 +1,46 @@
+"""Regression test: collect_events tolerates Event nodes with null properties.
+
+``LadybugAdapter.collect_events`` parsed each event node's ``properties`` with an
+unguarded ``json.loads(node["properties"])``. The local backend returns
+``properties`` as a raw JSON string that can be ``None``/empty, so a single Event
+node within 1-2 hops that has no properties raised
+``TypeError: the JSON object must be str, bytes or bytearray, not NoneType`` and
+aborted the entire TEMPORAL search. The parse is now guarded, matching every
+other ``properties`` access in the adapter.
+
+The method is exercised unbound with a stub ``self`` (no live Kuzu needed),
+feeding a mocked query result whose first event node has ``properties=None``.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
+
+
+@pytest.mark.asyncio
+async def test_collect_events_handles_null_properties():
+    nodes = [
+        {"id": "id-1", "name": "Event without props", "properties": None},
+        {"id": "id-2", "name": "Event with props", "properties": json.dumps({"description": "d2"})},
+    ]
+    # collect_events reads result[0][0] as the list of event nodes.
+    query_result = [[nodes]]
+
+    stub = SimpleNamespace(
+        _normalize_temporal_ids=lambda ids: ids,
+        query=AsyncMock(return_value=query_result),
+    )
+
+    # On dev this raises TypeError from json.loads(None).
+    result = await LadybugAdapter.collect_events(stub, ids=["id-1"])
+
+    events = result[0]["events"]
+    assert len(events) == 2
+    by_id = {e["id"]: e for e in events}
+    # Null-properties node is handled with an empty props dict.
+    assert by_id["id-1"]["description"] is None
+    assert by_id["id-2"]["description"] == "d2"


### PR DESCRIPTION
## Description

`LadybugAdapter.collect_events` (used by TEMPORAL search) parses each event node's `properties` with an unguarded `json.loads`:

```python
for node in result[0][0]:
    props = json.loads(node["properties"])
```

The local Kuzu/Ladybug backend returns `properties` as a raw JSON string that can be `None`/empty. Every other `properties` access in this adapter guards it (`node.get("properties")`, `if "properties" in ...`) — this one site does not. So an Event node reachable within the 1–2 hop traversal that has no `properties` raises:

```
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```

…which aborts the entire TEMPORAL search.

The fix guards the parse, falling back to an empty dict when `properties` is `None`/empty.

## Acceptance Criteria

- `collect_events` tolerates Event nodes with null/empty `properties` (no `TypeError`); such an event simply has no `description`/`location`.

Regression test (raises `TypeError` on `dev`, passes with the fix):

```
--- BEFORE: dev code (bug present) ---
FAILED ...test_ladybug_collect_events_null_props.py::test_collect_events_handles_null_properties
  - TypeError: the JSON object must be str, bytes or bytearray, not NoneType
1 failed in 0.93s

--- AFTER: fix applied ---
1 passed in 0.10s
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="732" height="422" alt="image" src="https://github.com/user-attachments/assets/1413eabd-8ee2-4c71-8ae9-0f3f120903f7" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
