### PR TITLE
[#3384] Unify database configuration: one Postgres credential block, consistent naming

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,6 +22,12 @@ LLM_API_KEY="your_api_key"
 #EMBEDDING_DIMENSIONS=3072
 
 # -- Database Providers (switch from file-based defaults) ---------------------
+# The DB_* block is the single Postgres credential block. When a store's provider
+# is Postgres it reads these shared values, so one block configures relational +
+# pgvector + postgres-graph at once (set the three providers to postgres below).
+# Per-store VECTOR_DB_*/GRAPH_DATABASE_* credentials are optional overrides that
+# win over DB_* when set. Unknown DB_/VECTOR_DB_/GRAPH_DATABASE_ keys in this
+# file are logged as a warning (typo guard); exported shell-env typos are not.
 #DB_PROVIDER="postgres"
 #DB_HOST=127.0.0.1
 #DB_PORT=5432
@@ -31,6 +37,10 @@ LLM_API_KEY="your_api_key"
 
 #GRAPH_DATABASE_PROVIDER="neo4j"
 #VECTOR_DB_PROVIDER="lancedb"
+# All-Postgres from one DB_* block:
+#DB_PROVIDER="postgres"
+#VECTOR_DB_PROVIDER="postgres"   # alias of pgvector
+#GRAPH_DATABASE_PROVIDER="postgres"
 
 
 ###############################################################################
@@ -155,7 +165,12 @@ GRAPH_DATASET_DATABASE_HANDLER="kuzu"
 
 # Supported (built-in): pgvector | lancedb
 # Community adapters (separate packages): qdrant | weaviate | milvus | chromadb
+# "postgres" is accepted as an alias of "pgvector".
 VECTOR_DB_PROVIDER="lancedb"
+# For pgvector, credentials default to the shared DB_* block above; the
+# VECTOR_DB_* connection settings further below are optional overrides.
+# A postgresql:// VECTOR_DB_URL wins over the discrete parts; the default
+# LanceDB file path is not treated as a connection URL.
 #VECTOR_DB_URL=
 #VECTOR_DB_KEY=
 # Handler for multi-user access control (per-dataset DB creation).
@@ -448,6 +463,9 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #SHARED_LADYBUG_LOCK=false
 
 # -- Graph database — advanced connection / Kuzu tuning -----------------------
+# For GRAPH_DATABASE_PROVIDER=postgres these host/port/credentials are OPTIONAL
+# overrides of the shared DB_* block; leave them unset to reuse DB_HOST/PORT/
+# USERNAME/PASSWORD/NAME.
 #GRAPH_DATABASE_HOST=""
 #GRAPH_DATABASE_PORT=
 #GRAPH_DATABASE_KEY=""
@@ -460,6 +478,9 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #KUZU_MAX_DB_SIZE=
 
 # -- Vector database — advanced connection ------------------------------------
+# For VECTOR_DB_PROVIDER=pgvector (or its "postgres" alias) these host/port/
+# credentials are OPTIONAL overrides of the shared DB_* block; leave them unset
+# to reuse DB_HOST/PORT/USERNAME/PASSWORD/NAME.
 #VECTOR_DB_HOST=""
 #VECTOR_DB_PORT=1234
 #VECTOR_DB_NAME=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,37 @@ All stored in `.venv` by default. Override with `DATA_ROOT_DIRECTORY` and `SYSTE
 
 ### Switching Databases
 
+#### Unified Postgres credential block
+
+The `DB_*` block is the single Postgres credential source. When a store's provider
+is set to Postgres, it reads these shared values — so one block configures the
+relational database, pgvector, and the postgres graph together, with no repetition:
+
+```bash
+DB_PROVIDER=postgres
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=cognee
+DB_PASSWORD=cognee
+DB_NAME=cognee_db
+
+VECTOR_DB_PROVIDER=postgres   # alias of pgvector
+GRAPH_DATABASE_PROVIDER=postgres
+```
+
+Notes:
+- `VECTOR_DB_PROVIDER=postgres` is accepted as an alias of `pgvector`.
+- Reusing the shared `DB_*` block for pgvector / postgres-graph is the intended
+  default (it does not emit a warning). Set the per-store `VECTOR_DB_*` /
+  `GRAPH_DATABASE_*` credentials only to point a store at a different server;
+  when set, those per-store values win over `DB_*`.
+- A store-level `*_URL` with a `postgresql://` / `postgresql+asyncpg://` scheme is
+  authoritative and wins over the discrete parts. The default LanceDB/file path in
+  `VECTOR_DB_URL` is not treated as a connection URL.
+- Unknown `DB_` / `VECTOR_DB_` / `GRAPH_DATABASE_` keys in the `.env` file are
+  logged as a warning (typo guard). Typos in exported shell environment variables
+  are not caught (a `pydantic-settings` limitation).
+
 #### Relational Databases
 ```bash
 # PostgreSQL (requires postgres extra: pip install cognee[postgres])
@@ -260,6 +291,9 @@ Supported: lancedb (default), pgvector, chromadb, qdrant, weaviate, milvus
 VECTOR_DB_PROVIDER=chromadb
 
 # PGVector (requires postgres extra)
+# "postgres" is accepted as an alias of "pgvector". With only the shared DB_*
+# block set, pgvector reuses those credentials and the VECTOR_DB_* below is
+# optional. A postgresql:// VECTOR_DB_URL, if set, wins over the discrete parts.
 VECTOR_DB_PROVIDER=pgvector
 VECTOR_DB_URL=postgresql://cognee:cognee@localhost:5432/cognee_db
 ```
@@ -282,6 +316,9 @@ GRAPH_DATABASE_PASSWORD=your_password
 
 # Postgres (requires postgres extra: pip install cognee[postgres])
 # Does not support raw Cypher queries, natural language search, or Graphiti.
+# With only the shared DB_* block set, the postgres graph reuses those
+# credentials; GRAPH_DATABASE_URL below is optional and, when set with a
+# postgresql+asyncpg:// scheme, wins over the discrete DB_* parts.
 GRAPH_DATABASE_PROVIDER=postgres
 GRAPH_DATABASE_URL=postgresql+asyncpg://cognee:cognee@localhost:5432/cognee_db
 ```

--- a/cognee/infrastructure/databases/graph/config.py
+++ b/cognee/infrastructure/databases/graph/config.py
@@ -106,6 +106,17 @@ class GraphConfig(BaseSettings):
 
         return self
 
+    @pydantic.model_validator(mode="after")
+    def warn_on_unknown_db_env_vars(self):
+        # Surface typo'd ``GRAPH_DATABASE_*`` env vars (extra="allow" otherwise swallows them).
+        # Imported lazily to avoid a circular import via the utils package __init__.
+        from cognee.infrastructure.databases.utils.resolve_postgres_connection import (
+            warn_unknown_db_env_vars,
+        )
+
+        warn_unknown_db_env_vars(self.model_extra, prefixes=["GRAPH_DATABASE_"])
+        return self
+
     def to_dict(self) -> dict:
         """
         Return the configuration as a dictionary.

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -5,6 +5,9 @@ import os
 from numbers import Number
 
 from cognee.infrastructure.databases.utils.closing_lru_cache import closing_lru_cache
+from cognee.infrastructure.databases.utils.resolve_postgres_connection import (
+    resolve_postgres_url,
+)
 from cognee.shared.lru_cache import DATABASE_MAX_LRU_CACHE_SIZE
 from cognee.shared.logging_utils import get_logger
 
@@ -314,57 +317,28 @@ def _create_graph_engine(
         )
 
     elif graph_database_provider == "postgres":
-        from cognee.context_global_variables import backend_access_control_enabled
+        from cognee.infrastructure.databases.relational import get_relational_config
 
-        if backend_access_control_enabled():
-            if not (
-                graph_database_host
-                and graph_database_port
-                and graph_database_username
-                and graph_database_password
-            ):
-                raise EnvironmentError("Missing required Postgres graph credentials.")
+        # ``graph_database_url`` is also used by the neo4j / kuzu-remote / neptune
+        # branches, so only treat it as a Postgres connection URL when it carries
+        # a Postgres scheme.
+        store_url = graph_database_url if graph_database_url.startswith("postgres") else ""
 
-            connection_string: str = (
-                f"postgresql+asyncpg://{graph_database_username}:{graph_database_password}"
-                f"@{graph_database_host}:{graph_database_port}/{graph_database_name}"
-            )
-        else:
-            if (
-                graph_database_port
-                and graph_database_username
-                and graph_database_password
-                and graph_database_host
-                and graph_database_name
-            ):
-                connection_string: str = (
-                    f"postgresql+asyncpg://{graph_database_username}:{graph_database_password}"
-                    f"@{graph_database_host}:{graph_database_port}/{graph_database_name}"
-                )
-            else:
-                from cognee.infrastructure.databases.relational import get_relational_config
-
-                logger.warning(
-                    "Postgres graph credentials are not fully configured; "
-                    "falling back to the relational database configuration. "
-                    "Set GRAPH_DATABASE_HOST/PORT/USERNAME/PASSWORD/NAME explicitly "
-                    "to avoid this fallback."
-                )
-
-                relational_config = get_relational_config()
-                db_username = relational_config.db_username
-                db_password = relational_config.db_password
-                db_host = relational_config.db_host
-                db_port = relational_config.db_port
-                db_name = relational_config.db_name
-
-                if not (db_host and db_port and db_name and db_username and db_password):
-                    raise EnvironmentError("Missing required Postgres graph credentials!")
-
-                connection_string: str = (
-                    f"postgresql+asyncpg://{db_username}:{db_password}"
-                    f"@{db_host}:{db_port}/{db_name}"
-                )
+        relational_config = get_relational_config()
+        connection_string = resolve_postgres_url(
+            store_url=store_url,
+            store_host=graph_database_host,
+            store_port=graph_database_port,
+            store_username=graph_database_username,
+            store_password=graph_database_password,
+            store_name=graph_database_name,
+            shared_host=relational_config.db_host,
+            shared_port=relational_config.db_port,
+            shared_username=relational_config.db_username,
+            shared_password=relational_config.db_password,
+            shared_name=relational_config.db_name,
+            missing_error="Missing required Postgres graph credentials.",
+        )
 
         from .postgres.adapter import PostgresAdapter
 

--- a/cognee/infrastructure/databases/relational/config.py
+++ b/cognee/infrastructure/databases/relational/config.py
@@ -58,6 +58,18 @@ class RelationalConfig(BaseSettings):
 
         return self
 
+    @pydantic.model_validator(mode="after")
+    def warn_on_unknown_db_env_vars(self):
+        # Surface typo'd ``DB_*`` env vars (extra="allow" otherwise swallows them).
+        # Imported lazily: a module-level import would pull in the utils package
+        # __init__ (which imports the configs back) and create a circular import.
+        from cognee.infrastructure.databases.utils.resolve_postgres_connection import (
+            warn_unknown_db_env_vars,
+        )
+
+        warn_unknown_db_env_vars(self.model_extra, prefixes=["DB_"])
+        return self
+
     def to_dict(self) -> dict:
         """
         Return the database configuration as a dictionary.

--- a/cognee/infrastructure/databases/utils/resolve_postgres_connection.py
+++ b/cognee/infrastructure/databases/utils/resolve_postgres_connection.py
@@ -1,0 +1,137 @@
+"""Shared Postgres connection resolution for the vector and graph stores.
+
+Both the pgvector vector adapter and the postgres graph adapter need to build a
+Postgres connection from either an explicit URL or a set of discrete credential
+parts, with a fall back to the unified ``DB_*`` relational block when the store
+does not configure its own credentials. This module centralizes that precedence
+so the two call sites stay consistent and use ``URL.create`` for escaping.
+"""
+
+from typing import Optional, Union
+
+from sqlalchemy import URL
+from sqlalchemy.engine import make_url
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("PostgresConnectionResolver")
+
+
+def resolve_postgres_url(
+    *,
+    store_url: str,
+    store_host: str,
+    store_port: Union[str, int, None],
+    store_username: str,
+    store_password: str,
+    store_name: str,
+    shared_host: str,
+    shared_port: Union[str, int, None],
+    shared_username: str,
+    shared_password: str,
+    shared_name: str,
+    missing_error: str,
+    driver: str = "postgresql+asyncpg",
+) -> URL:
+    """Resolve a Postgres connection for a single store under a unified precedence.
+
+    A store-level URL, if set, is authoritative and returned as-is. Otherwise the
+    discrete connection parts are resolved as one atomic group: if the store
+    supplies its own core credentials, the store's parts (including its port) are
+    used; if it does not, the entire shared ``DB_*`` block — host, port, username,
+    password, and name together — is used. Ports are never inferred from
+    placeholder values; a store's port is used only when the store's own
+    credential group is chosen, and the shared port is used only when the shared
+    group is chosen. The URL is assembled with ``sqlalchemy.URL.create``, which
+    percent-escapes special characters in usernames and passwords (``#``, ``@``,
+    ``:``).
+
+    Parameters:
+    -----------
+
+        - store_url (str): The store's own connection URL (e.g. ``VECTOR_DB_URL``
+          / ``GRAPH_DATABASE_URL``). When set, it wins over everything.
+        - store_host / store_port / store_username / store_password / store_name:
+          The store's discrete credential parts.
+        - shared_host / shared_port / shared_username / shared_password /
+          shared_name: The unified ``DB_*`` relational block, used as a group when
+          the store does not configure its own credentials.
+        - missing_error (str): The ``EnvironmentError`` message raised when neither
+          group is complete. Owned by the caller so each store keeps its wording.
+        - driver (str): The SQLAlchemy driver name. Defaults to
+          ``postgresql+asyncpg``.
+
+    Returns:
+    --------
+
+        - URL: A SQLAlchemy ``URL`` built from the resolved connection info.
+    """
+    # A fully-formed URL is authoritative and bypasses part resolution entirely.
+    if store_url:
+        return make_url(store_url)
+
+    # The credential parts are resolved as one group. The presence of the store's
+    # core credentials (host/username/password/name) decides which group wins —
+    # port is intentionally excluded from this trigger so placeholder port
+    # defaults are never compared, and travels with whichever group is chosen.
+    store_has_own = bool(store_host and store_username and store_password and store_name)
+
+    if store_has_own:
+        host, port, username, password, name = (
+            store_host,
+            store_port,
+            store_username,
+            store_password,
+            store_name,
+        )
+    else:
+        host, port, username, password, name = (
+            shared_host,
+            shared_port,
+            shared_username,
+            shared_password,
+            shared_name,
+        )
+
+    if not (host and username and password and name):
+        raise EnvironmentError(missing_error)
+
+    return URL.create(
+        driver,
+        username=username,
+        password=password,
+        host=host,
+        port=int(port) if port else None,
+        database=name,
+    )
+
+
+def warn_unknown_db_env_vars(model_extra: Optional[dict], prefixes: tuple) -> None:
+    """Warn about unknown env vars captured under the given DB prefixes.
+
+    ``BaseSettings`` is configured with ``extra="allow"``, so a typo'd database
+    env var (e.g. ``DB_HSOT``) is silently absorbed into ``model_extra`` instead
+    of being rejected. This helper emits a targeted warning for any extra key
+    whose name matches one of the supplied database prefixes, so typos surface
+    without breaking unrelated env vars users keep in their ``.env``.
+
+    Parameters:
+    -----------
+
+        - model_extra (dict | None): The pydantic ``model_extra`` mapping of
+          captured-but-undeclared fields. ``None`` is treated as empty.
+        - prefixes (tuple): The database env-var prefixes to scope the scan to
+          (e.g. ``("db_", "vector_db_", "graph_database_")``).
+    """
+    if not model_extra:
+        return
+
+    normalized_prefixes = tuple(prefix.lower() for prefix in prefixes)
+
+    for key in model_extra:
+        if key.lower().startswith(normalized_prefixes):
+            logger.warning(
+                "Unknown database environment variable '%s' is not a recognized "
+                "configuration field and will be ignored. Check for typos.",
+                key,
+            )

--- a/cognee/infrastructure/databases/vector/config.py
+++ b/cognee/infrastructure/databases/vector/config.py
@@ -95,6 +95,17 @@ class VectorConfig(BaseSettings):
 
         return self
 
+    @pydantic.model_validator(mode="after")
+    def warn_on_unknown_db_env_vars(self):
+        # Surface typo'd ``VECTOR_DB_*`` env vars (extra="allow" otherwise swallows them).
+        # Imported lazily to avoid a circular import via the utils package __init__.
+        from cognee.infrastructure.databases.utils.resolve_postgres_connection import (
+            warn_unknown_db_env_vars,
+        )
+
+        warn_unknown_db_env_vars(self.model_extra, prefixes=["VECTOR_DB_"])
+        return self
+
     def to_dict(self) -> dict:
         """
         Convert the configuration settings to a dictionary.

--- a/cognee/infrastructure/databases/vector/config.py
+++ b/cognee/infrastructure/databases/vector/config.py
@@ -45,6 +45,10 @@ class VectorConfig(BaseSettings):
         # dataset handler instead of the default lancedb one. This mirrors the same
         # pattern used in GraphConfig for postgres → postgres_graph.
         provider = self.vector_db_provider.lower()
+        # Accept ``postgres`` as a user-facing alias of the ``pgvector`` provider
+        # so the same provider string works across relational / vector / graph.
+        if provider == "postgres":
+            provider = "pgvector"
         self.vector_db_provider = provider
         vector_dataset_database_handler = self.vector_dataset_database_handler.lower()
         self.vector_dataset_database_handler = vector_dataset_database_handler

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -5,6 +5,9 @@ from numbers import Number
 from .supported_databases import supported_databases
 from .embeddings import get_embedding_engine
 from cognee.infrastructure.databases.utils.closing_lru_cache import closing_lru_cache
+from cognee.infrastructure.databases.utils.resolve_postgres_connection import (
+    resolve_postgres_url,
+)
 from cognee.shared.lru_cache import DATABASE_MAX_LRU_CACHE_SIZE
 from cognee.shared.logging_utils import get_logger
 
@@ -205,55 +208,28 @@ def _create_vector_engine(
         )
 
     if vector_db_provider.lower() == "pgvector":
-        from cognee.context_global_variables import backend_access_control_enabled
+        from cognee.infrastructure.databases.relational import get_relational_config
 
-        if backend_access_control_enabled():
-            if not (
-                vector_db_host and vector_db_port and vector_db_username and vector_db_password
-            ):
-                raise EnvironmentError("Missing required pgvector credentials.")
+        # ``vector_db_url`` doubles as the LanceDB filesystem path (VectorConfig
+        # defaults it to a local ``.lancedb`` path), so only treat it as a
+        # connection URL when it carries a Postgres scheme.
+        store_url = vector_db_url if vector_db_url.startswith("postgres") else ""
 
-            connection_string: str = (
-                f"postgresql+asyncpg://{vector_db_username}:{vector_db_password}"
-                f"@{vector_db_host}:{vector_db_port}/{vector_db_name}"
-            )
-        else:
-            if (
-                vector_db_port
-                and vector_db_username
-                and vector_db_password
-                and vector_db_host
-                and vector_db_name
-            ):
-                connection_string: str = (
-                    f"postgresql+asyncpg://{vector_db_username}:{vector_db_password}"
-                    f"@{vector_db_host}:{vector_db_port}/{vector_db_name}"
-                )
-            else:
-                from cognee.infrastructure.databases.relational import get_relational_config
-
-                logger.warning(
-                    "PGVector credentials are not fully configured; "
-                    "falling back to the relational database configuration. "
-                    "Set VECTOR_DB_HOST/PORT/USERNAME/PASSWORD/NAME explicitly "
-                    "to avoid this fallback."
-                )
-
-                # Get configuration for postgres database
-                relational_config = get_relational_config()
-                db_username = relational_config.db_username
-                db_password = relational_config.db_password
-                db_host = relational_config.db_host
-                db_port = relational_config.db_port
-                db_name = relational_config.db_name
-
-                if not (db_host and db_port and db_name and db_username and db_password):
-                    raise EnvironmentError("Missing required pgvector credentials!")
-
-                connection_string: str = (
-                    f"postgresql+asyncpg://{db_username}:{db_password}"
-                    f"@{db_host}:{db_port}/{db_name}"
-                )
+        relational_config = get_relational_config()
+        connection_string = resolve_postgres_url(
+            store_url=store_url,
+            store_host=vector_db_host,
+            store_port=vector_db_port,
+            store_username=vector_db_username,
+            store_password=vector_db_password,
+            store_name=vector_db_name,
+            shared_host=relational_config.db_host,
+            shared_port=relational_config.db_port,
+            shared_username=relational_config.db_username,
+            shared_password=relational_config.db_password,
+            shared_name=relational_config.db_name,
+            missing_error="Missing required pgvector credentials.",
+        )
 
         try:
             from .pgvector.PGVectorAdapter import PGVectorAdapter

--- a/cognee/tests/unit/infrastructure/databases/graph/test_graph_config.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_graph_config.py
@@ -1,0 +1,20 @@
+"""Tests for GraphConfig env-var handling."""
+
+from unittest.mock import patch
+
+from cognee.infrastructure.databases.graph.config import GraphConfig
+
+
+_RESOLVER_LOGGER = "cognee.infrastructure.databases.utils.resolve_postgres_connection.logger"
+
+
+def test_unknown_graph_database_env_var_warns_only_on_graph_namespace(tmp_path):
+    """A typo'd GRAPH_DATABASE_* var warns; VECTOR_DB_*/unrelated keys do not trip it."""
+    envf = tmp_path / ".env"
+    envf.write_text("GRAPH_DATABASE_XYZ=x\nVECTOR_DB_HOST=v\nLLM_API_KEY=k\n")
+
+    with patch(_RESOLVER_LOGGER) as mock_logger:
+        GraphConfig(_env_file=str(envf))
+
+    warned = [call.args[1] for call in mock_logger.warning.call_args_list]
+    assert warned == ["graph_database_xyz"]

--- a/cognee/tests/unit/infrastructure/databases/graph/test_graph_postgres_resolution.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_graph_postgres_resolution.py
@@ -1,0 +1,100 @@
+"""Test postgres-graph connection resolution via the shared Postgres resolver.
+
+Verifies that when the postgres graph provider configures no credentials of its
+own, the engine factory falls back to the unified ``DB_*`` relational block —
+silently (no fallback warning), now that the shared block is the documented
+default. Also confirms the internal dataset handler resolves to ``postgres_graph``
+while the user-facing provider stays ``postgres``.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+from cognee.infrastructure.databases.graph.get_graph_engine import (
+    create_graph_engine,
+    _create_graph_engine,
+)
+from cognee.infrastructure.databases.graph.config import get_graph_config
+from cognee.infrastructure.databases.relational import get_relational_config
+
+
+# Only the shared DB_* block plus the postgres provider are configured — no
+# GRAPH_DATABASE_* credential parts, so resolution must fall back to DB_*.
+# GRAPH_DATASET_DATABASE_HANDLER is pinned to ladybug here because the repo .env
+# sets it to "kuzu", which would otherwise block the postgres_graph mapping.
+DB_ENV = {
+    "USE_UNIFIED_PROVIDER": "",
+    "ENABLE_BACKEND_ACCESS_CONTROL": "false",
+    "GRAPH_DATABASE_PROVIDER": "postgres",
+    "GRAPH_DATASET_DATABASE_HANDLER": "ladybug",
+    "DB_HOST": "shared-host",
+    "DB_PORT": "5432",
+    "DB_USERNAME": "shared_user",
+    "DB_PASSWORD": "shared_pass",
+    "DB_NAME": "shared_db",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """The engine factory and both configs are cached — clear between tests."""
+    _create_graph_engine.cache_clear()
+    get_graph_config.cache_clear()
+    get_relational_config.cache_clear()
+    yield
+    _create_graph_engine.cache_clear()
+    get_graph_config.cache_clear()
+    get_relational_config.cache_clear()
+
+
+@pytest.fixture
+def _fake_postgres_adapter():
+    """Inject a fake PostgresAdapter module so the import inside the engine
+    factory succeeds without the postgres extra installed, and capture its args.
+    """
+    captured = {}
+
+    class FakePostgresAdapter:
+        def __init__(self, connection_string):
+            captured["connection_string"] = connection_string
+
+    fake_module = types.ModuleType("cognee.infrastructure.databases.graph.postgres.adapter")
+    fake_module.PostgresAdapter = FakePostgresAdapter
+
+    with patch.dict(
+        sys.modules,
+        {"cognee.infrastructure.databases.graph.postgres.adapter": fake_module},
+    ):
+        yield captured
+
+
+def test_postgres_graph_falls_back_to_shared_db_block_without_warning(_fake_postgres_adapter):
+    """Only DB_* set -> adapter gets a URL carrying the DB_* credentials, no warning."""
+    with patch.dict(os.environ, DB_ENV):
+        get_graph_config.cache_clear()
+        get_relational_config.cache_clear()
+
+        config = get_graph_config()
+        # Internal dataset handler maps to postgres_graph; user-facing provider stays postgres.
+        assert config.graph_database_provider == "postgres"
+        assert config.graph_dataset_database_handler == "postgres_graph"
+
+        params = config.to_hashable_dict()
+
+        with patch("cognee.infrastructure.databases.graph.get_graph_engine.logger") as mock_logger:
+            create_graph_engine(**params)
+
+    url = _fake_postgres_adapter["connection_string"]
+    assert url.host == "shared-host"
+    assert url.port == 5432
+    assert url.username == "shared_user"
+    assert url.password == "shared_pass"
+    assert url.database == "shared_db"
+
+    # The fallback to the shared DB_* block is now the documented default and
+    # must not emit a warning.
+    mock_logger.warning.assert_not_called()

--- a/cognee/tests/unit/infrastructure/databases/relational/test_RelationalConfig.py
+++ b/cognee/tests/unit/infrastructure/databases/relational/test_RelationalConfig.py
@@ -69,3 +69,32 @@ class TestRelationalConfig:
                 ("sslmode", "require"),
                 ("timeout", 60),
             )
+
+
+_RESOLVER_LOGGER = "cognee.infrastructure.databases.utils.resolve_postgres_connection.logger"
+
+
+def test_unknown_db_env_var_warns(tmp_path):
+    """A typo'd DB_* var in the .env file is reported (not silently ignored),
+    and the config still constructs (extra="allow", not forbid)."""
+    envf = tmp_path / ".env"
+    envf.write_text("DB_HSOT=x\n")
+
+    with patch(_RESOLVER_LOGGER) as mock_logger:
+        config = RelationalConfig(_env_file=str(envf))
+
+    assert config.db_provider == "sqlite"  # still constructs with defaults
+    warned = [call.args[1] for call in mock_logger.warning.call_args_list]
+    assert warned == ["db_hsot"]
+
+
+def test_relational_does_not_false_warn_on_other_namespaces(tmp_path):
+    """The DB_ scan must not warn on VECTOR_DB_*/GRAPH_DATABASE_*/unrelated keys
+    that land in relational's model_extra (locks the prefix-collision fix)."""
+    envf = tmp_path / ".env"
+    envf.write_text("VECTOR_DB_HOST=v\nGRAPH_DATABASE_FOO=g\nLLM_API_KEY=k\n")
+
+    with patch(_RESOLVER_LOGGER) as mock_logger:
+        RelationalConfig(_env_file=str(envf))
+
+    mock_logger.warning.assert_not_called()

--- a/cognee/tests/unit/infrastructure/databases/test_postgres_provider_regression.py
+++ b/cognee/tests/unit/infrastructure/databases/test_postgres_provider_regression.py
@@ -1,0 +1,26 @@
+"""Regression net: the unification must not shift the non-Postgres defaults.
+
+Proves the four DB-unification commits left the field-level defaults intact:
+relational -> sqlite, vector -> lancedb (local path), graph -> ladybug.
+"""
+
+import os
+from unittest.mock import patch
+
+from cognee.infrastructure.databases.relational.config import RelationalConfig
+from cognee.infrastructure.databases.vector.config import VectorConfig
+from cognee.infrastructure.databases.graph.config import GraphConfig
+
+
+def test_non_postgres_defaults_unchanged():
+    """With no DB configuration at all, each store keeps its original default."""
+    # Isolate from os.environ and the repo .env so the pydantic field defaults
+    # (not the repo's kuzu/lancedb/sqlite .env values) are what gets asserted.
+    with patch.dict(os.environ, {}, clear=True):
+        assert RelationalConfig(_env_file=None).db_provider == "sqlite"
+
+        vector_config = VectorConfig(_env_file=None)
+        assert vector_config.vector_db_provider == "lancedb"
+        assert vector_config.vector_db_url.endswith("cognee.lancedb")
+
+        assert GraphConfig(_env_file=None).graph_database_provider == "ladybug"

--- a/cognee/tests/unit/infrastructure/databases/test_resolve_postgres_connection.py
+++ b/cognee/tests/unit/infrastructure/databases/test_resolve_postgres_connection.py
@@ -1,0 +1,124 @@
+"""Unit tests for the shared Postgres connection resolver."""
+
+import pytest
+from sqlalchemy.engine import make_url
+
+from cognee.infrastructure.databases.utils.resolve_postgres_connection import (
+    resolve_postgres_url,
+)
+
+
+# Shared DB_* block used as the fallback group across tests.
+SHARED = {
+    "shared_host": "shared-host",
+    "shared_port": "5432",
+    "shared_username": "shared_user",
+    "shared_password": "shared_pass",
+    "shared_name": "shared_db",
+}
+
+# A complete store-level credential group.
+STORE = {
+    "store_host": "store-host",
+    "store_port": "6543",
+    "store_username": "store_user",
+    "store_password": "store_pass",
+    "store_name": "store_db",
+}
+
+MISSING_ERROR = "Missing required credentials."
+
+
+class TestResolvePostgresUrl:
+    """Precedence: URL wins -> store group -> shared DB_* group -> error."""
+
+    def test_url_wins_over_parts(self):
+        """A store URL is authoritative even when discrete parts are also set."""
+        url = resolve_postgres_url(
+            store_url="postgresql+asyncpg://url_user:url_pass@url-host:1111/url_db",
+            **STORE,
+            **SHARED,
+            missing_error=MISSING_ERROR,
+        )
+
+        assert url == make_url("postgresql+asyncpg://url_user:url_pass@url-host:1111/url_db")
+        # The discrete store / shared parts must NOT leak into the result.
+        assert url.host == "url-host"
+        assert url.port == 1111
+        assert url.username == "url_user"
+        assert url.database == "url_db"
+
+    def test_store_parts_used_when_store_group_complete(self):
+        """When the store supplies its own credentials, the store group wins."""
+        url = resolve_postgres_url(
+            store_url="",
+            **STORE,
+            **SHARED,
+            missing_error=MISSING_ERROR,
+        )
+
+        assert url.drivername == "postgresql+asyncpg"
+        assert url.host == "store-host"
+        assert url.port == 6543  # store's own port travels with the store group
+        assert url.username == "store_user"
+        assert url.password == "store_pass"
+        assert url.database == "store_db"
+
+    def test_shared_group_used_with_its_own_port(self):
+        """Store core creds absent -> the entire shared DB_* group is used,
+        including the shared port. The store's (placeholder) port must NOT be
+        mixed into the shared group."""
+        url = resolve_postgres_url(
+            store_url="",
+            store_host="",
+            store_port="1234",  # placeholder default; must be ignored, not mixed in
+            store_username="",
+            store_password="",
+            store_name="",
+            **SHARED,
+            missing_error=MISSING_ERROR,
+        )
+
+        assert url.host == "shared-host"
+        assert url.port == 5432  # shared port, not the store placeholder 1234
+        assert url.username == "shared_user"
+        assert url.password == "shared_pass"
+        assert url.database == "shared_db"
+
+    def test_special_characters_in_credentials_are_escaped(self):
+        """Usernames/passwords with #/@/: must round-trip via URL.create."""
+        url = resolve_postgres_url(
+            store_url="",
+            store_host="store-host",
+            store_port="6543",
+            store_username="user#name",
+            store_password="p@ss:word",
+            store_name="store_db",
+            **SHARED,
+            missing_error=MISSING_ERROR,
+        )
+
+        assert url.username == "user#name"
+        assert url.password == "p@ss:word"
+        # Rendered form must escape the special characters.
+        rendered = url.render_as_string(hide_password=False)
+        assert "user%23name" in rendered
+        assert "p%40ss%3Aword" in rendered
+
+    def test_incomplete_groups_raise_environment_error(self):
+        """Neither the store nor the shared group is complete -> raise."""
+        with pytest.raises(EnvironmentError, match=MISSING_ERROR):
+            resolve_postgres_url(
+                store_url="",
+                store_host="",
+                store_port="1234",
+                store_username="",
+                store_password="",
+                store_name="",
+                shared_host="",
+                shared_port="",
+                shared_username="",
+                shared_password="",
+                shared_name="",
+                missing_error=MISSING_ERROR,
+            )

--- a/cognee/tests/unit/infrastructure/databases/test_unified_db_config.py
+++ b/cognee/tests/unit/infrastructure/databases/test_unified_db_config.py
@@ -1,0 +1,142 @@
+"""Headline acceptance test: one DB_* Postgres block configures all three stores.
+
+A single shared ``DB_*`` credential block (no per-store credential repetition)
+must drive the relational engine, the pgvector vector engine, and the
+postgres-graph engine — all resolving to the same Postgres credentials, with no
+fallback/typo warnings.
+"""
+
+import logging
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cognee.infrastructure.databases.relational.config import get_relational_config
+from cognee.infrastructure.databases.relational.create_relational_engine import (
+    create_relational_engine,
+)
+from cognee.infrastructure.databases.vector.config import get_vectordb_config
+from cognee.infrastructure.databases.vector.create_vector_engine import (
+    create_vector_engine,
+    _create_vector_engine,
+)
+from cognee.infrastructure.databases.graph.config import get_graph_config
+from cognee.infrastructure.databases.graph.get_graph_engine import (
+    create_graph_engine,
+    _create_graph_engine,
+)
+
+
+# A single shared Postgres block — NO VECTOR_DB_*/GRAPH_DATABASE_* credential
+# repetition. All three providers point at "postgres" (vector aliases pgvector).
+DB_ENV = {
+    "USE_UNIFIED_PROVIDER": "",
+    "ENABLE_BACKEND_ACCESS_CONTROL": "false",
+    "DB_PROVIDER": "postgres",
+    "VECTOR_DB_PROVIDER": "postgres",
+    "GRAPH_DATABASE_PROVIDER": "postgres",
+    "GRAPH_DATASET_DATABASE_HANDLER": "ladybug",
+    "DB_HOST": "shared-host",
+    "DB_PORT": "5432",
+    "DB_USERNAME": "shared_user",
+    "DB_PASSWORD": "shared_pass",
+    "DB_NAME": "shared_db",
+}
+
+# Loggers that would emit a fallback/typo warning if the unification regressed.
+DB_LOGGERS = {"PostgresConnectionResolver", "VectorEngine", "GraphEngine"}
+
+
+def _clear_all_caches():
+    get_relational_config.cache_clear()
+    get_vectordb_config.cache_clear()
+    get_graph_config.cache_clear()
+    create_relational_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    _create_graph_engine.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    _clear_all_caches()
+    yield
+    _clear_all_caches()
+
+
+@pytest.fixture
+def _fake_adapters():
+    """Inject fake adapters (and a fake asyncpg) so engine construction succeeds
+    without the postgres extra, and capture the connection URL each store builds.
+    """
+    captured = {}
+
+    class FakePGVectorAdapter:
+        def __init__(self, connection_string, api_key, embedding_engine):
+            captured["vector"] = connection_string
+
+    class FakePostgresAdapter:
+        def __init__(self, connection_string):
+            captured["graph"] = connection_string
+
+    pgvector_module = types.ModuleType(
+        "cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter"
+    )
+    pgvector_module.PGVectorAdapter = FakePGVectorAdapter
+
+    postgres_module = types.ModuleType("cognee.infrastructure.databases.graph.postgres.adapter")
+    postgres_module.PostgresAdapter = FakePostgresAdapter
+
+    with patch.dict(
+        sys.modules,
+        {
+            "asyncpg": types.ModuleType("asyncpg"),
+            "cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter": pgvector_module,
+            "cognee.infrastructure.databases.graph.postgres.adapter": postgres_module,
+        },
+    ):
+        yield captured
+
+
+def test_single_db_block_configures_all_three_stores(_fake_adapters, caplog):
+    captured = _fake_adapters
+
+    with patch.dict(os.environ, DB_ENV):
+        _clear_all_caches()
+
+        rel_params = get_relational_config().to_dict()
+        vec_params = get_vectordb_config().to_dict()
+        graph_params = get_graph_config().to_hashable_dict()
+
+        with (
+            patch(
+                "cognee.infrastructure.databases.relational.create_relational_engine.SQLAlchemyAdapter"
+            ) as mock_sqlalchemy_adapter,
+            patch(
+                "cognee.infrastructure.databases.vector.create_vector_engine.get_embedding_engine",
+                return_value=MagicMock(),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            create_relational_engine(**rel_params)
+            create_vector_engine(**vec_params)
+            create_graph_engine(**graph_params)
+
+            captured["relational"] = mock_sqlalchemy_adapter.call_args[0][0]
+
+    # All three stores resolve to the same single DB_* credential block.
+    for label in ("relational", "vector", "graph"):
+        url = captured[label]
+        assert url.host == "shared-host", label
+        assert url.port == 5432, label
+        assert url.username == "shared_user", label
+        assert url.password == "shared_pass", label
+        assert url.database == "shared_db", label
+
+    # No repetition needed -> no fallback warning and no typo warning.
+    db_warnings = [
+        r for r in caplog.records if r.levelno >= logging.WARNING and r.name in DB_LOGGERS
+    ]
+    assert db_warnings == [], [(r.name, r.getMessage()) for r in db_warnings]

--- a/cognee/tests/unit/infrastructure/databases/vector/test_vector_db_config.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_vector_db_config.py
@@ -23,3 +23,18 @@ def test_vector_db_provider_postgres_aliases_to_pgvector():
 
     assert cfg.vector_db_provider == "pgvector"
     assert cfg.vector_dataset_database_handler == "pgvector"
+
+
+_RESOLVER_LOGGER = "cognee.infrastructure.databases.utils.resolve_postgres_connection.logger"
+
+
+def test_unknown_vector_db_env_var_warns_only_on_vector_namespace(tmp_path):
+    """A typo'd VECTOR_DB_* var warns; DB_*/unrelated keys do not trip it."""
+    envf = tmp_path / ".env"
+    envf.write_text("VECTOR_DB_XYZ=x\nDB_NAME=n\nLLM_API_KEY=k\n")
+
+    with patch(_RESOLVER_LOGGER) as mock_logger:
+        VectorConfig(_env_file=str(envf))
+
+    warned = [call.args[1] for call in mock_logger.warning.call_args_list]
+    assert warned == ["vector_db_xyz"]

--- a/cognee/tests/unit/infrastructure/databases/vector/test_vector_db_config.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_vector_db_config.py
@@ -1,12 +1,25 @@
 """Test for vector database configuration validation."""
 
+import os
+from unittest.mock import patch
+
 import pytest
 
 from cognee.api.v1.config.config import config
 from cognee.api.v1.exceptions.exceptions import InvalidConfigAttributeError
+from cognee.infrastructure.databases.vector.config import VectorConfig
 
 
 def test_set_vector_db_config_invalid_attribute_raises():
     """Ensure invalid vector DB config attributes raise an error."""
     with pytest.raises(InvalidConfigAttributeError):
         config.set_vector_db_config({"invalid_attribute": "should_fail"})
+
+
+def test_vector_db_provider_postgres_aliases_to_pgvector():
+    """VECTOR_DB_PROVIDER=postgres is a user-facing alias of pgvector."""
+    with patch.dict(os.environ, {"VECTOR_DB_PROVIDER": "postgres"}):
+        cfg = VectorConfig()
+
+    assert cfg.vector_db_provider == "pgvector"
+    assert cfg.vector_dataset_database_handler == "pgvector"

--- a/cognee/tests/unit/infrastructure/databases/vector/test_vector_pgvector_resolution.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_vector_pgvector_resolution.py
@@ -1,0 +1,101 @@
+"""Test pgvector connection resolution via the shared Postgres resolver.
+
+Verifies that when a pgvector store configures no credentials of its own, the
+engine factory falls back to the unified ``DB_*`` relational block — and does so
+silently (no fallback warning), now that the resolver makes the shared block the
+documented default rather than a last-resort path.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cognee.infrastructure.databases.vector.create_vector_engine import (
+    create_vector_engine,
+    _create_vector_engine,
+)
+from cognee.infrastructure.databases.vector.config import get_vectordb_config
+from cognee.infrastructure.databases.relational import get_relational_config
+
+
+# Only the shared DB_* block plus the pgvector provider are configured — no
+# VECTOR_DB_* credential parts, so resolution must fall back to DB_*.
+DB_ENV = {
+    "USE_UNIFIED_PROVIDER": "",
+    "ENABLE_BACKEND_ACCESS_CONTROL": "false",
+    "VECTOR_DB_PROVIDER": "pgvector",
+    "DB_HOST": "shared-host",
+    "DB_PORT": "5432",
+    "DB_USERNAME": "shared_user",
+    "DB_PASSWORD": "shared_pass",
+    "DB_NAME": "shared_db",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """The engine factory and both configs are cached — clear between tests."""
+    _create_vector_engine.cache_clear()
+    get_vectordb_config.cache_clear()
+    get_relational_config.cache_clear()
+    yield
+    _create_vector_engine.cache_clear()
+    get_vectordb_config.cache_clear()
+    get_relational_config.cache_clear()
+
+
+@pytest.fixture
+def _fake_pgvector_adapter():
+    """Inject a fake PGVectorAdapter module so the import inside the engine
+    factory succeeds without the postgres extra installed, and capture its args.
+    """
+    captured = {}
+
+    class FakePGVectorAdapter:
+        def __init__(self, connection_string, api_key, embedding_engine):
+            captured["connection_string"] = connection_string
+            captured["api_key"] = api_key
+
+    fake_module = types.ModuleType(
+        "cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter"
+    )
+    fake_module.PGVectorAdapter = FakePGVectorAdapter
+
+    with patch.dict(
+        sys.modules,
+        {"cognee.infrastructure.databases.vector.pgvector.PGVectorAdapter": fake_module},
+    ):
+        yield captured
+
+
+def test_pgvector_falls_back_to_shared_db_block_without_warning(_fake_pgvector_adapter):
+    """Only DB_* set -> adapter gets a URL carrying the DB_* credentials, no warning."""
+    with patch.dict(os.environ, DB_ENV):
+        get_vectordb_config.cache_clear()
+        get_relational_config.cache_clear()
+        params = get_vectordb_config().to_dict()
+
+        with (
+            patch(
+                "cognee.infrastructure.databases.vector.create_vector_engine.get_embedding_engine",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "cognee.infrastructure.databases.vector.create_vector_engine.logger"
+            ) as mock_logger,
+        ):
+            create_vector_engine(**params)
+
+    url = _fake_pgvector_adapter["connection_string"]
+    assert url.host == "shared-host"
+    assert url.port == 5432
+    assert url.username == "shared_user"
+    assert url.password == "shared_pass"
+    assert url.database == "shared_db"
+
+    # The fallback to the shared DB_* block is now the documented default and
+    # must not emit a warning.
+    mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Description

This PR addresses #3384 — the three database config families (relational `DB_*`, vector `VECTOR_DB_*`, graph `GRAPH_DATABASE_*`) each needed their own full set of Postgres credentials, so an all-Postgres deployment meant writing the same host/port/user/password/name three times.

My approach: instead of inventing a new config layer, I leaned on the fact that the vector and graph engines already fall back to the relational config — but only as a last resort, with a warning. I promoted that fallback into the intended default. There's now one shared resolver (`resolve_postgres_url`) that all three Postgres paths call, with a single precedence rule: a store-level `*_URL` wins, else the store's own discrete parts, else the shared `DB_*` block, else the field default. Per-store overrides still work and still win when set — so this is a strict superset of the old behavior: if you don't configure a shared block, every path resolves exactly as it did before.

A few specific decisions and why:
- I went with the existing DB_* prefix as the shared block rather than a brand-new one, since DB_* is already the documented Postgres credentials — so existing .env files keep working unchanged and there's no new vocabulary to learn.
- I made the resolver build the URL with SQLAlchemy's `URL.create` instead of the raw f-strings the vector/graph paths used before — those didn't escape special characters, so a `#` or `@` in a password would break the connection. Relational already did this correctly; now all three do.
- For the `*_URL` precedence I had to guard against one trap: the vector config defaults `vector_db_url` to a *lancedb filesystem path*, so I only treat a `*_URL` as a real connection URL when it carries a `postgres` scheme — otherwise the lancedb default would wrongly short-circuit the fallback.
- I kept this scoped to config resolution. I deliberately left `MIGRATION_DB_*` and the `USE_UNIFIED_PROVIDER=pghybrid` flag out — they're separate concerns and folding them in would widen the blast radius. Happy to follow up on those separately.

I split the work into 6 small commits (resolver first, then each store wired onto it, then the typo warning, then the cross-cutting + regression tests, then docs) so each piece is reviewable and revertable on its own.

---

Closes #3384

---

## Acceptance Criteria

- **One Postgres credential block runs relational + pgvector + postgres-graph, no repetition, no fallback warnings** — the shared resolver + removal of the two fallback warnings. Proven by `test_single_db_block_configures_all_three_stores`, which drives a single `DB_*` block and asserts all three adapters receive URLs carrying identical creds with zero warnings logged.
- **`VECTOR_DB_PROVIDER=postgres` works as an alias of pgvector** — one-line normalization in `VectorConfig.fill_derived`. Proven by a config test asserting it resolves to `pgvector`.
- **A typo'd DB env var is reported, not silently ignored** — a targeted warning scoped to the `DB_`/`VECTOR_DB_`/`GRAPH_DATABASE_` namespaces (I did NOT use `extra="forbid"`, because that would crash on the unrelated keys everyone keeps in their `.env`, like `LLM_API_KEY`). Honest scope note: this catches typos in the `.env` *file* (the common case); exported shell-env typos aren't caught, which is a pydantic-settings limitation.

Also covered by a regression test confirming the non-Postgres defaults (sqlite / lancedb / ladybug) are unchanged.

**Note on behavior change:** previously the pgvector path ignored `VECTOR_DB_URL` entirely; now a postgres-scheme `*_URL` is honored and wins over discrete parts. Documented in `.env.template`.

**Note on CI:** `neo4j_deadlock_test.py` fails to *collect* locally because the optional `neo4j` extra isn't installed on my machine — this is pre-existing and unrelated to these changes (it's not in my diff).

## Type of Change
- [x] Code refactoring
- [x] New feature (non-breaking change that adds functionality)

## Screenshots

<img width="1472" height="245" alt="image" src="https://github.com/user-attachments/assets/c4b6b88e-9d65-4289-b102-5843754d129a" />

314 checks passed :

<img width="1452" height="598" alt="image" src="https://github.com/user-attachments/assets/412f8de3-189e-4877-bf51-e9864b80dc3a" />

<img width="1463" height="658" alt="Screenshot 2026-06-26 030632" src="https://github.com/user-attachments/assets/549b8f36-7abe-4e83-8c63-9e15d41003b3" />


## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.