### PR TITLE
feat(graph): Part 2 — graph-native delete/rollback (on COG-5522 Part 0)

### DIFF
--- a/cognee/api/v1/datasets/datasets.py
+++ b/cognee/api/v1/datasets/datasets.py
@@ -179,7 +179,22 @@ class datasets:
             raise UnauthorizedDataAccessError(f"Data {data_id} not accessible.")
 
         async with set_database_global_context_variables(dataset_id, dataset.owner_id):
-            if not await has_data_related_nodes(dataset_id, data_id):
+            # Graph-native graphs have no relational ledger rows, so the
+            # has_data_related_nodes gate would wrongly route to legacy_delete.
+            # Route them straight to delete_data_nodes_and_edges, which detects
+            # the graph-native marker and removes the source ref via the
+            # unified boundary. Old/unmarked graphs keep the existing gate.
+            from cognee.infrastructure.databases.graph.get_graph_engine import (
+                get_graph_engine,
+            )
+            from cognee.infrastructure.databases.provenance.markers import (
+                is_graph_native_graph,
+            )
+
+            graph_engine = await get_graph_engine()
+            if await is_graph_native_graph(graph_engine):
+                await delete_data_nodes_and_edges(dataset_id, data_id, user.id)
+            elif not await has_data_related_nodes(dataset_id, data_id):
                 await legacy_delete(data, "soft")
             else:
                 await delete_data_nodes_and_edges(dataset_id, data_id, user.id)

--- a/cognee/infrastructure/databases/provenance/markers.py
+++ b/cognee/infrastructure/databases/provenance/markers.py
@@ -1,0 +1,60 @@
+"""Graph-native provenance markers.
+
+A graph is "graph-native" when its graph-level metadata advertises the
+graph-native delete mode. Marking happens lazily for empty graphs only, via
+``set_graph_metadata``. On pre-Part-1 backends ``set_graph_metadata`` and
+``get_graph_metadata`` raise ``UnsupportedProvenanceCapability``, so nothing is
+ever marked and the whole graph-native path stays inert — old/unmarked graphs
+keep using the relational ledger.
+"""
+
+from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
+from cognee.infrastructure.databases.provenance import (
+    GRAPH_DELETE_MODE_GRAPH_NATIVE,
+    GRAPH_DELETE_MODE_KEY,
+    GRAPH_PROVENANCE_VERSION,
+    GRAPH_PROVENANCE_VERSION_KEY,
+)
+
+
+async def is_graph_native_graph(graph_engine) -> bool:
+    """Return True when the graph metadata marks it as graph-native.
+
+    Fail-safe: any exception (including ``UnsupportedProvenanceCapability`` from
+    a backend that does not implement provenance) is treated as "not
+    graph-native" so callers fall back to the relational-ledger delete path.
+    """
+    try:
+        metadata = await graph_engine.get_graph_metadata()
+    except Exception:
+        return False
+
+    return metadata.get(GRAPH_DELETE_MODE_KEY) == GRAPH_DELETE_MODE_GRAPH_NATIVE
+
+
+async def ensure_graph_native_for_new_graph(graph_engine) -> bool:
+    """Mark an empty graph as graph-native, returning whether it is graph-native.
+
+    - Already graph-native -> True (idempotent, no re-mark).
+    - Non-empty (existing/old graph) -> False; it stays on the ledger path.
+    - Empty graph -> attempt to mark via ``set_graph_metadata``. On
+      ``UnsupportedProvenanceCapability`` (pre-Part-1 backend) -> False. Only a
+      successful mark returns True.
+    """
+    if await is_graph_native_graph(graph_engine):
+        return True
+
+    if not await graph_engine.is_empty():
+        return False
+
+    try:
+        await graph_engine.set_graph_metadata(
+            {
+                GRAPH_PROVENANCE_VERSION_KEY: GRAPH_PROVENANCE_VERSION,
+                GRAPH_DELETE_MODE_KEY: GRAPH_DELETE_MODE_GRAPH_NATIVE,
+            }
+        )
+    except UnsupportedProvenanceCapability:
+        return False
+
+    return True

--- a/cognee/infrastructure/databases/unified/provenance_delete_planner.py
+++ b/cognee/infrastructure/databases/unified/provenance_delete_planner.py
@@ -1,0 +1,216 @@
+"""Retry-safe planner for graph-native source-ref removal.
+
+Given snapshots of the matched nodes/edges and the set of source refs to remove
+from each, the planner decides which artifacts become *unowned* (no owning
+source ref remains -> hard delete) versus which merely *survive* (some ref
+remains -> detach the targeted refs only). It then performs the removal in a
+retry-safe order:
+
+  1. delete vectors for unowned artifacts (from snapshots only),
+  2. ``remove_*_source_refs`` for the targeted refs on ALL matched artifacts
+     (idempotent),
+  3. ``delete_nodes`` / ``delete_edge_triples`` for the unowned artifacts.
+
+Vectors are deleted first so that a failure leaves graph provenance intact and a
+retry converges. All three steps are individually idempotent.
+
+Vector ids mirror ``delete_from_graph_and_vector``:
+  - node -> collection ``f"{node_type}_{field}"`` for each indexed field,
+    id = node_id;
+  - edge -> ``EdgeType.id_for(edge_text)`` in ``EdgeType_relationship_name``;
+    ``generate_node_id(source_id + relationship_name + target_id)`` in
+    ``Triplet_text`` (best-effort; the collection may not exist).
+"""
+
+from cognee.infrastructure.databases.provenance import (
+    EdgeDeleteData,
+    EdgeIdentity,
+    NodeDeleteData,
+)
+from cognee.modules.engine.utils import generate_node_id
+from cognee.modules.graph.models.EdgeType import EdgeType
+from cognee.modules.graph.utils.prepare_edges_for_storage import get_edge_retrieval_text
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("provenance_delete_planner")
+
+
+def _is_unowned(current_refs: list[str], removed_refs: list[str]) -> bool:
+    """True when removing ``removed_refs`` leaves no owning source ref."""
+    return len(set(current_refs) - set(removed_refs)) == 0
+
+
+async def execute_source_ref_removal(
+    graph_engine,
+    vector_engine,
+    *,
+    node_data: dict[str, NodeDeleteData],
+    edge_data: dict[EdgeIdentity, EdgeDeleteData],
+    refs_by_node: dict[str, list[str]],
+    refs_by_edge: dict[EdgeIdentity, list[str]],
+) -> None:
+    """Remove the given source refs and hard-delete artifacts that become unowned."""
+    # ------------------------------------------------------------------
+    # 1. Partition matched artifacts into unowned (delete) vs surviving (detach).
+    # ------------------------------------------------------------------
+    unowned_node_ids: list[str] = []
+    for node_id, data in node_data.items():
+        removed = refs_by_node.get(node_id, [])
+        if _is_unowned(data.source_ref_keys, removed):
+            unowned_node_ids.append(node_id)
+
+    unowned_edges: list[EdgeIdentity] = []
+    for edge, data in edge_data.items():
+        removed = refs_by_edge.get(edge, [])
+        if _is_unowned(data.source_ref_keys, removed):
+            unowned_edges.append(edge)
+
+    # ------------------------------------------------------------------
+    # 2. Delete vectors for unowned artifacts (from snapshots only).
+    # ------------------------------------------------------------------
+    node_vector_collections: dict[str, list[str]] = {}
+    for node_id in unowned_node_ids:
+        data = node_data[node_id]
+        for field in data.indexed_fields:
+            collection_name = f"{data.node_type}_{field}"
+            node_vector_collections.setdefault(collection_name, []).append(node_id)
+
+    for collection, ids in node_vector_collections.items():
+        await vector_engine.delete_data_points(collection, ids)
+
+    if unowned_edges:
+        edge_type_ids: list[str] = []
+        triplet_ids: list[str] = []
+        for edge in unowned_edges:
+            data = edge_data[edge]
+            edge_text = get_edge_retrieval_text(data.edge_text, edge.relationship_name)
+            if edge_text:
+                edge_type_ids.append(str(EdgeType.id_for(edge_text)))
+            triplet_ids.append(
+                str(generate_node_id(edge.source_id + edge.relationship_name + edge.target_id))
+            )
+
+        if edge_type_ids:
+            await vector_engine.delete_data_points("EdgeType_relationship_name", edge_type_ids)
+
+        if triplet_ids:
+            try:
+                await vector_engine.delete_data_points("Triplet_text", triplet_ids)
+            except Exception:
+                # Triplet collection may not exist if triplet embedding was never enabled.
+                pass
+
+    # ------------------------------------------------------------------
+    # 3. Remove the targeted refs from ALL matched artifacts (idempotent).
+    #    Surviving artifacts keep their remaining refs; unowned ones are then
+    #    hard-deleted below.
+    # ------------------------------------------------------------------
+    nodes_by_removed_refs: dict[tuple[str, ...], list[str]] = {}
+    for node_id in node_data:
+        removed = refs_by_node.get(node_id, [])
+        if not removed:
+            continue
+        nodes_by_removed_refs.setdefault(tuple(removed), []).append(node_id)
+
+    for removed_refs, node_ids in nodes_by_removed_refs.items():
+        await graph_engine.remove_node_source_refs(node_ids, list(removed_refs))
+
+    edges_by_removed_refs: dict[tuple[str, ...], list[EdgeIdentity]] = {}
+    for edge in edge_data:
+        removed = refs_by_edge.get(edge, [])
+        if not removed:
+            continue
+        edges_by_removed_refs.setdefault(tuple(removed), []).append(edge)
+
+    for removed_refs, edges in edges_by_removed_refs.items():
+        await graph_engine.remove_edge_source_refs(edges, list(removed_refs))
+
+    # ------------------------------------------------------------------
+    # 4. Hard-delete unowned artifacts.
+    # ------------------------------------------------------------------
+    if unowned_node_ids:
+        await graph_engine.delete_nodes(unowned_node_ids)
+
+    if unowned_edges:
+        await graph_engine.delete_edge_triples(unowned_edges)
+
+    # ------------------------------------------------------------------
+    # 5. Post-delete cleanup parity with delete_from_graph_and_vector
+    #    (best-effort, non-fatal).
+    # ------------------------------------------------------------------
+    await _cleanup_orphaned_edge_types(graph_engine, unowned_edges, edge_data)
+    await _cleanup_orphaned_nodeset_tags(graph_engine, vector_engine, unowned_node_ids, node_data)
+
+
+async def _cleanup_orphaned_edge_types(
+    graph_engine,
+    unowned_edges: list[EdgeIdentity],
+    edge_data: dict[EdgeIdentity, EdgeDeleteData],
+) -> None:
+    """Prune EdgeType nodes whose retrieval text no longer appears in the graph."""
+    if not unowned_edges:
+        return
+
+    deleted_edge_texts: set[str] = set()
+    for edge in unowned_edges:
+        data = edge_data[edge]
+        edge_text = get_edge_retrieval_text(data.edge_text, edge.relationship_name)
+        if edge_text:
+            deleted_edge_texts.add(edge_text)
+
+    if not deleted_edge_texts:
+        return
+
+    try:
+        _, remaining_edges = await graph_engine.get_graph_data()
+        remaining_edge_texts: set[str] = set()
+        for edge in remaining_edges:
+            properties = edge[3] if len(edge) > 3 and isinstance(edge[3], dict) else {}
+            edge_text = get_edge_retrieval_text(properties.get("edge_text"), edge[2])
+            if edge_text:
+                remaining_edge_texts.add(edge_text)
+
+        orphaned_edge_type_ids = [
+            str(EdgeType.id_for(edge_text))
+            for edge_text in deleted_edge_texts
+            if edge_text not in remaining_edge_texts
+        ]
+
+        if orphaned_edge_type_ids:
+            await graph_engine.delete_nodes(orphaned_edge_type_ids)
+            logger.info(
+                "Deleted %d orphaned EdgeType node(s)",
+                len(orphaned_edge_type_ids),
+            )
+    except Exception as error:
+        logger.warning("EdgeType cleanup failed (non-fatal): %s", error)
+
+
+async def _cleanup_orphaned_nodeset_tags(
+    graph_engine,
+    vector_engine,
+    unowned_node_ids: list[str],
+    node_data: dict[str, NodeDeleteData],
+) -> None:
+    """Strip NodeSet tags belonging to deleted NodeSet nodes from surviving rows."""
+    removed_nodeset_tags: set[str] = set()
+    for node_id in unowned_node_ids:
+        data = node_data[node_id]
+        if data.node_type == "NodeSet":
+            label = data.node_properties.get("name")
+            if label:
+                removed_nodeset_tags.add(label)
+
+    if not removed_nodeset_tags:
+        return
+
+    tags_to_remove = sorted(removed_nodeset_tags)
+    try:
+        await graph_engine.remove_belongs_to_set_tags(tags_to_remove)
+    except Exception as error:
+        logger.warning("Graph NodeSet tag cleanup failed (non-fatal): %s", error)
+
+    try:
+        await vector_engine.remove_belongs_to_set_tags(tags_to_remove)
+    except Exception as error:
+        logger.warning("Vector NodeSet tag cleanup failed (non-fatal): %s", error)

