### PR TITLE
chore: remove unused imports from recall module

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -1,8 +1,6 @@
 import re
-from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from cognee.context_global_variables import set_session_user_context_variable
@@ -32,8 +30,7 @@ from cognee.modules.recall.types.RecallResponse import (
     ResponseQAEntry,
 )
 from cognee.modules.recall.types.SearchResultItem import SearchResultItem
-from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
-from cognee.modules.search.types import SearchResult, SearchType
+from cognee.modules.search.types import  SearchType
 from cognee.modules.users.exceptions.exceptions import UserNotFoundError
 from cognee.modules.users.methods import get_default_user
 from cognee.shared.logging_utils import get_logger


### PR DESCRIPTION
## Description

While reviewing the recall module, I noticed a few imports in `cognee/api/v1/recall/recall.py` that were no longer being used. This PR removes those unused imports to keep the file cleaner and improve maintainability.

No functional changes were made. The update is limited to code cleanup and does not affect the behavior of the recall API.

## Acceptance Criteria

* Removed unused imports from `cognee/api/v1/recall/recall.py`.
* Verified that the module continues to work as expected after the cleanup.
* No changes to existing functionality or API behavior.
* The change is limited to code cleanup and does not affect runtime logic.

## Type of Change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [x] Code refactoring
* [ ] Other (please specify):

## Screenshots

Local test execution:

```bash
pytest cognee/tests/unit/api/v1/recall/test_recall_api.py -v
```

Result:

<img width="778" height="169" alt="image" src="https://github.com/user-attachments/assets/f99644ae-cce5-471c-ac9f-103c5befda1b" />


## Pre-submission Checklist

* [x] I have tested my changes thoroughly before submitting this PR
* [x] This PR contains minimal changes necessary to address the issue/feature
* [x] My code follows the project's coding standards and style guidelines
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)
* [ ] All new and existing tests pass
* [x] I have searched existing PRs to ensure this change hasn't been submitted already
* [ ] I have linked any relevant issues in the description
* [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
