### PR TITLE
fix: use correct data_size column name in re-ingestion update path

### DIFF
--- a/cognee/tasks/ingestion/ingest_data.py
+++ b/cognee/tasks/ingestion/ingest_data.py
@@ -183,7 +183,7 @@ async def ingest_data(
                 data_point.owner_id = user.id
                 data_point.content_hash = new_content_hash
                 data_point.raw_content_hash = storage_file_metadata["content_hash"]
-                data_point.file_size = original_file_metadata["file_size"]
+                data_point.data_size = original_file_metadata["file_size"]
                 data_point.external_metadata = ext_metadata
                 data_point.node_set = json.dumps(node_set) if node_set else None
                 data_point.tenant_id = user.tenant_id if user.tenant_id else None


### PR DESCRIPTION
The update branch in  was setting , but the  model column is named . The create branch uses the correct name. Because  is not a mapped column, SQLAlchemy silently drops the assignment and the persisted value is never updated on re-ingestion.

Fixes #3160