### PR TITLE
docs: document public package API

### DIFF
--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -1,3 +1,18 @@
+"""Public Python API for Cognee.
+
+This module exposes the main functions and objects intended for direct use
+through ``import cognee``. It groups the stable V1 API, memory-oriented V2 API,
+visualization helpers, tracing utilities, migration helpers, and session models
+behind a single package-level entrypoint.
+
+Common entrypoints include:
+    add: Add data to a Cognee dataset.
+    cognify: Process ingested data into Cognee's knowledge representation.
+    search: Query processed data using the configured search type.
+    remember: Store memory-oriented entries using the V2 API.
+    recall: Retrieve information from memory-oriented entries.
+    delete: Remove data from Cognee-managed storage.
+"""
 # ruff: noqa: E402
 from cognee.version import get_cognee_version
 


### PR DESCRIPTION
## Description
Fixes #2314

Adds a package-level docstring to `cognee/__init__.py` to document the public Python API exposed through `import cognee`.

## Changes
- Added module-level documentation for the package entrypoint
- Listed common public API entrypoints
- No runtime behavior changes

## Type of Change
-  Documentation

## Pre-submission Checklist
-  Minimal change to address the issue
-  No new dependencies introduced
-  I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin