### PR TITLE
fix: load regex entity config with utf-8 encoding

### DIFF
--- a/cognee/tasks/entity_completion/entity_extractors/regex_entity_config.py
+++ b/cognee/tasks/entity_completion/entity_extractors/regex_entity_config.py
@@ -40,7 +40,7 @@ class RegexEntityConfig:
     def _load_config(self) -> None:
         """Load and process the configuration from the JSON file."""
         try:
-            with open(self.config_path, "r") as f:
+            with open(self.config_path, "r", encoding="utf-8") as f:
                 config_list = json.load(f)
         except FileNotFoundError:
             logger.error(f"Config file not found: {self.config_path}")


### PR DESCRIPTION
## Description
Fixes #3316

This PR explicitly sets `encoding="utf-8"` when loading the regex entity extraction config JSON.

On Windows, Python may use the system locale encoding by default, which can break config loading when the JSON contains UTF-8 characters. Explicitly using UTF-8 makes the behavior consistent across platforms.

## Changes
- Updated `RegexEntityConfig._load_config()` to open the config file with `encoding="utf-8"`

## Type of Change
- Bug fix

## Pre-submission Checklist
- Minimal change to address the issue
- No new dependencies introduced
- I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin