### PR TITLE
fix(embeddings): skip retry on deterministic terminal split failures (#3319)

### DIFF
--- a/cognee/infrastructure/databases/exceptions/__init__.py
+++ b/cognee/infrastructure/databases/exceptions/__init__.py
@@ -9,6 +9,7 @@ from .exceptions import (
     EntityAlreadyExistsError,
     DatabaseNotCreatedError,
     EmbeddingException,
+    TerminalEmbeddingException,
     MissingQueryParameterError,
     MutuallyExclusiveQueryParametersError,
     CacheConnectionError,

--- a/cognee/infrastructure/databases/exceptions/exceptions.py
+++ b/cognee/infrastructure/databases/exceptions/exceptions.py
@@ -104,6 +104,28 @@ class EmbeddingException(CogneeConfigurationError):
         super().__init__(message, name, status_code)
 
 
+class TerminalEmbeddingException(EmbeddingException):
+    """
+    Non-retryable embedding failure for deterministic error conditions.
+
+    Raised when the context-window recovery logic has exhausted all split
+    attempts (e.g. a single token that still exceeds the model's context
+    window).  Unlike transient ``EmbeddingException`` errors, retrying this
+    exception is futile because the input is inherently too large to embed.
+
+    Retry decorators on ``embed_text`` methods should exclude this subclass
+    via ``retry_if_not_exception_type`` so the failure propagates immediately.
+    """
+
+    def __init__(
+        self,
+        message: str = "Text is too short to split further but exceeds context window.",
+        name: str = "TerminalEmbeddingException",
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+    ):
+        super().__init__(message, name, status_code)
+
+
 class MissingQueryParameterError(CogneeValidationError):
     """
     Raised when neither 'query_text' nor 'query_vector' is provided,

--- a/cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py
@@ -24,7 +24,7 @@ from tenacity import (
 
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
-from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.databases.exceptions import EmbeddingException, TerminalEmbeddingException
 from cognee.infrastructure.llm.tokenizer.TikToken import (
     TikTokenTokenizer,
 )
@@ -86,7 +86,7 @@ class FastembedEmbeddingEngine(EmbeddingEngine):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(8, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, asyncio.CancelledError)
+            (litellm.exceptions.NotFoundError, asyncio.CancelledError, TerminalEmbeddingException)
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -151,7 +151,7 @@ class FastembedEmbeddingEngine(EmbeddingEngine):
                     s = original_texts[0]
                     third = len(s) // 3
                     if third == 0:
-                        raise EmbeddingException(
+                        raise TerminalEmbeddingException(
                             "Text is too short to split further but exceeds context window."
                         ) from error
                     left_part, right_part = s[: third * 2], s[third:]

--- a/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
@@ -53,6 +53,18 @@ class EmbeddingException(Exception):
         super().__init__(self.message)
 
 
+class TerminalEmbeddingException(EmbeddingException):
+    """Non-retryable embedding failure for deterministic error conditions.
+
+    Raised when the context-window recovery logic has exhausted all split
+    attempts.  Retry decorators exclude this subclass so the failure
+    propagates immediately.
+    """
+
+    def __init__(self, message: str, name: str = "TerminalEmbeddingException"):
+        super().__init__(message, name)
+
+
 class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
     """
     Embedding engine for any server that exposes the OpenAI ``/v1/embeddings`` API.
@@ -114,7 +126,7 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
     @retry(
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type((ValueError, asyncio.CancelledError)),
+        retry=retry_if_not_exception_type((ValueError, asyncio.CancelledError, TerminalEmbeddingException)),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -180,7 +192,7 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
                     s = original_texts[0]
                     third = len(s) // 3
                     if third == 0:
-                        raise EmbeddingException(
+                        raise TerminalEmbeddingException(
                             "Text is too short to split further but exceeds context window."
                         ) from error
                     left_part, right_part = s[: third * 2], s[third:]

--- a/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
+++ b/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
-from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.databases.exceptions import EmbeddingException, TerminalEmbeddingException
 
 
 @pytest.mark.asyncio
@@ -132,5 +132,5 @@ async def test_fastembed_raises_when_short_text_still_exceeds_context_window():
 
         engine = FastembedEmbeddingEngine(model="test-model", dimensions=2)
 
-        with pytest.raises(EmbeddingException, match="too short to split further"):
+        with pytest.raises(TerminalEmbeddingException, match="too short to split further"):
             await engine.embed_text(["ab"])

--- a/cognee/tests/unit/infrastructure/test_terminal_embedding_no_retry.py
+++ b/cognee/tests/unit/infrastructure/test_terminal_embedding_no_retry.py
@@ -1,0 +1,80 @@
+"""Verify that the terminal split path (third == 0) raises TerminalEmbeddingException
+immediately without hitting the @retry decorator.
+
+Before the fix, the terminal split raised a generic EmbeddingException which the
+retry decorator caught and retried with exponential backoff (up to 128 seconds per
+attempt).  After the fix the terminal case propagates immediately.
+
+See: https://github.com/topoteretes/cognee/issues/3319
+"""
+
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cognee.infrastructure.databases.exceptions import (
+    EmbeddingException,
+    TerminalEmbeddingException,
+)
+
+
+# ---------------------------------------------------------------------------
+# TerminalEmbeddingException IS-A EmbeddingException
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_embedding_exception_is_subclass_of_embedding_exception():
+    """TerminalEmbeddingException must remain a subclass so existing except
+    blocks that catch EmbeddingException still work."""
+    assert issubclass(TerminalEmbeddingException, EmbeddingException)
+
+
+def test_terminal_embedding_exception_carries_message():
+    exc = TerminalEmbeddingException("custom message")
+    assert "custom message" in str(exc)
+    assert exc.name == "TerminalEmbeddingException"
+
+
+# ---------------------------------------------------------------------------
+# FastembedEmbeddingEngine — terminal split does NOT retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fastembed_terminal_split_does_not_retry():
+    """A two-character input that triggers the context-window handler should
+    raise TerminalEmbeddingException immediately (no retry backoff)."""
+    pytest.importorskip("fastembed")
+
+    with (
+        patch(
+            "cognee.infrastructure.databases.vector.embeddings.FastembedEmbeddingEngine."
+            "FastembedEmbeddingEngine.get_tokenizer",
+            return_value=Mock(),
+        ),
+        patch(
+            "cognee.infrastructure.databases.vector.embeddings.FastembedEmbeddingEngine."
+            "TextEmbedding",
+        ) as mock_text_embedding,
+    ):
+        embedding_model = Mock()
+        embedding_model.embed.side_effect = RuntimeError("context window exceeded")
+        mock_text_embedding.return_value = embedding_model
+
+        from cognee.infrastructure.databases.vector.embeddings.FastembedEmbeddingEngine import (
+            FastembedEmbeddingEngine,
+        )
+
+        engine = FastembedEmbeddingEngine(model="test-model", dimensions=2)
+
+        start = time.monotonic()
+        with pytest.raises(TerminalEmbeddingException, match="too short to split further"):
+            await engine.embed_text(["ab"])
+        elapsed = time.monotonic() - start
+
+        # If retries were happening this would take >=8 seconds (first backoff).
+        # A clean fast-fail should complete in well under 2 seconds.
+        assert elapsed < 2.0, (
+            f"Terminal split took {elapsed:.1f}s — retry decorator is probably still catching it"
+        )


### PR DESCRIPTION
## Root cause
When `embed_text` encounters an input that is too short to be split further (`third == 0`) but still exceeds the model's context window, it raises an `EmbeddingException`. Because the `@retry` decorator on the engine only excluded `NotFoundError` and `CancelledError`, it caught this exception and uselessly retried it with exponential backoff for up to 128 seconds per attempt, even though the failure is deterministic.

## Fix
1. Introduced `TerminalEmbeddingException` (a subclass of `EmbeddingException`) to represent this deterministic error.
2. Updated the two engines (`FastembedEmbeddingEngine`, `OpenAICompatibleEmbeddingEngine`) where `embed_text` is wrapped by `@retry` to:
   - Raise `TerminalEmbeddingException` instead of `EmbeddingException` in the terminal split path.
   - Exclude `TerminalEmbeddingException` from their `retry_if_not_exception_type` logic.

## Why `TerminalEmbeddingException`?
Creating a subclass allows us to maintain the existing retry behavior for transient `EmbeddingException` errors (like connectivity issues or timeouts) while ensuring the deterministic terminal case fails immediately.

## Regression test
Added a regression test (`test_terminal_embedding_no_retry.py`) verifying that the terminal split path completes instantly (<2s) rather than triggering the exponential backoff.

*(Note: I am raising this PR now before explicit assignment as I will be unavailable for the next 12-15 hours due to timezone differences, and wanted to get this up for review.)*
