### PR TITLE
feat(migration): live-API importers for Mem0, Graphiti, Zep, and Letta

### DIFF
--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -69,7 +69,8 @@ from .api.v1 import (
 from .memory import MemoryEntry, QAEntry, TraceEntry, FeedbackEntry
 
 # Memory migration (cognee.migration has the provider sources:
-# Mem0Source, ZepSource/GraphitiSource, LettaSource, COGXArchiveSource)
+# Mem0Source, ZepSource/GraphitiSource, LettaSource, COGXArchiveSource,
+# and live-API importers: Mem0LiveSource, GraphitiLiveSource, ZepLiveSource, LettaLiveSource)
 from . import migration
 
 # Tracing / Observability

--- a/cognee/migration/__init__.py
+++ b/cognee/migration/__init__.py
@@ -3,9 +3,12 @@
 Importing from other memory systems (pass any source to ``cognee.remember``)::
 
     from cognee.migration import Mem0Source, ZepSource, LettaSource
+    from cognee.migration import Mem0LiveSource, GraphitiLiveSource
 
     await cognee.remember(Mem0Source("mem0_export.json"))
     await cognee.remember(ZepSource("graphiti_dump.json", mode="hybrid"))
+    await cognee.remember(Mem0LiveSource(client=mem0_client, filters={"user_id": "alice"}))
+    await cognee.remember(GraphitiLiveSource(graphiti=graphiti))
 
 Exporting (``cognee.export``)::
 
@@ -37,11 +40,15 @@ from cognee.modules.migration import (
     ExportResult,
     GraphEdge,
     GraphSnapshot,
+    GraphitiLiveSource,
     GraphitiSource,
     IMPORT_MODES,
+    LettaLiveSource,
     LettaSource,
+    Mem0LiveSource,
     Mem0Source,
     MemorySource,
+    ZepLiveSource,
     ZepSource,
     build_snapshot,
     datapoint_registry,
@@ -69,11 +76,15 @@ __all__ = [
     "ExportResult",
     "GraphEdge",
     "GraphSnapshot",
+    "GraphitiLiveSource",
     "GraphitiSource",
     "IMPORT_MODES",
+    "LettaLiveSource",
     "LettaSource",
+    "Mem0LiveSource",
     "Mem0Source",
     "MemorySource",
+    "ZepLiveSource",
     "ZepSource",
     "build_snapshot",
     "datapoint_registry",

--- a/cognee/modules/migration/__init__.py
+++ b/cognee/modules/migration/__init__.py
@@ -28,10 +28,14 @@ from .snapshot import GraphEdge, GraphSnapshot, build_snapshot, datapoint_regist
 from .sources import (
     IMPORT_MODES,
     COGXArchiveSource,
+    GraphitiLiveSource,
     GraphitiSource,
+    LettaLiveSource,
     LettaSource,
+    Mem0LiveSource,
     Mem0Source,
     MemorySource,
+    ZepLiveSource,
     ZepSource,
 )
 
@@ -70,9 +74,13 @@ __all__ = [
     "translate_records",
     "IMPORT_MODES",
     "COGXArchiveSource",
+    "GraphitiLiveSource",
     "GraphitiSource",
+    "LettaLiveSource",
     "LettaSource",
+    "Mem0LiveSource",
     "Mem0Source",
     "MemorySource",
+    "ZepLiveSource",
     "ZepSource",
 ]

--- a/cognee/modules/migration/sources/__init__.py
+++ b/cognee/modules/migration/sources/__init__.py
@@ -1,6 +1,7 @@
 from .base import MemorySource, IMPORT_MODES
 from .cogx_archive import COGXArchiveSource
 from .letta import LettaSource
+from .live import GraphitiLiveSource, LettaLiveSource, Mem0LiveSource, ZepLiveSource
 from .mem0 import Mem0Source
 from .zep import GraphitiSource, ZepSource
 
@@ -8,8 +9,12 @@ __all__ = [
     "MemorySource",
     "IMPORT_MODES",
     "COGXArchiveSource",
-    "LettaSource",
-    "Mem0Source",
+    "GraphitiLiveSource",
     "GraphitiSource",
+    "LettaLiveSource",
+    "LettaSource",
+    "Mem0LiveSource",
+    "Mem0Source",
+    "ZepLiveSource",
     "ZepSource",
 ]

--- a/cognee/modules/migration/sources/letta.py
+++ b/cognee/modules/migration/sources/letta.py
@@ -51,6 +51,88 @@ def _message_text(message: Dict[str, Any]) -> str:
     return ""
 
 
+def normalize_letta_data(data: Union[str, Path, Dict[str, Any]]) -> Dict[str, Any]:
+    """Parse Letta agent file export into a dict."""
+    if isinstance(data, (str, Path)):
+        data = json.loads(Path(data).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Unrecognized Letta agent file: expected a JSON object.")
+    return data
+
+
+async def iter_letta_records(
+    data: Dict[str, Any], source_system: str = "letta"
+) -> AsyncIterator[COGXRecord]:
+    """Yield COGX records from a normalized Letta agent export dict."""
+    agents = _first_list(data, "agents")
+    if not agents:
+        agents = [data]
+
+    shared_blocks = {
+        str(block.get("id")): block for block in _first_list(data, "blocks") if block.get("id")
+    }
+
+    for agent_index, agent in enumerate(agents):
+        agent_name = str(agent.get("name") or f"agent-{agent_index}")
+        scope = COGXScope(agent_id=agent_name)
+
+        blocks = _first_list(agent, "core_memory", "blocks", "memory_blocks")
+        if not blocks and shared_blocks:
+            block_ids = agent.get("block_ids") or agent.get("core_memory_block_ids") or []
+            blocks = [shared_blocks[str(bid)] for bid in block_ids if str(bid) in shared_blocks]
+        for block_index, block in enumerate(blocks):
+            value = block.get("value") or block.get("content") or ""
+            if not isinstance(value, str) or not value.strip():
+                continue
+            label = str(block.get("label") or block.get("name") or f"block-{block_index}")
+            yield COGXMemoryBlock(
+                external_system=source_system,
+                external_id=str(block.get("id") or f"{agent_name}:block:{label}"),
+                label=label,
+                value=value,
+                limit=block.get("limit"),
+                scope=scope,
+            )
+
+        messages = _first_list(agent, "messages", "in_context_messages", "message_history")
+        turns = []
+        for message in messages:
+            text = _message_text(message)
+            role = str(message.get("role") or "unknown")
+            if not text.strip() or role in ("system", "tool"):
+                continue
+            turns.append(
+                COGXTurn(
+                    role=role,
+                    content=text,
+                    occurred_at=parse_timestamp(
+                        message.get("created_at") or message.get("timestamp")
+                    ),
+                )
+            )
+        if turns:
+            yield COGXEpisode(
+                external_system=source_system,
+                external_id=f"{agent_name}:messages",
+                title=f"Conversation history of agent {agent_name}",
+                turns=turns,
+                scope=scope,
+            )
+
+        passages = _first_list(agent, "archival_memory", "passages", "archival_passages")
+        for passage_index, passage in enumerate(passages):
+            text = passage.get("text") or passage.get("content")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            yield COGXDocument(
+                external_system=source_system,
+                external_id=str(passage.get("id") or f"{agent_name}:passage:{passage_index}"),
+                content=text,
+                created_at=parse_timestamp(passage.get("created_at")),
+                scope=scope,
+            )
+
+
 class LettaSource(MemorySource):
     source_system = "letta"
 
@@ -59,80 +141,8 @@ class LettaSource(MemorySource):
         self._data = data
 
     def _load_raw(self) -> Dict[str, Any]:
-        data = self._data
-        if isinstance(data, (str, Path)):
-            data = json.loads(Path(data).read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            raise ValueError("Unrecognized Letta agent file: expected a JSON object.")
-        return data
+        return normalize_letta_data(self._data)
 
     async def records(self) -> AsyncIterator[COGXRecord]:
-        data = self._load_raw()
-        agents = _first_list(data, "agents")
-        if not agents:
-            # A file may serialize a single agent at the top level.
-            agents = [data]
-
-        shared_blocks = {
-            str(block.get("id")): block for block in _first_list(data, "blocks") if block.get("id")
-        }
-
-        for agent_index, agent in enumerate(agents):
-            agent_name = str(agent.get("name") or f"agent-{agent_index}")
-            scope = COGXScope(agent_id=agent_name)
-
-            blocks = _first_list(agent, "core_memory", "blocks", "memory_blocks")
-            if not blocks and shared_blocks:
-                block_ids = agent.get("block_ids") or agent.get("core_memory_block_ids") or []
-                blocks = [shared_blocks[str(bid)] for bid in block_ids if str(bid) in shared_blocks]
-            for block_index, block in enumerate(blocks):
-                value = block.get("value") or block.get("content") or ""
-                if not isinstance(value, str) or not value.strip():
-                    continue
-                label = str(block.get("label") or block.get("name") or f"block-{block_index}")
-                yield COGXMemoryBlock(
-                    external_system=self.source_system,
-                    external_id=str(block.get("id") or f"{agent_name}:block:{label}"),
-                    label=label,
-                    value=value,
-                    limit=block.get("limit"),
-                    scope=scope,
-                )
-
-            messages = _first_list(agent, "messages", "in_context_messages", "message_history")
-            turns = []
-            for message in messages:
-                text = _message_text(message)
-                role = str(message.get("role") or "unknown")
-                if not text.strip() or role in ("system", "tool"):
-                    continue
-                turns.append(
-                    COGXTurn(
-                        role=role,
-                        content=text,
-                        occurred_at=parse_timestamp(
-                            message.get("created_at") or message.get("timestamp")
-                        ),
-                    )
-                )
-            if turns:
-                yield COGXEpisode(
-                    external_system=self.source_system,
-                    external_id=f"{agent_name}:messages",
-                    title=f"Conversation history of agent {agent_name}",
-                    turns=turns,
-                    scope=scope,
-                )
-
-            passages = _first_list(agent, "archival_memory", "passages", "archival_passages")
-            for passage_index, passage in enumerate(passages):
-                text = passage.get("text") or passage.get("content")
-                if not isinstance(text, str) or not text.strip():
-                    continue
-                yield COGXDocument(
-                    external_system=self.source_system,
-                    external_id=str(passage.get("id") or f"{agent_name}:passage:{passage_index}"),
-                    content=text,
-                    created_at=parse_timestamp(passage.get("created_at")),
-                    scope=scope,
-                )
+        async for record in iter_letta_records(self._load_raw(), source_system=self.source_system):
+            yield record

--- a/cognee/modules/migration/sources/live/__init__.py
+++ b/cognee/modules/migration/sources/live/__init__.py
@@ -1,0 +1,16 @@
+"""Live-API memory sources: fetch from running provider services."""
+
+from .graphiti import GraphitiLiveSource, fetch_graphiti_snapshot
+from .letta import LettaLiveSource, fetch_letta_snapshot
+from .mem0 import Mem0LiveSource
+from .zep import ZepLiveSource, fetch_zep_snapshot
+
+__all__ = [
+    "GraphitiLiveSource",
+    "LettaLiveSource",
+    "Mem0LiveSource",
+    "ZepLiveSource",
+    "fetch_graphiti_snapshot",
+    "fetch_letta_snapshot",
+    "fetch_zep_snapshot",
+]

--- a/cognee/modules/migration/sources/live/_utils.py
+++ b/cognee/modules/migration/sources/live/_utils.py
@@ -1,0 +1,68 @@
+"""Shared helpers for live-API memory sources."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any, Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def require_extra(extra: str, import_name: str) -> Any:
+    """Import *import_name* or raise with an install hint for cognee[extra]."""
+    try:
+        return __import__(import_name, fromlist=[""])
+    except ImportError as error:
+        raise ImportError(
+            f"Live import requires the optional '{extra}' dependency. "
+            f"Install it with: pip install cognee[{extra}]"
+        ) from error
+
+
+async def call_maybe_async(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Invoke *func* whether it is sync or async."""
+    result = func(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def run_sync(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Run a blocking SDK call off the event loop."""
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+async def paginate_uuid_cursor(
+    fetch_page: Callable[..., Any],
+    *,
+    page_size: int,
+    cursor_kw: str = "uuid_cursor",
+    limit_kw: str = "limit",
+) -> list[Any]:
+    """Collect all items from a uuid-cursor paginated API."""
+    items: list[Any] = []
+    cursor = None
+    while True:
+        kwargs = {limit_kw: page_size}
+        if cursor is not None:
+            kwargs[cursor_kw] = cursor
+        batch = await call_maybe_async(fetch_page, **kwargs)
+        if not batch:
+            break
+        items.extend(batch)
+        if len(batch) < page_size:
+            break
+        last = batch[-1]
+        cursor = getattr(last, "uuid_", None) or getattr(last, "uuid", None)
+        if cursor is None and isinstance(last, dict):
+            cursor = last.get("uuid") or last.get("uuid_")
+        if cursor is None:
+            break
+    return items
+
+
+async def await_if_needed(value: Any | Awaitable[Any]) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value

--- a/cognee/modules/migration/sources/live/graphiti.py
+++ b/cognee/modules/migration/sources/live/graphiti.py
@@ -1,0 +1,167 @@
+"""Live Graphiti (OSS) memory source."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from cognee.modules.migration.cogx import COGXRecord
+from cognee.modules.migration.sources.base import MemorySource
+from cognee.modules.migration.sources.live._utils import call_maybe_async
+from cognee.modules.migration.sources.zep import iter_zep_graph_records
+
+
+def _serialize_graphiti_node(node: Any) -> Dict[str, Any]:
+    if hasattr(node, "model_dump"):
+        data = node.model_dump(mode="json")
+    elif isinstance(node, dict):
+        data = dict(node)
+    elif hasattr(node, "__dict__"):
+        data = {key: value for key, value in vars(node).items() if not key.startswith("_")}
+    else:
+        data = {key: getattr(node, key) for key in dir(node) if not key.startswith("_")}
+    source = data.get("source")
+    if hasattr(source, "value"):
+        data["source"] = source.value
+    return data
+
+
+async def _paginate_graphiti_nodes(
+    node_cls: Any, driver: Any, group_ids: List[str], page_size: int
+):
+    items: List[Any] = []
+    cursor = None
+    while True:
+        kwargs: Dict[str, Any] = {
+            "driver": driver,
+            "group_ids": group_ids,
+            "limit": page_size,
+        }
+        if cursor is not None:
+            kwargs["uuid_cursor"] = cursor
+        try:
+            batch = await call_maybe_async(node_cls.get_by_group_ids, **kwargs)
+        except Exception as error:
+            error_name = type(error).__name__
+            if error_name in ("GroupsEdgesNotFoundError", "GroupsNodesNotFoundError"):
+                return []
+            raise
+        if not batch:
+            break
+        items.extend(batch)
+        if len(batch) < page_size:
+            break
+        last = batch[-1]
+        cursor = getattr(last, "uuid", None)
+        if cursor is None:
+            break
+    return items
+
+
+async def fetch_graphiti_snapshot(
+    graphiti: Any,
+    group_ids: Optional[List[str]] = None,
+    page_size: int = 500,
+) -> Dict[str, Any]:
+    """Export a Graphiti knowledge graph into the ZepSource dict shape."""
+    from cognee.modules.migration.sources.live._utils import require_extra
+
+    graphiti_core = require_extra("graphiti", "graphiti_core")
+    EpisodicNode = graphiti_core.nodes.EpisodicNode
+    EntityNode = graphiti_core.nodes.EntityNode
+    EntityEdge = graphiti_core.edges.EntityEdge
+
+    driver = getattr(graphiti, "driver", None)
+    if driver is None and hasattr(graphiti, "clients"):
+        driver = graphiti.clients.driver
+    if driver is None:
+        raise ValueError("Graphiti instance must expose a graph driver.")
+    resolved_group_ids = group_ids
+    if resolved_group_ids is None:
+        resolved_group_ids = await _discover_group_ids(driver)
+
+    episodes = await _paginate_graphiti_nodes(EpisodicNode, driver, resolved_group_ids, page_size)
+    nodes = await _paginate_graphiti_nodes(EntityNode, driver, resolved_group_ids, page_size)
+    edges = await _paginate_graphiti_nodes(EntityEdge, driver, resolved_group_ids, page_size)
+
+    return {
+        "episodes": [_serialize_graphiti_node(episode) for episode in episodes],
+        "nodes": [_serialize_graphiti_node(node) for node in nodes],
+        "edges": [_serialize_graphiti_node(edge) for edge in edges],
+    }
+
+
+async def _discover_group_ids(driver: Any) -> List[str]:
+    query = "MATCH (n) WHERE n.group_id IS NOT NULL RETURN DISTINCT n.group_id AS group_id"
+    try:
+        result = await call_maybe_async(driver.execute_query, query)
+    except Exception:
+        return [""]
+    records = result
+    if isinstance(result, tuple):
+        records = result[0]
+    group_ids = []
+    for row in records or []:
+        if isinstance(row, dict):
+            value = row.get("group_id")
+        else:
+            value = row[0] if row else None
+        if value is not None and value not in group_ids:
+            group_ids.append(value)
+    return group_ids or [""]
+
+
+class GraphitiLiveSource(MemorySource):
+    """Fetch a Graphiti knowledge graph from a running graph database.
+
+    Pass an injected ``graphiti_core.Graphiti`` instance (credentials and
+    connection are configured by the caller). On first ``records()`` the full
+    graph is snapshotted into memory and replayed on subsequent calls.
+
+    Communities, sagas, and non-entity edge types are not exported.
+
+    Args:
+        graphiti: Connected ``graphiti_core.Graphiti`` instance.
+        group_ids: Graph partitions to export; ``None`` discovers distinct
+            ``group_id`` values via Cypher.
+        page_size: Batch size for ``get_by_group_ids`` pagination.
+        mode: Import mode (default ``hybrid``).
+        close_on_fetch: Close the Graphiti client after the snapshot is taken.
+    """
+
+    source_system = "graphiti"
+    replayable = True
+
+    def __init__(
+        self,
+        graphiti: Any,
+        group_ids: Optional[List[str]] = None,
+        page_size: int = 500,
+        mode: str = "hybrid",
+        close_on_fetch: bool = False,
+    ):
+        super().__init__(mode=mode)
+        self._graphiti = graphiti
+        self._group_ids = group_ids
+        self._page_size = page_size
+        self._close_on_fetch = close_on_fetch
+        self._snapshot: Optional[Dict[str, Any]] = None
+
+    async def _ensure_snapshot(self) -> Dict[str, Any]:
+        if self._snapshot is None:
+            try:
+                self._snapshot = await fetch_graphiti_snapshot(
+                    self._graphiti,
+                    group_ids=self._group_ids,
+                    page_size=self._page_size,
+                )
+            finally:
+                if self._close_on_fetch:
+                    close = getattr(self._graphiti, "close", None)
+                    if close is not None:
+                        await call_maybe_async(close)
+        return self._snapshot
+
+    async def records(self) -> AsyncIterator[COGXRecord]:
+        snapshot = await self._ensure_snapshot()
+        async for record in iter_zep_graph_records(snapshot, source_system=self.source_system):
+            yield record

--- a/cognee/modules/migration/sources/live/letta.py
+++ b/cognee/modules/migration/sources/live/letta.py
@@ -1,0 +1,142 @@
+"""Live Letta API memory source."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from cognee.modules.migration.cogx import COGXRecord
+from cognee.modules.migration.sources.base import MemorySource
+from cognee.modules.migration.sources.letta import iter_letta_records
+from cognee.modules.migration.sources.live._utils import call_maybe_async
+
+_ROLE_MAP = {
+    "user_message": "user",
+    "assistant_message": "assistant",
+    "system_message": "system",
+}
+
+
+def _isoformat(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _map_role(message: Any) -> str:
+    message_type = getattr(message, "message_type", None) or getattr(message, "role", None)
+    if message_type in _ROLE_MAP:
+        return _ROLE_MAP[message_type]
+    if isinstance(message_type, str):
+        return message_type
+    return "unknown"
+
+
+def _block_dict(block: Any) -> Dict[str, Any]:
+    return {
+        "id": getattr(block, "id", None),
+        "label": getattr(block, "label", None) or getattr(block, "name", None),
+        "value": getattr(block, "value", None) or getattr(block, "content", None),
+        "limit": getattr(block, "limit", None),
+    }
+
+
+def _message_dict(message: Any) -> Dict[str, Any]:
+    return {
+        "role": _map_role(message),
+        "content": getattr(message, "content", None),
+        "created_at": _isoformat(
+            getattr(message, "date", None) or getattr(message, "created_at", None)
+        ),
+    }
+
+
+def _passage_dict(passage: Any) -> Dict[str, Any]:
+    return {
+        "id": getattr(passage, "id", None),
+        "text": getattr(passage, "text", None) or getattr(passage, "content", None),
+        "created_at": _isoformat(getattr(passage, "created_at", None)),
+    }
+
+
+async def _collect_iterator(items: Any) -> List[Any]:
+    if hasattr(items, "__aiter__"):
+        return [item async for item in items]
+    if hasattr(items, "__iter__") and not isinstance(items, (list, dict, str)):
+        return list(items)
+    return list(items or [])
+
+
+async def fetch_letta_snapshot(
+    client: Any, agent_ids: Optional[List[str]] = None
+) -> Dict[str, Any]:
+    """Export Letta agent state into the LettaSource agent-file dict shape."""
+    from cognee.modules.migration.sources.live._utils import require_extra
+
+    require_extra("letta", "letta_client")
+
+    if agent_ids is None:
+        agents = await _collect_iterator(await call_maybe_async(client.agents.list))
+        agent_ids = [getattr(agent, "id", None) for agent in agents]
+        agent_ids = [agent_id for agent_id in agent_ids if agent_id]
+
+    exports: List[Dict[str, Any]] = []
+    for agent_id in agent_ids:
+        agent = await call_maybe_async(client.agents.retrieve, agent_id)
+        blocks = await _collect_iterator(
+            await call_maybe_async(client.agents.blocks.list, agent_id=agent_id)
+        )
+        messages = await _collect_iterator(
+            await call_maybe_async(client.agents.messages.list, agent_id=agent_id, order="asc")
+        )
+        passages = await _collect_iterator(
+            await call_maybe_async(client.agents.passages.list, agent_id=agent_id)
+        )
+        exports.append(
+            {
+                "name": getattr(agent, "name", None) or agent_id,
+                "core_memory": [_block_dict(block) for block in blocks],
+                "messages": [_message_dict(message) for message in messages],
+                "archival_memory": [_passage_dict(passage) for passage in passages],
+            }
+        )
+    return {"agents": exports}
+
+
+class LettaLiveSource(MemorySource):
+    """Fetch Letta agent memory via an injected Letta client.
+
+    Args:
+        client: ``letta_client.Letta`` or ``AsyncLetta`` instance.
+        agent_ids: Agents to export; ``None`` exports all agents from
+            ``agents.list()``.
+        mode: Import mode (default ``re-derive``).
+    """
+
+    source_system = "letta"
+    replayable = True
+
+    def __init__(
+        self,
+        client: Any,
+        agent_ids: Optional[List[str]] = None,
+        mode: str = "re-derive",
+    ):
+        super().__init__(mode=mode)
+        self._client = client
+        self._agent_ids = agent_ids
+        self._snapshot: Optional[Dict[str, Any]] = None
+
+    async def _ensure_snapshot(self) -> Dict[str, Any]:
+        if self._snapshot is None:
+            self._snapshot = await fetch_letta_snapshot(self._client, agent_ids=self._agent_ids)
+        return self._snapshot
+
+    async def records(self) -> AsyncIterator[COGXRecord]:
+        snapshot = await self._ensure_snapshot()
+        async for record in iter_letta_records(snapshot, source_system=self.source_system):
+            yield record

--- a/cognee/modules/migration/sources/live/mem0.py
+++ b/cognee/modules/migration/sources/live/mem0.py
@@ -1,0 +1,123 @@
+"""Live Mem0 API memory source."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from cognee.modules.migration.cogx import COGXRecord
+from cognee.modules.migration.sources.base import MemorySource
+from cognee.modules.migration.sources.live._utils import call_maybe_async, require_extra
+from cognee.modules.migration.sources.mem0 import iter_mem0_records, normalize_mem0_items
+
+_ENTITY_FILTER_KEYS = ("user_id", "agent_id", "app_id", "run_id")
+
+
+class Mem0LiveSource(MemorySource):
+    """Fetch memories from a running Mem0 instance via an injected client.
+
+    Credentials and API keys must be configured on the client by the caller
+    (for example ``MemoryClient(api_key=...)``). This source only paginates
+    ``get_all()`` and maps results into COGX.
+
+    The snapshot is taken on the first ``records()`` call and cached; subsequent
+    calls replay the same point-in-time data (``replayable=True``).
+
+    Args:
+        client: ``mem0.MemoryClient``, ``mem0.AsyncMemoryClient``, or OSS ``Memory``.
+        filters: Mem0 v3 filter dict with at least one entity id, unless
+            ``discover_entities=True``.
+        mode: Import fidelity mode (default ``re-derive``).
+        page_size: Page size for platform ``get_all`` pagination.
+        discover_entities: When True, call ``users()`` and fetch memories per
+            discovered entity scope.
+    """
+
+    source_system = "mem0"
+    replayable = True
+
+    def __init__(
+        self,
+        client: Any,
+        filters: Optional[Dict[str, Any]] = None,
+        mode: str = "re-derive",
+        page_size: int = 100,
+        discover_entities: bool = False,
+    ):
+        super().__init__(mode=mode)
+        self._client = client
+        self._filters = filters or {}
+        self._page_size = page_size
+        self._discover_entities = discover_entities
+        self._snapshot: Optional[List[Dict[str, Any]]] = None
+
+    async def _fetch_all(self) -> List[Dict[str, Any]]:
+        require_extra("mem0", "mem0")
+
+        if self._discover_entities:
+            return await self._fetch_discovered()
+        if not any(self._filters.get(key) for key in _ENTITY_FILTER_KEYS):
+            raise ValueError(
+                "Mem0LiveSource requires entity-scoped filters (user_id, agent_id, "
+                "app_id, or run_id) or discover_entities=True."
+            )
+        return await self._paginate_get_all(self._filters)
+
+    async def _fetch_discovered(self) -> List[Dict[str, Any]]:
+        users_fn = getattr(self._client, "users", None)
+        if users_fn is None:
+            raise ValueError("discover_entities=True requires a client with users().")
+        users = await call_maybe_async(users_fn)
+        if not isinstance(users, list):
+            users = users.get("results", []) if isinstance(users, dict) else []
+
+        memories: List[Dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        for entry in users:
+            if not isinstance(entry, dict):
+                continue
+            entity_filters = {
+                key: entry[key] for key in _ENTITY_FILTER_KEYS if entry.get(key) is not None
+            }
+            if not entity_filters:
+                continue
+            for item in await self._paginate_get_all(entity_filters):
+                memory_id = str(item.get("id", ""))
+                if memory_id and memory_id in seen_ids:
+                    continue
+                if memory_id:
+                    seen_ids.add(memory_id)
+                memories.append(item)
+        return memories
+
+    async def _paginate_get_all(self, filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+        get_all = getattr(self._client, "get_all", None)
+        if get_all is None:
+            raise ValueError(
+                "Mem0 client must expose get_all(filters=..., page=..., page_size=...)."
+            )
+
+        memories: List[Dict[str, Any]] = []
+        page = 1
+        while True:
+            response = await call_maybe_async(
+                get_all, filters=filters, page=page, page_size=self._page_size
+            )
+            if isinstance(response, list):
+                memories.extend(response)
+                break
+            batch = response.get("results", []) if isinstance(response, dict) else []
+            memories.extend(batch)
+            if not isinstance(response, dict) or not response.get("next"):
+                break
+            page += 1
+        return memories
+
+    async def _ensure_snapshot(self) -> List[Dict[str, Any]]:
+        if self._snapshot is None:
+            self._snapshot = await self._fetch_all()
+        return self._snapshot
+
+    async def records(self) -> AsyncIterator[COGXRecord]:
+        items = normalize_mem0_items(await self._ensure_snapshot())
+        async for record in iter_mem0_records(items, source_system=self.source_system):
+            yield record

--- a/cognee/modules/migration/sources/live/zep.py
+++ b/cognee/modules/migration/sources/live/zep.py
@@ -1,0 +1,186 @@
+"""Live Zep Cloud memory source."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from cognee.modules.migration.cogx import COGXRecord
+from cognee.modules.migration.sources.base import MemorySource
+from cognee.modules.migration.sources.live._utils import call_maybe_async, paginate_uuid_cursor
+from cognee.modules.migration.sources.zep import iter_zep_graph_records
+
+
+def _isoformat(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _zep_episode_dict(episode: Any, user_id: Optional[str] = None) -> Dict[str, Any]:
+    return {
+        "uuid": getattr(episode, "uuid_", None) or getattr(episode, "uuid", None),
+        "name": getattr(episode, "name", None),
+        "content": getattr(episode, "content", None) or getattr(episode, "episode_body", None),
+        "created_at": _isoformat(getattr(episode, "created_at", None)),
+        "valid_at": _isoformat(getattr(episode, "valid_at", None)),
+        "group_id": getattr(episode, "group_id", None) or getattr(episode, "session_id", None),
+        "user_id": user_id,
+        "source_description": getattr(episode, "source_description", None),
+    }
+
+
+def _zep_node_dict(node: Any) -> Dict[str, Any]:
+    labels = getattr(node, "labels", None) or getattr(node, "label", None)
+    if labels is not None and not isinstance(labels, list):
+        labels = [labels]
+    return {
+        "uuid": getattr(node, "uuid_", None) or getattr(node, "uuid", None),
+        "name": getattr(node, "name", None),
+        "labels": labels,
+        "summary": getattr(node, "summary", None) or getattr(node, "description", None),
+        "attributes": getattr(node, "attributes", None) or {},
+        "created_at": _isoformat(getattr(node, "created_at", None)),
+        "group_id": getattr(node, "group_id", None),
+    }
+
+
+def _zep_edge_dict(edge: Any) -> Dict[str, Any]:
+    return {
+        "uuid": getattr(edge, "uuid_", None) or getattr(edge, "uuid", None),
+        "source_node_uuid": getattr(edge, "source_node_uuid", None),
+        "target_node_uuid": getattr(edge, "target_node_uuid", None),
+        "name": getattr(edge, "name", None) or getattr(edge, "relation", None),
+        "fact": getattr(edge, "fact", None),
+        "valid_at": _isoformat(getattr(edge, "valid_at", None)),
+        "invalid_at": _isoformat(
+            getattr(edge, "invalid_at", None) or getattr(edge, "expired_at", None)
+        ),
+        "created_at": _isoformat(getattr(edge, "created_at", None)),
+        "episodes": getattr(edge, "episodes", None) or [],
+        "group_id": getattr(edge, "group_id", None),
+    }
+
+
+async def fetch_zep_snapshot(
+    client: Any,
+    *,
+    user_id: Optional[str] = None,
+    graph_id: Optional[str] = None,
+    episode_lastn: int = 10_000,
+    page_size: int = 100,
+) -> Dict[str, Any]:
+    """Export Zep Cloud graph data into the ZepSource dict shape."""
+    from cognee.modules.migration.sources.live._utils import require_extra
+
+    require_extra("zep", "zep_cloud")
+
+    if not user_id and not graph_id:
+        raise ValueError("ZepLiveSource requires user_id or graph_id.")
+
+    graph = client.graph
+    if user_id:
+        episode_resp = await call_maybe_async(
+            graph.episode.get_by_user_id, user_id=user_id, lastn=episode_lastn
+        )
+        nodes = await paginate_uuid_cursor(
+            lambda **kwargs: graph.node.get_by_user_id(user_id=user_id, **kwargs),
+            page_size=page_size,
+        )
+        edges = await paginate_uuid_cursor(
+            lambda **kwargs: graph.edge.get_by_user_id(user_id=user_id, **kwargs),
+            page_size=page_size,
+        )
+    else:
+        episode_resp = await call_maybe_async(
+            graph.episode.get_by_graph_id, graph_id=graph_id, lastn=episode_lastn
+        )
+        nodes = await paginate_uuid_cursor(
+            lambda **kwargs: graph.node.get_by_graph_id(graph_id=graph_id, **kwargs),
+            page_size=page_size,
+        )
+        edges = await paginate_uuid_cursor(
+            lambda **kwargs: graph.edge.get_by_graph_id(graph_id=graph_id, **kwargs),
+            page_size=page_size,
+        )
+
+    episodes = getattr(episode_resp, "episodes", None) or episode_resp or []
+    if not isinstance(episodes, list):
+        episodes = []
+
+    episode_dicts = [_zep_episode_dict(episode, user_id=user_id) for episode in episodes]
+    edge_dicts = [_zep_edge_dict(edge) for edge in edges]
+
+    # Fetch episodes referenced on edges but missing from the lastn window.
+    known_uuids = {item["uuid"] for item in episode_dicts if item.get("uuid")}
+    for edge in edge_dicts:
+        for episode_uuid in edge.get("episodes") or []:
+            if not episode_uuid or episode_uuid in known_uuids:
+                continue
+            try:
+                episode = await call_maybe_async(graph.episode.get, uuid_=episode_uuid)
+            except Exception:
+                continue
+            episode_dicts.append(_zep_episode_dict(episode, user_id=user_id))
+            known_uuids.add(episode_uuid)
+
+    return {
+        "episodes": episode_dicts,
+        "nodes": [_zep_node_dict(node) for node in nodes],
+        "edges": edge_dicts,
+    }
+
+
+class ZepLiveSource(MemorySource):
+    """Fetch Zep Cloud graph memory via an injected Zep client.
+
+      Episode history is limited to the most recent ``episode_lastn`` entries
+      because the Zep Cloud API does not expose episode cursor pagination.
+    Nodes and edges are fully paginated.
+
+      Args:
+          client: ``zep_cloud.Zep`` or ``zep_cloud.client.AsyncZep`` instance.
+          user_id: Zep user id to export (mutually exclusive with graph_id).
+          graph_id: Zep graph id to export (mutually exclusive with user_id).
+          episode_lastn: Maximum recent episodes to retrieve.
+          page_size: Page size for node/edge uuid-cursor pagination.
+          mode: Import mode (default ``hybrid``).
+    """
+
+    source_system = "zep"
+    replayable = True
+
+    def __init__(
+        self,
+        client: Any,
+        user_id: Optional[str] = None,
+        graph_id: Optional[str] = None,
+        episode_lastn: int = 10_000,
+        page_size: int = 100,
+        mode: str = "hybrid",
+    ):
+        super().__init__(mode=mode)
+        self._client = client
+        self._user_id = user_id
+        self._graph_id = graph_id
+        self._episode_lastn = episode_lastn
+        self._page_size = page_size
+        self._snapshot: Optional[Dict[str, Any]] = None
+
+    async def _ensure_snapshot(self) -> Dict[str, Any]:
+        if self._snapshot is None:
+            self._snapshot = await fetch_zep_snapshot(
+                self._client,
+                user_id=self._user_id,
+                graph_id=self._graph_id,
+                episode_lastn=self._episode_lastn,
+                page_size=self._page_size,
+            )
+        return self._snapshot
+
+    async def records(self) -> AsyncIterator[COGXRecord]:
+        snapshot = await self._ensure_snapshot()
+        async for record in iter_zep_graph_records(snapshot, source_system=self.source_system):
+            yield record

--- a/cognee/modules/migration/sources/mem0.py
+++ b/cognee/modules/migration/sources/mem0.py
@@ -22,6 +22,52 @@ from cognee.modules.migration.sources.base import MemorySource
 _CONTENT_KEYS = ("memory", "text", "data", "content")
 
 
+def normalize_mem0_items(data: Union[str, Path, List[Any], Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Parse Mem0 export shapes into a list of memory dicts."""
+    if isinstance(data, (str, Path)):
+        data = json.loads(Path(data).read_text(encoding="utf-8"))
+    if isinstance(data, dict):
+        for key in ("results", "memories", "items"):
+            if isinstance(data.get(key), list):
+                data = data[key]
+                break
+        else:
+            raise ValueError(
+                "Unrecognized Mem0 export shape: expected a list or a dict "
+                "with a 'results'/'memories' key."
+            )
+    if not isinstance(data, list):
+        raise ValueError("Unrecognized Mem0 export shape: expected a list of memories.")
+    return [item for item in data if isinstance(item, dict)]
+
+
+async def iter_mem0_records(
+    items: List[Dict[str, Any]], source_system: str = "mem0"
+) -> AsyncIterator[COGXRecord]:
+    """Yield COGX memory records from normalized Mem0 memory dicts."""
+    for index, item in enumerate(items):
+        content = next((item[key] for key in _CONTENT_KEYS if isinstance(item.get(key), str)), None)
+        if not content:
+            continue
+        categories = item.get("categories") or []
+        if isinstance(categories, str):
+            categories = [categories]
+        yield COGXMemory(
+            external_system=source_system,
+            external_id=str(item.get("id") or f"mem0-{index}"),
+            content=content,
+            categories=[str(category) for category in categories],
+            scope=COGXScope(
+                user_id=item.get("user_id"),
+                agent_id=item.get("agent_id"),
+                run_id=item.get("run_id"),
+            ),
+            created_at=parse_timestamp(item.get("created_at")),
+            updated_at=parse_timestamp(item.get("updated_at")),
+            metadata={"mem0_metadata": item.get("metadata")} if item.get("metadata") else {},
+        )
+
+
 class Mem0Source(MemorySource):
     source_system = "mem0"
 
@@ -30,44 +76,8 @@ class Mem0Source(MemorySource):
         self._data = data
 
     def _load_raw(self) -> List[Dict[str, Any]]:
-        data = self._data
-        if isinstance(data, (str, Path)):
-            data = json.loads(Path(data).read_text(encoding="utf-8"))
-        if isinstance(data, dict):
-            for key in ("results", "memories", "items"):
-                if isinstance(data.get(key), list):
-                    data = data[key]
-                    break
-            else:
-                raise ValueError(
-                    "Unrecognized Mem0 export shape: expected a list or a dict "
-                    "with a 'results'/'memories' key."
-                )
-        if not isinstance(data, list):
-            raise ValueError("Unrecognized Mem0 export shape: expected a list of memories.")
-        return [item for item in data if isinstance(item, dict)]
+        return normalize_mem0_items(self._data)
 
     async def records(self) -> AsyncIterator[COGXRecord]:
-        for index, item in enumerate(self._load_raw()):
-            content = next(
-                (item[key] for key in _CONTENT_KEYS if isinstance(item.get(key), str)), None
-            )
-            if not content:
-                continue
-            categories = item.get("categories") or []
-            if isinstance(categories, str):
-                categories = [categories]
-            yield COGXMemory(
-                external_system=self.source_system,
-                external_id=str(item.get("id") or f"mem0-{index}"),
-                content=content,
-                categories=[str(category) for category in categories],
-                scope=COGXScope(
-                    user_id=item.get("user_id"),
-                    agent_id=item.get("agent_id"),
-                    run_id=item.get("run_id"),
-                ),
-                created_at=parse_timestamp(item.get("created_at")),
-                updated_at=parse_timestamp(item.get("updated_at")),
-                metadata={"mem0_metadata": item.get("metadata")} if item.get("metadata") else {},
-            )
+        async for record in iter_mem0_records(self._load_raw(), source_system=self.source_system):
+            yield record

--- a/cognee/modules/migration/sources/zep.py
+++ b/cognee/modules/migration/sources/zep.py
@@ -45,6 +45,80 @@ def _first_list(container: Dict[str, Any], *keys: str) -> List[Dict[str, Any]]:
     return []
 
 
+def normalize_zep_graph_data(data: Union[str, Path, Dict[str, Any]]) -> Dict[str, Any]:
+    """Parse Zep/Graphiti export into a dict."""
+    if isinstance(data, (str, Path)):
+        data = json.loads(Path(data).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Unrecognized Zep/Graphiti export: expected a JSON object.")
+    return data
+
+
+async def iter_zep_graph_records(
+    data: Dict[str, Any], source_system: str = "zep"
+) -> AsyncIterator[COGXRecord]:
+    """Yield COGX records from a normalized Zep/Graphiti graph export dict."""
+    for index, episode in enumerate(_first_list(data, "episodes", "episodic_nodes")):
+        content = episode.get("content") or episode.get("episode_body")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        occurred_at = parse_timestamp(episode.get("valid_at") or episode.get("created_at"))
+        yield COGXEpisode(
+            external_system=source_system,
+            external_id=str(episode.get("uuid") or episode.get("id") or f"episode-{index}"),
+            title=episode.get("name"),
+            turns=[COGXTurn(role="episode", content=content, occurred_at=occurred_at)],
+            created_at=parse_timestamp(episode.get("created_at")),
+            scope=COGXScope(
+                user_id=episode.get("user_id"),
+                session_id=episode.get("group_id") or episode.get("session_id"),
+            ),
+            metadata=(
+                {"source_description": episode.get("source_description")}
+                if episode.get("source_description")
+                else {}
+            ),
+        )
+
+    for index, node in enumerate(_first_list(data, "entities", "nodes", "entity_nodes")):
+        name = node.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        labels = node.get("labels") or node.get("label") or []
+        if isinstance(labels, str):
+            labels = [labels]
+        entity_type = next((label for label in labels if label != "Entity"), None)
+        yield COGXEntity(
+            external_system=source_system,
+            external_id=str(node.get("uuid") or node.get("id") or f"entity-{index}"),
+            name=name,
+            entity_type=entity_type,
+            description=node.get("summary") or node.get("description"),
+            attributes=node.get("attributes") or {},
+            created_at=parse_timestamp(node.get("created_at")),
+            scope=COGXScope(session_id=node.get("group_id")),
+        )
+
+    for index, edge in enumerate(_first_list(data, "facts", "edges", "entity_edges")):
+        subject_ref = edge.get("source_node_uuid") or edge.get("source")
+        object_ref = edge.get("target_node_uuid") or edge.get("target")
+        if not subject_ref or not object_ref:
+            continue
+        yield COGXFact(
+            external_system=source_system,
+            external_id=str(edge.get("uuid") or edge.get("id") or f"fact-{index}"),
+            subject_ref=str(subject_ref),
+            predicate=str(edge.get("name") or edge.get("relation") or "relates_to"),
+            object_ref=str(object_ref),
+            fact_text=edge.get("fact"),
+            valid_at=parse_timestamp(edge.get("valid_at")),
+            invalid_at=parse_timestamp(edge.get("invalid_at") or edge.get("expired_at")),
+            created_at=parse_timestamp(edge.get("created_at")),
+            provenance=[str(episode) for episode in edge.get("episodes") or []],
+            scope=COGXScope(session_id=edge.get("group_id")),
+        )
+
+
 class ZepSource(MemorySource):
     source_system = "zep"
 
@@ -53,78 +127,22 @@ class ZepSource(MemorySource):
         self._data = data
 
     def _load_raw(self) -> Dict[str, Any]:
-        data = self._data
-        if isinstance(data, (str, Path)):
-            data = json.loads(Path(data).read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            raise ValueError("Unrecognized Zep/Graphiti export: expected a JSON object.")
-        return data
+        return normalize_zep_graph_data(self._data)
 
     async def records(self) -> AsyncIterator[COGXRecord]:
-        data = self._load_raw()
-
-        for index, episode in enumerate(_first_list(data, "episodes", "episodic_nodes")):
-            content = episode.get("content") or episode.get("episode_body")
-            if not isinstance(content, str) or not content.strip():
-                continue
-            occurred_at = parse_timestamp(episode.get("valid_at") or episode.get("created_at"))
-            yield COGXEpisode(
-                external_system=self.source_system,
-                external_id=str(episode.get("uuid") or episode.get("id") or f"episode-{index}"),
-                title=episode.get("name"),
-                turns=[COGXTurn(role="episode", content=content, occurred_at=occurred_at)],
-                created_at=parse_timestamp(episode.get("created_at")),
-                scope=COGXScope(
-                    user_id=episode.get("user_id"),
-                    session_id=episode.get("group_id") or episode.get("session_id"),
-                ),
-                metadata=(
-                    {"source_description": episode.get("source_description")}
-                    if episode.get("source_description")
-                    else {}
-                ),
-            )
-
-        for index, node in enumerate(_first_list(data, "entities", "nodes", "entity_nodes")):
-            name = node.get("name")
-            if not isinstance(name, str) or not name.strip():
-                continue
-            labels = node.get("labels") or node.get("label") or []
-            if isinstance(labels, str):
-                labels = [labels]
-            entity_type = next((label for label in labels if label != "Entity"), None)
-            yield COGXEntity(
-                external_system=self.source_system,
-                external_id=str(node.get("uuid") or node.get("id") or f"entity-{index}"),
-                name=name,
-                entity_type=entity_type,
-                description=node.get("summary") or node.get("description"),
-                attributes=node.get("attributes") or {},
-                created_at=parse_timestamp(node.get("created_at")),
-                scope=COGXScope(session_id=node.get("group_id")),
-            )
-
-        for index, edge in enumerate(_first_list(data, "facts", "edges", "entity_edges")):
-            subject_ref = edge.get("source_node_uuid") or edge.get("source")
-            object_ref = edge.get("target_node_uuid") or edge.get("target")
-            if not subject_ref or not object_ref:
-                continue
-            yield COGXFact(
-                external_system=self.source_system,
-                external_id=str(edge.get("uuid") or edge.get("id") or f"fact-{index}"),
-                subject_ref=str(subject_ref),
-                predicate=str(edge.get("name") or edge.get("relation") or "relates_to"),
-                object_ref=str(object_ref),
-                fact_text=edge.get("fact"),
-                valid_at=parse_timestamp(edge.get("valid_at")),
-                invalid_at=parse_timestamp(edge.get("invalid_at") or edge.get("expired_at")),
-                created_at=parse_timestamp(edge.get("created_at")),
-                provenance=[str(episode) for episode in edge.get("episodes") or []],
-                scope=COGXScope(session_id=edge.get("group_id")),
-            )
+        async for record in iter_zep_graph_records(
+            self._load_raw(), source_system=self.source_system
+        ):
+            yield record
 
 
 class GraphitiSource(ZepSource):
     """Alias for OSS Graphiti exports (same shape as Zep graph exports)."""
 
     source_system = "graphiti"
+
+    async def records(self) -> AsyncIterator[COGXRecord]:
+        async for record in iter_zep_graph_records(
+            self._load_raw(), source_system=self.source_system
+        ):
+            yield record

--- a/cognee/tests/unit/migration/fixtures/live/graphiti_responses.json
+++ b/cognee/tests/unit/migration/fixtures/live/graphiti_responses.json
@@ -1,0 +1,34 @@
+{
+  "episodes": [
+    {
+      "uuid": "ep1",
+      "name": "chat",
+      "content": "Alice said she moved to Berlin",
+      "created_at": "2024-02-01T00:00:00Z",
+      "group_id": "g1"
+    }
+  ],
+  "nodes": [
+    {
+      "uuid": "n1",
+      "name": "Alice",
+      "labels": ["Entity", "Person"],
+      "summary": "A person"
+    },
+    {
+      "uuid": "n2",
+      "name": "Berlin"
+    }
+  ],
+  "edges": [
+    {
+      "uuid": "f1",
+      "source_node_uuid": "n1",
+      "target_node_uuid": "n2",
+      "name": "LIVES_IN",
+      "fact": "Alice lives in Berlin",
+      "valid_at": "2024-02-01T00:00:00Z",
+      "episodes": ["ep1"]
+    }
+  ]
+}

--- a/cognee/tests/unit/migration/fixtures/live/letta_responses.json
+++ b/cognee/tests/unit/migration/fixtures/live/letta_responses.json
@@ -1,0 +1,36 @@
+{
+  "agents": [
+    {
+      "name": "assistant",
+      "core_memory": [
+        {
+          "id": "blk1",
+          "label": "persona",
+          "value": "I am helpful",
+          "limit": 2000
+        }
+      ],
+      "messages": [
+        {
+          "role": "user",
+          "content": "hello",
+          "created_at": "2024-01-01T00:00:00Z"
+        },
+        {
+          "role": "assistant",
+          "content": [{"type": "text", "text": "hi there"}]
+        },
+        {
+          "role": "system",
+          "content": "ignored"
+        }
+      ],
+      "archival_memory": [
+        {
+          "id": "p1",
+          "text": "archived note"
+        }
+      ]
+    }
+  ]
+}

--- a/cognee/tests/unit/migration/fixtures/live/mem0_responses.json
+++ b/cognee/tests/unit/migration/fixtures/live/mem0_responses.json
@@ -1,0 +1,29 @@
+{
+  "page1": {
+    "count": 2,
+    "next": "page2",
+    "previous": null,
+    "results": [
+      {
+        "id": "mem-1",
+        "memory": "Alice works at Acme",
+        "user_id": "u1",
+        "categories": ["work"],
+        "created_at": "2024-01-01T00:00:00Z"
+      }
+    ]
+  },
+  "page2": {
+    "count": 2,
+    "next": null,
+    "previous": "page1",
+    "results": [
+      {
+        "id": "mem-2",
+        "text": "Alice likes tea",
+        "user_id": "u1",
+        "created_at": "2024-01-02T00:00:00Z"
+      }
+    ]
+  }
+}

--- a/cognee/tests/unit/migration/fixtures/live/zep_responses.json
+++ b/cognee/tests/unit/migration/fixtures/live/zep_responses.json
@@ -1,0 +1,30 @@
+{
+  "episodes": [
+    {
+      "uuid": "ep-zep-1",
+      "name": "session",
+      "content": "User asked about Berlin",
+      "created_at": "2024-03-01T00:00:00Z",
+      "group_id": "sess-1"
+    }
+  ],
+  "nodes": [
+    {
+      "uuid": "node-1",
+      "name": "Berlin",
+      "labels": ["Entity"],
+      "summary": "A city"
+    }
+  ],
+  "edges": [
+    {
+      "uuid": "edge-1",
+      "source_node_uuid": "node-1",
+      "target_node_uuid": "node-2",
+      "name": "LOCATED_IN",
+      "fact": "Berlin is in Germany",
+      "valid_at": "2024-03-01T00:00:00Z",
+      "episodes": ["ep-zep-1", "ep-missing"]
+    }
+  ]
+}

--- a/cognee/tests/unit/migration/test_live_remember_e2e.py
+++ b/cognee/tests/unit/migration/test_live_remember_e2e.py
@@ -1,0 +1,117 @@
+"""E2E tests: remember() dispatch with live MemorySource importers (mocked fetch)."""
+
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognee.api.v1.remember.remember import remember
+from cognee.modules.migration.sources.live.graphiti import GraphitiLiveSource
+from cognee.modules.migration.sources.live.letta import LettaLiveSource
+from cognee.modules.migration.sources.live.mem0 import Mem0LiveSource
+from cognee.modules.migration.sources.live.zep import ZepLiveSource
+from cognee.tests.unit.migration.test_import_source import _summary_items, install_sinks
+
+serve_state = importlib.import_module("cognee.api.v1.serve.state")
+shared_utils = importlib.import_module("cognee.shared.utils")
+
+FIXTURES = Path(__file__).parent / "fixtures" / "live"
+
+
+def _load_fixture(name: str):
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(serve_state, "get_remote_client", lambda: None)
+    monkeypatch.setattr(shared_utils, "send_telemetry", lambda *args, **kwargs: None)
+
+
+class TestRememberLiveSources:
+    def test_remember_mem0_live_re_derive(self, monkeypatch):
+        sinks = install_sinks(monkeypatch)
+        client = SimpleNamespace(
+            get_all=lambda **kwargs: {
+                "results": [{"id": "m1", "memory": "likes tea", "user_id": "u1"}],
+                "next": None,
+            }
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setitem(sys.modules, "mem0", MagicMock())
+            result = asyncio.run(remember(Mem0LiveSource(client, filters={"user_id": "u1"}), "ds"))
+
+        assert len(sinks.remember_calls) == 1
+        assert sinks.pipeline_calls == []
+        (summary,) = _summary_items(result)
+        assert summary["source_system"] == "mem0"
+        assert summary["mode"] == "re-derive"
+        assert summary["record_counts"]["memory"] == 1
+
+    def test_remember_graphiti_live_hybrid(self, monkeypatch):
+        sinks = install_sinks(monkeypatch)
+        fixture = _load_fixture("graphiti_responses.json")
+
+        async def fake_fetch(graphiti, group_ids=None, page_size=500):
+            return fixture
+
+        monkeypatch.setattr(
+            "cognee.modules.migration.sources.live.graphiti.fetch_graphiti_snapshot",
+            fake_fetch,
+        )
+        result = asyncio.run(remember(GraphitiLiveSource(SimpleNamespace(driver=object())), "ds"))
+
+        assert len(sinks.pipeline_calls) == 1
+        assert len(sinks.remember_calls) == 1
+        (summary,) = _summary_items(result)
+        assert summary["source_system"] == "graphiti"
+        assert summary["mode"] == "hybrid"
+        assert summary["graph_nodes"] == 3  # Alice, Berlin, and Person entity type
+        assert summary["graph_edges"] == 1
+
+    def test_remember_zep_live_preserve(self, monkeypatch):
+        sinks = install_sinks(monkeypatch)
+        fixture = _load_fixture("zep_responses.json")
+
+        async def fake_fetch(client, **kwargs):
+            return fixture
+
+        monkeypatch.setattr(
+            "cognee.modules.migration.sources.live.zep.fetch_zep_snapshot",
+            fake_fetch,
+        )
+        source = ZepLiveSource(SimpleNamespace(), user_id="u1", mode="preserve")
+        result = asyncio.run(remember(source, "ds"))
+
+        assert len(sinks.pipeline_calls) == 1
+        assert len(sinks.add_calls) == 1
+        assert sinks.remember_calls == []
+        (summary,) = _summary_items(result)
+        assert summary["source_system"] == "zep"
+        assert summary["mode"] == "preserve"
+
+    def test_remember_letta_live_re_derive(self, monkeypatch):
+        sinks = install_sinks(monkeypatch)
+        fixture = _load_fixture("letta_responses.json")
+
+        async def fake_fetch(client, agent_ids=None):
+            return fixture
+
+        monkeypatch.setattr(
+            "cognee.modules.migration.sources.live.letta.fetch_letta_snapshot",
+            fake_fetch,
+        )
+        result = asyncio.run(remember(LettaLiveSource(SimpleNamespace()), "ds"))
+
+        assert len(sinks.remember_calls) == 1
+        (summary,) = _summary_items(result)
+        assert summary["source_system"] == "letta"
+        assert summary["mode"] == "re-derive"
+        assert summary["record_counts"]["memory_block"] == 1
+        assert summary["record_counts"]["episode"] == 1
+        assert summary["record_counts"]["document"] == 1

--- a/cognee/tests/unit/migration/test_live_sources.py
+++ b/cognee/tests/unit/migration/test_live_sources.py
@@ -1,0 +1,313 @@
+"""Unit tests for live-API memory sources (mocked clients, no network)."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognee.modules.migration.sources.live.graphiti import (
+    GraphitiLiveSource,
+    fetch_graphiti_snapshot,
+)
+from cognee.modules.migration.sources.live.letta import LettaLiveSource, fetch_letta_snapshot
+from cognee.modules.migration.sources.live.mem0 import Mem0LiveSource
+from cognee.modules.migration.sources.live.zep import ZepLiveSource, fetch_zep_snapshot
+
+FIXTURES = Path(__file__).parent / "fixtures" / "live"
+
+
+def collect(source):
+    async def _collect():
+        return [record async for record in source.records()]
+
+    return asyncio.run(_collect())
+
+
+def _load_fixture(name: str):
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+class TestMem0LiveSource:
+    def test_paginates_and_maps_memories(self):
+        fixture = _load_fixture("mem0_responses.json")
+        calls = []
+
+        def get_all(filters=None, page=1, page_size=100):
+            calls.append(page)
+            return fixture["page1"] if page == 1 else fixture["page2"]
+
+        client = SimpleNamespace(get_all=get_all)
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setitem(sys.modules, "mem0", MagicMock())
+            records = collect(Mem0LiveSource(client, filters={"user_id": "u1"}, page_size=1))
+
+        assert calls == [1, 2]
+        assert len(records) == 2
+        assert {record.kind for record in records} == {"memory"}
+        assert records[0].external_id == "mem-1"
+        assert records[1].content == "Alice likes tea"
+
+    def test_skips_items_without_content(self):
+        client = SimpleNamespace(
+            get_all=lambda **kwargs: {
+                "results": [{"id": "1"}, {"id": "2", "memory": "kept"}],
+                "next": None,
+            }
+        )
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setitem(sys.modules, "mem0", MagicMock())
+            records = collect(Mem0LiveSource(client, filters={"user_id": "u1"}))
+        assert len(records) == 1
+        assert records[0].content == "kept"
+
+    def test_requires_entity_filters(self):
+        client = SimpleNamespace(get_all=lambda **kwargs: {"results": []})
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setitem(sys.modules, "mem0", MagicMock())
+            source = Mem0LiveSource(client)
+            with pytest.raises(ValueError, match="entity-scoped filters"):
+                collect(source)
+
+    def test_replayable_snapshot(self):
+        calls = []
+
+        def get_all(**kwargs):
+            calls.append(1)
+            return {"results": [{"id": "1", "memory": "once"}], "next": None}
+
+        client = SimpleNamespace(get_all=get_all)
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setitem(sys.modules, "mem0", MagicMock())
+            source = Mem0LiveSource(client, filters={"user_id": "u1"})
+            first = collect(source)
+            second = collect(source)
+
+        assert len(calls) == 1
+        assert len(first) == len(second) == 1
+
+
+class TestGraphitiLiveSource:
+    def test_fetch_and_map_graph_snapshot(self, monkeypatch):
+        fixture = _load_fixture("graphiti_responses.json")
+
+        class FakeEpisodicNode:
+            @staticmethod
+            async def get_by_group_ids(driver, group_ids, limit, uuid_cursor=None):
+                return [
+                    SimpleNamespace(**fixture["episodes"][0], source=SimpleNamespace(value="text"))
+                ]
+
+        class FakeEntityNode:
+            @staticmethod
+            async def get_by_group_ids(driver, group_ids, limit, uuid_cursor=None):
+                return [SimpleNamespace(**node) for node in fixture["nodes"]]
+
+        class FakeEntityEdge:
+            @staticmethod
+            async def get_by_group_ids(driver, group_ids, limit, uuid_cursor=None):
+                return [SimpleNamespace(**fixture["edges"][0])]
+
+        fake_graphiti_core = SimpleNamespace(
+            nodes=SimpleNamespace(EpisodicNode=FakeEpisodicNode, EntityNode=FakeEntityNode),
+            edges=SimpleNamespace(EntityEdge=FakeEntityEdge),
+        )
+        monkeypatch.setitem(sys.modules, "graphiti_core", fake_graphiti_core)
+
+        graphiti = SimpleNamespace(driver=object())
+        records = collect(GraphitiLiveSource(graphiti, group_ids=["g1"]))
+
+        kinds = [record.kind for record in records]
+        assert kinds == ["episode", "entity", "entity", "fact"]
+        assert records[-1].fact_text == "Alice lives in Berlin"
+
+    def test_fetch_graphiti_snapshot_helper(self, monkeypatch):
+        fixture = _load_fixture("graphiti_responses.json")
+
+        class FakeNode:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+            def model_dump(self, mode="json"):
+                return dict(self.__dict__)
+
+        class FakeEpisodicNode:
+            @staticmethod
+            async def get_by_group_ids(driver, group_ids, limit, uuid_cursor=None):
+                return [FakeNode(**fixture["episodes"][0], source="text")]
+
+        class FakeEntityNode:
+            @staticmethod
+            async def get_by_group_ids(driver, group_ids, limit, uuid_cursor=None):
+                return []
+
+        class GroupsEdgesNotFoundError(Exception):
+            pass
+
+        class FakeEntityEdge:
+            @staticmethod
+            async def get_by_group_ids(driver, group_ids, limit, uuid_cursor=None):
+                raise GroupsEdgesNotFoundError()
+
+        fake_graphiti_core = SimpleNamespace(
+            nodes=SimpleNamespace(EpisodicNode=FakeEpisodicNode, EntityNode=FakeEntityNode),
+            edges=SimpleNamespace(EntityEdge=FakeEntityEdge),
+        )
+        monkeypatch.setitem(sys.modules, "graphiti_core", fake_graphiti_core)
+
+        snapshot = asyncio.run(
+            fetch_graphiti_snapshot(SimpleNamespace(driver=object()), group_ids=[""])
+        )
+        assert len(snapshot["episodes"]) == 1
+        assert snapshot["edges"] == []
+
+
+class TestZepLiveSource:
+    def test_cursor_pagination_and_uuid_normalization(self, monkeypatch):
+        node_batches = [
+            [SimpleNamespace(uuid_="node-1", name="Berlin", labels=["Entity"], summary="A city")],
+            [],
+        ]
+        edge_batches = [
+            [
+                SimpleNamespace(
+                    uuid_="edge-1",
+                    source_node_uuid="node-1",
+                    target_node_uuid="node-2",
+                    name="LOCATED_IN",
+                    fact="Berlin is in Germany",
+                    valid_at="2024-03-01T00:00:00Z",
+                    episodes=["ep-zep-1", "ep-missing"],
+                )
+            ],
+            [],
+        ]
+        node_calls = []
+        edge_calls = []
+
+        def get_nodes(user_id, limit, uuid_cursor=None):
+            node_calls.append(uuid_cursor)
+            return node_batches.pop(0)
+
+        def get_edges(user_id, limit, uuid_cursor=None):
+            edge_calls.append(uuid_cursor)
+            return edge_batches.pop(0)
+
+        missing_episode = SimpleNamespace(
+            uuid_="ep-missing",
+            name="extra",
+            content="Referenced episode",
+            created_at="2024-03-02T00:00:00Z",
+        )
+
+        graph = SimpleNamespace(
+            episode=SimpleNamespace(
+                get_by_user_id=lambda user_id, lastn: SimpleNamespace(
+                    episodes=[
+                        SimpleNamespace(
+                            uuid_="ep-zep-1",
+                            name="session",
+                            content="User asked about Berlin",
+                            created_at="2024-03-01T00:00:00Z",
+                            group_id="sess-1",
+                        )
+                    ]
+                ),
+                get=lambda uuid_: missing_episode,
+            ),
+            node=SimpleNamespace(get_by_user_id=get_nodes),
+            edge=SimpleNamespace(get_by_user_id=get_edges),
+        )
+        client = SimpleNamespace(graph=graph)
+
+        monkeypatch.setitem(sys.modules, "zep_cloud", MagicMock())
+        records = collect(ZepLiveSource(client, user_id="user-1", page_size=1))
+
+        assert node_calls == [None, "node-1"]
+        assert edge_calls == [None, "edge-1"]
+        kinds = [record.kind for record in records]
+        assert kinds.count("episode") == 2
+        assert "entity" in kinds
+        assert "fact" in kinds
+
+    def test_fetch_zep_snapshot_requires_scope(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "zep_cloud", MagicMock())
+        with pytest.raises(ValueError, match="user_id or graph_id"):
+            asyncio.run(fetch_zep_snapshot(SimpleNamespace(graph=SimpleNamespace())))
+
+
+class TestLettaLiveSource:
+    def test_maps_agent_state(self, monkeypatch):
+        agent = SimpleNamespace(id="agent-1", name="assistant")
+        block = SimpleNamespace(id="blk1", label="persona", value="I am helpful", limit=2000)
+        messages = [
+            SimpleNamespace(
+                message_type="user_message",
+                content="hello",
+                date="2024-01-01T00:00:00Z",
+            ),
+            SimpleNamespace(
+                message_type="assistant_message",
+                content=[{"type": "text", "text": "hi there"}],
+                date=None,
+            ),
+            SimpleNamespace(message_type="system_message", content="ignored", date=None),
+        ]
+        passage = SimpleNamespace(id="p1", text="archived note", created_at="2024-01-02T00:00:00Z")
+
+        client = SimpleNamespace(
+            agents=SimpleNamespace(
+                list=lambda: [agent],
+                retrieve=lambda agent_id: agent,
+                blocks=SimpleNamespace(list=lambda agent_id: [block]),
+                messages=SimpleNamespace(list=lambda agent_id, order="asc": messages),
+                passages=SimpleNamespace(list=lambda agent_id: [passage]),
+            )
+        )
+
+        monkeypatch.setitem(sys.modules, "letta_client", MagicMock())
+        records = collect(LettaLiveSource(client))
+
+        kinds = [record.kind for record in records]
+        assert kinds.count("memory_block") == 1
+        assert kinds.count("episode") == 1
+        assert kinds.count("document") == 1
+
+        episode = next(record for record in records if record.kind == "episode")
+        assert len(episode.turns) == 2
+
+    def test_fetch_letta_snapshot_with_explicit_agent_ids(self, monkeypatch):
+        client = SimpleNamespace(
+            agents=SimpleNamespace(
+                retrieve=lambda agent_id: SimpleNamespace(name="bot"),
+                blocks=SimpleNamespace(list=lambda agent_id: []),
+                messages=SimpleNamespace(list=lambda agent_id, order="asc": []),
+                passages=SimpleNamespace(list=lambda agent_id: []),
+            )
+        )
+        monkeypatch.setitem(sys.modules, "letta_client", MagicMock())
+        snapshot = asyncio.run(fetch_letta_snapshot(client, agent_ids=["a1"]))
+        assert snapshot["agents"][0]["name"] == "bot"
+
+
+class TestReplayable:
+    def test_second_records_call_does_not_refetch(self, monkeypatch):
+        fetch_calls = []
+
+        async def fake_fetch(
+            client, user_id=None, graph_id=None, episode_lastn=10000, page_size=100
+        ):
+            fetch_calls.append(1)
+            return _load_fixture("zep_responses.json")
+
+        monkeypatch.setattr(
+            "cognee.modules.migration.sources.live.zep.fetch_zep_snapshot",
+            fake_fetch,
+        )
+        source = ZepLiveSource(SimpleNamespace(), user_id="u1")
+        collect(source)
+        collect(source)
+        assert len(fetch_calls) == 1

--- a/examples/python/migrate_from_live_memory.py
+++ b/examples/python/migrate_from_live_memory.py
@@ -1,0 +1,65 @@
+"""Migrate memory from running Mem0 or Graphiti instances into Cognee.
+
+Requires optional extras and environment variables::
+
+    pip install cognee[mem0,graphiti]
+    export MEM0_API_KEY=...
+    export GRAPH_DATABASE_URL=bolt://localhost:7687
+    export GRAPH_DATABASE_PASSWORD=...
+
+Run::
+
+    python examples/python/migrate_from_live_memory.py
+"""
+
+import asyncio
+import os
+import sys
+
+
+async def migrate_from_mem0(dataset_name: str = "migrated_mem0") -> None:
+    api_key = os.environ.get("MEM0_API_KEY")
+    user_id = os.environ.get("MEM0_USER_ID")
+    if not api_key or not user_id:
+        print("Skipping Mem0: set MEM0_API_KEY and MEM0_USER_ID.", file=sys.stderr)
+        return
+
+    from mem0 import MemoryClient
+
+    import cognee
+    from cognee.migration import Mem0LiveSource
+
+    client = MemoryClient(api_key=api_key)
+    source = Mem0LiveSource(client=client, filters={"user_id": user_id})
+    result = await cognee.remember(source, dataset_name=dataset_name)
+    print("Mem0 import:", result.items[-1] if result.items else result)
+
+
+async def migrate_from_graphiti(dataset_name: str = "migrated_graphiti") -> None:
+    url = os.environ.get("GRAPH_DATABASE_URL")
+    password = os.environ.get("GRAPH_DATABASE_PASSWORD", "")
+    if not url:
+        print("Skipping Graphiti: set GRAPH_DATABASE_URL.", file=sys.stderr)
+        return
+
+    from graphiti_core import Graphiti
+
+    import cognee
+    from cognee.migration import GraphitiLiveSource
+
+    graphiti = Graphiti(url, os.environ.get("GRAPH_DATABASE_USERNAME", "neo4j"), password)
+    try:
+        source = GraphitiLiveSource(graphiti=graphiti, mode="hybrid")
+        result = await cognee.remember(source, dataset_name=dataset_name)
+        print("Graphiti import:", result.items[-1] if result.items else result)
+    finally:
+        await graphiti.close()
+
+
+async def main() -> None:
+    await migrate_from_mem0()
+    await migrate_from_graphiti()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,9 @@ evals = [
 ]
 
 graphiti = ["graphiti-core>=0.28.0"]
+mem0 = ["mem0ai>=0.1.114"]
+zep = ["zep-cloud>=3.22.0"]
+letta = ["letta-client>=1.12.0"]
 # Note: New s3fs and boto3 versions don't work well together
 # Always use comaptible fixed versions of these two dependencies
 aws = ["s3fs[boto3]==2025.3.2"]

--- a/uv.lock
+++ b/uv.lock
@@ -1348,11 +1348,17 @@ langchain = [
     { name = "langchain-text-splitters" },
     { name = "langsmith" },
 ]
+letta = [
+    { name = "letta-client" },
+]
 llama-cpp = [
     { name = "llama-cpp-python", extra = ["server"] },
 ]
 llama-index = [
     { name = "llama-index-core" },
+]
+mem0 = [
+    { name = "mem0ai" },
 ]
 mistral = [
     { name = "mistral-common", version = "1.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
@@ -1411,6 +1417,9 @@ tracing = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
 ]
+zep = [
+    { name = "zep-cloud" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1467,6 +1476,7 @@ requires-dist = [
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "langfuse", marker = "extra == 'monitoring'", specifier = ">=2.32.0,<3" },
     { name = "langsmith", marker = "extra == 'langchain'", specifier = ">=0.2.3,<1.0.0" },
+    { name = "letta-client", marker = "extra == 'letta'", specifier = ">=1.12.0" },
     { name = "limits", specifier = ">=4.4.1,<5" },
     { name = "litellm", specifier = ">=1.83.7" },
     { name = "llama-cpp-python", extras = ["server"], marker = "extra == 'llama-cpp'", specifier = ">=0.3.0,<1.0.0" },
@@ -1479,6 +1489,7 @@ requires-dist = [
     { name = "lxml", marker = "python_full_version >= '3.14' and extra == 'docs'", specifier = ">=6.0.1,<7" },
     { name = "lxml", marker = "python_full_version >= '3.14' and extra == 'scraping'", specifier = ">=6.0.1,<7" },
     { name = "matplotlib", marker = "extra == 'evals'", specifier = ">=3.8.3,<4" },
+    { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.114" },
     { name = "mistral-common", marker = "extra == 'mistral'", specifier = ">=1.5.2,<2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.9.10,<2" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.42,<10" },
@@ -1551,8 +1562,9 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.6.0" },
     { name = "uvicorn", specifier = ">=0.34.0,<1.0.0" },
     { name = "websockets", specifier = ">=15.0.1,<16.0.0" },
+    { name = "zep-cloud", marker = "extra == 'zep'", specifier = ">=3.22.0" },
 ]
-provides-extras = ["api", "distributed", "scraping", "fastembed", "neo4j", "neptune", "postgres", "postgres-binary", "notebook", "langchain", "llama-index", "huggingface", "ollama", "mistral", "anthropic", "azure", "deepeval", "posthog", "groq", "llama-cpp", "docs", "codegraph", "evals", "graphiti", "aws", "dlt", "baml", "dev", "debug", "redis", "tracing", "monitoring", "docling"]
+provides-extras = ["api", "distributed", "scraping", "fastembed", "neo4j", "neptune", "postgres", "postgres-binary", "notebook", "langchain", "llama-index", "huggingface", "ollama", "mistral", "anthropic", "azure", "deepeval", "posthog", "groq", "llama-cpp", "docs", "codegraph", "evals", "graphiti", "mem0", "zep", "letta", "aws", "dlt", "baml", "dev", "debug", "redis", "tracing", "monitoring", "docling"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3716,6 +3728,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "huggingface-hub"
 version = "0.36.2"
@@ -4751,6 +4768,23 @@ wheels = [
 ]
 
 [[package]]
+name = "letta-client"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/55/34a347fb443f5797045cde591c34ee2926650e99f1f0d5f565dcefa99120/letta_client-1.12.1.tar.gz", hash = "sha256:3073adb6cc1ce3b906a40d8ce3b2b77a77ac1887ca2135770590cfe3cef6eba9", size = 396805, upload-time = "2026-06-02T00:31:12.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/af/b140a7117b4385b3e1b060df97d9d39703f0c54e156a4d889de8bb8dd48f/letta_client-1.12.1-py3-none-any.whl", hash = "sha256:6f554569a684d57e7f4e4513f8ce6792129b305df37393c650e50776f61baf99", size = 418856, upload-time = "2026-06-02T00:31:14.475Z" },
+]
+
+[[package]]
 name = "limits"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5609,6 +5643,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mem0ai"
+version = "1.0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openai" },
+    { name = "posthog" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pytz" },
+    { name = "qdrant-client" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/1e/2f8a8cc4b8e7f6126f3367d27dc65eac5cd4ceb854888faa3a8f62a2c0a0/mem0ai-1.0.11.tar.gz", hash = "sha256:ddb803bedc22bd514606d262407782e88df929f6991b59f6972fb8a25cc06001", size = 201758, upload-time = "2026-04-06T11:31:43.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/b5/f822c94e1b901f8a700af134c2473646de9a7db26364566f6a72d527d235/mem0ai-1.0.11-py3-none-any.whl", hash = "sha256:bcf4d678dc0a4d4e8eccaebe05562eae022fcdc825a0e3095d02f28cf61a5b6d", size = 297138, upload-time = "2026-04-06T11:31:41.716Z" },
 ]
 
 [[package]]
@@ -9652,6 +9704,25 @@ wheels = [
 ]
 
 [[package]]
+name = "qdrant-client"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/45/5b1bdd15a3c7730eefb9c113600829e20d689b82b5a23f9e07d107094004/qdrant_client-1.18.0.tar.gz", hash = "sha256:52e8ece1a7d40519801bf0b70713bfa0f6b7ae28c7275bbe0b0286fbed7f6db4", size = 352580, upload-time = "2026-05-11T14:12:38.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/10/c437bd2ac41ef30d3019063e6ce537dc111e9214473b337ee88f7fa6359a/qdrant_client-1.18.0-py3-none-any.whl", hash = "sha256:093aa8cf8a420ee3ad2a68b007e1378d7992b2600e0b53c193fc172674f659cd", size = 398126, upload-time = "2026-05-11T14:12:36.998Z" },
+]
+
+[[package]]
 name = "rapidfuzz"
 version = "3.14.5"
 source = { registry = "https://pypi.org/simple" }
@@ -13311,6 +13382,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
     { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "zep-cloud"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/45/18b0eebca6d4ff0250fa0b25d6074247e5bcaddbf5e46ee5815359111082/zep_cloud-3.23.0.tar.gz", hash = "sha256:fb96946dca1c417d9e537873038d323ba9fa6d3470395fb3c75a309bfba63a0b", size = 88446, upload-time = "2026-06-04T19:57:06.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/f5/6eb3038444cb860123dccf9ecc04746aacdbcf2b7ff3461a2221ae20f018/zep_cloud-3.23.0-py3-none-any.whl", hash = "sha256:77a8eb0ab3f7ae6a0464d34773a9b7799090d9031e8a2f772bd7fdbb221b4405", size = 155733, upload-time = "2026-06-04T19:57:05.555Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #3404
Part of #3401

## Description

Right now migration only works from file/dict dumps (`Mem0Source("export.json")`, etc.). I added thin live sources that fetch from a running service via an injected client, normalize the response, and reuse the existing COGX mapping logic.

Design choices:
- **Injected clients** — API keys/URLs stay with the caller, not inside the source classes
- **Snapshot on first `records()`** — fetch once, cache in memory, `replayable=True` so preserve-mode streaming still works
- **No duplicated mapping** — extracted `iter_mem0_records` / `iter_zep_graph_records` / `iter_letta_records` and live sources call those same helpers
- **Optional extras** — `mem0`, `zep`, `letta` in pyproject; `graphiti` extra already existed

New files under `cognee/modules/migration/sources/live/`:
- `Mem0LiveSource` — paginated `get_all()`, optional `discover_entities`
- `GraphitiLiveSource` — full graph export via `get_by_group_ids` (not search/windowed APIs)
- `ZepLiveSource` — uuid-cursor pagination for nodes/edges; episodes via `lastn`
- `LettaLiveSource` — blocks, messages, passages per agent

## Acceptance Criteria

- [x] Live sources accept injected clients (no hardcoded credentials)
- [x] `cognee.remember(Mem0LiveSource(...))` works end-to-end (mocked in `test_live_remember_e2e.py`)
- [x] `cognee.remember(GraphitiLiveSource(...))` works end-to-end (mocked in `test_live_remember_e2e.py`)
- [x] Zep + Letta live sources implemented with unit tests
- [x] `replayable` set appropriately; snapshot is point-in-time
- [x] `pytest cognee/tests/unit/migration/ -v` — 116 passed locally
- [x] `ruff check` + `ruff format` passed (pre-commit hooks)

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<img width="1910" height="1650" alt="cognee_1" src="https://github.com/user-attachments/assets/6c179f46-ae94-47d3-94a3-8f6e88ca0a77" />
<img width="1908" height="1700" alt="cognee_2" src="https://github.com/user-attachments/assets/59125db0-7f74-4858-a3a4-378aecaf75d4" />
