### PR TITLE
refactor(ingestion): stream S3 files without temp storage

### DIFF
--- a/cognee/infrastructure/loaders/LoaderEngine.py
+++ b/cognee/infrastructure/loaders/LoaderEngine.py
@@ -1,6 +1,5 @@
-from typing import Any
-
-import filetype
+from pathlib import Path
+from typing import Any, BinaryIO
 
 from cognee.infrastructure.files.utils.guess_file_type import guess_file_type
 from cognee.shared.logging_utils import get_logger
@@ -84,11 +83,32 @@ class LoaderEngine:
         Returns:
             LoaderInterface that can handle the file, or None if not found
         """
-        from pathlib import Path
-
         file_info = guess_file_type(file_path)  # ty:ignore[invalid-argument-type]
 
         path_extension = Path(file_path).suffix.lstrip(".")
+
+        return self._get_loader(path_extension, file_info.extension, file_info.mime, preferred_loaders)
+
+    def get_loader_for_stream(
+        self,
+        file: BinaryIO,
+        file_name: str,
+        preferred_loaders: dict[str, dict[str, Any]] | None,
+    ) -> LoaderInterface | None:
+        file_info = guess_file_type(file, file_name)
+        file.seek(0)
+
+        path_extension = Path(file_name).suffix.lstrip(".")
+
+        return self._get_loader(path_extension, file_info.extension, file_info.mime, preferred_loaders)
+
+    def _get_loader(
+        self,
+        path_extension: str,
+        detected_extension: str,
+        mime_type: str,
+        preferred_loaders: dict[str, dict[str, Any]] | None,
+    ) -> LoaderInterface | None:
 
         # Try preferred loaders first
         if preferred_loaders:
@@ -96,10 +116,10 @@ class LoaderEngine:
                 if loader_name in self._loaders:
                     loader = self._loaders[loader_name]
                     # Try with path extension first (for text formats like html)
-                    if loader.can_handle(extension=path_extension, mime_type=file_info.mime):
+                    if loader.can_handle(extension=path_extension, mime_type=mime_type):
                         return loader
                     # Fall back to content-detected extension
-                    if loader.can_handle(extension=file_info.extension, mime_type=file_info.mime):
+                    if loader.can_handle(extension=detected_extension, mime_type=mime_type):
                         return loader
                 else:
                     logger.info(f"Skipping {loader_name}: Preferred Loader not registered")
@@ -109,10 +129,10 @@ class LoaderEngine:
             if loader_name in self._loaders:
                 loader = self._loaders[loader_name]
                 # Try with path extension first (for text formats like html)
-                if loader.can_handle(extension=path_extension, mime_type=file_info.mime):
+                if loader.can_handle(extension=path_extension, mime_type=mime_type):
                     return loader
                 # Fall back to content-detected extension
-                if loader.can_handle(extension=file_info.extension, mime_type=file_info.mime):
+                if loader.can_handle(extension=detected_extension, mime_type=mime_type):
                     return loader
             else:
                 logger.info(
@@ -120,6 +140,27 @@ class LoaderEngine:
                 )
 
         return None
+
+    async def load_file_stream(
+        self,
+        file: BinaryIO,
+        file_name: str,
+        preferred_loaders: dict[str, dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> tuple[str, LoaderInterface]:
+        loader = self.get_loader_for_stream(file, file_name, preferred_loaders)
+        if not loader:
+            raise ValueError(self._no_loader_message(file_name))
+
+        logger.debug(f"Loading {file_name} with {loader.loader_name}")
+
+        loader_config = {}
+        if preferred_loaders and loader.loader_name in preferred_loaders:
+            loader_config = preferred_loaders[loader.loader_name]
+
+        merged_kwargs = {**loader_config, **kwargs, "file_stream": file}
+
+        return await loader.load(file_name, **merged_kwargs), loader
 
     async def load_file(
         self,

--- a/cognee/infrastructure/loaders/core/audio_loader.py
+++ b/cognee/infrastructure/loaders/core/audio_loader.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any
+from typing import Any, BinaryIO
 
 from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
 from cognee.infrastructure.files.utils.get_file_metadata import get_file_metadata
@@ -63,7 +63,12 @@ class AudioLoader(LoaderInterface):
             return True
         return False
 
-    async def load(self, file_path: str, **kwargs: Any) -> str:
+    async def load(
+        self,
+        file_path: str,
+        file_stream: BinaryIO | None = None,
+        **kwargs: Any,
+    ) -> str:
         """
         Load and process the audio file.
 
