### PR TITLE
fix(permissions): keep shared-dataset documents when filtering by name

### DIFF
--- a/cognee/modules/users/permissions/methods/get_document_ids_for_user.py
+++ b/cognee/modules/users/permissions/methods/get_document_ids_for_user.py
@@ -49,7 +49,7 @@ async def get_document_ids_for_user(user_id: UUID, datasets: list[str] = None) -
                         await session.scalars(
                             select(Dataset.id).where(
                                 Dataset.name == dataset,
-                                Dataset.owner_id == user_id,
+                                Dataset.id.in_(dataset_ids),
                             )
                         )
                     ).one_or_none()

--- a/cognee/tests/unit/users/permissions/test_get_document_ids_for_user_shared_dataset.py
+++ b/cognee/tests/unit/users/permissions/test_get_document_ids_for_user_shared_dataset.py
@@ -1,0 +1,68 @@
+import importlib
+import os
+import tempfile
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+    SQLAlchemyAdapter,
+)
+from cognee.modules.data.models import Data, Dataset, DatasetData
+from cognee.modules.users.models import ACL, Permission
+from cognee.modules.users.models.Principal import Principal
+
+gdifu = importlib.import_module(
+    "cognee.modules.users.permissions.methods.get_document_ids_for_user"
+)
+gdd = importlib.import_module("cognee.modules.data.methods.get_dataset_data")
+get_document_ids_for_user = gdifu.get_document_ids_for_user
+
+OWNER_ID = uuid4()  # user B -- owns the dataset
+READER_ID = uuid4()  # user A -- only has a read ACL on it
+DATASET_ID = uuid4()
+DATA_ID = uuid4()
+DATASET_NAME = "shared_dataset"
+
+
+async def _make_engine():
+    """Create a throwaway SQLite-backed relational engine seeded with a dataset
+    owned by user B and shared to user A with a read ACL, containing one doc."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    engine = SQLAlchemyAdapter(f"sqlite+aiosqlite:///{tmp.name}")
+    await engine.create_database()
+
+    async with engine.get_async_session() as session:
+        async with session.begin():
+            session.add(Principal(id=OWNER_ID, type="principal"))
+            session.add(Principal(id=READER_ID, type="principal"))
+            session.add(Dataset(id=DATASET_ID, name=DATASET_NAME, owner_id=OWNER_ID))
+            session.add(Data(id=DATA_ID, name="doc1", data_size=10))
+            session.add(DatasetData(dataset_id=DATASET_ID, data_id=DATA_ID))
+            perm = Permission(name="read")
+            session.add(perm)
+            session.add(ACL(principal_id=READER_ID, dataset_id=DATASET_ID, permission=perm))
+
+    return engine, tmp.name
+
+
+@pytest.mark.asyncio
+async def test_name_filter_keeps_acl_shared_dataset_documents(monkeypatch):
+    engine, db_path = await _make_engine()
+    # Both the lookup and its get_dataset_data helper must use the test engine.
+    monkeypatch.setattr(gdifu, "get_relational_engine", lambda: engine)
+    monkeypatch.setattr(gdd, "get_relational_engine", lambda: engine)
+    try:
+        unfiltered = await get_document_ids_for_user(READER_ID)
+        assert [str(i) for i in unfiltered] == [str(DATA_ID)]
+
+        # filtering by the shared dataset's name must not drop it.
+        by_name = await get_document_ids_for_user(READER_ID, datasets=[DATASET_NAME])
+        assert [str(i) for i in by_name] == [str(DATA_ID)], (
+            "documents of an ACL-shared dataset must survive a name filter; "
+            f"got {[str(i) for i in by_name]}"
+        )
+    finally:
+        await engine.engine.dispose()
+        os.unlink(db_path)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

Closes #3290

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

`get_document_ids_for_user(user_id, datasets=...)` is meant to return documents the user has read access to, and its initial ACL-based query correctly includes datasets that have been shared with the user.

The problem occurs when `datasets=[...]` is used. The dataset name lookup adds an ownership check:

```python
select(Dataset.id).where(
    Dataset.name == dataset,
    Dataset.owner_id == user_id,   # <- only matches datasets the user OWNS
)
```

Because of this, datasets shared through ACLs but owned by someone else are not found. The function then silently excludes documents from those datasets. As a result, an unfiltered call returns the documents, but adding the dataset's own name as a filter makes them disappear.

This is a fail-closed bug that doesn't leak data, but it incorrectly hides documents the user is allowed to read.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

- A dataset owned by user B and shared to user A through a `read` ACL, containing one document, must yield that document for user A both with and without a `datasets=[name]` filter.
- The unfiltered path is unchanged.
- Added regression test `cognee/tests/unit/users/permissions/test_get_document_ids_for_user_shared_dataset.py` drives the real `get_document_ids_for_user` against a throwaway SQLite engine seeded with the real ORM models. It fails before the change (name-filtered call returns `[]`) and passes after.

Verified in a clean `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` container:

```
===== FAIL-BEFORE (unfixed source) =====
FAILED cognee/tests/unit/users/permissions/test_get_document_ids_for_user_shared_dataset.py::test_name_filter_keeps_acl_shared_dataset_documents
EXIT_BEFORE=1
===== PASS-AFTER (fixed source) =====
cognee/tests/unit/users/permissions/test_get_document_ids_for_user_shared_dataset.py::test_name_filter_keeps_acl_shared_dataset_documents PASSED [100%]
EXIT_AFTER=0
```

`ruff format --check` and `ruff check` both pass on the two changed files.

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

<img width="1235" height="244" alt="image" src="https://github.com/user-attachments/assets/c89c7d1e-415c-424c-aa27-337af76eff09" />


## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
