### PR TITLE
fix(infra): dispose engine pool after dropping tables on

### DIFF
--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -640,6 +640,16 @@ class SQLAlchemyAdapter:
                             await connection.execute(drop_table_query)
                         metadata.clear()
 
+                # Dispose the engine and clear the cache so the next
+                # get_relational_engine() creates a fresh pool. Without this,
+                # existing connections retain cached asyncpg prepared statements
+                # that become invalid after the schema is recreated by setup().
+                await self.engine.dispose(close=True)
+                from cognee.infrastructure.databases.relational.create_relational_engine import (
+                    create_relational_engine,
+                )
+                create_relational_engine.cache_clear()
+
         except Exception as e:
             logger.error(f"Error deleting database: {e}")
             raise e


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
Fixes #3347
## Description
Fix stale asyncpg prepared statement cache after prune + setup cycle on PostgreSQL.

When `prune_system(metadata=True)` is called, the PostgreSQL branch of `SQLAlchemyAdapter.delete_database()` drops all tables but neither disposes the engine nor clears the LRU cache. After `setup()` recreates the schema on the same engine pool, subsequent queries hit `InvalidCachedStatementError` because asyncpg's cached prepared statements reference the old schema.

The fix adds `engine.dispose(close=True)` and `create_relational_engine.cache_clear()` to the PostgreSQL branch, mirroring what the SQLite branch already does.

## Acceptance Criteria
- [x] `delete_database()` disposes the engine pool after dropping tables for PostgreSQL
- [x] `delete_database()` clears the `create_relational_engine` LRU cache for PostgreSQL
- [x] Tests pass for both PostgreSQL and SQLite paths
- [x] No regression in the existing SQLite path

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Unit test results for `test_SqlAlchemyAdapter.py`:
```
$ uv run pytest cognee/tests/unit/infrastructure/databases/relational/test_SqlAlchemyAdapter.py -v
...
```

<img width="546" height="290" alt="image" src="https://github.com/user-attachments/assets/fbef325e-282b-4c72-8028-ab074132b1ad" />

Integration test (PostgreSQL): `cognee/tests/test_relational_db_migration.py` via `test_migration_postgres()` or `cognee/tests/test_delete_by_id.py` — both exercise the prune → setup → query cycle that previously failed with `InvalidCachedStatementError`.

<img width="551" height="135" alt="image" src="https://github.com/user-attachments/assets/6caec32f-ad14-49a1-904e-9ba96510dea9" />


## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
