### PR TITLE
docs: fix outdated simple_example.py references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ ty check .
 ### Running Cognee
 ```bash
 # Using Python SDK
-python examples/python/simple_example.py
+uv run python examples/demos/simple_cognee_example.py
 
 # Using CLI
 cognee-cli add "Your text here"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,27 +112,7 @@ Copy `.env.template` to `.env` and provide your OPENAI_API_KEY as LLM_API_KEY
 Make sure to run ```shell uv sync ``` in the root cloned folder or set up a virtual environment to run cognee
 
 ```shell
-python examples/python/simple_example.py
-```
-or
-
-```shell
-uv run python examples/python/simple_example.py
-```
-
-### Running Simple Example
-
-Copy `.env.template` to `.env` and provide your OPENAI_API_KEY as LLM_API_KEY
-
-Make sure to run ```shell uv sync ``` in the root cloned folder or set up a virtual environment to run cognee
-
-```shell
-python cognee/cognee/examples/python/simple_example.py
-```
-or
-
-```shell
-uv run python cognee/cognee/examples/python/simple_example.py
+uv run python examples/demos/simple_cognee_example.py
 ```
 
 ## 4. 📤 Submitting Changes


### PR DESCRIPTION
## Description

While setting up the project locally and following the contributor onboarding flow, I noticed that the documentation referenced `examples/python/simple_example.py`, which no longer exists in the repository.

To verify this, I checked the repository contents and confirmed that the current onboarding example is `examples/demos/simple_cognee_example.py`, which is also referenced in `examples/README.md`.

This PR updates the outdated references and removes a duplicated "Running Simple Example" section from `CONTRIBUTING.md` to make the onboarding process clearer for new contributors.

## Acceptance Criteria

- References to the deleted `examples/python/simple_example.py` have been removed
- Documentation now points to `examples/demos/simple_cognee_example.py`
- Duplicate onboarding/example section removed from `CONTRIBUTING.md`
- Documentation remains consistent with `examples/README.md`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [x] Other (documentation update)