### PR TITLE
docs: add beginner-friendly knowledge graph example (closes #2738)

### DIFF
--- a/examples/python/beginner_knowledge_graph.py
+++ b/examples/python/beginner_knowledge_graph.py
@@ -1,0 +1,69 @@
+import asyncio
+import cognee
+
+
+async def session_one():
+    """First session — agent learns and stores research findings."""
+    print("\n========== SESSION 1: Agent learns new facts ==========\n")
+
+    # Clear any previous memory for a clean demo
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    print("✓ Memory cleared (fresh start)\n")
+
+    # Agent ingests research findings into the knowledge graph
+    await cognee.remember("Transformer models use self-attention to process sequences in parallel.")
+    await cognee.remember("GPT is a transformer-based model trained on next-token prediction.")
+    await cognee.remember("BERT is a transformer model trained using masked language modeling.")
+    await cognee.remember("Self-attention allows each token to attend to every other token in the sequence.")
+    print("✓ Research findings stored in knowledge graph\n")
+
+    # Query within same session
+    results = await cognee.recall("How do transformers process sequences?")
+    print("Query: 'How do transformers process sequences?'")
+    for r in results:
+        print(f"  → {r}")
+
+
+async def session_two():
+    """Second session — agent picks up exactly where it left off."""
+    print("\n========== SESSION 2: Agent resumes with full memory ==========\n")
+    print("(No re-ingestion. No context window tricks. Just persistent memory.)\n")
+
+    # No remember() calls here — graph already exists from session 1
+    results = await cognee.recall("What is the difference between GPT and BERT?")
+    print("Query: 'What is the difference between GPT and BERT?'")
+    for r in results:
+        print(f"  → {r}")
+
+    print()
+
+    results = await cognee.recall("What is self-attention?")
+    print("Query: 'What is self-attention?'")
+    for r in results:
+        print(f"  → {r}")
+
+    # Enrich the graph with additional connections
+    await cognee.improve()
+    print("\n✓ Knowledge graph enriched with improve()\n")
+
+
+async def main():
+    print("=== Cognee: Persistent AI Memory Demo ===")
+    print("Showing why stateless LLMs fall short and how Cognee fixes it.\n")
+
+    await session_one()
+    await session_two()
+
+    print("\n========== WHAT JUST HAPPENED ==========")
+    print("Session 1: Agent learned facts → graph was built")
+    print("Session 2: Agent recalled across sessions → zero context loss")
+    print("This is what cognee.remember() + cognee.recall() unlocks.\n")
+
+    # Cleanup
+    await cognee.forget(dataset="main_dataset")
+    print("✓ Memory cleaned up with forget()\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Closes #2738

## What this adds
A minimal, well-commented example at `examples/python/beginner_knowledge_graph.py` that walks a first-time user through the full cognee memory lifecycle across two simulated sessions:

- Session 1: Agent ingests facts → knowledge graph is built (24 nodes, 39 edges)
- Session 2: Agent recalls across sessions with zero re-ingestion → proves persistent memory

Covers all four core APIs: `remember()`, `recall()`, `improve()`, `forget()`

## Why
New users unfamiliar with knowledge graphs need a concrete end-to-end example that shows *why* persistent memory matters — not just how to call the API.

## Tests
[paste your terminal screenshot here]

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin

<img width="1389" height="868" alt="WhatsApp Image 2026-06-25 at 12 53 47" src="https://github.com/user-attachments/assets/996a9b11-8f84-43f6-b961-47f982ff5915" />
<img width="1389" height="868" alt="WhatsApp Image 2026-06-25 at 12 53 42" src="https://github.com/user-attachments/assets/32c014d3-c293-41a9-9596-a780fba13e6e" />
<img width="1389" height="868" alt="WhatsApp Image 2026-06-25 at 12 53 35" src="https://github.com/user-attachments/assets/3eb5254a-43b9-4904-a082-7d1ccb30d4a2" />
<img width="1389" height="868" alt="WhatsApp Image 2026-06-25 at 12 53 30" src="https://github.com/user-attachments/assets/02f6ac31-7949-4b3c-b1d0-fd1fdc395666" />
<img width="1389" height="868" alt="WhatsApp Image 2026-06-25 at 12 53 23" src="https://github.com/user-attachments/assets/d12ce785-63a7-474d-bbe8-add918045b04" />
<img width="1389" height="868" alt="WhatsApp Image 2026-06-25 at 12 53 15" src="https://github.com/user-attachments/assets/975700a8-146b-41f4-8094-9a84b099119e" />