### PR TITLE
fix: hide SaaS-only billing routes in open-source UI

### DIFF
--- a/cognee-frontend/src/ui/elements/UpgradeBanner.tsx
+++ b/cognee-frontend/src/ui/elements/UpgradeBanner.tsx
@@ -1,37 +1,7 @@
 "use client";
 
-import { Flex, Text, Button } from "@mantine/core";
-import { useRouter } from "next/navigation";
-import { tokens } from "@/ui/theme/tokens";
-
 export default function UpgradeBanner() {
-  const router = useRouter();
-
-  return (
-    <Flex
-      align="center"
-      justify="space-between"
-      className="rounded-[0.5rem] px-[2rem] py-[1rem]"
-      style={{
-        background: `linear-gradient(135deg, ${tokens.purple}12 0%, #ffffff 50%, ${tokens.purple}08 100%)`,
-        border: `1px solid ${tokens.purple}30`,
-      }}
-    >
-      <div>
-        <Text fw={600} size="sm" c={tokens.textDark}>
-          No active subscription
-        </Text>
-        <Text size="sm" c={tokens.textSecondary}>
-          Subscribe to unlock data uploads, search, and all features.
-        </Text>
-      </div>
-      <Button
-        color="primary2.6"
-        size="sm"
-        onClick={() => router.push("/setup")}
-      >
-        Upgrade
-      </Button>
-    </Flex>
-  );
+  // The open-source edition does not include SaaS billing infrastructure.
+  // In the commercial version, this renders the subscription upgrade prompt.
+  return null;
 }

--- a/cognee-frontend/src/ui/layout/Navbar/UserProfile.tsx
+++ b/cognee-frontend/src/ui/layout/Navbar/UserProfile.tsx
@@ -71,7 +71,7 @@ function HelpIcon() {
 const menuItems = [
   { label: "Settings", href: "/settings", external: false, icon: <SettingsIcon />, track: null },
   { label: "Access Management", href: "/access-management", external: false, icon: <AccessManagementIcon />, track: null },
-  { label: "Billing", href: "/setup", external: false, icon: <BillingIcon />, track: null },
+  // { label: "Billing", href: "/setup", external: false, icon: <BillingIcon />, track: null }, // SaaS only
   { label: "Discord Community", href: "https://discord.gg/m63hxKsp4p", external: true, icon: <DiscordIcon />, track: "https://discord.gg/m63hxKsp4p" },
   { label: "Help", href: "mailto:social@cognee.ai", external: true, icon: <HelpIcon />, track: "mailto:social@cognee.ai" },
 ];


### PR DESCRIPTION
## Description

This PR fixes the broken billing links in the open-source frontend.

Currently, clicking "Billing" in the UserProfile menu or "View Plan" in the UpgradeBanner redirects to `/setup`. This throws a 404 or a redirect loop because the SaaS billing infrastructure (Stripe/Auth0) doesn't exist in the open-source repo.

To fix this, I commented out the Billing link in `UserProfile.tsx` and returned `null` for the `UpgradeBanner` component so open-source users don't encounter broken routes.

Fixes topoteretes/cognee#3315

## Acceptance Criteria

- [X] The "Billing" option no longer appears in the user profile dropdown.
- [X] The "Upgrade" banner asking for a subscription is completely hidden.
- [X] Users can no longer trigger a broken redirect to `/setup`.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code