### PR TITLE
feat(graph): Part 2 — graph-native delete/rollback for new graphs

### DIFF
--- a/cognee/api/v1/datasets/datasets.py
+++ b/cognee/api/v1/datasets/datasets.py
@@ -179,7 +179,17 @@ class datasets:
             raise UnauthorizedDataAccessError(f"Data {data_id} not accessible.")
 
         async with set_database_global_context_variables(dataset_id, dataset.owner_id):
-            if not await has_data_related_nodes(dataset_id, data_id):
+            from cognee.infrastructure.databases.graph import get_graph_engine
+            from cognee.modules.graph.provenance.markers import is_graph_native_graph
+
+            # Graph-native graphs keep no relational nodes/edges rows, so the
+            # has_data_related_nodes gate would wrongly route them to
+            # legacy_delete. Route them straight to delete_data_nodes_and_edges,
+            # which dispatches to the unified graph-native path.
+            graph_engine = await get_graph_engine()
+            if await is_graph_native_graph(graph_engine):
+                await delete_data_nodes_and_edges(dataset_id, data_id, user.id)
+            elif not await has_data_related_nodes(dataset_id, data_id):
                 await legacy_delete(data, "soft")
             else:
                 await delete_data_nodes_and_edges(dataset_id, data_id, user.id)

--- a/cognee/infrastructure/databases/graph/graph_db_interface.py
+++ b/cognee/infrastructure/databases/graph/graph_db_interface.py
@@ -554,3 +554,36 @@ class GraphDBInterface(ABC):
             - edges (List[EdgeIdentity]): Edge identities to delete.
         """
         raise UnsupportedProvenanceCapability("delete_edges")
+
+    async def attach_provenance_refs_to_nodes(
+        self, node_ids: List[str], property_key: str, refs: List[str]
+    ) -> None:
+        """Append ``refs`` to the ``property_key`` array of each node in ``node_ids``.
+
+        The write-side inverse of ``detach_provenance_refs_from_nodes``. Used by
+        graph-native ``add_data_points`` to stamp source refs / source-run refs /
+        dataset ids onto nodes after the graph write succeeds. Idempotent:
+        re-attaching an existing ref is a no-op.
+
+        Parameters:
+        -----------
+            - node_ids (List[str]): Graph node ids to stamp.
+            - property_key (str): One of the provenance list keys (e.g. "source_refs").
+            - refs (List[str]): Ref values to append to that array.
+        """
+        raise UnsupportedProvenanceCapability("attach_provenance_refs_to_nodes")
+
+    async def attach_provenance_refs_to_edges(
+        self, edges: List["EdgeIdentity"], property_key: str, refs: List[str]
+    ) -> None:
+        """Append ``refs`` to the ``property_key`` array of each edge in ``edges``.
+
+        The write-side inverse of ``detach_provenance_refs_from_edges``.
+
+        Parameters:
+        -----------
+            - edges (List[EdgeIdentity]): Edge identities to stamp.
+            - property_key (str): One of the provenance list keys (e.g. "source_refs").
+            - refs (List[str]): Ref values to append to that array.
+        """
+        raise UnsupportedProvenanceCapability("attach_provenance_refs_to_edges")

--- a/cognee/infrastructure/databases/graph/graph_db_interface.py
+++ b/cognee/infrastructure/databases/graph/graph_db_interface.py
@@ -4,7 +4,11 @@ from typing import Optional, Dict, Any, List, Tuple, Type, Union
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.graph.provenance.exceptions import UnsupportedProvenanceCapability
-from cognee.modules.graph.provenance.snapshots import EdgeDeleteData, NodeDeleteData
+from cognee.modules.graph.provenance.snapshots import (
+    EdgeDeleteData,
+    EdgeIdentity,
+    NodeDeleteData,
+)
 
 logger = get_logger()
 
@@ -503,3 +507,50 @@ class GraphDBInterface(ABC):
             - source_run_ref (str): A source-run ref (see provenance.make_source_run_ref).
         """
         raise UnsupportedProvenanceCapability("get_edges_delete_data_by_source_run_ref")
+
+    # ------------------------------------------------------------------
+    # Graph-native provenance write primitives (Part 0 contract)
+    #
+    # The delete/rollback planner uses these to detach a provenance ref from a
+    # surviving artifact (one ref removed, the artifact kept) and to delete edges
+    # by identity (nodes already have delete_nodes). Raising defaults; Part 1
+    # implements them on real adapters.
+    # ------------------------------------------------------------------
+
+    async def detach_provenance_refs_from_nodes(
+        self, node_ids: List[str], property_key: str, refs: List[str]
+    ) -> None:
+        """Remove ``refs`` from the ``property_key`` array of each node in ``node_ids``.
+
+        Used to detach a source ref / source-run ref / dataset id from artifacts
+        that survive a delete because another ref still owns them.
+
+        Parameters:
+        -----------
+            - node_ids (List[str]): Graph node ids to detach from.
+            - property_key (str): One of the provenance list keys (e.g. "source_refs").
+            - refs (List[str]): Ref values to remove from that array.
+        """
+        raise UnsupportedProvenanceCapability("detach_provenance_refs_from_nodes")
+
+    async def detach_provenance_refs_from_edges(
+        self, edges: List["EdgeIdentity"], property_key: str, refs: List[str]
+    ) -> None:
+        """Remove ``refs`` from the ``property_key`` array of each edge in ``edges``.
+
+        Parameters:
+        -----------
+            - edges (List[EdgeIdentity]): Edge identities to detach from.
+            - property_key (str): One of the provenance list keys (e.g. "source_refs").
+            - refs (List[str]): Ref values to remove from that array.
+        """
+        raise UnsupportedProvenanceCapability("detach_provenance_refs_from_edges")
+
+    async def delete_edges(self, edges: List["EdgeIdentity"]) -> None:
+        """Delete the given edges from the graph by identity.
+
+        Parameters:
+        -----------
+            - edges (List[EdgeIdentity]): Edge identities to delete.
+        """
+        raise UnsupportedProvenanceCapability("delete_edges")

--- a/cognee/infrastructure/databases/unified/provenance_delete_planner.py
+++ b/cognee/infrastructure/databases/unified/provenance_delete_planner.py
@@ -1,0 +1,154 @@
+"""Graph-native delete planner (Part 2).
+
+Given delete-data snapshots read off the graph (Part 0 ``NodeDeleteData`` /
+``EdgeDeleteData``) and a target ref to remove, this planner decides which
+artifacts are now unowned (their last owning ref is gone → hard delete) versus
+which survive (another ref still owns them → detach), computes the vector ids to
+clean **only from the snapshots** (never from relational rows), and executes a
+retry-safe ordering:
+
+    read provenance + payloads  (done by the caller, passed in)
+    → compute vector ids        (from snapshots only)
+    → delete vectors            (unowned artifacts)
+    → detach surviving artifacts (remove the ref in the graph)
+    → delete unowned artifacts  (graph)
+
+Because every graph mutation happens *after* the vector deletes, a failed vector
+delete leaves graph provenance untouched and a retry re-reads the same state and
+converges. The detach/delete steps are idempotent, so a retry after a partial
+graph mutation also converges to the clean final state. Unsupported-capability
+errors from the reads propagate to the caller before any mutation.
+
+Vector id derivation mirrors ``delete_from_graph_and_vector`` exactly so the two
+paths target identical collections/ids:
+  - node: collection ``f"{node_type}_{field}"`` for each indexed field, id = node_id
+  - edge: ``EdgeType.id_for(edge_retrieval_text)`` in ``EdgeType_relationship_name``
+          and ``generate_node_id(source+relationship+target)`` in ``Triplet_text``
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+from cognee.modules.engine.utils import generate_node_id
+from cognee.modules.graph.models.EdgeType import EdgeType
+from cognee.modules.graph.provenance.results import ProvenanceDeleteResult
+from cognee.modules.graph.provenance.snapshots import EdgeDeleteData, NodeDeleteData
+from cognee.modules.graph.utils.prepare_edges_for_storage import get_edge_retrieval_text
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("provenance_delete_planner")
+
+# Survival predicate: given a snapshot whose target ref(s) have been removed,
+# return True if the artifact should survive (be detached) rather than deleted.
+NodeSurvives = Callable[[NodeDeleteData], bool]
+EdgeSurvives = Callable[[EdgeDeleteData], bool]
+
+
+def _edge_retrieval_text(edge: EdgeDeleteData) -> str:
+    return get_edge_retrieval_text(edge.edge_retrieval_text, edge.identity.relationship_name)
+
+
+def _node_vector_ids(nodes: List[NodeDeleteData]) -> Dict[str, List[str]]:
+    """Map vector collection name → node ids to delete, from snapshots only."""
+    collections: Dict[str, List[str]] = {}
+    for node in nodes:
+        for field in node.indexed_fields:
+            collections.setdefault(f"{node.node_type}_{field}", []).append(str(node.node_id))
+    return collections
+
+
+def _edge_type_vector_ids(edges: List[EdgeDeleteData]) -> List[str]:
+    ids = []
+    for edge in edges:
+        text = _edge_retrieval_text(edge)
+        if text:
+            ids.append(str(EdgeType.id_for(text)))
+    return ids
+
+
+def _triplet_vector_ids(edges: List[EdgeDeleteData]) -> List[str]:
+    ids = []
+    for edge in edges:
+        identity = edge.identity
+        ids.append(
+            str(
+                generate_node_id(
+                    str(identity.source_node_id)
+                    + identity.relationship_name
+                    + str(identity.target_node_id)
+                )
+            )
+        )
+    return ids
+
+
+async def execute_ref_removal(
+    graph_engine,
+    vector_engine,
+    *,
+    nodes: List[NodeDeleteData],
+    edges: List[EdgeDeleteData],
+    property_key: str,
+    refs_to_remove: List[str],
+    node_survives: NodeSurvives,
+    edge_survives: EdgeSurvives,
+) -> ProvenanceDeleteResult:
+    """Remove ``refs_to_remove`` (stored under ``property_key``) from the given
+    artifacts, deleting unowned ones from graph + vector and detaching survivors.
+
+    The caller supplies the already-read snapshots and the survival predicates
+    that encode the operation's ownership rule (source-ref delete, dataset
+    delete, or run rollback).
+    """
+    surviving_nodes = [n for n in nodes if node_survives(n)]
+    unowned_nodes = [n for n in nodes if not node_survives(n)]
+    surviving_edges = [e for e in edges if edge_survives(e)]
+    unowned_edges = [e for e in edges if not edge_survives(e)]
+
+    if not nodes and not edges:
+        return ProvenanceDeleteResult()
+
+    # 1) Compute vector ids for the unowned artifacts (snapshots only).
+    node_vector_ids = _node_vector_ids(unowned_nodes)
+    edge_type_ids = _edge_type_vector_ids(unowned_edges)
+    triplet_ids = _triplet_vector_ids(unowned_edges)
+
+    # 2) Delete vectors FIRST so a failure here leaves graph provenance intact.
+    for collection, ids in node_vector_ids.items():
+        if ids:
+            await vector_engine.delete_data_points(collection, ids)
+    if edge_type_ids:
+        await vector_engine.delete_data_points("EdgeType_relationship_name", edge_type_ids)
+    if triplet_ids:
+        try:
+            await vector_engine.delete_data_points("Triplet_text", triplet_ids)
+        except Exception:
+            # Triplet collection may not exist if triplet embedding was never enabled.
+            logger.debug("Triplet_text collection absent; skipping triplet vector delete.")
+
+    # 3) Detach the removed refs from surviving artifacts (idempotent).
+    if surviving_nodes:
+        await graph_engine.detach_provenance_refs_from_nodes(
+            [str(n.node_id) for n in surviving_nodes], property_key, list(refs_to_remove)
+        )
+    if surviving_edges:
+        await graph_engine.detach_provenance_refs_from_edges(
+            [e.identity for e in surviving_edges], property_key, list(refs_to_remove)
+        )
+
+    # 4) Delete unowned artifacts from the graph (idempotent).
+    if unowned_nodes:
+        await graph_engine.delete_nodes([str(n.node_id) for n in unowned_nodes])
+    if unowned_edges:
+        await graph_engine.delete_edges([e.identity for e in unowned_edges])
+
+    return ProvenanceDeleteResult(
+        nodes_deleted=len(unowned_nodes),
+        edges_deleted=len(unowned_edges),
+        nodes_detached=len(surviving_nodes),
+        edges_detached=len(surviving_edges),
+    )
+
+
+__all__ = ["execute_ref_removal"]

--- a/cognee/infrastructure/databases/unified/provenance_delete_planner.py
+++ b/cognee/infrastructure/databases/unified/provenance_delete_planner.py
@@ -83,6 +83,58 @@ def _triplet_vector_ids(edges: List[EdgeDeleteData]) -> List[str]:
     return ids
 
 
+def _remaining_edge_retrieval_text(edge_tuple) -> str:
+    properties = edge_tuple[3] if len(edge_tuple) > 3 and isinstance(edge_tuple[3], dict) else {}
+    return get_edge_retrieval_text(properties.get("edge_text"), edge_tuple[2])
+
+
+async def _strip_orphaned_nodeset_tags(graph_engine, vector_engine, unowned_nodes) -> None:
+    """Strip now-orphaned NodeSet labels from surviving rows/nodes.
+
+    Mirrors delete_from_graph_and_vector: when a uniquely-owned NodeSet node is
+    deleted, surviving entities tagged with its label must stop advertising it.
+    Best-effort and non-fatal — adapters without ``remove_belongs_to_set_tags``
+    keep the default no-op.
+    """
+    labels = sorted({n.label for n in unowned_nodes if n.node_type == "NodeSet" and n.label})
+    if not labels:
+        return
+    try:
+        await graph_engine.remove_belongs_to_set_tags(labels)
+    except Exception as error:  # noqa: BLE001 - cleanup is non-fatal
+        logger.warning("Graph NodeSet tag cleanup failed (non-fatal): %s", error)
+    try:
+        await vector_engine.remove_belongs_to_set_tags(labels)
+    except Exception as error:  # noqa: BLE001 - cleanup is non-fatal
+        logger.warning("Vector NodeSet tag cleanup failed (non-fatal): %s", error)
+
+
+async def _prune_orphaned_edge_types(graph_engine, unowned_edges) -> None:
+    """Delete EdgeType nodes whose retrieval text no longer occurs on any edge.
+
+    Mirrors delete_from_graph_and_vector's orphan-EdgeType pass. Best-effort and
+    non-fatal — reads the remaining graph to recompute surviving edge texts.
+    """
+    if not unowned_edges:
+        return
+    deleted_edge_texts = {t for t in (_edge_retrieval_text(e) for e in unowned_edges) if t}
+    if not deleted_edge_texts:
+        return
+    try:
+        _, remaining_edges = await graph_engine.get_graph_data()
+        remaining_texts = {
+            t for t in (_remaining_edge_retrieval_text(e) for e in remaining_edges) if t
+        }
+        orphaned_ids = [
+            str(EdgeType.id_for(text)) for text in deleted_edge_texts if text not in remaining_texts
+        ]
+        if orphaned_ids:
+            await graph_engine.delete_nodes(orphaned_ids)
+            logger.info("Deleted %d orphaned EdgeType node(s).", len(orphaned_ids))
+    except Exception as error:  # noqa: BLE001 - cleanup is non-fatal
+        logger.warning("EdgeType cleanup failed (non-fatal): %s", error)
+
+
 async def execute_ref_removal(
     graph_engine,
     vector_engine,
@@ -101,13 +153,13 @@ async def execute_ref_removal(
     that encode the operation's ownership rule (source-ref delete, dataset
     delete, or run rollback).
     """
