### PR TITLE
feat(search): default to hybrid retriever; recall auto_route off by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,8 @@ Key files:
 `search(query_text, query_type)` → route to retriever type → filter by permissions → return results
 
 Available search types (from `cognee/modules/search/types/SearchType.py`):
-- **GRAPH_COMPLETION** (default) - Graph traversal + LLM completion
+- **HYBRID_COMPLETION** (default) - Blends chunk, entity, and optional global graph context + LLM completion (runs chunk and entity retrieval concurrently)
+- **GRAPH_COMPLETION** - Graph traversal + LLM completion
 - **GRAPH_SUMMARY_COMPLETION** - Uses pre-computed summaries with graph context
 - **GRAPH_COMPLETION_COT** - Chain-of-thought reasoning over graph
 - **GRAPH_COMPLETION_CONTEXT_EXTENSION** - Extended context graph retrieval

--- a/cognee/api/v1/recall/query_router.py
+++ b/cognee/api/v1/recall/query_router.py
@@ -20,7 +20,7 @@ class RouteResult:
 
     search_type: SearchType
     confidence: float
-    runner_up: SearchType = SearchType.GRAPH_COMPLETION
+    runner_up: SearchType = SearchType.HYBRID_COMPLETION
     runner_up_score: float = 0.0
     all_scores: dict = field(default_factory=dict)
 
@@ -146,7 +146,7 @@ _RULES: list[tuple[re.Pattern, SearchType, float]] = [
     ),
 ]
 
-_DEFAULT = SearchType.GRAPH_COMPLETION
+_DEFAULT = SearchType.HYBRID_COMPLETION
 _DEFAULT_BASE_SCORE = 2.0
 
 # Track explicit user overrides to surface misrouting patterns.

