### PR TITLE
fix: prevent UnboundLocalError when datasets are omitted

### DIFF
--- a/cognee/tests/unit/modules/pipelines/test_background_pipeline_task_anchoring.py
+++ b/cognee/tests/unit/modules/pipelines/test_background_pipeline_task_anchoring.py
@@ -9,6 +9,8 @@ module-level ``_BACKGROUND_PIPELINE_TASKS`` set and discards it on completion.
 
 import gc
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -60,3 +62,35 @@ async def test_background_pipeline_task_is_anchored_until_done(monkeypatch):
     await asyncio.sleep(0)  # allow the done-callback to run
     assert task not in pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS
     assert len(pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS) == 0
+
+
+@pytest.mark.asyncio
+async def test_user_provided_without_datasets_does_not_raise(monkeypatch):
+    # Regression: UnboundLocalError when user is supplied but datasets is omitted.
+    # `cognee-cli cognify --background` (no --datasets flag) hits this path.
+    monkeypatch.setattr(pipeline_execution_mode, "push_to_queue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        pipeline_execution_mode,
+        "get_authorized_existing_datasets",
+        AsyncMock(return_value=[]),
+    )
+    # Ensure the provided user is used.
+    monkeypatch.setattr(
+        pipeline_execution_mode,
+        "get_default_user",
+        AsyncMock(
+            side_effect=AssertionError("get_default_user must not be called when user is in params")
+        ),
+    )
+
+    async def dummy_pipeline(**kwargs):
+        yield _FakeRunInfo(dataset_id="ds1")  # pragma: no cover
+
+    result = await run_pipeline_as_background_process(
+        dummy_pipeline,
+        user=SimpleNamespace(id="test-user-id"),
+        # datasets intentionally omitted → params.get("datasets") is None
+    )
+    await asyncio.sleep(0)  # flush any background no-op task
+
+    assert isinstance(result, dict)


### PR DESCRIPTION
## Description

While testing the background pipeline execution flow, I noticed that
`run_pipeline_as_background_process()` could raise an `UnboundLocalError`
when a user is provided but `datasets` is omitted.

The local `user` variable was only assigned inside the branch that fetches the
default user, leaving it uninitialized when a user was already supplied.

This PR initializes `user` before that conditional and adds a regression test
to ensure this execution path remains covered.

## Acceptance Criteria

* Fixes the `UnboundLocalError` when `user` is provided and `datasets` is omitted.
* Adds a regression test covering this execution path.
* Verified the updated tests pass locally.
* Verified with `ruff check` and `ruff format --check`.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Code refactoring
* [ ] Other (please specify):

## Screenshots

Local validation:

* `ruff check`
* `ruff format --check`
* `pytest cognee/tests/unit/modules/pipelines/test_background_pipeline_task_anchoring.py -v`

(Attach the screenshots below.)
<img width="1470" height="956" alt="1" src="https://github.com/user-attachments/assets/cf88ded2-1ea7-4cbc-ba25-5bf039e90e4b" />

<img width="1470" height="956" alt="2" src="https://github.com/user-attachments/assets/dd4035c5-498e-4969-b454-b07569447dce" />

<img width="1470" height="956" alt="3" src="https://github.com/user-attachments/assets/b382864b-7553-4a85-9f1c-da367bc1a259" />



## Pre-submission Checklist

* [x] **I have tested my changes thoroughly before submitting this PR**
* [x] **This PR contains minimal changes necessary to address the issue/feature**
* [x] My code follows the project's coding standards and style guidelines
* [x] I have added tests that prove my fix is effective
* [ ] I have added necessary documentation (not applicable)
* [x] All new and existing tests pass
* [ ] I have linked any relevant issues in the description (N/A)
* [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
