### PR TITLE
feat: add TwelveLabs Marengo embedding provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -531,6 +531,15 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #EMBEDDING_DIMENSIONS=768
 #HUGGINGFACE_TOKENIZER="nomic-ai/nomic-embed-text-v1.5"
 
+########## TwelveLabs Marengo (multimodal embeddings) #########################
+# Marengo embeds text into the same 512-dim space as video/image/audio, so text
+# queries are comparable to embeddings of ingested video. Free key: https://twelvelabs.io
+# EMBEDDING_API_KEY falls back to TWELVELABS_API_KEY if unset.
+#EMBEDDING_PROVIDER="twelvelabs"
+#EMBEDDING_MODEL="marengo3.0"
+#EMBEDDING_API_KEY="your-twelvelabs-api-key"
+#EMBEDDING_DIMENSIONS=512
+
 ########## OpenRouter (also free) #############################################
 #LLM_API_KEY="<<go-get-one-yourself"
 #LLM_PROVIDER="custom"

--- a/cognee/infrastructure/databases/vector/embeddings/TwelveLabsEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/TwelveLabsEmbeddingEngine.py
@@ -1,0 +1,260 @@
+import asyncio
+import math
+import os
+import logging
+from typing import List, Optional
+
+import aiohttp
+import litellm
+import numpy as np
+from tenacity import (
+    retry,
+    stop_after_delay,
+    wait_exponential_jitter,
+    retry_if_not_exception_type,
+    before_sleep_log,
+)
+
+from cognee.shared.logging_utils import get_logger
+from cognee.infrastructure.databases.vector.embeddings.EmbeddingEngine import EmbeddingEngine
+from cognee.infrastructure.databases.exceptions import EmbeddingException
+from cognee.infrastructure.llm.tokenizer.TikToken import TikTokenTokenizer
+from cognee.shared.rate_limiting import embedding_rate_limiter_context_manager
+from cognee.shared.utils import create_secure_ssl_context
+from cognee.infrastructure.databases.vector.embeddings.utils import (
+    sanitize_embedding_text_inputs,
+    handle_embedding_response,
+)
+
+logger = get_logger("TwelveLabsEmbeddingEngine")
+
+# Marengo is a multimodal model: the same vector space is shared by text,
+# image, audio and video, so text embedded here is directly comparable to
+# embeddings of ingested video. marengo3.0 produces 512-dim vectors.
+DEFAULT_MODEL = "marengo3.0"
+DEFAULT_DIMENSIONS = 512
+DEFAULT_ENDPOINT = "https://api.twelvelabs.io/v1.3/embed"
+
+
+class TwelveLabsEmbeddingEngine(EmbeddingEngine):
+    """
+    Implements an embedding engine backed by TwelveLabs' Marengo multimodal model.
+
+    Marengo embeds text into the same 512-dimensional space as video, image and
+    audio, which lets cognee store text queries and ingested video in one vector
+    store and search across them. This engine handles the text side; video is
+    embedded through TwelveLabs' video tasks at ingestion time.
+
+    Public methods:
+    - embed_text
+    - get_vector_size
+    - get_batch_size
+    - get_tokenizer
+
+    Instance variables:
+    - model
+    - dimensions
+    - max_completion_tokens
+    - endpoint
+    - api_key
+    - mock
+    """
+
+    model: str
+    dimensions: int
+    max_completion_tokens: int
+    endpoint: str
+    api_key: Optional[str]
+    mock: bool
+
+    MAX_RETRIES = 5
+
+    def __init__(
+        self,
+        model: Optional[str] = DEFAULT_MODEL,
+        dimensions: Optional[int] = DEFAULT_DIMENSIONS,
+        max_completion_tokens: int = 512,
+        endpoint: Optional[str] = DEFAULT_ENDPOINT,
+        api_key: Optional[str] = None,
+        batch_size: int = 100,
+    ):
+        self.model = model or DEFAULT_MODEL
+        self.dimensions = dimensions or DEFAULT_DIMENSIONS
+        self.max_completion_tokens = max_completion_tokens
+        self.endpoint = endpoint or DEFAULT_ENDPOINT
+        # Falls back to the standalone TwelveLabs env var so the key does not
+        # have to be threaded through EMBEDDING_API_KEY when only video is used.
+        self.api_key = api_key or os.getenv("TWELVELABS_API_KEY")
+        self.batch_size = batch_size
+        self.tokenizer = self.get_tokenizer()
+
+        enable_mocking = os.getenv("MOCK_EMBEDDING", "false")
+        if isinstance(enable_mocking, bool):
+            enable_mocking = str(enable_mocking).lower()
+        self.mock = enable_mocking in ("true", "1", "yes")
+
+    async def embed_text(self, text: List[str]) -> List[List[float]]:
+        """
+        Generate Marengo embedding vectors for a list of text prompts.
+
+        If mocking is enabled, returns a list of zero vectors instead of actual
+        embeddings.
+
+        Parameters:
+        -----------
+
+            - text (List[str]): A list of text prompts for which to generate embeddings.
+
+        Returns:
+        --------
+
+            - List[List[float]]: A list of embedding vectors corresponding to the text
+              prompts.
+        """
+        original_texts = text if isinstance(text, list) else [text]
+        sanitized_text = sanitize_embedding_text_inputs(original_texts)
+
+        if self.mock:
+            embeddings = [[0.0] * self.dimensions for _ in sanitized_text]
+            return handle_embedding_response(original_texts, embeddings, self.dimensions)
+
+        if not self.api_key:
+            raise EmbeddingException(
+                "TwelveLabs API key is missing. Set EMBEDDING_API_KEY or TWELVELABS_API_KEY. "
+                "Get a free key at https://twelvelabs.io"
+            )
+
+        try:
+            embeddings = await asyncio.gather(
+                *[self._get_embedding(prompt) for prompt in sanitized_text]
+            )
+            return handle_embedding_response(original_texts, embeddings, self.dimensions)
+        except Exception as error:
+            error_str = str(error).lower()
+            context_error_patterns = (
+                "context length",
+                "context window",
+                "input length",
+                "too long",
+                "maximum context",
+                "maximum tokens",
+                "max tokens",
+            )
+            if any(pattern in error_str for pattern in context_error_patterns):
+                if len(original_texts) > 1:
+                    mid = math.ceil(len(original_texts) / 2)
+                    left_vecs, right_vecs = await asyncio.gather(
+                        self.embed_text(original_texts[:mid]),
+                        self.embed_text(original_texts[mid:]),
+                    )
+                    embeddings = left_vecs + right_vecs
+                    return handle_embedding_response(original_texts, embeddings, self.dimensions)
+
+                if len(original_texts) == 1:
+                    s = original_texts[0]
+                    third = len(s) // 3
+                    if third == 0:
+                        raise EmbeddingException(
+                            "Text is too short to split further but exceeds context window."
+                        ) from error
+                    left_part, right_part = s[: third * 2], s[third:]
+                    (left_vec,), (right_vec,) = await asyncio.gather(
+                        self.embed_text([left_part]),
+                        self.embed_text([right_part]),
+                    )
+                    pooled = (np.array(left_vec) + np.array(right_vec)) / 2
+                    embeddings = [pooled.tolist()]
+                    return handle_embedding_response(original_texts, embeddings, self.dimensions)
+
+                return handle_embedding_response(original_texts, embeddings, self.dimensions)
+
+            logger.error(f"Embedding error in TwelveLabsEmbeddingEngine: {str(error)}")
+            raise EmbeddingException(
+                f"Failed to index data points using model {self.model}"
+            ) from error
+
+    @retry(
+        stop=stop_after_delay(128),
+        wait=wait_exponential_jitter(8, 128),
+        retry=retry_if_not_exception_type(
+            (litellm.exceptions.NotFoundError, ValueError, asyncio.CancelledError)
+        ),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+    async def _get_embedding(self, prompt: str) -> List[float]:
+        """
+        Call the TwelveLabs /embed endpoint for a single text prompt.
+
+        The endpoint accepts multipart/form-data (``model_name`` + ``text``) and
+        returns ``text_embedding.segments[0].float``.
+        """
+        # The /embed endpoint only accepts multipart/form-data. aiohttp encodes a
+        # FormData of plain strings as application/x-www-form-urlencoded unless at
+        # least one field carries an explicit content_type, so set one to force
+        # the multipart boundary encoding.
+        form = aiohttp.FormData()
+        form.add_field("model_name", self.model, content_type="text/plain")
+        form.add_field("text", prompt, content_type="text/plain")
+
+        headers = {"x-api-key": self.api_key}
+
+        ssl_context = create_secure_ssl_context()
+        connector = aiohttp.TCPConnector(ssl=ssl_context)
+        async with aiohttp.ClientSession(connector=connector) as session:
+            async with embedding_rate_limiter_context_manager():
+                async with session.post(
+                    self.endpoint, data=form, headers=headers, timeout=60.0
+                ) as response:
+                    data = await response.json()
+
+                    if "text_embedding" not in data:
+                        message = data.get("message", data)
+                        msg_str = str(message).lower()
+                        if "too long" in msg_str or ("max" in msg_str and "token" in msg_str):
+                            raise ValueError(f"Text too long for embedding model: {message}")
+                        raise RuntimeError(f"TwelveLabs embedding API error: {message}")
+
+                    segments = data["text_embedding"].get("segments", [])
+                    if not segments or "float" not in segments[0]:
+                        raise ValueError(f"Unexpected response format from TwelveLabs: {data}")
+                    return segments[0]["float"]
+
+    def get_vector_size(self) -> int:
+        """
+        Retrieve the size of the embedding vectors.
+
+        Returns:
+        --------
+
+            - int: The dimension of the embedding vectors.
+        """
+        return self.dimensions
+
+    def get_batch_size(self) -> int:
+        """
+        Return the desired batch size for embedding calls.
+
+        Returns:
+
+        """
+        return self.batch_size
+
+    def get_tokenizer(self):
+        """
+        Instantiate and return the tokenizer used for preparing text for embedding.
+
+        Marengo does not publish a public tokenizer; TikToken is used purely for
+        chunk-size estimation, matching the FastembedEmbeddingEngine approach.
+
+        Returns:
+        --------
+
+            A tokenizer object configured for the specified maximum token size.
+        """
+        logger.debug("Loading tokenizer for TwelveLabsEmbeddingEngine...")
+        tokenizer = TikTokenTokenizer(
+            model="gpt-4o", max_completion_tokens=self.max_completion_tokens
+        )
+        logger.debug("Tokenizer loaded for TwelveLabsEmbeddingEngine")
+        return tokenizer

--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -31,6 +31,11 @@ def _resolve_embedding_dimensions(provider: Optional[str], model: Optional[str])
     bare_model = model.split("/")[-1] if "/" in model else model
     candidates = [model, bare_model, f"{provider_lower}/{bare_model}"]
 
+    # TwelveLabs' Marengo is multimodal and not known to litellm/fastembed;
+    # every current Marengo model produces 512-dim vectors.
+    if provider_lower == "twelvelabs":
+        return 512
+
     if provider_lower == "fastembed":
         try:
             from fastembed import TextEmbedding

--- a/cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py
@@ -101,6 +101,18 @@ def create_embedding_engine(
             batch_size=embedding_batch_size,
         )
 
+    if embedding_provider == "twelvelabs":
+        from .TwelveLabsEmbeddingEngine import TwelveLabsEmbeddingEngine
+
+        return TwelveLabsEmbeddingEngine(
+            model=embedding_model,
+            dimensions=embedding_dimensions,
+            max_completion_tokens=embedding_max_completion_tokens,
+            endpoint=embedding_endpoint,
+            api_key=embedding_api_key or llm_api_key,
+            batch_size=embedding_batch_size,
+        )
+
     if embedding_provider == "openai_compatible":
         from .OpenAICompatibleEmbeddingEngine import OpenAICompatibleEmbeddingEngine
 

--- a/cognee/tests/unit/infrastructure/test_twelvelabs_embedding_engine.py
+++ b/cognee/tests/unit/infrastructure/test_twelvelabs_embedding_engine.py
@@ -1,0 +1,101 @@
+"""
+Tests for TwelveLabsEmbeddingEngine (Marengo).
+
+Verifies that the engine:
+- Returns mock embeddings when MOCK_EMBEDDING is set
+- Reports correct vector size and batch size
+- Parses the TwelveLabs /embed response shape (text_embedding.segments[0].float)
+- Posts model_name + text to the configured endpoint with the x-api-key header
+
+The network-touching test mocks _get_embedding so it runs offline.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class TestTwelveLabsEmbeddingEngine:
+    """Unit tests for TwelveLabsEmbeddingEngine."""
+
+    def _make_engine(self, **kwargs):
+        defaults = {
+            "model": "marengo3.0",
+            "dimensions": 512,
+            "max_completion_tokens": 512,
+            "endpoint": "https://api.twelvelabs.io/v1.3/embed",
+            "api_key": "test-key",
+            "batch_size": 100,
+        }
+        defaults.update(kwargs)
+
+        from cognee.infrastructure.databases.vector.embeddings.TwelveLabsEmbeddingEngine import (
+            TwelveLabsEmbeddingEngine,
+        )
+
+        return TwelveLabsEmbeddingEngine(**defaults)
+
+    @pytest.mark.asyncio
+    async def test_mock_embedding(self, monkeypatch):
+        """When MOCK_EMBEDDING=true, embed_text returns zero vectors of correct dimensions."""
+        monkeypatch.setenv("MOCK_EMBEDDING", "true")
+        engine = self._make_engine(dimensions=512)
+        result = await engine.embed_text(["hello", "world"])
+        assert len(result) == 2
+        assert len(result[0]) == 512
+        assert all(v == 0.0 for v in result[0])
+
+    @pytest.mark.asyncio
+    async def test_embed_text_returns_per_prompt_vectors(self, monkeypatch):
+        """embed_text returns one Marengo vector per input prompt."""
+        monkeypatch.delenv("MOCK_EMBEDDING", raising=False)
+        engine = self._make_engine()
+        engine._get_embedding = AsyncMock(return_value=[0.1] * 512)
+
+        result = await engine.embed_text(["one", "two", "three"])
+
+        assert engine._get_embedding.await_count == 3
+        assert len(result) == 3
+        assert len(result[0]) == 512
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises(self, monkeypatch):
+        """A missing API key produces a clear EmbeddingException, not a network error."""
+        monkeypatch.delenv("MOCK_EMBEDDING", raising=False)
+        monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+        from cognee.infrastructure.databases.exceptions import EmbeddingException
+
+        engine = self._make_engine(api_key=None)
+        with pytest.raises(EmbeddingException):
+            await engine.embed_text(["hello"])
+
+    def test_get_vector_size_defaults_to_512(self):
+        """Marengo defaults to 512 dimensions when none is supplied."""
+        engine = self._make_engine(dimensions=None)
+        assert engine.get_vector_size() == 512
+
+    def test_get_batch_size(self):
+        engine = self._make_engine(batch_size=50)
+        assert engine.get_batch_size() == 50
+
+    def test_factory_dispatches_to_twelvelabs(self):
+        """create_embedding_engine routes provider='twelvelabs' to this engine."""
+        from cognee.infrastructure.databases.vector.embeddings.get_embedding_engine import (
+            create_embedding_engine,
+        )
+        from cognee.infrastructure.databases.vector.embeddings.TwelveLabsEmbeddingEngine import (
+            TwelveLabsEmbeddingEngine,
+        )
+
+        engine = create_embedding_engine(
+            "twelvelabs", "marengo3.0", 512, 512, None, "k", None, 100, None, "k", "openai"
+        )
+        assert isinstance(engine, TwelveLabsEmbeddingEngine)
+
+    def test_config_resolves_marengo_dimensions(self):
+        """The config helper resolves twelvelabs to 512 dims without env override."""
+        from cognee.infrastructure.databases.vector.embeddings.config import (
+            _resolve_embedding_dimensions,
+        )
+
+        assert _resolve_embedding_dimensions("twelvelabs", "marengo3.0") == 512


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Description

This adds an opt-in embedding provider backed by TwelveLabs' **Marengo** multimodal model. Marengo embeds text into the same 512-dimensional vector space as video, image and audio. That property is the reason this is interesting for cognee specifically: once video is embedded with Marengo, a Marengo-embedded *text* query is directly comparable to it in the same vector store, so text and video memories can live in one graph and be searched together. This PR ships the text side of that (the embedding engine); embedding ingested video through Marengo, and Pegasus-based video understanding at ingestion time, are natural follow-ups that build on this same provider.

I modelled `TwelveLabsEmbeddingEngine` directly on the existing `OllamaEmbeddingEngine` so it fits the codebase rather than inventing a new pattern: it's `aiohttp`-based (no new dependency), supports `MOCK_EMBEDDING`, reuses the shared context-window split fallback, the tenacity retry policy, and `embedding_rate_limiter_context_manager`. It calls the public REST endpoint (`https://api.twelvelabs.io/v1.3/embed`, `x-api-key`, multipart `model_name`+`text`) and reads `text_embedding.segments[0].float`.

Wiring is the same as every other provider:
- `create_embedding_engine` gains a `provider == "twelvelabs"` branch
- `_resolve_embedding_dimensions` returns 512 for `twelvelabs` so users don't have to set `EMBEDDING_DIMENSIONS` by hand (Marengo isn't in the litellm/fastembed registries)
- `.env.template` documents the provider next to the Ollama/Azure blocks
- `EMBEDDING_API_KEY` falls back to `TWELVELABS_API_KEY`

It is **fully opt-in and non-breaking**: nothing happens unless you set `EMBEDDING_PROVIDER="twelvelabs"`. No defaults change.

## Acceptance Criteria

* Selecting `EMBEDDING_PROVIDER="twelvelabs"` returns a working 512-dim embedder.
* No existing behaviour changes when the provider is not selected.
* Verified live against the real Marengo API and with offline unit tests (below).

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Testing

**Live smoke test** against the real Marengo API (`marengo3.0`):
```
$ python -c "...TwelveLabsEmbeddingEngine().embed_text(['a cat playing piano','sunset over the ocean'])..."
SMOKE_OK count=2 dim=512
```

**Offline unit tests** (mock embeddings, factory dispatch, config dimension resolution, missing-key error):
```
$ uv run pytest cognee/tests/unit/infrastructure/test_twelvelabs_embedding_engine.py -q
.......                                                          [100%]
7 passed in 0.15s
```

Existing embedding tests still pass (no regression):
```
$ uv run pytest .../test_openai_compatible_embedding_engine.py .../test_embedding_config.py \
    .../test_embedding_context_window_fallbacks.py .../test_twelvelabs_embedding_engine.py -q
24 passed, 2 skipped
```
`ruff format` / `ruff check` are clean on the changed files.

## Screenshots
N/A — CLI test output is quoted above (all green).

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my feature works
- [x] I have added necessary documentation (.env.template)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

---
You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
