### PR TITLE
feat(validate): implement knowledge graph integrity validation checks…

### DIFF
--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -58,6 +58,8 @@ from .api.v1 import (
     recall,
     improve,
     forget,
+    validate,
+    ValidationReport,
     serve,
     disconnect,
     visualize,

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -29,6 +29,7 @@ from cognee.api.v1.remember.routers import get_remember_router
 from cognee.api.v1.recall.routers import get_recall_router
 from cognee.api.v1.improve.routers import get_improve_router
 from cognee.api.v1.forget.routers import get_forget_router
+from cognee.api.v1.validate.routers import get_validate_router
 from cognee.api.v1.responses.routers import get_responses_router
 from cognee.api.v1.llm.routers import get_llm_router
 from cognee.api.v1.sync.routers import get_sync_router
@@ -309,6 +310,7 @@ app.include_router(get_remember_router(), prefix="/api/v1/remember", tags=["reme
 app.include_router(get_recall_router(), prefix="/api/v1/recall", tags=["recall"])
 app.include_router(get_improve_router(), prefix="/api/v1/improve", tags=["improve"])
 app.include_router(get_forget_router(), prefix="/api/v1/forget", tags=["forget"])
+app.include_router(get_validate_router(), prefix="/api/v1/validate", tags=["validate"])
 
 
 @app.get("/")

--- a/cognee/api/v1/__init__.py
+++ b/cognee/api/v1/__init__.py
@@ -2,6 +2,7 @@ from .remember import remember, RememberResult
 from .recall import recall
 from .improve import improve
 from .forget import forget
+from .validate import validate, ValidationReport
 from .serve import serve, disconnect
 from .push import push, PushResult
 from .export import export, ExportResult

--- a/cognee/api/v1/validate/__init__.py
+++ b/cognee/api/v1/validate/__init__.py
@@ -1,0 +1,2 @@
+from .validate import validate
+from .models import ValidationReport, ValidationIssue, ValidationStatus, IssueSeverity

--- a/cognee/api/v1/validate/checks.py
+++ b/cognee/api/v1/validate/checks.py
@@ -1,0 +1,178 @@
+"""Individual validation checks for knowledge graph integrity.
+
+Each check is a standalone async function that inspects one aspect
+of the graph/vector/relational state and appends issues to the report.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.data.models import Data
+from cognee.modules.data.models.DatasetData import DatasetData
+from cognee.shared.logging_utils import get_logger
+
+from .models import IssueSeverity, ValidationReport
+
+logger = get_logger("validate")
+
+
+async def check_graph_vector_sync(report: ValidationReport, graph_engine, vector_engine):
+    """Verify that every embeddable graph node has a vector entry and vice versa."""
+    report.checks_run.append("graph_vector_sync")
+
+    nodes, edges = await graph_engine.get_graph_data()
+    node_ids = {str(node[0]) for node in nodes}
+
+    report.summary["graph_nodes"] = len(nodes)
+    report.summary["graph_edges"] = len(edges)
+
+    if not nodes:
+        return
+
+    embeddable_types = set()
+    for _, props in nodes:
+        node_type = props.get("type", "")
+        if node_type:
+            embeddable_types.add(node_type)
+
+    vector_ids: set[str] = set()
+    collections_found: list[str] = []
+
+    for node_type in embeddable_types:
+        for field_suffix in ("_name", "_text", "_description"):
+            collection_name = f"{node_type}{field_suffix}"
+            try:
+                if not await vector_engine.has_collection(collection_name):
+                    continue
+                collections_found.append(collection_name)
+                results = await vector_engine.retrieve(collection_name, list(node_ids))
+                for r in results:
+                    rid = str(r.id) if hasattr(r, "id") else str(r.get("id", ""))
+                    if rid:
+                        vector_ids.add(rid)
+            except Exception as exc:
+                logger.debug("Skipping collection %s: %s", collection_name, exc)
+
+    report.summary["vector_collections"] = collections_found
+    report.summary["vector_entries"] = len(vector_ids)
+
+    in_graph_not_vector = node_ids - vector_ids
+    # Only flag nodes whose type actually has a vector collection
+    typed_nodes = {}
+    for nid, props in nodes:
+        typed_nodes[str(nid)] = props.get("type", "")
+
+    nodes_missing_vectors = [
+        nid
+        for nid in in_graph_not_vector
+        if any(
+            f"{typed_nodes.get(nid, '')}{s}" in collections_found
+            for s in ("_name", "_text", "_description")
+        )
+    ]
+
+    if nodes_missing_vectors:
+        report.add_issue(
+            IssueSeverity.WARNING,
+            "unembedded_nodes",
+            count=len(nodes_missing_vectors),
+            detail=(
+                f"{len(nodes_missing_vectors)} graph node(s) have embeddable fields "
+                f"but no matching vector entry"
+            ),
+        )
+
+    in_vector_not_graph = vector_ids - node_ids
+    if in_vector_not_graph:
+        report.add_issue(
+            IssueSeverity.WARNING,
+            "orphaned_vector_entries",
+            count=len(in_vector_not_graph),
+            detail=(f"{len(in_vector_not_graph)} vector entry/entries have no matching graph node"),
+        )
+
+
+async def check_dangling_edges(report: ValidationReport, graph_engine):
+    """Find edges that reference non-existent source or target nodes."""
+    report.checks_run.append("dangling_edges")
+
+    nodes, edges = await graph_engine.get_graph_data()
+    node_ids = {str(node[0]) for node in nodes}
+    dangling = 0
+
+    for edge in edges:
+        source, target = str(edge[0]), str(edge[1])
+        if source not in node_ids or target not in node_ids:
+            dangling += 1
+
+    if dangling:
+        report.add_issue(
+            IssueSeverity.ERROR,
+            "dangling_edges",
+            count=dangling,
+            detail=f"{dangling} edge(s) reference non-existent node(s)",
+        )
+
+
+async def check_isolated_nodes(report: ValidationReport, graph_engine):
+    """Find nodes with zero edges (potential extraction failures)."""
+    report.checks_run.append("isolated_nodes")
+
+    nodes, edges = await graph_engine.get_graph_data()
+    connected = set()
+    for edge in edges:
+        connected.add(str(edge[0]))
+        connected.add(str(edge[1]))
+
+    # Exclude structural node types that are naturally leaf nodes
+    structural_types = {"NodeSet", "DocumentChunk", "TextSummary"}
+
+    isolated = 0
+    for nid, props in nodes:
+        if str(nid) not in connected and props.get("type", "") not in structural_types:
+            isolated += 1
+
+    if isolated:
+        report.add_issue(
+            IssueSeverity.INFO,
+            "isolated_nodes",
+            count=isolated,
+            detail=f"{isolated} node(s) have zero edges (excluding structural types)",
+        )
+
+
+async def check_uncognified_data(report: ValidationReport, dataset_id: UUID):
+    """Find data items that were added but never processed by the pipeline."""
+    report.checks_run.append("uncognified_data")
+
+    db_engine = get_relational_engine()
+
+    async with db_engine.get_async_session() as session:
+        data_ids_query = select(DatasetData.data_id).where(DatasetData.dataset_id == dataset_id)
+        data_records = (
+            (await session.execute(select(Data).where(Data.id.in_(data_ids_query)))).scalars().all()
+        )
+
+    total = len(data_records)
+    report.summary["data_items"] = total
+
+    uncognified = 0
+    for record in data_records:
+        status = record.pipeline_status or {}
+        cognify_status = status.get("cognify_pipeline", {})
+        ds_key = str(dataset_id)
+        if ds_key not in cognify_status or "Completed" not in str(cognify_status.get(ds_key, "")):
+            uncognified += 1
+
+    report.summary["uncognified_data_items"] = uncognified
+
+    if uncognified:
+        severity = IssueSeverity.WARNING if uncognified < total else IssueSeverity.ERROR
+        report.add_issue(
+            severity,
+            "uncognified_data",
+            count=uncognified,
+            detail=f"{uncognified}/{total} data item(s) not yet processed by cognify pipeline",
+        )

--- a/cognee/api/v1/validate/models.py
+++ b/cognee/api/v1/validate/models.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ValidationStatus(str, Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+
+
+class IssueSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class ValidationIssue(BaseModel):
+    severity: IssueSeverity
+    type: str
+    count: int = 0
+    detail: str = ""
+
+
+class ValidationReport(BaseModel):
+    status: ValidationStatus = ValidationStatus.HEALTHY
+    dataset: str = ""
+    issues: List[ValidationIssue] = Field(default_factory=list)
+    summary: Dict[str, Any] = Field(default_factory=dict)
+    checks_run: List[str] = Field(default_factory=list)
+
+    def add_issue(
+        self,
+        severity: IssueSeverity,
+        issue_type: str,
+        count: int = 0,
+        detail: str = "",
+    ):
+        self.issues.append(
+            ValidationIssue(severity=severity, type=issue_type, count=count, detail=detail)
+        )
+        if severity == IssueSeverity.ERROR:
+            self.status = ValidationStatus.UNHEALTHY
+        elif severity == IssueSeverity.WARNING and self.status == ValidationStatus.HEALTHY:
+            self.status = ValidationStatus.DEGRADED

--- a/cognee/api/v1/validate/routers/__init__.py
+++ b/cognee/api/v1/validate/routers/__init__.py
@@ -1,0 +1,1 @@
+from .get_validate_router import get_validate_router

--- a/cognee/api/v1/validate/routers/get_validate_router.py
+++ b/cognee/api/v1/validate/routers/get_validate_router.py
@@ -1,0 +1,66 @@
+from uuid import UUID
+from typing import Optional
+from pydantic import ConfigDict, Field
+from fastapi import Depends, APIRouter
+from fastapi.responses import JSONResponse
+
+from cognee.api.DTO import InDTO
+from cognee.modules.users.models import User
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("validate_router")
+
+
+class ValidatePayloadDTO(InDTO):
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"dataset": "main_dataset"}]},
+    )
+
+    dataset: Optional[str] = Field(
+        default="main_dataset",
+        examples=["main_dataset"],
+        description="Dataset name to validate.",
+    )
+    dataset_id: Optional[UUID] = Field(
+        default=None,
+        examples=[""],
+        description="Dataset UUID, alternative to `dataset`.",
+    )
+
+
+def get_validate_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.post("")
+    async def validate_endpoint(
+        payload: ValidatePayloadDTO, user: User = Depends(get_authenticated_user)
+    ):
+        """Validate knowledge graph integrity for a dataset.
+
+        Cross-checks graph, vector, and relational stores to surface
+        inconsistencies like unembedded nodes, dangling edges, or
+        uncognified data items.
+
+        Returns a ValidationReport with status, issues list, and summary.
+        """
+        from cognee.api.v1.validate import validate
+
+        dataset_ref = payload.dataset_id or payload.dataset or "main_dataset"
+
+        try:
+            report = await validate(dataset=dataset_ref, user=user)
+            return report.model_dump()
+        except ValueError as exc:
+            return JSONResponse(
+                status_code=422,
+                content={"error": str(exc)},
+            )
+        except Exception as error:
+            logger.error("Validate endpoint error: %s", error, exc_info=True)
+            return JSONResponse(
+                status_code=500,
+                content={"error": "Validation failed due to an internal error."},
+            )
+
+    return router

--- a/cognee/api/v1/validate/validate.py
+++ b/cognee/api/v1/validate/validate.py
@@ -1,0 +1,99 @@
+"""Dataset-level knowledge graph integrity validation."""
+
+from typing import Any, Optional, Union
+from uuid import UUID
+
+from cognee.shared.logging_utils import get_logger
+
+from .models import ValidationReport, ValidationStatus
+
+logger = get_logger("validate")
+
+
+async def validate(
+    dataset: Union[str, UUID] = "main_dataset",
+    *,
+    user: Any = None,
+) -> ValidationReport:
+    """Validate the integrity of a dataset's knowledge graph.
+
+    Cross-checks the graph, vector, and relational stores to surface
+    inconsistencies that would otherwise only show up as bad search
+    results.
+
+    Args:
+        dataset: Dataset name or UUID. Requires read permission.
+        user: User context. Resolved to default user when None.
+
+    Returns:
+        ValidationReport with status, issues list, and summary stats.
+
+    Example::
+
+        report = await cognee.validate("my_dataset")
+        print(report.status)
+        for issue in report.issues:
+            print(f"[{issue.severity}] {issue.type}: {issue.detail}")
+    """
+    from cognee.context_global_variables import set_database_global_context_variables
+    from cognee.infrastructure.databases.graph import get_graph_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.modules.engine.operations.setup import setup
+    from cognee.modules.users.methods import get_default_user
+
+    from .checks import (
+        check_dangling_edges,
+        check_graph_vector_sync,
+        check_isolated_nodes,
+        check_uncognified_data,
+    )
+
+    await setup()
+
+    if user is None:
+        user = await get_default_user()
+
+    dataset_id = await _resolve_dataset_id(dataset, user)
+
+    report = ValidationReport(dataset=str(dataset))
+
+    async with set_database_global_context_variables(dataset_id, user.id):
+        graph_engine = await get_graph_engine()
+        vector_engine = get_vector_engine()
+
+        is_empty = await graph_engine.is_empty()
+        if is_empty:
+            report.summary["graph_nodes"] = 0
+            report.summary["graph_edges"] = 0
+            # Still check for uncognified data — graph being empty might be the problem
+            await check_uncognified_data(report, dataset_id)
+            return report
+
+        await check_graph_vector_sync(report, graph_engine, vector_engine)
+        await check_dangling_edges(report, graph_engine)
+        await check_isolated_nodes(report, graph_engine)
+        await check_uncognified_data(report, dataset_id)
+
+    logger.info(
+        "validate: dataset=%s status=%s issues=%d",
+        dataset,
+        report.status,
+        len(report.issues),
+    )
+
+    return report
+
+
+async def _resolve_dataset_id(dataset_ref: Union[str, UUID], user) -> UUID:
+    if isinstance(dataset_ref, UUID):
+        from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+
+        ds = await get_authorized_dataset(user, dataset_ref, "read")
+        if not ds:
+            raise ValueError(f"Dataset {dataset_ref} not found or not accessible.")
+        return ds.id
+
+    from cognee.modules.data.methods import get_authorized_dataset_by_name
+
+    ds = await get_authorized_dataset_by_name(dataset_ref, user, "read")
+    return ds.id

--- a/cognee/tests/unit/api/test_validate.py
+++ b/cognee/tests/unit/api/test_validate.py
@@ -1,0 +1,228 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.api.v1.validate.models import (
+    IssueSeverity,
+    ValidationReport,
+    ValidationStatus,
+)
+from cognee.api.v1.validate.checks import (
+    check_dangling_edges,
+    check_graph_vector_sync,
+    check_isolated_nodes,
+    check_uncognified_data,
+)
+
+
+# ── Model tests ──
+
+
+def test_report_starts_healthy():
+    report = ValidationReport(dataset="test")
+    assert report.status == ValidationStatus.HEALTHY
+    assert report.issues == []
+
+
+def test_warning_degrades_to_degraded():
+    report = ValidationReport()
+    report.add_issue(IssueSeverity.WARNING, "test_warning", detail="something")
+    assert report.status == ValidationStatus.DEGRADED
+
+
+def test_error_sets_unhealthy():
+    report = ValidationReport()
+    report.add_issue(IssueSeverity.ERROR, "test_error", count=1)
+    assert report.status == ValidationStatus.UNHEALTHY
+
+
+def test_error_overrides_degraded():
+    report = ValidationReport()
+    report.add_issue(IssueSeverity.WARNING, "w1")
+    report.add_issue(IssueSeverity.ERROR, "e1")
+    assert report.status == ValidationStatus.UNHEALTHY
+
+
+def test_info_keeps_healthy():
+    report = ValidationReport()
+    report.add_issue(IssueSeverity.INFO, "informational", count=5)
+    assert report.status == ValidationStatus.HEALTHY
+
+
+# ── Check tests ──
+
+
+@pytest.mark.asyncio
+async def test_dangling_edges_detected():
+    nodes = [("n1", {"type": "Entity"}), ("n2", {"type": "Entity"})]
+    edges = [
+        ("n1", "n2", "relates_to", {}),
+        ("n1", "n999", "points_to", {}),  # n999 doesn't exist
+    ]
+    graph_engine = AsyncMock()
+    graph_engine.get_graph_data = AsyncMock(return_value=(nodes, edges))
+
+    report = ValidationReport()
+    await check_dangling_edges(report, graph_engine)
+
+    assert report.status == ValidationStatus.UNHEALTHY
+    assert len(report.issues) == 1
+    assert report.issues[0].type == "dangling_edges"
+    assert report.issues[0].count == 1
+
+
+@pytest.mark.asyncio
+async def test_no_dangling_edges():
+    nodes = [("n1", {"type": "Entity"}), ("n2", {"type": "Entity"})]
+    edges = [("n1", "n2", "relates_to", {})]
+    graph_engine = AsyncMock()
+    graph_engine.get_graph_data = AsyncMock(return_value=(nodes, edges))
+
+    report = ValidationReport()
+    await check_dangling_edges(report, graph_engine)
+
+    assert report.status == ValidationStatus.HEALTHY
+    assert len(report.issues) == 0
+
+
+@pytest.mark.asyncio
+async def test_isolated_nodes_detected():
+    nodes = [
+        ("n1", {"type": "Entity"}),
+        ("n2", {"type": "Entity"}),
+        ("n3", {"type": "Entity"}),
+    ]
+    edges = [("n1", "n2", "relates_to", {})]  # n3 is isolated
+    graph_engine = AsyncMock()
+    graph_engine.get_graph_data = AsyncMock(return_value=(nodes, edges))
+
+    report = ValidationReport()
+    await check_isolated_nodes(report, graph_engine)
+
+    assert report.issues[0].type == "isolated_nodes"
+    assert report.issues[0].count == 1
+
+
+@pytest.mark.asyncio
+async def test_structural_types_excluded_from_isolation():
+    nodes = [
+        ("n1", {"type": "Entity"}),
+        ("n2", {"type": "Entity"}),
+        ("chunk1", {"type": "DocumentChunk"}),  # structural, should not be flagged
+    ]
+    edges = [("n1", "n2", "relates_to", {})]
+    graph_engine = AsyncMock()
+    graph_engine.get_graph_data = AsyncMock(return_value=(nodes, edges))
+
+    report = ValidationReport()
+    await check_isolated_nodes(report, graph_engine)
+
+    assert len(report.issues) == 0
+
+
+@pytest.mark.asyncio
+async def test_graph_vector_sync_detects_orphaned_vectors():
+    nodes = [("n1", {"type": "Entity"})]
+    edges = []
+    graph_engine = AsyncMock()
+    graph_engine.get_graph_data = AsyncMock(return_value=(nodes, edges))
+
+    orphan_result = MagicMock()
+    orphan_result.id = "n_orphan"
+
+    real_result = MagicMock()
+    real_result.id = "n1"
+
+    vector_engine = AsyncMock()
+    vector_engine.has_collection = AsyncMock(side_effect=lambda name: name == "Entity_name")
+    vector_engine.retrieve = AsyncMock(return_value=[real_result, orphan_result])
+
+    report = ValidationReport()
+    await check_graph_vector_sync(report, graph_engine, vector_engine)
+
+    orphan_issues = [i for i in report.issues if i.type == "orphaned_vector_entries"]
+    assert len(orphan_issues) == 1
+    assert orphan_issues[0].count == 1
+
+
+@pytest.mark.asyncio
+async def test_uncognified_data_detected():
+    dataset_id = uuid4()
+
+    data_record = SimpleNamespace(
+        id=uuid4(),
+        pipeline_status={"add_pipeline": {str(dataset_id): "Completed"}},
+    )
+
+    with patch("cognee.api.v1.validate.checks.get_relational_engine") as mock_engine:
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [data_record]
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_engine.return_value.get_async_session.return_value = ctx
+
+        report = ValidationReport()
+        await check_uncognified_data(report, dataset_id)
+
+    assert report.summary["data_items"] == 1
+    assert report.summary["uncognified_data_items"] == 1
+    assert report.issues[0].type == "uncognified_data"
+
+
+@pytest.mark.asyncio
+async def test_uncognified_data_all_processed():
+    dataset_id = uuid4()
+    ds_str = str(dataset_id)
+
+    data_record = SimpleNamespace(
+        id=uuid4(),
+        pipeline_status={"cognify_pipeline": {ds_str: "Completed"}},
+    )
+
+    with patch("cognee.api.v1.validate.checks.get_relational_engine") as mock_engine:
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [data_record]
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_engine.return_value.get_async_session.return_value = ctx
+
+        report = ValidationReport()
+        await check_uncognified_data(report, dataset_id)
+
+    assert report.summary["uncognified_data_items"] == 0
+    assert len(report.issues) == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_graph_still_checks_uncognified():
+    """An empty graph should still report uncognified data items."""
+    report = ValidationReport()
+    report.summary["graph_nodes"] = 0
+
+    dataset_id = uuid4()
+    data_record = SimpleNamespace(id=uuid4(), pipeline_status={})
+
+    with patch("cognee.api.v1.validate.checks.get_relational_engine") as mock_engine:
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [data_record]
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_engine.return_value.get_async_session.return_value = ctx
+
+        await check_uncognified_data(report, dataset_id)
+
+    assert report.issues[0].type == "uncognified_data"


### PR DESCRIPTION
## Description
After running `cognify()`, there is currently no way to check whether the resulting knowledge graph is actually consistent. Nodes can end up in the graph without corresponding vector entries (making them invisible to semantic search), edges can point to deleted nodes and data items can sit unprocessed without any indication to the user.

This PR adds `cognee.validate(dataset)` which is a data-layer integrity checker that cross-checks the graph, vector, and relational stores and returns a structured report.

**What it checks:**
- **Graph↔Vector sync** - flags nodes with embeddable fields that have no vector entry, and vector entries with no matching graph node
- **Dangling edges** - edges whose source or target node doesn't exist
- **Isolated nodes** - nodes with zero edges, excluding structural types like DocumentChunk and NodeSet
- **Uncognified data** - data items added to the dataset but never processed by the cognify pipeline

**What it returns:**
```python
report = await cognee.validate("my_dataset")
# report.status: "healthy" | "degraded" | "unhealthy"
# report.issues: list of ValidationIssue(severity, type, count, detail)
# report.summary: {"graph_nodes": 234, "graph_edges": 891, "vector_entries": 456, ...}
```

**How it's structured**

- `cognee/api/v1/validate/models.py` — `ValidationReport`, `ValidationIssue` pydantic models
- `cognee/api/v1/validate/checks.py` — each check is a standalone async function
- `cognee/api/v1/validate/validate.py` — main entry point, wires up engines and runs checks
- `cognee/api/v1/validate/routers/` — REST endpoint at `POST /api/v1/validate`
- Exported as `cognee.validate()` and `cognee.ValidationReport` from the top-level package

Uses only the existing `GraphDBInterface` and `VectorDBInterface` methods, so it works with all supported backends.

Closes #3345 

## Acceptance Criteria
- `cognee.validate("dataset_name")` returns a `ValidationReport` with status, issues and summary
- Dangling edges are flagged as errors, unembedded nodes and orphaned vectors as warnings, isolated nodes as info
- Uncognified data items are detected by checking `pipeline_status` in the relational DB
- All checks are independently testable. 13 unit tests covering models and each check function
- REST endpoint at `POST /api/v1/validate` returns the same report as JSON
- Works with all graph/vector backends (uses adapter interfaces only)
- This is a purely additive change and does not affect existing behavior 

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
The screenshot shows all the local tests passing.
<img width="1058" height="139" alt="image" src="https://github.com/user-attachments/assets/ca0a3790-db96-4aa0-8719-6a05383a6199" />


## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.