--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -320,7 +320,7 @@ async def recall(
     datasets: list[str] | None = None,
     dataset_ids: list[UUID] | None = None,
     top_k: int = 15,
-    auto_route: bool = True,
+    auto_route: bool = False,
     scope: str | list[str] | None = None,
     system_prompt: str | None = None,
     system_prompt_path: str = "answer_simple_question.txt",
@@ -351,10 +351,10 @@ async def recall(
     Each result dict includes a ``_source`` key (``"session"`` or
     ``"graph"``) so callers can tell where the result came from.
 
-    When ``query_type`` is omitted and ``auto_route`` is True (default),
-    a lightweight rule-based classifier picks the best search strategy.
-    Set ``auto_route=False`` to skip the classifier and use
-    GRAPH_COMPLETION as the default, or pass ``query_type`` explicitly.
+    When ``query_type`` is omitted and ``auto_route`` is False (default),
+    recall uses HYBRID_COMPLETION. Set ``auto_route=True`` to run a
+    lightweight rule-based classifier that picks the best search strategy
+    per query, or pass ``query_type`` explicitly to choose one.
 
     Args:
         query_text: Natural-language query.
@@ -363,7 +363,7 @@ async def recall(
         dataset_ids: Dataset UUIDs to search within. Takes precedence over datasets.
         top_k: Maximum results to return (default *15*).
         auto_route: If True and query_type is None, classify the query
-            automatically. If False, fall back to GRAPH_COMPLETION.
+            automatically. If False (default), use HYBRID_COMPLETION.
 
     Returns:
         Search results. When searching session-only, returns a list of
@@ -517,7 +517,7 @@ async def recall(
                 result = route_query(query_text)
                 local_query_type = result.search_type
             else:
-                local_query_type = SearchType.GRAPH_COMPLETION
+                local_query_type = SearchType.HYBRID_COMPLETION
 
             span.set_attribute(
                 COGNEE_SEARCH_TYPE,

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -23,11 +23,11 @@ from cognee.shared.utils import send_telemetry
 
 
 class RecallPayloadDTO(InDTO):
-    # Default preserved as GRAPH_COMPLETION for backward compatibility
-    # with existing HTTP clients. Pass ``search_type: null`` explicitly
-    # to opt into auto-routing (the new ``cognee.recall`` default).
+    # Default is HYBRID_COMPLETION (chunk + entity + optional global context).
+    # Pass ``search_type: null`` explicitly to opt into auto-routing
+    # (the ``cognee.recall`` default, which also falls back to HYBRID_COMPLETION).
     search_type: Optional[SearchType] = Field(
-        default=SearchType.GRAPH_COMPLETION,
+        default=SearchType.HYBRID_COMPLETION,
         description=(
             "Search strategy, e.g. GRAPH_COMPLETION, RAG_COMPLETION, CHUNKS, SUMMARIES. "
             "Pass null to let cognee auto-route the query to the best strategy."
@@ -131,7 +131,7 @@ def get_recall_router() -> APIRouter:
         topK); both camelCase and snake_case are accepted.
 
         - **search_type** (Optional[SearchType]): Type of search to perform
-          (default: GRAPH_COMPLETION). Pass null to enable automatic query routing.
+          (default: HYBRID_COMPLETION). Pass null to enable automatic query routing.
         - **datasets** (Optional[List[str]]): Dataset names to search within
         - **dataset_ids** (Optional[List[UUID]]): Dataset UUIDs to search within;
           take precedence over dataset names when both are provided
@@ -171,6 +171,9 @@ def get_recall_router() -> APIRouter:
             results = await cognee_recall(
                 query_text=payload.query,
                 query_type=payload.search_type,
+                # Preserve the HTTP contract: an explicit ``search_type: null``
+                # opts into auto-routing; otherwise the resolved search_type is used.
+                auto_route=payload.search_type is None,
                 user=user,
                 datasets=payload.datasets,
                 dataset_ids=payload.dataset_ids,

--- a/cognee/api/v1/responses/default_tools.py
+++ b/cognee/api/v1/responses/default_tools.py
@@ -14,6 +14,7 @@ DEFAULT_TOOLS = [
                     "type": "string",
                     "description": "Type of search to perform",
                     "enum": [
+                        "HYBRID_COMPLETION",
                         "CODE",
                         "GRAPH_COMPLETION",
                         "NATURAL_LANGUAGE",

--- a/cognee/api/v1/responses/dispatch_function.py
+++ b/cognee/api/v1/responses/dispatch_function.py
@@ -55,16 +55,16 @@ async def handle_search(arguments: Dict[str, Any], user) -> list:
     if not query and "search_query" in required_params:
         return "Error: Missing required 'search_query' parameter"
 
-    search_type_str = arguments.get("search_type", "GRAPH_COMPLETION")
+    search_type_str = arguments.get("search_type", "HYBRID_COMPLETION")
     valid_search_types = (
         search_tool["parameters"]["properties"]["search_type"]["enum"]
         if search_tool
-        else ["CODE", "GRAPH_COMPLETION", "NATURAL_LANGUAGE"]
+        else ["HYBRID_COMPLETION", "CODE", "GRAPH_COMPLETION", "NATURAL_LANGUAGE"]
     )
 
     if search_type_str not in valid_search_types:
-        logger.warning(f"Invalid search_type: {search_type_str}, defaulting to GRAPH_COMPLETION")
-        search_type_str = "GRAPH_COMPLETION"
+        logger.warning(f"Invalid search_type: {search_type_str}, defaulting to HYBRID_COMPLETION")
+        search_type_str = "HYBRID_COMPLETION"
 
     query_type = SearchType[search_type_str]
 

--- a/cognee/api/v1/responses/routers/default_tools.py
+++ b/cognee/api/v1/responses/routers/default_tools.py
@@ -14,6 +14,7 @@ DEFAULT_TOOLS = [
                     "type": "string",
                     "description": "Type of search to perform",
                     "enum": [
+                        "HYBRID_COMPLETION",
                         "CODE",
                         "GRAPH_COMPLETION",
                         "NATURAL_LANGUAGE",

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -24,9 +24,10 @@ from cognee.shared.utils import send_telemetry
 #       To search for datasets not owned by the request sender dataset UUID is needed
 class SearchPayloadDTO(InDTO):
     search_type: SearchType = Field(
-        default=SearchType.GRAPH_COMPLETION,
+        default=SearchType.HYBRID_COMPLETION,
         description=(
-            "Retrieval strategy. Common values: GRAPH_COMPLETION (default, graph context + LLM"
+            "Retrieval strategy. Common values: HYBRID_COMPLETION (default, chunk + entity +"
+            " optional global context + LLM answer), GRAPH_COMPLETION (graph context + LLM"
             " answer), RAG_COMPLETION, CHUNKS, SUMMARIES, TEMPORAL, FEELING_LUCKY (auto-select),"
             " AGENTIC_COMPLETION (enables skills/tools/max_iter)."
         ),
@@ -170,7 +171,7 @@ def get_search_router() -> APIRouter:
         types and can be scoped to specific datasets.
 
         ## Request Parameters
-        - **search_type** (SearchType): Type of search to perform (default: GRAPH_COMPLETION). Use AGENTIC_COMPLETION to enable skills, tools and max_iter.
+        - **search_type** (SearchType): Type of search to perform (default: HYBRID_COMPLETION). Use AGENTIC_COMPLETION to enable skills, tools and max_iter.
         - **datasets** (Optional[List[str]]): List of dataset names to search within
         - **dataset_ids** (Optional[List[UUID]]): List of dataset UUIDs to search within
         - **query** (str): The search query string

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -29,7 +29,7 @@ logger = get_logger()
 
 async def search(
     query_text: str,
-    query_type: SearchType = SearchType.GRAPH_COMPLETION,
+    query_type: SearchType = SearchType.HYBRID_COMPLETION,
     user: Optional[User] = None,
     datasets: Optional[Union[list[str], str]] = None,
     dataset_ids: Optional[Union[list[UUID], UUID]] = None,
@@ -90,7 +90,13 @@ async def search(
 
     Search Types & Use Cases:
 
-        **GRAPH_COMPLETION** (Default - Recommended):
+        **HYBRID_COMPLETION** (Default - Recommended):
+            Natural language Q&A blending chunk, entity, and optional global graph
+            context with LLM reasoning. Runs chunk and entity retrieval concurrently.
+            Best for: General-purpose questions needing both passages and graph structure.
+            Returns: Conversational AI responses backed by hybrid context.
+
+        **GRAPH_COMPLETION**:
             Natural language Q&A using full graph context and LLM reasoning.
             Best for: Complex questions, analysis, summaries, insights.
             Returns: Conversational AI responses with graph-backed context.
@@ -138,7 +144,7 @@ async def search(
             - "What functions handle user authentication?"
 
         query_type: SearchType enum specifying the search mode.
-                   Defaults to GRAPH_COMPLETION for conversational AI responses.
+                   Defaults to HYBRID_COMPLETION for conversational AI responses.
 
         user: User context for data access permissions. Uses default if None.
 

--- a/cognee/cli/commands/recall_command.py
+++ b/cognee/cli/commands/recall_command.py
@@ -27,8 +27,8 @@ Otherwise, this is a memory-oriented alias for `cognee search`.
             "--query-type",
             "-t",
             choices=SEARCH_TYPE_CHOICES,
-            default="GRAPH_COMPLETION",
-            help="Search mode (default: GRAPH_COMPLETION)",
+            default="HYBRID_COMPLETION",
+            help="Search mode (default: HYBRID_COMPLETION)",
         )
         parser.add_argument(
             "--datasets",

--- a/cognee/cli/commands/search_command.py
+++ b/cognee/cli/commands/search_command.py
@@ -50,8 +50,8 @@ Search Types & Use Cases:
             "--query-type",
             "-t",
             choices=SEARCH_TYPE_CHOICES,
-            default="GRAPH_COMPLETION",
-            help="Search mode (default: GRAPH_COMPLETION for conversational AI responses)",
+            default="HYBRID_COMPLETION",
+            help="Search mode (default: HYBRID_COMPLETION for conversational AI responses)",
         )
         parser.add_argument(
             "--datasets",

--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
@@ -144,7 +144,7 @@ class TestSearchCommand:
         assert "output_format" in actions
 
         # Check default values
-        assert actions["query_type"].default == "GRAPH_COMPLETION"
+        assert actions["query_type"].default == "HYBRID_COMPLETION"
         assert actions["top_k"].default == 10
         assert actions["output_format"].default == "pretty"
 

--- a/cognee/tests/unit/api/v2/test_query_router.py
+++ b/cognee/tests/unit/api/v2/test_query_router.py
@@ -9,7 +9,9 @@ class TestFactualQueries:
         assert route_query("Who won Nobel Prizes?").search_type == SearchType.HYBRID_COMPLETION
 
     def test_simple_what(self):
-        assert route_query("What did Einstein discover?").search_type == SearchType.HYBRID_COMPLETION
+        assert (
+            route_query("What did Einstein discover?").search_type == SearchType.HYBRID_COMPLETION
+        )
 
     def test_short_list(self):
         assert route_query("List all scientists").search_type == SearchType.HYBRID_COMPLETION

--- a/cognee/tests/unit/api/v2/test_query_router.py
+++ b/cognee/tests/unit/api/v2/test_query_router.py
@@ -6,13 +6,13 @@ from cognee.modules.search.types import SearchType
 
 class TestFactualQueries:
     def test_simple_who(self):
-        assert route_query("Who won Nobel Prizes?").search_type == SearchType.GRAPH_COMPLETION
+        assert route_query("Who won Nobel Prizes?").search_type == SearchType.HYBRID_COMPLETION
 
     def test_simple_what(self):
-        assert route_query("What did Einstein discover?").search_type == SearchType.GRAPH_COMPLETION
+        assert route_query("What did Einstein discover?").search_type == SearchType.HYBRID_COMPLETION
 
     def test_short_list(self):
-        assert route_query("List all scientists").search_type == SearchType.GRAPH_COMPLETION
+        assert route_query("List all scientists").search_type == SearchType.HYBRID_COMPLETION
 
 
 class TestCypherQueries:
@@ -134,7 +134,7 @@ class TestConfidence:
 
     def test_default_has_base_confidence(self):
         r = route_query("Tell me something interesting")
-        assert r.search_type == SearchType.GRAPH_COMPLETION
+        assert r.search_type == SearchType.HYBRID_COMPLETION
         assert r.confidence >= 0
 
 
@@ -148,7 +148,7 @@ class TestAmbiguousQueries:
         assert r.search_type == SearchType.GRAPH_SUMMARY_COMPLETION
 
     def test_default_for_vague_query(self):
-        assert route_query("Tell me something").search_type == SearchType.GRAPH_COMPLETION
+        assert route_query("Tell me something").search_type == SearchType.HYBRID_COMPLETION
 
 
 class TestOverrideTracking:


### PR DESCRIPTION
## Summary

Switches the default retriever from **GRAPH_COMPLETION** to the new **HYBRID_COMPLETION** (`HybridRetriever`) across the search and recall surfaces. `HybridRetriever` blends chunk, entity, and optional global graph context, running chunk and entity retrieval concurrently.

Per request, `cognee.recall()` now defaults to `auto_route=False`, so recall uses `HYBRID_COMPLETION` directly rather than running the rule-based classifier.

## Changes

- **`cognee.search()` SDK** + **HTTP `/search`** — default `query_type` / `search_type` → `HYBRID_COMPLETION`.
- **`cognee.recall()` SDK** — default `auto_route=False` (uses `HYBRID_COMPLETION`). The classifier fallback (`query_router._DEFAULT`) and `RouteResult.runner_up` also move to `HYBRID_COMPLETION`, so auto-routing (opt-in via `auto_route=True`) still resolves to hybrid when no pattern matches.
- **HTTP `/recall`** — `RecallPayloadDTO.search_type` defaults to `HYBRID_COMPLETION`; the router now passes `auto_route=(search_type is None)` so the documented "pass `search_type: null` to auto-route" contract is preserved.
- **CLI** — `search` / `recall` `--query-type` defaults → `HYBRID_COMPLETION`.
- **Responses API** — tool `search_type` enum gains `HYBRID_COMPLETION`; `dispatch_function` uses it as the fallback default.
- **Docs/docstrings** — `CLAUDE.md`, `search()` and `recall()` docstrings updated.

## Behavior matrix (after this change)

| Entry point | Default |
|---|---|
| `cognee.search()` SDK / HTTP `/search` | HYBRID_COMPLETION |
| `cognee.recall()` SDK (`auto_route=False`) | HYBRID_COMPLETION |
| HTTP `/recall` | HYBRID_COMPLETION (pass `search_type: null` to auto-route) |

## Testing

- `pytest cognee/tests/unit/api/v1/recall/test_recall_api.py` — 3 passed (tests pass explicit `auto_route`, unaffected by the default flip).
- `ruff check` / `ruff format` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)