### PR TITLE
feat(search): expose data_id and chunk_id for source provenance (#3311)

### DIFF
--- a/cognee/modules/recall/methods/normalize_search_payload.py
+++ b/cognee/modules/recall/methods/normalize_search_payload.py
@@ -73,6 +73,30 @@ def _score_from(value: Any) -> Optional[float]:
     return None
 
 
+def _provenance_metadata(raw: dict) -> dict:
+    """Surface stable source identifiers from a chunk/summary payload.
+
+    Lets callers map a result back to the data they ingested and inspect the
+    cited chunk. ``document_id`` is the ingested Data item's id (cognify sets
+    ``Document.id = data.id``), exposed here as ``data_id``; ``id`` is the
+    chunk's own node id. Only keys actually present are included.
+    """
+    metadata: dict[str, Any] = {}
+    data_id = raw.get("document_id")
+    if data_id is not None:
+        metadata["data_id"] = str(data_id)
+    chunk_id = raw.get("id")
+    if chunk_id is not None:
+        metadata["chunk_id"] = str(chunk_id)
+    chunk_index = raw.get("chunk_index")
+    if isinstance(chunk_index, int) and not isinstance(chunk_index, bool):
+        metadata["chunk_index"] = chunk_index
+    document_name = raw.get("document_name")
+    if document_name is not None:
+        metadata["document_name"] = str(document_name)
+    return metadata
+
+
 def _build_item(
     entry: Any,
     payload: SearchResultPayload,
@@ -102,6 +126,7 @@ def _build_item(
         score=_score_from(entry),
         dataset_id=str(payload.dataset_id) if payload.dataset_id else None,
         dataset_name=payload.dataset_name,
+        metadata=_provenance_metadata(raw),
         raw=raw,
     )
 

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -133,6 +133,21 @@ def _get_payload(obj: Any) -> Optional[dict]:
     return None
 
 
+def _provenance_suffix(data_id: Optional[str], chunk_id: Optional[str]) -> str:
+    """Render a '(data_id: …, chunk_id: …)' annotation for whichever ids exist.
+
+    Lets a reader map the citation back to the ingested data item and the exact
+    cited chunk, instead of only a (possibly auto-generated) document name and a
+    positional chunk number.
+    """
+    parts = []
+    if data_id:
+        parts.append(f"data_id: {data_id}")
+    if chunk_id:
+        parts.append(f"chunk_id: {chunk_id}")
+    return f" ({', '.join(parts)})" if parts else ""
+
+
 def _chunk_id(obj: Any, payload: dict) -> Optional[str]:
     """Resolve a stable chunk id for dedup, preferring the object id."""
     obj_id = getattr(obj, "id", None)
@@ -201,8 +216,8 @@ def format_chunk_references(
             # rather than presenting unverifiable retrieval order as provenance.
             return ""
 
-    # (overlap_score, document_name, number, text) per usable candidate.
-    candidates: List[Tuple[int, str, int, str]] = []
+    # (overlap_score, document_name, number, text, data_id, chunk_id) per candidate.
+    candidates: List[Tuple[int, str, int, str, Optional[str], Optional[str]]] = []
     seen: set = set()
 
     for obj in iterator:
@@ -219,7 +234,13 @@ def format_chunk_references(
         if document_name is None or number is None or text is None:
             continue
 
-        dedup_key = _chunk_id(obj, payload) or f"{document_name}#{number}"
+        chunk_id = _chunk_id(obj, payload)
+        # document_id == the ingested Data item's id (cognify sets
+        # Document.id = data.id), i.e. the dataId a caller needs to map a
+        # citation back to the document they ingested.
+        data_id = _clean_str(payload.get("document_id"))
+
+        dedup_key = chunk_id or f"{document_name}#{number}"
         if dedup_key in seen:
             continue
         seen.add(dedup_key)
@@ -233,7 +254,7 @@ def format_chunk_references(
                 # certainly not a source of the answer.
                 continue
 
-        candidates.append((score, document_name, number, text))
+        candidates.append((score, document_name, number, text, data_id, chunk_id))
 
     if not candidates:
         return ""
@@ -244,8 +265,9 @@ def format_chunk_references(
 
     max_bullets = _clamp_limit(limit)
     bullets = [
-        f'- chunk {number} of document {document_name}: "{_snippet(text)}"'
-        for _, document_name, number, text in candidates[:max_bullets]
+        f"- chunk {number} of document {document_name}"
+        f'{_provenance_suffix(data_id, chunk_id)}: "{_snippet(text)}"'
+        for _, document_name, number, text, data_id, chunk_id in candidates[:max_bullets]
     ]
 
     return EVIDENCE_HEADER + "\n" + "\n".join(bullets)

--- a/cognee/tests/unit/modules/recall/test_normalize_search_payload.py
+++ b/cognee/tests/unit/modules/recall/test_normalize_search_payload.py
@@ -14,3 +14,42 @@ def test_hybrid_completion_normalizes_as_graph_completion():
 
     assert len(items) == 1
     assert items[0].kind == SearchResultKind.GRAPH_COMPLETION
+
+
+def test_chunk_result_exposes_provenance_metadata():
+    """CHUNK results surface data_id/chunk_id/chunk_index so callers can trace
+    a result back to the ingested document and the cited chunk."""
+    chunk = {
+        "id": "chunk-9",
+        "document_id": "data-123",  # == ingested Data item id
+        "document_name": "report.pdf",
+        "chunk_index": 4,
+        "text": "Revenue grew 12 percent.",
+    }
+    payload = SearchResultPayload(
+        result_object=[chunk],
+        search_type=SearchType.CHUNKS,
+    )
+
+    items = normalize_search_payload(payload)
+
+    assert len(items) == 1
+    metadata = items[0].metadata
+    assert metadata["data_id"] == "data-123"
+    assert metadata["chunk_id"] == "chunk-9"
+    assert metadata["chunk_index"] == 4
+    assert metadata["document_name"] == "report.pdf"
+    # raw still preserves the full original payload.
+    assert items[0].raw["document_id"] == "data-123"
+
+
+def test_completion_result_has_no_provenance_metadata():
+    """A plain completion string carries no chunk ids -> empty metadata."""
+    payload = SearchResultPayload(
+        completion=["Alexander is the Russian Emperor."],
+        search_type=SearchType.GRAPH_COMPLETION,
+    )
+
+    items = normalize_search_payload(payload)
+
+    assert items[0].metadata == {}

--- a/cognee/tests/unit/modules/retrieval/test_include_references_wiring.py
+++ b/cognee/tests/unit/modules/retrieval/test_include_references_wiring.py
@@ -107,7 +107,7 @@ async def test_completion_references_enabled_appends_evidence():
 
     assert len(completion) == 1
     assert completion[0].startswith(f"{MOCK_ANSWER}\n\nEvidence:\n")
-    assert "- chunk 1 of document report.pdf:" in completion[0]
+    assert "- chunk 1 of document report.pdf (chunk_id: chunk-1):" in completion[0]
 
 
 @pytest.mark.asyncio
@@ -230,7 +230,7 @@ async def test_graph_references_enabled_appends_answer_grounded_evidence():
 
     assert len(completion) == 1
     assert completion[0].startswith(f"{MOCK_ANSWER}\n\nEvidence:\n")
-    assert "- chunk 3 of document report.pdf:" in completion[0]
+    assert "- chunk 3 of document report.pdf (chunk_id: chunk-1):" in completion[0]
     # The answer text itself is the vector query.
     assert engine.search.await_args.args[1] == MOCK_ANSWER
 

--- a/cognee/tests/unit/modules/retrieval/test_references_helpers.py
+++ b/cognee/tests/unit/modules/retrieval/test_references_helpers.py
@@ -59,7 +59,16 @@ def test_format_chunk_references_reads_scored_result_like_objects():
     objs = [FakeScored(_payload(), "id-1")]
     result = format_chunk_references(objs)
 
-    assert "- chunk 5 of document annual_report.pdf:" in result
+    assert "- chunk 5 of document annual_report.pdf (chunk_id: id-1):" in result
+
+
+def test_format_chunk_references_includes_data_id_and_chunk_id():
+    """document_id (== ingested data id) and chunk id are surfaced in the bullet."""
+    result = format_chunk_references([_payload(document_id="data-123", id="chunk-9")])
+
+    assert (
+        "- chunk 5 of document annual_report.pdf (data_id: data-123, chunk_id: chunk-9):" in result
+    )
 
 
 def test_format_chunk_references_empty_when_document_name_missing():
@@ -110,7 +119,7 @@ def test_format_chunk_references_dedups_by_id():
     ]
     result = format_chunk_references(objs)
 
-    assert result.count("- chunk 5 of document annual_report.pdf:") == 1
+    assert result.count("- chunk 5 of document annual_report.pdf (chunk_id: same-id):") == 1
 
 
 def test_format_chunk_references_caps_and_clamps_limit():
@@ -216,7 +225,7 @@ async def test_answer_grounded_references_query_chunk_index_with_answer():
     result = await build_answer_grounded_chunk_references("Revenue grew 12 percent.", engine)
 
     assert result.startswith(EVIDENCE_HEADER + "\n")
-    assert "- chunk 3 of document report.pdf:" in result
+    assert "- chunk 3 of document report.pdf (chunk_id: chunk-1):" in result
     engine.search.assert_awaited_once()
     assert engine.search.await_args.args[0] == "DocumentChunk_text"
     assert engine.search.await_args.args[1] == "Revenue grew 12 percent."


### PR DESCRIPTION
Resolves #3311.

## Problem
Search results identify their source only by a **document name** (often auto-generated for raw-text ingestion) and a **positional chunk number** — with no stable id. So callers can't:
- map a result back to the **ingested `Data` item** (the thing they `add()`ed), or
- **inspect the cited chunk** ("what's in chunk 351?").

This affects both `search()` and `recall()` (they share one normalizer) and is most visible in `GRAPH_COMPLETION` evidence, e.g. *"Entity … appears in chunk 351 of document leo%20tolstoy%20-%20war%20and%20peace"*.

## Key insight
The ids are **already available at query time** — no new extraction needed:
- `cognify` creates the `Document` with `id = data.id` (`classify_documents.py`), so a chunk's `document_id` **is** the ingested data id (`dataId`).
- The chunk also carries its own node id.

They just weren't surfaced.

## Changes
- **`normalize_search_payload`** — populate `SearchResultItem.metadata` with `data_id`, `chunk_id`, `chunk_index`, `document_name` for chunk/summary results. Since both `search()` and `recall()` go through this normalizer, both get structured provenance. (`raw` already preserved the full payload.)
- **`references.py`** — include `data_id` and `chunk_id` in the `GRAPH_COMPLETION` evidence bullets (they were computed for dedup but dropped from the output).

## Notes
- **No migration** — works for already-cognified data, since `document_id` is already stored on chunks.
- Unit tests added/updated (`test_normalize_search_payload.py`, `test_references_helpers.py`, `test_include_references_wiring.py`). 41 passing locally; `ruff check`/`format` clean.
- **Out of scope (follow-up):** exposing ids as *structured fields* on `GRAPH_COMPLETION` answers (the completion path normalizes only the answer string); here they're added to the evidence text. Happy to do that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)