@@ -78,11 +83,14 @@ class AudioLoader(LoaderInterface):
             FileNotFoundError: If file doesn't exist
             OSError: If file cannot be read
         """
-        if not os.path.exists(file_path):
+        if file_stream is None and not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
 
-        with open(file_path, "rb") as f:
-            file_metadata = await get_file_metadata(f)
+        if file_stream is None:
+            with open(file_path, "rb") as f:
+                file_metadata = await get_file_metadata(f)
+        else:
+            file_metadata = await get_file_metadata(file_stream, file_path)
         # Name ingested file of current loader based on original file content hash
         storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 

--- a/cognee/infrastructure/loaders/core/csv_loader.py
+++ b/cognee/infrastructure/loaders/core/csv_loader.py
@@ -1,6 +1,7 @@
 import csv
+import io
 import os
-from typing import Any
+from typing import Any, BinaryIO
 
 from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
 from cognee.infrastructure.files.utils.get_file_metadata import get_file_metadata
@@ -44,7 +45,13 @@ class CsvLoader(LoaderInterface):
 
         return False
 
-    async def load(self, file_path: str, encoding: str = "utf-8", **kwargs: Any) -> str:
+    async def load(
+        self,
+        file_path: str,
+        encoding: str = "utf-8",
+        file_stream: BinaryIO | None = None,
+        **kwargs: Any,
+    ) -> str:
         """
         Load and process the csv file.
 
@@ -61,18 +68,27 @@ class CsvLoader(LoaderInterface):
             UnicodeDecodeError: If file cannot be decoded with specified encoding
             OSError: If file cannot be read
         """
-        if not os.path.exists(file_path):
+        if file_stream is None and not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
 
-        with open(file_path, "rb") as f:
-            file_metadata = await get_file_metadata(f)
+        if file_stream is None:
+            with open(file_path, "rb") as f:
+                file_metadata = await get_file_metadata(f)
+        else:
+            file_metadata = await get_file_metadata(file_stream, file_path)
         # Name ingested file of current loader based on original file content hash
         storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
         row_texts = []
         row_index = 1
 
-        with open(file_path, encoding=encoding, newline="") as file:
+        if file_stream is None:
+            file = open(file_path, encoding=encoding, newline="")
+        else:
+            file_stream.seek(0)
+            file = io.StringIO(file_stream.read().decode(encoding), newline="")
+
+        with file:
             reader = csv.DictReader(file)
             for row in reader:
                 pairs = [f"{str(k)}: {str(v)}" for k, v in row.items()]

--- a/cognee/infrastructure/loaders/core/image_loader.py
+++ b/cognee/infrastructure/loaders/core/image_loader.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any
+from typing import Any, BinaryIO
 
 from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
 from cognee.infrastructure.files.utils.get_file_metadata import get_file_metadata
@@ -77,7 +77,12 @@ class ImageLoader(LoaderInterface):
 
         return False
 
-    async def load(self, file_path: str, **kwargs: Any) -> str:
+    async def load(
+        self,
+        file_path: str,
+        file_stream: BinaryIO | None = None,
+        **kwargs: Any,
+    ) -> str:
         """
         Load and process the image file.
 
@@ -93,11 +98,14 @@ class ImageLoader(LoaderInterface):
             UnicodeDecodeError: If file cannot be decoded with specified encoding
             OSError: If file cannot be read
         """
-        if not os.path.exists(file_path):
+        if file_stream is None and not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
 
-        with open(file_path, "rb") as f:
-            file_metadata = await get_file_metadata(f)
+        if file_stream is None:
+            with open(file_path, "rb") as f:
+                file_metadata = await get_file_metadata(f)
+        else:
+            file_metadata = await get_file_metadata(file_stream, file_path)
         # Name ingested file of current loader based on original file content hash
         storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 

--- a/cognee/infrastructure/loaders/core/text_loader.py
+++ b/cognee/infrastructure/loaders/core/text_loader.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any
+from typing import Any, BinaryIO
 
 from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
 from cognee.infrastructure.files.utils.get_file_metadata import get_file_metadata
@@ -50,7 +50,13 @@ class TextLoader(LoaderInterface):
 
         return False
 
-    async def load(self, file_path: str, encoding: str = "utf-8", **kwargs: Any) -> str:
+    async def load(
+        self,
+        file_path: str,
+        encoding: str = "utf-8",
+        file_stream: BinaryIO | None = None,
+        **kwargs: Any,
+    ) -> str:
         """
         Load and process the text file.
 
