### PR TITLE
docs: fix is_embeddable docstring to match current behavior

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/utils.py
+++ b/cognee/infrastructure/databases/vector/embeddings/utils.py
@@ -5,20 +5,39 @@ logger = setup_logging()
 
 
 def is_embeddable(s: str) -> bool:
+
     """
-    Check if input string is embeddable, if not it will be replaced with a dummy value to prevent API errors.
-    Empty strings and a string with only a space character are not embeddable.
-    If input string contains at least one alphanumeric character, it is considered embeddable.
+
+    Check whether an input string should be treated as embeddable.
+
+    A string is considered embeddable if it is a string and contains at least
+
+    one non-whitespace character after stripping. Empty or whitespace-only
+
+    strings are not embeddable and will be replaced with a dummy value to
+
+    prevent API errors.
+
     """
+
     if not isinstance(s, str):
+
         return False
+
     # Strip whitespace to check if the string is empty or only contains spaces
+
     s = s.strip()
+
     if len(s) >= 1:
+
         return True
+
     logger.debug(
+
         "Input string was not embeddable. Skipping embedding and using dummy value instead."
+
     )
+
     return False
 
 


### PR DESCRIPTION
## Summary

This PR updates the `is_embeddable()` docstring in `cognee/infrastructure/databases/vector/embeddings/utils.py` to match the current implementation.

## What changed

The previous docstring stated that a string is embeddable only if it contains at least one alphanumeric character. However, the current implementation returns `True` for any string that contains at least one non-whitespace character after stripping.

This PR updates the docstring to reflect the actual runtime behavior and leaves the implementation unchanged.

## Why

The previous wording could mislead users into expecting punctuation-only strings such as `"!!!"` or `"."` to be treated as non-embeddable, even though the current implementation considers them embeddable.

Keeping the documentation aligned with the code makes the behavior of `is_embeddable()` and downstream functions such as `sanitize_embedding_text_inputs()` clearer.

## Scope

- Docs-only change

- No runtime behavior changed