### PR TITLE
docs: fix is_embeddable docstring to match its actual check

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/utils.py
+++ b/cognee/infrastructure/databases/vector/embeddings/utils.py
@@ -8,7 +8,7 @@ def is_embeddable(s: str) -> bool:
     """
     Check if input string is embeddable, if not it will be replaced with a dummy value to prevent API errors.
     Empty strings and a string with only a space character are not embeddable.
-    If input string contains at least one alphanumeric character, it is considered embeddable.
+    If input string contains at least one non-whitespace character, it is considered embeddable.
     """
     if not isinstance(s, str):
         return False

--- a/cognee/tests/unit/infrastructure/databases/vector/test_is_embeddable.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_is_embeddable.py
@@ -1,0 +1,36 @@
+from cognee.infrastructure.databases.vector.embeddings.utils import (
+    is_embeddable,
+    sanitize_embedding_text_inputs,
+)
+
+
+def test_non_whitespace_strings_are_embeddable():
+    # string is embeddable when it has at least one non-whitespace character,
+    # as documented in is_embeddable's docstring.
+    assert is_embeddable("a") is True
+    assert is_embeddable("  hi ") is True
+    # punctuation/symbol-only strings have no alphanumeric character but are
+    # still non-whitespace, so they are embeddable.
+    assert is_embeddable("!!!") is True
+    assert is_embeddable(".") is True
+
+
+def test_empty_or_whitespace_only_strings_are_not_embeddable():
+    assert is_embeddable("") is False
+    assert is_embeddable("   ") is False
+
+
+def test_non_string_inputs_are_not_embeddable():
+    assert is_embeddable(None) is False
+    assert is_embeddable(123) is False
+
+
+def test_sanitize_replaces_only_empty_or_whitespace_inputs():
+    # non-whitespace inputs are kept verbatim; empty/whitespace-only ones are
+    # replaced with the "." dummy to avoid embedding-API errors.
+    assert sanitize_embedding_text_inputs(["abc", "!!!", "", "   "]) == [
+        "abc",
+        "!!!",
+        ".",
+        ".",
+    ]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

Closes #3438

While reading the embedding-sanitization helpers I noticed the `is_embeddable` docstring describes a check the function doesn't actually do. It says:

> If input string contains at least one alphanumeric character, it is considered embeddable.

But the implementation only strips whitespace and returns `True` for any non-empty result — it never looks at `isalnum()`:

```python
s = s.strip()
if len(s) >= 1:
    return True
```

So a punctuation- or symbol-only string like `"!!!"` or `"."` (no alphanumeric character at all) is treated as embeddable, which the docstring says shouldn't happen. The same wording is misleading for `sanitize_embedding_text_inputs`, which keeps those strings verbatim instead of replacing them with the `"."` dummy.

The existing behavior looks intentional — treating any non-whitespace text as embeddable is what feeds the zero-vector substitution in `handle_embedding_response` and the dummy-value replacement that prevents embedding-API 422 errors. Changing the code to actually require an alphanumeric character would change which inputs get a real vs. zero embedding, which I didn't want to do as a drive-by. So this PR fixes the **docstring** to describe what the function really checks ("at least one non-whitespace character") and adds a small unit test that pins the documented behavior.

This is a docs/comment-only change to the function body; no runtime behavior changes.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

- `is_embeddable`'s docstring matches its actual behavior (non-whitespace, not alphanumeric).
- A unit test documents the contract: non-whitespace strings (including punctuation-only) are embeddable; empty/whitespace-only and non-`str` inputs are not; `sanitize_embedding_text_inputs` replaces only empty/whitespace-only inputs with the `"."` dummy.
- `ruff format --check` / `ruff check` clean; new test passes.

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [x] Other (please specify): **Documentation fix** (docstring corrected to match behavior; behavior unchanged) + accompanying unit test

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->
Local run (Docker, `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`):

<img width="645" height="426" alt="image" src="https://github.com/user-attachments/assets/400e1529-1f46-4260-b0be-eef8c5c5717c" />


## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
