### PR TITLE
fix(retrieval): align triplet search results with searchable entities

### DIFF
--- a/cognee/modules/retrieval/context_providers/TripletSearchContextProvider.py
+++ b/cognee/modules/retrieval/context_providers/TripletSearchContextProvider.py
@@ -88,5 +88,8 @@ class TripletSearchContextProvider(BaseContextProvider):
         if not search_tasks:
             return "No valid entities found for context search."
 
+        searchable_entities = [
+            entity for entity in entities if self._get_entity_text(entity) is not None
+        ]
         results = await asyncio.gather(*search_tasks)
-        return await self._results_to_context(entities, results)
+        return await self._results_to_context(searchable_entities, results)

--- a/cognee/tests/unit/modules/retrieval/test_triplet_search_context_provider.py
+++ b/cognee/tests/unit/modules/retrieval/test_triplet_search_context_provider.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.modules.retrieval.context_providers.TripletSearchContextProvider import (
+    TripletSearchContextProvider,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_context_pairs_results_with_matching_entities_when_some_have_empty_text():
+    provider = TripletSearchContextProvider()
+
+    entities = [
+        SimpleNamespace(name="", description="", text=""),
+        SimpleNamespace(name="", description="entity b"),
+        SimpleNamespace(name="", description="entity c"),
+    ]
+
+    async def fake_triplet_search(*, query: str, **_kwargs):
+        entity_text = query[: -len(" user query")]
+        return [SimpleNamespace(label=f"triplet-for-{entity_text}")]
+
+    with (
+        patch(
+            "cognee.modules.retrieval.context_providers.TripletSearchContextProvider.get_memory_fragment",
+            new=AsyncMock(return_value=object()),
+        ),
+        patch(
+            "cognee.modules.retrieval.context_providers.TripletSearchContextProvider.brute_force_triplet_search",
+            side_effect=fake_triplet_search,
+        ),
+        patch(
+            "cognee.modules.retrieval.context_providers.TripletSearchContextProvider.format_triplets",
+            side_effect=lambda triplets: triplets[0].label,
+        ),
+    ):
+        context = await provider.get_context(entities, "user query")
+
+    assert "Context for entity b:" in context
+    assert "Context for entity c:" in context
+    assert "triplet-for-entity b" in context
+    assert "triplet-for-entity c" in context
+    assert "Context for :" not in context


### PR DESCRIPTION
Fixes #3465

## Summary

`TripletSearchContextProvider.get_context()` now pairs triplet search results with the same filtered entity list used to build search tasks, instead of the full input entity list.

## Motivation

`_get_search_tasks()` only creates tasks for entities with non-empty searchable text, but `get_context()` previously zipped `asyncio.gather()` results against the unfiltered `entities` list. When any entity had empty text, `zip()` shifted pairings and silently dropped trailing entities, returning context attributed to the wrong entities.

## Changes

- Filter `searchable_entities` with the same `_get_entity_text()` guard used by `_get_search_tasks()`.
- Pass `searchable_entities` into `_results_to_context()` so each result maps to the entity that produced it.
- Add a focused unit test that mocks triplet search and asserts per-entity alignment when a leading entity has empty text.

## Tests

```bash
uv run pytest cognee/tests/unit/modules/retrieval/test_triplet_search_context_provider.py -q
# 1 passed

uv run ruff check cognee/modules/retrieval/context_providers/TripletSearchContextProvider.py cognee/tests/unit/modules/retrieval/test_triplet_search_context_provider.py
# All checks passed
```

## Notes

- `SummarizedTripletSearchContextProvider` inherits `get_context()` and is covered by the same fix.
- No behavior change for the all-empty-entities case; it still returns `"No valid entities found for context search."`