### PR TITLE
fix: telemetry crash safety + narrow cli user resolution exception (#3276)

### DIFF
--- a/cognee/cli/user_resolution.py
+++ b/cognee/cli/user_resolution.py
@@ -29,11 +29,12 @@ async def resolve_cli_user(user_id: Optional[str] = None, strict: bool = False):
             f"Example: --user-id 550e8400-e29b-41d4-a716-446655440000"
         )
 
+    from cognee.infrastructure.databases.exceptions import EntityNotFoundError
     from cognee.modules.users.methods import get_user
 
     try:
         return await get_user(uid)
-    except Exception:
+    except EntityNotFoundError:
         if strict:
             raise ValueError(
                 f"--user-id {uid} does not exist.  Refusing to fall back to the default "

--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -269,8 +269,13 @@ def send_telemetry(event_name: str, user_id: str | UUID, additional_properties: 
         },
     }
 
-    loop = asyncio.get_running_loop()
-    loop.create_task(_send_telemetry_request(payload))
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_send_telemetry_request(payload))
+    except RuntimeError:
+        # No running event loop (shutdown, sync context, etc.) — telemetry is
+        # best-effort; dropping the event is better than crashing the caller.
+        pass
 
 
 def embed_logo(p: Any, layout_scale: float, logo_alpha: float, position: str):


### PR DESCRIPTION
## Description

Fixes #3276

Two defensive fixes that prevent pipeline crashes and make debugging easier.

### 1. `send_telemetry()` — no longer crashes when no event loop is running

`send_telemetry()` called `asyncio.get_running_loop()` unconditionally. If the event loop had been shut down (e.g. during teardown) or didn't exist (sync context), this raised `RuntimeError` and crashed the caller mid-pipeline. The HTTP request was already fire-and-forget via `create_task` (non-blocking with 5s timeout), but the synchronous preamble was a crash risk.

**Fix:** Wrap `get_running_loop()` / `create_task()` in `try/except RuntimeError` so telemetry is truly best-effort and never takes down a pipeline.

### 2. `resolve_cli_user()` — narrow exception handling

`resolve_cli_user()` caught all `Exception` subclasses with a bare `except Exception:`, silently swallowing database connectivity errors, ORM failures, and other infrastructure issues as if the user simply didn't exist. This made debugging near impossible — a dead database looked identical to a missing user.

**Fix:** Narrow the handler to `EntityNotFoundError` (raised by `get_user()` when the UUID doesn't match). Genuine system errors now propagate with the original traceback.

## Changes

| File | Change |
|---|---|
| `cognee/shared/utils.py` | Wrap `get_running_loop()` + `create_task()` in try/except RuntimeError |
| `cognee/cli/user_resolution.py` | Replace `except Exception:` with `except EntityNotFoundError:` |

## Verification

- [x] `python -m pytest cognee/tests/test_telemetry.py` — 3 passed
- [x] `python -m pytest cognee/tests/unit/shared/test_telemetry_tracking.py` — 3 passed
- [x] Module imports verified

## DCO

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin