### PR TITLE
Fix/ollama chunk context window

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -525,6 +525,7 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #LLM_MODEL="llama3.1:8b"
 #LLM_PROVIDER="ollama"
 #LLM_ENDPOINT="http://localhost:11434/v1"
+#OLLAMA_NUM_CTX=4096
 #EMBEDDING_PROVIDER="ollama"
 #EMBEDDING_MODEL="nomic-embed-text:latest"
 #EMBEDDING_ENDPOINT="http://localhost:11434/api/embed"

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -75,6 +75,8 @@ class LLMConfig(BaseSettings):
     llama_cpp_n_gpu_layers: int = 0
     llama_cpp_chat_format: str = "chatml"
 
+    ollama_num_ctx: int = 4096
+
     fallback_api_key: str = ""
     fallback_endpoint: str = ""
     fallback_model: str = ""
@@ -256,6 +258,7 @@ class LLMConfig(BaseSettings):
             "llama_cpp_n_ctx": self.llama_cpp_n_ctx,
             "llama_cpp_n_gpu_layers": self.llama_cpp_n_gpu_layers,
             "llama_cpp_chat_format": self.llama_cpp_chat_format,
+            "ollama_num_ctx": self.ollama_num_ctx,
             "llm_args": self.llm_args,
         }
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -64,6 +64,7 @@ class _LLMClientCacheKey:
     llama_cpp_n_ctx: int
     llama_cpp_n_gpu_layers: int
     llama_cpp_chat_format: str
+    ollama_num_ctx: int
 
 
 # Define an Enum for LLM Providers
@@ -178,6 +179,7 @@ def _build_llm_client_cache_key(llm_config, max_completion_tokens: int) -> _LLMC
         llama_cpp_n_ctx=llm_config.llama_cpp_n_ctx,
         llama_cpp_n_gpu_layers=llm_config.llama_cpp_n_gpu_layers,
         llama_cpp_chat_format=llm_config.llama_cpp_chat_format,
+        ollama_num_ctx=llm_config.ollama_num_ctx,
     )
 
 
@@ -258,6 +260,7 @@ def _get_llm_client_cached(cache_key: _LLMClientCacheKey) -> LLMInterface:
             max_completion_tokens,
             instructor_mode=cache_key.instructor_mode,
             llm_args=llm_args,
+            num_ctx=cache_key.ollama_num_ctx,
         )
 
     elif provider == LLMProvider.ANTHROPIC:
@@ -383,19 +386,11 @@ def get_llm_client(raise_api_key_error: bool = True) -> LLMInterface:
         llm_config.llm_azure_use_managed_identity,
     )
 
-    # Check if max_token value is defined in liteLLM for given model
-    # if not use value from cognee configuration
     from cognee.infrastructure.llm.utils import (
-        get_model_max_completion_tokens,
+        resolve_llm_token_limit,
     )  # imported here to avoid circular imports
 
-    model_max_completion_tokens = get_model_max_completion_tokens(llm_config.llm_model)
-    user_max = llm_config.llm_max_completion_tokens
-    if model_max_completion_tokens is not None:
-        # Use the lower of the model's hard limit and the user's configured ceiling
-        max_completion_tokens = min(model_max_completion_tokens, user_max)
-    else:
-        max_completion_tokens = user_max
+    max_completion_tokens = resolve_llm_token_limit(llm_config.llm_model, llm_config)
 
     cache_key = _build_llm_client_cache_key(llm_config, max_completion_tokens)
     return _get_llm_client_cached(cache_key)

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -62,13 +62,18 @@ class OllamaAPIAdapter(LLMInterface):
         max_completion_tokens: int,
         instructor_mode: str | None = None,
         llm_args: dict[str, Any] | None = None,
+        num_ctx: int = 4096,
     ) -> None:
         self.name = name
         self.model = model
         self.api_key = api_key
         self.endpoint = endpoint
         self.max_completion_tokens = max_completion_tokens
-        self.llm_args: dict[str, Any] = llm_args or {}
+        self.num_ctx = num_ctx
+        self.llm_args: dict[str, Any] = dict(llm_args or {})
+        extra_body = self.llm_args.setdefault("extra_body", {})
+        options = extra_body.setdefault("options", {})
+        options.setdefault("num_ctx", num_ctx)
 
         self.instructor_mode = instructor_mode if instructor_mode else self.default_instructor_mode
 

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -14,6 +14,29 @@ logger = get_logger()
 CONNECTION_TEST_TIMEOUT_SECONDS = 30
 
 
+def resolve_llm_token_limit(model_name: str, llm_config) -> int:
+    """
+    Resolve the token budget used for chunk sizing and LLM context.
+
+    Uses LiteLLM's model lookup when available. For providers whose models are
+    not in LiteLLM (e.g. Ollama, llama.cpp), falls back to the configured
+    context window so chunks fit the context the model actually loads.
+    """
+    model_max = get_model_max_completion_tokens(model_name)
+    user_max = llm_config.llm_max_completion_tokens
+
+    if model_max is not None:
+        return min(model_max, user_max)
+
+    provider = llm_config.llm_provider
+    if provider == "ollama":
+        return min(llm_config.ollama_num_ctx, user_max)
+    if provider == "llama_cpp":
+        return min(llm_config.llama_cpp_n_ctx, user_max)
+
+    return user_max
+
+
 def get_max_chunk_tokens() -> int:
     """
     Calculate the maximum number of tokens allowed in a chunk.

--- a/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
+++ b/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
@@ -45,6 +45,7 @@ def _llm_config(**overrides):
         "llama_cpp_n_ctx": 2048,
         "llama_cpp_n_gpu_layers": 1,
         "llama_cpp_chat_format": "chatml",
+        "ollama_num_ctx": 4096,
     }
     config.update(overrides)
     return LLMConfig(**config)
@@ -66,6 +67,7 @@ def test_llm_client_cache_key_covers_adapter_configuration_fields():
         _build_llm_client_cache_key(_llm_config(fallback_model="other-model"), 1024),
         _build_llm_client_cache_key(_llm_config(llm_args={"temperature": 1}), 1024),
         _build_llm_client_cache_key(_llm_config(llm_azure_use_managed_identity=True), 1024),
+        _build_llm_client_cache_key(_llm_config(ollama_num_ctx=8192), 1024),
         _build_llm_client_cache_key(_llm_config(), max_completion_tokens=4096),
     ]
 

--- a/cognee/tests/unit/infrastructure/llm/test_llm_token_limit.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_token_limit.py
@@ -1,33 +1,34 @@
-from cognee.infrastructure.llm.config import LLMConfig
+from types import SimpleNamespace
+
 from cognee.infrastructure.llm.utils import resolve_llm_token_limit
 
 
+def _llm_config(**overrides):
+    config = {
+        "llm_provider": "openai",
+        "llm_max_completion_tokens": 16384,
+        "ollama_num_ctx": 4096,
+        "llama_cpp_n_ctx": 2048,
+    }
+    config.update(overrides)
+    return SimpleNamespace(**config)
+
+
 def test_resolve_llm_token_limit_uses_ollama_num_ctx_when_model_unknown():
-    config = LLMConfig(
-        llm_provider="ollama",
-        llm_model="llama3.1:8b",
-        llm_max_completion_tokens=16384,
-        ollama_num_ctx=4096,
-    )
+    config = _llm_config(llm_provider="ollama", ollama_num_ctx=4096)
 
     assert resolve_llm_token_limit("llama3.1:8b", config) == 4096
 
 
 def test_resolve_llm_token_limit_uses_llama_cpp_n_ctx_when_model_unknown():
-    config = LLMConfig(
-        llm_provider="llama_cpp",
-        llm_model="local-model",
-        llm_max_completion_tokens=16384,
-        llama_cpp_n_ctx=2048,
-    )
+    config = _llm_config(llm_provider="llama_cpp", llama_cpp_n_ctx=2048)
 
     assert resolve_llm_token_limit("local-model", config) == 2048
 
 
 def test_resolve_llm_token_limit_respects_user_ceiling_for_ollama():
-    config = LLMConfig(
+    config = _llm_config(
         llm_provider="ollama",
-        llm_model="llama3.1:8b",
         llm_max_completion_tokens=2048,
         ollama_num_ctx=4096,
     )
@@ -36,10 +37,6 @@ def test_resolve_llm_token_limit_respects_user_ceiling_for_ollama():
 
 
 def test_resolve_llm_token_limit_falls_back_to_user_max_for_known_providers():
-    config = LLMConfig(
-        llm_provider="openai",
-        llm_model="openai/unknown-model-not-in-litellm",
-        llm_max_completion_tokens=8192,
-    )
+    config = _llm_config(llm_max_completion_tokens=8192)
 
     assert resolve_llm_token_limit("openai/unknown-model-not-in-litellm", config) == 8192

--- a/cognee/tests/unit/infrastructure/llm/test_llm_token_limit.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_token_limit.py
@@ -1,0 +1,45 @@
+from cognee.infrastructure.llm.config import LLMConfig
+from cognee.infrastructure.llm.utils import resolve_llm_token_limit
+
+
+def test_resolve_llm_token_limit_uses_ollama_num_ctx_when_model_unknown():
+    config = LLMConfig(
+        llm_provider="ollama",
+        llm_model="llama3.1:8b",
+        llm_max_completion_tokens=16384,
+        ollama_num_ctx=4096,
+    )
+
+    assert resolve_llm_token_limit("llama3.1:8b", config) == 4096
+
+
+def test_resolve_llm_token_limit_uses_llama_cpp_n_ctx_when_model_unknown():
+    config = LLMConfig(
+        llm_provider="llama_cpp",
+        llm_model="local-model",
+        llm_max_completion_tokens=16384,
+        llama_cpp_n_ctx=2048,
+    )
+
+    assert resolve_llm_token_limit("local-model", config) == 2048
+
+
+def test_resolve_llm_token_limit_respects_user_ceiling_for_ollama():
+    config = LLMConfig(
+        llm_provider="ollama",
+        llm_model="llama3.1:8b",
+        llm_max_completion_tokens=2048,
+        ollama_num_ctx=4096,
+    )
+
+    assert resolve_llm_token_limit("llama3.1:8b", config) == 2048
+
+
+def test_resolve_llm_token_limit_falls_back_to_user_max_for_known_providers():
+    config = LLMConfig(
+        llm_provider="openai",
+        llm_model="openai/unknown-model-not-in-litellm",
+        llm_max_completion_tokens=8192,
+    )
+
+    assert resolve_llm_token_limit("openai/unknown-model-not-in-litellm", config) == 8192

--- a/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
@@ -39,6 +39,7 @@ async def test_acreate_structured_output_awaits_async_client():
         model="llama3",
         name="ollama",
         max_completion_tokens=128,
+        num_ctx=4096,
     )
 
     sentinel = _Resp(value="ok")
@@ -55,6 +56,30 @@ async def test_acreate_structured_output_awaits_async_client():
 
     # The async client is awaited directly...
     adapter.aclient.chat.completions.create.assert_awaited_once()
+    call_kwargs = adapter.aclient.chat.completions.create.await_args.kwargs
+    assert call_kwargs["extra_body"]["options"]["num_ctx"] == 4096
     # ...not offloaded to a worker thread, and its result is returned unchanged.
     assert not to_thread_spy.called, "structured call must be awaited natively, not offloaded"
     assert result is sentinel
+
+
+@pytest.mark.asyncio
+async def test_acreate_structured_output_does_not_override_user_num_ctx():
+    adapter = OllamaAPIAdapter(
+        endpoint="http://localhost:11434/v1",
+        api_key="ollama",
+        model="llama3",
+        name="ollama",
+        max_completion_tokens=128,
+        num_ctx=4096,
+        llm_args={"extra_body": {"options": {"num_ctx": 8192}}},
+    )
+
+    adapter.aclient = Mock()
+    adapter.aclient.chat.completions.create = AsyncMock(return_value=_Resp(value="ok"))
+
+    with patch(f"{_MODULE}.llm_rate_limiter_context_manager", _null_rate_limiter):
+        await adapter.acreate_structured_output("hello", "system prompt", _Resp)
+
+    call_kwargs = adapter.aclient.chat.completions.create.await_args.kwargs
+    assert call_kwargs["extra_body"]["options"]["num_ctx"] == 8192


### PR DESCRIPTION
## Description

Fixes #3436.

When using Ollama, cognee was sizing document chunks from `llm_max_completion_tokens` (default `16384`) because Ollama model names such as `llama3.1:8b` are not present in LiteLLM's lookup table. This caused the chunk size to become `8191` tokens, which is roughly double Ollama's default `4096` context window and could lead to context overflow during `cognify`.

### Changes

* Added `OLLAMA_NUM_CTX` (default `4096`), following the same pattern as `LLAMA_CPP_N_CTX`.
* `resolve_llm_token_limit()` now falls back to the configured context window for Ollama (and `llama.cpp` via `llama_cpp_n_ctx`) instead of the generic `16384` default.
* `get_max_chunk_tokens()` automatically picks up the resolved limit through the LLM client.
* `OllamaAPIAdapter` now passes `num_ctx` via `extra_body.options.num_ctx`, keeping chunk sizing and the loaded model context in sync.
* Updated `.env.template` with the new configuration option.

## Acceptance Criteria

* ✅ Ollama models not present in LiteLLM no longer fall back to `16384` for chunk sizing.
* ✅ `OLLAMA_NUM_CTX` controls both chunk cutoff and Ollama request context.
* ✅ Existing `LLM_ARGS` overrides for `num_ctx` are preserved.
* ✅ With default `OLLAMA_NUM_CTX=4096`, chunk size becomes `2048` (`4096 / 2`) instead of `8191`.
* ✅ With `OLLAMA_NUM_CTX=8192`, chunk size becomes `4096`.
* ✅ Unit tests cover token limit resolution, cache key changes, and Ollama adapter `num_ctx` passthrough.

## Local Verification

```bash
uv run pytest \
  cognee/tests/unit/infrastructure/llm/test_llm_token_limit.py \
  cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py \
  cognee/tests/unit/infrastructure/llm/test_get_llm_client.py -v
```

**Result:** `14 passed`

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Code refactoring
* [ ] Other

## Screenshots

<img width="1402" height="746" alt="Screenshot 2026-06-25 145231" src="https://github.com/user-attachments/assets/e0df11ff-7823-4529-8cea-3b267895ae85" />

## Pre-submission Checklist

* [x] I have tested my changes thoroughly before submitting this PR.
* [x] This PR contains minimal changes necessary to address the issue/feature.
* [x] My code follows the project's coding standards and style guidelines.
* [x] I have added tests that prove my fix is effective.
* [x] I have added necessary documentation.
* [x] All new and existing tests pass.
* [x] I have searched existing PRs to ensure this change hasn't been submitted already.
* [x] I have linked relevant issues in the description.
* [x] My commits have clear and descriptive messages.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