+    if not nodes and not edges:
+        return ProvenanceDeleteResult()
+
     surviving_nodes = [n for n in nodes if node_survives(n)]
     unowned_nodes = [n for n in nodes if not node_survives(n)]
     surviving_edges = [e for e in edges if edge_survives(e)]
     unowned_edges = [e for e in edges if not edge_survives(e)]
-
-    if not nodes and not edges:
-        return ProvenanceDeleteResult()
 
     # 1) Compute vector ids for the unowned artifacts (snapshots only).
     node_vector_ids = _node_vector_ids(unowned_nodes)
@@ -142,6 +194,12 @@ async def execute_ref_removal(
         await graph_engine.delete_nodes([str(n.node_id) for n in unowned_nodes])
     if unowned_edges:
         await graph_engine.delete_edges([e.identity for e in unowned_edges])
+
+    # 5) Post-delete cleanup mirroring delete_from_graph_and_vector: strip now
+    # orphaned NodeSet tags and prune orphaned EdgeType nodes. Both are
+    # non-fatal best-effort passes (some adapters/fakes don't implement them).
+    await _strip_orphaned_nodeset_tags(graph_engine, vector_engine, unowned_nodes)
+    await _prune_orphaned_edge_types(graph_engine, unowned_edges)
 
     return ProvenanceDeleteResult(
         nodes_deleted=len(unowned_nodes),

--- a/cognee/infrastructure/databases/unified/unified_store_engine.py
+++ b/cognee/infrastructure/databases/unified/unified_store_engine.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
 from typing import Optional, cast
+from uuid import UUID
 
 from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface
 from cognee.infrastructure.databases.vector.vector_db_interface import VectorDBInterface
+from cognee.modules.graph.provenance.constants import (
+    DATASET_IDS_KEY,
+    SOURCE_REFS_KEY,
+    SOURCE_RUN_REFS_KEY,
+)
+from cognee.modules.graph.provenance.refs import make_source_run_ref
+from cognee.modules.graph.provenance.results import ProvenanceDeleteResult
 
 from .capabilities import EngineCapability
+from .graph_vector_store_interface import GraphVectorStoreInterface
+from .provenance_delete_planner import execute_ref_removal
 
 
-class UnifiedStoreEngine:
+class UnifiedStoreEngine(GraphVectorStoreInterface):
     """Facade that wraps graph and vector engines with capability flags.
 
     For separate backends (e.g. Ladybug + LanceDB), holds two independent engine
@@ -63,3 +73,94 @@ class UnifiedStoreEngine:
     @property
     def is_same_backend(self) -> bool:
         return self._graph is not None and self._graph is self._vector
+
+    # ------------------------------------------------------------------
+    # Graph-native delete / rollback (GraphVectorStoreInterface, Part 2)
+    # ------------------------------------------------------------------
+
+    def supports_graph_native_delete(self) -> bool:
+        """True only when this engine can read graph provenance and delete vectors.
+
+        Requires GRAPH + VECTOR capabilities and a graph backend that implements
+        the Part 0 provenance read primitives. Backends without those keep
+        delete/rollback on the relational-ledger path.
+        """
+        if not (
+            self.has_capability(EngineCapability.GRAPH)
+            and self.has_capability(EngineCapability.VECTOR)
+        ):
+            return False
+        if self._graph is None:
+            return False
+        return self._graph.supports_graph_native_provenance()
+
+    async def delete_by_source_ref(self, source_ref: str) -> ProvenanceDeleteResult:
+        nodes = await self.graph.get_nodes_delete_data_by_source_ref(source_ref)
+        edges = await self.graph.get_edges_delete_data_by_source_ref(source_ref)
+
+        # A node/edge survives if another source ref still owns it.
+        def node_survives(node) -> bool:
+            return bool(set(node.source_refs) - {source_ref})
+
+        def edge_survives(edge) -> bool:
+            return bool(set(edge.source_refs) - {source_ref})
+
+        return await execute_ref_removal(
+            self.graph,
+            self.vector,
+            nodes=nodes,
+            edges=edges,
+            property_key=SOURCE_REFS_KEY,
+            refs_to_remove=[source_ref],
+            node_survives=node_survives,
+            edge_survives=edge_survives,
+        )
+
+    async def delete_by_dataset_id(self, dataset_id: UUID) -> ProvenanceDeleteResult:
+        dataset_key = str(dataset_id)
+        nodes = await self.graph.get_nodes_delete_data_by_dataset_id(dataset_id)
+        edges = await self.graph.get_edges_delete_data_by_dataset_id(dataset_id)
+
+        # An artifact survives if it still belongs to another dataset.
+        def node_survives(node) -> bool:
+            return bool(set(node.dataset_ids) - {dataset_key})
+
+        def edge_survives(edge) -> bool:
+            return bool(set(edge.dataset_ids) - {dataset_key})
+
+        return await execute_ref_removal(
+            self.graph,
+            self.vector,
+            nodes=nodes,
+            edges=edges,
+            property_key=DATASET_IDS_KEY,
+            refs_to_remove=[dataset_key],
+            node_survives=node_survives,
+            edge_survives=edge_survives,
+        )
+
+    async def rollback_by_pipeline_run_id(
+        self, pipeline_run_id: UUID, dataset_id: UUID
+    ) -> ProvenanceDeleteResult:
+        run_ref = make_source_run_ref(dataset_id, pipeline_run_id)
+        nodes = await self.graph.get_nodes_delete_data_by_source_run_ref(run_ref)
+        edges = await self.graph.get_edges_delete_data_by_source_run_ref(run_ref)
+
+        # Hard-delete only what the run solely introduced: no surviving source
+        # ref and no other source-run ref keeps the artifact alive.
+        def node_survives(node) -> bool:
+            return bool(node.source_refs) or bool(set(node.source_run_refs) - {run_ref})
+
+        def edge_survives(edge) -> bool:
+            return bool(edge.source_refs) or bool(set(edge.source_run_refs) - {run_ref})
+
+        return await execute_ref_removal(
+            self.graph,
+            self.vector,
+            nodes=nodes,
+            edges=edges,
+            property_key=SOURCE_RUN_REFS_KEY,
+            refs_to_remove=[run_ref],
+            node_survives=node_survives,
+            edge_survives=edge_survives,
+        )

--- a/cognee/modules/cognify/rollback.py
+++ b/cognee/modules/cognify/rollback.py
@@ -5,8 +5,11 @@ from sqlalchemy import and_, delete, distinct, select
 from sqlalchemy.orm import aliased, attributes as orm_attributes
 
 from cognee.context_global_variables import multi_user_support_possible
+from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.data.models import Data
+from cognee.modules.graph.provenance.markers import is_graph_native_graph
 from cognee.modules.graph.legacy.has_edges_in_legacy_ledger import has_edges_in_legacy_ledger
 from cognee.modules.graph.legacy.has_nodes_in_legacy_ledger import has_nodes_in_legacy_ledger
 from cognee.modules.graph.methods.delete_from_graph_and_vector import delete_from_graph_and_vector
@@ -39,6 +42,31 @@ def _extract_data_ids(data_ingestion_info: Any) -> set[UUID]:
     return data_ids
 
 
+async def _reset_cognify_pipeline_status(session, target_data_ids, dataset_id) -> None:
+    """Clear the cognify_pipeline status for the given data ids in this dataset.
+
+    Shared by the graph-native and relational-ledger rollback paths. Does not
+    commit — the caller owns the transaction.
+    """
+    dataset_id_str = str(dataset_id)
+    if not target_data_ids:
+        return
+    data_records = (
+        (await session.execute(select(Data).where(Data.id.in_(list(target_data_ids)))))
+        .scalars()
+        .all()
+    )
+    for data_record in data_records:
+        if not data_record.pipeline_status:
+            continue
+        if (
+            "cognify_pipeline" in data_record.pipeline_status
+            and dataset_id_str in data_record.pipeline_status["cognify_pipeline"]
+        ):
+            del data_record.pipeline_status["cognify_pipeline"][dataset_id_str]
+            orm_attributes.flag_modified(data_record, "pipeline_status")
+
+
 async def cognify_rollback_handler(
     pipeline_run_id: UUID,
     dataset: Any,
@@ -58,6 +86,27 @@ async def cognify_rollback_handler(
 
     user_id = getattr(user, "id", None)
     db_engine = get_relational_engine()
+
+    # Graph-native graphs carry provenance on the graph; route rollback through
+    # the unified boundary by the run's source-run ref, then reset pipeline
+    # status. Old/unmarked graphs (the default until Part 1) fall through to the
+    # relational-ledger rollback below.
+    graph_engine = await get_graph_engine()
+    unified = await get_unified_engine()
+    if await is_graph_native_graph(graph_engine) and unified.supports_graph_native_delete():
+        await unified.rollback_by_pipeline_run_id(pipeline_run_id, dataset_id)
+        target_data_ids = _extract_data_ids(data_ingestion_info)
+        if target_data_ids:
+            async with db_engine.get_async_session() as session:
+                await _reset_cognify_pipeline_status(session, target_data_ids, dataset_id)
+                await session.commit()
+        logger.info(
+            "Graph-native cognify rollback completed for run %s (dataset=%s, user=%s).",
+            pipeline_run_id,
+            dataset_id,
+            user_id,
+        )
+        return
 
     async with db_engine.get_async_session() as session:
         target_nodes = (

--- a/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
@@ -18,7 +18,10 @@ from cognee.modules.graph.methods import (
 from cognee.modules.graph.methods.delete_from_graph_and_vector import (
     delete_from_graph_and_vector,
 )
+from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+from cognee.modules.graph.provenance.markers import is_graph_native_graph
+from cognee.modules.graph.provenance.refs import make_source_ref
 from cognee.modules.users.methods.get_user import get_user
 from cognee.shared.logging_utils import get_logger
 
@@ -32,6 +35,15 @@ async def delete_data_nodes_and_edges(dataset_id: UUID, data_id: UUID, user_id: 
     # Check if user has delete permissions for the dataset before proceeding with deletion of related graph/vector nodes and edges.
     dataset = await get_authorized_dataset(user, dataset_id, "delete")
     dataset_id = dataset.id
+
+    # Graph-native graphs carry provenance on the graph; route the delete
+    # through the unified boundary by source ref. Old/unmarked graphs (the
+    # default until Part 1) fall through to the relational-ledger path below.
+    graph_engine = await get_graph_engine()
+    unified = await get_unified_engine()
+    if await is_graph_native_graph(graph_engine) and unified.supports_graph_native_delete():
+        await unified.delete_by_source_ref(make_source_ref(dataset_id, data_id))
+        return
 
     if backend_access_control_enabled():
         affected_nodes = await get_data_related_nodes(dataset_id, data_id)

--- a/cognee/modules/graph/methods/delete_dataset_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_dataset_nodes_and_edges.py
@@ -14,7 +14,10 @@ from cognee.modules.graph.methods import (
 from cognee.modules.graph.methods.delete_from_graph_and_vector import (
     delete_from_graph_and_vector,
 )
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+from cognee.modules.graph.provenance.markers import is_graph_native_graph
 from cognee.modules.users.methods.get_user import get_user
 
 
@@ -23,6 +26,14 @@ async def delete_dataset_nodes_and_edges(dataset_id: UUID, user_id: UUID) -> Non
     # Check if user has delete permission for the dataset before proceeding with deletion of related graph/vector nodes and edges.
     dataset = await get_authorized_dataset(user, dataset_id, "delete")
     dataset_id = dataset.id
+
+    # Graph-native graphs route the whole-dataset delete through the unified
+    # boundary. Old/unmarked graphs keep the relational-ledger path below.
+    graph_engine = await get_graph_engine()
+    unified = await get_unified_engine()
+    if await is_graph_native_graph(graph_engine) and unified.supports_graph_native_delete():
+        await unified.delete_by_dataset_id(dataset_id)
+        return
 
     if backend_access_control_enabled():
         affected_nodes = await get_dataset_related_nodes(dataset_id)

--- a/cognee/modules/graph/provenance/markers.py
+++ b/cognee/modules/graph/provenance/markers.py
@@ -1,0 +1,100 @@
+"""Graph-native marker: the routing authority for delete/rollback (Part 2).
+
+A graph is "graph-native" when it carries a marker node stamped with the
+current ``provenance_version`` and ``delete_mode = "graph_native"``. Delete and
+rollback consult this marker to decide whether to take the graph-native path
+(provenance lives on the graph) or fall back to the relational nodes/edges
+ledger (old graphs, retired in Part 3).
+
+The marker is a single well-known node read/written through the existing
+``GraphDBInterface`` node CRUD (``get_node`` / ``add_node`` / ``is_empty``), so
+it needs none of the Part 1 storage primitives — only graphs newly created
+under Part 2 get marked, and every pre-existing graph stays on the ledger path
+until migrated.
+"""
+
+from uuid import NAMESPACE_OID, uuid5
+
+from cognee.modules.graph.provenance.constants import (
+    DELETE_MODE_GRAPH_NATIVE,
+    DELETE_MODE_KEY,
+    PROVENANCE_VERSION,
+    PROVENANCE_VERSION_KEY,
+)
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("graph_native_marker")
+
+# Well-known id of the marker node. Stable across graphs so a single lookup
+# answers "is this graph graph-native?".
+GRAPH_NATIVE_MARKER_NODE_ID = str(uuid5(NAMESPACE_OID, "cognee:graph-native-marker:v1"))
+
+# Node ``type`` for the marker so it is trivially distinguishable and never
+# mistaken for a content node by traversal/search.
+GRAPH_NATIVE_MARKER_NODE_TYPE = "GraphNativeProvenanceMarker"
+
+
+def _marker_properties() -> dict:
+    return {
+        "id": GRAPH_NATIVE_MARKER_NODE_ID,
+        "type": GRAPH_NATIVE_MARKER_NODE_TYPE,
+        PROVENANCE_VERSION_KEY: PROVENANCE_VERSION,
+        DELETE_MODE_KEY: DELETE_MODE_GRAPH_NATIVE,
+    }
+
+
+async def is_graph_native_graph(graph_engine) -> bool:
+    """Return True when ``graph_engine`` carries the graph-native marker node.
+
+    This is the routing authority: a True result means delete/rollback may use
+    graph provenance; False means the graph predates Part 2 and must stay on the
+    relational ledger path. Any error reading the marker is treated as "not
+    graph-native" so routing fails safe onto the ledger.
+    """
+    try:
+        marker = await graph_engine.get_node(GRAPH_NATIVE_MARKER_NODE_ID)
+    except Exception as error:  # noqa: BLE001 - fail safe onto the ledger path
+        logger.debug("Graph-native marker lookup failed; treating as ledger graph: %s", error)
+        return False
+
+    if not marker:
+        return False
+
+    return marker.get(DELETE_MODE_KEY) == DELETE_MODE_GRAPH_NATIVE
+
+
+async def ensure_graph_native_for_new_graph(graph_engine) -> bool:
+    """Mark a brand-new (empty) graph as graph-native; leave existing graphs alone.
+
+    Must be called BEFORE the first nodes are written, so an empty graph can be
+    distinguished from a populated pre-Part-2 one. Returns True if the graph is
+    graph-native after this call (already marked, or marked just now), False if
+    it is a pre-existing unmarked graph that must stay on the ledger path.
+
+    Idempotent: re-marking an already-marked graph is a no-op.
+    """
+    if await is_graph_native_graph(graph_engine):
+        return True
+
+    try:
+        is_empty = await graph_engine.is_empty()
+    except Exception as error:  # noqa: BLE001 - fail safe onto the ledger path
+        logger.debug("Graph emptiness check failed; treating as ledger graph: %s", error)
+        return False
+
+    if not is_empty:
+        # Pre-existing graph with content but no marker → an old graph. It keeps
+        # the relational ledger path until Part 3 migrates it.
+        return False
+
+    await graph_engine.add_node(GRAPH_NATIVE_MARKER_NODE_ID, _marker_properties())
+    logger.info("Marked new graph as graph-native (delete_mode=%s).", DELETE_MODE_GRAPH_NATIVE)
+    return True
+
+
+__all__ = [
+    "GRAPH_NATIVE_MARKER_NODE_ID",
+    "GRAPH_NATIVE_MARKER_NODE_TYPE",
+    "is_graph_native_graph",
+    "ensure_graph_native_for_new_graph",
+]

--- a/cognee/modules/graph/provenance/markers.py
+++ b/cognee/modules/graph/provenance/markers.py
@@ -72,9 +72,19 @@ async def ensure_graph_native_for_new_graph(graph_engine) -> bool:
     it is a pre-existing unmarked graph that must stay on the ledger path.
 
     Idempotent: re-marking an already-marked graph is a no-op.
+
+    A graph is only ever marked when the backend actually implements the
+    graph-native provenance primitives (``supports_graph_native_provenance()``).
+    Until Part 1 lands those on the real adapters, this returns False on the
+    default stack, so add/cognify keep writing the relational ledger and nothing
+    routes through the graph-native path — Part 2 stays inert in production while
+    being fully exercised against the Part 0 fakes.
     """
     if await is_graph_native_graph(graph_engine):
         return True
+
+    if not graph_engine.supports_graph_native_provenance():
+        return False
 
     try:
         is_empty = await graph_engine.is_empty()

--- a/cognee/modules/graph/provenance/snapshots.py
+++ b/cognee/modules/graph/provenance/snapshots.py
@@ -49,6 +49,9 @@ class NodeDeleteData:
             remaining source ref.
         source_run_refs: Source-run refs (see refs.make_source_run_ref) that
             touched the node. Used by rollback to scope removal to one run.
+        dataset_ids: Dataset ids (stringified) the node belongs to. Used by
+            dataset-scoped delete to decide survival: a node shared across
+            datasets survives a single-dataset delete.
     """
 
     node_id: str
@@ -57,6 +60,7 @@ class NodeDeleteData:
     indexed_fields: tuple[str, ...] = ()
     source_refs: tuple[str, ...] = ()
     source_run_refs: tuple[str, ...] = ()
+    dataset_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -72,12 +76,14 @@ class EdgeDeleteData:
             no distinct retrieval text was stored.
         source_refs: Source refs the edge belongs to (see NodeDeleteData).
         source_run_refs: Source-run refs that touched the edge (see NodeDeleteData).
+        dataset_ids: Dataset ids (stringified) the edge belongs to (see NodeDeleteData).
     """
 
     identity: EdgeIdentity
     edge_retrieval_text: str | None = None
     source_refs: tuple[str, ...] = ()
     source_run_refs: tuple[str, ...] = ()
+    dataset_ids: tuple[str, ...] = ()
 
 
 __all__ = ["EdgeIdentity", "NodeDeleteData", "EdgeDeleteData"]

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -7,6 +7,14 @@ from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.databases.unified.capabilities import EngineCapability
 from cognee.infrastructure.databases.relational import get_async_session
 from cognee.modules.graph.methods import upsert_edges, upsert_nodes
+from cognee.modules.graph.provenance.markers import ensure_graph_native_for_new_graph
+from cognee.modules.graph.provenance.refs import make_source_ref, make_source_run_ref
+from cognee.modules.graph.provenance.constants import (
+    DATASET_IDS_KEY,
+    SOURCE_REFS_KEY,
+    SOURCE_RUN_REFS_KEY,
+)
+from cognee.modules.graph.provenance.snapshots import EdgeIdentity
 from cognee.modules.graph.utils import (
     deduplicate_nodes_and_edges,
     ensure_default_edge_properties,
@@ -91,7 +99,16 @@ async def add_data_points(
     vector_engine = unified.vector
     use_hybrid = unified.has_capability(EngineCapability.HYBRID_WRITE)
 
+    # Graph-native graphs carry provenance on the graph itself (stamped after
+    # the writes below) and write no relational ledger rows. Marking only ever
+    # happens on a brand-new empty graph whose backend implements the provenance
+    # primitives, so on the default stack (until Part 1) this is always False and
+    # the existing ledger path below runs unchanged.
+    is_graph_native = False
     if user and dataset and data_item:
+        is_graph_native = await ensure_graph_native_for_new_graph(graph_engine)
+
+    if user and dataset and data_item and not is_graph_native:
         # Single session for all upserts: one transaction, one commit. The
         # rollback ledger is written BEFORE the graph/vector writes so a
         # failed write can always be swept by the rollback handler.
@@ -157,6 +174,35 @@ async def add_data_points(
             )
 
         edges.extend(custom_edges)
+
+    if is_graph_native and user and dataset and data_item:
+        # Stamp provenance AFTER the graph writes succeed, so a failed node/edge
+        # write never leaves orphan provenance. `edges` now includes custom
+        # edges (extended above), so both are stamped in one pass. source_run
+        # refs are attached only when a pipeline_run_id is present — without one
+        # the artifact is deletable (source ref + dataset id) but carries no run
+        # ownership, mirroring the ledger's pipeline_run_id=None behaviour.
+        source_ref = make_source_ref(dataset.id, data_item.id)
+        dataset_key = str(dataset.id)
+        node_ids = [str(node.id) for node in nodes]
+        edge_identities = [EdgeIdentity(str(edge[0]), edge[2], str(edge[1])) for edge in edges]
+
+        await graph_engine.attach_provenance_refs_to_nodes(node_ids, SOURCE_REFS_KEY, [source_ref])
+        await graph_engine.attach_provenance_refs_to_nodes(node_ids, DATASET_IDS_KEY, [dataset_key])
+        await graph_engine.attach_provenance_refs_to_edges(
+            edge_identities, SOURCE_REFS_KEY, [source_ref]
+        )
+        await graph_engine.attach_provenance_refs_to_edges(
+            edge_identities, DATASET_IDS_KEY, [dataset_key]
+        )
+        if pipeline_run_id:
+            run_ref = make_source_run_ref(dataset.id, pipeline_run_id)
+            await graph_engine.attach_provenance_refs_to_nodes(
+                node_ids, SOURCE_RUN_REFS_KEY, [run_ref]
+            )
+            await graph_engine.attach_provenance_refs_to_edges(
+                edge_identities, SOURCE_RUN_REFS_KEY, [run_ref]
+            )
 
     if embed_triplets:
         triplets = _create_triplets_from_graph(nodes, edges)

--- a/cognee/tests/integration/tasks/test_graph_native_delete_part2.py
+++ b/cognee/tests/integration/tasks/test_graph_native_delete_part2.py
@@ -1,0 +1,502 @@
+"""Part 2 default-stack integration gate for graph-native delete/rollback.
+
+These are the REAL end-to-end tests for graph-native delete/rollback as they
+WILL run once Part 1 (Ladybug provenance primitives + LanceDB vector deletes)
+lands. They drive the public surface — ``cognee.add`` + ``cognee.cognify`` to
+build a graph, then ``cognee.forget`` / dataset delete / ``cognify_rollback_handler``
+to remove parts of it — and assert the resulting graph + vector state against
+the default stack (Ladybug graph + LanceDB vector + SQLite relational).
+
+The whole module is intentionally collected-but-skipped: the routing authority
+(``ensure_graph_native_for_new_graph`` / ``is_graph_native_graph``), the
+``UnifiedStoreEngine`` orchestration, and the Part 0 contract are all committed,
+but the live add/delete/rollback paths do not yet call the unified boundary, and
+the Ladybug/LanceDB provenance read+delete primitives are not yet implemented.
+Enabling these before Part 1 would exercise the raising defaults on
+``GraphDBInterface``/``GraphVectorStoreInterface`` and fail spuriously.
+
+Acceptance bar these encode (all against the default stack, both access-control
+modes):
+- shared-artifact survival on data-item delete (a node/edge shared between two
+  data items keeps its other source ref and stays in the graph + vector store);
+- cross-dataset preservation on dataset delete (a node shared across two
+  datasets survives deletion of one dataset);
+- unowned-edge deletion (an edge whose last source ref is removed is hard-deleted
+  from the graph and its EdgeType/Triplet vectors are cleaned);
+- rollback removing only run-introduced artifacts (a failed/rolled-back run
+  leaves a prior run's artifacts intact);
+- retry convergence after an injected vector failure (a vector-delete failure
+  leaves graph provenance untouched; the retry converges to the clean state).
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.context_global_variables import (
+    graph_db_config,
+    set_database_global_context_variables,
+    vector_db_config,
+)
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.unified.get_unified_engine import get_unified_engine
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.cognify.rollback import cognify_rollback_handler
+from cognee.modules.data.methods import create_authorized_dataset
+from cognee.modules.engine.operations.setup import setup as engine_setup
+from cognee.modules.graph.provenance import make_source_ref
+from cognee.modules.graph.provenance.markers import is_graph_native_graph
+from cognee.modules.pipelines.models import PipelineContext
+from cognee.modules.users.methods import get_default_user
+from cognee.tasks.storage.add_data_points import add_data_points
+from cognee.tests.utils.assert_graph_nodes_not_present import assert_graph_nodes_not_present
+from cognee.tests.utils.assert_graph_nodes_present import assert_graph_nodes_present
+from cognee.tests.utils.assert_nodes_vector_index_not_present import (
+    assert_nodes_vector_index_not_present,
+)
+from cognee.tests.utils.assert_nodes_vector_index_present import assert_nodes_vector_index_present
+
+# Part 2 integration gate: enable once Part 1 real adapters (Ladybug provenance
+# primitives + LanceDB) land. Until then these collect but skip.
+pytestmark = pytest.mark.skip(
+    reason=(
+        "Part 2 integration gate: enable once Part 1 real adapters "
+        "(Ladybug provenance primitives + LanceDB) land — COG-5522 Part 1"
+    )
+)
+
+
+class Person(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"]}
+
+
+@pytest_asyncio.fixture(params=[False, True], ids=["no_access_control", "access_control"])
+async def graph_native_environment(request, tmp_path, monkeypatch):
+    """Clean default-stack environment, parametrized over both access-control modes.
+
+    Mirrors test_cognify_rollback_recovery's fixture (Ladybug + LanceDB + SQLite,
+    pruned per test) but additionally toggles ENABLE_BACKEND_ACCESS_CONTROL so the
+    same delete/rollback assertions are proven in both single-tenant and
+    per-user/dataset-isolated modes. Yields the access-control flag so tests that
+    need per-mode behaviour (e.g. multi-user datasets) can branch.
+    """
+    pytest.importorskip("ladybug")
+    pytest.importorskip("lancedb")
+
+    access_control_enabled: bool = request.param
+
+    monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")
+    monkeypatch.setenv(
+        "ENABLE_BACKEND_ACCESS_CONTROL", "true" if access_control_enabled else "false"
+    )
+    monkeypatch.setenv("GRAPH_DATASET_DATABASE_HANDLER", "ladybug")
+    monkeypatch.setenv("VECTOR_DATASET_DATABASE_HANDLER", "lancedb")
+    monkeypatch.setenv("RAISE_INCREMENTAL_LOADING_ERRORS", "false")
+
+    test_id = request.node.name
+    root = pathlib.Path(tmp_path) / test_id
+    system_directory_path = str(root / "system")
+    data_directory_path = str(root / "data")
+
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+
+    graph_db_config.set(None)
+    vector_db_config.set(None)
+    cognee.config.set_graph_db_config(
+        {
+            "graph_database_provider": "ladybug",
+            "graph_dataset_database_handler": "ladybug",
+        }
+    )
+    cognee.config.set_vector_db_config(
+        {
+            "vector_db_provider": "lancedb",
+            "vector_dataset_database_handler": "lancedb",
+        }
+    )
+    cognee.config.set_relational_db_config({"db_provider": "sqlite"})
+    cognee.config.set_migration_db_config({"migration_db_provider": "sqlite"})
+    cognee.config.system_root_directory(system_directory_path)
+    cognee.config.data_root_directory(data_directory_path)
+    cognee.config.set_vector_db_url(str(root / "system" / "databases" / "cognee.lancedb"))
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await engine_setup()
+
+    yield SimpleNamespace(access_control_enabled=access_control_enabled)
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+@asynccontextmanager
+async def _dataset_context(dataset_id, owner_id):
+    async with set_database_global_context_variables(dataset_id, owner_id):
+        yield
+
+
+async def _seed_shared_nodes(dataset, user, data_id, pipeline_run_id, nodes, custom_edges):
+    """Write nodes/edges through the real add_data_points so graph-native refs attach.
+
+    Once Part 1+2 land, add_data_points marks the (empty) graph as graph-native
+    and stamps source refs / source-run refs / dataset ids directly onto the
+    nodes/edges and their vector payloads — no relational nodes/edges ledger
+    rows. These helpers stand in for the entity-extraction output of cognify so
+    a test can control exactly which artifacts are shared between data items.
+    """
+    async with _dataset_context(dataset.id, dataset.owner_id):
+        await add_data_points(
+            nodes,
+            custom_edges=custom_edges,
+            ctx=PipelineContext(
+                user=user,
+                dataset=dataset,
+                data_item=SimpleNamespace(id=data_id),
+                pipeline_name="cognify_pipeline",
+                pipeline_run_id=pipeline_run_id,
+            ),
+        )
+
+
+async def _node_source_refs(node_id):
+    """Read the source refs stamped on a graph node via the Part 1 read primitive."""
+    graph_engine = await get_graph_engine()
+    node = await graph_engine.get_node(str(node_id))
+    return set(node.get("source_refs", [])) if node else set()
+
+
+# ---------------------------------------------------------------------------
+# shared-artifact survival on data-item delete
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_data_item_delete_keeps_shared_artifacts(graph_native_environment):
+    """Deleting one data item drops its source ref but keeps artifacts shared with
+    a second data item, in both graph and vector stores."""
+    user = await get_default_user()
+    dataset = await create_authorized_dataset("gn_shared_artifact", user)
+
+    add_a = await cognee.add("Alice works with Bob.", dataset_name=dataset.name, user=user)
+    add_b = await cognee.add("Bob mentors Carol.", dataset_name=dataset.name, user=user)
+    data_id_a = add_a.data_ingestion_info[0]["data_id"]
+    data_id_b = add_b.data_ingestion_info[0]["data_id"]
+
+    run_a = uuid4()
+    run_b = uuid4()
+
+    # Bob is shared across both data items; Alice belongs only to data item A.
+    alice = Person(name="Alice")
+    bob = Person(name="Bob")
+    carol = Person(name="Carol")
+
+    await _seed_shared_nodes(
+        dataset,
+        user,
+        data_id_a,
+        run_a,
+        [alice, bob],
+        [(alice.id, bob.id, "works_with", {"edge_text": "works with"})],
+    )
+    await _seed_shared_nodes(
+        dataset,
+        user,
+        data_id_b,
+        run_b,
+        [bob, carol],
+        [(bob.id, carol.id, "mentors", {"edge_text": "mentors"})],
+    )
+
+    # The freshly created default-stack graph must be graph-native (Part 2 marker).
+    assert await is_graph_native_graph(await get_graph_engine())
+
+    await assert_graph_nodes_present([alice, bob, carol])
+    await assert_nodes_vector_index_present([alice, bob, carol])
+
+    ref_a = make_source_ref(dataset.id, data_id_a)
+    ref_b = make_source_ref(dataset.id, data_id_b)
+    assert ref_a in await _node_source_refs(bob.id)
+    assert ref_b in await _node_source_refs(bob.id)
+
+    # Delete data item A (memory + record). Bob survives via data item B's ref.
+    async with _dataset_context(dataset.id, dataset.owner_id):
+        await cognee.forget(data_id=data_id_a, dataset_id=dataset.id, user=user)
+
+    await assert_graph_nodes_not_present([alice])  # solely owned by A → gone
+    await assert_graph_nodes_present([bob, carol])  # shared / B-only → kept
+    await assert_nodes_vector_index_not_present([alice])
+    await assert_nodes_vector_index_present([bob, carol])
+
+    # Bob keeps only data item B's source ref.
+    bob_refs = await _node_source_refs(bob.id)
+    assert ref_a not in bob_refs
+    assert ref_b in bob_refs
+
+
+# ---------------------------------------------------------------------------
+# cross-dataset preservation on dataset delete
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_dataset_delete_preserves_cross_dataset_artifacts(graph_native_environment):
+    """Deleting one dataset keeps a node that also belongs to a second dataset.
+
+    In access-control mode datasets are isolated, so a node genuinely shared
+    across two datasets only arises in the shared single-tenant graph; in that
+    mode we assert dataset A's solely-owned node is removed while the shared
+    backend graph keeps the cross-dataset node. In single-tenant mode both
+    datasets live in the same graph and the cross-dataset node must survive."""
+    user = await get_default_user()
+    dataset_a = await create_authorized_dataset("gn_cross_a", user)
+    dataset_b = await create_authorized_dataset("gn_cross_b", user)
+
+    add_a = await cognee.add("Quantum entanglement basics.", dataset_name=dataset_a.name, user=user)
+    add_b = await cognee.add("Quantum computing primer.", dataset_name=dataset_b.name, user=user)
+    data_id_a = add_a.data_ingestion_info[0]["data_id"]
+    data_id_b = add_b.data_ingestion_info[0]["data_id"]
+
+    run_a = uuid4()
+    run_b = uuid4()
+
+    a_only = Person(name="Entanglement")
+    shared = Person(name="Quantum")  # belongs to both datasets
+    b_only = Person(name="Computing")
+
+    await _seed_shared_nodes(
+        dataset_a,
+        user,
+        data_id_a,
+        run_a,
+        [a_only, shared],
+        [(a_only.id, shared.id, "is_about", {"edge_text": "is about"})],
+    )
+    await _seed_shared_nodes(
+        dataset_b,
+        user,
+        data_id_b,
+        run_b,
+        [shared, b_only],
+        [(shared.id, b_only.id, "is_about", {"edge_text": "is about"})],
+    )
+
+    # Delete the whole of dataset A (graph + vector + records).
+    await cognee.forget(dataset_id=dataset_a.id, user=user)
+
+    if graph_native_environment.access_control_enabled:
+        # Dataset B has its own isolated graph; its artifacts must remain.
+        async with _dataset_context(dataset_b.id, dataset_b.owner_id):
+            await assert_graph_nodes_present([b_only, shared])
+            await assert_nodes_vector_index_present([b_only, shared])
+        # Dataset A's isolated graph is gone entirely.
+        async with _dataset_context(dataset_a.id, dataset_a.owner_id):
+            await assert_graph_nodes_not_present([a_only])
+    else:
+        # Single shared graph: A-only removed, cross-dataset node + B kept.
+        await assert_graph_nodes_not_present([a_only])
+        await assert_graph_nodes_present([shared, b_only])
+        await assert_nodes_vector_index_not_present([a_only])
+        await assert_nodes_vector_index_present([shared, b_only])
+        # The shared node now belongs only to dataset B.
+        graph_engine = await get_graph_engine()
+        shared_node = await graph_engine.get_node(str(shared.id))
+        assert str(dataset_a.id) not in set(shared_node.get("dataset_ids", []))
+        assert str(dataset_b.id) in set(shared_node.get("dataset_ids", []))
+
+
+# ---------------------------------------------------------------------------
+# unowned-edge deletion
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_data_item_delete_hard_deletes_unowned_edge(graph_native_environment):
+    """An edge whose last source ref is removed is hard-deleted from the graph and
+    its EdgeType/Triplet vectors are cleaned, even when its endpoint nodes survive."""
+    user = await get_default_user()
+    dataset = await create_authorized_dataset("gn_unowned_edge", user)
+
+    add_a = await cognee.add("Alice collaborates with Bob.", dataset_name=dataset.name, user=user)
+    add_b = await cognee.add("Alice and Bob both exist.", dataset_name=dataset.name, user=user)
+    data_id_a = add_a.data_ingestion_info[0]["data_id"]
+    data_id_b = add_b.data_ingestion_info[0]["data_id"]
+
+    alice = Person(name="Alice")
+    bob = Person(name="Bob")
+
+    # The collaborates_with edge is introduced only by data item A; both nodes
+    # are kept alive by data item B (no edge), so deleting A must drop the edge
+    # while keeping both endpoint nodes.
+    await _seed_shared_nodes(
+        dataset,
+        user,
+        data_id_a,
+        uuid4(),
+        [alice, bob],
+        [(alice.id, bob.id, "collaborates_with", {"edge_text": "collaborates with"})],
+    )
+    await _seed_shared_nodes(
+        dataset,
+        user,
+        data_id_b,
+        uuid4(),
+        [alice, bob],
+        [],
+    )
+
+    from cognee.tests.utils.assert_graph_edges_present import assert_graph_edges_present
+    from cognee.tests.utils.assert_graph_edges_not_present import assert_graph_edges_not_present
+    from cognee.tests.utils.assert_edges_vector_index_present import (
+        assert_edges_vector_index_present,
+    )
+    from cognee.tests.utils.assert_edges_vector_index_not_present import (
+        assert_edges_vector_index_not_present,
+    )
+
+    edge = (alice.id, bob.id, "collaborates_with", {"edge_text": "collaborates with"})
+    await assert_graph_edges_present([edge])
+    await assert_edges_vector_index_present([edge])
+
+    async with _dataset_context(dataset.id, dataset.owner_id):
+        await cognee.forget(data_id=data_id_a, dataset_id=dataset.id, user=user)
+
+    # Endpoint nodes survive (kept by data item B); the edge is hard-deleted.
+    await assert_graph_nodes_present([alice, bob])
+    await assert_graph_edges_not_present([edge])
+    await assert_edges_vector_index_not_present([edge])
+
+
+# ---------------------------------------------------------------------------
+# rollback removing only run-introduced artifacts
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_rollback_removes_only_run_introduced_artifacts(graph_native_environment):
+    """Rolling back one run removes only what that run solely introduced, leaving a
+    prior run's artifacts (and shared nodes) intact in graph + vector stores."""
+    user = await get_default_user()
+    dataset = await create_authorized_dataset("gn_rollback_scope", user)
+
+    add_old = await cognee.add("Baseline knowledge.", dataset_name=dataset.name, user=user)
+    add_new = await cognee.add("New knowledge to roll back.", dataset_name=dataset.name, user=user)
+    old_data_id = add_old.data_ingestion_info[0]["data_id"]
+    new_data_id = add_new.data_ingestion_info[0]["data_id"]
+
+    old_run = uuid4()
+    new_run = uuid4()
+
+    baseline = Person(name="Baseline")
+    new_only = Person(name="NewOnly")
+    shared = Person(name="Shared")  # touched by the old run, re-touched by the new run
+
+    await _seed_shared_nodes(
+        dataset,
+        user,
+        old_data_id,
+        old_run,
+        [baseline, shared],
+        [(baseline.id, shared.id, "relates_to", {"edge_text": "relates to"})],
+    )
+    await _seed_shared_nodes(
+        dataset,
+        user,
+        new_data_id,
+        new_run,
+        [new_only, shared],
+        [(new_only.id, shared.id, "relates_to", {"edge_text": "relates to"})],
+    )
+
+    await assert_graph_nodes_present([baseline, new_only, shared])
+
+    async with _dataset_context(dataset.id, dataset.owner_id):
+        await cognify_rollback_handler(
+            pipeline_run_id=new_run,
+            dataset=dataset,
+            user=user,
+            data_ingestion_info=[{"data_id": str(new_data_id)}],
+        )
+
+    # Only the node the new run solely introduced is gone.
+    await assert_graph_nodes_not_present([new_only])
+    await assert_graph_nodes_present([baseline, shared])
+    await assert_nodes_vector_index_not_present([new_only])
+    await assert_nodes_vector_index_present([baseline, shared])
+
+    # The shared node keeps the old run's source ref; rolling back the new run
+    # must not strip the data-item ownership the old run established.
+    old_ref = make_source_ref(dataset.id, old_data_id)
+    new_ref = make_source_ref(dataset.id, new_data_id)
+    shared_refs = await _node_source_refs(shared.id)
+    assert old_ref in shared_refs
+    assert new_ref not in shared_refs
+
+
+# ---------------------------------------------------------------------------
+# retry convergence after an injected vector failure
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_vector_failure_leaves_graph_untouched_then_retry_converges(
+    graph_native_environment, monkeypatch
+):
+    """A vector-delete failure during delete leaves graph provenance untouched
+    (vectors are deleted first); retrying after the failure clears converges to
+    the clean final state across graph + vector stores."""
+    user = await get_default_user()
+    dataset = await create_authorized_dataset("gn_retry_converge", user)
+
+    add_a = await cognee.add("Solely owned data.", dataset_name=dataset.name, user=user)
+    data_id_a = add_a.data_ingestion_info[0]["data_id"]
+
+    solely = Person(name="Solely")
+    await _seed_shared_nodes(dataset, user, data_id_a, uuid4(), [solely], [])
+
+    await assert_graph_nodes_present([solely])
+    await assert_nodes_vector_index_present([solely])
+
+    ref_a = make_source_ref(dataset.id, data_id_a)
+
+    # Inject a one-shot vector-delete failure on the engine actually in use.
+    vector_engine = get_vector_engine()
+    original_delete = vector_engine.delete_data_points
+    state = {"fail": True}
+
+    async def _failing_delete(collection_name, data_point_ids, *args, **kwargs):
+        if state["fail"] and collection_name == "Person_name":
+            raise RuntimeError("injected vector delete failure on Person_name")
+        return await original_delete(collection_name, data_point_ids, *args, **kwargs)
+
+    monkeypatch.setattr(vector_engine, "delete_data_points", _failing_delete)
+
+    unified = await get_unified_engine()
+    assert unified.supports_graph_native_delete()
+
+    with pytest.raises(RuntimeError, match="injected vector delete failure"):
+        await unified.delete_by_source_ref(ref_a)
+
+    # Vectors are deleted first, so on failure the graph provenance is untouched:
+    # the node and its ref are still present and the artifact is recoverable.
+    await assert_graph_nodes_present([solely])
+    assert ref_a in await _node_source_refs(solely.id)
+
+    # Clear the failure and retry; the planner is retry-safe and converges.
+    state["fail"] = False
+    result = await unified.delete_by_source_ref(ref_a)
+
+    assert result.nodes_deleted == 1
+    await assert_graph_nodes_not_present([solely])
+    await assert_nodes_vector_index_not_present([solely])

--- a/cognee/tests/unit/modules/cognify/test_rollback.py
+++ b/cognee/tests/unit/modules/cognify/test_rollback.py
@@ -100,6 +100,16 @@ async def test_cognify_rollback_deletes_graph_before_relational(monkeypatch):
     async def _has_edges_in_legacy_ledger(_edges):
         return []
 
+    # Pin the graph as non-graph-native so rollback takes the relational-ledger
+    # path (the bare stub has no get_node, so is_graph_native_graph fails safe).
+    async def _get_graph_engine():
+        return SimpleNamespace()
+
+    async def _get_unified_engine():
+        return SimpleNamespace()
+
+    monkeypatch.setattr(rollback_module, "get_graph_engine", _get_graph_engine)
+    monkeypatch.setattr(rollback_module, "get_unified_engine", _get_unified_engine)
     monkeypatch.setattr(rollback_module, "get_relational_engine", lambda: engine)
     monkeypatch.setattr(rollback_module, "multi_user_support_possible", lambda: False)
     monkeypatch.setattr(rollback_module, "has_nodes_in_legacy_ledger", _has_nodes_in_legacy_ledger)
@@ -149,6 +159,14 @@ async def test_cognify_rollback_keeps_relational_rows_if_graph_delete_fails(monk
     async def _has_edges_in_legacy_ledger(_edges):
         return []
 
+    async def _get_graph_engine():
+        return SimpleNamespace()
+
+    async def _get_unified_engine():
+        return SimpleNamespace()
+
+    monkeypatch.setattr(rollback_module, "get_graph_engine", _get_graph_engine)
+    monkeypatch.setattr(rollback_module, "get_unified_engine", _get_unified_engine)
     monkeypatch.setattr(rollback_module, "get_relational_engine", lambda: engine)
     monkeypatch.setattr(rollback_module, "multi_user_support_possible", lambda: False)
     monkeypatch.setattr(rollback_module, "has_nodes_in_legacy_ledger", _has_nodes_in_legacy_ledger)

--- a/cognee/tests/unit/modules/graph/provenance/test_provenance_capabilities.py
+++ b/cognee/tests/unit/modules/graph/provenance/test_provenance_capabilities.py
@@ -341,12 +341,14 @@ def test_dataclass_field_names_are_stable():
         "indexed_fields",
         "source_refs",
         "source_run_refs",
+        "dataset_ids",
     ]
     assert [f.name for f in fields(EdgeDeleteData)] == [
         "identity",
         "edge_retrieval_text",
         "source_refs",
         "source_run_refs",
+        "dataset_ids",
     ]
     assert [f.name for f in fields(ProvenanceDeleteResult)] == [
         "nodes_deleted",

--- a/cognee/tests/unit/modules/graph/provenance/test_unified_graph_native_delete.py
+++ b/cognee/tests/unit/modules/graph/provenance/test_unified_graph_native_delete.py
@@ -1,0 +1,365 @@
+"""Part 2 unit tests: UnifiedStoreEngine graph-native delete/rollback vs fakes.
+
+These exercise the real planner + UnifiedStoreEngine orchestration against an
+in-memory fake graph engine (implements the Part 0 provenance read/write
+primitives) and a recording fake vector engine. They prove the acceptance
+criteria without any real DB or Part 1 adapter:
+
+- vectors deleted FIRST, refs removed from shared artifacts, only unowned
+  artifacts deleted, no-candidate requests no-op;
+- edge/triplet vector ids come from the Part 0 id helpers (EdgeType.id_for,
+  generate_node_id), and orchestration never reads relational Node/Edge rows;
+- an injected vector-delete failure raises with graph provenance untouched, and
+  a retry converges to the clean final state;
+- unsupported-capability reads propagate before any mutation.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from cognee.infrastructure.databases.unified.capabilities import EngineCapability
+from cognee.infrastructure.databases.unified.unified_store_engine import UnifiedStoreEngine
+from cognee.modules.engine.utils import generate_node_id
+from cognee.modules.graph.models.EdgeType import EdgeType
+from cognee.modules.graph.provenance import (
+    EdgeDeleteData,
+    EdgeIdentity,
+    NodeDeleteData,
+    UnsupportedProvenanceCapability,
+    make_source_ref,
+    make_source_run_ref,
+)
+
+DATASET_A = UUID("00000000-0000-0000-0000-0000000000a1")
+DATASET_B = UUID("00000000-0000-0000-0000-0000000000b2")
+DATA_1 = UUID("00000000-0000-0000-0000-0000000000d1")
+DATA_2 = UUID("00000000-0000-0000-0000-0000000000d2")
+RUN_OLD = UUID("00000000-0000-0000-0000-00000000ce01")
+RUN_NEW = UUID("00000000-0000-0000-0000-00000000ce02")
+
+
+class FakeVectorEngine:
+    """Records delete_data_points calls; can be told to fail a collection once."""
+
+    def __init__(self):
+        self.deleted: list[tuple[str, list[str]]] = []
+        self.fail_collection: str | None = None
+
+    async def delete_data_points(self, collection_name: str, data_point_ids: list[str]):
+        if self.fail_collection is not None and collection_name == self.fail_collection:
+            raise RuntimeError(f"injected vector delete failure on {collection_name}")
+        self.deleted.append((collection_name, list(data_point_ids)))
+
+
+class FakeProvenanceGraphEngine:
+    """In-memory graph implementing the Part 0 provenance read/write primitives.
+
+    Nodes are dicts keyed by node_id; edges are dicts keyed by EdgeIdentity. Each
+    carries source_refs / source_run_refs / dataset_ids as mutable sets — the
+    in-memory stand-in for what a real adapter stamps on the graph.
+    """
+
+    def __init__(self):
+        self.nodes: dict[str, dict] = {}
+        self.edges: dict[EdgeIdentity, dict] = {}
+
+    # -- capability flag ---------------------------------------------------
+    def supports_graph_native_provenance(self) -> bool:
+        return True
+
+    # -- seeding helpers ---------------------------------------------------
+    def add_node_record(
+        self,
+        node_id,
+        node_type="Entity",
+        indexed_fields=("name",),
+        label=None,
+        source_refs=(),
+        source_run_refs=(),
+        dataset_ids=(),
+    ):
+        self.nodes[str(node_id)] = {
+            "node_type": node_type,
+            "indexed_fields": tuple(indexed_fields),
+            "label": label,
+            "source_refs": set(source_refs),
+            "source_run_refs": set(source_run_refs),
+            "dataset_ids": set(str(d) for d in dataset_ids),
+        }
+
+    def add_edge_record(
+        self,
+        identity: EdgeIdentity,
+        edge_retrieval_text=None,
+        source_refs=(),
+        source_run_refs=(),
+        dataset_ids=(),
+    ):
+        self.edges[identity] = {
+            "edge_retrieval_text": edge_retrieval_text,
+            "source_refs": set(source_refs),
+            "source_run_refs": set(source_run_refs),
+            "dataset_ids": set(str(d) for d in dataset_ids),
+        }
+
+    # -- snapshot builders -------------------------------------------------
+    def _node_snapshot(self, node_id, rec) -> NodeDeleteData:
+        return NodeDeleteData(
+            node_id=node_id,
+            node_type=rec["node_type"],
+            label=rec["label"],
+            indexed_fields=rec["indexed_fields"],
+            source_refs=tuple(rec["source_refs"]),
+            source_run_refs=tuple(rec["source_run_refs"]),
+            dataset_ids=tuple(rec["dataset_ids"]),
+        )
+
+    def _edge_snapshot(self, identity, rec) -> EdgeDeleteData:
+        return EdgeDeleteData(
+            identity=identity,
+            edge_retrieval_text=rec["edge_retrieval_text"],
+            source_refs=tuple(rec["source_refs"]),
+            source_run_refs=tuple(rec["source_run_refs"]),
+            dataset_ids=tuple(rec["dataset_ids"]),
+        )
+
+    # -- read primitives ---------------------------------------------------
+    async def get_nodes_delete_data_by_source_ref(self, source_ref):
+        return [
+            self._node_snapshot(nid, r)
+            for nid, r in self.nodes.items()
+            if source_ref in r["source_refs"]
+        ]
+
+    async def get_edges_delete_data_by_source_ref(self, source_ref):
+        return [
+            self._edge_snapshot(i, r)
+            for i, r in self.edges.items()
+            if source_ref in r["source_refs"]
+        ]
+
+    async def get_nodes_delete_data_by_dataset_id(self, dataset_id):
+        key = str(dataset_id)
+        return [
+            self._node_snapshot(nid, r) for nid, r in self.nodes.items() if key in r["dataset_ids"]
+        ]
+
+    async def get_edges_delete_data_by_dataset_id(self, dataset_id):
+        key = str(dataset_id)
+        return [self._edge_snapshot(i, r) for i, r in self.edges.items() if key in r["dataset_ids"]]
+
+    async def get_nodes_delete_data_by_source_run_ref(self, source_run_ref):
+        return [
+            self._node_snapshot(nid, r)
+            for nid, r in self.nodes.items()
+            if source_run_ref in r["source_run_refs"]
+        ]
+
+    async def get_edges_delete_data_by_source_run_ref(self, source_run_ref):
+        return [
+            self._edge_snapshot(i, r)
+            for i, r in self.edges.items()
+            if source_run_ref in r["source_run_refs"]
+        ]
+
+    # -- write primitives --------------------------------------------------
+    async def detach_provenance_refs_from_nodes(self, node_ids, property_key, refs):
+        for nid in node_ids:
+            rec = self.nodes.get(str(nid))
+            if rec:
+                rec[property_key] -= set(refs)
+
+    async def detach_provenance_refs_from_edges(self, edges, property_key, refs):
+        for identity in edges:
+            rec = self.edges.get(identity)
+            if rec:
+                rec[property_key] -= set(refs)
+
+    async def delete_nodes(self, node_ids):
+        for nid in node_ids:
+            self.nodes.pop(str(nid), None)
+
+    async def delete_edges(self, edges):
+        for identity in edges:
+            self.edges.pop(identity, None)
+
+
+class RaisingGraphEngine(FakeProvenanceGraphEngine):
+    """Reads raise UnsupportedProvenanceCapability (an un-implemented backend)."""
+
+    async def get_nodes_delete_data_by_source_ref(self, source_ref):
+        raise UnsupportedProvenanceCapability("get_nodes_delete_data_by_source_ref")
+
+
+def _engine(graph, vector) -> UnifiedStoreEngine:
+    return UnifiedStoreEngine(
+        graph_engine=graph,
+        vector_engine=vector,
+        capabilities=EngineCapability.GRAPH | EngineCapability.VECTOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# delete_by_source_ref
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_delete_by_source_ref_deletes_unowned_detaches_shared():
+    graph = FakeProvenanceGraphEngine()
+    vector = FakeVectorEngine()
+    ref1 = make_source_ref(DATASET_A, DATA_1)
+    ref2 = make_source_ref(DATASET_A, DATA_2)
+    graph.add_node_record("solely", source_refs=(ref1,), dataset_ids=(DATASET_A,))
+    graph.add_node_record("shared", source_refs=(ref1, ref2), dataset_ids=(DATASET_A,))
+
+    result = _engine(graph, vector)
+    res = await result.delete_by_source_ref(ref1)
+
+    assert "solely" not in graph.nodes  # unowned → hard deleted
+    assert "shared" in graph.nodes  # survives via ref2
+    assert graph.nodes["shared"]["source_refs"] == {ref2}  # detached
+    assert res.nodes_deleted == 1
+    assert res.nodes_detached == 1
+    # Vector delete targeted only the unowned node's collection.
+    assert ("Entity_name", ["solely"]) in vector.deleted
+
+
+@pytest.mark.asyncio
+async def test_no_candidates_is_noop():
+    graph = FakeProvenanceGraphEngine()
+    vector = FakeVectorEngine()
+    res = await _engine(graph, vector).delete_by_source_ref(make_source_ref(DATASET_A, DATA_1))
+    assert (res.nodes_deleted, res.edges_deleted, res.nodes_detached, res.edges_detached) == (
+        0,
+        0,
+        0,
+        0,
+    )
+    assert vector.deleted == []
+
+
+# ---------------------------------------------------------------------------
+# edge/triplet vector ids come from the Part 0 id helpers
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_edge_vector_ids_use_part0_helpers():
+    graph = FakeProvenanceGraphEngine()
+    vector = FakeVectorEngine()
+    ref = make_source_ref(DATASET_A, DATA_1)
+    identity = EdgeIdentity("src", "works_with", "tgt")
+    graph.add_edge_record(
+        identity, edge_retrieval_text="works with", source_refs=(ref,), dataset_ids=(DATASET_A,)
+    )
+
+    await _engine(graph, vector).delete_by_source_ref(ref)
+
+    expected_edge_type_id = str(EdgeType.id_for("works with"))
+    expected_triplet_id = str(generate_node_id("src" + "works_with" + "tgt"))
+    assert ("EdgeType_relationship_name", [expected_edge_type_id]) in vector.deleted
+    assert ("Triplet_text", [expected_triplet_id]) in vector.deleted
+    assert identity not in graph.edges  # unowned edge deleted
+
+
+# ---------------------------------------------------------------------------
+# delete_by_dataset_id — cross-dataset preservation
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_delete_by_dataset_id_preserves_cross_dataset():
+    graph = FakeProvenanceGraphEngine()
+    vector = FakeVectorEngine()
+    a_ref = make_source_ref(DATASET_A, DATA_1)
+    graph.add_node_record("a_only", source_refs=(a_ref,), dataset_ids=(DATASET_A,))
+    graph.add_node_record("shared_ds", source_refs=(a_ref,), dataset_ids=(DATASET_A, DATASET_B))
+
+    res = await _engine(graph, vector).delete_by_dataset_id(DATASET_A)
+
+    assert "a_only" not in graph.nodes
+    assert "shared_ds" in graph.nodes
+    assert graph.nodes["shared_ds"]["dataset_ids"] == {str(DATASET_B)}
+    assert res.nodes_deleted == 1 and res.nodes_detached == 1
+
+
+# ---------------------------------------------------------------------------
+# rollback_by_pipeline_run_id — only what the run solely introduced
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_rollback_removes_only_run_introduced():
+    graph = FakeProvenanceGraphEngine()
+    vector = FakeVectorEngine()
+    old_run = make_source_run_ref(DATASET_A, RUN_OLD)
+    new_run = make_source_run_ref(DATASET_A, RUN_NEW)
+    src_ref = make_source_ref(DATASET_A, DATA_1)
+    graph.add_node_record("only_new", source_run_refs=(new_run,), dataset_ids=(DATASET_A,))
+    graph.add_node_record("both_runs", source_run_refs=(old_run, new_run), dataset_ids=(DATASET_A,))
+    graph.add_node_record(
+        "has_src", source_refs=(src_ref,), source_run_refs=(new_run,), dataset_ids=(DATASET_A,)
+    )
+
+    res = await _engine(graph, vector).rollback_by_pipeline_run_id(RUN_NEW, DATASET_A)
+
+    assert "only_new" not in graph.nodes  # solely from the rolled-back run
+    assert graph.nodes["both_runs"]["source_run_refs"] == {old_run}  # detached
+    assert graph.nodes["has_src"]["source_run_refs"] == set()  # detached, kept by source ref
+    assert res.nodes_deleted == 1 and res.nodes_detached == 2
+
+
+@pytest.mark.asyncio
+async def test_rollback_is_dataset_scoped():
+    graph = FakeProvenanceGraphEngine()
+    vector = FakeVectorEngine()
+    graph.add_node_record(
+        "a", source_run_refs=(make_source_run_ref(DATASET_A, RUN_NEW),), dataset_ids=(DATASET_A,)
+    )
+    res = await _engine(graph, vector).rollback_by_pipeline_run_id(RUN_NEW, DATASET_B)
+    assert "a" in graph.nodes  # different dataset → different run ref → no-op
+    assert (res.nodes_deleted, res.nodes_detached) == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# retry-safety: injected vector failure leaves graph untouched, retry converges
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_vector_failure_leaves_graph_untouched_then_retry_converges():
+    graph = FakeProvenanceGraphEngine()
+    vector = FakeVectorEngine()
+    ref = make_source_ref(DATASET_A, DATA_1)
+    graph.add_node_record("solely", source_refs=(ref,), dataset_ids=(DATASET_A,))
+    vector.fail_collection = "Entity_name"
+
+    engine = _engine(graph, vector)
+    with pytest.raises(RuntimeError, match="injected vector delete failure"):
+        await engine.delete_by_source_ref(ref)
+
+    # Graph provenance untouched — the node and its ref are still present.
+    assert "solely" in graph.nodes
+    assert graph.nodes["solely"]["source_refs"] == {ref}
+
+    # Retry after clearing the failure converges to the clean final state.
+    vector.fail_collection = None
+    res = await engine.delete_by_source_ref(ref)
+    assert "solely" not in graph.nodes
+    assert res.nodes_deleted == 1
+
+
+# ---------------------------------------------------------------------------
+# unsupported-capability reads propagate before any mutation
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_unsupported_capability_propagates_before_mutation():
+    graph = RaisingGraphEngine()
+    vector = FakeVectorEngine()
+    ref = make_source_ref(DATASET_A, DATA_1)
+    graph.add_node_record("n", source_refs=(ref,), dataset_ids=(DATASET_A,))
+
+    with pytest.raises(UnsupportedProvenanceCapability):
+        await _engine(graph, vector).delete_by_source_ref(ref)
+
+    assert vector.deleted == []  # no vector mutation before the read failed
+    assert "n" in graph.nodes  # no graph mutation
+
+
+@pytest.mark.asyncio
+async def test_engine_advertises_support_with_provenance_graph():
+    assert _engine(FakeProvenanceGraphEngine(), FakeVectorEngine()).supports_graph_native_delete()

--- a/cognee/tests/unit/tasks/storage/test_add_data_points.py
+++ b/cognee/tests/unit/tasks/storage/test_add_data_points.py
@@ -63,6 +63,9 @@ def _make_unified_mock():
     unified.graph = graph_engine
     unified.vector = vector_engine
     unified.has_capability = MagicMock(return_value=False)
+    # Default-stack backend is not graph-native (until Part 1), so add_data_points
+    # takes the relational-ledger path. supports_* is a sync bool, not a coroutine.
+    graph_engine.supports_graph_native_provenance = MagicMock(return_value=False)
     return unified, graph_engine, vector_engine
 
 

--- a/temp/delete_improvements/phase2_graph_native_new_graphs.md
+++ b/temp/delete_improvements/phase2_graph_native_new_graphs.md
@@ -1,0 +1,329 @@
+# Part 2 — graph-native delete & rollback for new graphs
+
+This is the implementation plan for Part 2 of the graph-native delete/rollback
+work (see `phases_overview.md`). It builds directly on the locked Part 0 contract
+(`part0_contract.md`) and runs in parallel with Part 1 (storage primitives).
+
+**Goal.** Re-point `delete`, dataset-delete, `forget`, and `rollback` at the
+graph itself — reading provenance off nodes/edges instead of the relational
+`nodes`/`edges` ledger — **but only for graphs created under
+`delete_mode="graph_native"`**. Every pre-existing (unmarked) graph keeps the
+ledger path untouched until Part 3 migrates it. No data is dropped, no API
+surface changes, and the new path is exercised end-to-end against the Part 0
+fake stores before any real backend is wired (that gate is owned by Part 1).
+
+## Where this sits relative to Part 0 and Part 1
+
+Part 0 already shipped the *spine* of Part 2 — committed, with no live caller:
+
+| Spine file | Role |
+| --- | --- |
+| `cognee/modules/graph/provenance/markers.py` | `is_graph_native_graph` / `ensure_graph_native_for_new_graph` — **the routing authority**. |
+| `cognee/modules/graph/provenance/constants.py` | marker values + property keys (`SOURCE_REFS_KEY`, `SOURCE_RUN_REFS_KEY`, `DATASET_IDS_KEY`, `DELETE_MODE_KEY`, `PROVENANCE_VERSION_KEY`). |
+| `cognee/modules/graph/provenance/refs.py` | `make_source_ref(dataset_id, data_id)` / `make_source_run_ref(dataset_id, pipeline_run_id)`. |
+| `cognee/modules/graph/provenance/snapshots.py` | `EdgeIdentity` / `NodeDeleteData` / `EdgeDeleteData` (now incl. `dataset_ids`). |
+| `cognee/modules/graph/provenance/results.py` | `ProvenanceDeleteResult`. |
+| `cognee/infrastructure/databases/unified/provenance_delete_planner.py` | retry-safe ref-removal planner (`execute_ref_removal`). |
+| `cognee/infrastructure/databases/unified/unified_store_engine.py` | `UnifiedStoreEngine.delete_by_source_ref` / `delete_by_dataset_id` / `rollback_by_pipeline_run_id`. |
+| `cognee/infrastructure/databases/graph/graph_db_interface.py` | provenance read + write primitives (raising defaults). |
+| `cognee/tests/unit/modules/graph/provenance/test_unified_graph_native_delete.py` | the reference test harness (fake provenance graph + recording vector engine). |
+| `cognee/tests/unit/modules/graph/provenance/test_fake_graph_vector_store.py` | Part 0 reference semantics. |
+
+What is **not yet** done — and is the subject of this plan — is the *wiring*:
+write-site stamping, the routing branches in the live delete/rollback entry
+points, the ledger-consumer guards, and the integration gate. The planner and
+`UnifiedStoreEngine` already pass against the Part 0 fakes; Part 2 makes the
+live code paths reach them for graph-native graphs, while leaving old graphs on
+the ledger.
+
+Part 2 depends on Part 1 only for the **real adapter** implementations of the
+`GraphDBInterface` read/write primitives and the LanceDB vector reads. Against
+the fakes, Part 2 is self-contained and complete today.
+
+## The six phases
+
+```
+Part 0 (spine, committed)
+   │
+   ├── Phase 1  delete orchestration   ─┐
+   ├── Phase 2  rollback orchestration ─┤ (validated vs Part 0 fakes)
+   ├── Phase 3  write stamping         ─┤
+   ├── Phase 4  delete/rollback routing ┤
+   ├── Phase 5  ledger consumers        ┘
+   └── Phase 6  integration gate  ── gated on Part 1 (kept skipped; PR stays draft)
+```
+
+### Phase 1 — delete orchestration
+
+Drive single-data-item and whole-dataset deletes through
+`UnifiedStoreEngine.delete_by_source_ref` / `delete_by_dataset_id` instead of
+the ledger discovery + `delete_from_graph_and_vector` chain.
+
+- A per-data delete computes `make_source_ref(dataset_id, data_id)` and calls
+  `delete_by_source_ref`. The engine reads `NodeDeleteData`/`EdgeDeleteData` off
+  the graph (`get_nodes_delete_data_by_source_ref` /
+  `get_edges_delete_data_by_source_ref`), and the planner removes that one ref.
+- A whole-dataset delete calls `delete_by_dataset_id(dataset_id)`, which reads by
+  `DATASET_IDS_KEY` and removes the dataset id ref.
+- Orchestration **never reads relational `Node`/`Edge` rows** — vector ids are
+  derived only from the snapshots, via the Part 0 helpers (see
+  `provenance_delete_planner.py`):
+  - node vectors: collection `f"{node_type}_{field}"`, id `= node_id`;
+  - edge type vectors: `EdgeType.id_for(edge_retrieval_text)` in
+    `EdgeType_relationship_name`;
+  - triplet vectors: `generate_node_id(source + relationship + target)` in
+    `Triplet_text` (absent-collection tolerated).
+- Ownership rule (mirrors the ledger's "unique by slug"): an artifact is
+  hard-deleted only when the removed ref was its *last* owning ref; otherwise it
+  is **detached** (ref stripped, artifact kept). Custom edges are deleted by the
+  same path because they carry the same source refs (see Phase 3).
+
+Validated by `test_unified_graph_native_delete.py`:
+`test_delete_by_source_ref_deletes_unowned_detaches_shared`,
+`test_delete_by_dataset_id_preserves_cross_dataset`,
+`test_edge_vector_ids_use_part0_helpers`, `test_no_candidates_is_noop`.
+
+### Phase 2 — rollback orchestration
+
+Drive `cognify_rollback_handler` through
+`UnifiedStoreEngine.rollback_by_pipeline_run_id(pipeline_run_id, dataset_id)`.
+
+- The engine computes `make_source_run_ref(dataset_id, pipeline_run_id)`, reads
+  by `SOURCE_RUN_REFS_KEY`, and removes that run ref.
+- Rollback hard-deletes only what the run **solely** introduced: an artifact
+  survives if it still carries any `source_ref` **or** any *other*
+  `source_run_ref`. This is the graph-native equivalent of the ledger's
+  "exclude still-shared slugs" aliased query.
+- Rollback is dataset-scoped: the run ref is a hash of
+  `(dataset_id, pipeline_run_id)`, so a rollback for a run in a different dataset
+  reads nothing and no-ops.
+- After the store op, the handler still resets `pipeline_status` exactly as
+  today — only the artifact discovery/removal moves to the graph-native path.
+
+Validated by `test_rollback_removes_only_run_introduced`,
+`test_rollback_is_dataset_scoped`.
+
+### Phase 3 — write stamping
+
+At the single central write site
+(`cognee/tasks/storage/add_data_points.py`), for graph-native graphs, stamp
+provenance **onto the graph artifacts** and **skip the relational ledger
+upserts** entirely. The stamping rules:
+
+1. **Refs are attached after a successful graph write**, never before. The graph
+   `add_nodes`/`add_edges` (and `add_nodes_with_vectors`/`add_edges_with_vectors`
+   on hybrid backends) must succeed first; only then are
+   `source_refs` / `source_run_refs` / `dataset_ids` / `delete_mode` /
+   `provenance_version` stamped. A write that fails leaves no orphaned
+   provenance, mirroring the planner's "mutate provenance last" discipline on
+   the delete side.
+2. **Marked graphs skip the ledger.** When `is_graph_native_graph(graph_engine)`
+   is true, `add_data_points` does **not** call `upsert_nodes`/`upsert_edges`
+   (rows 1–3 of `write_site_inventory.md`); the on-graph stamp is the single
+   source of truth. Unmarked (old) graphs keep writing ledger rows.
+3. **Custom edges are stamped too.** The `custom_edges` branch
+   (`add_data_points.py:147`) attaches the same source refs / run refs /
+   dataset ids as data-point edges, so a later `delete_by_source_ref` /
+   `rollback_by_pipeline_run_id` finds and removes them. (Today they reuse the
+   same ledger session; under graph-native they reuse the same stamp.)
+4. **No dataset / no data-item ⇒ non-provenanced.** The existing guard
+   (`add_data_points.py:94`, requires `user and dataset and data_item`) is
+   preserved: when any is missing, the graph write proceeds with **no source
+   refs and no dataset ids** — exactly as today it writes no ledger rows. Such
+   artifacts are simply not reachable by graph-native delete (same coverage gap
+   the ledger has, documented in `write_site_inventory.md`).
+5. **No `pipeline_run_id` ⇒ refs but no run ownership.** When `dataset` and
+   `data_item` are present but `pipeline_run_id` is `None` (e.g. the
+   coding-rules edge persistence and the migration loader's `_provenance_ctx`,
+   per `write_site_inventory.md`), the artifact still gets `source_refs` and
+   `dataset_ids` (so per-data / dataset delete works) but **no
+   `source_run_refs`** (so rollback cannot scope it to a run — matching the
+   ledger's `pipeline_run_id=None` behaviour exactly).
+
+Acceptance for this phase is structural: a graph-native `add_data_points` writes
+**zero** `upsert_nodes`/`upsert_edges` calls and attaches node + edge source
+refs (incl. custom edges); writes without dataset/data-item stay
+non-provenanced; writes without `pipeline_run_id` attach refs but create no run
+ownership.
+
+> Marking happens via `ensure_graph_native_for_new_graph(graph_engine)` called
+> **before the first nodes are written** on a brand-new graph (so an empty graph
+> is distinguishable from a populated pre-Part-2 one). The natural call site is
+> the pipeline's first graph-writing step / engine bootstrap, before
+> `add_data_points` runs.
+
+### Phase 4 — delete / rollback routing
+
+Each live entry point gains a single front-door branch keyed on the marker, then
+either calls the unified boundary (graph-native) or the existing ledger flow
+(old graphs). **The marker is the routing authority** — see "How the marker
+routes" below.
+
+Entry points that route through the unified boundary for graph-native graphs:
+
+| Entry point (file) | Today (ledger path, kept for old graphs) | Graph-native route |
+| --- | --- | --- |
+| `cognee/api/v1/datasets/datasets.py` — `Datasets.delete_data` | `has_data_related_nodes` → `delete_data_nodes_and_edges` (or `legacy_delete`) | `delete_by_source_ref` |
+| `cognee/api/v1/datasets/datasets.py` — `Datasets.delete` (whole dataset) | `delete_dataset_nodes_and_edges` | `delete_by_dataset_id` |
+| `cognee/api/v1/forget/forget.py` — forget handlers (incl. `memory_only=True`) | `delete_data_nodes_and_edges` / `delete_dataset_nodes_and_edges` | `delete_by_source_ref` / `delete_by_dataset_id` |
+| `cognee/api/v1/delete/routers/get_delete_router.py` — deprecated `delete()` | funnels into `Datasets.delete_data` | same branch as `delete_data` |
+| `cognee/modules/cognify/rollback.py` — `cognify_rollback_handler` | `select(Node)`/`select(Edge)` by `pipeline_run_id` → `delete_from_graph_and_vector` | `rollback_by_pipeline_run_id` |
+
+`forget(memory_only=True)` is explicitly in scope: it removes graph/vector
+artifacts while leaving the relational data records, which is exactly what the
+graph-native delete does (it never touches relational rows). The deprecated
+`delete()` router and the dlt orphan-cleanup caller
+(`tasks/ingestion/resolve_dlt_sources.py`) inherit the branch from the
+orchestrators they call, so they need no separate change beyond the shared
+front door.
+
+**Old graphs keep the ledger path.** The branch is `if await
+is_graph_native_graph(graph_engine): <unified boundary> else: <existing ledger
+flow>`. Because `is_graph_native_graph` returns `False` for any graph without
+the marker (and fails safe to `False` on any read error), every pre-Part-2 graph
+takes the unchanged ledger path. The ledger consumers (groups (a) in
+`ledger_consumer_inventory.md`) are not removed — that is Part 3.
+
+### Phase 5 — ledger consumers
+
+Ledger consumers read graph provenance **only inside their graph-native
+branch**; their ledger reads are unchanged on the old-graph branch.
+
+- The selection/discovery consumers (`get_data_related_nodes/edges`,
+  `get_dataset_related_nodes/edges`, `has_data_related_nodes`,
+  `get_shared_slugs_losing_dataset_anchor`,
+  `get_orphaned_nodeset_labels_for_dataset`) and the central executor
+  `delete_from_graph_and_vector` are **bypassed** on the graph-native branch
+  (their work is done by the planner + `UnifiedStoreEngine`), and **kept intact**
+  on the old-graph branch.
+- The legacy-flag checks (`has_nodes_in_legacy_ledger` /
+  `has_edges_in_legacy_ledger`) are not consulted on the graph-native branch —
+  the `delete_mode` marker already answered "is this graph-native?" at the
+  front door.
+- The non-delete analytics consumer
+  (`get_global_context_graph_inputs`, group (b) in the inventory) is **out of
+  Part 2 scope**: it still reads the ledger. Part 3 re-sources it. Because Part 2
+  only *adds* on-graph stamps and never drops ledger rows for old graphs, this
+  consumer keeps working throughout.
+
+Acceptance: ledger consumers read graph provenance only in their graph-native
+branch; old unmarked graphs keep the ledger path bit-for-bit.
+
+### Phase 6 — integration gate (gated on Part 1)
+
+A default-stack integration suite (Ladybug graph + LanceDB vector + SQLite)
+that runs a real add → cognify → delete / rollback cycle and asserts the
+graph-native path actually removed the right nodes/edges/vectors and detached
+the shared ones. This suite is **authored in Part 2 but kept skipped** until
+Part 1 lands the real adapter primitives (`supports_graph_native_provenance`,
+the `get_*_delete_data_*` reads, `detach_provenance_refs_from_*`, `delete_edges`
+on Ladybug; the LanceDB vector reads). Until then:
+
+- the suite is marked skipped (e.g. `pytest.mark.skip(reason="needs Part 1
+  adapter primitives")`);
+- the Part 2 PR stays **draft** so it cannot merge ahead of its dependency;
+- all the *unit-level* acceptance criteria are met today against the Part 0
+  fakes, which require no real backend.
+
+## How the marker is the routing authority
+
+`markers.py` is the single decision point. Two functions, both reading/writing
+one well-known marker node through the existing `GraphDBInterface` node CRUD —
+no Part 1 primitives required:
+
+- `is_graph_native_graph(graph_engine)` — returns `True` iff the graph carries
+  the marker node (`GRAPH_NATIVE_MARKER_NODE_ID`, type
+  `GraphNativeProvenanceMarker`) with `delete_mode == "graph_native"`. **Any read
+  error returns `False`**, so routing fails safe onto the ledger.
+- `ensure_graph_native_for_new_graph(graph_engine)` — marks a brand-new
+  (`is_empty()`) graph as graph-native and returns `True`; returns `False` for a
+  populated-but-unmarked graph (an old graph that must stay on the ledger).
+  Idempotent.
+
+This gives the clean cut Part 2 needs: every entry point in Phase 4 calls
+`is_graph_native_graph` once and branches. A graph is graph-native if and only
+if it was created after Part 2 marked it at first write (Phase 3). No
+per-artifact inspection, no migration, no ambiguity — and old graphs are
+*structurally* incapable of taking the new path until Part 3 backfills the
+marker.
+
+## The planner's retry-safe ordering
+
+`execute_ref_removal` (`provenance_delete_planner.py`) is the heart of all three
+`UnifiedStoreEngine` ops. Its ordering is what makes a partial failure safe:
+
+```
+read provenance + payloads   (caller: get_*_delete_data_by_*)
+ → compute vector ids         (from snapshots only — never relational rows)
+ → delete vectors             (unowned artifacts first)
+ → detach surviving artifacts (strip the ref in the graph; idempotent)
+ → delete unowned artifacts   (graph; idempotent)
+```
+
+Because **every graph mutation happens after the vector deletes**:
+
+- a failed vector delete leaves **graph provenance untouched**, so a retry
+  re-reads the identical state and converges;
+- the detach and delete steps are idempotent (removing an absent ref / deleting
+  an absent node is a no-op), so a retry after a partial *graph* mutation also
+  converges to the clean final state;
+- unsupported-capability errors from the reads propagate to the caller
+  **before any mutation** — the engine never half-deletes when a backend can't
+  answer a read.
+
+The survival predicates differ per op (defined in `unified_store_engine.py`):
+source-ref delete survives on another `source_ref`; dataset delete survives on
+another dataset id; rollback survives on any `source_ref` or any other
+`source_run_ref`. The planner is otherwise op-agnostic.
+
+This is exercised directly by
+`test_vector_failure_leaves_graph_untouched_then_retry_converges` and
+`test_unsupported_capability_propagates_before_mutation`.
+
+## Acceptance criteria
+
+All unit-level criteria are met today against the Part 0 fakes
+(`test_unified_graph_native_delete.py`, `test_fake_graph_vector_store.py`):
+
+1. `delete_by_source_ref` / `delete_by_dataset_id` / `rollback_by_pipeline_run_id`
+   pass vs the Part 0 fakes: **vectors deleted first**, refs removed from shared
+   artifacts (detach), only unowned artifacts hard-deleted, no-candidate request
+   is a no-op.
+2. Edge/triplet vector ids use the Part 0 helpers (`EdgeType.id_for`,
+   `generate_node_id`); orchestration **never reads relational `Node`/`Edge`
+   rows**.
+3. An injected vector-delete failure raises with **graph provenance untouched**,
+   and a retry converges.
+4. Unsupported capabilities propagate **before any mutation**.
+5. Graph-native `add_data_points` attaches node/edge source refs incl. custom
+   edges and writes **no** `upsert_nodes`/`upsert_edges`.
+6. Writes without dataset/data-item stay **non-provenanced**; writes without
+   `pipeline_run_id` attach refs but create **no run ownership**.
+7. Graph-native delete / dataset-delete / `forget(memory_only=True)` /
+   deprecated `delete()` / rollback route through the unified boundary, while old
+   unmarked graphs keep the ledger path.
+8. Ledger consumers read graph provenance **only in their graph-native branch**.
+
+**Gated on Part 1:** the default-stack integration gate (Phase 6). It is
+authored in Part 2 but **kept skipped** until Part 1 implements the real Ladybug
++ LanceDB primitives, and the **PR stays draft** until then.
+
+## First backend scope
+
+Inherited from Part 0: **Ladybug (graph) + LanceDB (vector) + SQLite
+(relational)**. Other graph/vector backends keep
+`supports_graph_native_provenance() == False`, so
+`UnifiedStoreEngine.supports_graph_native_delete()` is `False` and they fall back
+to the ledger path regardless of the marker. (As a defensive belt-and-braces,
+the Phase 4 branch can require both `is_graph_native_graph(...)` **and**
+`unified.supports_graph_native_delete()` before taking the unified boundary.)
+
+## Out of scope (Part 3)
+
+- Backfilling on-graph provenance for ledger-era graphs and flipping them to
+  `graph_native`.
+- Removing the ledger consumers (groups (a) in `ledger_consumer_inventory.md`)
+  and dropping the `nodes`/`edges` tables and the legacy
+  `GraphRelationshipLedger`.
+- Re-sourcing the memify global-context analytics read (consumer 19) off the
+  graph.


### PR DESCRIPTION
## Context

Part 2 of the graph-native delete/rollback plan (parent Part 0: PR #3282). Makes **newly-marked graphs** use on-graph provenance for delete and rollback through the unified graph+vector boundary, while **old unmarked graphs stay on the relational `nodes`/`edges` ledger** until Part 3. Built against the Part 0 fakes; the default-stack integration gate is authored but **kept skipped until Part 1 lands** — so this PR stays a draft.

**Base:** `feat/graph-native-provenance-part0` (merges into the Part 0 PR, not `dev`).

Plan doc: `temp/delete_improvements/phase2_graph_native_new_graphs.md`.

## What ships

**Spine** (`5a86ecb54`)
- `provenance/markers.py` — `is_graph_native_graph` / `ensure_graph_native_for_new_graph`, the routing authority (a marker node via existing graph CRUD; only marks a new empty graph whose backend implements the provenance primitives).
- `provenance_delete_planner.py` — retry-safe planner: compute vector ids from snapshots only (`EdgeType.id_for`, `generate_node_id`), delete vectors first, detach survivors, delete unowned, then mirror the ledger path's NodeSet-tag + orphaned-EdgeType cleanup.
- `UnifiedStoreEngine` implements `GraphVectorStoreInterface`: `delete_by_source_ref` / `delete_by_dataset_id` / `rollback_by_pipeline_run_id`, matching the Part 0 `FakeGraphVectorStore` semantics.
- `GraphDBInterface` write primitives (`detach_*`, `delete_edges`, `attach_*`) with raising defaults; `dataset_ids` added to the snapshots.

**Wiring** (`c638af6f6`)
- **Write stamping** in `add_data_points`: marked graphs skip the ledger and get source/run/dataset refs stamped after the graph write succeeds (custom edges included; run refs only when `pipeline_run_id` present).
- **Routing**: data-item delete → `delete_by_source_ref`; dataset delete → `delete_by_dataset_id`; rollback → `rollback_by_pipeline_run_id` (+ `pipeline_status` reset); `datasets.delete_data` no longer mis-routes graph-native graphs to `legacy_delete`; `forget(memory_only=True)` and deprecated `delete()` route transitively. Auth unchanged; old graphs keep the ledger path.

## Acceptance criteria

- [x] `delete_by_source_ref` / `delete_by_dataset_id` / `rollback_by_pipeline_run_id` pass vs Part 0 fakes (vectors first, refs removed from shared, only unowned deleted, no-candidate no-op).
- [x] Edge/triplet vector ids use the Part 0 id helpers; orchestration never reads relational `Node`/`Edge` rows.
- [x] Injected vector-delete failure raises with graph provenance untouched; retry converges; unsupported capabilities propagate before mutation.
- [x] Graph-native `add_data_points` attaches node/edge source refs (incl. custom edges) and writes no `upsert_nodes`/`upsert_edges`; no-context writes stay non-provenanced; no-`pipeline_run_id` writes attach refs but no run ownership.
- [x] Delete/dataset-delete/forget/deprecated-delete/rollback route through the unified boundary; old unmarked graphs keep the ledger path.
- [ ] **Default-stack integration gate** (Ladybug + LanceDB + SQLite, both access-control modes) — authored, **module-skipped until Part 1**. PR stays draft until then.

## Tests

`provenance + rollback + add_data_points + forget` suites: **94 passed, 3 skipped**. 9 new orchestration unit tests against fake provenance graph + recording vector engines. Adversarial spine review passed all 6 criteria (its one major follow-up — cleanup parity — is implemented here).

## Excluded

Real adapter storage primitives (Part 1); old-graph migration + ledger retirement (Part 3); any provenance scanning on search/retrieval/traversal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)