### PR TITLE
fix(embeddings): avoid retrying unsplittable context errors

### DIFF
--- a/cognee/infrastructure/databases/exceptions/__init__.py
+++ b/cognee/infrastructure/databases/exceptions/__init__.py
@@ -8,6 +8,7 @@ from .exceptions import (
     EntityNotFoundError,
     EntityAlreadyExistsError,
     DatabaseNotCreatedError,
+    EmbeddingContextWindowTooSmallError,
     EmbeddingException,
     MissingQueryParameterError,
     MutuallyExclusiveQueryParametersError,

--- a/cognee/infrastructure/databases/exceptions/exceptions.py
+++ b/cognee/infrastructure/databases/exceptions/exceptions.py
@@ -104,6 +104,18 @@ class EmbeddingException(CogneeConfigurationError):
         super().__init__(message, name, status_code)
 
 
+class EmbeddingContextWindowTooSmallError(EmbeddingException):
+    """Raised when over-length embedding input cannot be split any further."""
+
+    def __init__(
+        self,
+        message: str = "Text is too short to split further but exceeds context window.",
+        name: str = "EmbeddingContextWindowTooSmallError",
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+    ):
+        super().__init__(message, name, status_code)
+
+
 class MissingQueryParameterError(CogneeValidationError):
     """
     Raised when neither 'query_text' nor 'query_vector' is provided,

--- a/cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py
@@ -24,7 +24,10 @@ from tenacity import (
 
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
-from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.databases.exceptions import (
+    EmbeddingContextWindowTooSmallError,
+    EmbeddingException,
+)
 from cognee.infrastructure.llm.tokenizer.TikToken import (
     TikTokenTokenizer,
 )
@@ -86,7 +89,11 @@ class FastembedEmbeddingEngine(EmbeddingEngine):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(8, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, asyncio.CancelledError)
+            (
+                EmbeddingContextWindowTooSmallError,
+                litellm.exceptions.NotFoundError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -151,9 +158,7 @@ class FastembedEmbeddingEngine(EmbeddingEngine):
                     s = original_texts[0]
                     third = len(s) // 3
                     if third == 0:
-                        raise EmbeddingException(
-                            "Text is too short to split further but exceeds context window."
-                        ) from error
+                        raise EmbeddingContextWindowTooSmallError from error
                     left_part, right_part = s[: third * 2], s[third:]
                     (left_vec,), (right_vec,) = await asyncio.gather(
                         self.embed_text([left_part]),

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -18,7 +18,10 @@ import os
 from urllib.parse import urlparse
 import httpx
 from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
-from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.databases.exceptions import (
+    EmbeddingContextWindowTooSmallError,
+    EmbeddingException,
+)
 
 from cognee.infrastructure.llm.tokenizer.HuggingFace import (
     HuggingFaceTokenizer,
@@ -114,7 +117,11 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(2, 128),
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, asyncio.CancelledError)
+            (
+                EmbeddingContextWindowTooSmallError,
+                litellm.exceptions.NotFoundError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -195,6 +202,8 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
                 logger.debug(f"Pooling embeddings of text string with size: {len(text[0])}")
                 s = text[0]
                 third = len(s) // 3
+                if third == 0:
+                    raise EmbeddingContextWindowTooSmallError from error
                 # We are using thirds to intentionally have overlap between split parts
                 # for better embedding calculation
                 left_part, right_part = s[: third * 2], s[third:]

--- a/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
@@ -38,19 +38,14 @@ from cognee.infrastructure.databases.vector.embeddings.utils import (
     handle_embedding_response,
     sanitize_embedding_text_inputs,
 )
+from cognee.infrastructure.databases.exceptions import (
+    EmbeddingContextWindowTooSmallError,
+    EmbeddingException,
+)
 from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("OpenAICompatibleEmbeddingEngine")
-
-
-class EmbeddingException(Exception):
-    """Raised when an embedding request fails."""
-
-    def __init__(self, message: str, name: str = "EmbeddingException"):
-        self.message = message
-        self.name = name
-        super().__init__(self.message)
 
 
 class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
@@ -114,7 +109,9 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
     @retry(
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type((ValueError, asyncio.CancelledError)),
+        retry=retry_if_not_exception_type(
+            (EmbeddingContextWindowTooSmallError, ValueError, asyncio.CancelledError)
+        ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -180,9 +177,7 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
                     s = original_texts[0]
                     third = len(s) // 3
                     if third == 0:
-                        raise EmbeddingException(
-                            "Text is too short to split further but exceeds context window."
-                        ) from error
+                        raise EmbeddingContextWindowTooSmallError from error
                     left_part, right_part = s[: third * 2], s[third:]
                     (left_vec,), (right_vec,) = await asyncio.gather(
                         self.embed_text([left_part]),

--- a/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
+++ b/cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py
@@ -1,9 +1,12 @@
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import numpy as np
 import pytest
 
-from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.databases.exceptions import (
+    EmbeddingContextWindowTooSmallError,
+    EmbeddingException,
+)
 
 
 @pytest.mark.asyncio
@@ -134,3 +137,55 @@ async def test_fastembed_raises_when_short_text_still_exceeds_context_window():
 
         with pytest.raises(EmbeddingException, match="too short to split further"):
             await engine.embed_text(["ab"])
+
+        assert embedding_model.embed.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_litellm_embedding_does_not_retry_unsplittable_context_window_error():
+    import litellm
+
+    with patch(
+        "cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine."
+        "LiteLLMEmbeddingEngine.get_tokenizer",
+        return_value=Mock(),
+    ):
+        from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+            LiteLLMEmbeddingEngine,
+        )
+
+        engine = LiteLLMEmbeddingEngine(model="test-model", dimensions=2)
+
+    context_error = litellm.exceptions.BadRequestError(
+        message="maximum input length exceeded",
+        model="test-model",
+        llm_provider="openai",
+    )
+
+    with patch("litellm.aembedding", AsyncMock(side_effect=context_error)) as embed_mock:
+        with pytest.raises(EmbeddingContextWindowTooSmallError):
+            await engine.embed_text(["ab"])
+
+        assert embed_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_embedding_does_not_retry_unsplittable_context_window_error():
+    with patch(
+        "cognee.infrastructure.databases.vector.embeddings.OpenAICompatibleEmbeddingEngine."
+        "OpenAICompatibleEmbeddingEngine.get_tokenizer",
+        return_value=Mock(),
+    ):
+        from cognee.infrastructure.databases.vector.embeddings.OpenAICompatibleEmbeddingEngine import (
+            OpenAICompatibleEmbeddingEngine,
+        )
+
+        engine = OpenAICompatibleEmbeddingEngine(model="test-model", dimensions=2)
+
+    create_mock = AsyncMock(side_effect=RuntimeError("context window exceeded"))
+    engine._client.embeddings.create = create_mock
+
+    with pytest.raises(EmbeddingContextWindowTooSmallError):
+        await engine.embed_text(["ab"])
+
+    assert create_mock.await_count == 1


### PR DESCRIPTION
## Description

Fixes #3319.

`EmbeddingException` is used for several embedding failures, and some of those should remain retryable. The deterministic context-window fallback case is different: once a single text is too short to split further, retrying the same input only waits through tenacity backoff and cannot recover.

This adds a narrow `EmbeddingContextWindowTooSmallError` subclass for that terminal fallback condition, and excludes only that subtype from retries in the Fastembed, LiteLLM, and OpenAI-compatible embedding engines. Ordinary `EmbeddingException` remains retryable.

## Acceptance Criteria

- Deterministic "too short to split further" context-window failures return immediately.
- Other embedding failures still use the existing retry policy.
- Fastembed, LiteLLM, and OpenAI-compatible embedding engines share the same terminal exception behavior.
- Regression tests assert the provider call is made once for unsplittable context-window input.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Validation

- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check cognee/infrastructure/databases/exceptions/exceptions.py cognee/infrastructure/databases/exceptions/__init__.py cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff format --check cognee/infrastructure/databases/exceptions/exceptions.py cognee/infrastructure/databases/exceptions/__init__.py cognee/infrastructure/databases/vector/embeddings/FastembedEmbeddingEngine.py cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py cognee/tests/unit/infrastructure/test_embedding_context_window_fallbacks.py`

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
