### PR TITLE
fix: prevent unbounded Redis session list growth and OOM on retrievalFix redis memory leak

### DIFF
--- a/cognee/infrastructure/databases/cache/config.py
+++ b/cognee/infrastructure/databases/cache/config.py
@@ -31,6 +31,8 @@ class CacheConfig(BaseSettings):
     - auto_feedback: When caching is True, run automatic feedback detection and session-context
       guidance on each query (default True). Adds one structured-output LLM call per answered
       turn; set AUTO_FEEDBACK=false to disable.
+    - max_session_history_items: Maximum number of QA turns, agent traces, and session contexts
+      kept in fast-cache per session (default: 1000). Set to None to keep unbounded history.
     """
 
     cache_backend: Literal["redis", "fs", "tapes", "sqlite", "postgres"] = "sqlite"
@@ -47,6 +49,7 @@ class CacheConfig(BaseSettings):
     agentic_lock_expire: int = 240
     agentic_lock_timeout: int = 300
     session_ttl_seconds: Optional[int] = 604800
+    max_session_history_items: Optional[int] = 1000
     max_session_context_chars: Optional[int] = None
     usage_logging: bool = False
     usage_logging_ttl: int = 604800
@@ -80,6 +83,7 @@ class CacheConfig(BaseSettings):
             "agentic_lock_expire": self.agentic_lock_expire,
             "agentic_lock_timeout": self.agentic_lock_timeout,
             "session_ttl_seconds": self.session_ttl_seconds,
+            "max_session_history_items": self.max_session_history_items,
             "max_session_context_chars": self.max_session_context_chars,
             "usage_logging": self.usage_logging,
             "usage_logging_ttl": self.usage_logging_ttl,

--- a/cognee/infrastructure/databases/cache/get_cache_engine.py
+++ b/cognee/infrastructure/databases/cache/get_cache_engine.py
@@ -70,6 +70,7 @@ def create_cache_engine(
     agentic_lock_expire: int = 240,
     agentic_lock_timeout: int = 300,
     session_ttl_seconds: int | None = 604800,
+    max_session_history_items: int | None = 1000,
     tapes_ingest_url: str = "http://localhost:8082",
     tapes_provider: str = "openai",
     tapes_agent_name: str = "cognee",
@@ -91,6 +92,8 @@ def create_cache_engine(
     - log_key: Identifier used for usage logging.
     - agentic_lock_expire: Duration to hold the lock after acquisition.
     - agentic_lock_timeout: Max time to wait for the lock before failing.
+    - session_ttl_seconds: Time-to-live for Redis session keys in seconds.
+    - max_session_history_items: Max number of items kept in fast-cache per session.
     - cache_db_url: SQLAlchemy async URL for the SQL cache backends.
     - cache_purge_interval_seconds: Minimum interval between global TTL purge sweeps.
 
@@ -101,7 +104,9 @@ def create_cache_engine(
     config = get_cache_config()
     if config.caching or config.usage_logging:
         if config.cache_backend == "redis":
-            from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+            from cognee.infrastructure.databases.cache.redis.RedisAdapter import (
+                RedisAdapter,
+            )
 
             return RedisAdapter(
                 host=cache_host,
@@ -113,6 +118,7 @@ def create_cache_engine(
                 timeout=agentic_lock_expire,
                 blocking_timeout=agentic_lock_timeout,
                 session_ttl_seconds=session_ttl_seconds,
+                max_session_history_items=max_session_history_items,
             )
         elif config.cache_backend == "fs":
             return FSCacheAdapter(session_ttl_seconds=session_ttl_seconds)
@@ -135,13 +141,17 @@ def create_cache_engine(
             )
 
             try:
-                connection_string = _resolve_cache_db_url(config.cache_backend, cache_db_url)
+                connection_string = _resolve_cache_db_url(
+                    config.cache_backend, cache_db_url
+                )
             except CacheConnectionError as error:
                 # An explicitly chosen backend must fail loudly. The implicit
                 # sqlite default, however, can land on deployments it cannot
                 # serve (e.g. system root on S3) - degrade to the filesystem
                 # cache there so sessions keep working out of the box.
-                explicitly_chosen = "cache_backend" in getattr(config, "model_fields_set", set())
+                explicitly_chosen = "cache_backend" in getattr(
+                    config, "model_fields_set", set()
+                )
                 if config.cache_backend != "sqlite" or explicitly_chosen:
                     raise
                 logger.warning(
@@ -188,6 +198,7 @@ def get_cache_engine(
         agentic_lock_expire=config.agentic_lock_expire,
         agentic_lock_timeout=config.agentic_lock_timeout,
         session_ttl_seconds=config.session_ttl_seconds,
+        max_session_history_items=config.max_session_history_items,
         tapes_ingest_url=config.tapes_ingest_url,
         tapes_provider=config.tapes_provider,
         tapes_agent_name=config.tapes_agent_name,

--- a/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
+++ b/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
@@ -8,7 +8,10 @@ import redis.asyncio as aioredis
 from pydantic import BaseModel, ValidationError
 
 from cognee.infrastructure.databases.cache.cache_db_interface import CacheDBInterface
-from cognee.infrastructure.databases.cache.models import SessionAgentTraceEntry, SessionQAEntry
+from cognee.infrastructure.databases.cache.models import (
+    SessionAgentTraceEntry,
+    SessionQAEntry,
+)
 from cognee.infrastructure.databases.exceptions import (
     CacheConnectionError,
     SessionQAEntryValidationError,
@@ -33,6 +36,7 @@ class RedisAdapter(CacheDBInterface):
         blocking_timeout=300,
         connection_timeout=30,
         session_ttl_seconds: int | None = 604800,
+        max_session_history_items: int | None = 1000,
     ):
         """Initialize sync/async Redis clients and validate connectivity up front."""
         super().__init__(host, port, lock_name, log_key)
@@ -41,6 +45,7 @@ class RedisAdapter(CacheDBInterface):
         self.port = port
         self.connection_timeout = connection_timeout
         self.session_ttl_seconds = session_ttl_seconds
+        self.max_session_history_items = max_session_history_items
 
         try:
             self.sync_redis = redis.Redis(
@@ -152,12 +157,33 @@ class RedisAdapter(CacheDBInterface):
         )
         return entry.model_dump()
 
-    async def _load_entries(self, session_key: str, start: int = 0, end: int = -1) -> list[dict]:
-        """Load and deserialize a Redis list slice for the given key."""
-        raw = await self.async_redis.lrange(session_key, start, end)
-        return [json.loads(e) for e in raw] if raw else []
+    async def _load_entries(
+        self, session_key: str, start: int = 0, end: int = -1
+    ) -> list[dict]:
+        """Load and deserialize a Redis list slice for the given key, using chunked reads for full list."""
+        # If requesting the full list, use chunked reads to avoid OOM on massive lists
+        if start == 0 and end == -1:
+            results = []
+            cursor = 0
+            chunk_size = 1000
+            while True:
+                raw_chunk = await self.async_redis.lrange(
+                    session_key, cursor, cursor + chunk_size - 1
+                )
+                if not raw_chunk:
+                    break
+                results.extend(json.loads(e) for e in raw_chunk)
+                if len(raw_chunk) < chunk_size:
+                    break
+                cursor += chunk_size
+            return results
+        else:
+            raw = await self.async_redis.lrange(session_key, start, end)
+            return [json.loads(e) for e in raw] if raw else []
 
-    async def _write_entry_at(self, session_key: str, index: int, entry_dump: dict) -> None:
+    async def _write_entry_at(
+        self, session_key: str, index: int, entry_dump: dict
+    ) -> None:
         """Overwrite a single serialized entry in-place within a Redis list."""
         await self.async_redis.lset(session_key, index, json.dumps(entry_dump))
 
@@ -306,6 +332,10 @@ class RedisAdapter(CacheDBInterface):
                 used_session_context_ids=used_session_context_ids,
             )
             await self.async_redis.rpush(session_key, json.dumps(qa_entry))
+            if self.max_session_history_items is not None:
+                await self.async_redis.ltrim(
+                    session_key, -self.max_session_history_items, -1
+                )
             await self._apply_session_ttl(session_key)
         except (redis.ConnectionError, redis.TimeoutError) as e:
             error_msg = f"Redis connection error while adding Q&A: {str(e)}"
@@ -329,12 +359,16 @@ class RedisAdapter(CacheDBInterface):
         data = await self.async_redis.lrange(session_key, -last_n, -1)
         return [SessionQAEntry.model_validate_json(d) for d in data] if data else []
 
-    async def get_all_qa_entries(self, user_id: str, session_id: str) -> list[SessionQAEntry]:
+    async def get_all_qa_entries(
+        self, user_id: str, session_id: str
+    ) -> list[SessionQAEntry]:
         """
         Retrieve all Q/A/context triplets for the given session.
         """
         session_key = self._session_key(user_id, session_id)
-        return [SessionQAEntry(**entry) for entry in await self._load_entries(session_key)]
+        return [
+            SessionQAEntry(**entry) for entry in await self._load_entries(session_key)
+        ]
 
     async def get_qa_entries_by_ids(
         self,
@@ -552,13 +586,21 @@ class RedisAdapter(CacheDBInterface):
                 session_feedback=session_feedback,
             )
             await self.async_redis.rpush(trace_key, json.dumps(trace_entry))
+            if self.max_session_history_items is not None:
+                await self.async_redis.ltrim(
+                    trace_key, -self.max_session_history_items, -1
+                )
             await self._apply_session_ttl(trace_key)
         except (redis.ConnectionError, redis.TimeoutError) as e:
-            error_msg = f"Redis connection error while appending agent trace step: {str(e)}"
+            error_msg = (
+                f"Redis connection error while appending agent trace step: {str(e)}"
+            )
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
         except Exception as e:
-            error_msg = f"Unexpected error while appending agent trace step to Redis: {str(e)}"
+            error_msg = (
+                f"Unexpected error while appending agent trace step to Redis: {str(e)}"
+            )
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
 
@@ -572,7 +614,10 @@ class RedisAdapter(CacheDBInterface):
                 SessionAgentTraceEntry(**entry)
                 for entry in await self._load_entries(trace_key, -last_n, -1)
             ]
-        return [SessionAgentTraceEntry(**entry) for entry in await self._load_entries(trace_key)]
+        return [
+            SessionAgentTraceEntry(**entry)
+            for entry in await self._load_entries(trace_key)
+        ]
 
     async def get_agent_trace_feedback(
         self, user_id: str, session_id: str, last_n: int | None = None
@@ -593,17 +638,25 @@ class RedisAdapter(CacheDBInterface):
         try:
             context_key = self._session_context_key(user_id, session_id)
             await self.async_redis.rpush(context_key, json.dumps(entry_dump))
+            if self.max_session_history_items is not None:
+                await self.async_redis.ltrim(
+                    context_key, -self.max_session_history_items, -1
+                )
             await self._apply_session_ttl(context_key)
         except (redis.ConnectionError, redis.TimeoutError) as e:
             error_msg = f"Redis connection error while adding session context: {str(e)}"
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
         except Exception as e:
-            error_msg = f"Unexpected error while adding session context to Redis: {str(e)}"
+            error_msg = (
+                f"Unexpected error while adding session context to Redis: {str(e)}"
+            )
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
 
-    async def get_session_context_entries(self, user_id: str, session_id: str) -> list[dict]:
+    async def get_session_context_entries(
+        self, user_id: str, session_id: str
+    ) -> list[dict]:
         """Retrieve all stored session-context entries for the given session."""
         context_key = self._session_context_key(user_id, session_id)
         return await self._load_entries(context_key)
@@ -623,11 +676,15 @@ class RedisAdapter(CacheDBInterface):
                     return True
             return False
         except (redis.ConnectionError, redis.TimeoutError) as e:
-            error_msg = f"Redis connection error while updating session context: {str(e)}"
+            error_msg = (
+                f"Redis connection error while updating session context: {str(e)}"
+            )
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
         except Exception as e:
-            error_msg = f"Unexpected error while updating session context in Redis: {str(e)}"
+            error_msg = (
+                f"Unexpected error while updating session context in Redis: {str(e)}"
+            )
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
 
@@ -637,11 +694,15 @@ class RedisAdapter(CacheDBInterface):
             context_key = self._session_context_key(user_id, session_id)
             return (await self.async_redis.delete(context_key)) > 0
         except (redis.ConnectionError, redis.TimeoutError) as e:
-            error_msg = f"Redis connection error while deleting session context: {str(e)}"
+            error_msg = (
+                f"Redis connection error while deleting session context: {str(e)}"
+            )
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
         except Exception as e:
-            error_msg = f"Unexpected error while deleting session context from Redis: {str(e)}"
+            error_msg = (
+                f"Unexpected error while deleting session context from Redis: {str(e)}"
+            )
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
 
@@ -715,7 +776,9 @@ class RedisAdapter(CacheDBInterface):
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
         except Exception as e:
-            error_msg = f"Unexpected error while retrieving usage logs from Redis: {str(e)}"
+            error_msg = (
+                f"Unexpected error while retrieving usage logs from Redis: {str(e)}"
+            )
             logger.error(error_msg)
             raise CacheConnectionError(error_msg) from e
 

--- a/cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py
@@ -31,6 +31,17 @@ class _InMemoryRedisList:
         e = (end + 1) if end >= 0 else len(lst) + end + 1
         return lst[s:e]
 
+    async def ltrim(self, key: str, start: int, end: int):
+        lst = self.data.get(key, [])
+        if not lst:
+            return
+        s = start if start >= 0 else max(0, len(lst) + start)
+        e = (end + 1) if end >= 0 else min(len(lst), len(lst) + end + 1)
+        if s >= e or s >= len(lst):
+            self.data[key] = []
+        else:
+            self.data[key] = lst[s:e]
+
     async def llen(self, key: str):
         return len(self.data.get(key, []))
 
@@ -73,7 +84,9 @@ def adapter(redis_store):
         patch(f"{patch_mod}.redis.Redis", return_value=MagicMock(ping=MagicMock())),
         patch(f"{patch_mod}.aioredis.Redis", return_value=redis_store),
     ):
-        from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+        from cognee.infrastructure.databases.cache.redis.RedisAdapter import (
+            RedisAdapter,
+        )
 
         yield RedisAdapter(host="localhost", port=6379)
 
@@ -102,7 +115,9 @@ def test_acquire_lock_returns_handle_and_disables_thread_local(redis_store):
         patch(f"{patch_mod}.redis.Redis", return_value=sync_redis),
         patch(f"{patch_mod}.aioredis.Redis", return_value=redis_store),
     ):
-        from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+        from cognee.infrastructure.databases.cache.redis.RedisAdapter import (
+            RedisAdapter,
+        )
 
         adapter = RedisAdapter(host="localhost", port=6379)
 
@@ -118,7 +133,9 @@ def test_acquire_lock_returns_handle_and_disables_thread_local(redis_store):
     )
 
 
-def test_release_lock_releases_passed_handle_without_clobbering_current_lock(redis_store):
+def test_release_lock_releases_passed_handle_without_clobbering_current_lock(
+    redis_store,
+):
     """Concurrent Kuzu queries must release their own lock, not whichever lock is latest."""
     first_lock = _FakeRedisLock()
     second_lock = _FakeRedisLock()
@@ -128,7 +145,9 @@ def test_release_lock_releases_passed_handle_without_clobbering_current_lock(red
         patch(f"{patch_mod}.redis.Redis", return_value=MagicMock(ping=MagicMock())),
         patch(f"{patch_mod}.aioredis.Redis", return_value=redis_store),
     ):
-        from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+        from cognee.infrastructure.databases.cache.redis.RedisAdapter import (
+            RedisAdapter,
+        )
 
         adapter = RedisAdapter(host="localhost", port=6379)
 
@@ -150,6 +169,30 @@ async def test_create_and_get(adapter):
 
 
 @pytest.mark.asyncio
+async def test_max_session_history_limit(redis_store):
+    """RedisAdapter trims session history if max_session_history_items is set."""
+    patch_mod = "cognee.infrastructure.databases.cache.redis.RedisAdapter"
+    with (
+        patch(f"{patch_mod}.redis.Redis", return_value=MagicMock(ping=MagicMock())),
+        patch(f"{patch_mod}.aioredis.Redis", return_value=redis_store),
+    ):
+        from cognee.infrastructure.databases.cache.redis.RedisAdapter import (
+            RedisAdapter,
+        )
+
+        adapter = RedisAdapter(host="localhost", port=6379, max_session_history_items=2)
+
+    await adapter.create_qa_entry("u1", "s1", "Q1", "C", "A", qa_id="id1")
+    await adapter.create_qa_entry("u1", "s1", "Q2", "C", "A", qa_id="id2")
+    await adapter.create_qa_entry("u1", "s1", "Q3", "C", "A", qa_id="id3")
+
+    entries = await adapter.get_all_qa_entries("u1", "s1")
+    assert len(entries) == 2
+    assert entries[0].qa_id == "id2"
+    assert entries[1].qa_id == "id3"
+
+
+@pytest.mark.asyncio
 async def test_create_qa_entry_sets_session_ttl_when_enabled(adapter, redis_store):
     """Session keys receive TTL on create when Redis session TTL is enabled."""
     await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
@@ -167,7 +210,9 @@ async def test_create_qa_entry_does_not_set_session_ttl_when_disabled(redis_stor
         patch(f"{patch_mod}.redis.Redis", return_value=MagicMock(ping=MagicMock())),
         patch(f"{patch_mod}.aioredis.Redis", return_value=redis_store),
     ):
-        from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+        from cognee.infrastructure.databases.cache.redis.RedisAdapter import (
+            RedisAdapter,
+        )
 
         adapter = RedisAdapter(host="localhost", port=6379, session_ttl_seconds=0)
 
@@ -238,7 +283,9 @@ async def test_append_agent_trace_step_and_get_session(adapter):
 
 
 @pytest.mark.asyncio
-async def test_append_agent_trace_step_sets_trace_ttl_when_enabled(adapter, redis_store):
+async def test_append_agent_trace_step_sets_trace_ttl_when_enabled(
+    adapter, redis_store
+):
     """Trace keys receive TTL on append when Redis session TTL is enabled."""
     await adapter.append_agent_trace_step(
         "u1",
@@ -445,7 +492,9 @@ async def test_update_invalid_raises(adapter):
 async def test_delete_feedback(adapter):
     """delete_feedback sets feedback_text and feedback_score to None."""
     await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
-    await adapter.update_qa_entry("u1", "s1", "id1", feedback_text="good", feedback_score=5)
+    await adapter.update_qa_entry(
+        "u1", "s1", "id1", feedback_text="good", feedback_score=5
+    )
     ok = await adapter.delete_feedback("u1", "s1", "id1")
     assert ok
     entries = await adapter.get_all_qa_entries("u1", "s1")
@@ -457,7 +506,9 @@ async def test_delete_feedback(adapter):
 async def test_delete_feedback_refreshes_session_ttl(adapter, redis_store):
     """Clearing feedback should refresh the session TTL."""
     await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
-    await adapter.update_qa_entry("u1", "s1", "id1", feedback_text="good", feedback_score=5)
+    await adapter.update_qa_entry(
+        "u1", "s1", "id1", feedback_text="good", feedback_score=5
+    )
     redis_store.expire_calls.clear()
 
     ok = await adapter.delete_feedback("u1", "s1", "id1")
@@ -576,7 +627,9 @@ async def test_get_latest_qa_backward_compat(adapter):
 
 
 @pytest.mark.asyncio
-async def test_get_qa_entries_by_ids_returns_matching_rows_in_chronological_order(adapter):
+async def test_get_qa_entries_by_ids_returns_matching_rows_in_chronological_order(
+    adapter,
+):
     await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
     await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
     await adapter.create_qa_entry("u1", "s1", "Q3", "C3", "A3", qa_id="id3")


### PR DESCRIPTION
This PR addresses an unbounded memory growth issue in the Redis fast-cache and a corresponding memory exhaustion risk in Python.

While auditing the session memory pipeline, I noticed that rpush is used without any list truncation (ltrim) in the RedisAdapter. Since every interaction also refreshes the session TTL, active long-running sessions will grow indefinitely in Redis. Furthermore, retrieving these sessions via _load_entries fetches the entire list into the Python heap simultaneously via lrange(0, -1), which could cause massive latency spikes or OOM errors for large sessions.

To fix this safely, this PR:

Introduces max_session_history_items to CacheConfig (defaulting to 1000). Setting it to None acts as an escape hatch to keep the legacy unbounded behavior.
Implements ltrim as a sliding window in the Redis adapter immediately after appending new turns.
Updates _load_entries to perform chunked reads when fetching full lists, providing defense-in-depth against OOMs for any existing massive lists already in production.
Note on Safety / Data Loss: Since index_session_qa is called synchronously alongside create_qa_entry, every turn is still durably indexed into the Vector DB (SESSION_QA_VECTOR_COLLECTION) before ltrim drops anything. The Redis fast-cache safely retains the most recent 1000 turns for low-latency context, while the semantic graph accurately retains all historical context.

Type of Change
 Bug fix (non-breaking change which fixes an issue)
 Performance Improvement
Testing
Added test_max_session_history_limit in test_redis_adapter_crud.py to verify the ltrim sliding window logic works as expected.
Verified no regressions in existing cache CRUD tests.