### PR TITLE
fix(llm): use provider-aware defaults for ollama chunk sizing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -525,6 +525,8 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #LLM_MODEL="llama3.1:8b"
 #LLM_PROVIDER="ollama"
 #LLM_ENDPOINT="http://localhost:11434/v1"
+# Context window for Ollama models (Ollama default is 4096)
+#OLLAMA_NUM_CTX=4096
 #EMBEDDING_PROVIDER="ollama"
 #EMBEDDING_MODEL="nomic-embed-text:latest"
 #EMBEDDING_ENDPOINT="http://localhost:11434/api/embed"

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -74,6 +74,7 @@ class LLMConfig(BaseSettings):
     llama_cpp_n_ctx: int = 2048
     llama_cpp_n_gpu_layers: int = 0
     llama_cpp_chat_format: str = "chatml"
+    ollama_num_ctx: int = 4096
 
     fallback_api_key: str = ""
     fallback_endpoint: str = ""

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -50,7 +50,7 @@ def get_model_max_completion_tokens(model_name: str) -> int | None:
 
     Checks if the provided model name is present in the predefined model cost dictionary. If
     found, it logs the maximum token count for that model and returns it. If the model name
-    is not recognized, it logs an informational message and returns None.
+    is not recognized, it falls back to provider-specific context sizes.
 
     Parameters:
     -----------
@@ -62,12 +62,11 @@ def get_model_max_completion_tokens(model_name: str) -> int | None:
 
         Number of max tokens of model, or None if model is unknown
     """
-    max_completion_tokens: int | None = None
-
     if model_name in litellm.model_cost:
         if "max_tokens" in litellm.model_cost[model_name]:
             max_completion_tokens = litellm.model_cost[model_name]["max_tokens"]
             logger.debug(f"Max input tokens for {model_name}: {max_completion_tokens}")
+            return max_completion_tokens
         else:
             logger.debug(
                 f"Model max_tokens not found in LiteLLM's model_cost for model {model_name}."
@@ -75,7 +74,17 @@ def get_model_max_completion_tokens(model_name: str) -> int | None:
     else:
         logger.debug("Model not found in LiteLLM's model_cost.")
 
-    return max_completion_tokens
+    # Provider-aware safe defaults when LiteLLM has no record
+    from cognee.infrastructure.llm.config import get_llm_config
+    llm_config = get_llm_config()
+    
+    provider = (llm_config.llm_provider or "").lower()
+    if provider == "ollama":
+        return llm_config.ollama_num_ctx
+    if provider in ("llama_cpp", "llama.cpp"):
+        return llm_config.llama_cpp_n_ctx
+
+    return None
 
 
 async def test_llm_connection() -> None:


### PR DESCRIPTION
***


Fixes #3436 

### What this PR does
Resolves an issue where Cognee generates chunks larger than the Ollama context window because LiteLLM's `model_cost` lookup returns `None` for Ollama models. 

Instead of falling back to a hardcoded 16384 token limit, the chunk calculation now safely falls back to a provider-aware context value.

### Key Changes
- **`utils.py`**: Updated `get_model_max_completion_tokens()` to use provider-specific context values when LiteLLM lookup fails.
- **`config.py`**: Introduced `ollama_num_ctx` (default `4096`) to `LLMConfig`, mirroring the existing `llama_cpp_n_ctx` pattern.
- **`.env.template`**: Added `OLLAMA_NUM_CTX` documentation so users can easily override the default context window if necessary.

*(Note: Users who wish to modify the context allocated at runtime inside Ollama can continue to do so securely using the pre-existing `LLM_ARGS` mechanism.)*

***