### PR TITLE
fix: initialize database before resolving CLI user

### DIFF
--- a/cognee/cli/user_resolution.py
+++ b/cognee/cli/user_resolution.py
@@ -16,6 +16,13 @@ async def resolve_cli_user(user_id: Optional[str] = None, strict: bool = False):
     error instead — used by ownership-sensitive commands (e.g. ``agents``) where a
     silent fallback to the default user would break the isolation the flag promises.
     """
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.run_migrations import run_migrations
+
+    db_engine = get_relational_engine()
+    await db_engine.create_database()
+    await run_migrations()
+
     from cognee.modules.users.methods import get_default_user
 
     if not user_id:


### PR DESCRIPTION
Running cognee-cli against a fresh Postgres database fails with DatabaseNotCreatedError because the CLI calls get_default_user() before the database schema has been created. The API server handles this in its lifespan hook (create_database + run_migrations), but the CLI has no equivalent initialization.

Added create_database() and run_migrations() calls at the top of resolve_cli_user(), which is the common entry point for all CLI commands that need a user. Both calls are idempotent — they're no-ops on subsequent invocations.

Fixes #3267