--- a/cognee/infrastructure/databases/unified/unified_store_engine.py
+++ b/cognee/infrastructure/databases/unified/unified_store_engine.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import Optional, cast
 
+from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
 from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface
 from cognee.infrastructure.databases.vector.vector_db_interface import VectorDBInterface
 
 from .capabilities import EngineCapability
 from .graph_vector_store_interface import GraphVectorStoreInterface
+from .provenance_delete_planner import execute_source_ref_removal
 
 
 class UnifiedStoreEngine(GraphVectorStoreInterface):
@@ -64,3 +66,87 @@ class UnifiedStoreEngine(GraphVectorStoreInterface):
     @property
     def is_same_backend(self) -> bool:
         return self._graph is not None and self._graph is self._vector
+
+    def supports_graph_native_delete(self) -> bool:
+        """Return True when this engine can perform graph-native delete/rollback.
+
+        Requires both GRAPH and VECTOR capabilities and present engines. Routing
+        additionally checks ``is_graph_native_graph`` on the graph; unsupported
+        provenance reads raise ``UnsupportedProvenanceCapability`` from the
+        adapter (there is no separate provenance-capability flag).
+        """
+        return (
+            self.has_capability(EngineCapability.GRAPH)
+            and self.has_capability(EngineCapability.VECTOR)
+            and self._graph is not None
+            and self._vector is not None
+        )
+
+    async def delete_by_source_ref(self, source_ref_key: str) -> None:
+        """Delete artifacts owned only by the given source ref; detach the rest."""
+        if not self.supports_graph_native_delete():
+            raise UnsupportedProvenanceCapability()
+        graph = self.graph
+        vector = self.vector
+
+        node_ids = await graph.find_nodes_by_source_ref(source_ref_key)
+        edges = await graph.find_edges_by_source_ref(source_ref_key)
+
+        node_data = await graph.get_node_delete_data(node_ids)
+        edge_data = await graph.get_edge_delete_data(edges)
+
+        refs_by_node = {node_id: [source_ref_key] for node_id in node_data}
+        refs_by_edge = {edge: [source_ref_key] for edge in edge_data}
+
+        await execute_source_ref_removal(
+            graph,
+            vector,
+            node_data=node_data,
+            edge_data=edge_data,
+            refs_by_node=refs_by_node,
+            refs_by_edge=refs_by_edge,
+        )
+
+    async def delete_by_dataset_id(self, dataset_id: str) -> None:
+        """Remove the dataset's source refs; delete artifacts left unowned."""
+        if not self.supports_graph_native_delete():
+            raise UnsupportedProvenanceCapability()
+        graph = self.graph
+        vector = self.vector
+
+        refs_by_node = await graph.find_node_source_refs_by_dataset(dataset_id)
+        refs_by_edge = await graph.find_edge_source_refs_by_dataset(dataset_id)
+
+        node_data = await graph.get_node_delete_data(list(refs_by_node.keys()))
+        edge_data = await graph.get_edge_delete_data(list(refs_by_edge.keys()))
+
+        await execute_source_ref_removal(
+            graph,
+            vector,
+            node_data=node_data,
+            edge_data=edge_data,
+            refs_by_node=refs_by_node,
+            refs_by_edge=refs_by_edge,
+        )
+
+    async def rollback_by_pipeline_run_id(self, pipeline_run_id: str) -> None:
+        """Remove the refs a run attached; delete artifacts left unowned."""
+        if not self.supports_graph_native_delete():
+            raise UnsupportedProvenanceCapability()
+        graph = self.graph
+        vector = self.vector
+
+        refs_by_node = await graph.find_node_source_refs_by_pipeline_run(pipeline_run_id)
+        refs_by_edge = await graph.find_edge_source_refs_by_pipeline_run(pipeline_run_id)
+
+        node_data = await graph.get_node_delete_data(list(refs_by_node.keys()))
+        edge_data = await graph.get_edge_delete_data(list(refs_by_edge.keys()))
+
+        await execute_source_ref_removal(
+            graph,
+            vector,
+            node_data=node_data,
+            edge_data=edge_data,
+            refs_by_node=refs_by_node,
+            refs_by_edge=refs_by_edge,
+        )

--- a/cognee/modules/cognify/rollback.py
+++ b/cognee/modules/cognify/rollback.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import aliased, attributes as orm_attributes
 
 from cognee.context_global_variables import multi_user_support_possible
 from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.databases.unified import get_unified_engine
+from cognee.infrastructure.databases.provenance.markers import is_graph_native_graph
 from cognee.modules.data.models import Data
 from cognee.modules.graph.legacy.has_edges_in_legacy_ledger import has_edges_in_legacy_ledger
 from cognee.modules.graph.legacy.has_nodes_in_legacy_ledger import has_nodes_in_legacy_ledger
@@ -39,6 +41,29 @@ def _extract_data_ids(data_ingestion_info: Any) -> set[UUID]:
     return data_ids
 
 
