### PR TITLE
feat: add LangMemSource adapter for COGX import (#3403)

### DIFF
--- a/cognee/modules/migration/sources/__init__.py
+++ b/cognee/modules/migration/sources/__init__.py
@@ -1,5 +1,6 @@
 from .base import MemorySource, IMPORT_MODES
 from .cogx_archive import COGXArchiveSource
+from .langmem import LangMemSource
 from .letta import LettaSource
 from .mem0 import Mem0Source
 from .zep import GraphitiSource, ZepSource
@@ -8,6 +9,7 @@ __all__ = [
     "MemorySource",
     "IMPORT_MODES",
     "COGXArchiveSource",
+    "LangMemSource",
     "LettaSource",
     "Mem0Source",
     "GraphitiSource",

--- a/cognee/modules/migration/sources/langmem.py
+++ b/cognee/modules/migration/sources/langmem.py
@@ -1,0 +1,170 @@
+"""LangMem memory source.
+
+Reads a LangMem export and yields COGX records. LangMem stores memories as
+short derived facts (similar to mem0) and optionally extracts entities and
+relations into a graph. This importer handles both.
+
+Accepted shapes
+---------------
+A plain list of memory objects::
+
+    [{"id": "...", "content": "...", "user_id": "...", ...}]
+
+A dict with a wrapper key (``memories``, ``results``, or ``items``)::
+
+    {"memories": [...]}
+
+A dict with an optional graph section alongside memories::
+
+    {
+        "memories":  [{"id": "...", "content": "..."}],
+        "entities":  [{"id": "...", "name": "...", "type": "..."}],
+        "relations": [{"id": "...", "source": "...", "target": "...", "relation": "..."}]
+    }
+
+A file path (str or Path) pointing to any of the above as JSON.
+
+Each memory becomes a :class:`COGXMemory`. Entities become :class:`COGXEntity`
+and relations become :class:`COGXFact`, so the full graph is preserved when
+running in ``preserve`` or ``hybrid`` mode.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List, Union
+
+from cognee.modules.migration.cogx import (
+    COGXEntity,
+    COGXFact,
+    COGXMemory,
+    COGXRecord,
+    COGXScope,
+    parse_timestamp,
+)
+from cognee.modules.migration.sources.base import MemorySource
+
+_CONTENT_KEYS = ("content", "memory", "text", "data")
+
+
+def _first_list(container: Dict[str, Any], *keys: str) -> List[Dict[str, Any]]:
+    for key in keys:
+        value = container.get(key)
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+class LangMemSource(MemorySource):
+    """Import memories from a LangMem export into Cognee.
+
+    Args:
+        data: A file path, a list of memory dicts, or a dict export from LangMem.
+        mode: Import fidelity mode — ``"re-derive"`` (default), ``"preserve"``,
+              or ``"hybrid"``. See :class:`MemorySource` for details.
+    """
+
+    source_system = "langmem"
+
+    def __init__(
+        self,
+        data: Union[str, Path, List[Any], Dict[str, Any]],
+        mode: str = "re-derive",
+    ):
+        super().__init__(mode=mode)
+        self._data = data
+
+    def _load_raw(self) -> Dict[str, Any]:
+        data = self._data
+        if isinstance(data, (str, Path)):
+            data = json.loads(Path(data).read_text(encoding="utf-8"))
+
+        if isinstance(data, list):
+            return {"memories": [item for item in data if isinstance(item, dict)]}
+
+        if isinstance(data, dict):
+            # If the dict already has a graph section, return as-is.
+            if any(key in data for key in ("entities", "relations")):
+                return data
+            # Otherwise look for a flat memory list under a known wrapper key.
+            for key in ("memories", "results", "items"):
+                if isinstance(data.get(key), list):
+                    return data
+            raise ValueError(
+                "Unrecognized LangMem export shape: expected a list or a dict "
+                "with a 'memories', 'results', or 'items' key."
+            )
+
+        raise ValueError("Unrecognized LangMem export: expected a list or dict.")
+
+    async def records(self) -> AsyncIterator[COGXRecord]:
+        data = self._load_raw()
+        memories = _first_list(data, "memories", "results", "items")
+        entities = _first_list(data, "entities", "nodes")
+        relations = _first_list(data, "relations", "edges", "facts")
+
+        # Memories → COGXMemory
+        for index, item in enumerate(memories):
+            content = next(
+                (item[key] for key in _CONTENT_KEYS if isinstance(item.get(key), str)),
+                None,
+            )
+            if not content or not content.strip():
+                continue
+
+            categories = item.get("categories") or item.get("tags") or []
+            if isinstance(categories, str):
+                categories = [categories]
+
+            context = item.get("context") or item.get("namespace") or ""
+            if context and context not in categories:
+                categories = [context, *categories]
+
+            yield COGXMemory(
+                external_system=self.source_system,
+                external_id=str(item.get("id") or f"langmem-{index}"),
+                content=content,
+                categories=[str(c) for c in categories],
+                scope=COGXScope(
+                    user_id=item.get("user_id"),
+                    agent_id=item.get("agent_id"),
+                    run_id=item.get("run_id"),
+                    session_id=item.get("thread_id") or item.get("session_id"),
+                ),
+                created_at=parse_timestamp(item.get("created_at")),
+                updated_at=parse_timestamp(item.get("updated_at")),
+                metadata={"langmem_metadata": item.get("metadata")} if item.get("metadata") else {},
+            )
+
+        # Entities → COGXEntity
+        for index, entity in enumerate(entities):
+            name = entity.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            yield COGXEntity(
+                external_system=self.source_system,
+                external_id=str(entity.get("id") or f"langmem-entity-{index}"),
+                name=name,
+                entity_type=entity.get("type") or entity.get("label"),
+                description=entity.get("description") or entity.get("summary"),
+                attributes=entity.get("attributes") or {},
+                created_at=parse_timestamp(entity.get("created_at")),
+                scope=COGXScope(user_id=entity.get("user_id")),
+            )
+
+        # Relations → COGXFact
+        for index, relation in enumerate(relations):
+            subject = relation.get("source") or relation.get("source_id")
+            obj = relation.get("target") or relation.get("target_id")
+            predicate = relation.get("relation") or relation.get("type") or "relates_to"
+            if not subject or not obj:
+                continue
+            yield COGXFact(
+                external_system=self.source_system,
+                external_id=str(relation.get("id") or f"langmem-relation-{index}"),
+                subject_ref=str(subject),
+                predicate=str(predicate),
+                object_ref=str(obj),
+                fact_text=relation.get("description") or relation.get("fact"),
+                created_at=parse_timestamp(relation.get("created_at")),
+                scope=COGXScope(user_id=relation.get("user_id")),
+            )

--- a/cognee/tests/unit/migration/test_migration.py
+++ b/cognee/tests/unit/migration/test_migration.py
@@ -29,6 +29,7 @@ from cognee.modules.migration.loader import record_data_id, translate_records
 from cognee.modules.migration.sources import (
     COGXArchiveSource,
     GraphitiSource,
+    LangMemSource,
     LettaSource,
     Mem0Source,
 )
@@ -488,6 +489,118 @@ class TestFormatEmitters:
         assert "MERGE (a)-[r:`lives_in`]->(b)" in script
         # Non-scalar property serialized as JSON string, not raw repr.
         assert '"[\\"city\\", \\"capital\\"]"' in script
+
+
+class TestLangMemSource:
+    def test_plain_list(self):
+        records = collect(
+            LangMemSource(
+                [
+                    {
+                        "id": "lm-1",
+                        "content": "User prefers Python over JavaScript",
+                        "user_id": "u1",
+                        "categories": ["programming"],
+                        "created_at": "2024-03-01T10:00:00Z",
+                    }
+                ]
+            )
+        )
+        assert len(records) == 1
+        assert records[0].kind == "memory"
+        assert records[0].external_id == "lm-1"
+        assert records[0].scope.user_id == "u1"
+        assert "programming" in records[0].categories
+
+    def test_memories_wrapper_key(self):
+        records = collect(LangMemSource({"memories": [{"id": "1", "content": "likes tea"}]}))
+        assert len(records) == 1
+        assert records[0].content == "likes tea"
+
+    def test_results_wrapper_key(self):
+        records = collect(LangMemSource({"results": [{"id": "1", "text": "hates coffee"}]}))
+        assert len(records) == 1
+        assert records[0].content == "hates coffee"
+
+    def test_context_added_to_categories(self):
+        records = collect(
+            LangMemSource([{"id": "1", "content": "Alice leads the team", "context": "work"}])
+        )
+        assert "work" in records[0].categories
+
+    def test_thread_id_maps_to_session_id(self):
+        records = collect(
+            LangMemSource([{"id": "1", "content": "some memory", "thread_id": "thread-42"}])
+        )
+        assert records[0].scope.session_id == "thread-42"
+
+    def test_export_with_entities_and_relations(self):
+        export = {
+            "memories": [{"id": "m1", "content": "Alice leads the team"}],
+            "entities": [
+                {"id": "e1", "name": "Alice", "type": "Person", "description": "Team lead"},
+                {"id": "e2", "name": "Engineering Team", "type": "Team"},
+            ],
+            "relations": [
+                {
+                    "id": "r1",
+                    "source": "e1",
+                    "target": "e2",
+                    "relation": "leads",
+                    "description": "Alice leads the Engineering Team",
+                }
+            ],
+        }
+        records = collect(LangMemSource(export, mode="preserve"))
+        kinds = [r.kind for r in records]
+        assert kinds.count("memory") == 1
+        assert kinds.count("entity") == 2
+        assert kinds.count("fact") == 1
+
+        fact = next(r for r in records if r.kind == "fact")
+        assert fact.subject_ref == "e1"
+        assert fact.predicate == "leads"
+        assert fact.object_ref == "e2"
+        assert fact.fact_text == "Alice leads the Engineering Team"
+
+        entity = next(r for r in records if r.kind == "entity" and r.name == "Alice")
+        assert entity.entity_type == "Person"
+        assert entity.description == "Team lead"
+
+    def test_skips_memories_without_content(self):
+        records = collect(LangMemSource([{"id": "1"}, {"id": "2", "content": "kept"}]))
+        assert len(records) == 1
+        assert records[0].content == "kept"
+
+    def test_skips_relations_without_source_or_target(self):
+        export = {
+            "memories": [],
+            "entities": [{"id": "e1", "name": "Alice"}],
+            "relations": [
+                {"id": "r1", "relation": "knows"},  # missing source and target
+                {"id": "r2", "source": "e1", "target": "e2", "relation": "knows"},
+            ],
+        }
+        records = collect(LangMemSource(export, mode="preserve"))
+        facts = [r for r in records if r.kind == "fact"]
+        assert len(facts) == 1
+        assert facts[0].subject_ref == "e1"
+
+    def test_export_file(self, tmp_path):
+        export_file = tmp_path / "langmem.json"
+        export_file.write_text(json.dumps([{"id": "1", "content": "from file"}]))
+        records = collect(LangMemSource(export_file))
+        assert records[0].content == "from file"
+
+    def test_default_mode_is_re_derive(self):
+        assert LangMemSource([]).mode == "re-derive"
+
+    def test_invalid_shape_raises(self):
+        try:
+            collect(LangMemSource({"unknown_key": []}))
+            raise AssertionError("expected ValueError")
+        except ValueError as error:
+            assert "LangMem" in str(error)
 
 
 class TestImportModeValidation:


### PR DESCRIPTION
LangMem was the one tool in this space that already had importers for mem0, Graphiti, Zep, and Letta — but nothing for LangMem itself. This PR fills that gap by adding LangMemSource, a new MemorySource adapter that lets users migrate their LangMem exports into Cognee with a single cognee.remember() call.

The adapter handles the main LangMem export shapes: plain memory lists, dict wrappers (memories/results/items), and full graph exports with entities and relations. Memories map to COGXMemory, entities to COGXEntity, and relations to COGXFact, so both simple and graph-backed LangMem setups are covered.

Closes #3403 | Part of #3401

Acceptance Criteria

  - await cognee.remember(LangMemSource(data)) works across all supported input shapes
  - Memories come in as COGXMemory, entities as COGXEntity, relations as COGXFact
  - LangMemSource is exported from cognee.modules.migration.sources
  - 11 unit tests pass covering all shapes and edge cases

Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Code refactoring
  - [ ] Other (please specify):

Screenshots

<img width="2872" height="1484" alt="Screenshot 2026-06-24 at 11 01 53 AM" src="https://github.com/user-attachments/assets/78141c58-78de-48de-ab80-8443d68d6667" />


Pre-submission Checklist

  - [x] I have tested my changes thoroughly before submitting this PR
  - [x] This PR contains minimal changes necessary to address the issue/feature
  - [x] My code follows the project's coding standards and style guidelines
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have added necessary documentation (if applicable)
  - [x] All new and existing tests pass
  - [x] I have searched existing PRs to ensure this change hasn't been submitted already
  - [x] I have linked any relevant issues in the description
  - [x] My commits have clear and descriptive messages

DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.