### PR TITLE
fix(llm): support configurable context window for Ollama

### DIFF
--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -74,6 +74,7 @@ class LLMConfig(BaseSettings):
     llama_cpp_n_ctx: int = 2048
     llama_cpp_n_gpu_layers: int = 0
     llama_cpp_chat_format: str = "chatml"
+    ollama_num_ctx: int = 2048
 
     fallback_api_key: str = ""
     fallback_endpoint: str = ""
@@ -256,6 +257,7 @@ class LLMConfig(BaseSettings):
             "llama_cpp_n_ctx": self.llama_cpp_n_ctx,
             "llama_cpp_n_gpu_layers": self.llama_cpp_n_gpu_layers,
             "llama_cpp_chat_format": self.llama_cpp_chat_format,
+            "ollama_num_ctx": self.ollama_num_ctx,
             "llm_args": self.llm_args,
         }
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -64,6 +64,7 @@ class _LLMClientCacheKey:
     llama_cpp_n_ctx: int
     llama_cpp_n_gpu_layers: int
     llama_cpp_chat_format: str
+    ollama_num_ctx: int
 
 
 # Define an Enum for LLM Providers
@@ -178,6 +179,7 @@ def _build_llm_client_cache_key(llm_config, max_completion_tokens: int) -> _LLMC
         llama_cpp_n_ctx=llm_config.llama_cpp_n_ctx,
         llama_cpp_n_gpu_layers=llm_config.llama_cpp_n_gpu_layers,
         llama_cpp_chat_format=llm_config.llama_cpp_chat_format,
+        ollama_num_ctx=llm_config.ollama_num_ctx,
     )
 
 
@@ -251,13 +253,14 @@ def _get_llm_client_cached(cache_key: _LLMClientCacheKey) -> LLMInterface:
 
     elif provider == LLMProvider.OLLAMA:
         return OllamaAPIAdapter(
-            cache_key.endpoint,
-            llm_api_key,
-            cache_key.model,
-            "Ollama",
-            max_completion_tokens,
+            endpoint=cache_key.endpoint,
+            api_key=llm_api_key,
+            model=cache_key.model,
+            name="Ollama",
+            max_completion_tokens=max_completion_tokens,
             instructor_mode=cache_key.instructor_mode,
             llm_args=llm_args,
+            ollama_num_ctx=cache_key.ollama_num_ctx,
         )
 
     elif provider == LLMProvider.ANTHROPIC:
@@ -394,6 +397,8 @@ def get_llm_client(raise_api_key_error: bool = True) -> LLMInterface:
     if model_max_completion_tokens is not None:
         # Use the lower of the model's hard limit and the user's configured ceiling
         max_completion_tokens = min(model_max_completion_tokens, user_max)
+    elif provider == LLMProvider.OLLAMA:
+        max_completion_tokens = llm_config.ollama_num_ctx
     else:
         max_completion_tokens = user_max
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -62,6 +62,7 @@ class OllamaAPIAdapter(LLMInterface):
         max_completion_tokens: int,
         instructor_mode: str | None = None,
         llm_args: dict[str, Any] | None = None,
+        ollama_num_ctx: int | None = None,
     ) -> None:
         self.name = name
         self.model = model
@@ -69,6 +70,7 @@ class OllamaAPIAdapter(LLMInterface):
         self.endpoint = endpoint
         self.max_completion_tokens = max_completion_tokens
         self.llm_args: dict[str, Any] = llm_args or {}
+        self.ollama_num_ctx = ollama_num_ctx
 
         self.instructor_mode = instructor_mode if instructor_mode else self.default_instructor_mode
 
@@ -118,6 +120,11 @@ class OllamaAPIAdapter(LLMInterface):
             - BaseModel: A structured output that conforms to the specified response model.
         """
         merged_kwargs = {**self.llm_args, **kwargs}
+
+        if self.ollama_num_ctx is not None:
+            extra_body = merged_kwargs.get("extra_body", {}) or {}
+            if "num_ctx" not in extra_body:
+                merged_kwargs["extra_body"] = {**extra_body, "num_ctx": self.ollama_num_ctx}
 
         # A plain string needs no schema — skip instructor and hit the OpenAI-
         # compatible endpoint directly. Instructor's JSON/tool-call schemas cause

--- a/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
@@ -58,3 +58,56 @@ async def test_acreate_structured_output_awaits_async_client():
     # ...not offloaded to a worker thread, and its result is returned unchanged.
     assert not to_thread_spy.called, "structured call must be awaited natively, not offloaded"
     assert result is sentinel
+
+
+@pytest.mark.asyncio
+async def test_acreate_structured_output_injects_ollama_num_ctx():
+    adapter = OllamaAPIAdapter(
+        endpoint="http://localhost:11434/v1",
+        api_key="ollama",
+        model="llama3",
+        name="ollama",
+        max_completion_tokens=128,
+        ollama_num_ctx=4096,
+    )
+
+    sentinel = _Resp(value="ok")
+    adapter.aclient = Mock()
+    adapter.aclient.chat.completions.create = AsyncMock(return_value=sentinel)
+
+    with patch(f"{_MODULE}.llm_rate_limiter_context_manager", _null_rate_limiter):
+        result = await adapter.acreate_structured_output("hello", "system prompt", _Resp)
+
+    adapter.aclient.chat.completions.create.assert_awaited_once()
+    _, kwargs = adapter.aclient.chat.completions.create.call_args
+    assert "extra_body" in kwargs
+    assert kwargs["extra_body"] == {"num_ctx": 4096}
+    assert result is sentinel
+
+
+@pytest.mark.asyncio
+async def test_acreate_structured_output_str_response_injects_ollama_num_ctx():
+    adapter = OllamaAPIAdapter(
+        endpoint="http://localhost:11434/v1",
+        api_key="ollama",
+        model="llama3",
+        name="ollama",
+        max_completion_tokens=128,
+        ollama_num_ctx=4096,
+    )
+
+    sentinel = Mock()
+    sentinel.choices = [Mock()]
+    sentinel.choices[0].message = Mock()
+    sentinel.choices[0].message.content = "plain string response"
+    adapter.client = Mock()
+    adapter.client.chat.completions.create = AsyncMock(return_value=sentinel)
+
+    with patch(f"{_MODULE}.llm_rate_limiter_context_manager", _null_rate_limiter):
+        result = await adapter.acreate_structured_output("hello", "system prompt", str)
+
+    adapter.client.chat.completions.create.assert_awaited_once()
+    _, kwargs = adapter.client.chat.completions.create.call_args
+    assert "extra_body" in kwargs
+    assert kwargs["extra_body"] == {"num_ctx": 4096}
+    assert result == "plain string response"


### PR DESCRIPTION
## Summary

This PR resolves #3436 by introducing a configurable context window parameter (`ollama_num_ctx`) for the Ollama LLM provider.

### Changes

- **LLMConfig (`cognee/infrastructure/llm/config.py`)**: Added `ollama_num_ctx` (default: `2048`) to configure the Ollama context window size. Included it in config serialization.
- **Client Caching & Factory (`cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py`)**: 
  - Included `ollama_num_ctx` in the cached client key (`_LLMClientCacheKey`).
  - Sets `max_completion_tokens = llm_config.ollama_num_ctx` if the provider is Ollama. This aligns `get_max_chunk_tokens()` to correctly size the cutoff to half of the context window.
  - Passes `ollama_num_ctx` to the Ollama API adapter during construction.
- **OllamaAPIAdapter (`cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py`)**: Accepts `ollama_num_ctx` and passes it to Ollama chat completion calls as `num_ctx` in the `extra_body` payload.
- **Unit Tests (`cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py`)**: Added test cases verifying that `ollama_num_ctx` is correctly passed in the OpenAI-compatible API request for both structured outputs and plain string endpoints.

### Verification & Test Results

1. Verified that the chunk cutoff size is correctly calculated using `ollama_num_ctx // 2` for Ollama ingestion.
2. Ran the unit test suite inside the local environment and verified all tests passed successfully:
   ```bash
   .venv/Scripts/pytest cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py -v
   ```
   **Output:** `3 passed, 10 warnings in 1.67s`

Closes #3436
