### PR TITLE
Feature/backend db matrix flow

### DIFF
--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -33,6 +33,7 @@ class BaseConfig(BaseSettings):
         self.data_root_directory = ensure_absolute_path(self.data_root_directory)
         self.system_root_directory = ensure_absolute_path(self.system_root_directory)
         self.logs_root_directory = ensure_absolute_path(self.logs_root_directory)
+        self.cache_root_directory = ensure_absolute_path(self.cache_root_directory)
 
         # Set monitoring tool based on available keys
         if self.langfuse_public_key and self.langfuse_secret_key:

--- a/cognee/tests/deployment/conftest.py
+++ b/cognee/tests/deployment/conftest.py
@@ -1,0 +1,444 @@
+import os
+import time
+import json
+import socket
+import pytest
+import httpx
+import asyncio
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "deployment: Mark test as deployment E2E test")
+
+
+def is_docker_available():
+    try:
+        result = subprocess.run(
+            ["docker", "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+# Resolve references helper
+def resolve_ref(ref, root_schema):
+    parts = ref.split("/")
+    current = root_schema
+    for part in parts:
+        if part == "#":
+            continue
+        if part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+# Schema generator helper
+def generate_mock_from_schema(schema, root_schema=None):
+    if root_schema is None:
+        root_schema = schema
+
+    if "$ref" in schema:
+        resolved = resolve_ref(schema["$ref"], root_schema)
+        if resolved:
+            return generate_mock_from_schema(resolved, root_schema)
+        return None
+
+    if "type" not in schema:
+        if "anyOf" in schema:
+            for sub in schema["anyOf"]:
+                if sub.get("type") != "null":
+                    return generate_mock_from_schema(sub, root_schema)
+        return None
+
+    t = schema["type"]
+    if isinstance(t, list):
+        types = [x for x in t if x != "null"]
+        t = types[0] if types else "null"
+
+    if "enum" in schema:
+        return schema["enum"][0]
+
+    if t == "string":
+        return "mock_value"
+    elif t in ("integer", "number"):
+        return 1
+    elif t == "boolean":
+        return True
+    elif t == "array":
+        item_schema = schema.get("items", {})
+        val = generate_mock_from_schema(item_schema, root_schema)
+        return [val] if val is not None else []
+    elif t == "object":
+        properties = schema.get("properties", {})
+        res = {}
+        for prop_name, prop_schema in properties.items():
+            res[prop_name] = generate_mock_from_schema(prop_schema, root_schema)
+        return res
+    return None
+
+
+class MockOpenAIHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"status": "healthy"}).encode("utf-8"))
+
+    def do_POST(self):
+        content_length = int(self.headers["Content-Length"])
+        post_data = self.rfile.read(content_length)
+        req_body = json.loads(post_data.decode("utf-8"))
+
+        path = self.path
+        if path.endswith("/chat/completions"):
+            arguments = "{}"
+            if "tools" in req_body:
+                tool = req_body["tools"][0]
+                tool_name = tool["function"]["name"]
+                parameters_schema = tool["function"]["parameters"]
+                mock_data = generate_mock_from_schema(parameters_schema)
+                arguments = json.dumps(mock_data)
+
+                resp = {
+                    "id": "chatcmpl-mock",
+                    "object": "chat.completion",
+                    "created": 123456789,
+                    "model": req_body.get("model", "mock-model"),
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "call_mock",
+                                        "type": "function",
+                                        "function": {"name": tool_name, "arguments": arguments},
+                                    }
+                                ],
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+                }
+            else:
+                resp_content = "This is a mock response from the mock OpenAI API."
+
+                response_format = req_body.get("response_format")
+                if response_format and response_format.get("type") == "json_object":
+                    schema = response_format.get("json_schema", {}).get("schema")
+                    if schema:
+                        resp_content = json.dumps(generate_mock_from_schema(schema))
+                    else:
+                        resp_content = json.dumps(
+                            {"summary": "Mock summary", "key_features": ["f1"]}
+                        )
+
+                resp = {
+                    "id": "chatcmpl-mock",
+                    "object": "chat.completion",
+                    "created": 123456789,
+                    "model": req_body.get("model", "mock-model"),
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": resp_content},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+                }
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(resp).encode("utf-8"))
+
+        elif path.endswith("/embeddings"):
+            input_data = req_body.get("input", [])
+            if isinstance(input_data, str):
+                input_data = [input_data]
+
+            dimensions = 1536
+            data_list = []
+            for idx, item in enumerate(input_data):
+                data_list.append(
+                    {"object": "embedding", "index": idx, "embedding": [0.1] * dimensions}
+                )
+
+            resp = {
+                "object": "list",
+                "data": data_list,
+                "model": req_body.get("model", "mock-embedding-model"),
+                "usage": {
+                    "prompt_tokens": len(input_data) * 2,
+                    "total_tokens": len(input_data) * 2,
+                },
+            }
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(resp).encode("utf-8"))
+
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def get_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def mock_openai_port():
+    return get_free_port()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_openai_server(mock_openai_port):
+    server = HTTPServer(("0.0.0.0", mock_openai_port), MockOpenAIHandler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+
+    # Wait for mock server to be healthy
+    healthy = False
+    for _ in range(10):
+        try:
+            res = httpx.get(f"http://127.0.0.1:{mock_openai_port}")
+            if res.status_code == 200:
+                healthy = True
+                break
+        except Exception:
+            pass
+        time.sleep(0.5)
+
+    if not healthy:
+        raise RuntimeError("Failed to start mock OpenAI server")
+
+    yield f"http://127.0.0.1:{mock_openai_port}"
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.fixture(scope="session")
+def build_cognee_image():
+    if not is_docker_available():
+        pytest.skip("Docker not available")
+
+    print("\nBuilding Cognee Docker image...")
+    build_process = subprocess.run(
+        ["docker", "compose", "build", "cognee"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if build_process.returncode != 0:
+        print("Docker compose build stdout:")
+        print(build_process.stdout)
+        print("Docker compose build stderr:")
+        print(build_process.stderr)
+        raise RuntimeError("Failed to build Cognee Docker image")
+    print("Cognee Docker image built successfully.")
+
+
+def wait_for_health(url: str, timeout: int = 60) -> bool:
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            response = httpx.get(url)
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("status") == "ready":
+                    return True
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+
+@pytest.fixture
+def running_container(mock_openai_port, build_cognee_image, tmp_path):
+    if not is_docker_available():
+        pytest.skip("Docker not available")
+
+    # We will use this list to store clean up tasks
+    cleanups = []
+
+    def _run(db_stack="sqlite"):
+        test_env = {
+            "LLM_PROVIDER": "openai",
+            "LLM_MODEL": "gpt-3.5-turbo",
+            "LLM_ENDPOINT": f"http://host.docker.internal:{mock_openai_port}/v1",
+            "LLM_API_KEY": "mock-key",
+            "EMBEDDING_PROVIDER": "openai",
+            "EMBEDDING_ENDPOINT": f"http://host.docker.internal:{mock_openai_port}/v1",
+            "EMBEDDING_API_KEY": "mock-key",
+            "MOCK_EMBEDDING": "true",
+            "DB_PROVIDER": "sqlite",
+            "GRAPH_DATABASE_PROVIDER": "ladybug",
+            "VECTOR_DB_PROVIDER": "lancedb",
+        }
+
+        compose_cmd = ["docker", "compose"]
+
+        if db_stack == "postgres":
+            test_env.update(
+                {
+                    "DB_PROVIDER": "postgres",
+                    "DB_HOST": "postgres",
+                    "DB_PORT": "5432",
+                    "DB_NAME": "cognee_db",
+                    "DB_USERNAME": "cognee",
+                    "DB_PASSWORD": "cognee",
+                    "VECTOR_DB_PROVIDER": "pgvector",
+                    "VECTOR_DB_URL": "postgresql+asyncpg://cognee:cognee@postgres:5432/cognee_db",
+                    "GRAPH_DATABASE_PROVIDER": "postgres",
+                }
+            )
+            compose_cmd.extend(["--profile", "postgres"])
+
+        elif db_stack == "neo4j":
+            test_env.update(
+                {
+                    "DB_PROVIDER": "postgres",
+                    "DB_HOST": "postgres",
+                    "DB_PORT": "5432",
+                    "DB_NAME": "cognee_db",
+                    "DB_USERNAME": "cognee",
+                    "DB_PASSWORD": "cognee",
+                    "VECTOR_DB_PROVIDER": "pgvector",
+                    "VECTOR_DB_URL": "postgresql+asyncpg://cognee:cognee@postgres:5432/cognee_db",
+                    "GRAPH_DATABASE_PROVIDER": "neo4j",
+                    "GRAPH_DATABASE_URL": "bolt://neo4j:7687",
+                    "GRAPH_DATABASE_USERNAME": "neo4j",
+                    "GRAPH_DATABASE_PASSWORD": "pleaseletmein",
+                }
+            )
+            compose_cmd.extend(["--profile", "postgres", "--profile", "neo4j"])
+
+        # Write docker-compose.test.yml dynamically
+        yaml_lines = ["services:", "  cognee:", "    environment:"]
+        for k, v in test_env.items():
+            yaml_lines.append(f"      - {k}={v}")
+
+        test_compose_path = tmp_path / "docker-compose.test.yml"
+        test_compose_path.write_text("\n".join(yaml_lines))
+
+        # Start containers
+        cmd = compose_cmd + ["-f", "docker-compose.yml", "-f", str(test_compose_path), "up", "-d"]
+
+        # We need to start the correct services
+        services_to_start = ["cognee"]
+        if db_stack == "postgres":
+            services_to_start.append("postgres")
+        elif db_stack == "neo4j":
+            services_to_start.extend(["postgres", "neo4j"])
+
+        cmd.extend(services_to_start)
+
+        # Register cleanup action
+        def cleanup_action():
+            print(f"\nTearing down containers for {db_stack}...")
+            down_cmd = compose_cmd + [
+                "-f",
+                "docker-compose.yml",
+                "-f",
+                str(test_compose_path),
+                "down",
+                "-v",
+            ]
+            subprocess.run(down_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        cleanups.append(cleanup_action)
+
+        # Run startup command
+        up_process = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        if up_process.returncode != 0:
+            print("Docker compose up failed!")
+            print("stdout:", up_process.stdout)
+            print("stderr:", up_process.stderr)
+            raise RuntimeError("Failed to spin up Docker containers")
+
+        # Wait for health
+        healthy = wait_for_health("http://localhost:8000/health", timeout=90)
+        if not healthy:
+            # Get logs to help debug
+            logs_process = subprocess.run(
+                compose_cmd
+                + ["-f", "docker-compose.yml", "-f", str(test_compose_path), "logs", "cognee"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            print("\nCognee container failed to become healthy. Container logs:")
+            print(logs_process.stdout)
+            raise RuntimeError("Cognee API container failed health check")
+
+        return "http://localhost:8000"
+
+    yield _run
+
+    # Run all cleanups in reverse order
+    for cleanup in reversed(cleanups):
+        try:
+            cleanup()
+        except Exception as e:
+            print(f"Error during docker cleanup: {e}")
+
+
+@pytest.fixture
+def api_client():
+    class AuthenticatedClient:
+        def __init__(self, base_url: str):
+            self.base_url = base_url
+            self.client = httpx.AsyncClient(base_url=base_url, timeout=30.0)
+            self.headers = {}
+
+        async def register_and_login(self, email="user@example.com", password="password"):
+            # Register user
+            register_data = {
+                "email": email,
+                "password": password,
+                "is_active": True,
+                "is_superuser": False,
+                "is_verified": True,
+            }
+            try:
+                await self.client.post("/api/v1/auth/register", json=register_data)
+            except Exception:
+                pass  # Already exists or other register issues, proceed to login
+
+            # Login
+            login_data = {"username": email, "password": password}
+            response = await self.client.post("/api/v1/auth/login", data=login_data)
+            response.raise_for_status()
+            token_data = response.json()
+            token = token_data["access_token"]
+            self.headers = {"Authorization": f"Bearer {token}"}
+            self.client.headers.update(self.headers)
+            return token
+
+        async def post(self, url, **kwargs):
+            return await self.client.post(url, **kwargs)
+
+        async def get(self, url, **kwargs):
+            return await self.client.get(url, **kwargs)
+
+        async def close(self):
+            await self.client.aclose()
+
+    return AuthenticatedClient

--- a/cognee/tests/deployment/test_backend_db_matrix.py
+++ b/cognee/tests/deployment/test_backend_db_matrix.py
@@ -1,0 +1,67 @@
+import pytest
+
+
+@pytest.mark.deployment
+@pytest.mark.asyncio
+@pytest.mark.parametrize("db_stack", ["sqlite", "postgres", "neo4j"])
+async def test_db_matrix(db_stack, running_container, api_client):
+    # Start container with specific db stack
+    base_url = running_container(db_stack)
+
+    # Initialize authenticated API client
+    client = api_client(base_url)
+    await client.register_and_login(email="user@example.com", password="password")
+
+    # 1. Add data to a new dataset
+    dataset_name = f"test_{db_stack}_dataset"
+    file_content = f"This is testing the {db_stack} database stack in the matrix."
+    files = {"data": (f"test_{db_stack}.txt", file_content, "text/plain")}
+    data = {"datasetName": dataset_name, "run_in_background": "false"}
+
+    print(f"\n[{db_stack}] Adding data to dataset...")
+    add_response = await client.post("/api/v1/add", files=files, data=data)
+    assert add_response.status_code == 200, f"[{db_stack}] Add failed: {add_response.text}"
+    print(f"[{db_stack}] Add call succeeded.")
+
+    # 2. Get dataset details to find UUID
+    datasets_response = await client.get("/api/v1/datasets")
+    assert datasets_response.status_code == 200
+    datasets_list = datasets_response.json()
+
+    target_dataset = None
+    for d in datasets_list:
+        if d["name"] == dataset_name:
+            target_dataset = d
+            break
+
+    assert target_dataset is not None, f"[{db_stack}] Dataset not found in datasets list"
+    dataset_id = target_dataset["id"]
+    print(f"[{db_stack}] Found dataset {dataset_name} with ID: {dataset_id}")
+
+    # 3. Trigger cognify processing
+    cognify_payload = {"datasets": [dataset_name], "run_in_background": False}
+    print(f"[{db_stack}] Triggering cognify...")
+    cognify_response = await client.post("/api/v1/cognify", json=cognify_payload)
+    assert cognify_response.status_code == 200, (
+        f"[{db_stack}] Cognify failed: {cognify_response.text}"
+    )
+    print(f"[{db_stack}] Cognify call succeeded.")
+
+    # 4. Search the processed dataset
+    search_payload = {
+        "query": "database",
+        "search_type": "GRAPH_COMPLETION",
+        "datasets": [dataset_name],
+    }
+    print(f"[{db_stack}] Searching dataset...")
+    search_response = await client.post("/api/v1/search", json=search_payload)
+    assert search_response.status_code == 200, f"[{db_stack}] Search failed: {search_response.text}"
+
+    search_results = search_response.json()
+    assert len(search_results) > 0, f"[{db_stack}] No search results returned"
+
+    result_text = search_results[0]["search_result"]
+    assert result_text is not None
+    print(f"[{db_stack}] Search call succeeded. Result text:", result_text)
+
+    await client.close()

--- a/cognee/tests/deployment/test_deployment_harness.py
+++ b/cognee/tests/deployment/test_deployment_harness.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+@pytest.mark.deployment
+@pytest.mark.asyncio
+async def test_basic_harness(running_container, api_client):
+    # Start container with SQLite stack (default)
+    base_url = running_container("sqlite")
+
+    # Initialize authenticated API client
+    client = api_client(base_url)
+    await client.register_and_login(email="user@example.com", password="password")
+
+    # 1. Add data to a new dataset
+    dataset_name = "test_dataset"
+    file_content = "The quick brown fox jumps over the lazy dog."
+    files = {"data": ("test.txt", file_content, "text/plain")}
+    data = {"datasetName": dataset_name, "run_in_background": "false"}
+
+    print("\nAdding data to dataset...")
+    add_response = await client.post("/api/v1/add", files=files, data=data)
+    assert add_response.status_code == 200, f"Add failed: {add_response.text}"
+    print("Add call succeeded.")
+
+    # 2. Get dataset details to find UUID
+    datasets_response = await client.get("/api/v1/datasets")
+    assert datasets_response.status_code == 200
+    datasets_list = datasets_response.json()
+
+    target_dataset = None
+    for d in datasets_list:
+        if d["name"] == dataset_name:
+            target_dataset = d
+            break
+
+    assert target_dataset is not None, "Dataset not found in datasets list"
+    dataset_id = target_dataset["id"]
+    print(f"Found dataset {dataset_name} with ID: {dataset_id}")
+
+    # 3. Trigger cognify processing
+    cognify_payload = {"datasets": [dataset_name], "run_in_background": False}
+    print("Triggering cognify processing...")
+    cognify_response = await client.post("/api/v1/cognify", json=cognify_payload)
+    assert cognify_response.status_code == 200, f"Cognify failed: {cognify_response.text}"
+    print("Cognify call succeeded.")
+
+    # 4. Search the processed dataset
+    search_payload = {"query": "fox", "search_type": "GRAPH_COMPLETION", "datasets": [dataset_name]}
+    print("Searching dataset...")
+    search_response = await client.post("/api/v1/search", json=search_payload)
+    assert search_response.status_code == 200, f"Search failed: {search_response.text}"
+
+    search_results = search_response.json()
+    assert len(search_results) > 0, "No search results returned"
+
+    # Under the mock LLM, search_result should contain the mock API response
+    result_text = search_results[0]["search_result"]
+    assert result_text is not None
+    print("Search call succeeded. Result text:", result_text)
+
+    await client.close()


### PR DESCRIPTION
### What problem is solved?
Currently, our deployment CI only verifies that the Docker containers can build and boot up. It doesn't actually test if Cognee works inside the running container. We lacked E2E test coverage for verifying our API endpoints and database integrations inside a container environment.
### How it works (Why & How):
1. **Shared Test Harness (`conftest.py`):** I created a new deployment E2E test harness under `cognee/tests/deployment/`. It manages starting the container, polling the `/health` endpoint until it is ready, registering/authenticating a test user, and performing API calls.
2. **Local Mock LLM Server:** To run these tests without requiring real OpenAI API keys, I built a background mock HTTP server. It dynamically parses whatever Pydantic schema is requested by Cognee (resolving any `$ref` structures), and returns mock JSON data/vectors. This allows the full pipeline (`add -> cognify -> search`) to pass with fake keys.
3. **Database Matrix (`test_backend_db_matrix.py`):** The test harness runs the E2E flow parameterized across all three main database configurations inside the container:
   - SQLite + LanceDB + Kuzu (Default)
   - Postgres + PGVector + Postgres-graph
   - Postgres + PGVector + Neo4j Graph
4. **Graceful Skipping:** If Docker is not installed or running locally on a developer's machine, the tests automatically detect this and skip (`pytest.skip`) instead of raising errors. This keeps local runs clean while allowing the CI server to run them fully.
---
## Acceptance Criteria
* Booting up the Cognee container and driving a complete `add -> cognify -> search` golden flow succeeds.
* Drive tests across the SQLite, Postgres, and Neo4j backend database matrix in the running container.
* Tests skip gracefully when run locally without Docker, and pass when run in a Docker environment.
* Formatting and linting checks pass cleanly.
---
## Type of Change
- [x] New feature (non-breaking change that adds functionality)
