### PR TITLE
feat(retrieval): truth-subspace reranking + activate feedback signal (P2)

### DIFF
--- a/cognee/api/v1/improve/improve.py
+++ b/cognee/api/v1/improve/improve.py
@@ -40,6 +40,7 @@ async def improve(
     node_name: Optional[List[str]] = None,
     session_ids: Optional[List[str]] = None,
     build_global_context_index: bool = False,
+    build_truth_subspace: bool = False,
     **kwargs: Unpack[ImproveKwargs],
 ):
     """Enrich an existing knowledge graph with additional context and rules.
@@ -86,6 +87,10 @@ async def improve(
             context index after default enrichment. Skipped in background
             mode because ordered background pipeline chaining is not
             supported yet.
+        build_truth_subspace: Opt-in flag (default ``False``) for building the
+            truth subspace from distilled session learnings after distillation
+            and before enrichment. Only runs when ``session_ids`` is provided.
+            Off by default = no behaviour change.
         **kwargs: Additional options -- see ``ImproveKwargs``.
 
     Returns:
@@ -113,6 +118,7 @@ async def improve(
             "session_ids": ",".join(session_ids) if session_ids else "",
             "run_in_background": run_in_background,
             "build_global_context_index": build_global_context_index,
+            "build_truth_subspace": build_truth_subspace,
             "cognee_version": cognee_version,
         },
     )
@@ -198,6 +204,26 @@ async def improve(
                 )
                 if distilled:
                     stages_run.append("distill_sessions")
+
+                # Stage 2d: build the truth subspace from distilled session
+                # learnings (opt-in, default OFF). Runs after distillation so
+                # freshly accepted lessons are available as anchors, and before
+                # enrichment. Non-fatal — never blocks the rest of improve().
+                if build_truth_subspace:
+                    try:
+                        from cognee.modules.truth_subspace.build import (
+                            build_truth_subspace as _build_truth_subspace,
+                        )
+
+                        result_ts = await _build_truth_subspace(
+                            dataset=dataset,
+                            session_ids=session_ids,
+                            user=user,
+                        )
+                        logger.info("improve: truth subspace built -> %s", result_ts)
+                        stages_run.append("build_truth_subspace")
+                    except Exception as e:
+                        logger.warning("improve: truth subspace build failed (non-fatal): %s", e)
 
             # Stage 3: default enrichment (triplet embeddings)
             from cognee.modules.memify import memify

--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
+from cognee.base_config import get_base_config
 from cognee.context_global_variables import set_session_user_context_variable
 from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.vector.embeddings.config import EmbeddingConfig
@@ -375,7 +376,7 @@ async def recall(
     context_profile: str = "qa",
     wide_search_top_k: int | None = 100,
     triplet_distance_penalty: float | None = 6.5,
-    feedback_influence: float = 0.0,
+    feedback_influence: float = get_base_config().default_feedback_influence,
     verbose: bool = False,
     retriever_specific_config: dict | None = None,
     neighborhood_depth: int | None = None,

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -8,6 +8,7 @@ from cognee.infrastructure.databases.vector.embeddings.config import EmbeddingCo
 from cognee.infrastructure.llm.config import LLMConfig
 from cognee.modules.search.types import SearchResult, SearchType
 from cognee.modules.users.methods import get_default_user
+from cognee.base_config import get_base_config
 from cognee.modules.search.methods import search as search_function
 from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.data.exceptions import DatasetNotFoundError
@@ -43,7 +44,7 @@ async def search(
     session_id: Optional[str] = None,
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
-    feedback_influence: float = 0.0,
+    feedback_influence: float = get_base_config().default_feedback_influence,
     verbose: bool = False,
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,

--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -14,6 +14,11 @@ class BaseConfig(BaseSettings):
     cache_root_directory: str = get_absolute_path(".cognee_cache")
     logs_root_directory: str = os.getenv("COGNEE_LOGS_DIR", str(Path.home() / ".cognee" / "logs"))
     monitoring_tool: object = Observer.NONE
+    # Default blend weight for the learned feedback signal during graph search.
+    # Conservative non-zero default so the existing feedback blend is read unless
+    # a caller overrides it. Set DEFAULT_FEEDBACK_INFLUENCE=0.0 to fully restore
+    # the previous baseline behavior. Must stay in range [0, 1].
+    default_feedback_influence: float = float(os.getenv("DEFAULT_FEEDBACK_INFLUENCE", "0.1"))
 
     @pydantic.model_validator(mode="after")
     def validate_paths(self):

--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -15,10 +15,8 @@ class BaseConfig(BaseSettings):
     logs_root_directory: str = os.getenv("COGNEE_LOGS_DIR", str(Path.home() / ".cognee" / "logs"))
     monitoring_tool: object = Observer.NONE
     # Default blend weight for the learned feedback signal during graph search.
-    # Conservative non-zero default so the existing feedback blend is read unless
-    # a caller overrides it. Set DEFAULT_FEEDBACK_INFLUENCE=0.0 to fully restore
-    # the previous baseline behavior. Must stay in range [0, 1].
-    default_feedback_influence: float = float(os.getenv("DEFAULT_FEEDBACK_INFLUENCE", "0.1"))
+    # Opt-in by default to preserve existing retrieval behavior.
+    default_feedback_influence: float = float(os.getenv("DEFAULT_FEEDBACK_INFLUENCE", "0.0"))
 
     @pydantic.model_validator(mode="after")
     def validate_paths(self):

--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -27,6 +27,7 @@ from cognee.infrastructure.databases.utils.resolve_dataset_database_connection_i
 #       for different async tasks, threads and processes
 vector_db_config = ContextVar("vector_db_config", default=None)
 graph_db_config = ContextVar("graph_db_config", default=None)
+current_dataset_id = ContextVar("current_dataset_id", default=None)
 # Note: same mechanism for LLM and embedding configs so that the LiteLLM client
 #       and the embedding engine can use per-context (e.g. per-request) configs.
 llm_config = ContextVar("llm_config", default=None)
@@ -111,7 +112,14 @@ class DatabaseContextManager:
     Note: Single-use object, should not be reused across multiple calls.
     """
 
