### PR TITLE
fix: give each per-field index copy its own metadata dict

### DIFF
--- a/cognee/tasks/temporal_awareness/index_graphiti_objects.py
+++ b/cognee/tasks/temporal_awareness/index_graphiti_objects.py
@@ -63,7 +63,7 @@ async def index_and_transform_graphiti_nodes_and_edges():
 
             if getattr(graphiti_node, field_name, None) is not None:
                 indexed_data_point = graphiti_node.model_copy()
-                indexed_data_point.metadata["index_fields"] = [field_name]
+                indexed_data_point.metadata = {**graphiti_node.metadata, "index_fields": [field_name]}
                 index_points[index_name].append(indexed_data_point)
 
     for index_name, indexable_points in index_points.items():
@@ -90,7 +90,7 @@ async def index_and_transform_graphiti_nodes_and_edges():
                 index_points[index_name] = []
 
             indexed_data_point = edge.model_copy()
-            indexed_data_point.metadata["index_fields"] = [field_name]
+            indexed_data_point.metadata = {**edge.metadata, "index_fields": [field_name]}
             index_points[index_name].append(indexed_data_point)
 
     for index_name, indexable_points in index_points.items():


### PR DESCRIPTION
model_copy() is shallow in Pydantic v2, so looping over index_fields and mutating indexed_data_point.metadata['index_fields'] on each iteration clobbers the shared dict. Every copy ends up with the last field's value, so the name and summary indexes silently embed content values.

Changed both the GraphitiNode (line 65-66) and EdgeType (line 92-93) branches to assign a fresh dict instead of mutating the shared one.

Fixes #3292