### PR TITLE
fix(config): validate cache_root_directory as absolute path

### DIFF
--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -33,6 +33,7 @@ class BaseConfig(BaseSettings):
         self.data_root_directory = ensure_absolute_path(self.data_root_directory)
         self.system_root_directory = ensure_absolute_path(self.system_root_directory)
         self.logs_root_directory = ensure_absolute_path(self.logs_root_directory)
+        self.cache_root_directory = ensure_absolute_path(self.cache_root_directory)
 
         # Set monitoring tool based on available keys
         if self.langfuse_public_key and self.langfuse_secret_key:


### PR DESCRIPTION
I noticed in base_config.py that cache_root_directory was accidentally missing the ensure_absolute_path() check that all the other root directories (data_root_directory, system_root_directory, etc.) receive.

I just added that one missing line so it behaves consistently with the rest of the app and avoids path resolution issues.

Fixes #3343