-    __slots__ = ("_dataset", "_user_id", "_llm_config", "_embedding_config", "_applied")
+    __slots__ = (
+        "_dataset",
+        "_user_id",
+        "_llm_config",
+        "_embedding_config",
+        "_applied",
+        "_dataset_token",
+    )
 
     def __init__(
         self,
@@ -125,10 +133,13 @@ class DatabaseContextManager:
         self._llm_config = llm_config
         self._embedding_config = embedding_config
         self._applied = False
+        self._dataset_token = None
 
     async def apply_database_context_variables(
         self, dataset: Union[str, UUID], user_id: UUID
     ) -> None:
+        self._dataset_token = current_dataset_id.set(str(dataset) if dataset is not None else None)
+
         # LLM and embedding configs are an explicit, caller-provided override and
         # are intentionally applied regardless of backend access control: callers
         # may want per-context LLM/embedding configs even in single-tenant mode.
@@ -255,6 +266,10 @@ class DatabaseContextManager:
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._dataset_token is not None:
+            current_dataset_id.reset(self._dataset_token)
+            self._dataset_token = None
+
         if not backend_access_control_enabled():
             return None
 

--- a/cognee/infrastructure/databases/graph/graph_db_interface.py
+++ b/cognee/infrastructure/databases/graph/graph_db_interface.py
@@ -354,6 +354,22 @@ class GraphDBInterface(ABC):
         """
         raise NotImplementedError("set_node_feedback_weights is not implemented for this adapter")
 
+    async def get_node_truth_alignments(self, node_ids: List[str]) -> Dict[str, List[float]]:
+        """
+        Retrieve node truth alignments for multiple node ids.
+        Returns only found node ids.
+        """
+        raise NotImplementedError("get_node_truth_alignments is not implemented for this adapter")
+
+    async def set_node_truth_alignments(
+        self, node_truth_alignments: Dict[str, List[float]]
+    ) -> Dict[str, bool]:
+        """
+        Persist node truth alignments for multiple node ids.
+        Returns per-id update success.
+        """
+        raise NotImplementedError("set_node_truth_alignments is not implemented for this adapter")
+
     async def get_edge_feedback_weights(self, edge_object_ids: List[str]) -> Dict[str, float]:
         """
         Retrieve edge feedback weights for multiple edge_object_ids.

--- a/cognee/infrastructure/databases/graph/graph_db_interface.py
+++ b/cognee/infrastructure/databases/graph/graph_db_interface.py
@@ -354,22 +354,6 @@ class GraphDBInterface(ABC):
         """
         raise NotImplementedError("set_node_feedback_weights is not implemented for this adapter")
 
-    async def get_node_truth_alignments(self, node_ids: List[str]) -> Dict[str, List[float]]:
-        """
-        Retrieve node truth alignments for multiple node ids.
-        Returns only found node ids.
-        """
-        raise NotImplementedError("get_node_truth_alignments is not implemented for this adapter")
-
-    async def set_node_truth_alignments(
-        self, node_truth_alignments: Dict[str, List[float]]
-    ) -> Dict[str, bool]:
-        """
-        Persist node truth alignments for multiple node ids.
-        Returns per-id update success.
-        """
-        raise NotImplementedError("set_node_truth_alignments is not implemented for this adapter")
-
     async def get_node_truth_state(self, node_ids: List[str]) -> Dict[str, Dict[str, Any]]:
         """
         Retrieve node truth alignment state for multiple node ids.

--- a/cognee/infrastructure/databases/graph/graph_db_interface.py
+++ b/cognee/infrastructure/databases/graph/graph_db_interface.py
@@ -370,6 +370,22 @@ class GraphDBInterface(ABC):
         """
         raise NotImplementedError("set_node_truth_alignments is not implemented for this adapter")
 
+    async def get_node_truth_state(self, node_ids: List[str]) -> Dict[str, Dict[str, Any]]:
+        """
+        Retrieve node truth alignment state for multiple node ids.
+        Returns only found node ids.
+        """
+        raise NotImplementedError("get_node_truth_state is not implemented for this adapter")
+
+    async def set_node_truth_state(
+        self, node_truth_state: Dict[str, Dict[str, Any]]
+    ) -> Dict[str, bool]:
+        """
+        Persist node truth alignment state for multiple node ids.
+        Returns per-id update success.
+        """
+        raise NotImplementedError("set_node_truth_state is not implemented for this adapter")
+
     async def get_edge_feedback_weights(self, edge_object_ids: List[str]) -> Dict[str, float]:
         """
         Retrieve edge feedback weights for multiple edge_object_ids.

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -1556,6 +1556,47 @@ class LadybugAdapter(GraphDBInterface):
         rows_dicts = self._rows_to_dicts(result, ["node_id"])
         return {str(r["node_id"]) for r in rows_dicts if r.get("node_id") is not None}
 
+    def _build_node_truth_alignment_updates(
+        self,
+        nodes: List[Dict[str, Any]],
+        node_truth_alignments: Dict[str, List[float]],
+    ) -> List[Dict[str, Any]]:
+        """Build UNWIND items for node truth alignment updates."""
+        updates = []
+        for node in nodes:
+            node_id = node.get("id")
+            if not isinstance(node_id, str) or node_id not in node_truth_alignments:
+                continue
+            properties = {
+                k: v
+                for k, v in node.items()
+                if k not in {"id", "name", "type", "created_at", "updated_at"}
+            }
+            properties["truth_alignment"] = list(node_truth_alignments[node_id])
+            updates.append(
+                {"node_id": node_id, "properties": json.dumps(properties, cls=JSONEncoder)}
+            )
+        return updates
+
+    async def _execute_node_truth_alignment_updates(
+        self, updates: List[Dict[str, Any]]
+    ) -> Set[str]:
+        """Run node truth alignment UNWIND/SET; return set of updated node_ids."""
+        if not updates:
+            return set()
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
+        query = """
+        UNWIND $items AS item
+        MATCH (n:Node)
+        WHERE n.id = item.node_id
+        SET n.properties = item.properties,
+            n.updated_at = timestamp($updated_at)
+        RETURN n.id AS node_id
+        """
+        result = await self.query(query, {"items": updates, "updated_at": now})
+        rows_dicts = self._rows_to_dicts(result, ["node_id"])
+        return {str(r["node_id"]) for r in rows_dicts if r.get("node_id") is not None}
+
     def _build_edge_feedback_updates(
         self,
         edge_rows: List[Dict[str, Any]],
@@ -1640,6 +1681,41 @@ class LadybugAdapter(GraphDBInterface):
         if not updates:
             return {nid: False for nid in node_ids}
         updated_ids = await self._execute_node_feedback_updates(updates)
+        return {nid: (nid in updated_ids) for nid in node_ids}
+
+    async def get_node_truth_alignments(self, node_ids: List[str]) -> Dict[str, List[float]]:
+        if not node_ids:
+            return {}
+        valid_node_ids = [node_id for node_id in node_ids if isinstance(node_id, str) and node_id]
+        if not valid_node_ids:
+            return {}
+        nodes = await self.get_nodes(valid_node_ids)
+        result: Dict[str, List[float]] = {}
+        for node in nodes:
+            node_id = node.get("id")
+            if not isinstance(node_id, str):
+                continue
+            value = node.get("truth_alignment", [])
+            if isinstance(value, (list, tuple)):
+                result[node_id] = list(value)
+            else:
+                result[node_id] = []
+        return result
+
+    async def set_node_truth_alignments(
+        self, node_truth_alignments: Dict[str, List[float]]
+    ) -> Dict[str, bool]:
+        if not node_truth_alignments:
+            return {}
+        node_ids = list(node_truth_alignments.keys())
+        valid_node_ids = [nid for nid in node_ids if isinstance(nid, str) and nid]
+        if not valid_node_ids:
+            return {nid: False for nid in node_ids}
+        nodes = await self.get_nodes(valid_node_ids)
+        updates = self._build_node_truth_alignment_updates(nodes, node_truth_alignments)
+        if not updates:
+            return {nid: False for nid in node_ids}
+        updated_ids = await self._execute_node_truth_alignment_updates(updates)
         return {nid: (nid in updated_ids) for nid in node_ids}
 
     async def get_edge_feedback_weights(self, edge_object_ids: List[str]) -> Dict[str, float]:

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -1556,32 +1556,33 @@ class LadybugAdapter(GraphDBInterface):
         rows_dicts = self._rows_to_dicts(result, ["node_id"])
         return {str(r["node_id"]) for r in rows_dicts if r.get("node_id") is not None}
 
-    def _build_node_truth_alignment_updates(
+    def _build_node_truth_state_updates(
         self,
         nodes: List[Dict[str, Any]],
-        node_truth_alignments: Dict[str, List[float]],
+        node_truth_state: Dict[str, Dict[str, Any]],
     ) -> List[Dict[str, Any]]:
-        """Build UNWIND items for node truth alignment updates."""
+        """Build UNWIND items for node truth state updates."""
         updates = []
         for node in nodes:
             node_id = node.get("id")
-            if not isinstance(node_id, str) or node_id not in node_truth_alignments:
+            if not isinstance(node_id, str) or node_id not in node_truth_state:
                 continue
+            state = node_truth_state[node_id]
             properties = {
                 k: v
                 for k, v in node.items()
                 if k not in {"id", "name", "type", "created_at", "updated_at"}
             }
-            properties["truth_alignment"] = list(node_truth_alignments[node_id])
+            properties["truth_alignment"] = list(state.get("truth_alignment") or [])
+            if state.get("truth_epoch") is not None:
+                properties["truth_epoch"] = int(state["truth_epoch"])
             updates.append(
                 {"node_id": node_id, "properties": json.dumps(properties, cls=JSONEncoder)}
             )
         return updates
 
-    async def _execute_node_truth_alignment_updates(
-        self, updates: List[Dict[str, Any]]
-    ) -> Set[str]:
-        """Run node truth alignment UNWIND/SET; return set of updated node_ids."""
+    async def _execute_node_truth_state_updates(self, updates: List[Dict[str, Any]]) -> Set[str]:
+        """Run node truth state UNWIND/SET; return set of updated node_ids."""
         if not updates:
             return set()
         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
@@ -1683,40 +1684,60 @@ class LadybugAdapter(GraphDBInterface):
         updated_ids = await self._execute_node_feedback_updates(updates)
         return {nid: (nid in updated_ids) for nid in node_ids}
 
-    async def get_node_truth_alignments(self, node_ids: List[str]) -> Dict[str, List[float]]:
+    async def get_node_truth_state(self, node_ids: List[str]) -> Dict[str, Dict[str, Any]]:
         if not node_ids:
             return {}
         valid_node_ids = [node_id for node_id in node_ids if isinstance(node_id, str) and node_id]
         if not valid_node_ids:
             return {}
         nodes = await self.get_nodes(valid_node_ids)
-        result: Dict[str, List[float]] = {}
+        result: Dict[str, Dict[str, Any]] = {}
         for node in nodes:
             node_id = node.get("id")
             if not isinstance(node_id, str):
                 continue
             value = node.get("truth_alignment", [])
+            epoch = node.get("truth_epoch")
             if isinstance(value, (list, tuple)):
-                result[node_id] = list(value)
+                alignment = list(value)
             else:
-                result[node_id] = []
+                alignment = []
+            try:
+                truth_epoch = int(epoch) if epoch is not None else None
+            except (TypeError, ValueError):
+                truth_epoch = None
+            result[node_id] = {"truth_alignment": alignment, "truth_epoch": truth_epoch}
         return result
 
-    async def set_node_truth_alignments(
-        self, node_truth_alignments: Dict[str, List[float]]
+    async def set_node_truth_state(
+        self, node_truth_state: Dict[str, Dict[str, Any]]
     ) -> Dict[str, bool]:
-        if not node_truth_alignments:
+        if not node_truth_state:
             return {}
-        node_ids = list(node_truth_alignments.keys())
+        node_ids = list(node_truth_state.keys())
         valid_node_ids = [nid for nid in node_ids if isinstance(nid, str) and nid]
         if not valid_node_ids:
             return {nid: False for nid in node_ids}
         nodes = await self.get_nodes(valid_node_ids)
-        updates = self._build_node_truth_alignment_updates(nodes, node_truth_alignments)
+        updates = self._build_node_truth_state_updates(nodes, node_truth_state)
         if not updates:
             return {nid: False for nid in node_ids}
-        updated_ids = await self._execute_node_truth_alignment_updates(updates)
+        updated_ids = await self._execute_node_truth_state_updates(updates)
         return {nid: (nid in updated_ids) for nid in node_ids}
+
+    async def get_node_truth_alignments(self, node_ids: List[str]) -> Dict[str, List[float]]:
+        states = await self.get_node_truth_state(node_ids)
+        return {node_id: state.get("truth_alignment", []) for node_id, state in states.items()}
+
+    async def set_node_truth_alignments(
+        self, node_truth_alignments: Dict[str, List[float]]
+    ) -> Dict[str, bool]:
+        return await self.set_node_truth_state(
+            {
+                node_id: {"truth_alignment": alignment}
+                for node_id, alignment in node_truth_alignments.items()
+            }
+        )
 
     async def get_edge_feedback_weights(self, edge_object_ids: List[str]) -> Dict[str, float]:
         if not edge_object_ids:

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -1725,20 +1725,6 @@ class LadybugAdapter(GraphDBInterface):
         updated_ids = await self._execute_node_truth_state_updates(updates)
         return {nid: (nid in updated_ids) for nid in node_ids}
 
-    async def get_node_truth_alignments(self, node_ids: List[str]) -> Dict[str, List[float]]:
-        states = await self.get_node_truth_state(node_ids)
-        return {node_id: state.get("truth_alignment", []) for node_id, state in states.items()}
-
-    async def set_node_truth_alignments(
-        self, node_truth_alignments: Dict[str, List[float]]
-    ) -> Dict[str, bool]:
-        return await self.set_node_truth_state(
-            {
-                node_id: {"truth_alignment": alignment}
-                for node_id, alignment in node_truth_alignments.items()
-            }
-        )
-
     async def get_edge_feedback_weights(self, edge_object_ids: List[str]) -> Dict[str, float]:
         if not edge_object_ids:
             return {}

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -546,6 +546,62 @@ class LanceDBAdapter(VectorDBInterface):
                 collection_name, collection, payload_schema, lance_data_points
             )
 
+    async def upsert_raw_vectors(
+        self,
+        collection_name: str,
+        points: list[dict],
+        payload_schema: Optional[type[BaseModel]] = None,
+    ) -> None:
+        """Upsert caller-provided vectors without invoking the embedding engine."""
+        if not points:
+            return
+        if payload_schema is None:
+            raise ValueError("payload_schema is required for LanceDB raw vector upserts")
+
+        vector_size = self.embedding_engine.get_vector_size()
+        LanceDataPoint = self._make_lance_datapoint_cls(payload_schema, vector_size)
+
+        if not await self.has_collection(collection_name):
+            async with self.VECTOR_DB_LOCK:
+                if not await self.has_collection(collection_name):
+                    connection = await self.get_connection()
+                    await connection.create_table(
+                        name=collection_name,
+                        schema=self._schema_for_create_table(LanceDataPoint),
+                        exist_ok=True,
+                    )
+
+        collection = await self.get_collection(collection_name)
+
+        raw_points = []
+        for point in points:
+            point_id = point.get("id")
+            vector = point.get("vector")
+            payload_value = point.get("payload")
+            if point_id is None:
+                raise ValueError("Raw vector point is missing id")
+            if not isinstance(vector, list):
+                raise ValueError("Raw vector point vector must be a list")
+            if len(vector) != vector_size:
+                raise ValueError(
+                    f"Raw vector size {len(vector)} does not match expected size {vector_size}"
+                )
+            raw_points.append(
+                LanceDataPoint(
+                    id=str(point_id),
+                    vector=vector,
+                    payload=payload_schema.model_validate(payload_value).model_dump(),
+                )
+            )
+
+        async with self.VECTOR_DB_LOCK:
+            await (
+                collection.merge_insert("id")
+                .when_matched_update_all()
+                .when_not_matched_insert_all()
+                .execute(self._records_for_write(raw_points))
+            )
+
     async def _migrate_collection_schema(
         self,
         collection_name: str,

--- a/cognee/infrastructure/databases/vector/vector_db_interface.py
+++ b/cognee/infrastructure/databases/vector/vector_db_interface.py
@@ -63,6 +63,21 @@ class VectorDBInterface(Protocol):
         """
         raise NotImplementedError
 
+    async def upsert_raw_vectors(
+        self,
+        collection_name: str,
+        points: list[dict],
+        payload_schema: Optional[Any] = None,
+    ) -> None:
+        """
+        Upsert already-computed vectors into the specified collection.
+
+        This is for small system-owned vector state where re-embedding from text would be
+        incorrect. Adapters that do not support raw vector writes should raise
+        NotImplementedError.
+        """
+        raise NotImplementedError("upsert_raw_vectors is not implemented for this adapter")
+
     @abstractmethod
     async def retrieve(self, collection_name: str, data_point_ids: list[str]):
         """

--- a/cognee/modules/chunking/models/DocumentChunk.py
+++ b/cognee/modules/chunking/models/DocumentChunk.py
@@ -42,4 +42,5 @@ class DocumentChunk(DataPoint):
     # and not part of id/dedup.
     truth_alignment: Optional[list[float]] = None
     truth_subspace_signature: Optional[str] = None
+    truth_epoch: Optional[int] = None
     metadata: dict = {"index_fields": ["text"]}

--- a/cognee/modules/chunking/models/DocumentChunk.py
+++ b/cognee/modules/chunking/models/DocumentChunk.py
@@ -38,4 +38,8 @@ class DocumentChunk(DataPoint):
     importance_weight: Optional[float] = 0.5
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    # Optional truth-alignment fields; never embedded (kept out of index_fields)
+    # and not part of id/dedup.
+    truth_alignment: Optional[list[float]] = None
+    truth_subspace_signature: Optional[str] = None
     metadata: dict = {"index_fields": ["text"]}

--- a/cognee/modules/chunking/models/DocumentChunk.py
+++ b/cognee/modules/chunking/models/DocumentChunk.py
@@ -41,6 +41,5 @@ class DocumentChunk(DataPoint):
     # Optional truth-alignment fields; never embedded (kept out of index_fields)
     # and not part of id/dedup.
     truth_alignment: Optional[list[float]] = None
-    truth_subspace_signature: Optional[str] = None
     truth_epoch: Optional[int] = None
     metadata: dict = {"index_fields": ["text"]}

--- a/cognee/modules/engine/models/Entity.py
+++ b/cognee/modules/engine/models/Entity.py
@@ -13,6 +13,7 @@ class Entity(DataPoint):
     # and not part of id/dedup (kept out of identity_fields).
     truth_alignment: Optional[list[float]] = None
     truth_subspace_signature: Optional[str] = None
+    truth_epoch: Optional[int] = None
     # identity_fields makes the id deterministic and namespaced by class
     # (``Entity:<name>``) when constructed without an explicit id — the same
     # value ``Entity.id_for(name)`` produces. Prevents the random-uuid4 footgun.

--- a/cognee/modules/engine/models/Entity.py
+++ b/cognee/modules/engine/models/Entity.py
@@ -9,6 +9,10 @@ class Entity(DataPoint):
     is_a: Optional[EntityType] = None
     description: str
     relations: List[tuple] = []
+    # Optional truth-alignment fields; never embedded (kept out of index_fields)
+    # and not part of id/dedup (kept out of identity_fields).
+    truth_alignment: Optional[list[float]] = None
+    truth_subspace_signature: Optional[str] = None
     # identity_fields makes the id deterministic and namespaced by class
     # (``Entity:<name>``) when constructed without an explicit id — the same
     # value ``Entity.id_for(name)`` produces. Prevents the random-uuid4 footgun.

--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -10,6 +10,7 @@ from cognee.modules.graph.exceptions import (
 from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Node, Edge
 from cognee.modules.graph.cognee_graph.CogneeAbstractGraph import CogneeAbstractGraph
+from cognee.base_config import get_base_config
 import heapq
 
 logger = get_logger("CogneeGraph")
@@ -36,7 +37,7 @@ class CogneeGraph(CogneeAbstractGraph):
         self.edges_by_distance_key = {}
         self.directed = directed
         self.triplet_distance_penalty = 6.5
-        self.feedback_influence = 0.0
+        self.feedback_influence = get_base_config().default_feedback_influence
 
     def add_node(self, node: Node) -> None:
         if node.id in self.nodes:
@@ -236,7 +237,7 @@ class CogneeGraph(CogneeAbstractGraph):
         node_name_filter_operator: str = "OR",
         relevant_ids_to_filter: Optional[List[str]] = None,
         triplet_distance_penalty: float = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
     ) -> None:
         if node_dimension < 1 or edge_dimension < 1:
             raise InvalidDimensionsError()
@@ -322,7 +323,7 @@ class CogneeGraph(CogneeAbstractGraph):
         node_dimension: int = 1,
         edge_dimension: int = 1,
         triplet_distance_penalty: float = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
     ) -> None:
         """
         Project a neighborhood subgraph from the database around seed nodes.

--- a/cognee/modules/retrieval/graph_completion_context_extension_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_context_extension_retriever.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Optional, List, Type, Union
 
+from cognee.base_config import get_base_config
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.utils.query_state import QueryState
 from cognee.modules.retrieval.utils.validate_queries import validate_retriever_input
@@ -28,7 +29,7 @@ class GraphCompletionContextExtensionRetriever(GraphCompletionRetriever):
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
         triplet_distance_penalty: Optional[float] = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
         context_extension_rounds: int = 4,
         session_id: Optional[str] = None,
         response_model: Type = str,

--- a/cognee/modules/retrieval/graph_completion_cot_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_cot_retriever.py
@@ -4,6 +4,7 @@ from typing import Optional, List, Type, Any, Union
 
 from pydantic import BaseModel
 
+from cognee.base_config import get_base_config
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.utils.query_state import QueryState
 from cognee.modules.retrieval.utils.validate_queries import validate_retriever_input
@@ -64,7 +65,7 @@ class GraphCompletionCotRetriever(GraphCompletionRetriever):
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
         triplet_distance_penalty: Optional[float] = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
         max_iter: int = 4,
         session_id: Optional[str] = None,
         response_model: Type = str,

--- a/cognee/modules/retrieval/graph_completion_decomposition_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_decomposition_retriever.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Any, List, Optional, Type
 
+from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
 from cognee.infrastructure.llm.prompts import read_query_prompt
@@ -40,7 +41,7 @@ class GraphCompletionDecompositionRetriever(GraphCompletionRetriever):
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
         triplet_distance_penalty: Optional[float] = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
         session_id: Optional[str] = None,
         response_model: Type = str,
         neighborhood_depth: Optional[int] = None,

--- a/cognee/modules/retrieval/graph_completion_retriever.py
+++ b/cognee/modules/retrieval/graph_completion_retriever.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Any, Dict, List, Optional, Type, Union
 
+from cognee.base_config import get_base_config
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.utils.validate_queries import validate_retriever_input
@@ -51,7 +52,7 @@ class GraphCompletionRetriever(BaseRetriever):
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
         triplet_distance_penalty: Optional[float] = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
         session_id: Optional[str] = None,
         response_model: Type = str,
         neighborhood_depth: Optional[int] = None,

--- a/cognee/modules/retrieval/graph_summary_completion_retriever.py
+++ b/cognee/modules/retrieval/graph_summary_completion_retriever.py
@@ -1,5 +1,6 @@
 from typing import Optional, Type, List
 
+from cognee.base_config import get_base_config
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.utils.completion import summarize_text
 
@@ -28,7 +29,7 @@ class GraphSummaryCompletionRetriever(GraphCompletionRetriever):
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
         triplet_distance_penalty: Optional[float] = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
         session_id: Optional[str] = None,
         include_references: bool = False,
     ):

--- a/cognee/modules/retrieval/hybrid/chunks.py
+++ b/cognee/modules/retrieval/hybrid/chunks.py
@@ -35,7 +35,8 @@ async def retrieve_hybrid_chunks(
     query_vector: Optional[list[float]] = None,
     use_truth_weight: bool = False,
     q_coords: Optional[list[float]] = None,
-    coords_by_id: Optional[dict] = None,
+    truth_state_by_id: Optional[dict] = None,
+    current_truth_epoch: Optional[int] = None,
 ) -> dict[str, Any]:
     candidate_limit = max(0, chunks_top_k * 2)
     summary_limit = summary_candidate_limit(chunks_top_k, text_summaries_top_k)
@@ -85,7 +86,8 @@ async def retrieve_hybrid_chunks(
         use_importance_weight,
         use_truth_weight=use_truth_weight,
         q_coords=q_coords,
-        coords_by_id=coords_by_id,
+        truth_state_by_id=truth_state_by_id,
+        current_truth_epoch=current_truth_epoch,
     )
     if summary_limit > 0:
         await load_summary_text_for_ranked_pairs(

--- a/cognee/modules/retrieval/hybrid/chunks.py
+++ b/cognee/modules/retrieval/hybrid/chunks.py
@@ -33,6 +33,9 @@ async def retrieve_hybrid_chunks(
     node_name_filter_operator: str,
     use_importance_weight: bool,
     query_vector: Optional[list[float]] = None,
+    use_truth_weight: bool = False,
+    q_coords: Optional[list[float]] = None,
+    coords_by_id: Optional[dict] = None,
 ) -> dict[str, Any]:
     candidate_limit = max(0, chunks_top_k * 2)
     summary_limit = summary_candidate_limit(chunks_top_k, text_summaries_top_k)
@@ -76,7 +79,14 @@ async def retrieve_hybrid_chunks(
         )
         attach_source_chunks(pairs, source_chunks)
 
-    ranked_pairs = rank_chunk_summary_pairs(pairs, chunks_top_k, use_importance_weight)
+    ranked_pairs = rank_chunk_summary_pairs(
+        pairs,
+        chunks_top_k,
+        use_importance_weight,
+        use_truth_weight=use_truth_weight,
+        q_coords=q_coords,
+        coords_by_id=coords_by_id,
+    )
     if summary_limit > 0:
         await load_summary_text_for_ranked_pairs(
             vector_engine,

--- a/cognee/modules/retrieval/hybrid/ranking.py
+++ b/cognee/modules/retrieval/hybrid/ranking.py
@@ -1,10 +1,16 @@
+from typing import Optional
+
 from cognee.modules.retrieval.hybrid.results import payload, result_id
+from cognee.modules.truth_subspace.align import truth_factor
 
 
 def rank_chunk_summary_pairs(
     pairs: list[dict],
     limit: int,
     use_importance_weight: bool,
+    use_truth_weight: bool = False,
+    q_coords: Optional[list[float]] = None,
+    coords_by_id: Optional[dict] = None,
 ) -> list[dict]:
     if limit <= 0:
         return []
@@ -30,6 +36,9 @@ def rank_chunk_summary_pairs(
             final_score *= _importance_factor(chunk)
 
         chunk_id = pair["chunk_id"] or result_id(chunk) or ""
+        if use_truth_weight and q_coords:
+            final_score *= truth_factor((coords_by_id or {}).get(chunk_id, []), q_coords)
+
         ranked.append((final_score, rrf_score, min(ranks), chunk_id, pair))
 
     ranked.sort(key=lambda item: (-item[0], -item[1], item[2], item[3]))

--- a/cognee/modules/retrieval/hybrid/ranking.py
+++ b/cognee/modules/retrieval/hybrid/ranking.py
@@ -10,7 +10,8 @@ def rank_chunk_summary_pairs(
     use_importance_weight: bool,
     use_truth_weight: bool = False,
     q_coords: Optional[list[float]] = None,
-    coords_by_id: Optional[dict] = None,
+    truth_state_by_id: Optional[dict] = None,
+    current_truth_epoch: Optional[int] = None,
 ) -> list[dict]:
     if limit <= 0:
         return []
@@ -36,8 +37,10 @@ def rank_chunk_summary_pairs(
             final_score *= _importance_factor(chunk)
 
         chunk_id = pair["chunk_id"] or result_id(chunk) or ""
-        if use_truth_weight and q_coords:
-            final_score *= truth_factor((coords_by_id or {}).get(chunk_id, []), q_coords)
+        if use_truth_weight and q_coords and current_truth_epoch is not None:
+            truth_state = (truth_state_by_id or {}).get(chunk_id, {})
+            if truth_state.get("truth_epoch") == current_truth_epoch:
+                final_score *= truth_factor(truth_state.get("truth_alignment", []), q_coords)
 
         ranked.append((final_score, rrf_score, min(ranks), chunk_id, pair))
 

--- a/cognee/modules/retrieval/hybrid_retriever.py
+++ b/cognee/modules/retrieval/hybrid_retriever.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import Any, Dict, List, Optional, Type
 
-from cognee.context_global_variables import session_user
+from cognee.context_global_variables import current_dataset_id, session_user
 from cognee.infrastructure.databases.cache.config import CacheConfig
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.session.get_session_manager import get_session_manager
@@ -14,7 +14,7 @@ from cognee.modules.retrieval.hybrid.context import (
 )
 from cognee.modules.retrieval.hybrid.entities import build_entities
 from cognee.modules.retrieval.hybrid.facts import edge_rank_by_id, select_facts
-from cognee.modules.retrieval.hybrid.results import payload, result_id
+from cognee.modules.retrieval.hybrid.results import result_id
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.modules.retrieval.utils.global_context import (
     format_global_context_prelude,
@@ -23,7 +23,8 @@ from cognee.modules.retrieval.utils.global_context import (
 )
 from cognee.modules.retrieval.utils.validate_queries import validate_retriever_input
 from cognee.modules.truth_subspace import align
-from cognee.modules.truth_subspace.constants import DEFAULT_K, TRUTH_ANCHOR_COLLECTION
+from cognee.modules.truth_subspace.centroids import load_centroids, pad_coords
+from cognee.modules.truth_subspace.constants import DEFAULT_K
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("HybridRetriever")
@@ -83,7 +84,9 @@ class HybridRetriever(BaseRetriever):
         query_embeddings = await self._unified_engine.vector.embedding_engine.embed_text([query])
         query_vector = query_embeddings[0]
 
-        q_coords, coords_by_id = await self._build_truth_context(query_vector)
+        q_coords, truth_state_by_id, current_truth_epoch = await self._build_truth_context(
+            query_vector
+        )
 
         chunk_objects, (entities, facts) = await asyncio.gather(
             retrieve_hybrid_chunks(
@@ -97,7 +100,8 @@ class HybridRetriever(BaseRetriever):
                 query_vector=query_vector,
                 use_truth_weight=self.use_truth_weight,
                 q_coords=q_coords,
-                coords_by_id=coords_by_id,
+                truth_state_by_id=truth_state_by_id,
+                current_truth_epoch=current_truth_epoch,
             ),
             self._retrieve_entities_and_facts(query, query_vector),
         )
@@ -106,58 +110,37 @@ class HybridRetriever(BaseRetriever):
     async def _build_truth_context(self, query_vector: list[float]) -> tuple:
         """Truth-subspace alignment context for the chunk lane.
 
-        Returns ``(q_coords, coords_by_id)``. Both are ``None`` when the truth
-        weight is off or the TruthAnchor collection is absent/empty, so ranking
-        stays at exact baseline. Fails open to baseline on any error.
-
-        ``q_coords`` is the query projected onto the active anchor directions.
-        Stored anchor vectors are not returned by the vector search, so each
-        anchor coordinate is derived from the cosine-distance score the backend
-        returns: ``cosine = 1 - score`` for the cosine LanceDB backend.
+        Returns ``(q_coords, truth_state_by_id, current_truth_epoch)``. Values
+        are ``None`` when the truth weight is off or centroid slots are absent,
+        so ranking stays at exact baseline. Fails open to baseline on any error.
         """
         if not self.use_truth_weight:
-            return None, None
+            return None, None, None
 
         try:
-            anchor_hits = await search_collection(
-                self._unified_engine.vector,
-                TRUTH_ANCHOR_COLLECTION,
-                "",
-                DEFAULT_K * 4,
-                None,
-                "OR",
-                apply_node_filter=False,
-                query_vector=query_vector,
-            )
-            if not anchor_hits:
-                return None, None
+            dataset_id = current_dataset_id.get()
+            if dataset_id is None:
+                return None, None, None
 
-            # cosine = 1 - score for the cosine-distance LanceDB backend
-            score_by_id = {str(hit.id): 1.0 - float(hit.score) for hit in anchor_hits}
-            active_anchors = align.active_anchor_order(
-                [
-                    {"id": hit.id, "created_at": payload(hit).get("created_at")}
-                    for hit in anchor_hits
-                ],
-                DEFAULT_K,
-            )
-            # Order q_coords by the active anchor order so it lines up with the
-            # node truth_alignment vectors, which are built in the same order.
-            q_coords = [score_by_id[str(anchor["id"])] for anchor in active_anchors]
-            if not q_coords:
-                return None, None
+            centroids = await load_centroids(self._unified_engine.vector, str(dataset_id))
+            if not centroids:
+                return None, None, None
+
+            centroid_vectors = [centroid.centroid for centroid in centroids]
+            q_coords = pad_coords(align.query_coords(query_vector, centroid_vectors), DEFAULT_K)
+            current_truth_epoch = max(centroid.truth_epoch for centroid in centroids)
 
             candidate_chunk_ids = await self._candidate_chunk_ids(query_vector)
             if not candidate_chunk_ids:
-                return q_coords, {}
+                return q_coords, {}, current_truth_epoch
 
-            coords_by_id = await self._unified_engine.graph.get_node_truth_alignments(
+            truth_state_by_id = await self._unified_engine.graph.get_node_truth_state(
                 candidate_chunk_ids
             )
-            return q_coords, coords_by_id
+            return q_coords, truth_state_by_id, current_truth_epoch
         except Exception as error:
             logger.debug("Truth-subspace lookup failed; using baseline ranking: %s", error)
-            return None, None
+            return None, None, None
 
     async def _candidate_chunk_ids(self, query_vector: list[float]) -> list[str]:
         """Candidate DocumentChunk ids whose truth alignments we batch-fetch.

--- a/cognee/modules/retrieval/hybrid_retriever.py
+++ b/cognee/modules/retrieval/hybrid_retriever.py
@@ -14,6 +14,7 @@ from cognee.modules.retrieval.hybrid.context import (
 )
 from cognee.modules.retrieval.hybrid.entities import build_entities
 from cognee.modules.retrieval.hybrid.facts import edge_rank_by_id, select_facts
+from cognee.modules.retrieval.hybrid.results import payload, result_id
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.modules.retrieval.utils.global_context import (
     format_global_context_prelude,
@@ -21,6 +22,11 @@ from cognee.modules.retrieval.utils.global_context import (
     search_top_global_context_summaries,
 )
 from cognee.modules.retrieval.utils.validate_queries import validate_retriever_input
+from cognee.modules.truth_subspace import align
+from cognee.modules.truth_subspace.constants import DEFAULT_K, TRUTH_ANCHOR_COLLECTION
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("HybridRetriever")
 
 
 class HybridRetriever(BaseRetriever):
@@ -42,6 +48,7 @@ class HybridRetriever(BaseRetriever):
         system_prompt: Optional[str] = None,
         text_summaries_top_k: Optional[int] = None,
         use_importance_weight: bool = True,
+        use_truth_weight: bool = False,
         facts_top_k: Optional[int] = 5,
     ):
         self.chunks_top_k = chunks_top_k if chunks_top_k is not None else 5
@@ -58,6 +65,7 @@ class HybridRetriever(BaseRetriever):
         self.system_prompt = system_prompt
         self.text_summaries_top_k = text_summaries_top_k
         self.use_importance_weight = use_importance_weight
+        self.use_truth_weight = use_truth_weight
         self.facts_top_k = facts_top_k if facts_top_k is not None else 5
 
     def _use_session_cache(self) -> bool:
@@ -75,6 +83,8 @@ class HybridRetriever(BaseRetriever):
         query_embeddings = await self._unified_engine.vector.embedding_engine.embed_text([query])
         query_vector = query_embeddings[0]
 
+        q_coords, coords_by_id = await self._build_truth_context(query_vector)
+
         chunk_objects, (entities, facts) = await asyncio.gather(
             retrieve_hybrid_chunks(
                 vector_engine=self._unified_engine.vector,
@@ -85,10 +95,91 @@ class HybridRetriever(BaseRetriever):
                 node_name_filter_operator=self.node_name_filter_operator,
                 use_importance_weight=self.use_importance_weight,
                 query_vector=query_vector,
+                use_truth_weight=self.use_truth_weight,
+                q_coords=q_coords,
+                coords_by_id=coords_by_id,
             ),
             self._retrieve_entities_and_facts(query, query_vector),
         )
         return {**chunk_objects, "entities": entities, "facts": facts}
+
+    async def _build_truth_context(self, query_vector: list[float]) -> tuple:
+        """Truth-subspace alignment context for the chunk lane.
+
+        Returns ``(q_coords, coords_by_id)``. Both are ``None`` when the truth
+        weight is off or the TruthAnchor collection is absent/empty, so ranking
+        stays at exact baseline. Fails open to baseline on any error.
+
+        ``q_coords`` is the query projected onto the active anchor directions.
+        Stored anchor vectors are not returned by the vector search, so each
+        anchor coordinate is derived from the cosine-distance score the backend
+        returns: ``cosine = 1 - score`` for the cosine LanceDB backend.
+        """
+        if not self.use_truth_weight:
+            return None, None
+
+        try:
+            anchor_hits = await search_collection(
+                self._unified_engine.vector,
+                TRUTH_ANCHOR_COLLECTION,
+                "",
+                DEFAULT_K * 4,
+                None,
+                "OR",
+                apply_node_filter=False,
+                query_vector=query_vector,
+            )
+            if not anchor_hits:
+                return None, None
+
+            # cosine = 1 - score for the cosine-distance LanceDB backend
+            score_by_id = {str(hit.id): 1.0 - float(hit.score) for hit in anchor_hits}
+            active_anchors = align.active_anchor_order(
+                [
+                    {"id": hit.id, "created_at": payload(hit).get("created_at")}
+                    for hit in anchor_hits
+                ],
+                DEFAULT_K,
+            )
+            # Order q_coords by the active anchor order so it lines up with the
+            # node truth_alignment vectors, which are built in the same order.
+            q_coords = [score_by_id[str(anchor["id"])] for anchor in active_anchors]
+            if not q_coords:
+                return None, None
+
+            candidate_chunk_ids = await self._candidate_chunk_ids(query_vector)
+            if not candidate_chunk_ids:
+                return q_coords, {}
+
+            coords_by_id = await self._unified_engine.graph.get_node_truth_alignments(
+                candidate_chunk_ids
+            )
+            return q_coords, coords_by_id
+        except Exception as error:
+            logger.debug("Truth-subspace lookup failed; using baseline ranking: %s", error)
+            return None, None
+
+    async def _candidate_chunk_ids(self, query_vector: list[float]) -> list[str]:
+        """Candidate DocumentChunk ids whose truth alignments we batch-fetch.
+
+        Mirrors the chunk lane's vector candidate window so the truth coords map
+        covers the chunks that ranking can surface."""
+        candidate_limit = max(0, self.chunks_top_k * 2)
+        chunk_hits = await search_collection(
+            self._unified_engine.vector,
+            "DocumentChunk_text",
+            "",
+            candidate_limit,
+            self.node_name,
+            self.node_name_filter_operator,
+            query_vector=query_vector,
+        )
+        ids = []
+        for hit in chunk_hits:
+            chunk_id = result_id(hit)
+            if chunk_id:
+                ids.append(str(chunk_id))
+        return ids
 
     async def _retrieve_entities_and_facts(self, query: str, query_vector: list[float]) -> tuple:
         """Entity lane, run concurrently with the chunk lane so the graph round trip for

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Type
 from datetime import datetime
 
 from operator import itemgetter
+from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.llm.prompts import render_prompt
 from cognee.infrastructure.llm import LLMGateway
@@ -43,7 +44,7 @@ class TemporalRetriever(GraphCompletionRetriever):
         node_name_filter_operator: str = "OR",
         wide_search_top_k: Optional[int] = 100,
         triplet_distance_penalty: Optional[float] = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
         session_id: Optional[str] = None,
         response_model: Type = str,
         include_references: bool = False,

--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List, Optional, Type, Union
 
 from cognee.modules.observability import OtelStatusCode as StatusCode
 
+from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
 from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
@@ -54,7 +55,7 @@ async def get_memory_fragment(
     relevant_ids_to_filter: Optional[List[str]] = None,
     memory_fragment_filter: Optional[List[dict]] = None,
     triplet_distance_penalty: Optional[float] = 6.5,
-    feedback_influence: float = 0.0,
+    feedback_influence: float = get_base_config().default_feedback_influence,
     graph_engine=None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = 10,
@@ -225,7 +226,7 @@ async def brute_force_triplet_search(
     node_name_filter_operator: str = "OR",
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
-    feedback_influence: float = 0.0,
+    feedback_influence: float = get_base_config().default_feedback_influence,
     unified_engine: Optional[UnifiedStoreEngine] = None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = 10,

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -1,6 +1,7 @@
 import os
 from typing import Callable, List, Optional, Type, Tuple
 
+from cognee.base_config import get_base_config
 from cognee.modules.retrieval.base_retriever import BaseRetriever
 
 from cognee.modules.engine.models.node_set import NodeSet
@@ -65,7 +66,9 @@ async def get_search_type_retriever_instance(
     node_name_filter_operator = kwargs.get("node_name_filter_operator", "OR")
     wide_search_top_k = kwargs.get("wide_search_top_k", 100)
     triplet_distance_penalty = kwargs.get("triplet_distance_penalty", 6.5)
-    feedback_influence = kwargs.get("feedback_influence", 0.0)
+    feedback_influence = kwargs.get(
+        "feedback_influence", get_base_config().default_feedback_influence
+    )
     session_id = kwargs.get("session_id")
     neighborhood_depth = kwargs.get("neighborhood_depth")
     neighborhood_seed_top_k = kwargs.get("neighborhood_seed_top_k")
@@ -115,6 +118,7 @@ async def get_search_type_retriever_instance(
                 "use_importance_weight": retriever_specific_config.get(
                     "use_importance_weight", True
                 ),
+                "use_truth_weight": retriever_specific_config.get("use_truth_weight", False),
                 "facts_top_k": retriever_specific_config.get("facts_top_k", top_k),
             },
         ),

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -369,15 +369,13 @@ async def search_in_datasets_context(
             # still forward any per-call LLM/embedding overrides onto the async
             # context (set_database_global_context_variables applies these even
             # in single-tenant mode and ignores the dataset argument).
-            if llm_config is not None or embedding_config is not None:
-                async with set_database_global_context_variables(
-                    dataset.id if dataset else None,
-                    user.id,
-                    llm_config=llm_config,
-                    embedding_config=embedding_config,
-                ):
-                    return await get_retriever_output(**retriever_kwargs)
-            return await get_retriever_output(**retriever_kwargs)
+            async with set_database_global_context_variables(
+                dataset.id if dataset else None,
+                user.id,
+                llm_config=llm_config,
+                embedding_config=embedding_config,
+            ):
+                return await get_retriever_output(**retriever_kwargs)
 
         tasks.append(_search_without_context())
 

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Tuple, Type, Union
 from uuid import UUID
 
 from cognee import __version__ as cognee_version
+from cognee.base_config import get_base_config
 from cognee.context_global_variables import (
     backend_access_control_enabled,
     set_database_global_context_variables,
@@ -51,7 +52,7 @@ async def search(
     session_id: Optional[str] = None,
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
-    feedback_influence: float = 0.0,
+    feedback_influence: float = get_base_config().default_feedback_influence,
     verbose=False,
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
@@ -164,7 +165,7 @@ async def authorized_search(
     session_id: Optional[str] = None,
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
-    feedback_influence: float = 0.0,
+    feedback_influence: float = get_base_config().default_feedback_influence,
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
@@ -224,7 +225,7 @@ async def search_in_datasets_context(
     session_id: Optional[str] = None,
     wide_search_top_k: Optional[int] = 100,
     triplet_distance_penalty: Optional[float] = 6.5,
-    feedback_influence: float = 0.0,
+    feedback_influence: float = get_base_config().default_feedback_influence,
     retriever_specific_config: Optional[dict] = None,
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
@@ -251,7 +252,7 @@ async def search_in_datasets_context(
         session_id: Optional[str] = None,
         wide_search_top_k: Optional[int] = 100,
         triplet_distance_penalty: Optional[float] = 6.5,
-        feedback_influence: float = 0.0,
+        feedback_influence: float = get_base_config().default_feedback_influence,
         retriever_specific_config: Optional[dict] = None,
         neighborhood_depth: Optional[int] = None,
         neighborhood_seed_top_k: Optional[int] = None,

--- a/cognee/modules/session_distillation/distill.py
+++ b/cognee/modules/session_distillation/distill.py
@@ -27,6 +27,7 @@ from cognee.infrastructure.session.session_context_builder import coerce_active_
 from cognee.infrastructure.session.session_context_models import SessionContextEntry
 from cognee.modules.data.models import Dataset
 from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.truth_subspace.constants import truth_session_node_set
 from cognee.modules.users.methods import get_default_user
 from cognee.modules.users.models import User
 from cognee.shared.async_utils import gather_with_concurrency_limit
@@ -374,7 +375,8 @@ async def publish_distilled_lessons(
     from cognee.api.v1.add import add
     from cognee.api.v1.cognify import cognify
 
-    await add(documents, dataset_id=scope.dataset.id, user=scope.user, node_set=DISTILLATE_NODE_SET)
+    node_set = [*DISTILLATE_NODE_SET, truth_session_node_set(scope.session_id)]
+    await add(documents, dataset_id=scope.dataset.id, user=scope.user, node_set=node_set)
     await cognify(datasets=[scope.dataset.id], user=scope.user)
     return documents
 

--- a/cognee/modules/truth_subspace/align.py
+++ b/cognee/modules/truth_subspace/align.py
@@ -84,6 +84,6 @@ def truth_factor(node_coords: Sequence[float], q_coords: Sequence[float]) -> flo
 
 
 def stable_signature(ordered_ids: Sequence[object]) -> str:
-    """Stable sha1 signature of an ordered id sequence."""
+    """Stable sha256 signature of an ordered id sequence."""
     joined = "|".join(str(item_id) for item_id in ordered_ids)
-    return hashlib.sha1(joined.encode("utf-8")).hexdigest()
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()

--- a/cognee/modules/truth_subspace/align.py
+++ b/cognee/modules/truth_subspace/align.py
@@ -8,7 +8,7 @@ that pass nothing leave baseline scoring untouched.
 
 import hashlib
 import math
-from typing import Any, Sequence
+from typing import Sequence
 
 
 def cosine(a: Sequence[float], b: Sequence[float]) -> float:
@@ -30,37 +30,37 @@ def cosine(a: Sequence[float], b: Sequence[float]) -> float:
     return dot / (math.sqrt(norm_a) * math.sqrt(norm_b))
 
 
-def node_coords(node_vec: Sequence[float], anchor_vecs: Sequence[Sequence[float]]) -> list[float]:
-    """Project ``node_vec`` onto each anchor (per-anchor cosine).
+def node_coords(node_vec: Sequence[float], basis_vecs: Sequence[Sequence[float]]) -> list[float]:
+    """Project ``node_vec`` onto each basis vector using cosine similarity.
 
-    The result is zero-padded to ``len(anchor_vecs)`` so the coordinate vector
-    always has one entry per anchor.
+    The result is zero-padded to ``len(basis_vecs)`` so the coordinate vector
+    always has one entry per basis vector.
     """
-    coords = [cosine(node_vec, anchor_vec) for anchor_vec in anchor_vecs]
-    # cosine already yields 0.0 per anchor, so length == len(anchor_vecs) holds;
+    coords = [cosine(node_vec, basis_vec) for basis_vec in basis_vecs]
+    # cosine already yields 0.0 per vector, so length == len(basis_vecs) holds;
     # pad defensively to keep the contract explicit.
-    while len(coords) < len(anchor_vecs):
+    while len(coords) < len(basis_vecs):
         coords.append(0.0)
     return coords
 
 
-def query_coords(q_vec: Sequence[float], anchor_vecs: Sequence[Sequence[float]]) -> list[float]:
-    """Project a query vector onto each anchor (per-anchor cosine), zero-padded."""
-    return node_coords(q_vec, anchor_vecs)
+def query_coords(q_vec: Sequence[float], basis_vecs: Sequence[Sequence[float]]) -> list[float]:
+    """Project a query vector onto each basis vector, zero-padded."""
+    return node_coords(q_vec, basis_vecs)
 
 
 def truth_score(node_coords: Sequence[float], q_coords: Sequence[float]) -> float:
-    """Truth score in [0, 1]: the node's alignment with the anchors the query cares about.
+    """Truth score in [0, 1]: the node's alignment with directions the query cares about.
 
-    A query-relevance-weighted average of the node's per-anchor alignments, using
+    A query-relevance-weighted average of the node's per-direction alignments, using
     the (clamped) query coordinates as weights. This is magnitude-sensitive on
-    purpose: a node strongly aligned with the anchors scores higher. Cosine of the
-    two coord vectors does NOT work here — every anchor cosine is positive, so all
+    purpose: a node strongly aligned with those directions scores higher. Cosine of the
+    two coord vectors does NOT work here — every basis cosine is positive, so all
     coord vectors share one octant and their cosine collapses to ~1 regardless of
     magnitude, erasing the very signal we rank on.
 
     Returns ``0.5`` (NEUTRAL) when either coord vector is empty, or when the query
-    aligns with no anchor (no weight to spread).
+    aligns with no direction (no weight to spread).
     """
     if not node_coords or not q_coords:
         return 0.5
@@ -83,27 +83,7 @@ def truth_factor(node_coords: Sequence[float], q_coords: Sequence[float]) -> flo
     return 0.75 + 0.5 * truth_score(node_coords, q_coords)
 
 
-def active_anchor_order(anchors: Sequence[Any], k: int) -> list:
-    """Deterministically order anchors and take the most recent ``k``.
-
-    Sorts by ``created_at`` descending, then by ``id`` (as a tiebreak), then
-    returns the first ``k``. Works with objects exposing ``created_at``/``id``
-    attributes or mappings with those keys.
-    """
-
-    def _get(anchor: Any, key: str) -> Any:
-        if isinstance(anchor, dict):
-            return anchor.get(key)
-        return getattr(anchor, key, None)
-
-    ordered = sorted(
-        anchors,
-        key=lambda anchor: (-(_get(anchor, "created_at") or 0), str(_get(anchor, "id"))),
-    )
-    return list(ordered[:k])
-
-
-def anchor_signature(ordered_ids: Sequence[Any]) -> str:
+def stable_signature(ordered_ids: Sequence[object]) -> str:
     """Stable sha1 signature of an ordered id sequence."""
-    joined = "|".join(str(anchor_id) for anchor_id in ordered_ids)
+    joined = "|".join(str(item_id) for item_id in ordered_ids)
     return hashlib.sha1(joined.encode("utf-8")).hexdigest()

--- a/cognee/modules/truth_subspace/align.py
+++ b/cognee/modules/truth_subspace/align.py
@@ -1,0 +1,109 @@
+"""Pure truth-subspace alignment functions.
+
+No I/O, no database access, no LLM calls — just deterministic math over plain
+python lists. Everything here is NEUTRAL when inputs are missing/empty/zero:
+``truth_score`` returns ``0.5`` and ``truth_factor`` returns ``1.0`` so callers
+that pass nothing leave baseline scoring untouched.
+"""
+
+import hashlib
+import math
+from typing import Any, Sequence
+
+
+def cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity of two vectors. Returns 0.0 for a zero/empty vector."""
+    if not a or not b:
+        return 0.0
+
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+
+    return dot / (math.sqrt(norm_a) * math.sqrt(norm_b))
+
+
+def node_coords(node_vec: Sequence[float], anchor_vecs: Sequence[Sequence[float]]) -> list[float]:
+    """Project ``node_vec`` onto each anchor (per-anchor cosine).
+
+    The result is zero-padded to ``len(anchor_vecs)`` so the coordinate vector
+    always has one entry per anchor.
+    """
+    coords = [cosine(node_vec, anchor_vec) for anchor_vec in anchor_vecs]
+    # cosine already yields 0.0 per anchor, so length == len(anchor_vecs) holds;
+    # pad defensively to keep the contract explicit.
+    while len(coords) < len(anchor_vecs):
+        coords.append(0.0)
+    return coords
+
+
+def query_coords(q_vec: Sequence[float], anchor_vecs: Sequence[Sequence[float]]) -> list[float]:
+    """Project a query vector onto each anchor (per-anchor cosine), zero-padded."""
+    return node_coords(q_vec, anchor_vecs)
+
+
+def truth_score(node_coords: Sequence[float], q_coords: Sequence[float]) -> float:
+    """Truth score in [0, 1]: the node's alignment with the anchors the query cares about.
+
+    A query-relevance-weighted average of the node's per-anchor alignments, using
+    the (clamped) query coordinates as weights. This is magnitude-sensitive on
+    purpose: a node strongly aligned with the anchors scores higher. Cosine of the
+    two coord vectors does NOT work here — every anchor cosine is positive, so all
+    coord vectors share one octant and their cosine collapses to ~1 regardless of
+    magnitude, erasing the very signal we rank on.
+
+    Returns ``0.5`` (NEUTRAL) when either coord vector is empty, or when the query
+    aligns with no anchor (no weight to spread).
+    """
+    if not node_coords or not q_coords:
+        return 0.5
+
+    weights = [max(float(q), 0.0) for q in q_coords]
+    total_weight = sum(weights)
+    if total_weight == 0.0:
+        return 0.5
+
+    weighted = sum(float(n) * w for n, w in zip(node_coords, weights))
+    return max(0.0, min(1.0, weighted / total_weight))
+
+
+def truth_factor(node_coords: Sequence[float], q_coords: Sequence[float]) -> float:
+    """Multiplicative score factor in [0.75, 1.25].
+
+    ``0.75 + 0.5 * truth_score``. Returns ``1.0`` (NEUTRAL) when coords are
+    missing/zero, since ``truth_score`` is ``0.5`` there.
+    """
+    return 0.75 + 0.5 * truth_score(node_coords, q_coords)
+
+
+def active_anchor_order(anchors: Sequence[Any], k: int) -> list:
+    """Deterministically order anchors and take the most recent ``k``.
+
+    Sorts by ``created_at`` descending, then by ``id`` (as a tiebreak), then
+    returns the first ``k``. Works with objects exposing ``created_at``/``id``
+    attributes or mappings with those keys.
+    """
+
+    def _get(anchor: Any, key: str) -> Any:
+        if isinstance(anchor, dict):
+            return anchor.get(key)
+        return getattr(anchor, key, None)
+
+    ordered = sorted(
+        anchors,
+        key=lambda anchor: (-(_get(anchor, "created_at") or 0), str(_get(anchor, "id"))),
+    )
+    return list(ordered[:k])
+
+
+def anchor_signature(ordered_ids: Sequence[Any]) -> str:
+    """Stable sha1 signature of an ordered id sequence."""
+    joined = "|".join(str(anchor_id) for anchor_id in ordered_ids)
+    return hashlib.sha1(joined.encode("utf-8")).hexdigest()

--- a/cognee/modules/truth_subspace/build.py
+++ b/cognee/modules/truth_subspace/build.py
@@ -25,12 +25,13 @@ from . import align
 from .centroids import (
     build_centroids_from_learning_vectors,
     centroids_changed,
+    extend_centroids_with_learning_vectors,
     learning_id,
     load_centroids,
     pad_coords,
     upsert_centroids,
 )
-from .constants import DEFAULT_K, TRUTH_NODE_SET
+from .constants import DEFAULT_K, TRUTH_NODE_SET, truth_session_node_set
 
 logger = get_logger("truth_subspace")
 
@@ -46,7 +47,13 @@ def _node_index_text(node_data: dict) -> str:
     return str(text).strip()
 
 
-async def _fetch_learning_statements(graph_engine) -> List[str]:
+def _truth_node_sets(session_ids: Optional[List[str]]) -> List[str]:
+    if not session_ids:
+        return TRUTH_NODE_SET
+    return [truth_session_node_set(session_id) for session_id in session_ids if session_id]
+
+
+async def _fetch_learning_statements(graph_engine, session_ids: Optional[List[str]]) -> List[str]:
     """Read accepted lesson statements from the session_learnings node set.
 
     Traverses the ``session_learnings`` NodeSet to its member DocumentChunk
@@ -57,7 +64,7 @@ async def _fetch_learning_statements(graph_engine) -> List[str]:
     try:
         nodes, _edges = await graph_engine.get_nodeset_subgraph(
             node_type=NodeSet,
-            node_name=TRUTH_NODE_SET,
+            node_name=_truth_node_sets(session_ids),
         )
     except Exception as error:
         logger.warning("truth_subspace: learning lookup failed open: %s", error)
@@ -121,7 +128,7 @@ async def build_truth_subspace(
         graph_engine = await get_graph_engine()
 
         # Step 1: accepted learning statements from session_learnings.
-        statements = await _fetch_learning_statements(graph_engine)
+        statements = await _fetch_learning_statements(graph_engine, session_ids)
         if not statements:
             logger.info("truth_subspace: no learnings found, nothing to build")
             return empty_result
@@ -158,25 +165,33 @@ async def build_truth_subspace(
             }
 
         updated_at = int(datetime.now(timezone.utc).timestamp() * 1000)
-        rebuilt_centroids = build_centroids_from_learning_vectors(
-            str(dataset_obj.id),
-            list(zip(learning_ids, learning_vecs)),
-            truth_epoch=previous_epoch,
-            updated_at=updated_at,
-            k=k,
-        )
+        learning_vectors = list(zip(learning_ids, learning_vecs))
+
+        def build_for_epoch(truth_epoch: int):
+            if session_ids:
+                return extend_centroids_with_learning_vectors(
+                    str(dataset_obj.id),
+                    existing_centroids,
+                    learning_vectors,
+                    truth_epoch=truth_epoch,
+                    updated_at=updated_at,
+                    k=k,
+                )
+            return build_centroids_from_learning_vectors(
+                str(dataset_obj.id),
+                learning_vectors,
+                truth_epoch=truth_epoch,
+                updated_at=updated_at,
+                k=k,
+            )
+
+        rebuilt_centroids = build_for_epoch(previous_epoch)
         if not rebuilt_centroids:
             return empty_result
 
         if centroids_changed(existing_centroids, rebuilt_centroids):
             current_epoch = previous_epoch + 1
-            centroids = build_centroids_from_learning_vectors(
-                str(dataset_obj.id),
-                list(zip(learning_ids, learning_vecs)),
-                truth_epoch=current_epoch,
-                updated_at=updated_at,
-                k=k,
-            )
+            centroids = build_for_epoch(current_epoch)
             try:
                 await upsert_centroids(vector_engine, centroids)
             except Exception as error:

--- a/cognee/modules/truth_subspace/build.py
+++ b/cognee/modules/truth_subspace/build.py
@@ -1,26 +1,11 @@
-"""Build the truth subspace for a dataset's distilled session learnings.
+"""Build centroid-slot truth coordinates for a dataset's session learnings.
 
-The truth subspace is a small set of accepted lesson statements (the
-``session_learnings`` node set) used as semantic *anchors*. Each graph node is
-projected onto those anchors and the resulting coordinate vector is persisted on
-the node, so retrieval can later nudge scores toward statements the system has
-already accepted as true.
-
-The whole build is fail-open and OFF BY DEFAULT: callers opt in explicitly. When
-there are no anchors, nothing is written and an empty-ish result is returned, so
-baseline behaviour is untouched.
-
-Flow:
-
-1. ANCHORS   traverse the ``session_learnings`` node set -> anchor statements.
-2. UPSERT    build :class:`TruthAnchor` data points and upsert them.
-3. EMBED     embed the active anchor statements in memory.
-4. ACTIVE K  deterministically pick the most-recent ``k`` anchors + signature.
-5. LOAD      load the DocumentChunk subgraph and extract each node's index text.
-6. COORDS    embed node texts (batched) and project onto the active anchors.
-7. PERSIST   write per-node coordinate vectors via the graph engine.
+The ``session_learnings`` node set is replayed on every build into up to
+``DEFAULT_K`` deterministic centroid slots. DocumentChunk nodes are projected
+onto those slots and persisted with the centroid epoch used to compute them.
 """
 
+from datetime import datetime, timezone
 from typing import List, Optional, Union
 from uuid import UUID
 
@@ -37,8 +22,15 @@ from cognee.modules.users.methods import get_default_user
 from cognee.shared.logging_utils import get_logger
 
 from . import align
-from .constants import DEFAULT_K, TRUTH_ANCHOR_COLLECTION, TRUTH_NODE_SET
-from .models import TruthAnchor
+from .centroids import (
+    build_centroids_from_learning_vectors,
+    centroids_changed,
+    learning_id,
+    load_centroids,
+    pad_coords,
+    upsert_centroids,
+)
+from .constants import DEFAULT_K, TRUTH_NODE_SET
 
 logger = get_logger("truth_subspace")
 
@@ -54,7 +46,7 @@ def _node_index_text(node_data: dict) -> str:
     return str(text).strip()
 
 
-async def _fetch_anchor_statements(graph_engine) -> List[str]:
+async def _fetch_learning_statements(graph_engine) -> List[str]:
     """Read accepted lesson statements from the session_learnings node set.
 
     Traverses the ``session_learnings`` NodeSet to its member DocumentChunk
@@ -68,7 +60,7 @@ async def _fetch_anchor_statements(graph_engine) -> List[str]:
             node_name=TRUTH_NODE_SET,
         )
     except Exception as error:
-        logger.warning("truth_subspace: anchor lookup failed open: %s", error)
+        logger.warning("truth_subspace: learning lookup failed open: %s", error)
         return []
 
     statements: List[str] = []
@@ -112,22 +104,12 @@ async def build_truth_subspace(
     user=None,
     k: int = DEFAULT_K,
 ) -> dict:
-    """Build/refresh the truth subspace for ``dataset``.
-
-    Reads accepted session-learning statements as anchors, upserts them as
-    :class:`TruthAnchor` data points, embeds the active anchors, then projects
-    every DocumentChunk node onto those anchors and persists the per-node
-    coordinate vectors on the graph.
-
-    Fail-open and logged throughout, mirroring the ``improve()`` distillation
-    stage. Returns ``{"anchors": n, "nodes_scored": m, "signature": str}``.
-    When there are no anchors, returns early writing nothing.
-    """
+    """Build/refresh centroid slots and chunk coordinates for ``dataset``."""
     resolved_user = user if user is not None else session_user.get()
     if resolved_user is None or getattr(resolved_user, "id", None) is None:
         resolved_user = await get_default_user()
 
-    empty_result = {"anchors": 0, "nodes_scored": 0, "signature": ""}
+    empty_result = {"anchors": 0, "nodes_scored": 0, "signature": "", "truth_epoch": 0}
 
     dataset_obj = await _resolve_dataset(dataset, resolved_user)
     if dataset_obj is None:
@@ -138,43 +120,78 @@ async def build_truth_subspace(
         vector_engine = get_vector_engine()
         graph_engine = await get_graph_engine()
 
-        # Step 1: ANCHORS — accepted lesson statements from session_learnings.
-        statements = await _fetch_anchor_statements(graph_engine)
+        # Step 1: accepted learning statements from session_learnings.
+        statements = await _fetch_learning_statements(graph_engine)
         if not statements:
-            logger.info("truth_subspace: no anchors found, nothing to build")
+            logger.info("truth_subspace: no learnings found, nothing to build")
             return empty_result
 
-        # Step 2: UPSERT TruthAnchor data points. No belongs_to_set tag: the
-        # query-time anchor search is unscoped (apply_node_filter=False), and a
-        # NodeSet object does not serialize into the LanceDB anchor collection.
-        anchors = [
-            TruthAnchor(id=TruthAnchor.id_for(statement), statement=statement)
-            for statement in statements
-        ]
         try:
-            # Pre-create the collection. create_data_points auto-creates a missing
-            # collection while already holding VECTOR_DB_LOCK, then calls
-            # create_collection which re-acquires the same non-reentrant lock —
-            # a deadlock on first run. Creating it up front (lock acquired once)
-            # makes create_data_points take its collection-exists fast path.
-            await vector_engine.create_collection(
-                TRUTH_ANCHOR_COLLECTION, payload_schema=TruthAnchor
-            )
-            await vector_engine.create_data_points(TRUTH_ANCHOR_COLLECTION, anchors)
+            existing_centroids = await load_centroids(vector_engine, str(dataset_obj.id), k)
         except Exception as error:
-            logger.warning("truth_subspace: anchor upsert failed open: %s", error)
+            logger.debug("truth_subspace: centroid load failed open: %s", error)
+            existing_centroids = []
 
-        # Step 3 & 4: ACTIVE K + signature, then embed the active anchors.
-        active_anchors = align.active_anchor_order(anchors, k)
-        active_statements = [anchor.statement for anchor in active_anchors]
-        signature = align.anchor_signature([anchor.id for anchor in active_anchors])
+        previous_epoch = max((centroid.truth_epoch for centroid in existing_centroids), default=0)
+        learning_items = sorted(
+            {
+                learning_id(statement): statement
+                for statement in statements
+                if str(statement).strip()
+            }.items(),
+            key=lambda item: item[0],
+        )
+        learning_ids = [item[0] for item in learning_items]
+        learning_texts = [item[1] for item in learning_items]
+        signature = align.stable_signature(learning_ids)
 
         embedding_engine = get_embedding_engine()
         try:
-            anchor_vecs = await embedding_engine.embed_text(active_statements)
+            learning_vecs = await embedding_engine.embed_text(learning_texts)
         except Exception as error:
-            logger.warning("truth_subspace: anchor embedding failed open: %s", error)
-            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+            logger.warning("truth_subspace: learning embedding failed open: %s", error)
+            return {
+                "anchors": len(existing_centroids),
+                "nodes_scored": 0,
+                "signature": signature,
+                "truth_epoch": previous_epoch,
+            }
+
+        updated_at = int(datetime.now(timezone.utc).timestamp() * 1000)
+        rebuilt_centroids = build_centroids_from_learning_vectors(
+            str(dataset_obj.id),
+            list(zip(learning_ids, learning_vecs)),
+            truth_epoch=previous_epoch,
+            updated_at=updated_at,
+            k=k,
+        )
+        if not rebuilt_centroids:
+            return empty_result
+
+        if centroids_changed(existing_centroids, rebuilt_centroids):
+            current_epoch = previous_epoch + 1
+            centroids = build_centroids_from_learning_vectors(
+                str(dataset_obj.id),
+                list(zip(learning_ids, learning_vecs)),
+                truth_epoch=current_epoch,
+                updated_at=updated_at,
+                k=k,
+            )
+            try:
+                await upsert_centroids(vector_engine, centroids)
+            except Exception as error:
+                logger.warning("truth_subspace: centroid upsert failed open: %s", error)
+                return {
+                    "anchors": len(centroids),
+                    "nodes_scored": 0,
+                    "signature": signature,
+                    "truth_epoch": current_epoch,
+                }
+        else:
+            current_epoch = previous_epoch
+            centroids = existing_centroids
+
+        centroid_vecs = [centroid.centroid for centroid in centroids]
 
         # Step 5: LOAD nodes — ALL DocumentChunk nodes in the dataset (the chunk
         # lane the hybrid retriever reranks). Scoping to the session_learnings
@@ -188,7 +205,12 @@ async def build_truth_subspace(
             nodes, _edges = await graph_engine.get_graph_data()
         except Exception as error:
             logger.warning("truth_subspace: node load failed open: %s", error)
-            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+            return {
+                "anchors": len(centroids),
+                "nodes_scored": 0,
+                "signature": signature,
+                "truth_epoch": current_epoch,
+            }
 
         chunk_label = DocumentChunk.__name__
         scored: dict = {}
@@ -204,37 +226,59 @@ async def build_truth_subspace(
             node_texts.append(text)
 
         if not node_texts:
-            logger.info("truth_subspace: %d anchors, no scoreable nodes", len(active_anchors))
-            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+            logger.info("truth_subspace: %d centroids, no scoreable nodes", len(centroids))
+            return {
+                "anchors": len(centroids),
+                "nodes_scored": 0,
+                "signature": signature,
+                "truth_epoch": current_epoch,
+            }
 
         # Step 6: EMBED node texts (batched) and compute coords per node.
         node_vecs = await _embed_in_batches(embedding_engine, node_texts)
         for node_id, node_vec in zip(node_ids, node_vecs):
             try:
-                coords = align.node_coords(node_vec, anchor_vecs)
-                scored[node_id] = coords
+                coords = pad_coords(align.node_coords(node_vec, centroid_vecs), k)
+                scored[node_id] = {
+                    "truth_alignment": coords,
+                    "truth_epoch": current_epoch,
+                }
             except Exception as error:
                 # Per-node fail-open: one bad node never sinks the batch.
                 logger.debug("truth_subspace: coords failed for node %s: %s", node_id, error)
 
         if not scored:
-            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+            return {
+                "anchors": len(centroids),
+                "nodes_scored": 0,
+                "signature": signature,
+                "truth_epoch": current_epoch,
+            }
 
         # Step 7: PERSIST per-node coordinate vectors.
         try:
-            await graph_engine.set_node_truth_alignments(scored)
+            write_result = await graph_engine.set_node_truth_state(scored)
         except Exception as error:
             logger.warning("truth_subspace: persisting alignments failed open: %s", error)
-            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+            return {
+                "anchors": len(centroids),
+                "nodes_scored": 0,
+                "signature": signature,
+                "truth_epoch": current_epoch,
+            }
+
+        nodes_scored = sum(1 for ok in write_result.values() if ok)
 
     logger.info(
-        "truth_subspace: built subspace -> anchors=%d nodes_scored=%d signature=%s",
-        len(active_anchors),
-        len(scored),
+        "truth_subspace: built subspace -> centroids=%d nodes_scored=%d epoch=%d signature=%s",
+        len(centroids),
+        nodes_scored,
+        current_epoch,
         signature,
     )
     return {
-        "anchors": len(active_anchors),
-        "nodes_scored": len(scored),
+        "anchors": len(centroids),
+        "nodes_scored": nodes_scored,
         "signature": signature,
+        "truth_epoch": current_epoch,
     }

--- a/cognee/modules/truth_subspace/build.py
+++ b/cognee/modules/truth_subspace/build.py
@@ -1,0 +1,240 @@
+"""Build the truth subspace for a dataset's distilled session learnings.
+
+The truth subspace is a small set of accepted lesson statements (the
+``session_learnings`` node set) used as semantic *anchors*. Each graph node is
+projected onto those anchors and the resulting coordinate vector is persisted on
+the node, so retrieval can later nudge scores toward statements the system has
+already accepted as true.
+
+The whole build is fail-open and OFF BY DEFAULT: callers opt in explicitly. When
+there are no anchors, nothing is written and an empty-ish result is returned, so
+baseline behaviour is untouched.
+
+Flow:
+
+1. ANCHORS   traverse the ``session_learnings`` node set -> anchor statements.
+2. UPSERT    build :class:`TruthAnchor` data points and upsert them.
+3. EMBED     embed the active anchor statements in memory.
+4. ACTIVE K  deterministically pick the most-recent ``k`` anchors + signature.
+5. LOAD      load the DocumentChunk subgraph and extract each node's index text.
+6. COORDS    embed node texts (batched) and project onto the active anchors.
+7. PERSIST   write per-node coordinate vectors via the graph engine.
+"""
+
+from typing import List, Optional, Union
+from uuid import UUID
+
+from cognee.context_global_variables import session_user, set_database_global_context_variables
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector.embeddings.get_embedding_engine import (
+    get_embedding_engine,
+)
+from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.engine.models import NodeSet
+from cognee.modules.users.methods import get_default_user
+from cognee.shared.logging_utils import get_logger
+
+from . import align
+from .constants import DEFAULT_K, TRUTH_ANCHOR_COLLECTION, TRUTH_NODE_SET
+from .models import TruthAnchor
+
+logger = get_logger("truth_subspace")
+
+# Node text embedding batch size — keep memory bounded on large subgraphs.
+NODE_EMBED_BATCH_SIZE = 64
+
+
+def _node_index_text(node_data: dict) -> str:
+    """Extract a node's index text for embedding (DocumentChunk -> ``text``)."""
+    if not isinstance(node_data, dict):
+        return ""
+    text = node_data.get("text") or node_data.get("name") or ""
+    return str(text).strip()
+
+
+async def _fetch_anchor_statements(graph_engine) -> List[str]:
+    """Read accepted lesson statements from the session_learnings node set.
+
+    Traverses the ``session_learnings`` NodeSet to its member DocumentChunk
+    nodes and returns their de-duplicated text. This is query-free: a vector
+    search would require a query vector, but here we just want every lesson in
+    the set. Fail-open -> [].
+    """
+    try:
+        nodes, _edges = await graph_engine.get_nodeset_subgraph(
+            node_type=NodeSet,
+            node_name=TRUTH_NODE_SET,
+        )
+    except Exception as error:
+        logger.warning("truth_subspace: anchor lookup failed open: %s", error)
+        return []
+
+    statements: List[str] = []
+    seen = set()
+    for _node_id, node_data in nodes or []:
+        if not isinstance(node_data, dict):
+            continue
+        if node_data.get("type") != DocumentChunk.__name__:
+            continue
+        text = str(node_data.get("text") or "").strip()
+        key = text.casefold()
+        if text and key not in seen:
+            statements.append(text)
+            seen.add(key)
+    return statements
+
+
+async def _embed_in_batches(embedding_engine, texts: List[str]) -> List[List[float]]:
+    """Embed ``texts`` in bounded batches, preserving order. Fail-open -> []."""
+    vectors: List[List[float]] = []
+    for start in range(0, len(texts), NODE_EMBED_BATCH_SIZE):
+        batch = texts[start : start + NODE_EMBED_BATCH_SIZE]
+        try:
+            vectors.extend(await embedding_engine.embed_text(batch))
+        except Exception as error:
+            logger.warning("truth_subspace: node embedding batch failed open: %s", error)
+            # Keep alignment: pad failed batch with empty vectors (NEUTRAL coords).
+            vectors.extend([[] for _ in batch])
+    return vectors
+
+
+async def _resolve_dataset(dataset: Union[str, UUID], user):
+    """Resolve a writable dataset object for ``user`` (or None)."""
+    datasets = await get_authorized_existing_datasets([dataset], "write", user)
+    return datasets[0] if datasets else None
+
+
+async def build_truth_subspace(
+    dataset: Union[str, UUID],
+    session_ids: Optional[List[str]],
+    user=None,
+    k: int = DEFAULT_K,
+) -> dict:
+    """Build/refresh the truth subspace for ``dataset``.
+
+    Reads accepted session-learning statements as anchors, upserts them as
+    :class:`TruthAnchor` data points, embeds the active anchors, then projects
+    every DocumentChunk node onto those anchors and persists the per-node
+    coordinate vectors on the graph.
+
+    Fail-open and logged throughout, mirroring the ``improve()`` distillation
+    stage. Returns ``{"anchors": n, "nodes_scored": m, "signature": str}``.
+    When there are no anchors, returns early writing nothing.
+    """
+    resolved_user = user if user is not None else session_user.get()
+    if resolved_user is None or getattr(resolved_user, "id", None) is None:
+        resolved_user = await get_default_user()
+
+    empty_result = {"anchors": 0, "nodes_scored": 0, "signature": ""}
+
+    dataset_obj = await _resolve_dataset(dataset, resolved_user)
+    if dataset_obj is None:
+        logger.warning("truth_subspace: dataset %s not found or not writable", dataset)
+        return empty_result
+
+    async with set_database_global_context_variables(dataset_obj.id, dataset_obj.owner_id):
+        vector_engine = get_vector_engine()
+        graph_engine = await get_graph_engine()
+
+        # Step 1: ANCHORS — accepted lesson statements from session_learnings.
+        statements = await _fetch_anchor_statements(graph_engine)
+        if not statements:
+            logger.info("truth_subspace: no anchors found, nothing to build")
+            return empty_result
+
+        # Step 2: UPSERT TruthAnchor data points. No belongs_to_set tag: the
+        # query-time anchor search is unscoped (apply_node_filter=False), and a
+        # NodeSet object does not serialize into the LanceDB anchor collection.
+        anchors = [
+            TruthAnchor(id=TruthAnchor.id_for(statement), statement=statement)
+            for statement in statements
+        ]
+        try:
+            # Pre-create the collection. create_data_points auto-creates a missing
+            # collection while already holding VECTOR_DB_LOCK, then calls
+            # create_collection which re-acquires the same non-reentrant lock —
+            # a deadlock on first run. Creating it up front (lock acquired once)
+            # makes create_data_points take its collection-exists fast path.
+            await vector_engine.create_collection(
+                TRUTH_ANCHOR_COLLECTION, payload_schema=TruthAnchor
+            )
+            await vector_engine.create_data_points(TRUTH_ANCHOR_COLLECTION, anchors)
+        except Exception as error:
+            logger.warning("truth_subspace: anchor upsert failed open: %s", error)
+
+        # Step 3 & 4: ACTIVE K + signature, then embed the active anchors.
+        active_anchors = align.active_anchor_order(anchors, k)
+        active_statements = [anchor.statement for anchor in active_anchors]
+        signature = align.anchor_signature([anchor.id for anchor in active_anchors])
+
+        embedding_engine = get_embedding_engine()
+        try:
+            anchor_vecs = await embedding_engine.embed_text(active_statements)
+        except Exception as error:
+            logger.warning("truth_subspace: anchor embedding failed open: %s", error)
+            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+
+        # Step 5: LOAD nodes — ALL DocumentChunk nodes in the dataset (the chunk
+        # lane the hybrid retriever reranks). Scoping to the session_learnings
+        # node set would only score the lessons themselves, never the corpus
+        # chunks a query actually retrieves, so reranking would be a no-op.
+        #
+        # Use get_graph_data (sequential queries) and filter by type in memory.
+        # get_filtered_graph_data runs its node/edge queries via asyncio.gather,
+        # which deadlocks on the single-connection Kuzu subprocess backend.
+        try:
+            nodes, _edges = await graph_engine.get_graph_data()
+        except Exception as error:
+            logger.warning("truth_subspace: node load failed open: %s", error)
+            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+
+        chunk_label = DocumentChunk.__name__
+        scored: dict = {}
+        node_ids: List[str] = []
+        node_texts: List[str] = []
+        for node_id, node_data in nodes:
+            if not isinstance(node_data, dict) or node_data.get("type") != chunk_label:
+                continue
+            text = _node_index_text(node_data)
+            if not node_id or not text:
+                continue
+            node_ids.append(str(node_id))
+            node_texts.append(text)
+
+        if not node_texts:
+            logger.info("truth_subspace: %d anchors, no scoreable nodes", len(active_anchors))
+            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+
+        # Step 6: EMBED node texts (batched) and compute coords per node.
+        node_vecs = await _embed_in_batches(embedding_engine, node_texts)
+        for node_id, node_vec in zip(node_ids, node_vecs):
+            try:
+                coords = align.node_coords(node_vec, anchor_vecs)
+                scored[node_id] = coords
+            except Exception as error:
+                # Per-node fail-open: one bad node never sinks the batch.
+                logger.debug("truth_subspace: coords failed for node %s: %s", node_id, error)
+
+        if not scored:
+            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+
+        # Step 7: PERSIST per-node coordinate vectors.
+        try:
+            await graph_engine.set_node_truth_alignments(scored)
+        except Exception as error:
+            logger.warning("truth_subspace: persisting alignments failed open: %s", error)
+            return {"anchors": len(active_anchors), "nodes_scored": 0, "signature": signature}
+
+    logger.info(
+        "truth_subspace: built subspace -> anchors=%d nodes_scored=%d signature=%s",
+        len(active_anchors),
+        len(scored),
+        signature,
+    )
+    return {
+        "anchors": len(active_anchors),
+        "nodes_scored": len(scored),
+        "signature": signature,
+    }

--- a/cognee/modules/truth_subspace/centroids.py
+++ b/cognee/modules/truth_subspace/centroids.py
@@ -1,0 +1,165 @@
+"""Centroid-slot helpers for truth-subspace reranking.
+
+The core invariant is simple: slot ``i`` always means the centroid stored in
+slot ``i`` for the current truth epoch. Everything here is deterministic so a
+rebuild from the same learning statements produces the same slots.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Sequence
+from uuid import NAMESPACE_OID, UUID, uuid5
+
+from .align import cosine
+from .constants import DEFAULT_K, TRUTH_CENTROID_COLLECTION
+from .models import TruthCentroidPayload
+
+
+def centroid_id(dataset_id: str, slot: int) -> UUID:
+    return uuid5(NAMESPACE_OID, f"TruthCentroid:{dataset_id}:{slot}")
+
+
+def learning_id(statement: str) -> str:
+    normalized = _normalize_statement(statement)
+    return str(uuid5(NAMESPACE_OID, f"TruthLearning:{normalized}"))
+
+
+def normalize(vector: Sequence[float]) -> list[float]:
+    values = [float(value) for value in vector]
+    norm = math.sqrt(sum(value * value for value in values))
+    if norm == 0.0:
+        return [0.0 for _ in values]
+    return [value / norm for value in values]
+
+
+def pad_coords(coords: Sequence[float], k: int = DEFAULT_K) -> list[float]:
+    values = [float(value) for value in list(coords)[:k]]
+    return values + [0.0 for _ in range(max(0, k - len(values)))]
+
+
+def weighted_centroid(old: Sequence[float], count: int, new: Sequence[float]) -> list[float]:
+    old_values = list(old)
+    new_values = list(new)
+    if not old_values:
+        return normalize(new_values)
+    safe_count = max(0, int(count))
+    merged = [
+        (safe_count * old_value + new_value) / (safe_count + 1)
+        for old_value, new_value in zip(old_values, new_values)
+    ]
+    return normalize(merged)
+
+
+def unique_learning_vectors(
+    statements: Sequence[str],
+    vectors: Sequence[Sequence[float]],
+) -> list[tuple[str, list[float]]]:
+    unique: dict[str, list[float]] = {}
+    for statement, vector in zip(statements, vectors):
+        if not str(statement).strip():
+            continue
+        unique.setdefault(learning_id(statement), list(vector))
+    return sorted(unique.items(), key=lambda item: item[0])
+
+
+def build_centroids_from_learning_vectors(
+    dataset_id: str,
+    learning_vectors: Sequence[tuple[str, Sequence[float]]],
+    truth_epoch: int,
+    updated_at: int | None = None,
+    k: int = DEFAULT_K,
+) -> list[TruthCentroidPayload]:
+    if updated_at is None:
+        updated_at = int(datetime.now(timezone.utc).timestamp() * 1000)
+
+    slots: list[dict] = []
+    for _learning_id, vector in learning_vectors:
+        normalized_vector = normalize(vector)
+        if len(slots) < k:
+            slots.append({"centroid": normalized_vector, "count": 1})
+            continue
+
+        nearest_slot = max(
+            range(len(slots)),
+            key=lambda index: cosine(normalized_vector, slots[index]["centroid"]),
+        )
+        slot = slots[nearest_slot]
+        slot["centroid"] = weighted_centroid(
+            slot["centroid"],
+            slot["count"],
+            normalized_vector,
+        )
+        slot["count"] += 1
+
+    return [
+        TruthCentroidPayload(
+            dataset_id=str(dataset_id),
+            slot=slot_index,
+            count=int(slot["count"]),
+            truth_epoch=int(truth_epoch),
+            updated_at=updated_at,
+            centroid=list(slot["centroid"]),
+        )
+        for slot_index, slot in enumerate(slots[:k])
+    ]
+
+
+def centroids_changed(
+    old: Sequence[TruthCentroidPayload],
+    new: Sequence[TruthCentroidPayload],
+    tolerance: float = 1e-6,
+) -> bool:
+    if len(old) != len(new):
+        return True
+
+    old_by_slot = {centroid.slot: centroid for centroid in old}
+    for new_centroid in new:
+        old_centroid = old_by_slot.get(new_centroid.slot)
+        if old_centroid is None:
+            return True
+        if old_centroid.count != new_centroid.count:
+            return True
+        if len(old_centroid.centroid) != len(new_centroid.centroid):
+            return True
+        for old_value, new_value in zip(old_centroid.centroid, new_centroid.centroid):
+            if abs(float(old_value) - float(new_value)) > tolerance:
+                return True
+    return False
+
+
+async def load_centroids(vector_engine, dataset_id: str, k: int = DEFAULT_K):
+    centroid_ids = [str(centroid_id(str(dataset_id), slot)) for slot in range(k)]
+    rows = await vector_engine.retrieve(TRUTH_CENTROID_COLLECTION, centroid_ids)
+    centroids = []
+    for row in rows:
+        payload = getattr(row, "payload", None)
+        if not isinstance(payload, dict):
+            continue
+        centroid = TruthCentroidPayload.model_validate(payload)
+        if centroid.dataset_id == str(dataset_id):
+            centroids.append(centroid)
+    return sorted(centroids, key=lambda centroid: centroid.slot)
+
+
+async def upsert_centroids(vector_engine, centroids: Sequence[TruthCentroidPayload]) -> None:
+    if not centroids:
+        return
+    points = [
+        {
+            "id": centroid_id(centroid.dataset_id, centroid.slot),
+            "vector": centroid.centroid,
+            "payload": centroid.model_dump(),
+        }
+        for centroid in centroids
+    ]
+    await vector_engine.upsert_raw_vectors(
+        TRUTH_CENTROID_COLLECTION,
+        points,
+        payload_schema=TruthCentroidPayload,
+    )
+
+
+def _normalize_statement(statement: str) -> str:
+    return " ".join(str(statement).casefold().split())

--- a/cognee/modules/truth_subspace/centroids.py
+++ b/cognee/modules/truth_subspace/centroids.py
@@ -71,14 +71,46 @@ def build_centroids_from_learning_vectors(
     updated_at: int | None = None,
     k: int = DEFAULT_K,
 ) -> list[TruthCentroidPayload]:
+    return extend_centroids_with_learning_vectors(
+        dataset_id,
+        [],
+        learning_vectors,
+        truth_epoch=truth_epoch,
+        updated_at=updated_at,
+        k=k,
+    )
+
+
+def extend_centroids_with_learning_vectors(
+    dataset_id: str,
+    existing_centroids: Sequence[TruthCentroidPayload],
+    learning_vectors: Sequence[tuple[str, Sequence[float]]],
+    truth_epoch: int,
+    updated_at: int | None = None,
+    k: int = DEFAULT_K,
+) -> list[TruthCentroidPayload]:
     if updated_at is None:
         updated_at = int(datetime.now(timezone.utc).timestamp() * 1000)
 
-    slots: list[dict] = []
-    for _learning_id, vector in learning_vectors:
+    slots = [
+        {
+            "centroid": list(centroid.centroid),
+            "count": int(centroid.count),
+            "learning_ids": list(centroid.learning_ids),
+        }
+        for centroid in sorted(existing_centroids, key=lambda centroid: centroid.slot)[:k]
+    ]
+    seen_learning_ids = {learning_id for slot in slots for learning_id in slot["learning_ids"]}
+
+    for new_learning_id, vector in learning_vectors:
+        if new_learning_id in seen_learning_ids:
+            continue
         normalized_vector = normalize(vector)
         if len(slots) < k:
-            slots.append({"centroid": normalized_vector, "count": 1})
+            slots.append(
+                {"centroid": normalized_vector, "count": 1, "learning_ids": [new_learning_id]}
+            )
+            seen_learning_ids.add(new_learning_id)
             continue
 
         nearest_slot = max(
@@ -86,12 +118,10 @@ def build_centroids_from_learning_vectors(
             key=lambda index: cosine(normalized_vector, slots[index]["centroid"]),
         )
         slot = slots[nearest_slot]
-        slot["centroid"] = weighted_centroid(
-            slot["centroid"],
-            slot["count"],
-            normalized_vector,
-        )
+        slot["centroid"] = weighted_centroid(slot["centroid"], slot["count"], normalized_vector)
         slot["count"] += 1
+        slot["learning_ids"].append(new_learning_id)
+        seen_learning_ids.add(new_learning_id)
 
     return [
         TruthCentroidPayload(
@@ -101,8 +131,9 @@ def build_centroids_from_learning_vectors(
             truth_epoch=int(truth_epoch),
             updated_at=updated_at,
             centroid=list(slot["centroid"]),
+            learning_ids=list(slot["learning_ids"]),
         )
-        for slot_index, slot in enumerate(slots[:k])
+        for slot_index, slot in enumerate(slots)
     ]
 
 
@@ -122,6 +153,8 @@ def centroids_changed(
         if old_centroid.count != new_centroid.count:
             return True
         if len(old_centroid.centroid) != len(new_centroid.centroid):
+            return True
+        if old_centroid.learning_ids != new_centroid.learning_ids:
             return True
         for old_value, new_value in zip(old_centroid.centroid, new_centroid.centroid):
             if abs(float(old_value) - float(new_value)) > tolerance:

--- a/cognee/modules/truth_subspace/constants.py
+++ b/cognee/modules/truth_subspace/constants.py
@@ -1,0 +1,3 @@
+TRUTH_ANCHOR_COLLECTION = "TruthAnchor_statement"
+TRUTH_NODE_SET = ["session_learnings"]
+DEFAULT_K = 8

--- a/cognee/modules/truth_subspace/constants.py
+++ b/cognee/modules/truth_subspace/constants.py
@@ -1,3 +1,3 @@
-TRUTH_ANCHOR_COLLECTION = "TruthAnchor_statement"
+TRUTH_CENTROID_COLLECTION = "TruthCentroid_vector"
 TRUTH_NODE_SET = ["session_learnings"]
 DEFAULT_K = 8

--- a/cognee/modules/truth_subspace/constants.py
+++ b/cognee/modules/truth_subspace/constants.py
@@ -1,3 +1,7 @@
 TRUTH_CENTROID_COLLECTION = "TruthCentroid_vector"
 TRUTH_NODE_SET = ["session_learnings"]
 DEFAULT_K = 8
+
+
+def truth_session_node_set(session_id: str) -> str:
+    return f"session_learnings:{session_id}"

--- a/cognee/modules/truth_subspace/models.py
+++ b/cognee/modules/truth_subspace/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from pydantic import Field
 
 
 class TruthCentroidPayload(BaseModel):
@@ -8,3 +9,4 @@ class TruthCentroidPayload(BaseModel):
     truth_epoch: int
     updated_at: int
     centroid: list[float]
+    learning_ids: list[str] = Field(default_factory=list)

--- a/cognee/modules/truth_subspace/models.py
+++ b/cognee/modules/truth_subspace/models.py
@@ -1,0 +1,19 @@
+from cognee.infrastructure.engine import DataPoint
+
+
+class TruthAnchor(DataPoint):
+    """A statement that anchors the truth subspace.
+
+    The id is derived deterministically from the statement
+    (``uuid5`` of ``"TruthAnchor:<normalized statement>"``) via the
+    ``identity_fields`` mechanism on :class:`DataPoint`, so the same statement
+    always maps to the same node and ``TruthAnchor.id_for(statement)`` returns
+    that same id. ``belongs_to_set`` tagging is applied by the caller, not here.
+    """
+
+    statement: str
+
+    metadata: dict = {
+        "index_fields": ["statement"],
+        "identity_fields": ["statement"],
+    }

--- a/cognee/modules/truth_subspace/models.py
+++ b/cognee/modules/truth_subspace/models.py
@@ -1,19 +1,10 @@
-from cognee.infrastructure.engine import DataPoint
+from pydantic import BaseModel
 
 
-class TruthAnchor(DataPoint):
-    """A statement that anchors the truth subspace.
-
-    The id is derived deterministically from the statement
-    (``uuid5`` of ``"TruthAnchor:<normalized statement>"``) via the
-    ``identity_fields`` mechanism on :class:`DataPoint`, so the same statement
-    always maps to the same node and ``TruthAnchor.id_for(statement)`` returns
-    that same id. ``belongs_to_set`` tagging is applied by the caller, not here.
-    """
-
-    statement: str
-
-    metadata: dict = {
-        "index_fields": ["statement"],
-        "identity_fields": ["statement"],
-    }
+class TruthCentroidPayload(BaseModel):
+    dataset_id: str
+    slot: int
+    count: int
+    truth_epoch: int
+    updated_at: int
+    centroid: list[float]

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_truth_state.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_truth_state.py
@@ -1,0 +1,54 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
+
+
+def test_build_node_truth_state_updates_preserves_properties_and_adds_epoch():
+    adapter = LadybugAdapter.__new__(LadybugAdapter)
+    updates = adapter._build_node_truth_state_updates(
+        [{"id": "n1", "type": "DocumentChunk", "text": "hello", "feedback_weight": 0.8}],
+        {"n1": {"truth_alignment": [1.0, 0.0], "truth_epoch": 7}},
+    )
+
+    assert len(updates) == 1
+    properties = json.loads(updates[0]["properties"])
+    assert properties["text"] == "hello"
+    assert properties["feedback_weight"] == 0.8
+    assert properties["truth_alignment"] == [1.0, 0.0]
+    assert properties["truth_epoch"] == 7
+    assert "id" not in properties
+    assert "type" not in properties
+
+
+@pytest.mark.asyncio
+async def test_get_node_truth_state_returns_alignment_and_epoch():
+    adapter = LadybugAdapter.__new__(LadybugAdapter)
+    adapter.get_nodes = AsyncMock(
+        return_value=[
+            {"id": "n1", "truth_alignment": [0.1, 0.2], "truth_epoch": "3"},
+            {"id": "n2", "truth_alignment": "bad", "truth_epoch": "bad"},
+        ]
+    )
+
+    state = await adapter.get_node_truth_state(["n1", "n2"])
+
+    assert state["n1"] == {"truth_alignment": [0.1, 0.2], "truth_epoch": 3}
+    assert state["n2"] == {"truth_alignment": [], "truth_epoch": None}
+
+
+@pytest.mark.asyncio
+async def test_set_node_truth_alignments_keeps_compatibility_wrapper():
+    adapter = LadybugAdapter.__new__(LadybugAdapter)
+    adapter.get_nodes = AsyncMock(return_value=[{"id": "n1", "text": "hello"}])
+    adapter._execute_node_truth_state_updates = AsyncMock(return_value={"n1"})
+
+    result = await adapter.set_node_truth_alignments({"n1": [0.5]})
+
+    assert result == {"n1": True}
+    updates = adapter._execute_node_truth_state_updates.await_args.args[0]
+    properties = json.loads(updates[0]["properties"])
+    assert properties["truth_alignment"] == [0.5]
+    assert "truth_epoch" not in properties

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_truth_state.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_truth_state.py
@@ -37,18 +37,3 @@ async def test_get_node_truth_state_returns_alignment_and_epoch():
 
     assert state["n1"] == {"truth_alignment": [0.1, 0.2], "truth_epoch": 3}
     assert state["n2"] == {"truth_alignment": [], "truth_epoch": None}
-
-
-@pytest.mark.asyncio
-async def test_set_node_truth_alignments_keeps_compatibility_wrapper():
-    adapter = LadybugAdapter.__new__(LadybugAdapter)
-    adapter.get_nodes = AsyncMock(return_value=[{"id": "n1", "text": "hello"}])
-    adapter._execute_node_truth_state_updates = AsyncMock(return_value={"n1"})
-
-    result = await adapter.set_node_truth_alignments({"n1": [0.5]})
-
-    assert result == {"n1": True}
-    updates = adapter._execute_node_truth_state_updates.await_args.args[0]
-    properties = json.loads(updates[0]["properties"])
-    assert properties["truth_alignment"] == [0.5]
-    assert "truth_epoch" not in properties

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_raw_vectors.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_raw_vectors.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel
+
+try:
+    from cognee.infrastructure.databases.vector.lancedb.LanceDBAdapter import LanceDBAdapter
+
+    HAS_LANCEDB = True
+except ModuleNotFoundError:
+    HAS_LANCEDB = False
+
+
+class _FakeEmbeddingEngine:
+    def get_vector_size(self):
+        return 3
+
+    def get_batch_size(self):
+        return 100
+
+    async def embed_text(self, _texts):
+        raise AssertionError("raw vector upsert must not call embed_text")
+
+
+class _RawPayload(BaseModel):
+    slot: int
+    label: str
+    centroid: list[float]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_lancedb_upsert_raw_vectors_writes_and_updates_payload(tmp_path):
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+    collection = "RawCentroid_vector"
+    point_id = uuid4()
+
+    await adapter.upsert_raw_vectors(
+        collection,
+        [
+            {
+                "id": point_id,
+                "vector": [1.0, 0.0, 0.0],
+                "payload": {"slot": 0, "label": "first", "centroid": [1.0, 0.0, 0.0]},
+            }
+        ],
+        payload_schema=_RawPayload,
+    )
+    await adapter.upsert_raw_vectors(
+        collection,
+        [
+            {
+                "id": point_id,
+                "vector": [0.0, 1.0, 0.0],
+                "payload": {"slot": 0, "label": "updated", "centroid": [0.0, 1.0, 0.0]},
+            }
+        ],
+        payload_schema=_RawPayload,
+    )
+
+    retrieved = await adapter.retrieve(collection, [str(point_id)])
+    assert len(retrieved) == 1
+    assert retrieved[0].payload["label"] == "updated"
+    assert retrieved[0].payload["centroid"] == [0.0, 1.0, 0.0]
+
+    results = await adapter.search(
+        collection,
+        query_vector=[0.0, 1.0, 0.0],
+        limit=1,
+        include_payload=True,
+    )
+    assert str(results[0].id) == str(point_id)
+    assert results[0].payload["label"] == "updated"

--- a/cognee/tests/unit/modules/retrieval/hybrid/test_truth_epoch_ranking.py
+++ b/cognee/tests/unit/modules/retrieval/hybrid/test_truth_epoch_ranking.py
@@ -1,0 +1,44 @@
+from cognee.modules.retrieval.hybrid.ranking import rank_chunk_summary_pairs
+
+
+def _pair(chunk_id: str, rank: int) -> dict:
+    return {
+        "chunk": {"id": chunk_id, "text": chunk_id, "importance_weight": 0.5},
+        "chunk_id": chunk_id,
+        "bm25_rank": rank,
+        "vector_rank": None,
+        "summary_rank": None,
+    }
+
+
+def test_truth_weight_only_applies_to_current_epoch_vectors():
+    ranked = rank_chunk_summary_pairs(
+        [_pair("stale", 0), _pair("current", 1)],
+        limit=2,
+        use_importance_weight=False,
+        use_truth_weight=True,
+        q_coords=[1.0],
+        truth_state_by_id={
+            "stale": {"truth_alignment": [1.0], "truth_epoch": 1},
+            "current": {"truth_alignment": [1.0], "truth_epoch": 2},
+        },
+        current_truth_epoch=2,
+    )
+
+    assert [pair["chunk_id"] for pair in ranked] == ["current", "stale"]
+
+
+def test_truth_weight_ignores_all_vectors_when_epoch_is_unknown():
+    ranked = rank_chunk_summary_pairs(
+        [_pair("first", 0), _pair("second", 1)],
+        limit=2,
+        use_importance_weight=False,
+        use_truth_weight=True,
+        q_coords=[1.0],
+        truth_state_by_id={
+            "second": {"truth_alignment": [1.0], "truth_epoch": 2},
+        },
+        current_truth_epoch=None,
+    )
+
+    assert [pair["chunk_id"] for pair in ranked] == ["first", "second"]

--- a/cognee/tests/unit/modules/retrieval/test_hybrid_truth_context.py
+++ b/cognee/tests/unit/modules/retrieval/test_hybrid_truth_context.py
@@ -1,0 +1,60 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognee.context_global_variables import current_dataset_id
+from cognee.modules.retrieval.hybrid_retriever import HybridRetriever
+from cognee.modules.truth_subspace.models import TruthCentroidPayload
+
+
+def _unified_engine():
+    engine = MagicMock()
+    engine.vector = MagicMock()
+    engine.graph = MagicMock()
+    engine.graph.get_node_truth_state = AsyncMock(
+        return_value={"chunk-1": {"truth_alignment": [1.0], "truth_epoch": 3}}
+    )
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_truth_context_loads_exact_centroid_slots_for_current_dataset():
+    retriever = HybridRetriever(chunks_top_k=1, use_truth_weight=True)
+    retriever._unified_engine = _unified_engine()
+    centroid_loader = AsyncMock(
+        return_value=[
+            TruthCentroidPayload(
+                dataset_id="dataset-1",
+                slot=0,
+                count=1,
+                truth_epoch=3,
+                updated_at=123,
+                centroid=[1.0, 0.0, 0.0],
+            )
+        ]
+    )
+    token = current_dataset_id.set("dataset-1")
+
+    try:
+        with (
+            patch(
+                "cognee.modules.retrieval.hybrid_retriever.load_centroids",
+                centroid_loader,
+            ),
+            patch.object(
+                retriever,
+                "_candidate_chunk_ids",
+                new=AsyncMock(return_value=["chunk-1"]),
+            ),
+        ):
+            q_coords, truth_state_by_id, current_truth_epoch = await retriever._build_truth_context(
+                [1.0, 0.0, 0.0]
+            )
+    finally:
+        current_dataset_id.reset(token)
+
+    centroid_loader.assert_awaited_once_with(retriever._unified_engine.vector, "dataset-1")
+    retriever._unified_engine.graph.get_node_truth_state.assert_awaited_once_with(["chunk-1"])
+    assert q_coords == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    assert truth_state_by_id == {"chunk-1": {"truth_alignment": [1.0], "truth_epoch": 3}}
+    assert current_truth_epoch == 3

--- a/cognee/tests/unit/modules/session_distillation/test_distillation_helpers.py
+++ b/cognee/tests/unit/modules/session_distillation/test_distillation_helpers.py
@@ -5,7 +5,7 @@ are tested directly with fixtures — no LLM, cache, or vector engine involved.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -281,6 +281,28 @@ class TestRenderLessonDocument:
         )
         assert "Plain statement.\n" in document
         assert "()" not in document
+
+    @pytest.mark.asyncio
+    async def test_publish_tags_lessons_with_global_and_session_node_sets(self):
+        scope = SimpleNamespace(
+            session_id="s-1",
+            dataset=SimpleNamespace(id=uuid4()),
+            user=SimpleNamespace(id=uuid4()),
+        )
+        add = AsyncMock()
+        cognify = AsyncMock()
+
+        with (
+            patch("cognee.api.v1.add.add", add),
+            patch("cognee.api.v1.cognify.cognify", cognify),
+        ):
+            await distill_module.publish_distilled_lessons(
+                scope,
+                [WrittenLesson(accept=True, statement="Keep reports concise.")],
+            )
+
+        assert add.await_args.kwargs["node_set"] == ["session_learnings", "session_learnings:s-1"]
+        cognify.assert_awaited_once_with(datasets=[scope.dataset.id], user=scope.user)
 
 
 class TestBuildWriterInput:

--- a/cognee/tests/unit/test_context_global_variables.py
+++ b/cognee/tests/unit/test_context_global_variables.py
@@ -1,0 +1,21 @@
+from uuid import uuid4
+
+import pytest
+
+from cognee.context_global_variables import (
+    current_dataset_id,
+    set_database_global_context_variables,
+)
+
+
+@pytest.mark.asyncio
+async def test_database_context_sets_and_resets_current_dataset_id(monkeypatch):
+    dataset_id = uuid4()
+    user_id = uuid4()
+    current_dataset_id.set("outer")
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+
+    async with set_database_global_context_variables(dataset_id, user_id):
+        assert current_dataset_id.get() == str(dataset_id)
+
+    assert current_dataset_id.get() == "outer"

--- a/cognee/tests/unit/truth_subspace/test_align.py
+++ b/cognee/tests/unit/truth_subspace/test_align.py
@@ -105,7 +105,7 @@ def test_stable_signature_stability():
     sig1 = align.stable_signature(ids)
     sig2 = align.stable_signature(ids)
     assert sig1 == sig2
-    assert len(sig1) == 40  # sha1 hex digest
+    assert len(sig1) == 64  # sha256 hex digest
 
 
 def test_stable_signature_order_sensitive():

--- a/cognee/tests/unit/truth_subspace/test_align.py
+++ b/cognee/tests/unit/truth_subspace/test_align.py
@@ -29,22 +29,22 @@ def test_cosine_empty_vector_returns_zero():
     assert align.cosine([1.0], []) == 0.0
 
 
-def test_node_coords_per_anchor():
-    anchors = [[1.0, 0.0], [0.0, 1.0]]
-    coords = align.node_coords([1.0, 0.0], anchors)
+def test_node_coords_per_basis_vector():
+    basis = [[1.0, 0.0], [0.0, 1.0]]
+    coords = align.node_coords([1.0, 0.0], basis)
     assert coords == [1.0, 0.0]
 
 
-def test_node_coords_zero_pad_to_anchor_count():
-    anchors = [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
-    coords = align.node_coords([0.0, 0.0], anchors)
-    assert len(coords) == len(anchors)
+def test_node_coords_zero_pad_to_basis_count():
+    basis = [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+    coords = align.node_coords([0.0, 0.0], basis)
+    assert len(coords) == len(basis)
     assert coords == [0.0, 0.0, 0.0]
 
 
 def test_query_coords_matches_node_coords():
-    anchors = [[1.0, 0.0], [0.0, 1.0]]
-    assert align.query_coords([0.0, 1.0], anchors) == align.node_coords([0.0, 1.0], anchors)
+    basis = [[1.0, 0.0], [0.0, 1.0]]
+    assert align.query_coords([0.0, 1.0], basis) == align.node_coords([0.0, 1.0], basis)
 
 
 def test_truth_factor_neutral_when_coords_missing():
@@ -69,8 +69,8 @@ def test_truth_score_neutral_cases():
 
 
 def test_truth_score_weighted_alignment():
-    # Query-relevance-weighted average of the node's per-anchor alignment.
-    # Only the first anchor has weight here, so the node's first coord wins.
+    # Query-relevance-weighted average of the node's per-direction alignment.
+    # Only the first direction has weight here, so the node's first coord wins.
     assert math.isclose(align.truth_score([1.0, 0.0], [1.0, 0.0]), 1.0, rel_tol=1e-9)
     assert math.isclose(align.truth_score([0.5, 0.0], [1.0, 0.0]), 0.5, rel_tol=1e-9)
     # Equal weights -> plain mean of the node coords.
@@ -78,7 +78,7 @@ def test_truth_score_weighted_alignment():
 
 
 def test_truth_score_is_magnitude_sensitive():
-    # The whole point: a node aligned MORE strongly with the anchors scores higher,
+    # The whole point: a node aligned MORE strongly with the directions scores higher,
     # even though both point the same direction (cosine would call them equal).
     q = [0.3, 0.3]
     assert align.truth_score([0.4, 0.4], q) > align.truth_score([0.2, 0.2], q)
@@ -100,50 +100,13 @@ def test_truth_factor_within_bounds():
     assert math.isclose(align.truth_factor([0.0, 0.0], [1.0, 1.0]), 0.75, rel_tol=1e-9)
 
 
-def test_active_anchor_order_recency():
-    anchors = [
-        {"id": "a", "created_at": 100},
-        {"id": "b", "created_at": 300},
-        {"id": "c", "created_at": 200},
-    ]
-    ordered = align.active_anchor_order(anchors, 2)
-    assert [a["id"] for a in ordered] == ["b", "c"]
-
-
-def test_active_anchor_order_tiebreak_by_id():
-    anchors = [
-        {"id": "z", "created_at": 100},
-        {"id": "a", "created_at": 100},
-        {"id": "m", "created_at": 100},
-    ]
-    ordered = align.active_anchor_order(anchors, 3)
-    assert [a["id"] for a in ordered] == ["a", "m", "z"]
-
-
-def test_active_anchor_order_takes_k():
-    anchors = [{"id": str(i), "created_at": i} for i in range(20)]
-    ordered = align.active_anchor_order(anchors, 8)
-    assert len(ordered) == 8
-
-
-def test_active_anchor_order_supports_attribute_objects():
-    class _Anchor:
-        def __init__(self, anchor_id, created_at):
-            self.id = anchor_id
-            self.created_at = created_at
-
-    anchors = [_Anchor("a", 100), _Anchor("b", 200)]
-    ordered = align.active_anchor_order(anchors, 1)
-    assert ordered[0].id == "b"
-
-
-def test_anchor_signature_stability():
+def test_stable_signature_stability():
     ids = ["a", "b", "c"]
-    sig1 = align.anchor_signature(ids)
-    sig2 = align.anchor_signature(ids)
+    sig1 = align.stable_signature(ids)
+    sig2 = align.stable_signature(ids)
     assert sig1 == sig2
     assert len(sig1) == 40  # sha1 hex digest
 
 
-def test_anchor_signature_order_sensitive():
-    assert align.anchor_signature(["a", "b"]) != align.anchor_signature(["b", "a"])
+def test_stable_signature_order_sensitive():
+    assert align.stable_signature(["a", "b"]) != align.stable_signature(["b", "a"])

--- a/cognee/tests/unit/truth_subspace/test_align.py
+++ b/cognee/tests/unit/truth_subspace/test_align.py
@@ -1,0 +1,149 @@
+import math
+
+import cognee.modules.truth_subspace.align as align
+
+
+def test_cosine_identical_vectors():
+    assert align.cosine([1.0, 0.0], [1.0, 0.0]) == 1.0
+
+
+def test_cosine_orthogonal_vectors():
+    assert align.cosine([1.0, 0.0], [0.0, 1.0]) == 0.0
+
+
+def test_cosine_opposite_vectors():
+    assert align.cosine([1.0, 0.0], [-1.0, 0.0]) == -1.0
+
+
+def test_cosine_scale_invariant():
+    assert math.isclose(align.cosine([1.0, 1.0], [2.0, 2.0]), 1.0, rel_tol=1e-9)
+
+
+def test_cosine_zero_vector_returns_zero():
+    assert align.cosine([0.0, 0.0], [1.0, 1.0]) == 0.0
+    assert align.cosine([1.0, 1.0], [0.0, 0.0]) == 0.0
+
+
+def test_cosine_empty_vector_returns_zero():
+    assert align.cosine([], [1.0]) == 0.0
+    assert align.cosine([1.0], []) == 0.0
+
+
+def test_node_coords_per_anchor():
+    anchors = [[1.0, 0.0], [0.0, 1.0]]
+    coords = align.node_coords([1.0, 0.0], anchors)
+    assert coords == [1.0, 0.0]
+
+
+def test_node_coords_zero_pad_to_anchor_count():
+    anchors = [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+    coords = align.node_coords([0.0, 0.0], anchors)
+    assert len(coords) == len(anchors)
+    assert coords == [0.0, 0.0, 0.0]
+
+
+def test_query_coords_matches_node_coords():
+    anchors = [[1.0, 0.0], [0.0, 1.0]]
+    assert align.query_coords([0.0, 1.0], anchors) == align.node_coords([0.0, 1.0], anchors)
+
+
+def test_truth_factor_neutral_when_coords_missing():
+    # NEUTRAL: empty coords => factor exactly 1.0
+    assert align.truth_factor([], []) == 1.0
+    assert align.truth_factor([0.1], []) == 1.0
+    assert align.truth_factor([], [0.1]) == 1.0
+
+
+def test_truth_factor_neutral_when_coords_zero():
+    # Zero coord vectors => cosine 0.0 => score 0.5 => factor 1.0
+    assert align.truth_factor([0.0, 0.0], [0.0, 0.0]) == 1.0
+
+
+def test_truth_score_neutral_cases():
+    # NEUTRAL (0.5): empty coords, or a query with no positive weight to spread.
+    assert align.truth_score([], []) == 0.5
+    assert align.truth_score([0.0, 0.0], [0.0, 0.0]) == 0.5
+    assert align.truth_score([1.0, 1.0], [0.0, 0.0]) == 0.5
+    # Negative query coords contribute no weight -> still neutral.
+    assert align.truth_score([1.0, 1.0], [-1.0, 0.0]) == 0.5
+
+
+def test_truth_score_weighted_alignment():
+    # Query-relevance-weighted average of the node's per-anchor alignment.
+    # Only the first anchor has weight here, so the node's first coord wins.
+    assert math.isclose(align.truth_score([1.0, 0.0], [1.0, 0.0]), 1.0, rel_tol=1e-9)
+    assert math.isclose(align.truth_score([0.5, 0.0], [1.0, 0.0]), 0.5, rel_tol=1e-9)
+    # Equal weights -> plain mean of the node coords.
+    assert math.isclose(align.truth_score([0.2, 0.8], [0.5, 0.5]), 0.5, rel_tol=1e-9)
+
+
+def test_truth_score_is_magnitude_sensitive():
+    # The whole point: a node aligned MORE strongly with the anchors scores higher,
+    # even though both point the same direction (cosine would call them equal).
+    q = [0.3, 0.3]
+    assert align.truth_score([0.4, 0.4], q) > align.truth_score([0.2, 0.2], q)
+
+
+def test_truth_factor_within_bounds():
+    cases = [
+        ([1.0, 0.0], [1.0, 0.0]),
+        ([0.0, 0.0], [1.0, 1.0]),
+        ([1.0, 1.0], [1.0, 0.0]),
+        ([0.3, 0.7, 0.1], [0.2, 0.9, 0.4]),
+    ]
+    for nc, qc in cases:
+        factor = align.truth_factor(nc, qc)
+        assert 0.75 <= factor <= 1.25
+
+    # Extremes hit the bounds exactly.
+    assert math.isclose(align.truth_factor([1.0, 0.0], [1.0, 0.0]), 1.25, rel_tol=1e-9)
+    assert math.isclose(align.truth_factor([0.0, 0.0], [1.0, 1.0]), 0.75, rel_tol=1e-9)
+
+
+def test_active_anchor_order_recency():
+    anchors = [
+        {"id": "a", "created_at": 100},
+        {"id": "b", "created_at": 300},
+        {"id": "c", "created_at": 200},
+    ]
+    ordered = align.active_anchor_order(anchors, 2)
+    assert [a["id"] for a in ordered] == ["b", "c"]
+
+
+def test_active_anchor_order_tiebreak_by_id():
+    anchors = [
+        {"id": "z", "created_at": 100},
+        {"id": "a", "created_at": 100},
+        {"id": "m", "created_at": 100},
+    ]
+    ordered = align.active_anchor_order(anchors, 3)
+    assert [a["id"] for a in ordered] == ["a", "m", "z"]
+
+
+def test_active_anchor_order_takes_k():
+    anchors = [{"id": str(i), "created_at": i} for i in range(20)]
+    ordered = align.active_anchor_order(anchors, 8)
+    assert len(ordered) == 8
+
+
+def test_active_anchor_order_supports_attribute_objects():
+    class _Anchor:
+        def __init__(self, anchor_id, created_at):
+            self.id = anchor_id
+            self.created_at = created_at
+
+    anchors = [_Anchor("a", 100), _Anchor("b", 200)]
+    ordered = align.active_anchor_order(anchors, 1)
+    assert ordered[0].id == "b"
+
+
+def test_anchor_signature_stability():
+    ids = ["a", "b", "c"]
+    sig1 = align.anchor_signature(ids)
+    sig2 = align.anchor_signature(ids)
+    assert sig1 == sig2
+    assert len(sig1) == 40  # sha1 hex digest
+
+
+def test_anchor_signature_order_sensitive():
+    assert align.anchor_signature(["a", "b"]) != align.anchor_signature(["b", "a"])

--- a/cognee/tests/unit/truth_subspace/test_build_centroid_slots.py
+++ b/cognee/tests/unit/truth_subspace/test_build_centroid_slots.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.truth_subspace.build import build_truth_subspace
+
+
+class _EmbeddingEngine:
+    async def embed_text(self, texts):
+        vectors_by_text = {
+            "alpha": [1.0, 0.0],
+            "beta": [0.0, 1.0],
+            "alpha corpus": [1.0, 0.0],
+        }
+        return [vectors_by_text[text] for text in texts]
+
+
+@pytest.mark.asyncio
+async def test_build_truth_subspace_writes_centroids_and_epoch_state(monkeypatch):
+    dataset = SimpleNamespace(id=uuid4(), owner_id=uuid4())
+    user = SimpleNamespace(id=uuid4())
+    vector_engine = MagicMock()
+    vector_engine.retrieve = AsyncMock(return_value=[])
+    vector_engine.upsert_raw_vectors = AsyncMock()
+
+    graph_engine = MagicMock()
+    graph_engine.get_nodeset_subgraph = AsyncMock(
+        return_value=(
+            [
+                ("learning-1", {"type": "DocumentChunk", "text": "alpha"}),
+                ("learning-2", {"type": "DocumentChunk", "text": "beta"}),
+            ],
+            [],
+        )
+    )
+    graph_engine.get_graph_data = AsyncMock(
+        return_value=(
+            [
+                ("chunk-1", {"type": "DocumentChunk", "text": "alpha corpus"}),
+            ],
+            [],
+        )
+    )
+    graph_engine.set_node_truth_state = AsyncMock(return_value={"chunk-1": True})
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+
+    with (
+        patch(
+            "cognee.modules.truth_subspace.build.get_authorized_existing_datasets",
+            new=AsyncMock(return_value=[dataset]),
+        ),
+        patch("cognee.modules.truth_subspace.build.get_vector_engine", return_value=vector_engine),
+        patch(
+            "cognee.modules.truth_subspace.build.get_graph_engine",
+            new=AsyncMock(return_value=graph_engine),
+        ),
+        patch(
+            "cognee.modules.truth_subspace.build.get_embedding_engine",
+            return_value=_EmbeddingEngine(),
+        ),
+    ):
+        result = await build_truth_subspace(dataset.id, session_ids=None, user=user)
+
+    assert result["anchors"] == 2
+    assert result["nodes_scored"] == 1
+    assert result["truth_epoch"] == 1
+    vector_engine.upsert_raw_vectors.assert_awaited_once()
+    graph_engine.set_node_truth_state.assert_awaited_once()
+
+    node_state = graph_engine.set_node_truth_state.await_args.args[0]
+    assert node_state["chunk-1"]["truth_epoch"] == 1
+    assert len(node_state["chunk-1"]["truth_alignment"]) == 8
+    assert sorted(node_state["chunk-1"]["truth_alignment"][:2]) == [0.0, 1.0]
+    assert node_state["chunk-1"]["truth_alignment"][2:] == [0.0] * 6

--- a/cognee/tests/unit/truth_subspace/test_build_centroid_slots.py
+++ b/cognee/tests/unit/truth_subspace/test_build_centroid_slots.py
@@ -17,8 +17,7 @@ class _EmbeddingEngine:
         return [vectors_by_text[text] for text in texts]
 
 
-@pytest.mark.asyncio
-async def test_build_truth_subspace_writes_centroids_and_epoch_state(monkeypatch):
+async def _run_build(monkeypatch, session_ids=None):
     dataset = SimpleNamespace(id=uuid4(), owner_id=uuid4())
     user = SimpleNamespace(id=uuid4())
     vector_engine = MagicMock()
@@ -61,7 +60,14 @@ async def test_build_truth_subspace_writes_centroids_and_epoch_state(monkeypatch
             return_value=_EmbeddingEngine(),
         ),
     ):
-        result = await build_truth_subspace(dataset.id, session_ids=None, user=user)
+        result = await build_truth_subspace(dataset.id, session_ids=session_ids, user=user)
+
+    return result, vector_engine, graph_engine
+
+
+@pytest.mark.asyncio
+async def test_build_truth_subspace_writes_centroids_and_epoch_state(monkeypatch):
+    result, vector_engine, graph_engine = await _run_build(monkeypatch)
 
     assert result["anchors"] == 2
     assert result["nodes_scored"] == 1
@@ -74,3 +80,16 @@ async def test_build_truth_subspace_writes_centroids_and_epoch_state(monkeypatch
     assert len(node_state["chunk-1"]["truth_alignment"]) == 8
     assert sorted(node_state["chunk-1"]["truth_alignment"][:2]) == [0.0, 1.0]
     assert node_state["chunk-1"]["truth_alignment"][2:] == [0.0] * 6
+
+
+@pytest.mark.asyncio
+async def test_build_truth_subspace_filters_learning_sets_by_session_ids(monkeypatch):
+    _result, _vector_engine, graph_engine = await _run_build(
+        monkeypatch, session_ids=["s-1", "s-2"]
+    )
+
+    graph_engine.get_nodeset_subgraph.assert_awaited_once()
+    assert graph_engine.get_nodeset_subgraph.await_args.kwargs["node_name"] == [
+        "session_learnings:s-1",
+        "session_learnings:s-2",
+    ]

--- a/cognee/tests/unit/truth_subspace/test_centroids.py
+++ b/cognee/tests/unit/truth_subspace/test_centroids.py
@@ -7,6 +7,7 @@ from cognee.modules.truth_subspace.centroids import (
     build_centroids_from_learning_vectors,
     centroid_id,
     centroids_changed,
+    extend_centroids_with_learning_vectors,
     learning_id,
     normalize,
     pad_coords,
@@ -71,6 +72,37 @@ def test_build_centroids_is_deterministic_for_same_inputs():
 
     assert [centroid.centroid for centroid in first] == [centroid.centroid for centroid in second]
     assert [centroid.count for centroid in first] == [centroid.count for centroid in second]
+
+
+def test_extend_centroids_adds_new_learning_ids_without_double_counting():
+    existing = build_centroids_from_learning_vectors(
+        "dataset-1",
+        [("a", [1.0, 0.0])],
+        truth_epoch=1,
+        updated_at=123,
+        k=2,
+    )
+
+    first = extend_centroids_with_learning_vectors(
+        "dataset-1",
+        existing,
+        [("a", [1.0, 0.0]), ("b", [0.0, 1.0])],
+        truth_epoch=2,
+        updated_at=456,
+        k=2,
+    )
+    second = extend_centroids_with_learning_vectors(
+        "dataset-1",
+        first,
+        [("b", [0.0, 1.0])],
+        truth_epoch=3,
+        updated_at=789,
+        k=2,
+    )
+
+    assert sum(centroid.count for centroid in first) == 2
+    assert [centroid.learning_ids for centroid in first] == [["a"], ["b"]]
+    assert [centroid.count for centroid in second] == [centroid.count for centroid in first]
 
 
 def test_centroids_changed_ignores_epoch_only_changes():

--- a/cognee/tests/unit/truth_subspace/test_centroids.py
+++ b/cognee/tests/unit/truth_subspace/test_centroids.py
@@ -1,0 +1,93 @@
+import math
+from uuid import UUID
+
+import pytest
+
+from cognee.modules.truth_subspace.centroids import (
+    build_centroids_from_learning_vectors,
+    centroid_id,
+    centroids_changed,
+    learning_id,
+    normalize,
+    pad_coords,
+    unique_learning_vectors,
+    weighted_centroid,
+)
+
+
+def test_centroid_id_is_deterministic_uuid():
+    first = centroid_id("dataset-1", 0)
+    second = centroid_id("dataset-1", 0)
+    assert first == second
+    assert isinstance(first, UUID)
+    assert first != centroid_id("dataset-1", 1)
+
+
+def test_learning_id_normalizes_whitespace_and_case():
+    assert learning_id(" Coffee  Matters ") == learning_id("coffee matters")
+
+
+def test_normalize_zero_vector_preserves_shape():
+    assert normalize([0.0, 0.0, 0.0]) == [0.0, 0.0, 0.0]
+
+
+def test_pad_coords_keeps_fixed_slot_count():
+    assert pad_coords([0.1, 0.2], k=4) == [0.1, 0.2, 0.0, 0.0]
+    assert pad_coords([0.1, 0.2, 0.3], k=2) == [0.1, 0.2]
+
+
+def test_weighted_centroid_updates_toward_new_vector():
+    updated = weighted_centroid([1.0, 0.0], 1, [0.0, 1.0])
+    assert math.isclose(updated[0], updated[1], rel_tol=1e-9)
+
+
+def test_unique_learning_vectors_deduplicates_by_statement_text():
+    pairs = unique_learning_vectors(
+        ["Coffee matters", " coffee   matters ", "Tea matters"],
+        [[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]],
+    )
+    assert len(pairs) == 2
+
+
+def test_build_centroids_creates_slots_until_limit():
+    learning_vectors = [(str(index), [1.0, float(index), 0.0]) for index in range(10)]
+    centroids = build_centroids_from_learning_vectors(
+        "dataset-1",
+        learning_vectors,
+        truth_epoch=3,
+        updated_at=123,
+        k=8,
+    )
+
+    assert [centroid.slot for centroid in centroids] == list(range(8))
+    assert all(centroid.truth_epoch == 3 for centroid in centroids)
+    assert sum(centroid.count for centroid in centroids) == 10
+
+
+def test_build_centroids_is_deterministic_for_same_inputs():
+    learning_vectors = [(str(index), [1.0, float(index), 0.0]) for index in range(10)]
+    first = build_centroids_from_learning_vectors("dataset-1", learning_vectors, 1, 123)
+    second = build_centroids_from_learning_vectors("dataset-1", learning_vectors, 9, 123)
+
+    assert [centroid.centroid for centroid in first] == [centroid.centroid for centroid in second]
+    assert [centroid.count for centroid in first] == [centroid.count for centroid in second]
+
+
+def test_centroids_changed_ignores_epoch_only_changes():
+    learning_vectors = [("a", [1.0, 0.0]), ("b", [0.0, 1.0])]
+    old = build_centroids_from_learning_vectors("dataset-1", learning_vectors, 1, 123)
+    new = build_centroids_from_learning_vectors("dataset-1", learning_vectors, 2, 123)
+
+    assert centroids_changed(old, new) is False
+
+
+def test_centroids_changed_detects_count_or_vector_changes():
+    old = build_centroids_from_learning_vectors("dataset-1", [("a", [1.0, 0.0])], 1, 123)
+    new = build_centroids_from_learning_vectors(
+        "dataset-1",
+        [("a", [1.0, 0.0]), ("b", [0.0, 1.0])],
+        1,
+        123,
+    )
+
+    assert centroids_changed(old, new) is True

--- a/examples/demos/truth_centroid_slots_demo.py
+++ b/examples/demos/truth_centroid_slots_demo.py
@@ -1,0 +1,258 @@
+"""End-to-end demo of truth centroid slots changing HybridRetriever ranking.
+
+This demo uses real cognee ingestion, cognification, vector search, graph state,
+and embeddings. It skips only the live session flow: instead, it writes distilled
+learnings directly into the ``session_learnings`` node set.
+
+Run from the repository root:
+
+    uv run python examples/demos/truth_centroid_slots_demo.py
+"""
+
+import asyncio
+import os
+import pathlib
+import sys
+
+os.environ.setdefault("COGNEE_CLI_MODE", "true")
+os.environ.setdefault("COGNEE_LOG_FILE", "false")
+os.environ.setdefault("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+os.environ.setdefault("LOG_LEVEL", "ERROR")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import cognee
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector.embeddings.get_embedding_engine import (
+    get_embedding_engine,
+)
+from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.retrieval.hybrid.results import payload
+from cognee.modules.retrieval.hybrid_retriever import HybridRetriever
+from cognee.modules.truth_subspace import align
+from cognee.modules.truth_subspace.build import build_truth_subspace
+from cognee.modules.truth_subspace.centroids import load_centroids
+from cognee.modules.users.methods import get_default_user
+
+
+DATASET = "truth_centroid_slots_demo"
+CORPUS_NODE_SET = ["truth_demo_corpus"]
+LEARNINGS_NODE_SET = ["session_learnings"]
+K = 2
+
+QUERY = "How should I prepare a warm drink at home?"
+
+DOCUMENTS = [
+    "Home warm drink preparation guide for coffee: grind size, bloom time, and water temperature.",  # A
+    "Home warm drink preparation guide for espresso: dose, pressure, extraction time, and crema.",  # B
+    "Home warm drink preparation guide for green tea: steeping time, cooler water, and bitter notes.",  # C
+    "Home warm drink preparation guide for herbal tea: chamomile, mint, flowers, and longer steeping.",  # D
+]
+
+LEARNING_BATCHES = [
+    (
+        "Batch 1: accepted coffee learnings",
+        [
+            "# Session learning — 2026-06-26 (session demo-coffee)\n\nThe user cares about coffee brewing, espresso extraction, grind size, and pour-over technique. (Learned while resolving a warm drink recommendation where coffee details were preferred.)",
+            "# Session learning — 2026-06-26 (session demo-coffee)\n\nFor this user, coffee preparation details should be preferred over tea background. (Learned while comparing coffee and tea guidance for the same user intent.)",
+        ],
+    ),
+    (
+        "Batch 2: accepted tea learnings",
+        [
+            "# Session learning — 2026-06-26 (session demo-tea)\n\nThe user is now focused on tea steeping, herbal infusions, chamomile, and water temperature. (Learned after the user's warm drink questions shifted toward tea preparation.)",
+            "# Session learning — 2026-06-26 (session demo-tea)\n\nFor this user, tea preparation details should be preferred for warm drink questions. (Learned while revising the durable preference from later session evidence.)",
+        ],
+    ),
+]
+
+
+def configure_demo_storage() -> None:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    cognee.config.set_graph_database_provider("kuzu")
+    cognee.config.set_vector_db_provider("lancedb")
+    cognee.config.system_root_directory(str(repo_root / ".cognee_system/truth_slots_demo"))
+    cognee.config.data_root_directory(str(repo_root / ".data_storage/truth_slots_demo"))
+
+
+async def hybrid_order(dataset_obj, use_truth_weight: bool) -> list[str]:
+    async with set_database_global_context_variables(dataset_obj.id, dataset_obj.owner_id):
+        retriever = HybridRetriever(
+            chunks_top_k=len(DOCUMENTS),
+            entities_top_k=0,
+            facts_top_k=0,
+            text_summaries_top_k=0,
+            node_name=CORPUS_NODE_SET,
+            use_truth_weight=use_truth_weight,
+        )
+        retrieved = await retriever.get_retrieved_objects(query=QUERY)
+    return [
+        _label_for_text(payload(chunk).get("text", "")) for chunk in retrieved.get("chunks", [])
+    ]
+
+
+async def graph_truth_table(dataset_obj):
+    async with set_database_global_context_variables(dataset_obj.id, dataset_obj.owner_id):
+        vector_engine = get_vector_engine()
+        graph_engine = await get_graph_engine()
+        centroids = await load_centroids(vector_engine, str(dataset_obj.id), K)
+        nodes, _edges = await graph_engine.get_graph_data()
+
+        labeled_node_ids = []
+        for node_id, node_data in nodes:
+            if not isinstance(node_data, dict) or node_data.get("type") != DocumentChunk.__name__:
+                continue
+            label = _label_for_text(str(node_data.get("text") or ""))
+            if label == "?":
+                continue
+            labeled_node_ids.append((str(node_id), label))
+
+        node_ids = [node_id for node_id, _label in labeled_node_ids]
+        truth_state = await graph_engine.get_node_truth_state(node_ids)
+        rows = []
+        for node_id, label in labeled_node_ids:
+            state = truth_state.get(node_id, {})
+            coords = list(state.get("truth_alignment") or [])
+            rows.append(
+                {
+                    "label": label,
+                    "slot_0": coords[0] if len(coords) > 0 else None,
+                    "slot_1": coords[1] if len(coords) > 1 else None,
+                    "epoch": state.get("truth_epoch"),
+                }
+            )
+
+    rows.sort(key=lambda row: row["label"])
+    return centroids, rows
+
+
+def _label_for_text(text: str) -> str:
+    normalized = " ".join(text.split())
+    for index, document in enumerate(DOCUMENTS):
+        document_text = " ".join(document.split())
+        if document_text in normalized or normalized in document_text:
+            return chr(65 + index)
+    return "?"
+
+
+def print_documents() -> None:
+    print("Documents")
+    print("---------")
+    for index, document in enumerate(DOCUMENTS):
+        print(f"{chr(65 + index)}. {document}")
+
+
+def print_order(title: str, order: list[str]) -> None:
+    print(f"\n{title}")
+    print("-" * len(title))
+    print(" > ".join(order) if order else "[no chunks retrieved]")
+
+
+async def slot_summaries(centroids, learning_texts: list[str]) -> dict[int, str]:
+    if not learning_texts:
+        return {}
+
+    embedding_engine = get_embedding_engine()
+    learning_vectors = await embedding_engine.embed_text(learning_texts)
+    summaries = {}
+    for centroid in centroids:
+        nearest_index = max(
+            range(len(learning_vectors)),
+            key=lambda index: align.cosine(centroid.centroid, learning_vectors[index]),
+        )
+        summaries[centroid.slot] = _shorten(learning_texts[nearest_index], 72)
+    return summaries
+
+
+def print_slots(centroids, summaries: dict[int, str]) -> None:
+    print("\nTruth slots")
+    print("-----------")
+    for slot in range(K):
+        centroid = next((item for item in centroids if item.slot == slot), None)
+        if centroid is None:
+            print(f"slot {slot}: [empty]")
+            continue
+        summary = summaries.get(slot, "[no nearest learning]")
+        print(f"slot {slot}: count={centroid.count} epoch={centroid.truth_epoch}")
+        print(f"        nearest learning: {summary}")
+
+
+def print_truth_table(rows: list[dict]) -> None:
+    print("\nGraph values stored on DocumentChunk nodes")
+    print("-----------------------------------------")
+    print("doc | slot 0 | slot 1 | epoch")
+    print("----|--------|--------|------")
+    for row in rows:
+        slot_0 = _format_coord(row["slot_0"])
+        slot_1 = _format_coord(row["slot_1"])
+        print(f"{row['label']}   | {slot_0:>6} | {slot_1:>6} | {row['epoch']}")
+
+
+def _format_coord(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.3f}"
+
+
+def _shorten(text: str, limit: int) -> str:
+    value = " ".join(text.split())
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3] + "..."
+
+
+async def main() -> None:
+    configure_demo_storage()
+    print("Resetting isolated demo store...")
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    print_documents()
+    print(f"\nQuery: {QUERY}")
+
+    print("\nIngesting documents A-D and running cognify...")
+    await cognee.add(DOCUMENTS, dataset_name=DATASET, node_set=CORPUS_NODE_SET)
+    await cognee.cognify(datasets=[DATASET])
+    user = await get_default_user()
+    datasets = await get_authorized_existing_datasets([DATASET], "write", user)
+    dataset_obj = datasets[0]
+
+    print_order("Baseline HybridRetriever order", await hybrid_order(dataset_obj, False))
+
+    accepted_learnings = []
+    for title, learnings in LEARNING_BATCHES:
+        print("\n" + title)
+        print("=" * len(title))
+        accepted_learnings.extend(learnings)
+        for learning in learnings:
+            print(f"learning: {learning}")
+
+        print("Cognifying learnings and rebuilding truth slots...")
+        await cognee.add(learnings, dataset_name=DATASET, node_set=LEARNINGS_NODE_SET)
+        await cognee.cognify(datasets=[DATASET])
+        result = await build_truth_subspace(
+            dataset=DATASET,
+            session_ids=None,
+            user=user,
+            k=K,
+        )
+        print(
+            f"build result: slots={result['anchors']} "
+            f"nodes_scored={result['nodes_scored']} epoch={result['truth_epoch']}"
+        )
+
+        centroids, rows = await graph_truth_table(dataset_obj)
+        summaries = await slot_summaries(centroids, accepted_learnings)
+        print_slots(centroids, summaries)
+        print_truth_table(rows)
+        print_order(
+            "HybridRetriever order with truth weighting",
+            await hybrid_order(dataset_obj, True),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/truth_subspace_reranking_demo.py
+++ b/examples/python/truth_subspace_reranking_demo.py
@@ -1,0 +1,177 @@
+"""Truth-Subspace Reranking — runnable demo.
+
+What it shows
+-------------
+A finished "session" teaches the system a preference (here: the user cares about
+*coffee*, not tea). We distill that into a **truth subspace** (anchor vectors built
+from the lessons), project every corpus chunk onto it, and store the per-chunk
+coordinates on the graph node. At query time the HYBRID retriever reads those
+coordinates and nudges ranking toward the learned preference.
+
+The demo retrieves the SAME ambiguous query twice — once with truth weighting OFF
+(exact baseline) and once ON — and prints a side-by-side rank diff so you can see
+the coffee chunks rise.
+
+Requirements
+------------
+- An LLM + embeddings provider configured (e.g. LLM_API_KEY in your .env). cognify
+  and retrieval call the embedding/LLM APIs.
+
+Run it
+------
+    python examples/python/truth_subspace_reranking_demo.py
+
+It uses a dedicated dataset ("truth_subspace_demo") and does NOT prune, so it will
+not touch your other cognee data. Re-running is safe (adds are content-addressed,
+the subspace build is a full recompute).
+"""
+
+import asyncio
+import os
+import sys
+
+# Run against THIS checkout of cognee even if a different copy is pip-installed,
+# so the truth-subspace code in this working tree is the one that executes.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import cognee
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.retrieval.hybrid.results import payload, result_id
+from cognee.modules.retrieval.hybrid_retriever import HybridRetriever
+from cognee.modules.truth_subspace.build import build_truth_subspace
+from cognee.modules.users.methods import get_default_user
+
+DATASET = "truth_subspace_demo"
+CORPUS_NODE_SET = ["beverages"]
+LESSONS_NODE_SET = ["session_learnings"]  # the node set build_truth_subspace reads anchors from
+
+# A small two-theme corpus. Each short doc becomes its own chunk.
+CORPUS = [
+    "Espresso is brewed by forcing hot water through finely ground coffee under high pressure.",
+    "A pour-over coffee drips a slow stream of hot water over a paper filter of ground coffee.",
+    "Cold brew coffee steeps coarse coffee grounds in cold water for twelve hours or more.",
+    "A French press steeps coffee grounds in hot water, then a metal plunger separates them.",
+    "Green tea is brewed with water below boiling to avoid a bitter, astringent flavor.",
+    "Black tea is steeped in fully boiling water for three to five minutes before serving.",
+    "Herbal tisanes are caffeine-free infusions of dried herbs, flowers, and dried fruit.",
+    "Matcha is a powdered green tea whisked into hot water with a bamboo whisk until frothy.",
+]
+
+# What a finished session "learned" about the user. These become the truth anchors.
+# They are about coffee, so coffee chunks align more strongly with the subspace.
+LESSONS = [
+    "The user is a dedicated coffee drinker who cares about espresso extraction and pour-over technique.",
+    "We learned the user wants coffee brewing recommendations specifically, and is not interested in tea.",
+    "For this user, coffee details — grind size, water temperature, and bloom time — matter most.",
+]
+
+QUERY = "How should I prepare my morning drink at home?"
+
+# Number of chunks to rank.
+TOP_K = len(CORPUS)
+
+
+def _theme(text: str) -> str:
+    coffee = ("coffee", "espresso", "pour-over", "french press", "cold brew")
+    return "☕ coffee" if any(w in text.lower() for w in coffee) else "🍵 tea   "
+
+
+def _snippet(text: str, width: int = 62) -> str:
+    text = " ".join(text.split())
+    return text if len(text) <= width else text[: width - 1] + "…"
+
+
+async def ranked_chunks(dataset_obj, query: str, use_truth_weight: bool):
+    """Return the hybrid retriever's ranked chunk dicts, within the dataset's DB context."""
+    async with set_database_global_context_variables(dataset_obj.id, dataset_obj.owner_id):
+        retriever = HybridRetriever(
+            chunks_top_k=TOP_K,
+            entities_top_k=0,  # focus the demo on chunk-lane reranking
+            facts_top_k=0,
+            node_name=CORPUS_NODE_SET,  # rank only the corpus, not the lesson chunks
+            use_truth_weight=use_truth_weight,
+        )
+        objects = await retriever.get_retrieved_objects(query=query)
+    return objects.get("chunks", [])
+
+
+def _text(chunk) -> str:
+    return payload(chunk).get("text", "")
+
+
+def print_ranking(title: str, chunks: list):
+    print(f"\n{title}")
+    print("  " + "-" * 74)
+    for i, chunk in enumerate(chunks, 1):
+        text = _text(chunk)
+        print(f"  {i:>2}. {_theme(text)}  {_snippet(text)}")
+
+
+def print_diff(baseline: list, truthful: list):
+    base_rank = {result_id(c): i for i, c in enumerate(baseline, 1)}
+    print("\nRANK CHANGE WITH TRUTH WEIGHTING ON (vs baseline)")
+    print("  " + "-" * 74)
+    for new_rank, chunk in enumerate(truthful, 1):
+        cid = result_id(chunk)
+        old = base_rank.get(cid)
+        if old is None:
+            delta = "  new"
+        elif old > new_rank:
+            delta = f"  ↑{old - new_rank}"
+        elif old < new_rank:
+            delta = f"  ↓{new_rank - old}"
+        else:
+            delta = "   ="
+        text = _text(chunk)
+        print(f"  {new_rank:>2}. {_theme(text)}  {_snippet(text, 52)}{delta}")
+
+
+async def main():
+    print("=" * 78)
+    print("Truth-Subspace Reranking demo")
+    print("=" * 78)
+
+    # 1) Ingest the corpus and build the knowledge graph.
+    print(f"\n[1/5] Adding {len(CORPUS)} corpus docs and cognifying (dataset='{DATASET}')…")
+    await cognee.add(CORPUS, dataset_name=DATASET, node_set=CORPUS_NODE_SET)
+    await cognee.cognify(datasets=[DATASET])
+
+    user = await get_default_user()
+    datasets = await get_authorized_existing_datasets([DATASET], "write", user)
+    dataset_obj = datasets[0]
+
+    # 2) Baseline ranking — truth weighting OFF (exact current behavior).
+    print(f"\n[2/5] Baseline retrieval (truth weighting OFF) for:\n      “{QUERY}”")
+    baseline = await ranked_chunks(dataset_obj, QUERY, use_truth_weight=False)
+    print_ranking("BASELINE RANKING", baseline)
+
+    # 3) A finished session's learnings → seed the session_learnings node set.
+    print(f"\n[3/5] Recording {len(LESSONS)} session learnings (favoring coffee)…")
+    await cognee.add(LESSONS, dataset_name=DATASET, node_set=LESSONS_NODE_SET)
+    await cognee.cognify(datasets=[DATASET])
+
+    # 4) Build the truth subspace: anchors from lessons → coords on every corpus chunk.
+    print("\n[4/5] Building the truth subspace (build_truth_subspace)…")
+    result = await build_truth_subspace(dataset=DATASET, session_ids=None, user=user)
+    print(f"      anchors={result['anchors']}  nodes_scored={result['nodes_scored']}")
+    if result["anchors"] == 0 or result["nodes_scored"] == 0:
+        print("      ⚠ No anchors or no scored nodes — truth weighting will be a no-op.")
+
+    # 5) Truth-weighted ranking — same query, truth weighting ON.
+    print("\n[5/5] Retrieval with truth weighting ON for the same query…")
+    truthful = await ranked_chunks(dataset_obj, QUERY, use_truth_weight=True)
+    print_ranking("TRUTH-WEIGHTED RANKING", truthful)
+
+    print_diff(baseline, truthful)
+
+    base_top = _theme(_text(baseline[0])) if baseline else "?"
+    truth_top = _theme(_text(truthful[0])) if truthful else "?"
+    print("\n" + "=" * 78)
+    print(f"Top result moved from  {base_top.strip()}  →  {truth_top.strip()}")
+    print("The learned coffee preference reshaped retrieval ordering. ✔")
+    print("=" * 78)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/truth_subspace_reranking_demo.py
+++ b/examples/python/truth_subspace_reranking_demo.py
@@ -3,10 +3,10 @@
 What it shows
 -------------
 A finished "session" teaches the system a preference (here: the user cares about
-*coffee*, not tea). We distill that into a **truth subspace** (anchor vectors built
-from the lessons), project every corpus chunk onto it, and store the per-chunk
-coordinates on the graph node. At query time the HYBRID retriever reads those
-coordinates and nudges ranking toward the learned preference.
+*coffee*, not tea). We distill that into deterministic centroid slots, project
+every corpus chunk onto those slots, and store the per-chunk coordinates on the
+graph node. At query time the HYBRID retriever reads current-epoch coordinates
+and nudges ranking toward the learned preference.
 
 The demo retrieves the SAME ambiguous query twice — once with truth weighting OFF
 (exact baseline) and once ON — and prints a side-by-side rank diff so you can see
@@ -44,7 +44,7 @@ from cognee.modules.users.methods import get_default_user
 
 DATASET = "truth_subspace_demo"
 CORPUS_NODE_SET = ["beverages"]
-LESSONS_NODE_SET = ["session_learnings"]  # the node set build_truth_subspace reads anchors from
+LESSONS_NODE_SET = ["session_learnings"]  # the node set build_truth_subspace reads learnings from
 
 # A small two-theme corpus. Each short doc becomes its own chunk.
 CORPUS = [
@@ -58,8 +58,8 @@ CORPUS = [
     "Matcha is a powdered green tea whisked into hot water with a bamboo whisk until frothy.",
 ]
 
-# What a finished session "learned" about the user. These become the truth anchors.
-# They are about coffee, so coffee chunks align more strongly with the subspace.
+# What a finished session "learned" about the user. These fill the truth centroid
+# slots. They are about coffee, so coffee chunks align more strongly.
 LESSONS = [
     "The user is a dedicated coffee drinker who cares about espresso extraction and pour-over technique.",
     "We learned the user wants coffee brewing recommendations specifically, and is not interested in tea.",
@@ -151,12 +151,12 @@ async def main():
     await cognee.add(LESSONS, dataset_name=DATASET, node_set=LESSONS_NODE_SET)
     await cognee.cognify(datasets=[DATASET])
 
-    # 4) Build the truth subspace: anchors from lessons → coords on every corpus chunk.
+    # 4) Build the truth subspace: lesson centroids -> coords on every corpus chunk.
     print("\n[4/5] Building the truth subspace (build_truth_subspace)…")
     result = await build_truth_subspace(dataset=DATASET, session_ids=None, user=user)
-    print(f"      anchors={result['anchors']}  nodes_scored={result['nodes_scored']}")
+    print(f"      centroid_slots={result['anchors']}  nodes_scored={result['nodes_scored']}")
     if result["anchors"] == 0 or result["nodes_scored"] == 0:
-        print("      ⚠ No anchors or no scored nodes — truth weighting will be a no-op.")
+        print("      ⚠ No centroid slots or no scored nodes — truth weighting will be a no-op.")
 
     # 5) Truth-weighted ranking — same query, truth weighting ON.
     print("\n[5/5] Retrieval with truth weighting ON for the same query…")


### PR DESCRIPTION
## Summary

Two related changes to the self-improvement / retrieval path. Both are **off by default and reversible**.

### P2 — turn the learned feedback signal on
The `feedback_weight` EMA loop already exists and writes to the graph, but `feedback_influence` defaulted to `0.0` everywhere, so it never reached ranking — the loop was inert.
- Add `base_config.default_feedback_influence` (env `DEFAULT_FEEDBACK_INFLUENCE`, default `0.1`) and route every hardcoded `feedback_influence=0.0` default through it.
- **Revert:** set `DEFAULT_FEEDBACK_INFLUENCE=0.0` (or flip the single config default) → full prior baseline, since the blend short-circuits at `<= 0.0`.

### Truth-subspace reranking (MVP)
After a session finishes, distil its `session_learnings` into a small set of **anchor vectors** (a "truth subspace"), project every chunk onto them, and persist the per-chunk alignment coordinates on the graph node. At query time the **hybrid retriever** reranks its chunk lane toward the learned preference.
- New `cognee/modules/truth_subspace/`: pure `align` math, `TruthAnchor` model, `build_truth_subspace()`.
- Graph adapter: `get/set_node_truth_alignments` (mirrors the `set_node_feedback_weights` precedent — per-node JSON, no re-embedding).
- `DocumentChunk` / `Entity`: optional `truth_alignment` + `truth_subspace_signature` fields (never embedded).
- `HybridRetriever`: `use_truth_weight` flag (**default `False`**); neutral / byte-for-byte baseline when off or when anchors/coords are absent.
- `improve(build_truth_subspace=True)`: opt-in stage after distillation.

## Demo

```bash
python examples/python/truth_subspace_reranking_demo.py   # needs LLM_API_KEY
```
A theme-neutral query is retrieved before/after the system learns a "coffee" preference. Coffee chunks measurably rise (top result flips tea → coffee); a side-by-side rank diff is printed.

## Tests
- 21 unit tests for the pure alignment math (`cognee/tests/unit/truth_subspace/test_align.py`).
- Verified off-by-default: with both flags off, ranking is unchanged from baseline.

## Notes for reviewers
Building the demo surfaced two **pre-existing** issues in cognee that this code merely triggers (worth separate tickets):
1. `LanceDBAdapter.create_data_points` → `create_collection` re-acquire the same non-reentrant `VECTOR_DB_LOCK`, deadlocking on first creation of a new collection. Worked around here by pre-creating the collection.
2. `get_filtered_graph_data` runs its node/edge queries via `asyncio.gather`, which deadlocks on the single-connection Kuzu subprocess backend. This MVP uses sequential `get_graph_data` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)