### PR TITLE
fix(config): validate cache_root_directory as an absolute path

### DIFF
--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -33,6 +33,9 @@ class BaseConfig(BaseSettings):
         self.data_root_directory = ensure_absolute_path(self.data_root_directory)
         self.system_root_directory = ensure_absolute_path(self.system_root_directory)
         self.logs_root_directory = ensure_absolute_path(self.logs_root_directory)
+        # cache_root_directory is a root directory too; validate it like the others
+        # (ensure_absolute_path passes s3:// URLs through unchanged).
+        self.cache_root_directory = ensure_absolute_path(self.cache_root_directory)
 
         return self
 

--- a/cognee/tests/unit/test_base_config.py
+++ b/cognee/tests/unit/test_base_config.py
@@ -1,0 +1,48 @@
+"""Regression tests for BaseConfig root-directory validation.
+
+`validate_paths` enforces absolute paths for the root directories via
+`ensure_absolute_path` (which raises on a relative path and passes ``s3://`` URLs
+through unchanged). ``cache_root_directory`` is a root directory too, but was the
+only one of the four not validated, so a relative ``CACHE_ROOT_DIRECTORY`` was
+silently accepted and later resolved against the current working directory --
+unlike its siblings, which reject the same value with a clear error.
+
+These tests lock in that ``cache_root_directory`` is validated identically.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from cognee.base_config import BaseConfig
+
+
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("CACHE_ROOT_DIRECTORY", raising=False)
+    monkeypatch.delenv("STORAGE_BACKEND", raising=False)
+
+
+def test_relative_cache_root_directory_is_rejected(monkeypatch):
+    _clear_env(monkeypatch)
+    with pytest.raises(ValueError):
+        BaseConfig(cache_root_directory="relative_cache_dir")
+
+
+def test_relative_sibling_directory_is_rejected(monkeypatch):
+    # Sanity check that the siblings already reject relative paths, so
+    # cache_root_directory must behave the same way.
+    _clear_env(monkeypatch)
+    with pytest.raises(ValueError):
+        BaseConfig(data_root_directory="relative_data_dir")
+
+
+def test_s3_cache_root_directory_is_preserved(monkeypatch):
+    _clear_env(monkeypatch)
+    cfg = BaseConfig(cache_root_directory="s3://bucket/cognee/cache")
+    assert cfg.cache_root_directory == "s3://bucket/cognee/cache"
+
+
+def test_absolute_cache_root_directory_is_accepted(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    cfg = BaseConfig(cache_root_directory=str(tmp_path))
+    assert Path(cfg.cache_root_directory).is_absolute()


### PR DESCRIPTION
# fix(config): validate cache_root_directory as an absolute path

## What

`BaseConfig.validate_paths` enforces absolute paths for `data_root_directory`,
`system_root_directory` and `logs_root_directory` via `ensure_absolute_path`
(which raises on a relative path and passes `s3://` URLs through unchanged).
`cache_root_directory` is a root directory too, but was the only one of the four
left unvalidated.

So a relative `CACHE_ROOT_DIRECTORY` was silently accepted and later resolved
against the current working directory (`cognee/shared/cache.py` →
`get_file_storage(...)` / `os.path.abspath(...)`), making the cache location
depend on the process's cwd — while the same value for its siblings raises a
clear error.

```diff
 self.data_root_directory = ensure_absolute_path(self.data_root_directory)
 self.system_root_directory = ensure_absolute_path(self.system_root_directory)
 self.logs_root_directory = ensure_absolute_path(self.logs_root_directory)
+self.cache_root_directory = ensure_absolute_path(self.cache_root_directory)
```

`ensure_absolute_path` returns `s3://` URLs unchanged, so the S3 cache
auto-configuration above it is unaffected.

Fixes #3343.

## Testing

Added `cognee/tests/unit/test_base_config.py`:

- relative `cache_root_directory` is rejected (regression guard; fails on the
  pre-fix code)
- a relative sibling (`data_root_directory`) is rejected too (shows the intended,
  consistent behavior)
- `s3://` cache path is preserved unchanged (the fix doesn't break S3)
- an absolute cache path is accepted

Cross-platform (no OS-specific behavior).