+async def _reset_pipeline_status(session, target_data_ids: set, dataset_id: Any) -> None:
+    """Clear the cognify_pipeline status for the rolled-back run's data ids."""
+    if not target_data_ids:
+        return
+
+    dataset_id_str = str(dataset_id)
+    data_records = (
+        (await session.execute(select(Data).where(Data.id.in_(list(target_data_ids)))))
+        .scalars()
+        .all()
+    )
+
+    for data_record in data_records:
+        if not data_record.pipeline_status:
+            continue
+        if (
+            "cognify_pipeline" in data_record.pipeline_status
+            and dataset_id_str in data_record.pipeline_status["cognify_pipeline"]
+        ):
+            del data_record.pipeline_status["cognify_pipeline"][dataset_id_str]
+            orm_attributes.flag_modified(data_record, "pipeline_status")
+
+
 async def cognify_rollback_handler(
     pipeline_run_id: UUID,
     dataset: Any,
@@ -58,6 +83,29 @@ async def cognify_rollback_handler(
 
     user_id = getattr(user, "id", None)
     db_engine = get_relational_engine()
+
+    # Graph-native graphs carry provenance in the graph (no relational ledger
+    # rows). Roll back through the unified boundary, which removes the refs the
+    # run attached and hard-deletes any artifact left unowned. We still reset
+    # the cognify pipeline status for the run's data ids so re-cognify works.
+    unified = await get_unified_engine()
+    if unified.supports_graph_native_delete():
+        graph_engine = unified.graph
+        if await is_graph_native_graph(graph_engine):
+            await unified.rollback_by_pipeline_run_id(str(pipeline_run_id))
+
+            target_data_ids = _extract_data_ids(data_ingestion_info)
+            async with db_engine.get_async_session() as session:
+                await _reset_pipeline_status(session, target_data_ids, dataset_id)
+                await session.commit()
+
+            logger.info(
+                "Graph-native cognify rollback completed for run %s (dataset=%s, user=%s).",
+                pipeline_run_id,
+                dataset_id,
+                user_id,
+            )
+            return
 
     async with db_engine.get_async_session() as session:
         target_nodes = (
@@ -175,23 +223,7 @@ async def cognify_rollback_handler(
                 )
             )
 
-        dataset_id_str = str(dataset_id)
-        if target_data_ids:
-            data_records = (
-                (await session.execute(select(Data).where(Data.id.in_(list(target_data_ids)))))
-                .scalars()
-                .all()
-            )
-
-            for data_record in data_records:
-                if not data_record.pipeline_status:
-                    continue
-                if (
-                    "cognify_pipeline" in data_record.pipeline_status
-                    and dataset_id_str in data_record.pipeline_status["cognify_pipeline"]
-                ):
-                    del data_record.pipeline_status["cognify_pipeline"][dataset_id_str]
-                    orm_attributes.flag_modified(data_record, "pipeline_status")
+        await _reset_pipeline_status(session, target_data_ids, dataset_id)
 
         await session.commit()
 

--- a/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
@@ -2,6 +2,9 @@ from uuid import UUID
 
 from cognee.context_global_variables import backend_access_control_enabled
 from cognee.infrastructure.databases.graph.get_graph_engine import get_graph_engine
+from cognee.infrastructure.databases.unified import get_unified_engine
+from cognee.infrastructure.databases.provenance import make_source_ref_key
+from cognee.infrastructure.databases.provenance.markers import is_graph_native_graph
 from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine
 from cognee.modules.graph.legacy.has_edges_in_legacy_ledger import has_edges_in_legacy_ledger
 from cognee.modules.graph.legacy.has_nodes_in_legacy_ledger import has_nodes_in_legacy_ledger
@@ -32,6 +35,16 @@ async def delete_data_nodes_and_edges(dataset_id: UUID, data_id: UUID, user_id: 
     # Check if user has delete permissions for the dataset before proceeding with deletion of related graph/vector nodes and edges.
     dataset = await get_authorized_dataset(user, dataset_id, "delete")
     dataset_id = dataset.id
+
+    # Graph-native graphs carry provenance in the graph (no relational ledger
+    # rows). Route them through the unified boundary, which removes the
+    # dataset/data source ref and hard-deletes any artifact left unowned.
+    unified = await get_unified_engine()
+    if unified.supports_graph_native_delete():
+        graph_engine = unified.graph
+        if await is_graph_native_graph(graph_engine):
+            await unified.delete_by_source_ref(make_source_ref_key(dataset_id, data_id))
+            return
 
     if backend_access_control_enabled():
         affected_nodes = await get_data_related_nodes(dataset_id, data_id)

--- a/cognee/modules/graph/methods/delete_dataset_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_dataset_nodes_and_edges.py
@@ -1,6 +1,8 @@
 from uuid import UUID
 
 from cognee.context_global_variables import backend_access_control_enabled
+from cognee.infrastructure.databases.unified import get_unified_engine
+from cognee.infrastructure.databases.provenance.markers import is_graph_native_graph
 from cognee.modules.graph.legacy.has_nodes_in_legacy_ledger import has_nodes_in_legacy_ledger
 from cognee.modules.graph.legacy.has_edges_in_legacy_ledger import has_edges_in_legacy_ledger
 from cognee.modules.graph.methods import (
@@ -23,6 +25,16 @@ async def delete_dataset_nodes_and_edges(dataset_id: UUID, user_id: UUID) -> Non
     # Check if user has delete permission for the dataset before proceeding with deletion of related graph/vector nodes and edges.
     dataset = await get_authorized_dataset(user, dataset_id, "delete")
     dataset_id = dataset.id
+
+    # Graph-native graphs carry provenance in the graph (no relational ledger
+    # rows). Route them through the unified boundary, which removes the
+    # dataset's source refs and hard-deletes any artifact left unowned.
+    unified = await get_unified_engine()
+    if unified.supports_graph_native_delete():
+        graph_engine = unified.graph
+        if await is_graph_native_graph(graph_engine):
+            await unified.delete_by_dataset_id(str(dataset_id))
+            return
 
     if backend_access_control_enabled():
         affected_nodes = await get_dataset_related_nodes(dataset_id)

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -5,6 +5,13 @@ from cognee.modules.pipelines.tasks.task import task_summary
 from cognee.infrastructure.engine import DataPoint
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.databases.unified.capabilities import EngineCapability
+from cognee.infrastructure.databases.provenance import (
+    EdgeIdentity,
+    make_source_ref_key,
+)
+from cognee.infrastructure.databases.provenance.markers import (
+    ensure_graph_native_for_new_graph,
+)
 from cognee.infrastructure.databases.relational import get_async_session
 from cognee.modules.graph.methods import upsert_edges, upsert_nodes
 from cognee.modules.graph.utils import (
@@ -91,32 +98,22 @@ async def add_data_points(
     vector_engine = unified.vector
     use_hybrid = unified.has_capability(EngineCapability.HYBRID_WRITE)
 
+    is_graph_native = False
     if user and dataset and data_item:
-        # Single session for all upserts: one transaction, one commit. The
-        # rollback ledger is written BEFORE the graph/vector writes so a
-        # failed write can always be swept by the rollback handler.
-        async with get_async_session() as session:
-            await upsert_nodes(
-                nodes,
-                tenant_id=user.tenant_id,
-                user_id=user.id,
-                dataset_id=dataset.id,
-                data_id=data_item.id,
-                session=session,
-                pipeline_run_id=pipeline_run_id,
-            )
-            await upsert_edges(
-                edges,
-                tenant_id=user.tenant_id,
-                user_id=user.id,
-                dataset_id=dataset.id,
-                data_id=data_item.id,
-                session=session,
-                pipeline_run_id=pipeline_run_id,
-            )
-            if custom_edges:
-                await upsert_edges(
-                    custom_edges,
+        # Graph-native graphs (empty graphs marked via graph metadata) carry
+        # their provenance in the graph itself, so they skip the relational
+        # rollback ledger entirely. On the default/pre-Part-1 stack marking is
+        # impossible (set_graph_metadata raises), so this stays False and the
+        # ledger path below runs unchanged.
+        is_graph_native = await ensure_graph_native_for_new_graph(graph_engine)
+
+        if not is_graph_native:
+            # Single session for all upserts: one transaction, one commit. The
+            # rollback ledger is written BEFORE the graph/vector writes so a
+            # failed write can always be swept by the rollback handler.
+            async with get_async_session() as session:
+                await upsert_nodes(
+                    nodes,
                     tenant_id=user.tenant_id,
                     user_id=user.id,
                     dataset_id=dataset.id,
@@ -124,7 +121,26 @@ async def add_data_points(
                     session=session,
                     pipeline_run_id=pipeline_run_id,
                 )
-            await session.commit()
+                await upsert_edges(
+                    edges,
+                    tenant_id=user.tenant_id,
+                    user_id=user.id,
+                    dataset_id=dataset.id,
+                    data_id=data_item.id,
+                    session=session,
+                    pipeline_run_id=pipeline_run_id,
+                )
+                if custom_edges:
+                    await upsert_edges(
+                        custom_edges,
+                        tenant_id=user.tenant_id,
+                        user_id=user.id,
+                        dataset_id=dataset.id,
+                        data_id=data_item.id,
+                        session=session,
+                        pipeline_run_id=pipeline_run_id,
+                    )
+                await session.commit()
 
     if use_hybrid:
         await graph_engine.add_nodes_with_vectors(nodes)
@@ -157,6 +173,22 @@ async def add_data_points(
             )
 
         edges.extend(custom_edges)
+
+    if is_graph_native and user and dataset and data_item:
+        # Graph-native provenance: now that the graph (and vector) writes have
+        # succeeded, stamp the source refs onto the written nodes/edges. A
+        # single attach call per artifact kind — the adapter derives the
+        # dataset_ids / run_ids / run_refs from the source ref key + run id.
+        source_ref_key = make_source_ref_key(dataset.id, data_item.id)
+        run_arg = str(pipeline_run_id) if pipeline_run_id else None
+
+        node_ids = [str(node.id) for node in nodes]
+        edge_ids = [EdgeIdentity(str(edge[0]), str(edge[1]), edge[2]) for edge in edges]
+
+        if node_ids:
+            await graph_engine.attach_node_source_refs(node_ids, [source_ref_key], run_arg)
+        if edge_ids:
+            await graph_engine.attach_edge_source_refs(edge_ids, [source_ref_key], run_arg)
 
     if embed_triplets:
         triplets = _create_triplets_from_graph(nodes, edges)

--- a/cognee/tests/integration/tasks/test_graph_native_delete_part2.py
+++ b/cognee/tests/integration/tasks/test_graph_native_delete_part2.py
@@ -1,0 +1,80 @@
+"""Integration tests for Part 2 graph-native delete/rollback on the default stack.
+
+These are realistic end-to-end tests against the default backends
+(Ladybug + LanceDB + SQLite): add → cognify → delete/rollback, asserting that
+graph nodes/edges and their vector points disappear for unowned artifacts while
+shared / cross-dataset artifacts survive.
+
+They are GATED OFF until Part 1 lands. The graph-native path only activates when
+``set_graph_metadata`` / ``attach_*`` are implemented on the real adapters
+(Part 1). Until then ``ensure_graph_native_for_new_graph`` returns ``False`` on
+the default stack and every graph stays on the relational ledger, so these tests
+would exercise the ledger path instead of the graph-native path. Enable once the
+Part 1 real adapters land.
+"""
+
+import pytest
+
+# COG-5522 Part 1 gate: keep the whole module collected-but-skipped until the
+# real adapters implement Lazar's provenance contract.
+pytestmark = pytest.mark.skip(
+    reason="Part 2 integration gate: enable once Part 1 real adapters land — COG-5522 Part 1"
+)
+
+
+@pytest.mark.asyncio
+async def test_delete_by_source_ref_end_to_end():
+    """add → cognify two data items in one dataset, delete one; its unowned graph
+    nodes/edges and vector points vanish while shared/other-item artifacts remain.
+    """
+    import cognee
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await cognee.add("Alice founded Acme in Berlin.", dataset_name="ds")
+    await cognee.add("Bob joined Globex in Paris.", dataset_name="ds")
+    await cognee.cognify(datasets=["ds"])
+
+    # TODO(Part 1): resolve the data id for the first item, call delete via the
+    # graph-native route, then assert the first item's unowned nodes/edges and
+    # their LanceDB points are gone while the second item's survive.
+    raise AssertionError("enable after Part 1")
+
+
+@pytest.mark.asyncio
+async def test_delete_by_dataset_id_preserves_other_dataset():
+    """Deleting one dataset leaves a second dataset's artifacts and shared
+    entities intact (cross-dataset preservation)."""
+    import cognee
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await cognee.add("Alice founded Acme in Berlin.", dataset_name="ds_a")
+    await cognee.add("Alice also advises Initech.", dataset_name="ds_b")
+    await cognee.cognify(datasets=["ds_a", "ds_b"])
+
+    # TODO(Part 1): delete ds_a; assert ds_a-only nodes/points gone, ds_b intact,
+    # shared "Alice" entity survives with ds_b ownership only.
+    raise AssertionError("enable after Part 1")
+
+
+@pytest.mark.asyncio
+async def test_rollback_by_pipeline_run_id_end_to_end():
+    """A cognify run's solely-introduced artifacts are removed on rollback;
+    artifacts owned by an earlier run survive."""
+    import cognee
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await cognee.add("Alice founded Acme.", dataset_name="ds")
+    await cognee.cognify(datasets=["ds"])
+    await cognee.add("Bob founded Globex.", dataset_name="ds")
+    # second cognify run introduces new artifacts whose run we will roll back
+    await cognee.cognify(datasets=["ds"])
+
+    # TODO(Part 1): capture the second run's pipeline_run_id, roll it back, then
+    # assert only that run's artifacts (and their vector points) are gone.
+    raise AssertionError("enable after Part 1")

--- a/cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_native_delete.py
+++ b/cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_native_delete.py
@@ -1,0 +1,549 @@
+"""Unit tests for the Part 2 graph-native delete/rollback spine.
+
+These exercise ``UnifiedStoreEngine.delete_by_source_ref`` /
+``delete_by_dataset_id`` / ``rollback_by_pipeline_run_id`` and the planner
+(`execute_source_ref_removal`) against an in-memory fake graph engine that
+implements Lazar's Part 0 provenance contract (parseable refs, ``EdgeIdentity``,
+the two-step discovery API, the metadata marker, and ``None``-returning delete
+methods) plus a recording fake vector engine.
+
+The fakes store provenance as ``source_ref_keys`` lists on each node/edge and
+derive ``source_dataset_ids`` / ``source_run_ids`` / ``source_run_refs`` on
+attach, exactly as a real adapter would. The tests prove the semantics from the
+spec:
+
+- unowned hard-delete + shared detach on ``delete_by_source_ref``;
+- cross-dataset preservation on ``delete_by_dataset_id``;
+- rollback removes only run-introduced artifacts;
+- vectors-first ordering + retry convergence after an injected vector failure;
+- unsupported-capability propagation;
+- no-candidate no-op.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
+from cognee.infrastructure.databases.provenance import (
+    EdgeDeleteData,
+    EdgeIdentity,
+    NodeDeleteData,
+    get_dataset_id_from_source_ref_key,
+    make_source_ref_key,
+    make_source_run_ref,
+)
+from cognee.infrastructure.databases.unified import UnifiedStoreEngine
+from cognee.infrastructure.databases.unified.capabilities import EngineCapability
+from cognee.modules.engine.utils import generate_node_id
+from cognee.modules.graph.models.EdgeType import EdgeType
+from cognee.modules.graph.utils.prepare_edges_for_storage import get_edge_retrieval_text
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# In-memory fakes implementing Lazar's contract.
+# ---------------------------------------------------------------------------
+
+
+class _FakeNode:
+    def __init__(self, node_id, node_type, indexed_fields, properties):
+        self.node_id = node_id
+        self.node_type = node_type
+        self.indexed_fields = list(indexed_fields)
+        self.properties = dict(properties)
+        # Provenance state — kept as parallel lists like a real adapter.
+        self.source_ref_keys: list[str] = []
+        self.source_run_refs: list[str] = []
+
+
+class _FakeEdge:
+    def __init__(self, edge: EdgeIdentity, edge_text, properties=None):
+        self.edge = edge
+        self.edge_text = edge_text
+        self.properties = dict(properties or {})
+        self.source_ref_keys: list[str] = []
+        self.source_run_refs: list[str] = []
+
+
+class FakeVectorEngine:
+    """Records delete_data_points / remove_belongs_to_set_tags calls.
+
+    ``fail_on_collection`` injects a single failure for the named collection to
+    prove the planner deletes vectors before any graph mutation (so a retry
+    converges).
+    """
+
+    def __init__(self, fail_on_collection: str | None = None):
+        self.deleted: list[tuple[str, list[str]]] = []
+        self.removed_tags: list[list[str]] = []
+        self._fail_on_collection = fail_on_collection
+        self._existing_collections = {
+            "Entity_name",
+            "NodeSet_name",
+            "EdgeType_relationship_name",
+        }
+
+    async def delete_data_points(self, collection: str, ids: list[str]) -> None:
+        if collection == self._fail_on_collection:
+            # Arm once, then let the retry succeed.
+            self._fail_on_collection = None
+            raise RuntimeError(f"injected vector failure on {collection}")
+        if collection not in self._existing_collections:
+            # Mirror the real "Triplet collection may not exist" case.
+            raise RuntimeError(f"collection {collection} does not exist")
+        self.deleted.append((collection, list(ids)))
+
+    async def remove_belongs_to_set_tags(self, tags: list[str]) -> None:
+        self.removed_tags.append(list(tags))
+
+
+class FakeProvenanceGraphEngine:
+    """In-memory graph implementing Lazar's Part 0 provenance methods."""
+
+    def __init__(self, supports_provenance: bool = True):
+        self._supports = supports_provenance
+        self._metadata: dict[str, str] = {}
+        self.nodes: dict[str, _FakeNode] = {}
+        self.edges: dict[EdgeIdentity, _FakeEdge] = {}
+
+    def _guard(self):
+        if not self._supports:
+            raise UnsupportedProvenanceCapability()
+
+    # -- test setup helpers (not part of the contract) ----------------------
+
+    def add_node(self, node_id, node_type, indexed_fields, properties=None):
+        node = _FakeNode(node_id, node_type, indexed_fields, properties or {})
+        self.nodes[node_id] = node
+        return node
+
+    def add_edge(self, source_id, target_id, relationship_name, edge_text, properties=None):
+        edge = EdgeIdentity(source_id, target_id, relationship_name)
+        self.edges[edge] = _FakeEdge(edge, edge_text, properties)
+        return edge
+
+    # -- marker --------------------------------------------------------------
+
+    async def get_graph_metadata(self) -> dict[str, str]:
+        self._guard()
+        return dict(self._metadata)
+
+    async def set_graph_metadata(self, metadata: dict[str, str]) -> None:
+        self._guard()
+        self._metadata.update(metadata)
+
+    async def is_empty(self) -> bool:
+        return not self.nodes and not self.edges
+
+    # -- write ---------------------------------------------------------------
+
+    async def attach_node_source_refs(self, node_ids, source_ref_keys, pipeline_run_id=None):
+        self._guard()
+        for node_id in node_ids:
+            node = self.nodes[node_id]
+            for key in source_ref_keys:
+                if key not in node.source_ref_keys:
+                    node.source_ref_keys.append(key)
+                if pipeline_run_id is not None:
+                    run_ref = make_source_run_ref(_as_uuid(pipeline_run_id), key)
+                    if run_ref not in node.source_run_refs:
+                        node.source_run_refs.append(run_ref)
+
+    async def attach_edge_source_refs(self, edges, source_ref_keys, pipeline_run_id=None):
+        self._guard()
+        for edge in edges:
+            row = self.edges[edge]
+            for key in source_ref_keys:
+                if key not in row.source_ref_keys:
+                    row.source_ref_keys.append(key)
+                if pipeline_run_id is not None:
+                    run_ref = make_source_run_ref(_as_uuid(pipeline_run_id), key)
+                    if run_ref not in row.source_run_refs:
+                        row.source_run_refs.append(run_ref)
+
+    async def remove_node_source_refs(self, node_ids, source_ref_keys):
+        self._guard()
+        removed = set(source_ref_keys)
+        for node_id in node_ids:
+            node = self.nodes.get(node_id)
+            if node is None:
+                continue  # idempotent: already gone
+            node.source_ref_keys = [k for k in node.source_ref_keys if k not in removed]
+            node.source_run_refs = [
+                r for r in node.source_run_refs if _source_ref_of(r) not in removed
+            ]
+
+    async def remove_edge_source_refs(self, edges, source_ref_keys):
+        self._guard()
+        removed = set(source_ref_keys)
+        for edge in edges:
+            row = self.edges.get(edge)
+            if row is None:
+                continue
+            row.source_ref_keys = [k for k in row.source_ref_keys if k not in removed]
+            row.source_run_refs = [
+                r for r in row.source_run_refs if _source_ref_of(r) not in removed
+            ]
+
+    async def delete_nodes(self, node_ids):
+        self._guard()
+        for node_id in node_ids:
+            self.nodes.pop(node_id, None)  # idempotent
+
+    async def delete_edge_triples(self, edges):
+        self._guard()
+        for edge in edges:
+            self.edges.pop(edge, None)  # idempotent
+
+    # -- read ----------------------------------------------------------------
+
+    async def get_node_delete_data(self, node_ids):
+        self._guard()
+        out: dict[str, NodeDeleteData] = {}
+        for node_id in node_ids:
+            node = self.nodes.get(node_id)
+            if node is None:
+                continue
+            out[node_id] = NodeDeleteData(
+                node_id=node_id,
+                node_type=node.node_type,
+                indexed_fields=list(node.indexed_fields),
+                node_properties=dict(node.properties),
+                source_ref_keys=list(node.source_ref_keys),
+                source_dataset_ids=_dataset_ids(node.source_ref_keys),
+                source_run_ids=_run_ids(node.source_run_refs),
+                source_run_refs=list(node.source_run_refs),
+            )
+        return out
+
+    async def get_edge_delete_data(self, edges):
+        self._guard()
+        out: dict[EdgeIdentity, EdgeDeleteData] = {}
+        for edge in edges:
+            row = self.edges.get(edge)
+            if row is None:
+                continue
+            out[edge] = EdgeDeleteData(
+                edge=edge,
+                edge_text=row.edge_text,
+                edge_properties=dict(row.properties),
+                source_ref_keys=list(row.source_ref_keys),
+                source_dataset_ids=_dataset_ids(row.source_ref_keys),
+                source_run_ids=_run_ids(row.source_run_refs),
+                source_run_refs=list(row.source_run_refs),
+            )
+        return out
+
+    async def find_nodes_by_source_ref(self, source_ref_key):
+        self._guard()
+        return [nid for nid, node in self.nodes.items() if source_ref_key in node.source_ref_keys]
+
+    async def find_edges_by_source_ref(self, source_ref_key):
+        self._guard()
+        return [e for e, row in self.edges.items() if source_ref_key in row.source_ref_keys]
+
+    async def find_node_source_refs_by_dataset(self, dataset_id):
+        self._guard()
+        out: dict[str, list[str]] = {}
+        for nid, node in self.nodes.items():
+            keys = [k for k in node.source_ref_keys if _dataset_of(k) == str(dataset_id)]
+            if keys:
+                out[nid] = keys
+        return out
+
+    async def find_edge_source_refs_by_dataset(self, dataset_id):
+        self._guard()
+        out: dict[EdgeIdentity, list[str]] = {}
+        for e, row in self.edges.items():
+            keys = [k for k in row.source_ref_keys if _dataset_of(k) == str(dataset_id)]
+            if keys:
+                out[e] = keys
+        return out
+
+    async def find_node_source_refs_by_pipeline_run(self, pipeline_run_id):
+        self._guard()
+        out: dict[str, list[str]] = {}
+        for nid, node in self.nodes.items():
+            keys = [
+                _source_ref_of(r)
+                for r in node.source_run_refs
+                if _run_of(r) == str(pipeline_run_id)
+            ]
+            if keys:
+                out[nid] = keys
+        return out
+
+    async def find_edge_source_refs_by_pipeline_run(self, pipeline_run_id):
+        self._guard()
+        out: dict[EdgeIdentity, list[str]] = {}
+        for e, row in self.edges.items():
+            keys = [
+                _source_ref_of(r) for r in row.source_run_refs if _run_of(r) == str(pipeline_run_id)
+            ]
+            if keys:
+                out[e] = keys
+        return out
+
+    async def get_graph_data(self):
+        self._guard()
+        nodes = [(nid, node.properties) for nid, node in self.nodes.items()]
+        edges = [
+            (e.source_id, e.target_id, e.relationship_name, {"edge_text": row.edge_text})
+            for e, row in self.edges.items()
+        ]
+        return nodes, edges
+
+    async def remove_belongs_to_set_tags(self, tags):
+        self._guard()
+        self.removed_tags = getattr(self, "removed_tags", [])
+        self.removed_tags.append(list(tags))
+
+
+# ---------------------------------------------------------------------------
+# parseable-ref helpers (mirror what a real adapter derives on attach).
+# ---------------------------------------------------------------------------
+
+
+def _as_uuid(value):
+    from uuid import UUID
+
+    return value if hasattr(value, "hex") else UUID(str(value))
+
+
+def _dataset_of(source_ref_key: str) -> str:
+    # "source_ref:v1:{dataset}:{data}"
+    return source_ref_key.split(":", 3)[2]
+
+
+def _source_ref_of(source_run_ref: str) -> str:
+    # "source_run_ref:v1:{run}:source_ref:v1:{dataset}:{data}"
+    return source_run_ref.split(":", 3)[3]
+
+
+def _run_of(source_run_ref: str) -> str:
+    return source_run_ref.split(":", 3)[2]
+
+
+def _dataset_ids(source_ref_keys):
+    return sorted({_dataset_of(k) for k in source_ref_keys})
+
+
+def _run_ids(source_run_refs):
+    return sorted({_run_of(r) for r in source_run_refs})
+
+
+def _build_engine(graph, vector):
+    return UnifiedStoreEngine(
+        graph_engine=graph,
+        vector_engine=vector,
+        capabilities=EngineCapability.GRAPH | EngineCapability.VECTOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_by_source_ref_unowned_delete_and_shared_detach():
+    """Nodes owned only by the deleted ref are hard-deleted; shared nodes detach."""
+    dataset_a = uuid4()
+    dataset_b = uuid4()
+    data_a = uuid4()
+    data_b = uuid4()
+    run = uuid4()
+
+    ref_a = make_source_ref_key(dataset_a, data_a)
+    ref_b = make_source_ref_key(dataset_b, data_b)
+
+    graph = FakeProvenanceGraphEngine()
+    owned = graph.add_node("n_owned", "Entity", ["name"], {"name": "Germany"})
+    shared = graph.add_node("n_shared", "Entity", ["name"], {"name": "Europe"})
+    edge_owned = graph.add_edge("n_owned", "n_shared", "located_in", "located in")
+
+    await graph.attach_node_source_refs(["n_owned"], [ref_a], run)
+    await graph.attach_node_source_refs(["n_shared"], [ref_a, ref_b], run)
+    await graph.attach_edge_source_refs([edge_owned], [ref_a], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.delete_by_source_ref(ref_a)
+
+    # Owned node gone; shared node survives with only ref_b remaining.
+    assert "n_owned" not in graph.nodes
+    assert "n_shared" in graph.nodes
+    assert graph.nodes["n_shared"].source_ref_keys == [ref_b]
+    # Owned edge gone.
+    assert edge_owned not in graph.edges
+
+    # Vectors deleted for the unowned node + edge, not the shared node.
+    deleted_collections = {c for c, _ in vector.deleted}
+    assert ("Entity_name", ["n_owned"]) in vector.deleted
+    assert all(ids != ["n_shared"] for _, ids in vector.deleted)
+    assert "EdgeType_relationship_name" in deleted_collections
+    assert owned is not None and shared is not None  # keep references explicit
+
+
+async def test_delete_by_dataset_id_preserves_cross_dataset_artifacts():
+    """Removing dataset A's refs leaves dataset-B-owned artifacts intact."""
+    dataset_a = uuid4()
+    dataset_b = uuid4()
+    ref_a = make_source_ref_key(dataset_a, uuid4())
+    ref_b = make_source_ref_key(dataset_b, uuid4())
+    run = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("only_a", "Entity", ["name"], {"name": "A-only"})
+    graph.add_node("only_b", "Entity", ["name"], {"name": "B-only"})
+    graph.add_node("shared", "Entity", ["name"], {"name": "shared"})
+
+    await graph.attach_node_source_refs(["only_a"], [ref_a], run)
+    await graph.attach_node_source_refs(["only_b"], [ref_b], run)
+    await graph.attach_node_source_refs(["shared"], [ref_a, ref_b], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.delete_by_dataset_id(str(dataset_a))
+
+    # A-owned-only node is gone; B-only untouched; shared survives with ref_b.
+    assert "only_a" not in graph.nodes
+    assert "only_b" in graph.nodes
+    assert graph.nodes["only_b"].source_ref_keys == [ref_b]
+    assert "shared" in graph.nodes
+    assert graph.nodes["shared"].source_ref_keys == [ref_b]
+
+    assert ("Entity_name", ["only_a"]) in vector.deleted
+    assert all(ids != ["only_b"] for _, ids in vector.deleted)
+
+
+async def test_rollback_removes_only_run_introduced_artifacts():
+    """Rollback removes refs the run attached; artifacts owned otherwise survive."""
+    dataset = uuid4()
+    ref_run1 = make_source_ref_key(dataset, uuid4())
+    ref_run2 = make_source_ref_key(dataset, uuid4())
+    run_1 = uuid4()
+    run_2 = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("only_run2", "Entity", ["name"], {"name": "new"})
+    graph.add_node("shared", "Entity", ["name"], {"name": "old"})
+
+    # run_1 attached ref_run1 to "shared"; run_2 later attached ref_run2 to both
+    # "shared" and "only_run2". Rolling back run_2 removes only ref_run2.
+    await graph.attach_node_source_refs(["shared"], [ref_run1], run_1)
+    await graph.attach_node_source_refs(["shared"], [ref_run2], run_2)
+    await graph.attach_node_source_refs(["only_run2"], [ref_run2], run_2)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.rollback_by_pipeline_run_id(str(run_2))
+
+    # only_run2's sole ref came in via run_2 -> unowned -> deleted.
+    assert "only_run2" not in graph.nodes
+    # shared still owns ref_run1 (attached by run_1) -> survives, detached of ref_run2.
+    assert "shared" in graph.nodes
+    assert graph.nodes["shared"].source_ref_keys == [ref_run1]
+
+    assert ("Entity_name", ["only_run2"]) in vector.deleted
+
+
+async def test_vectors_deleted_before_graph_mutation_and_retry_converges():
+    """An injected vector failure leaves graph intact; the retry completes."""
+    dataset = uuid4()
+    ref = make_source_ref_key(dataset, uuid4())
+    run = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("n1", "Entity", ["name"], {"name": "x"})
+    await graph.attach_node_source_refs(["n1"], [ref], run)
+
+    vector = FakeVectorEngine(fail_on_collection="Entity_name")
+    engine = _build_engine(graph, vector)
+
+    # First attempt fails inside the vector delete (before any graph mutation).
+    with pytest.raises(RuntimeError, match="injected vector failure"):
+        await engine.delete_by_source_ref(ref)
+
+    # Graph provenance is untouched: the node and its ref still exist.
+    assert "n1" in graph.nodes
+    assert graph.nodes["n1"].source_ref_keys == [ref]
+
+    # Retry converges now that the injected failure is disarmed.
+    await engine.delete_by_source_ref(ref)
+    assert "n1" not in graph.nodes
+    assert ("Entity_name", ["n1"]) in vector.deleted
+
+
+async def test_unsupported_capability_propagates():
+    """A backend without provenance raises UnsupportedProvenanceCapability."""
+    graph = FakeProvenanceGraphEngine(supports_provenance=False)
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    with pytest.raises(UnsupportedProvenanceCapability):
+        await engine.delete_by_source_ref(make_source_ref_key(uuid4(), uuid4()))
+
+
+async def test_no_candidate_is_a_noop():
+    """No matching artifacts -> no graph or vector mutation."""
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("survivor", "Entity", ["name"], {"name": "keep"})
+    other_ref = make_source_ref_key(uuid4(), uuid4())
+    await graph.attach_node_source_refs(["survivor"], [other_ref], uuid4())
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    unrelated_ref = make_source_ref_key(uuid4(), uuid4())
+    await engine.delete_by_source_ref(unrelated_ref)
+
+    assert "survivor" in graph.nodes
+    assert graph.nodes["survivor"].source_ref_keys == [other_ref]
+    assert vector.deleted == []
+
+
+async def test_supports_graph_native_delete_requires_both_capabilities():
+    graph = FakeProvenanceGraphEngine()
+    vector = FakeVectorEngine()
+
+    assert _build_engine(graph, vector).supports_graph_native_delete() is True
+
+    graph_only = UnifiedStoreEngine(graph_engine=graph, capabilities=EngineCapability.GRAPH)
+    assert graph_only.supports_graph_native_delete() is False
+
+
+async def test_orphaned_nodeset_tags_stripped_on_delete():
+    """Deleting a uniquely-owned NodeSet strips its tag from surviving rows."""
+    dataset = uuid4()
+    ref = make_source_ref_key(dataset, uuid4())
+    run = uuid4()
+
+    graph = FakeProvenanceGraphEngine()
+    graph.add_node("ns", "NodeSet", ["name"], {"name": "my_nodeset"})
+    await graph.attach_node_source_refs(["ns"], [ref], run)
+
+    vector = FakeVectorEngine()
+    engine = _build_engine(graph, vector)
+
+    await engine.delete_by_source_ref(ref)
+
+    assert "ns" not in graph.nodes
+    assert getattr(graph, "removed_tags", []) == [["my_nodeset"]]
+    assert vector.removed_tags == [["my_nodeset"]]
+
+
+# Sanity: the parseable-ref helpers used by the fakes agree with the contract.
+async def test_fake_dataset_helper_matches_contract():
+    dataset = uuid4()
+    ref = make_source_ref_key(dataset, uuid4())
+    assert _dataset_of(ref) == str(dataset)
+    assert str(get_dataset_id_from_source_ref_key(ref)) == _dataset_of(ref)
+
+
+# Reference the imports used only inside helpers so linters keep them.
+_ = (EdgeType, generate_node_id, get_edge_retrieval_text)

--- a/cognee/tests/unit/modules/cognify/test_rollback.py
+++ b/cognee/tests/unit/modules/cognify/test_rollback.py
@@ -100,6 +100,12 @@ async def test_cognify_rollback_deletes_graph_before_relational(monkeypatch):
     async def _has_edges_in_legacy_ledger(_edges):
         return []
 
+    # Pin the engine as non-graph-native so rollback takes the relational-ledger
+    # path (the unified branch is gated on supports_graph_native_delete()).
+    async def _get_unified_engine():
+        return SimpleNamespace(supports_graph_native_delete=lambda: False)
+
+    monkeypatch.setattr(rollback_module, "get_unified_engine", _get_unified_engine)
     monkeypatch.setattr(rollback_module, "get_relational_engine", lambda: engine)
     monkeypatch.setattr(rollback_module, "multi_user_support_possible", lambda: False)
     monkeypatch.setattr(rollback_module, "has_nodes_in_legacy_ledger", _has_nodes_in_legacy_ledger)
@@ -149,6 +155,12 @@ async def test_cognify_rollback_keeps_relational_rows_if_graph_delete_fails(monk
     async def _has_edges_in_legacy_ledger(_edges):
         return []
 
+    # Pin the engine as non-graph-native so rollback takes the relational-ledger
+    # path (the unified branch is gated on supports_graph_native_delete()).
+    async def _get_unified_engine():
+        return SimpleNamespace(supports_graph_native_delete=lambda: False)
+
+    monkeypatch.setattr(rollback_module, "get_unified_engine", _get_unified_engine)
     monkeypatch.setattr(rollback_module, "get_relational_engine", lambda: engine)
     monkeypatch.setattr(rollback_module, "multi_user_support_possible", lambda: False)
     monkeypatch.setattr(rollback_module, "has_nodes_in_legacy_ledger", _has_nodes_in_legacy_ledger)

--- a/cognee/tests/unit/tasks/storage/test_add_data_points.py
+++ b/cognee/tests/unit/tasks/storage/test_add_data_points.py
@@ -63,6 +63,10 @@ def _make_unified_mock():
     unified.graph = graph_engine
     unified.vector = vector_engine
     unified.has_capability = MagicMock(return_value=False)
+    # Default-stack backend is not graph-native (until Part 1): a non-empty/
+    # unmarked graph keeps add_data_points on the relational-ledger path.
+    graph_engine.is_empty = AsyncMock(return_value=False)
+    graph_engine.get_graph_metadata = AsyncMock(return_value={})
     return unified, graph_engine, vector_engine
 
 

--- a/temp/delete_improvements/part2_port_spec.md
+++ b/temp/delete_improvements/part2_port_spec.md
@@ -1,0 +1,155 @@
+# Part 2 port spec — rebase onto Lazar's Part 0 (COG-5522)
+
+Part 2 (graph-native delete/rollback for new graphs) was originally built on a
+*different* Part 0 contract. This spec re-ports it onto **Lazar's official Part 0**
+(`cognee/infrastructure/databases/provenance/` + the provenance methods on
+`GraphDBInterface` + `GraphVectorStoreInterface`). Follow this exactly; it is the
+authority. Read the live contract files first:
+
+- `cognee/infrastructure/databases/provenance/__init__.py`, `constants.py`,
+  `source_refs.py`, `delete_data.py`
+- `cognee/infrastructure/databases/exceptions/exceptions.py`
+  (`UnsupportedProvenanceCapability`, a `CogneeApiError`, HTTP 501, `log=False`)
+- `cognee/infrastructure/databases/graph/graph_db_interface.py` (provenance section)
+- `cognee/infrastructure/databases/unified/unified_store_engine.py`,
+  `graph_vector_store_interface.py`
+- `cognee/tests/unit/infrastructure/databases/provenance/test_provenance_contract.py`,
+  `fakes.py`
+
+## Lazar's contract (the target API)
+
+**Refs are parseable strings** (NOT opaque hashes):
+- `make_source_ref_key(dataset_id: UUID, data_id: UUID) -> "source_ref:v1:{dataset}:{data}"`
+- `make_source_run_ref(pipeline_run_id: UUID, source_ref_key: str) -> "source_run_ref:v1:{run}:{source_ref_key}"`
+- getters: `get_dataset_id_from_source_ref_key`, `get_data_id_from_source_ref_key`,
+  `get_pipeline_run_id_from_source_run_ref`, `get_source_ref_key_from_source_run_ref`
+
+**Constants:** `GRAPH_PROVENANCE_VERSION = "1"` (str), `GRAPH_DELETE_MODE_GRAPH_NATIVE = "graph_native"`,
+`GRAPH_PROVENANCE_VERSION_KEY = "provenance_version"`, `GRAPH_DELETE_MODE_KEY = "delete_mode"`.
+
+**Dataclasses** (`delete_data.py`):
+- `EdgeIdentity(source_id, target_id, relationship_name)` — NOTE field order: source, target, relationship.
+- `NodeDeleteData(node_id, node_type, indexed_fields, node_properties, source_ref_keys, source_dataset_ids, source_run_ids, source_run_refs)`
+- `EdgeDeleteData(edge, edge_text, edge_properties, source_ref_keys, source_dataset_ids, source_run_ids, source_run_refs)`
+
+**`GraphDBInterface` provenance methods** (all raise `UnsupportedProvenanceCapability` by default):
+- Write: `attach_node_source_refs(node_ids, source_ref_keys, pipeline_run_id=None)`,
+  `attach_edge_source_refs(edges, source_ref_keys, pipeline_run_id=None)`,
+  `remove_node_source_refs(node_ids, source_ref_keys)`,
+  `remove_edge_source_refs(edges, source_ref_keys)`,
+  `delete_edge_triples(edges)`
+- Read: `get_node_delete_data(node_ids) -> dict[str, NodeDeleteData]`,
+  `get_edge_delete_data(edges) -> dict[EdgeIdentity, EdgeDeleteData]`,
+  `find_nodes_by_source_ref(source_ref_key) -> list[str]`,
+  `find_edges_by_source_ref(source_ref_key) -> list[EdgeIdentity]`,
+  `find_node_source_refs_by_dataset(dataset_id) -> dict[str, list[str]]`,
+  `find_edge_source_refs_by_dataset(dataset_id) -> dict[EdgeIdentity, list[str]]`,
+  `find_node_source_refs_by_pipeline_run(pipeline_run_id) -> dict[str, list[str]]`,
+  `find_edge_source_refs_by_pipeline_run(pipeline_run_id) -> dict[EdgeIdentity, list[str]]`
+- Marker: `set_graph_metadata(metadata: dict[str,str])`, `get_graph_metadata() -> dict[str,str]`
+
+**`GraphVectorStoreInterface`** (delete_by_source_ref / delete_by_dataset_id /
+rollback_by_pipeline_run_id) take **str** args, return **None**, raise by default.
+`rollback_by_pipeline_run_id(pipeline_run_id: str)` is **single-arg**.
+
+## What to build (all NEW Part 2 code; keep old graphs on the ledger)
+
+### 1. Marker module — `cognee/infrastructure/databases/provenance/markers.py`
+- `async def is_graph_native_graph(graph_engine) -> bool`: read
+  `await graph_engine.get_graph_metadata()`; return
+  `meta.get(GRAPH_DELETE_MODE_KEY) == GRAPH_DELETE_MODE_GRAPH_NATIVE`. Catch ANY
+  exception (incl. `UnsupportedProvenanceCapability`) → return `False` (fail safe
+  to the ledger path).
+- `async def ensure_graph_native_for_new_graph(graph_engine) -> bool`: if already
+  graph-native → `True`. Else if `await graph_engine.is_empty()` is False → `False`
+  (old graph stays on ledger). Else try
+  `await graph_engine.set_graph_metadata({GRAPH_PROVENANCE_VERSION_KEY: GRAPH_PROVENANCE_VERSION, GRAPH_DELETE_MODE_KEY: GRAPH_DELETE_MODE_GRAPH_NATIVE})`;
+  on `UnsupportedProvenanceCapability` (backend has no provenance, i.e. pre-Part-1)
+  return `False`. Return `True` only after a successful mark.
+  This is the inertness gate: on the default stack `set_graph_metadata` raises, so
+  nothing is ever marked → Part 2 is inert until Part 1.
+
+### 2. Planner — `cognee/infrastructure/databases/unified/provenance_delete_planner.py`
+A retry-safe `execute_source_ref_removal(graph_engine, vector_engine, *, node_data: dict[str, NodeDeleteData], edge_data: dict[EdgeIdentity, EdgeDeleteData], refs_by_node: dict[str, list[str]], refs_by_edge: dict[EdgeIdentity, list[str]]) -> None`:
+- Determine unowned vs surviving from the snapshots: a node is **unowned** iff
+  `set(node_data[nid].source_ref_keys) - set(refs_by_node[nid])` is empty (removing
+  these refs leaves no owning ref); else it **survives** (detach). Same for edges
+  via `source_ref_keys`.
+- Vector ids **from snapshots only** (mirror `delete_from_graph_and_vector`):
+  node → `f"{node_type}_{field}"` for field in `indexed_fields`, id = node_id;
+  edge → `EdgeType.id_for(edge_text)` in `EdgeType_relationship_name`, and
+  `generate_node_id(source_id + relationship_name + target_id)` in `Triplet_text`
+  (wrap Triplet delete in try/except — collection may not exist).
+- **Ordering (retry-safe):** (1) delete vectors for unowned; (2) `remove_node_source_refs`
+  / `remove_edge_source_refs` for the targeted refs on ALL matched artifacts
+  (idempotent); (3) `delete_nodes(unowned node ids)` and `delete_edge_triples(unowned edges)`.
+  Vectors first so a failure leaves graph provenance intact and retry converges.
+- Post-delete cleanup parity with `delete_from_graph_and_vector` (best-effort, non-fatal,
+  try/except): strip orphaned NodeSet tags via `graph_engine.remove_belongs_to_set_tags`
+  + `vector_engine.remove_belongs_to_set_tags` using the NodeSet label read from the
+  unowned nodes' `node_properties` (NodeSet name; `node_type == "NodeSet"`); and prune
+  orphaned `EdgeType` nodes by recomputing remaining edge texts from
+  `graph_engine.get_graph_data()`.
+
+### 3. `UnifiedStoreEngine` delete/rollback (in `unified_store_engine.py`)
+Add the three methods (return **None**, str args) + `supports_graph_native_delete()`.
+- `supports_graph_native_delete()`: GRAPH+VECTOR caps and graph present. (Lazar has no
+  `supports_graph_native_provenance` flag; routing relies on `is_graph_native_graph`,
+  and unsupported reads raise.)
+- `delete_by_source_ref(source_ref_key)`: `node_ids = await graph.find_nodes_by_source_ref(key)`;
+  `edges = await graph.find_edges_by_source_ref(key)`; `node_data = await graph.get_node_delete_data(node_ids)`;
+  `edge_data = await graph.get_edge_delete_data(edges)`; build `refs_by_node = {nid: [key]}`,
+  `refs_by_edge = {e: [key]}`; call the planner.
+- `delete_by_dataset_id(dataset_id)`: `refs_by_node = await graph.find_node_source_refs_by_dataset(dataset_id)`
+  (dict node_id→source_ref_keys owned by the dataset); same for edges; fetch delete-data for
+  those ids; call the planner (removing those dataset-owned refs; unowned if no refs remain).
+- `rollback_by_pipeline_run_id(pipeline_run_id)`: `refs_by_node = await graph.find_node_source_refs_by_pipeline_run(pipeline_run_id)`
+  (source_ref_keys this run attached, per node); same for edges; fetch delete-data; call the
+  planner (removing the run's attached refs; unowned if no refs remain — i.e. the run solely
+  introduced the artifact).
+
+### 4. Write stamping — `cognee/tasks/storage/add_data_points.py`
+- Before the first node write, `is_graph_native = await ensure_graph_native_for_new_graph(graph_engine)`
+  (only inside the `if user and dataset and data_item:` block).
+- For marked graphs: SKIP `upsert_nodes`/`upsert_edges`. After the graph writes succeed,
+  `source_ref_key = make_source_ref_key(dataset.id, data_item.id)`; build node id list and
+  `EdgeIdentity(str(e[0]), str(e[1]), e[2])` list (source, target, relationship) for `edges`
+  (incl. custom edges, already extended into `edges`). Call
+  `await graph_engine.attach_node_source_refs(node_ids, [source_ref_key], str(pipeline_run_id) if pipeline_run_id else None)`
+  and `attach_edge_source_refs(edge_ids, [source_ref_key], <same run arg>)`. (ONE call each —
+  the adapter derives dataset_ids/run_ids/run_refs.)
+- Non-graph-native graphs keep the existing ledger upserts unchanged.
+
+### 5. Routing (old/unmarked graphs keep the ledger path; auth unchanged)
+- `cognee/modules/graph/methods/delete_data_nodes_and_edges.py`: after auth, if
+  `is_graph_native_graph(graph_engine)` and `unified.supports_graph_native_delete()` →
+  `await unified.delete_by_source_ref(make_source_ref_key(dataset_id, data_id)); return`.
+- `delete_dataset_nodes_and_edges.py`: → `await unified.delete_by_dataset_id(str(dataset_id)); return`.
+- `cognee/modules/cognify/rollback.py`: after the missing-id guard, if graph-native →
+  `await unified.rollback_by_pipeline_run_id(str(pipeline_run_id))`, reset pipeline_status for
+  the run's data ids (reuse the existing reset logic / factor a helper), `return`.
+- `cognee/api/v1/datasets/datasets.py` `delete_data`: graph-native graphs have no ledger rows,
+  so the `has_data_related_nodes` gate would wrongly route to `legacy_delete`. Add: if
+  `is_graph_native_graph(graph_engine)` → `delete_data_nodes_and_edges(...)`; else the existing gate.
+- `forget(memory_only=True)` and deprecated `delete()` route transitively (no edit).
+
+### 6. Tests + doc
+- Unit tests `cognee/tests/unit/.../provenance/test_unified_graph_native_delete.py`:
+  a `FakeProvenanceGraphEngine` implementing Lazar's provenance methods (find_*/get_*_delete_data/
+  attach_*/remove_*/delete_edge_triples/get_graph_metadata/set_graph_metadata/is_empty/get_graph_data/
+  delete_nodes/remove_belongs_to_set_tags) over in-memory nodes/edges carrying source_ref_keys
+  (+ derived dataset_ids/run refs), plus a recording `FakeVectorEngine`. Prove: unowned delete +
+  shared detach; cross-dataset preservation; rollback removes only run-introduced; vectors-first /
+  retry convergence on injected vector failure; unsupported-capability propagation; no-candidate
+  no-op. Match Lazar's `EdgeIdentity(source, target, relationship)` order and parseable refs.
+- Integration test (skipped, module `pytest.mark.skip` until Part 1):
+  `cognee/tests/integration/tasks/test_graph_native_delete_part2.py`.
+- Doc: `cognee/temp/delete_improvements/phase2_graph_native_new_graphs.md` updated for Lazar's contract.
+
+## Semantics summary
+- Ownership = `source_ref_keys` on the artifact. Removing a ref set → unowned iff none remain.
+- Dataset delete removes the dataset's refs (from `find_*_source_refs_by_dataset`).
+- Rollback removes the refs a run attached (from `find_*_source_refs_by_pipeline_run`).
+- Vectors deleted before any graph mutation; remove-refs + deletes are idempotent → retry-safe.
+- Marker = graph metadata; inert until Part 1 because `set_graph_metadata`/`attach_*` raise on
+  pre-Part-1 backends.

--- a/temp/delete_improvements/phase2_graph_native_new_graphs.md
+++ b/temp/delete_improvements/phase2_graph_native_new_graphs.md
@@ -1,0 +1,140 @@
+# Part 2 — graph-native delete/rollback for new graphs (Lazar's Part 0 contract)
+
+This is the Part 2 plan as re-ported onto **Lazar's official Part 0 contract**
+(`cognee/infrastructure/databases/provenance/` + the provenance methods on
+`GraphDBInterface` and `GraphVectorStoreInterface`). It supersedes the original
+Part 2 design that was built on a different contract (no opaque `uuid5` refs, no
+`ProvenanceDeleteResult`, no `dataset_ids` snapshot field, no marker node, no
+`supports_graph_native_provenance` flag).
+
+## Goal
+
+When a graph is **graph-native** (its graph-level metadata advertises the
+graph-native delete mode), delete and rollback are performed directly against the
+graph's own provenance — `source_ref_keys` carried on nodes/edges — instead of
+the relational ledger. Old/unmarked graphs keep the existing relational-ledger
+path completely unchanged. The new path is **inert until Part 1**, because
+`set_graph_metadata` / `attach_*` raise `UnsupportedProvenanceCapability` on
+pre-Part-1 backends, so no graph is ever marked.
+
+## Lazar's contract (the target API we build on)
+
+**Parseable refs** (`provenance/source_refs.py`):
+- `make_source_ref_key(dataset_id, data_id) -> "source_ref:v1:{dataset}:{data}"`
+- `make_source_run_ref(pipeline_run_id, source_ref_key) -> "source_run_ref:v1:{run}:{source_ref_key}"`
+- getters: `get_dataset_id_from_source_ref_key`, `get_data_id_from_source_ref_key`,
+  `get_pipeline_run_id_from_source_run_ref`, `get_source_ref_key_from_source_run_ref`
+
+**Constants** (`provenance/constants.py`): `GRAPH_PROVENANCE_VERSION = "1"`,
+`GRAPH_DELETE_MODE_GRAPH_NATIVE = "graph_native"`,
+`GRAPH_PROVENANCE_VERSION_KEY = "provenance_version"`,
+`GRAPH_DELETE_MODE_KEY = "delete_mode"`.
+
+**Dataclasses** (`provenance/delete_data.py`):
+- `EdgeIdentity(source_id, target_id, relationship_name)` — field order is
+  source, target, relationship.
+- `NodeDeleteData(node_id, node_type, indexed_fields, node_properties,
+  source_ref_keys, source_dataset_ids, source_run_ids, source_run_refs)`
+- `EdgeDeleteData(edge, edge_text, edge_properties, source_ref_keys,
+  source_dataset_ids, source_run_ids, source_run_refs)`
+
+**`GraphDBInterface` provenance methods** (all raise
+`UnsupportedProvenanceCapability` by default until Part 1):
+- write: `attach_node_source_refs`, `attach_edge_source_refs`,
+  `remove_node_source_refs`, `remove_edge_source_refs`, `delete_edge_triples`,
+  `delete_nodes`
+- read: `get_node_delete_data`, `get_edge_delete_data`,
+  `find_nodes_by_source_ref`, `find_edges_by_source_ref`,
+  `find_node_source_refs_by_dataset`, `find_edge_source_refs_by_dataset`,
+  `find_node_source_refs_by_pipeline_run`, `find_edge_source_refs_by_pipeline_run`
+- marker: `get_graph_metadata() -> dict[str,str]`, `set_graph_metadata(dict)`
+
+**`GraphVectorStoreInterface`**: `delete_by_source_ref(str)`,
+`delete_by_dataset_id(str)`, `rollback_by_pipeline_run_id(str)` — all take **str**
+args, return **None**, single-arg rollback.
+
+## Semantics
+
+- **Ownership** of a node/edge = its `source_ref_keys`. Removing a set of refs
+  leaves the artifact **unowned** iff none remain → hard delete. Otherwise it
+  **survives** → only the targeted refs are detached.
+- **Data delete** removes one `source_ref:v1:{dataset}:{data}` key.
+- **Dataset delete** removes all of a dataset's refs (from
+  `find_*_source_refs_by_dataset`).
+- **Rollback** removes the refs a run attached (from
+  `find_*_source_refs_by_pipeline_run` — derived from the run refs).
+- **Vectors are deleted before any graph mutation.** Remove-refs and deletes are
+  all idempotent, so a failure leaves graph provenance intact and a retry
+  converges.
+
+## Committed spine (already on this branch)
+
+1. **Marker** — `cognee/infrastructure/databases/provenance/markers.py`
+   - `is_graph_native_graph(graph_engine)`: reads `get_graph_metadata`; any
+     exception (incl. `UnsupportedProvenanceCapability`) → `False` (fail-safe to
+     the ledger).
+   - `ensure_graph_native_for_new_graph(graph_engine)`: already-marked → `True`;
+     non-empty graph → `False` (stays on ledger); empty graph → try
+     `set_graph_metadata({version, graph_native})`, `UnsupportedProvenanceCapability`
+     → `False`. Only a successful mark returns `True`. This is the inertness gate.
+
+2. **Planner** —
+   `cognee/infrastructure/databases/unified/provenance_delete_planner.py`
+   - `execute_source_ref_removal(graph_engine, vector_engine, *, node_data,
+     edge_data, refs_by_node, refs_by_edge) -> None`.
+   - Unowned vs surviving decided from the `source_ref_keys` snapshots:
+     `set(node_data[nid].source_ref_keys) - set(refs_by_node[nid])` empty → unowned.
+   - Vector ids from snapshots only (mirrors `delete_from_graph_and_vector`):
+     node → `f"{node_type}_{field}"` per `indexed_fields`, id = node_id;
+     edge → `EdgeType.id_for(edge_text)` in `EdgeType_relationship_name`, and
+     `generate_node_id(source_id + relationship_name + target_id)` in
+     `Triplet_text` (wrapped in try/except — collection may not exist).
+   - Retry-safe order: (1) delete vectors for unowned; (2) `remove_*_source_refs`
+     on all matched artifacts; (3) `delete_nodes` / `delete_edge_triples` for the
+     unowned ones.
+   - Best-effort cleanup parity: prune orphaned `EdgeType` nodes (recompute
+     remaining edge texts via `get_graph_data`) and strip orphaned NodeSet tags
+     (`node_type == "NodeSet"`, label from `node_properties["name"]`) via
+     `graph_engine.remove_belongs_to_set_tags` + `vector_engine.remove_belongs_to_set_tags`.
+
+3. **`UnifiedStoreEngine`** —
+   `cognee/infrastructure/databases/unified/unified_store_engine.py`
+   - `supports_graph_native_delete()`: GRAPH + VECTOR caps and both engines
+     present (no separate provenance-capability flag — unsupported reads raise).
+   - `delete_by_source_ref(key)`: find nodes/edges by ref, fetch delete-data,
+     build `refs_by_node = {nid: [key]}` / `refs_by_edge = {e: [key]}`, call planner.
+   - `delete_by_dataset_id(dataset_id)`: `refs_by_* = find_*_source_refs_by_dataset`,
+     fetch delete-data for those ids, call planner.
+   - `rollback_by_pipeline_run_id(pipeline_run_id)`:
+     `refs_by_* = find_*_source_refs_by_pipeline_run`, fetch delete-data, call planner.
+
+## Remaining Part 2 work (not in the spine)
+
+- **Write stamping** (`cognee/tasks/storage/add_data_points.py`): for marked
+  graphs, skip `upsert_nodes`/`upsert_edges`; after graph writes,
+  `attach_node_source_refs` / `attach_edge_source_refs` with the
+  `make_source_ref_key(dataset.id, data_item.id)` and the run id. One call each;
+  the adapter derives dataset/run ids and run refs.
+- **Routing**: `delete_data_nodes_and_edges.py`,
+  `delete_dataset_nodes_and_edges.py`, `cognify/rollback.py`, and
+  `datasets.py delete_data` route to the unified graph-native methods when
+  `is_graph_native_graph` and `supports_graph_native_delete`; otherwise keep the
+  ledger path. `forget(memory_only=True)` and deprecated `delete()` route
+  transitively.
+
+## Tests
+
+- **Unit** —
+  `cognee/tests/unit/infrastructure/databases/provenance/test_unified_graph_native_delete.py`:
+  a `FakeProvenanceGraphEngine` implementing Lazar's provenance methods over
+  in-memory nodes/edges keyed by `source_ref_keys` (deriving dataset ids + run
+  refs on attach), plus a recording `FakeVectorEngine`. Proves unowned
+  hard-delete + shared detach, cross-dataset preservation, rollback removes only
+  run-introduced artifacts, vectors-first + retry convergence after an injected
+  vector failure, unsupported-capability propagation, and the no-candidate no-op.
+  `9 passed`.
+- **Integration** (gated) —
+  `cognee/tests/integration/tasks/test_graph_native_delete_part2.py`: realistic
+  default-stack (Ladybug + LanceDB + SQLite) end-to-end delete/rollback, but
+  module-level `pytest.mark.skip` until Part 1 real adapters land (COG-5522 Part
+  1). Collects + skips (`3 skipped`).


### PR DESCRIPTION
## Context

Part 2 of the graph-native delete/rollback plan, **rebased onto the official Part 0 contract (PR #3279, `feature/cog-5522-delete-improvements-plan-contract`).** Makes newly-marked graphs use on-graph provenance for delete/rollback through the unified boundary; old unmarked graphs stay on the relational `nodes`/`edges` ledger until Part 3. Built against in-memory fakes of Part 0's contract; the default-stack integration gate is authored but **module-skipped until Part 1**, so this stays a draft.

**Base:** `feature/cog-5522-delete-improvements-plan-contract` (Lazar's Part 0).

This supersedes my earlier parallel attempt (#3288, which sat on a duplicate Part 0). It conforms to Lazar's contract exactly — see `temp/delete_improvements/part2_port_spec.md` for the mapping.

## Conforms to Part 0's contract
- Parseable refs: `make_source_ref_key` / `make_source_run_ref`
- `EdgeIdentity(source_id, target_id, relationship_name)`
- Two-step discovery: `find_*_by_source_ref` / `_by_dataset` / `_by_pipeline_run` → `get_node/edge_delete_data`
- Metadata marker: `get/set_graph_metadata` (no marker node)
- `rollback_by_pipeline_run_id(pipeline_run_id)` single-arg; delete methods return `None`
- `UnsupportedProvenanceCapability` (the Part 0 `CogneeApiError`)

## What ships
- **`provenance/markers.py`** — routing authority via graph metadata; inert on pre-Part-1 backends (`set_graph_metadata` raises → nothing marked).
- **`unified/provenance_delete_planner.py`** — retry-safe: vector ids from snapshots only, delete vectors first, `remove_*_source_refs`, then `delete_nodes`/`delete_edge_triples`; NodeSet-tag + orphaned-EdgeType cleanup parity.
- **`UnifiedStoreEngine`** — `delete_by_source_ref` / `delete_by_dataset_id` / `rollback_by_pipeline_run_id` + `supports_graph_native_delete()`.
- **Wiring** — `add_data_points` stamps marked graphs via `attach_*_source_refs` (incl. custom edges) and skips ledger upserts; delete/dataset-delete/rollback route through the unified boundary; `datasets.delete_data` routes graph-native graphs past the `has_data_related_nodes`→`legacy_delete` gate; `forget`/deprecated `delete()` route transitively.

## Tests
- 9 unit tests vs fakes implementing Part 0's contract (unowned delete + shared detach, cross-dataset preservation, rollback scoping, vectors-first + retry convergence, unsupported-capability propagation, no-candidate no-op).
- Provenance + rollback + add_data_points + forget: **86 passed**; existing dev tests pinned to the non-graph-native path.
- Default-stack integration suite authored, **module-skipped until Part 1** (3 scenarios).

## Acceptance criteria
- [x] delete/dataset-delete/rollback pass vs fakes; vectors first; only unowned deleted; no-candidate no-op
- [x] vector ids from Part 0 id helpers; orchestration never reads relational `Node`/`Edge`
- [x] injected vector failure leaves graph provenance intact; retry converges; unsupported capability propagates
- [x] graph-native `add_data_points` attaches refs (incl. custom edges), writes no `upsert_*`; no-context unchanged; no-`pipeline_run_id` → refs but no run ownership
- [x] routing through the unified boundary; old graphs keep the ledger path
- [ ] **default-stack integration gate** — authored, skipped until Part 1; PR stays draft

## Excluded
Real adapter storage primitives (Part 1); old-graph migration + ledger retirement (Part 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)