@@ -67,16 +73,23 @@ class TextLoader(LoaderInterface):
             UnicodeDecodeError: If file cannot be decoded with specified encoding
             OSError: If file cannot be read
         """
-        if not os.path.exists(file_path):
+        if file_stream is None and not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
 
-        with open(file_path, "rb") as f:
-            file_metadata = await get_file_metadata(f)
+        if file_stream is None:
+            with open(file_path, "rb") as f:
+                file_metadata = await get_file_metadata(f)
+        else:
+            file_metadata = await get_file_metadata(file_stream, file_path)
         # Name ingested file of current loader based on original file content hash
         storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
-        with open(file_path, encoding=encoding) as f:
-            content = f.read()
+        if file_stream is None:
+            with open(file_path, encoding=encoding) as f:
+                content = f.read()
+        else:
+            file_stream.seek(0)
+            content = file_stream.read().decode(encoding)
 
         if not kwargs.get("persist", True):
             return content

--- a/cognee/infrastructure/loaders/external/pypdf_loader.py
+++ b/cognee/infrastructure/loaders/external/pypdf_loader.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, BinaryIO
 
 from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
 from cognee.infrastructure.files.utils.get_file_metadata import get_file_metadata
@@ -34,7 +34,13 @@ class PyPdfLoader(LoaderInterface):
 
         return False
 
-    async def load(self, file_path: str, strict: bool = False, **kwargs: Any) -> str:
+    async def load(
+        self,
+        file_path: str,
+        strict: bool = False,
+        file_stream: BinaryIO | None = None,
+        **kwargs: Any,
+    ) -> str:
         """
         Load PDF file and extract text content.
 
@@ -58,12 +64,15 @@ class PyPdfLoader(LoaderInterface):
             ) from e
 
         try:
-            with open(file_path, "rb") as file:
+            file_context = open(file_path, "rb") if file_stream is None else None
+            file = file_context.__enter__() if file_context is not None else file_stream
+            try:
                 file_metadata = await get_file_metadata(file)
                 # Name ingested file of current loader based on original file content hash
                 storage_file_name = "text_" + file_metadata["content_hash"] + ".txt"
 
                 logger.info(f"Reading PDF: {file_path}")
+                file.seek(0)
                 reader = PdfReader(file, strict=strict)
 
                 content_parts = []
@@ -92,6 +101,9 @@ class PyPdfLoader(LoaderInterface):
                 full_file_path = await storage.store(storage_file_name, full_content)
 
                 return full_file_path
+            finally:
+                if file_context is not None:
+                    file_context.__exit__(None, None, None)
 
         except Exception as e:
             logger.error(f"Failed to process PDF {file_path}: {e}")

--- a/cognee/tasks/ingestion/data_item_to_text_file.py
+++ b/cognee/tasks/ingestion/data_item_to_text_file.py
@@ -1,8 +1,6 @@
 import os
 from urllib.parse import urlparse
-from typing import Any, List, Tuple
-from pathlib import Path
-import tempfile
+from typing import Any, Tuple
 
 from cognee.infrastructure.loaders.LoaderInterface import LoaderInterface
 from cognee.modules.ingestion.exceptions import IngestionError
@@ -24,15 +22,6 @@ class SaveDataSettings(BaseSettings):
 settings = SaveDataSettings()
 
 
-async def pull_from_s3(file_path, destination_file) -> None:
-    async with open_data_file(file_path) as file:
-        while True:
-            chunk = file.read(8192)
-            if not chunk:
-                break
-            destination_file.write(chunk)
-
-
 async def data_item_to_text_file(
     data_item_path: str,
     preferred_loaders: dict[str, dict[str, Any]] = None,
@@ -42,16 +31,9 @@ async def data_item_to_text_file(
 
         # data is s3 file path
         if parsed_url.scheme == "s3":
-            # TODO: Rework this to work with file streams and not saving data to temp storage
-            # Note: proper suffix information is needed for OpenAI to handle mp3 files
-            path_info = Path(parsed_url.path)
-            with tempfile.NamedTemporaryFile(mode="wb", suffix=path_info.suffix) as temp_file:
-                await pull_from_s3(data_item_path, temp_file)
-                temp_file.flush()  # Data needs to be saved to local storage
-                loader = get_loader_engine()
-                return await loader.load_file(temp_file.name, preferred_loaders), loader.get_loader(
-                    temp_file.name, preferred_loaders
-                )
+            loader = get_loader_engine()
+            async with open_data_file(data_item_path, mode="rb") as file:
+                return await loader.load_file_stream(file, data_item_path, preferred_loaders)
 
         # data is local file path
         elif parsed_url.scheme == "file":


### PR DESCRIPTION
## Description
Refactor S3 ingestion so uploaded S3 objects are processed directly from a stream instead of being written to a temporary file first. Remove temp-file handling and add load-file stream support and update text, audio, CSV, image, and PDF loaders to accept file stream input.

## Acceptance Criteria
- S3 ingestion path no longer creates a temporary local file
- Loader engine can dispatch streams via load_file_stream()

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING -->

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.