### PR TITLE
fix(frontend): hide billing/upgrade UI in open-source edition (#3315)

### DIFF
--- a/cognee-frontend/src/ui/elements/UpgradeBanner.tsx
+++ b/cognee-frontend/src/ui/elements/UpgradeBanner.tsx
@@ -3,8 +3,11 @@
 import { Flex, Text, Button } from "@mantine/core";
 import { useRouter } from "next/navigation";
 import { tokens } from "@/ui/theme/tokens";
+import isCloudEnvironment from "@/utils/isCloudEnvironment";
 
 export default function UpgradeBanner() {
+  if (!isCloudEnvironment()) return null;
+
   const router = useRouter();
 
   return (

--- a/cognee-frontend/src/ui/layout/Navbar/UserProfile.tsx
+++ b/cognee-frontend/src/ui/layout/Navbar/UserProfile.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { tokens } from "@/ui/theme/tokens";
 import trackEvent from "@/modules/analytics/trackEvent";
+import isCloudEnvironment from "@/utils/isCloudEnvironment";
 
 function SettingsIcon() {
   return (
@@ -68,13 +69,18 @@ function HelpIcon() {
   );
 }
 
-const menuItems = [
+const baseMenuItems = [
   { label: "Settings", href: "/settings", external: false, icon: <SettingsIcon />, track: null },
   { label: "Access Management", href: "/access-management", external: false, icon: <AccessManagementIcon />, track: null },
   { label: "Billing", href: "/setup", external: false, icon: <BillingIcon />, track: null },
   { label: "Discord Community", href: "https://discord.gg/m63hxKsp4p", external: true, icon: <DiscordIcon />, track: "https://discord.gg/m63hxKsp4p" },
   { label: "Help", href: "mailto:social@cognee.ai", external: true, icon: <HelpIcon />, track: "mailto:social@cognee.ai" },
 ];
+
+const cloudOnlyLabels = new Set(["Billing"]);
+const menuItems = baseMenuItems.filter(
+  (item) => isCloudEnvironment() || !cloudOnlyLabels.has(item.label)
+);
 
 export default function UserProfile() {
   const [user, setUser] = useState<CogneeUser>();


### PR DESCRIPTION
## Description

Fixes topoteretes/cognee#3315

The 'Billing' link in the UserProfile dropdown and the 'View Plan' button in the UpgradeBanner both navigated to `/setup`, a route that only exists in the SaaS/Cloud version. In the open-source edition no route handler exists for `/setup`, so clicks silently redirected back to the dashboard.

## Changes

* **UserProfile.tsx**: Filter out the "Billing" menu item when `isCloudEnvironment()` returns false (open-source mode)
* **UpgradeBanner.tsx**: Return null when `isCloudEnvironment()` returns false (open-source mode)

Both checks use the existing `isCloudEnvironment()` utility which reads `NEXT_PUBLIC_IS_CLOUD_ENVIRONMENT` (defaults to `true` for Cloud, set `false` for open-source).

## Verification

- [X] Frontend build succeeds (`npm run build` passes)
- [X] No TypeScript errors
- [X] Follows existing patterns (same `isCloudEnvironment()` used elsewhere)

## DCO

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin