### PR TITLE
feat(memify): add decay_memory — time-based feedback_weight decay + stale-orphan prune (#3390)

### DIFF
--- a/cognee/memify_pipelines/decay_memory.py
+++ b/cognee/memify_pipelines/decay_memory.py
@@ -1,0 +1,62 @@
+"""decay_memory memify pipeline — exposes the time-decay/prune task as a memify enrichment pipeline.
+
+Mirrors the whole-graph wrapper pattern (see consolidate_entity_descriptions / apply_feedback_weights):
+a `Task`-wrapped task fn run via `cognee.memify(...)`. The decay task walks the whole graph itself,
+so the extraction stage is an explicit no-op (otherwise memify falls back to its default
+triplet-embedding extraction).
+"""
+
+from typing import List, Optional
+
+import cognee
+from cognee.modules.pipelines.tasks.task import Task
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.memify.decay_memory import (
+    decay_memory,
+    DEFAULT_HALF_LIFE_DAYS,
+    DEFAULT_MIN_WEIGHT,
+)
+
+logger = get_logger("decay_memory_pipeline")
+
+
+async def _passthrough(data):
+    """No-op extraction stage: decay_memory reads the whole graph itself, so there's nothing to
+    extract. Provided explicitly so memify() doesn't fall back to default triplet-embedding extraction."""
+    return data
+
+
+async def decay_memory_pipeline(
+    half_life_days: float = DEFAULT_HALF_LIFE_DAYS,
+    min_weight: float = DEFAULT_MIN_WEIGHT,
+    protect_node_types: Optional[List[str]] = None,
+    dry_run: bool = True,
+    dataset: str = "main_dataset",
+):
+    """Age node feedback weights by half-life and prune stale orphans, over a dataset's graph.
+
+    dry_run=True (default) reports what *would* change without mutating the graph.
+    """
+    extraction_tasks = [Task(_passthrough)]
+    enrichment_tasks = [
+        Task(
+            decay_memory,
+            half_life_days=half_life_days,
+            min_weight=min_weight,
+            protect_node_types=protect_node_types,
+            dry_run=dry_run,
+        )
+    ]
+    result = await cognee.memify(
+        extraction_tasks=extraction_tasks,
+        enrichment_tasks=enrichment_tasks,
+        data=[{}],  # placeholder; decay_memory ignores it and walks the whole graph
+        dataset=dataset,
+    )
+    logger.info(
+        "decay_memory pipeline completed (dataset=%s, half_life_days=%s, dry_run=%s)",
+        dataset,
+        half_life_days,
+        dry_run,
+    )
+    return result

--- a/cognee/modules/visualization/operations_catalog.py
+++ b/cognee/modules/visualization/operations_catalog.py
@@ -192,6 +192,18 @@ _OPERATIONS: List[Dict[str, Any]] = [
             {"effect": "removes", "target_type": "TextSummary"},
         ],
     },
+    {
+        "name": "decay_memory",
+        "label": "decay / forget",
+        "kind": "self_improve",
+        "scope": "whole",
+        "summary": "Ages node feedback_weight by half-life, then prunes stale orphans below a threshold.",
+        "effects": [
+            {"effect": "modifies", "target_type": "Entity", "property": "feedback_weight"},
+            {"effect": "modifies", "target_type": "EntityType", "property": "feedback_weight"},
+            {"effect": "removes", "target_type": "Entity"},
+        ],
+    },
 ]
 
 

--- a/cognee/tasks/memify/decay_memory.py
+++ b/cognee/tasks/memify/decay_memory.py
@@ -1,0 +1,188 @@
+"""decay_memory — a memify/improve task that makes memory *fade*.
+
+Decays each node's `feedback_weight` over time (exponential half-life from `updated_at`/`created_at`),
+then prunes nodes that fall below a staleness threshold, preferring orphans (degree-one / disconnected).
+Today Cognee only has full `prune_*` wipes and targeted `forget()`; this adds gradual, time-based decay.
+
+Design notes:
+- Pure time-decay first: frequency/usage weights are non-functional today (see the RE-WEIGHT ticket),
+  so this decays `feedback_weight` purely by age. Usage-based decay can layer on once RE-WEIGHT lands.
+- `dry_run=True` is the default: it reports what *would* be decayed/pruned without mutating the graph,
+  mirroring `cleanup_unused_data`'s dry-run safety.
+- Composes existing primitives only: `get_graph_data`, `set_node_feedback_weights`, `delete_nodes`
+  (so it sits on top of, and doesn't touch, the in-flight graph delete/rollback refactor).
+"""
+
+import time
+from typing import Any, Optional, TypedDict
+
+from cognee.infrastructure.databases.graph.get_graph_engine import get_graph_engine
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("decay_memory")
+
+DEFAULT_HALF_LIFE_DAYS = 30.0
+DEFAULT_MIN_WEIGHT = 0.05
+DEFAULT_FEEDBACK_WEIGHT = 0.5  # matches DataPoint.feedback_weight default
+_MS_PER_DAY = 24 * 60 * 60 * 1000
+
+
+# --------------------------------------------------------------------------------------
+# Pure core (no I/O — unit-tested in isolation; this is the deterministic-aging guarantee)
+# --------------------------------------------------------------------------------------
+def decay_weight(weight: float, age_ms: int, half_life_ms: int) -> float:
+    """Exponential half-life decay: ``weight * 0.5 ** (age / half_life)``.
+
+    Deterministic for a given (weight, age, half_life). No decay for age<=0 or half_life<=0.
+    """
+    if half_life_ms <= 0 or age_ms <= 0:
+        return weight
+    return weight * (0.5 ** (age_ms / half_life_ms))
+
+
+def node_degrees(node_ids, edges) -> dict:
+    """``edges`` are (source_id, target_id, ...) tuples. Returns {node_id: degree} for node_ids.
+
+    Self-loops (source == target — Cognee writes a ``SELF`` edge per node) are ignored: they don't
+    connect a node to anything else, so a node whose only edge is its self-loop counts as an orphan.
+    """
+    degrees = {nid: 0 for nid in node_ids}
+    for edge in edges:
+        if not edge:
+            continue
+        source = edge[0]
+        target = edge[1] if len(edge) > 1 else None
+        if source == target:
+            continue
+        if source in degrees:
+            degrees[source] += 1
+        if target in degrees:
+            degrees[target] += 1
+    return degrees
+
+
+def select_prune(decayed_weights: dict, degrees: dict, min_weight: float) -> list:
+    """Node ids to prune: below ``min_weight`` AND an orphan / degree-one node (degree <= 1).
+
+    Restricting to leaves/orphans means a prune only ever removes a stale *leaf* — it can never delete
+    a connector and orphan a live subgraph. Stale hubs are left in place (they keep decaying, and become
+    prunable once their neighbours are gone). Ordered orphan-first (lowest degree, then weight).
+    """
+    candidates = [
+        nid
+        for nid, weight in decayed_weights.items()
+        if weight < min_weight and degrees.get(nid, 0) <= 1
+    ]
+    candidates.sort(key=lambda nid: (degrees.get(nid, 0), decayed_weights[nid]))
+    return candidates
+
+
+def _node_age_ms(props: dict, now_ms: int) -> int:
+    timestamp = props.get("updated_at") or props.get("created_at")
+    if not isinstance(timestamp, (int, float)) or timestamp <= 0:
+        return 0
+    age = now_ms - int(timestamp)
+    return age if age > 0 else 0
+
+
+def _node_type(props: dict):
+    metadata = props.get("metadata") if isinstance(props.get("metadata"), dict) else {}
+    return props.get("type") or props.get("node_type") or metadata.get("type")
+
+
+class DecayMemoryResult(TypedDict):
+    scanned: int
+    decayed: int
+    pruned: int
+    dry_run: bool
+    pruned_ids: list
+
+
+# --------------------------------------------------------------------------------------
+# Task
+# --------------------------------------------------------------------------------------
+async def decay_memory(
+    data: Any = None,
+    *,
+    half_life_days: float = DEFAULT_HALF_LIFE_DAYS,
+    min_weight: float = DEFAULT_MIN_WEIGHT,
+    protect_node_types: Optional[list] = None,
+    dry_run: bool = True,
+    now_ms: Optional[int] = None,
+) -> DecayMemoryResult:
+    """Age node ``feedback_weight`` by half-life, then prune nodes below ``min_weight`` (orphans first).
+
+    Parameters
+    ----------
+    data:
+        Accepted for memify-pipeline compatibility; ignored (this task walks the whole graph).
+    half_life_days:
+        Time for a node's weight to halve from disuse.
+    min_weight:
+        Nodes whose decayed weight falls below this are pruned.
+    protect_node_types:
+        Node types that are never decayed or pruned (e.g. structural / EntityType nodes).
+    dry_run:
+        When True (default), report what *would* change without mutating the graph.
+    now_ms:
+        Override the clock (epoch ms) — for deterministic tests.
+    """
+    protected = set(protect_node_types or [])
+    half_life_ms = max(0, int(half_life_days * _MS_PER_DAY))
+    now = now_ms if now_ms is not None else int(time.time() * 1000)
+
+    graph_engine = await get_graph_engine()
+    nodes, edges = await graph_engine.get_graph_data()
+
+    # Collect scannable nodes (skip protected types); keep props for the age timestamp.
+    scannable: dict = {}
+    for node_id, props in nodes:
+        props = props if isinstance(props, dict) else {}
+        if _node_type(props) in protected:
+            continue
+        scannable[node_id] = props
+
+    # Read AUTHORITATIVE current weights via the graph engine (same method apply_feedback_weights
+    # uses) rather than trusting the serialized property blob — only-found ids return, 0.5 otherwise.
+    stored_weights = await graph_engine.get_node_feedback_weights(list(scannable.keys()))
+
+    decayed_weights: dict = {}
+    updates: dict = {}
+    for node_id, props in scannable.items():
+        try:
+            current = float(stored_weights.get(node_id, DEFAULT_FEEDBACK_WEIGHT))
+        except (TypeError, ValueError):
+            current = DEFAULT_FEEDBACK_WEIGHT
+        new_weight = decay_weight(current, _node_age_ms(props, now), half_life_ms)
+        decayed_weights[node_id] = new_weight
+        if new_weight != current:
+            updates[node_id] = new_weight
+
+    scanned = len(scannable)
+    degrees = node_degrees(list(decayed_weights.keys()), edges)
+    prune_ids = select_prune(decayed_weights, degrees, min_weight)
+
+    # don't bother writing a decayed weight for a node we're about to delete
+    prune_set = set(prune_ids)
+    weight_updates = {nid: w for nid, w in updates.items() if nid not in prune_set}
+
+    if not dry_run:
+        if weight_updates:
+            await graph_engine.set_node_feedback_weights(weight_updates)
+        if prune_ids:
+            await graph_engine.delete_nodes(prune_ids)
+
+    logger.info(
+        "decay_memory: scanned=%d decayed=%d pruned=%d dry_run=%s",
+        scanned,
+        len(weight_updates),
+        len(prune_ids),
+        dry_run,
+    )
+    return {
+        "scanned": scanned,
+        "decayed": len(weight_updates),
+        "pruned": len(prune_ids),
+        "dry_run": dry_run,
+        "pruned_ids": prune_ids,
+    }

--- a/cognee/tests/integration/infrastructure/graph/test_decay_memory_integration.py
+++ b/cognee/tests/integration/infrastructure/graph/test_decay_memory_integration.py
@@ -1,0 +1,46 @@
+"""Integration test: decay_memory against a REAL kuzu graph (no graph mocks).
+
+Inserts DataPoint nodes with controlled feedback_weight + age into a temp kuzu DB, runs the task,
+and asserts weights decayed (and persisted) + a stale orphan was actually deleted from the graph.
+"""
+
+import pytest
+
+from cognee.infrastructure.databases.graph.kuzu.adapter import KuzuAdapter
+from cognee.infrastructure.engine.models.DataPoint import DataPoint
+from cognee.tasks.memify.decay_memory import decay_memory, _MS_PER_DAY
+
+NOW_MS = 2_000_000_000_000
+
+
+class _Node(DataPoint):
+    name: str = ""
+    metadata: dict = {"index_fields": ["name"]}
+
+
+@pytest.mark.asyncio
+async def test_decay_memory_against_real_kuzu_graph(tmp_path, monkeypatch):
+    adapter = KuzuAdapter(db_path=str(tmp_path / "kuzu_decay"))
+
+    fresh = _Node(name="fresh", feedback_weight=0.8, updated_at=NOW_MS)
+    old = _Node(name="old", feedback_weight=0.8, updated_at=NOW_MS - 30 * _MS_PER_DAY)      # one half-life
+    stale = _Node(name="stale", feedback_weight=0.1, updated_at=NOW_MS - 300 * _MS_PER_DAY)  # old + low -> prune
+    await adapter.add_nodes([fresh, old, stale])
+
+    async def _engine():
+        return adapter
+
+    monkeypatch.setattr("cognee.tasks.memify.decay_memory.get_graph_engine", _engine)
+
+    result = await decay_memory(half_life_days=30, min_weight=0.05, dry_run=False, now_ms=NOW_MS)
+
+    assert result["scanned"] == 3
+    assert result["pruned"] == 1
+    assert str(stale.id) in result["pruned_ids"]
+
+    weights = await adapter.get_node_feedback_weights([str(fresh.id), str(old.id)])
+    assert abs(weights[str(fresh.id)] - 0.8) < 1e-9   # age 0 -> unchanged
+    assert abs(weights[str(old.id)] - 0.4) < 1e-9     # one half-life -> halved, persisted to the DB
+
+    remaining = {node[1].get("name") for node in (await adapter.get_graph_data())[0]}
+    assert remaining == {"fresh", "old"}              # the stale orphan was deleted from the real graph

--- a/cognee/tests/unit/memify_pipelines/test_decay_memory_pipeline.py
+++ b/cognee/tests/unit/memify_pipelines/test_decay_memory_pipeline.py
@@ -1,0 +1,39 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.memify_pipelines.decay_memory import decay_memory_pipeline
+
+
+@pytest.mark.asyncio
+async def test_decay_memory_pipeline_wires_memify_tasks():
+    """The wrapper forwards its knobs onto the enrichment Task and calls memify with data=[{}] / dataset.
+
+    decay_memory's tuning params are keyword-only, and Task() stores them without validating against the
+    target signature — so a kwarg typo (e.g. ``half_life=`` vs ``half_life_days=``) would otherwise only
+    surface during a live memify run. This pins the wiring with no graph / no LLM / no DB lock.
+    """
+    with patch("cognee.memify", new=AsyncMock(return_value={"status": "ok"})) as memify_mock:
+        result = await decay_memory_pipeline(
+            half_life_days=10,
+            min_weight=0.2,
+            protect_node_types=["EntityType"],
+            dry_run=False,
+            dataset="ds-1",
+        )
+
+    assert result == {"status": "ok"}
+    memify_mock.assert_awaited_once()
+
+    kwargs = memify_mock.call_args.kwargs
+    assert kwargs["dataset"] == "ds-1"
+    assert kwargs["data"] == [{}]
+    assert len(kwargs["extraction_tasks"]) == 1  # the _passthrough no-op
+    assert len(kwargs["enrichment_tasks"]) == 1  # the decay_memory task
+
+    # the decay knobs must land on the enrichment Task as the exact keyword-only kwargs
+    enrichment_kwargs = kwargs["enrichment_tasks"][0].default_params["kwargs"]
+    assert enrichment_kwargs["half_life_days"] == 10
+    assert enrichment_kwargs["min_weight"] == 0.2
+    assert enrichment_kwargs["protect_node_types"] == ["EntityType"]
+    assert enrichment_kwargs["dry_run"] is False

--- a/cognee/tests/unit/modules/memify_tasks/test_decay_memory.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_decay_memory.py
@@ -56,10 +56,10 @@ def _patch_engine(mock):
 # ----------------------- pure core -----------------------
 def test_decay_is_deterministic_half_life():
     one_hl = HALF_LIFE_DAYS * _MS_PER_DAY
-    assert decay_weight(0.8, 0, one_hl) == 0.8                  # no age -> unchanged
+    assert decay_weight(0.8, 0, one_hl) == 0.8  # no age -> unchanged
     assert abs(decay_weight(0.8, one_hl, one_hl) - 0.4) < 1e-9  # one half-life -> halves
     assert abs(decay_weight(0.8, 2 * one_hl, one_hl) - 0.2) < 1e-9
-    assert decay_weight(0.5, 5, 0) == 0.5                       # guard: half_life 0 -> no decay
+    assert decay_weight(0.5, 5, 0) == 0.5  # guard: half_life 0 -> no decay
 
 
 def test_degrees_and_prune_selection():
@@ -69,37 +69,52 @@ def test_degrees_and_prune_selection():
     # a self-loop (Cognee writes a SELF edge per node) does not count as a connection -> orphan
     assert node_degrees(["a"], [("a", "a", "SELF", {})]) == {"a": 0}
     pruned = select_prune({"orphan": 0.01, "leaf": 0.01, "mid": 0.9}, degrees, min_weight=0.05)
-    assert "mid" not in pruned          # above threshold -> kept
-    assert pruned[0] == "orphan"        # orphan-first (lowest degree)
+    # both the degree-0 orphan AND the degree-1 leaf are pruned (degree <= 1), 'mid' (degree 2) is kept.
+    # Pinning the exact list guards the <=1 leaf boundary itself: a regression to "< 1" would silently
+    # stop pruning leaves (gutting the feature) yet still satisfy a looser "orphan first / mid absent" check.
+    assert pruned == [
+        "orphan",
+        "leaf",
+    ]  # orphan-first ordering, leaf included, connector 'mid' kept
     # a below-threshold but well-connected node is NEVER pruned (can't orphan a live subgraph)
-    pruned_hub = select_prune({"orphan": 0.01, "hub": 0.01}, {"orphan": 0, "hub": 3}, min_weight=0.05)
+    pruned_hub = select_prune(
+        {"orphan": 0.01, "hub": 0.01}, {"orphan": 0, "hub": 3}, min_weight=0.05
+    )
     assert pruned_hub == ["orphan"]
 
 
 # ----------------------- task (mocked graph) -----------------------
 @pytest.mark.asyncio
 async def test_dry_run_reports_without_mutating():
-    nodes = [_node("fresh", 0.8, 0), _node("old", 0.8, HALF_LIFE_DAYS)]  # 'old' aged exactly one half-life
+    nodes = [
+        _node("fresh", 0.8, 0),
+        _node("old", 0.8, HALF_LIFE_DAYS),
+    ]  # 'old' aged exactly one half-life
     graph = InMemoryGraph(nodes, [])
     with _patch_engine(graph):
         result = await decay_memory(
             half_life_days=HALF_LIFE_DAYS, min_weight=0.05, dry_run=True, now_ms=NOW_MS
         )
     assert result["scanned"] == 2
-    assert result["decayed"] == 1          # only 'old' changed
+    assert result["decayed"] == 1  # only 'old' changed
     assert result["dry_run"] is True
-    assert graph.weight_writes == {}       # dry_run -> graph untouched
+    assert graph.weight_writes == {}  # dry_run -> graph untouched
     assert graph.deleted == []
 
 
 @pytest.mark.asyncio
 async def test_prune_orphans_below_threshold_and_protect_types():
     nodes = [
-        _node("stale_orphan", 0.1, 300),                       # very old + small -> below min, orphan
-        _node("protected", 0.1, 300, node_type="EntityType"),  # would qualify, but type is protected
-        _node("fresh", 0.9, 0),                                # stays
+        _node("stale_orphan", 0.1, 300),  # below min, degree-0 orphan
+        _node("stale_leaf", 0.1, 300),  # below min, degree-1 leaf (only edge -> 'fresh')
+        _node(
+            "protected", 0.1, 300, node_type="EntityType"
+        ),  # would qualify, but type is protected
+        _node("fresh", 0.9, 0),  # stays (high weight); keeps its single edge
     ]
-    graph = InMemoryGraph(nodes, edges=[])  # stale_orphan has degree 0
+    # 'stale_leaf' -> 'fresh' makes stale_leaf a degree-1 leaf, so the prune runs the <=1 path
+    # all the way through delete_nodes (not just the degree-0 orphan case).
+    graph = InMemoryGraph(nodes, edges=[("stale_leaf", "fresh", "REL", {})])
     with _patch_engine(graph):
         result = await decay_memory(
             half_life_days=HALF_LIFE_DAYS,
@@ -108,7 +123,8 @@ async def test_prune_orphans_below_threshold_and_protect_types():
             dry_run=False,
             now_ms=NOW_MS,
         )
-    assert "protected" not in result["pruned_ids"]   # protected type never scanned/pruned
-    assert "stale_orphan" in result["pruned_ids"]
-    assert "fresh" not in result["pruned_ids"]
-    assert graph.deleted == result["pruned_ids"]     # real delete happened (dry_run=False)
+    assert "protected" not in result["pruned_ids"]  # protected type never scanned/pruned
+    assert "stale_orphan" in result["pruned_ids"]  # degree-0 orphan pruned
+    assert "stale_leaf" in result["pruned_ids"]  # degree-1 leaf pruned via the <=1 path
+    assert "fresh" not in result["pruned_ids"]  # high weight -> kept (its only edge is dropped)
+    assert graph.deleted == result["pruned_ids"]  # real delete happened (dry_run=False)

--- a/cognee/tests/unit/modules/memify_tasks/test_decay_memory.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_decay_memory.py
@@ -1,0 +1,114 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.tasks.memify.decay_memory import (
+    decay_memory,
+    decay_weight,
+    node_degrees,
+    select_prune,
+    _MS_PER_DAY,
+)
+
+NOW_MS = 1_000_000_000_000  # fixed clock for deterministic tests
+HALF_LIFE_DAYS = 30
+
+
+class InMemoryGraph:
+    """Minimal graph engine mock — same shape decay_memory consumes (get_graph_data) / writes."""
+
+    def __init__(self, nodes, edges):
+        self._nodes = nodes
+        self._edges = edges
+        # authoritative weights, derived from each node's feedback_weight prop
+        self._weights = {nid: props.get("feedback_weight", 0.5) for nid, props in nodes}
+        self.weight_writes = {}
+        self.deleted = []
+
+    async def get_graph_data(self):
+        return self._nodes, self._edges
+
+    async def get_node_feedback_weights(self, node_ids):
+        return {nid: self._weights[nid] for nid in node_ids if nid in self._weights}
+
+    async def set_node_feedback_weights(self, updates):
+        self.weight_writes = dict(updates)
+        return {nid: True for nid in updates}
+
+    async def delete_nodes(self, node_ids):
+        self.deleted = list(node_ids)
+
+
+def _node(node_id, weight, age_days, node_type=None):
+    props = {"feedback_weight": weight, "updated_at": NOW_MS - int(age_days * _MS_PER_DAY)}
+    if node_type:
+        props["type"] = node_type
+    return (node_id, props)
+
+
+def _patch_engine(mock):
+    return patch(
+        "cognee.tasks.memify.decay_memory.get_graph_engine",
+        AsyncMock(return_value=mock),
+    )
+
+
+# ----------------------- pure core -----------------------
+def test_decay_is_deterministic_half_life():
+    one_hl = HALF_LIFE_DAYS * _MS_PER_DAY
+    assert decay_weight(0.8, 0, one_hl) == 0.8                  # no age -> unchanged
+    assert abs(decay_weight(0.8, one_hl, one_hl) - 0.4) < 1e-9  # one half-life -> halves
+    assert abs(decay_weight(0.8, 2 * one_hl, one_hl) - 0.2) < 1e-9
+    assert decay_weight(0.5, 5, 0) == 0.5                       # guard: half_life 0 -> no decay
+
+
+def test_degrees_and_prune_selection():
+    edges = [("hub", "leaf", "REL", {}), ("hub", "mid", "REL", {}), ("mid", "out", "REL", {})]
+    degrees = node_degrees(["orphan", "leaf", "mid", "hub"], edges)
+    assert degrees == {"orphan": 0, "leaf": 1, "mid": 2, "hub": 2}
+    # a self-loop (Cognee writes a SELF edge per node) does not count as a connection -> orphan
+    assert node_degrees(["a"], [("a", "a", "SELF", {})]) == {"a": 0}
+    pruned = select_prune({"orphan": 0.01, "leaf": 0.01, "mid": 0.9}, degrees, min_weight=0.05)
+    assert "mid" not in pruned          # above threshold -> kept
+    assert pruned[0] == "orphan"        # orphan-first (lowest degree)
+    # a below-threshold but well-connected node is NEVER pruned (can't orphan a live subgraph)
+    pruned_hub = select_prune({"orphan": 0.01, "hub": 0.01}, {"orphan": 0, "hub": 3}, min_weight=0.05)
+    assert pruned_hub == ["orphan"]
+
+
+# ----------------------- task (mocked graph) -----------------------
+@pytest.mark.asyncio
+async def test_dry_run_reports_without_mutating():
+    nodes = [_node("fresh", 0.8, 0), _node("old", 0.8, HALF_LIFE_DAYS)]  # 'old' aged exactly one half-life
+    graph = InMemoryGraph(nodes, [])
+    with _patch_engine(graph):
+        result = await decay_memory(
+            half_life_days=HALF_LIFE_DAYS, min_weight=0.05, dry_run=True, now_ms=NOW_MS
+        )
+    assert result["scanned"] == 2
+    assert result["decayed"] == 1          # only 'old' changed
+    assert result["dry_run"] is True
+    assert graph.weight_writes == {}       # dry_run -> graph untouched
+    assert graph.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_prune_orphans_below_threshold_and_protect_types():
+    nodes = [
+        _node("stale_orphan", 0.1, 300),                       # very old + small -> below min, orphan
+        _node("protected", 0.1, 300, node_type="EntityType"),  # would qualify, but type is protected
+        _node("fresh", 0.9, 0),                                # stays
+    ]
+    graph = InMemoryGraph(nodes, edges=[])  # stale_orphan has degree 0
+    with _patch_engine(graph):
+        result = await decay_memory(
+            half_life_days=HALF_LIFE_DAYS,
+            min_weight=0.05,
+            protect_node_types=["EntityType"],
+            dry_run=False,
+            now_ms=NOW_MS,
+        )
+    assert "protected" not in result["pruned_ids"]   # protected type never scanned/pruned
+    assert "stale_orphan" in result["pruned_ids"]
+    assert "fresh" not in result["pruned_ids"]
+    assert graph.deleted == result["pruned_ids"]     # real delete happened (dry_run=False)


### PR DESCRIPTION

Closes #3390 (part of the #3389 memory-transformation umbrella).

## Description

This adds a `decay_memory` memify task that makes memory gradually **fade**: it decays each node's
`feedback_weight` over time (exponential half-life based on `updated_at`/`created_at`), then prunes the stale ones that are orphans or leaves (degree ≤ 1), so a prune never disconnects a live subgraph. Today Cognee only has full `prune_*`
wipes, targeted `forget()`, and an unwired binary TTL cleanup; there's no gradual, time-based decay.

I deliberately composed existing primitives instead of adding new graph plumbing:
- I read authoritative weights with `get_node_feedback_weights()` (the same method `apply_feedback_weights`
  uses) rather than trusting the serialized property blob.
- I compute node degree from `get_graph_data()`'s edges (so it doesn't depend on adapter-specific
  helpers) and delete via the stable `delete_nodes()` primitive — so it builds on the public delete API and stays decoupled from the internal delete/rollback refactor in flight (#3432/#3433), rather than depending on those internals.
  
Design decisions:
- **Pure time-decay first** — usage/frequency weights are non-functional today (per the RE-WEIGHT
  ticket #3391), so I decay `feedback_weight` purely by age for now.
- **`dry_run` defaults to True** — it reports what *would* change without mutating, mirroring
  `cleanup_unused_data`'s safety.
- **`protect_node_types`** guards structural / EntityType nodes from ever being decayed or pruned.
- Bitemporal `valid_from`/`valid_to` is intentionally **out of scope** here to keep this reviewable.

Files:
- `cognee/tasks/memify/decay_memory.py` — the task (pure decay/prune core + graph I/O)
- `cognee/memify_pipelines/decay_memory.py` — memify pipeline wrapper
- `cognee/modules/visualization/operations_catalog.py` — catalog entry (`modifies` feedback_weight / `removes`)
- unit tests + a real-kuzu integration test

## Acceptance Criteria

From the issue, all met:
- **Ages weights deterministically** — exponential half-life, exact.
- **Prunes only below-threshold orphan/leaf nodes (degree ≤ 1) — so a prune never disconnects a live subgraph.** (Prune behaviour verified on a real kuzu graph; the degree-≤1 guard is covered by a unit test.)
- **`dry_run=True` reports candidates and changes nothing.**

Proof — 5 tests pass (4 unit with a mocked graph + 1 integration against a **real kuzu graph**).
On the real graph: a node aged exactly one half-life went `0.8 → 0.4` (persisted), a fresh node was
unchanged, and a stale orphan was deleted.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Screenshots

**All tests passing (`5 passed`):**

<img width="1470" height="797" alt="Screenshot 2026-06-25 at 12 33 26 PM" src="https://github.com/user-attachments/assets/5e5146b0-0ad9-459c-9807-e7a424c322f0" />



**Real-graph run — `old` halves in one half-life and persists; stale orphan deleted:**

<img width="1470" height="480" alt="Screenshot 2026-06-25 at 12 33 39 PM" src="https://github.com/user-attachments/assets/1298140c-35b9-46dd-b58a-15bedfb44ca9" />


(I left "all new and existing tests pass" unchecked because Cognee's full suite needs CI services — DBs / LLM keys / network — to run locally; my new tests pass and the change is purely additive, so I'm leaving that to CI.)

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes
Developer Certificate of Origin.