### PR TITLE
fix(retrieval): don't mutate caller's collections in brute_force_triplet_search

### DIFF
--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -287,7 +287,10 @@ async def brute_force_triplet_search(
             ]
 
         if "EdgeType_relationship_name" not in collections:
-            collections.append("EdgeType_relationship_name")
+            # Rebind to a new list instead of mutating in place: callers (e.g.
+            # TripletSearchContextProvider) reuse the same `collections` list across
+            # many searches, and an in-place append would leak this entry back to them.
+            collections = [*collections, "EdgeType_relationship_name"]
 
         otel_span.set_attribute("cognee.retrieval.collection_count", len(collections))
         otel_span.set_attribute(COGNEE_VECTOR_COLLECTION, ", ".join(collections))

--- a/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
@@ -188,6 +188,38 @@ async def test_brute_force_triplet_search_always_includes_edge_collection():
 
 
 @pytest.mark.asyncio
+async def test_brute_force_triplet_search_does_not_mutate_caller_collections():
+    """Test that the caller's `collections` list is not mutated in place.
+
+    Regression test: the edge collection used to be appended directly to the
+    caller-owned list, so a caller reusing the same list across searches (e.g.
+    TripletSearchContextProvider) would see it grow on every call.
+    """
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.embedding_engine = AsyncMock()
+    mock_vector_engine.embedding_engine.embed_text = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    mock_vector_engine.search = AsyncMock(return_value=[])
+
+    caller_collections = ["Entity_name"]
+
+    with patch(
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        await brute_force_triplet_search(query="test", collections=caller_collections)
+        # Run twice with the same list to mimic a caller reusing it across searches.
+        await brute_force_triplet_search(query="test", collections=caller_collections)
+
+        # The edge collection must still be searched (handled via a local copy)...
+        call_collections = [
+            call[1]["collection_name"] for call in mock_vector_engine.search.call_args_list
+        ]
+        assert "EdgeType_relationship_name" in call_collections
+        # ...but the caller's list must be left untouched.
+        assert caller_collections == ["Entity_name"]
+
+
+@pytest.mark.asyncio
 async def test_brute_force_triplet_search_all_collections_empty():
     """Test that empty list is returned when all collections return no results."""
     mock_vector_engine = AsyncMock()


### PR DESCRIPTION
## Summary

Fixes #3481.

`brute_force_triplet_search()` was mutating the caller's `collections` list in place:

```python
if "EdgeType_relationship_name" not in collections:
    collections.append("EdgeType_relationship_name")
```

### Root cause

`TripletSearchContextProvider` stores `self.collections` once and passes that **same list object** into a `brute_force_triplet_search(...)` call for every entity in `_create_search_tasks()`. Because the function appended to the list it was handed, after the first search the provider's configured `self.collections` permanently grew an extra `"EdgeType_relationship_name"` entry, and the same list object was shared across the concurrently-gathered per-entity searches. A function shouldn't modify a list its caller owns.

### Fix

Rebind `collections` to a **new** list rather than appending in place:

```python
if "EdgeType_relationship_name" not in collections:
    collections = [*collections, "EdgeType_relationship_name"]
```

The edge collection is still searched exactly as before — only *where* the entry is added changes (a local copy), so the caller's list is left untouched. This also covers the `collections is None` branch, where the value is already a fresh local list.

### Verification

- Added a regression test (`test_brute_force_triplet_search_does_not_mutate_caller_collections`) that passes a caller-owned list into two consecutive searches and asserts the edge collection is still searched **and** the caller's list is unchanged (`["Entity_name"]`). It fails on `main`/`dev` before the fix and passes after.
- `pytest cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py` → **41 passed**.
- `ruff check` and `ruff format --check` clean on both changed files.
- The other 10 failures in the wider `cognee/tests/unit/modules/retrieval/` directory are pre-existing on a clean `dev` checkout (unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code)_