### PR TITLE
fix(ingestion): reopen S3 temp file by name on Windows (NamedTemporaryFile delete=False)

### DIFF
--- a/cognee/tasks/ingestion/data_item_to_text_file.py
+++ b/cognee/tasks/ingestion/data_item_to_text_file.py
@@ -45,13 +45,29 @@ async def data_item_to_text_file(
             # TODO: Rework this to work with file streams and not saving data to temp storage
             # Note: proper suffix information is needed for OpenAI to handle mp3 files
             path_info = Path(parsed_url.path)
-            with tempfile.NamedTemporaryFile(mode="wb", suffix=path_info.suffix) as temp_file:
+            # NamedTemporaryFile defaults to delete=True, which on Windows keeps an
+            # exclusive lock on the file and forbids reopening it by name while the
+            # handle is still open. The loader below reopens the file by name, so we
+            # create it with delete=False, close our handle first, and clean it up
+            # ourselves. (Mirrors the delete=False pattern used by the SQLAlchemy and
+            # ladybug S3 temp-file paths.)
+            temp_file = tempfile.NamedTemporaryFile(
+                mode="wb", suffix=path_info.suffix, delete=False
+            )
+            try:
                 await pull_from_s3(data_item_path, temp_file)
                 temp_file.flush()  # Data needs to be saved to local storage
+                temp_file.close()  # release the handle so the loader can reopen by name
                 loader = get_loader_engine()
                 return await loader.load_file(temp_file.name, preferred_loaders), loader.get_loader(
                     temp_file.name, preferred_loaders
                 )
+            finally:
+                temp_file.close()  # idempotent; covers the early-exception path
+                try:
+                    os.unlink(temp_file.name)
+                except OSError:
+                    pass
 
         # data is local file path
         elif parsed_url.scheme == "file":

--- a/cognee/tests/unit/tasks/test_data_item_to_text_file.py
+++ b/cognee/tests/unit/tasks/test_data_item_to_text_file.py
@@ -1,0 +1,89 @@
+"""Regression test for the Windows temp-file reopen bug in
+``data_item_to_text_file`` (S3 ingestion path).
+
+``tempfile.NamedTemporaryFile`` defaults to ``delete=True``, which on Windows
+keeps an exclusive lock on the file and forbids reopening it *by name* while the
+handle is still open. The S3 branch writes the downloaded bytes to such a temp
+file and then hands ``temp_file.name`` to the loader, which reopens it by name --
+raising ``PermissionError`` on Windows.
+
+The fix creates the temp file with ``delete=False``, closes the handle before the
+loader reopens it, and unlinks it afterwards. These tests lock that in:
+
+* the loader can reopen the file by name and read the written bytes (strict on
+  Windows, benign on POSIX), and
+* the temp file is created with ``delete=False`` and removed afterwards
+  (cross-platform guard -- a revert to ``delete=True`` fails on every OS).
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+import cognee.tasks.ingestion.data_item_to_text_file as ditf
+from cognee.tasks.ingestion.data_item_to_text_file import data_item_to_text_file
+
+
+class _FakeLoader:
+    loader_name = "fake_loader"
+
+
+class _FakeLoaderEngine:
+    """Stand-in for the loader engine that reopens the temp file *by name*,
+    mirroring what the real ``load_file`` / ``get_loader`` do."""
+
+    def __init__(self):
+        self.content_seen = None
+
+    async def load_file(self, file_path, preferred_loaders=None, **kwargs):
+        # The real loader reopens the path by name; on Windows this is exactly
+        # where the buggy delete=True handle raises PermissionError.
+        with open(file_path, "rb") as f:
+            self.content_seen = f.read()
+        return "STORAGE_PATH"
+
+    def get_loader(self, file_path, preferred_loaders=None):
+        # The real get_loader also touches the file (guess_file_type).
+        with open(file_path, "rb"):
+            pass
+        return _FakeLoader()
+
+
+@pytest.mark.asyncio
+async def test_s3_temp_file_reopened_by_name_and_cleaned_up():
+    engine = _FakeLoaderEngine()
+    captured = {}
+
+    async def fake_pull_from_s3(file_path, destination_file):
+        destination_file.write(b"payload-bytes")
+
+    real_named_temp_file = tempfile.NamedTemporaryFile
+
+    def spy_named_temp_file(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        handle = real_named_temp_file(*args, **kwargs)
+        captured["name"] = handle.name
+        return handle
+
+    with (
+        patch.object(ditf, "pull_from_s3", new=fake_pull_from_s3),
+        patch.object(ditf, "get_loader_engine", return_value=engine),
+        patch.object(ditf.tempfile, "NamedTemporaryFile", side_effect=spy_named_temp_file),
+    ):
+        storage_path, loader = await data_item_to_text_file("s3://bucket/key.txt")
+
+    # Functional contract preserved.
+    assert storage_path == "STORAGE_PATH"
+    assert isinstance(loader, _FakeLoader)
+
+    # Reopen-by-name succeeded (strict on Windows, benign on POSIX).
+    assert engine.content_seen == b"payload-bytes"
+
+    # Cross-platform regression guard: the temp file must be created with
+    # delete=False so the handle can be closed before the loader reopens it.
+    assert captured["kwargs"].get("delete") is False
+
+    # And it must still be cleaned up afterwards (no temp-file leak).
+    assert not os.path.exists(captured["name"])


### PR DESCRIPTION
# fix(ingestion): reopen S3 temp file by name on Windows (NamedTemporaryFile delete=False)

## What

`data_item_to_text_file()` (S3 branch) wrote the downloaded object to a
`tempfile.NamedTemporaryFile` created with the default `delete=True`, then passed
`temp_file.name` to the loader, which reopens the file **by name while the handle
is still open**. On Windows that raises `PermissionError [WinError 32]`, so every
S3 ingestion fails on Windows.

This changes the temp file to `delete=False`, closes the handle before the loader
reopens it, and unlinks the file in a `finally` block (so there is no temp-file
leak). This mirrors the `delete=False` pattern already used by the SQLAlchemy and
ladybug S3 temp-file paths.

Fixes #3339.

## Why this is correct

- The loader reads the file *during* `load_file()` / `get_loader()` (both of which
  open the path by name), and the downstream consumer in `ingest_data.py` uses the
  loader's returned storage path — not the temp file — so the temp file can safely
  be unlinked once both calls return.
- Behavior on Linux/macOS is unchanged.

## Testing

Added `cognee/tests/unit/tasks/test_data_item_to_text_file.py`:

- Drives the S3 branch with a fake loader that **reopens the temp file by name**
  (exactly what triggered the Windows failure) and asserts the written bytes are
  read back. This is strict on Windows and benign on POSIX.
- Asserts the temp file is created with `delete=False` and is removed afterwards —
  a cross-platform guard so a revert to `delete=True` fails on any OS.

Verified on Windows 11 / Python 3.13.7: the test passes on the fix and fails
(`PermissionError`) on the pre-fix code.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin