### PR TITLE
feat(frontend): sortable columns, file search, content preview, and search-type picker

### DIFF
--- a/cognee-frontend/src/app/(app)/dashboard/OverviewPage.tsx
+++ b/cognee-frontend/src/app/(app)/dashboard/OverviewPage.tsx
@@ -1046,6 +1046,7 @@ function DashboardSearch({
 }) {
   const [query, setQuery] = useState("");
   const [scope, setScope] = useState<SearchScope>("documents");
+  const [searchType, setSearchType] = useState<string>("GRAPH_COMPLETION");
   const [selectedDatasetId, setSelectedDatasetId] = useState<string>(datasets[0]?.id ?? "");
   const [results, setResults] = useState<unknown[]>([]);
   const [searching, setSearching] = useState(false);
@@ -1071,6 +1072,7 @@ function DashboardSearch({
         scope: sendScope as never,
         sessionId: sendSessionId,
         datasetIds: selectedDatasetId ? [selectedDatasetId] : datasets.map((d) => d.id),
+        searchType: scope === "documents" ? searchType : undefined,
       });
       setResults(Array.isArray(data) ? data : []);
     } catch {
@@ -1085,8 +1087,41 @@ function DashboardSearch({
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <span style={{ fontSize: 20, fontWeight: 300, color: "#1A1A1A", fontFamily: '"TWK Lausanne", system-ui, sans-serif' }}>Search your knowledge</span>
       </div>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <ScopePills value={scope} onChange={setScope} />
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 8 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <ScopePills value={scope} onChange={setScope} />
+          {scope === "documents" && (
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              {([
+                { value: "GRAPH_COMPLETION", label: "Graph" },
+                { value: "CHUNKS", label: "Chunks" },
+                { value: "SUMMARIES", label: "Summaries" },
+                { value: "RAG_COMPLETION", label: "RAG" },
+                { value: "FEELING_LUCKY", label: "Auto" },
+              ] as const).map(({ value, label }) => {
+                const active = searchType === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setSearchType(value)}
+                    className="cursor-pointer"
+                    style={{
+                      background: active ? "#6510F4" : "#FFFFFF",
+                      color: active ? "#FFFFFF" : "#71717A",
+                      border: active ? "none" : "1px solid #E4E4E7",
+                      borderRadius: 100, paddingBlock: 5, paddingInline: 11,
+                      fontSize: 12, lineHeight: "16px", fontFamily: "inherit",
+                      cursor: "pointer",
+                    }}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
         <div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "nowrap", marginRight: 24 }}>
           <span style={{ fontSize: 11, color: "#A1A1AA", letterSpacing: "0.1em", textTransform: "uppercase", whiteSpace: "nowrap", flexShrink: 0 }}>Search in</span>
           <select

--- a/cognee-frontend/src/app/(app)/datasets/DatasetsPage.tsx
+++ b/cognee-frontend/src/app/(app)/datasets/DatasetsPage.tsx
@@ -421,7 +421,7 @@ export default function DatasetsPage() {
   const selectedDataset = datasets.find((d) => d.id === selectedId) ?? null;
 
   const visibleDocs = [...(docSearch
-    ? selectedDocs.filter((d) => d.name.toLowerCase().includes(docSearch.toLowerCase()))
+    ? selectedDocs.filter((d) => decodeFilename(d.name).toLowerCase().includes(docSearch.toLowerCase()))
     : selectedDocs)].sort((a, b) => {
     let cmp = 0;
     if (docSortKey === "name") {

--- a/cognee-frontend/src/app/(app)/datasets/DatasetsPage.tsx
+++ b/cognee-frontend/src/app/(app)/datasets/DatasetsPage.tsx
@@ -30,6 +30,8 @@ interface FileEntry {
   size?: number;
 }
 
+type PreviewTab = "CHUNKS" | "SUMMARIES";
+
 type DisplayStatus = "pending" | "running" | "completed" | "failed" | "empty" | "loading";
 
 interface Dataset extends DatasetRaw {
@@ -144,6 +146,9 @@ export default function DatasetsPage() {
   const [selectedId, setSelectedId]       = useState<string | null>(null);
   const [selectedDocs, setSelectedDocs]   = useState<FileEntry[]>([]);
   const [docsLoading, setDocsLoading]     = useState(false);
+  const [docSearch, setDocSearch]         = useState("");
+  const [docSortKey, setDocSortKey]       = useState<"name" | "type" | "added">("added");
+  const [docSortDir, setDocSortDir]       = useState<"asc" | "desc">("desc");
 
   // Upload
   const [isDragOver, setIsDragOver]       = useState(false);
@@ -163,8 +168,50 @@ export default function DatasetsPage() {
   const [showPasteModal, setShowPasteModal] = useState(false);
   const [pasteText, setPasteText]           = useState("");
   const [pasting, setPasting]               = useState(false);
+
+  // Content preview
+  const [previewDoc, setPreviewDoc]         = useState<FileEntry | null>(null);
+  const [previewTab, setPreviewTab]         = useState<PreviewTab>("CHUNKS");
+  const [previewContent, setPreviewContent] = useState<string>("");
+  const [previewLoading, setPreviewLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const pollRef  = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchPreview = useCallback(async (doc: FileEntry, tab: PreviewTab) => {
+    if (!cogniInstance || !selectedId) return;
+    setPreviewLoading(true);
+    setPreviewContent("");
+    try {
+      const graphResp = await cogniInstance.fetch(`/v1/datasets/${selectedId}/graph`);
+      if (graphResp.ok) {
+        const graph = await graphResp.json();
+        const nodes = graph.nodes || [];
+
+        const docNode = nodes.find((n: any) =>
+          n.type === "TextDocument" && (n.label?.includes(doc.name) || n.id === doc.id)
+        );
+        const contentHash = docNode?.properties?.source_content_hash;
+
+        if (contentHash) {
+          if (tab === "CHUNKS") {
+            const chunks = nodes.filter((n: any) => n.type === "DocumentChunk" && n.properties?.source_content_hash === contentHash);
+            setPreviewContent(chunks.map((c: any) => c.properties?.text || "").join("\n\n---\n\n") || "No chunks found");
+          } else {
+            const summaries = nodes.filter((n: any) => n.type === "TextSummary" && n.properties?.source_content_hash === contentHash);
+            setPreviewContent(summaries.map((s: any) => s.properties?.text || "").join("\n\n---\n\n") || "No summaries found");
+          }
+        } else {
+          setPreviewContent("File not yet processed (run cognify first)");
+        }
+      } else {
+        setPreviewContent("Failed to load graph");
+      }
+    } catch {
+      setPreviewContent("Error loading content");
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [cogniInstance, selectedId]);
 
   const fetchStatuses = useCallback(async (ids: string[]) => {
     if (!cogniInstance || !ids.length) return;
@@ -249,10 +296,22 @@ export default function DatasetsPage() {
     }
   }
 
+  function handleDocSort(key: "name" | "type" | "added") {
+    if (key === docSortKey) {
+      setDocSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setDocSortKey(key);
+      setDocSortDir(key === "added" ? "desc" : "asc");
+    }
+  }
+
   async function handleSelectDataset(id: string) {
     if (selectedId === id) return;
     setSelectedId(id);
     setSelectedDocs([]);
+    setDocSearch("");
+    setDocSortKey("added");
+    setDocSortDir("desc");
     setDocsLoading(true);
     try {
       const data = await getDatasetData(id, cogniInstance!);
@@ -361,6 +420,25 @@ export default function DatasetsPage() {
 
   const selectedDataset = datasets.find((d) => d.id === selectedId) ?? null;
 
+  const visibleDocs = [...(docSearch
+    ? selectedDocs.filter((d) => d.name.toLowerCase().includes(docSearch.toLowerCase()))
+    : selectedDocs)].sort((a, b) => {
+    let cmp = 0;
+    if (docSortKey === "name") {
+      cmp = (a.name || "").localeCompare(b.name || "");
+    } else if (docSortKey === "type") {
+      const extA = (a.extension || a.name?.split(".").pop() || "").toLowerCase();
+      const extB = (b.extension || b.name?.split(".").pop() || "").toLowerCase();
+      cmp = extA.localeCompare(extB);
+    } else {
+      if (!a.createdAt && !b.createdAt) cmp = 0;
+      else if (!a.createdAt) return 1;
+      else if (!b.createdAt) return -1;
+      else cmp = a.createdAt.localeCompare(b.createdAt);
+    }
+    return docSortDir === "asc" ? cmp : -cmp;
+  });
+
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", fontFamily: '"Inter", system-ui, sans-serif', overflow: "hidden" }}>
       <TrackPageView page="Brains" />
@@ -459,6 +537,47 @@ export default function DatasetsPage() {
                 style={{ background: "#EF4444", border: "none", borderRadius: 8, padding: "8px 16px", fontSize: 13, fontWeight: 500, color: "#fff", fontFamily: "inherit" }}>
                 {deletingId === deleteTarget.id ? "Deleting…" : "Delete"}
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Content Preview Modal */}
+      {previewDoc && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.3)", zIndex: 100, display: "flex", alignItems: "center", justifyContent: "center" }}
+          onClick={() => setPreviewDoc(null)}>
+          <div onClick={(e) => e.stopPropagation()} style={{ background: "#fff", borderRadius: 12, padding: 24, width: 600, maxHeight: "80vh", display: "flex", flexDirection: "column", gap: 16, boxShadow: "0 16px 48px rgba(0,0,0,0.12)" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <h2 style={{ fontSize: 16, fontWeight: 600, color: "#18181B", margin: 0 }}>{decodeFilename(previewDoc.name)}</h2>
+              <button onClick={() => setPreviewDoc(null)} style={{ background: "none", border: "none", fontSize: 18, color: "#A1A1AA", cursor: "pointer" }}>✕</button>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <div style={{ display: "flex", gap: 4 }}>
+                {([
+                  { key: "CHUNKS", label: "Chunks", hint: "Text chunks extracted from this file" },
+                  { key: "SUMMARIES", label: "Summaries", hint: "AI-generated summaries of this file's content" },
+                ] as { key: PreviewTab; label: string; hint: string }[]).map(({ key, label, hint }) => (
+                  <button
+                    key={key}
+                    onClick={() => { setPreviewTab(key); fetchPreview(previewDoc, key); }}
+                    style={{
+                      padding: "6px 12px", fontSize: 11, fontWeight: 500, fontFamily: "inherit",
+                      border: "1px solid #E4E4E7", borderRadius: 6, cursor: "pointer",
+                      background: previewTab === key ? "#6510F4" : "#fff",
+                      color: previewTab === key ? "#fff" : "#52525B",
+                    }}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <span style={{ fontSize: 11, color: "#A1A1AA" }}>
+                {previewTab === "CHUNKS" && "Text chunks extracted from this file"}
+                {previewTab === "SUMMARIES" && "AI-generated summaries of this file's content"}
+              </span>
+            </div>
+            <div style={{ flex: 1, overflowY: "auto", background: "#FAFAFA", borderRadius: 8, padding: 16, fontSize: 13, color: "#18181B", whiteSpace: "pre-wrap", lineHeight: 1.6, minHeight: 200 }}>
+              {previewLoading ? "Loading…" : previewContent || "No content"}
             </div>
           </div>
         </div>
@@ -586,6 +705,23 @@ export default function DatasetsPage() {
               )}
             </div>
 
+            {/* Doc search */}
+            {selectedId && !docsLoading && selectedDocs.length > 0 && (
+              <div style={{ display: "flex", alignItems: "center", gap: 8, height: 36, paddingInline: 12, borderBottom: "1px solid #F4F4F5", flexShrink: 0 }}>
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="4.5" stroke="#A1A1AA" strokeWidth="1.5"/><path d="M10.5 10.5L14 14" stroke="#A1A1AA" strokeWidth="1.5" strokeLinecap="round"/></svg>
+                <input
+                  type="text"
+                  value={docSearch}
+                  onChange={(e) => setDocSearch(e.target.value)}
+                  placeholder="Filter by name…"
+                  style={{ flex: 1, border: "none", outline: "none", fontSize: 12, color: "#18181B", background: "transparent", fontFamily: "inherit" }}
+                />
+                {docSearch && (
+                  <button onClick={() => setDocSearch("")} style={{ background: "none", border: "none", color: "#A1A1AA", fontSize: 13, cursor: "pointer", padding: 0 }}>✕</button>
+                )}
+              </div>
+            )}
+
             {/* Upload progress */}
             {isUploading && (
               <div style={{ padding: "8px 16px", borderBottom: "1px solid #F4F4F5", background: "#FAFAF9", display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
@@ -612,7 +748,43 @@ export default function DatasetsPage() {
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#A1A1AA" strokeWidth="2" strokeLinecap="round" style={{ animation: "spin 1s linear infinite" }}><path d="M21 12a9 9 0 11-6.219-8.56" /></svg>
                   <span style={{ fontSize: 13, color: "#A1A1AA" }}>Loading…</span>
                 </div>
-              ) : selectedDocs.length === 0 ? (
+              ) : selectedDocs.length > 0 && (
+                <div style={{ display: "flex", alignItems: "center", background: "#FAFAF9", borderBottom: "1px solid #F4F4F5", padding: "6px 16px", flexShrink: 0 }}>
+                  <button
+                    onClick={() => handleDocSort("name")}
+                    className="cursor-pointer"
+                    style={{ flex: 1, fontSize: 11, fontWeight: 600, color: "#71717A", background: "none", border: "none", padding: 0, textAlign: "left", fontFamily: "inherit", display: "flex", alignItems: "center", gap: 3 }}
+                  >
+                    Name
+                    <span style={{ fontSize: 9, opacity: docSortKey === "name" ? 1 : 0.3 }}>
+                      {docSortKey === "name" ? (docSortDir === "asc" ? "▲" : "▼") : "⇅"}
+                    </span>
+                  </button>
+                  <button
+                    onClick={() => handleDocSort("type")}
+                    className="cursor-pointer"
+                    style={{ width: 52, fontSize: 11, fontWeight: 600, color: "#71717A", background: "none", border: "none", padding: 0, textAlign: "left", fontFamily: "inherit", flexShrink: 0, display: "flex", alignItems: "center", gap: 3 }}
+                  >
+                    Type
+                    <span style={{ fontSize: 9, opacity: docSortKey === "type" ? 1 : 0.3 }}>
+                      {docSortKey === "type" ? (docSortDir === "asc" ? "▲" : "▼") : "⇅"}
+                    </span>
+                  </button>
+                  <span style={{ width: 52, fontSize: 11, fontWeight: 600, color: "#71717A", flexShrink: 0 }}>Size</span>
+                  <button
+                    onClick={() => handleDocSort("added")}
+                    className="cursor-pointer"
+                    style={{ width: 80, fontSize: 11, fontWeight: 600, color: "#71717A", background: "none", border: "none", padding: 0, textAlign: "left", fontFamily: "inherit", flexShrink: 0, display: "flex", alignItems: "center", gap: 3 }}
+                  >
+                    Added
+                    <span style={{ fontSize: 9, opacity: docSortKey === "added" ? 1 : 0.3 }}>
+                      {docSortKey === "added" ? (docSortDir === "asc" ? "▲" : "▼") : "⇅"}
+                    </span>
+                  </button>
+                  <div style={{ width: 60, flexShrink: 0 }} />
+                </div>
+              )}
+              {selectedDocs.length === 0 ? (
                 <div
                   style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100%", gap: 10, cursor: "pointer" }}
                   onClick={() => fileInputRef.current?.click()}
@@ -627,13 +799,20 @@ export default function DatasetsPage() {
                 </div>
               ) : (
                 <>
-                  {selectedDocs.map((doc, i) => {
+                  {visibleDocs.length === 0 ? (
+                    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", padding: "32px 16px" }}>
+                      <span style={{ fontSize: 13, color: "#A1A1AA" }}>No files match &ldquo;{docSearch}&rdquo;</span>
+                    </div>
+                  ) : visibleDocs.map((doc, i) => {
                     const displayName = decodeFilename(doc.name);
                     const meta = getExtMeta(displayName, doc.extension);
                     return (
-                      <div key={doc.id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 16px", borderBottom: i < selectedDocs.length - 1 ? "1px solid #F4F4F5" : "none" }}>
+                      <div key={doc.id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 16px", borderBottom: i < visibleDocs.length - 1 ? "1px solid #F4F4F5" : "none" }}>
                         <FileIcon {...meta} />
-                        <span style={{ flex: 1, fontSize: 13, color: "#18181B", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{displayName}</span>
+                        <span
+                          onClick={() => { setPreviewDoc(doc); setPreviewTab("CHUNKS"); fetchPreview(doc, "CHUNKS"); }}
+                          style={{ flex: 1, fontSize: 13, color: "#6510F4", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", cursor: "pointer", textDecoration: "underline" }}
+                        >{displayName}</span>
                         <div style={{ display: "flex", alignItems: "center", gap: 12, flexShrink: 0 }}>
                           <span style={{ fontSize: 11, color: "#71717A", fontWeight: 500, minWidth: 32, textAlign: "right" }}>{meta.label}</span>
                           <span style={{ fontSize: 11, color: "#A1A1AA", minWidth: 52, textAlign: "right" }}>{formatSize(doc.size)}</span>

--- a/cognee-frontend/src/app/(app)/datasets/[id]/DatasetDetailPage.tsx
+++ b/cognee-frontend/src/app/(app)/datasets/[id]/DatasetDetailPage.tsx
@@ -29,6 +29,9 @@ interface FileEntry {
   createdAt?: string;
 }
 
+type SortKey = "name" | "type" | "added";
+type SortDir = "asc" | "desc";
+
 // ── File type colors and labels ──
 
 const EXT_META: Record<string, { fill: string; stroke: string; text: string; label: string }> = {
@@ -130,6 +133,18 @@ export default function DatasetDetailPage({ datasetId }: { datasetId: string }) 
   const [isConnectedSource, setIsConnectedSource] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("added");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "added" ? "desc" : "asc");
+    }
+  }
+
   const [showShareModal, setShowShareModal] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [sharedWith, setSharedWith] = useState<Set<string>>(new Set());
@@ -571,6 +586,21 @@ export default function DatasetDetailPage({ datasetId }: { datasetId: string }) 
   }
 
   const filtered = search ? files.filter((f) => f.name.toLowerCase().includes(search.toLowerCase())) : files;
+
+  const sorted = [...filtered].sort((a, b) => {
+    let cmp = 0;
+    if (sortKey === "name") {
+      cmp = decodeURIComponent(a.name).localeCompare(decodeURIComponent(b.name));
+    } else if (sortKey === "type") {
+      cmp = getTypeName(a.name, a.extension).localeCompare(getTypeName(b.name, b.extension));
+    } else {
+      if (!a.createdAt && !b.createdAt) cmp = 0;
+      else if (!a.createdAt) return 1;
+      else if (!b.createdAt) return -1;
+      else cmp = a.createdAt.localeCompare(b.createdAt);
+    }
+    return sortDir === "asc" ? cmp : -cmp;
+  });
 
   if (loading || isInitializing) {
     return <><TrackPageView page="Dataset Detail" additionalProperties={{ dataset_id: datasetId }} /><div style={{ padding: 32, display: "flex", alignItems: "center", justifyContent: "center", height: "100%" }}><span style={{ fontSize: 14, color: "#71717A" }}>Loading files...</span></div></>;
@@ -1198,23 +1228,50 @@ export default function DatasetDetailPage({ datasetId }: { datasetId: string }) 
       )}
 
       {/* Files table */}
-      {filtered.length > 0 ? (
+      {sorted.length > 0 ? (
         <div style={{ background: "#fff", border: "1px solid #E5E7EB", borderRadius: 12, overflow: "hidden" }}>
           <div style={{ display: "flex", alignItems: "center", background: "#FAFAF9", borderBottom: "1px solid #E5E7EB", padding: "12px 20px" }}>
-            <span style={{ flex: 1, fontSize: 12, fontWeight: 600, color: "#71717A" }}>Name</span>
-            <span style={{ width: 100, fontSize: 12, fontWeight: 600, color: "#71717A", flexShrink: 0 }}>Type</span>
+            <button
+              onClick={() => handleSort("name")}
+              className="cursor-pointer"
+              style={{ flex: 1, fontSize: 12, fontWeight: 600, color: "#71717A", background: "none", border: "none", padding: 0, textAlign: "left", fontFamily: "inherit", display: "flex", alignItems: "center", gap: 4 }}
+            >
+              Name
+              <span style={{ fontSize: 10, opacity: sortKey === "name" ? 1 : 0.3 }}>
+                {sortKey === "name" ? (sortDir === "asc" ? "▲" : "▼") : "⇅"}
+              </span>
+            </button>
+            <button
+              onClick={() => handleSort("type")}
+              className="cursor-pointer"
+              style={{ width: 100, fontSize: 12, fontWeight: 600, color: "#71717A", background: "none", border: "none", padding: 0, textAlign: "left", fontFamily: "inherit", flexShrink: 0, display: "flex", alignItems: "center", gap: 4 }}
+            >
+              Type
+              <span style={{ fontSize: 10, opacity: sortKey === "type" ? 1 : 0.3 }}>
+                {sortKey === "type" ? (sortDir === "asc" ? "▲" : "▼") : "⇅"}
+              </span>
+            </button>
             <span style={{ width: 80, fontSize: 12, fontWeight: 600, color: "#71717A", flexShrink: 0 }}>Size</span>
-            <span style={{ width: 140, fontSize: 12, fontWeight: 600, color: "#71717A", flexShrink: 0 }}>Added</span>
+            <button
+              onClick={() => handleSort("added")}
+              className="cursor-pointer"
+              style={{ width: 140, fontSize: 12, fontWeight: 600, color: "#71717A", background: "none", border: "none", padding: 0, textAlign: "left", fontFamily: "inherit", flexShrink: 0, display: "flex", alignItems: "center", gap: 4 }}
+            >
+              Added
+              <span style={{ fontSize: 10, opacity: sortKey === "added" ? 1 : 0.3 }}>
+                {sortKey === "added" ? (sortDir === "asc" ? "▲" : "▼") : "⇅"}
+              </span>
+            </button>
             <span style={{ width: 40, flexShrink: 0 }} />
           </div>
-          {filtered.map((file, i) => {
+          {sorted.map((file, i) => {
             const meta = getExtMeta(file.name, file.extension);
             const typeName = getTypeName(file.name, file.extension);
             return (
               <div
                 key={file.id}
                 className="hover:bg-cognee-hover"
-                style={{ display: "flex", alignItems: "center", padding: "14px 20px", borderBottom: i < filtered.length - 1 ? "1px solid #F4F4F5" : "none", transition: "background 150ms" }}
+                style={{ display: "flex", alignItems: "center", padding: "14px 20px", borderBottom: i < sorted.length - 1 ? "1px solid #F4F4F5" : "none", transition: "background 150ms" }}
               >
                 <div style={{ flex: 1, display: "flex", alignItems: "center", gap: 10 }}>
                   <FileIcon fill={meta.fill} stroke={meta.stroke} text={meta.text} label={meta.label} />

--- a/cognee-frontend/src/app/(app)/search/SearchPage.tsx
+++ b/cognee-frontend/src/app/(app)/search/SearchPage.tsx
@@ -140,6 +140,7 @@ export default function SearchPage() {
   const [input, setInput] = useState("");
   const [isSearching, setIsSearching] = useState(false);
   const [scope, setScope] = useState<SearchScope>("documents");
+  const [searchType, setSearchType] = useState<string>("GRAPH_COMPLETION");
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -248,6 +249,7 @@ export default function SearchPage() {
         scope: sendScope as never,
         sessionId: sendSessionId,
         datasetIds: searchDatasetIds,
+        searchType: scope === "documents" ? searchType : undefined,
       });
       const resultData = (Array.isArray(data) ? data : []) as SearchResultItem[];
       const content = normalizeResults(resultData);
@@ -440,8 +442,8 @@ export default function SearchPage() {
         {/* Input area */}
         <div style={{ background: "#fff", padding: "12px 32px 16px" }}>
           <div style={{ maxWidth: 800, marginInline: "auto", display: "flex", flexDirection: "column", gap: 8 }}>
-            {/* Controls: scope pills — dataset selected via breadcrumb */}
-            <div style={{ display: "flex", alignItems: "center" }}>
+            {/* Controls: scope pills + search type pills */}
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 8 }}>
               <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
                 {(["documents", "agent"] as const).map((s) => {
                   const active = scope === s;
@@ -466,6 +468,38 @@ export default function SearchPage() {
                   );
                 })}
               </div>
+
+              {scope === "documents" && (
+                <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                  {([
+                    { value: "GRAPH_COMPLETION", label: "Graph" },
+                    { value: "CHUNKS", label: "Chunks" },
+                    { value: "SUMMARIES", label: "Summaries" },
+                    { value: "RAG_COMPLETION", label: "RAG" },
+                    { value: "FEELING_LUCKY", label: "Auto" },
+                  ] as const).map(({ value, label }) => {
+                    const active = searchType === value;
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => setSearchType(value)}
+                        className="cursor-pointer"
+                        style={{
+                          background: active ? "#6510F4" : "#FFFFFF",
+                          color: active ? "#FFFFFF" : "#71717A",
+                          border: active ? "none" : "1px solid #E4E4E7",
+                          borderRadius: 100, paddingBlock: 4, paddingInline: 10,
+                          fontSize: 11, lineHeight: "16px", fontFamily: "inherit",
+                          cursor: "pointer",
+                        }}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
 
             {/* Input bar */}


### PR DESCRIPTION
## Description

A set of usability improvements to the Datasets and Search pages. All changes are pure UI — no backend API contract changes and no new dependencies.

**Sortable column headers** (`DatasetsPage.tsx`, `DatasetDetailPage.tsx`): clicking Name, Type, or Added sorts the file list; clicking the active column toggles direction. Active column shows ▲/▼; inactive columns show ⇅ at reduced opacity. Size column is intentionally non-sortable (file size is already displayed in-row). Sort state is derived locally — no additional API calls.

**Inline file search** (`DatasetsPage.tsx`): filter bar above the file list, case-insensitive substring match on filename. Resets automatically when a different dataset is selected. Shows a "No files match" empty state when the filter returns nothing.

**Content preview modal** (`DatasetsPage.tsx`): clicking a filename opens a modal that fetches the dataset graph and extracts matching `DocumentChunk` or `TextSummary` nodes for that file. Two tabs — Chunks (raw text chunks) and Summaries (AI-generated summaries). Falls back to a human-readable message when the file has not been processed yet.

**Search-type picker** (`SearchPage.tsx`, `OverviewPage.tsx`): when scope = "documents", a row of pill buttons appears — Graph / Chunks / Summaries / RAG / Auto. The selected type is passed as `searchType` to the search API call. Defaults to `GRAPH_COMPLETION` (existing behaviour). Hidden automatically when scope = "agent".

## Acceptance Criteria

1. Open Datasets page, select a dataset with several files
2. Click **Name** header → list sorts A-Z; click again → Z-A
3. Click **Added** header → list sorts newest-first by default
4. Type in the filter bar → list narrows in real time; clear → full list returns; "No files match" appears when nothing matches
5. Click a filename → preview modal opens; switch tabs → content updates
6. On Search page, switch to "documents" scope → type pills appear; select "Chunks" → search uses `searchType: CHUNKS`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="1895" height="589" alt="image" src="https://github.com/user-attachments/assets/d3876345-1f47-457b-ae6a-075cefc7a8a0" />

<img width="1871" height="576" alt="image" src="https://github.com/user-attachments/assets/e7ecbf46-2216-4dfb-9a09-aa9732016c65" />

<img width="2686" height="958" alt="image" src="https://github.com/user-attachments/assets/47c99e98-e9d0-4893-bb39-69ee4148538e" />

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.