### PR TITLE
fix: add close() method to Neo4jAdapter to prevent connection pool leak

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -98,6 +98,11 @@ class Neo4jAdapter(GraphDBInterface):
             keep_alive=True,
         )
 
+    async def close(self) -> None:
+        """Close the underlying Neo4j driver connection pool."""
+        if hasattr(self, "driver") and self.driver is not None:
+            await self.driver.close()
+
     async def initialize(self) -> None:
         """
         Initializes the database: adds uniqueness constraint on id and performs indexing


### PR DESCRIPTION
Neo4jAdapter is the only graph adapter missing a close() method. When evicted from closing_lru_cache, the cache's cleanup silently skips it (hasattr check fails), leaving the Neo4j driver connection pool open indefinitely.

Other adapters (PGVectorAdapter, LanceDBAdapter, PostgresAdapter) all implement close() correctly.

Fixes #3193