### PR TITLE
fix(ingestion): derive basename from Windows paths in classify()

### DIFF
--- a/cognee/modules/ingestion/classify.py
+++ b/cognee/modules/ingestion/classify.py
@@ -14,7 +14,11 @@ def classify(
         return TextData(data)
 
     if isinstance(data, BufferedReader) or isinstance(data, SpooledTemporaryFile):
-        return BinaryData(data, filename if filename else str(data.name).split("/")[-1])
+        # Normalize both POSIX ("/") and Windows ("\") separators before taking the
+        # basename. On Windows, data.name is a backslash path (e.g. C:\dir\file.pdf),
+        # so splitting on "/" alone would keep the whole path as the file's name.
+        derived_name = str(data.name).replace("\\", "/").split("/")[-1]
+        return BinaryData(data, filename if filename else derived_name)
 
     try:
         from s3fs import S3File

--- a/cognee/tests/unit/modules/ingestion/test_classify.py
+++ b/cognee/tests/unit/modules/ingestion/test_classify.py
@@ -1,0 +1,40 @@
+"""Regression tests for ``classify`` filename derivation.
+
+``classify`` derived a binary stream's name with ``str(data.name).split("/")[-1]``.
+On Windows, ``data.name`` is a backslash path (e.g. ``C:\\dir\\file.pdf``) with no
+forward slashes, so the split returned the *entire path* as the file's name --
+which then propagated into the stored document name / metadata.
+
+The fix normalizes both ``\\`` and ``/`` before taking the basename. These tests
+are cross-platform strict: a revert to splitting on ``/`` only fails on any OS,
+because the Windows-style input below contains backslashes regardless of host.
+"""
+
+import io
+from unittest.mock import MagicMock
+
+from cognee.modules.ingestion.classify import classify
+from cognee.modules.ingestion.data_types import BinaryData
+
+
+def _fake_binary_stream(name: str) -> MagicMock:
+    # spec=io.BufferedReader makes isinstance(stream, BufferedReader) pass in classify.
+    stream = MagicMock(spec=io.BufferedReader)
+    stream.name = name
+    return stream
+
+
+def test_windows_path_name_is_reduced_to_basename():
+    result = classify(_fake_binary_stream(r"C:\Users\foo\report.pdf"))
+    assert isinstance(result, BinaryData)
+    assert result.name == "report.pdf"
+
+
+def test_posix_path_name_is_reduced_to_basename():
+    result = classify(_fake_binary_stream("/home/user/report.pdf"))
+    assert result.name == "report.pdf"
+
+
+def test_explicit_filename_takes_precedence_over_stream_name():
+    result = classify(_fake_binary_stream(r"C:\Users\foo\ignored.pdf"), filename="explicit.pdf")
+    assert result.name == "explicit.pdf"


### PR DESCRIPTION
# fix(ingestion): derive basename from Windows paths in classify()

## What

`classify()` derived a binary stream's name with `str(data.name).split("/")[-1]`.
On Windows, `data.name` is a backslash path (e.g. `C:\dir\file.pdf`) with no
forward slashes, so the split returned the **entire path** as the file's name.
That value propagates into the stored document name and metadata
(`BinaryData.name` → `get_file_metadata` → `data_point.name`), so on Windows
ingested local files were recorded with their full `C:\...` path instead of the
basename.

This normalizes both `\` and `/` separators before taking the basename, matching
the convention already used by `_normalize_filename` in
`cognee/tasks/ingestion/utils.py`.

```diff
- return BinaryData(data, filename if filename else str(data.name).split("/")[-1])
+ derived_name = str(data.name).replace("\\", "/").split("/")[-1]
+ return BinaryData(data, filename if filename else derived_name)
```

Fixes #3341.

## Testing

Added `cognee/tests/unit/modules/ingestion/test_classify.py` with cross-platform
regression tests:

- Windows-style input (`C:\Users\foo\report.pdf`) → `report.pdf`
- POSIX-style input (`/home/user/report.pdf`) → `report.pdf`
- explicit `filename` argument takes precedence over the stream name

Because the Windows-style input contains backslashes regardless of host, a revert
to splitting on `/` only fails the test on **any** OS (Linux CI included).
Verified on Windows 11 / Python 3.13.7: the fix returns the basename where the
pre-fix code returned the full path.
