### PR TITLE
fix(serve): health-check first when reusing saved cloud credentials

### DIFF
--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -31,6 +31,11 @@ class CloudClient:
     # can legitimately exceed any fixed total; per-read inactivity stays
     # bounded instead. Applied per-request, only to archive uploads.
     UPLOAD_TIMEOUT = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=300)
+    # Health checks should fail fast so that startup can fall through to
+    # token refresh or device-code login. 5s total is plenty for a healthy
+    # service; any slower means Auth0/management is degraded, which is
+    # exactly the case we want to detect quickly. See issue #3249.
+    HEALTH_CHECK_TIMEOUT = aiohttp.ClientTimeout(total=5, sock_connect=2)
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
@@ -45,10 +50,27 @@ class CloudClient:
             await self._session.close()
             self._session = None
 
-    async def _health_check(self) -> bool:
-        """Verify the remote instance is reachable."""
+    async def _health_check(
+        self,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+    ) -> bool:
+        """Verify the remote instance is reachable.
+
+        Args:
+            timeout: Optional aiohttp.ClientTimeout to apply. Defaults to
+                ``None`` (aiohttp's session default — inherits
+                ``DEFAULT_TIMEOUT`` of 5 min total / 30s connect) to
+                preserve prior behaviour for existing callers. Pass
+                ``self.HEALTH_CHECK_TIMEOUT`` (5s/2s) explicitly when
+                checking at startup, so a degraded Auth0/management
+                backend surfaces fast and the caller can fall through to
+                token refresh or device-code login. See issue #3249.
+        """
         try:
             session = await self._get_session()
+            if timeout is not None:
+                async with session.get(f"{self.service_url}/health", timeout=timeout) as resp:
+                    return resp.status == 200
             async with session.get(f"{self.service_url}/health") as resp:
                 return resp.status == 200
         except Exception:

--- a/cognee/api/v1/serve/serve.py
+++ b/cognee/api/v1/serve/serve.py
@@ -134,9 +134,37 @@ async def _serve_cloud(
     mgmt_url = mgmt_url.rstrip("/")
 
     # Step 1: Check for saved credentials
+
     creds = load_credentials()
 
     if creds and creds.service_url and creds.api_key:
+        # Fast path: try the cached (service_url, api_key) first, regardless of
+        # access_token state. The access_token is only needed for Auth0/management
+        # calls (tenant discovery, key rotation, refresh), not for actually talking
+        # to the cognee service. If the service is reachable with the saved key we
+        # can connect immediately, even when Auth0/management is slow or down.
+        # See: #3249.
+        try:
+            client = CloudClient(creds.service_url, creds.api_key)
+            # Fast path uses a short, dedicated timeout so a degraded
+            # Auth0/management backend doesn't stall SDK startup. The
+            # underlying _health_check returns False on any exception
+            # (timeout, connection refused, non-2xx), so we simply fall
+            # through to the existing token-check / refresh path below.
+            if await client._health_check(timeout=client.HEALTH_CHECK_TIMEOUT):
+                logger.info("Using saved credentials for %s (health check)", creds.email)
+                set_remote_client(client)
+                print(f"  Connected to Cognee Cloud at {creds.service_url}")
+                return client
+            else:
+                logger.info("Saved service URL unreachable, falling through to token check")
+                await client.close()
+        except Exception as e:
+            logger.debug("Health check on saved creds failed: %s", e)
+
+        # Token check: only needed if we are about to call Auth0/management. This
+        # path is unchanged from before — kept as the original behavior so any
+        # security expectations around token rotation still apply.
         if not is_token_expired(creds):
             logger.info("Using saved credentials for %s", creds.email)
             client = CloudClient(creds.service_url, creds.api_key)

--- a/cognee/tests/unit/api/test_cloud_client_health_check_timeout.py
+++ b/cognee/tests/unit/api/test_cloud_client_health_check_timeout.py
@@ -1,0 +1,118 @@
+"""CloudClient._health_check accepts an explicit timeout, used by
+``_serve_cloud`` to fail fast when Auth0 / management is degraded.
+
+Before this change, ``_health_check`` was a single line that always used
+the session's default 5-minute ``ClientTimeout``. That meant a single
+``/health`` call at SDK startup could block up to 30 seconds when the
+service was unreachable (sock_connect=30s) — directly causing the
+"``cognee.serve()`` hangs on Auth0 outage" symptom in issue #3249.
+
+This test exercises the new ``timeout`` parameter and the new
+``HEALTH_CHECK_TIMEOUT`` class attribute, and locks in the default
+behaviour for callers that don't pass an explicit timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import aiohttp
+
+from cognee.api.v1.serve.cloud_client import CloudClient
+
+
+class _FakeResponse:
+    """Minimal aiohttp.ClientResponse stand-in for a /health call."""
+
+    def __init__(self, status: int = 200):
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Captures the ``timeout`` kwarg each call was made with."""
+
+    def __init__(self, status: int = 200):
+        self.calls: list[dict] = []
+        self._status = status
+
+    def get(self, url, **kwargs):
+        self.calls.append({"url": url, "kwargs": kwargs})
+        return _FakeResponse(self._status)
+
+    async def close(self):
+        pass
+
+
+def test_health_check_default_uses_class_timeout_when_not_specified():
+    client = CloudClient(service_url="https://example.test", api_key="k")
+    fake = _FakeSession(status=200)
+
+    async def run():
+        with patch.object(client, "_get_session", return_value=fake):
+            return await client._health_check()
+
+    result = asyncio.run(run())
+
+    assert result is True
+    assert len(fake.calls) == 1
+    # No explicit timeout → no `timeout` kwarg → preserves prior
+    # behaviour (aiohttp's session default kicks in).
+    assert "timeout" not in fake.calls[0]["kwargs"]
+    assert fake.calls[0]["url"] == "https://example.test/health"
+
+
+def test_health_check_with_explicit_timeout_uses_health_check_class_default():
+    client = CloudClient(service_url="https://example.test", api_key="k")
+    fake = _FakeSession(status=200)
+
+    async def run():
+        with patch.object(client, "_get_session", return_value=fake):
+            # Mirrors the call site in _serve_cloud.
+            return await client._health_check(timeout=client.HEALTH_CHECK_TIMEOUT)
+
+    result = asyncio.run(run())
+
+    assert result is True
+    passed = fake.calls[0]["kwargs"]["timeout"]
+    # 5s total / 2s sock_connect — short enough to surface Auth0/management
+    # outages quickly without flaking on a healthy service.
+    assert passed.total == 5
+    assert passed.sock_connect == 2
+
+
+def test_health_check_returns_false_on_non_2xx_status():
+    client = CloudClient(service_url="https://example.test", api_key="k")
+    fake = _FakeSession(status=500)
+
+    async def run():
+        with patch.object(client, "_get_session", return_value=fake):
+            return await client._health_check(timeout=client.HEALTH_CHECK_TIMEOUT)
+
+    assert asyncio.run(run()) is False
+
+
+def test_health_check_returns_false_when_session_get_raises():
+    """A network error (timeout, connection refused) must not propagate — the
+    fast-path caller relies on False to fall through to token refresh."""
+
+    client = CloudClient(service_url="https://example.test", api_key="k")
+
+    class _BrokenSession:
+        def get(self, *_args, **_kwargs):
+            raise aiohttp.ClientError("connection refused")
+
+        async def close(self):
+            pass
+
+    async def run():
+        with patch.object(client, "_get_session", return_value=_BrokenSession()):
+            return await client._health_check(timeout=client.HEALTH_CHECK_TIMEOUT)
+
+    assert asyncio.run(run()) is False

--- a/cognee/tests/unit/api/test_serve_cloud_health_check_first.py
+++ b/cognee/tests/unit/api/test_serve_cloud_health_check_first.py
@@ -1,0 +1,160 @@
+"""``_serve_cloud`` should fast-path on a saved credential whose
+``service_url`` is reachable, even if the cached ``access_token`` is
+already expired.
+
+Before this change, ``_serve_cloud`` checked ``is_token_expired(creds)``
+first and would unconditionally fall through to ``refresh_access_token``
+(or device-code login) whenever the local clock said the token had
+expired — even if the saved ``(service_url, api_key)`` was still
+perfectly able to talk to the cognee service. Auth0 / management being
+slow or temporarily down would then stall SDK startup.
+
+These tests exercise the *actual* ``_serve_cloud`` with its
+side-effects mocked at the import boundary, so we are validating the
+real control flow rather than a hand-rolled stub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cognee.api.v1.serve import credentials as creds_mod
+from cognee.api.v1.serve import serve as serve_mod
+from cognee.api.v1.serve import state as serve_state
+from cognee.api.v1.serve.credentials import CloudCredentials
+from cognee.api.v1.serve.serve import _serve_cloud
+
+
+def _build_saved_creds(*, expired: bool) -> CloudCredentials:
+    """A credential file that says we have a saved tenant. The
+    ``expires_at`` field is set in the past when ``expired=True`` so
+    ``is_token_expired`` returns True without us touching the wall
+    clock.
+    """
+    now = time.time()
+    return CloudCredentials(
+        access_token="access-token-123",
+        refresh_token="refresh-token-456",
+        expires_at=now - 3600 if expired else now + 3600,
+        service_url="https://cognee.test",
+        api_key="api-key-789",
+        management_url="https://api.dev.cloud.topoteretes.com",
+        tenant_id="tenant-1",
+        tenant_name="Test Tenant",
+        email="user@test.example",
+    )
+
+
+def _patch_all(*, refresh_mock, health_return: bool, creds):
+    """Return a context-manager stack that mocks every external call
+    ``_serve_cloud`` would make.
+
+    ``_serve_cloud`` does ``from X import Y`` *inside* its body. Each
+    call re-evaluates the import — so patching ``X.Y`` (the source
+    module) is the right target. Patching ``serve_mod.Y`` does NOT
+    work because ``serve_mod`` has no such attribute (Python only
+    binds the lazy import into the function's local namespace, not the
+    module's globals). Verified empirically with a stand-alone repro.
+    """
+    from cognee.api.v1.serve import device_auth as device_auth_mod
+
+    fake_client = MagicMock(name="CloudClient")
+    fake_client._health_check = AsyncMock(return_value=health_return)
+    fake_client.close = AsyncMock(return_value=None)
+    fake_client.HEALTH_CHECK_TIMEOUT = MagicMock(name="HEALTH_CHECK_TIMEOUT")
+
+    # Always mock device_code_login so the function can never reach
+    # the Auth0 device-code flow during these tests. Reaching it
+    # would mean the fast path *and* the refresh path both failed,
+    # which is not what we are testing here.
+    device_code_mock = AsyncMock(side_effect=AssertionError("device-code should not be reached"))
+
+    return [
+        patch.object(creds_mod, "load_credentials", return_value=creds),
+        # CloudClient is imported as `from .cloud_client import CloudClient`,
+        # i.e. `cognee.api.v1.serve.cloud_client.CloudClient` — patch
+        # that source module so the lazy import resolves to the mock.
+        patch("cognee.api.v1.serve.cloud_client.CloudClient", return_value=fake_client),
+        # refresh_access_token & device_code_login both come from
+        # cognee.api.v1.serve.device_auth.
+        patch.object(device_auth_mod, "refresh_access_token", new=refresh_mock),
+        patch.object(device_auth_mod, "device_code_login", new=device_code_mock),
+    ], fake_client
+
+
+def test_fast_path_uses_saved_creds_when_token_expired_and_health_ok():
+    """Health check passes → use saved creds → skip refresh entirely.
+
+    This is the core fix for #3249: Auth0/management availability
+    must not block SDK startup if the cognee service is reachable
+    with the saved key.
+    """
+    creds = _build_saved_creds(expired=True)
+    refresh_mock = AsyncMock(name="refresh_access_token")
+
+    patches, fake_client = _patch_all(refresh_mock=refresh_mock, health_return=True, creds=creds)
+
+    async def run():
+        with patches[0], patches[1], patches[2], patches[3]:
+            return await _serve_cloud()
+
+    result = asyncio.run(run())
+
+    # The fast-path client must be the one returned, and it must have
+    # been set as the remote singleton.
+    assert result is fake_client
+    assert serve_state.get_remote_client() is fake_client
+    # Refresh must not have been touched — this is the whole point of #3249.
+    refresh_mock.assert_not_called()
+    # And the health check must have been called with the short timeout.
+    fake_client._health_check.assert_awaited_once_with(timeout=fake_client.HEALTH_CHECK_TIMEOUT)
+
+
+def test_fast_path_falls_through_to_refresh_when_health_check_fails():
+    """When health check fails AND token is expired, the original
+    refresh path is still invoked (regression guard — we must not
+    break callers who relied on the previous behaviour).
+    """
+    creds = _build_saved_creds(expired=True)
+    refresh_mock = AsyncMock(
+        name="refresh_access_token",
+        return_value=MagicMock(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            id_token=None,
+            token_type="Bearer",
+            expires_in=3600,
+        ),
+    )
+
+    patches, fake_client = _patch_all(refresh_mock=refresh_mock, health_return=False, creds=creds)
+
+    async def run():
+        # All four patches go in together; if the implementation falls
+        # through past the refresh path, device_code_login will raise
+        # AssertionError (which we catch below and turn into a
+        # success signal — we only care that refresh was called and
+        # the unreachable client was closed).
+        with patches[0], patches[1], patches[2], patches[3]:
+            return await _serve_cloud()
+
+    try:
+        asyncio.run(run())
+    except AssertionError as e:
+        assert "device-code should not be reached" in str(e)
+        # device_code was reached only AFTER refresh — that is the
+        # correct behaviour. If it had been reached without refresh,
+        # the assert would still fire but the next two assertions
+        # would fail.
+
+    # Regression guard: when the fast-path health check fails, the
+    # original refresh path must still be invoked.
+    refresh_mock.assert_awaited_once()
+    # The unreachable fast-path client is closed once before falling
+    # through to the refresh path (which constructs its own client
+    # and would also close it — but since we patched CloudClient to
+    # return the same fake, the "second" close counts the refresh
+    # path's close). We just require at least one close.
+    assert fake_client.close.await_count >= 1


### PR DESCRIPTION
Fixes #3249.

## Problem

`cognee.serve()` in cloud mode currently gates on `is_token_expired(creds)` *before* trying to reach the cognee service. When the saved `(service_url, api_key)` is perfectly able to talk to the service, a slow or temporarily-down Auth0 / Management backend still blocks SDK startup — because we never even try the cheap local API-key path.

Compounding the issue: the existing `CloudClient._health_check()` inherits the session's 5-minute total / 30-second connect timeout. A single health probe at startup could stall for half a minute on a degraded network before falling through to token refresh.

## Fix

Two minimal, additive changes:

1. **`CloudClient._health_check()` accepts an optional `timeout`**, defaulting to `None` (preserves prior behaviour for every existing caller). A new class attribute `HEALTH_CHECK_TIMEOUT = ClientTimeout(total=5, sock_connect=2)` is defined for the fast path.

2. **`_serve_cloud` adds a fast path**: before any token check, attempt a short-timeout health probe against the cached `(service_url, api_key)`. On success, set the remote client and return — no Auth0 round-trip. On failure or exception, fall through to the existing token-expired / refresh / device-code path *unchanged*.

This is strictly a fast-path addition. Every existing behaviour is preserved as the fallback.

## Tests

- `test_cloud_client_health_check_timeout.py` — locks in the default behaviour of `_health_check` (no explicit timeout → no `timeout` kwarg) and the new fast-path timeout (5s / 2s), plus non-2xx and connection-failure handling.
- `test_serve_cloud_health_check_first.py` — drives the actual `_serve_cloud` with mocked external calls. Asserts:
  - **token expired + health OK → uses saved creds, refresh NOT called** (the new behaviour).
  - **token expired + health fails → still falls through to refresh** (regression guard for the original path).

All 9 tests pass (3 pre-existing + 6 new). `ruff check` and `ruff format --check` both clean.

## Out-of-scope

The issue mentions a follow-up "Add short timeout/retry strategy for _health_check() to reduce flakiness" — I've added the short timeout, but not a retry strategy. A single 5s attempt should be plenty for the common case; if maintainers want retries, that should be a follow-up so we can discuss policy (retry budget, exponential vs fixed backoff, etc.) on its own.

## Notes on test patching

`cognee/api/v1/serve/serve.py:111-129` lazy-imports its dependencies (`from X import Y`) inside `_serve_cloud`. I verified empirically that `patch.object(creds_mod, "load_credentials", ...)` works correctly because each call re-evaluates the import — patching the *source module* is the right target, not the enclosing `serve_mod`. There's a long docstring in the test explaining this for future contributors.