### PR TITLE
fix(graph): compute real connected components in Ladybug get_graph_metrics

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -39,6 +39,56 @@ DEFAULT_KUZU_BUFFER_POOL_SIZE = 1 << 35  # 32 GB (must be a power of 2 for Kuzu)
 DEFAULT_KUZU_MAX_DB_SIZE = 1 << 35  # 32 GB (must be a power of 2 for Kuzu)
 
 
+def _weakly_connected_component_sizes(
+    node_ids: List[Any], edges: List[Tuple[Any, Any]]
+) -> List[int]:
+    """Return the sizes of the graph's weakly connected components, largest first.
+
+    The graph is treated as undirected (edge direction is ignored). Nodes without
+    any edge form their own singleton component, and edge endpoints missing from
+    ``node_ids`` are ignored defensively. Implemented as a self-contained union-find
+    so the whole component — at any distance — is counted, with no traversal-depth
+    cap and no dependency on a graph-algorithm extension.
+
+    Parameters:
+    -----------
+
+        - node_ids (List[Any]): Identifiers of every node in the graph.
+        - edges (List[Tuple[Any, Any]]): ``(source, target)`` endpoint id pairs.
+
+    Returns:
+    --------
+
+        - List[int]: Component sizes ordered from largest to smallest.
+    """
+    parent = {node_id: node_id for node_id in node_ids}
+
+    def find(node):
+        root = node
+        while parent[root] != root:
+            root = parent[root]
+        # Path compression keeps repeated lookups cheap on large graphs.
+        while parent[node] != root:
+            parent[node], node = root, parent[node]
+        return root
+
+    def union(left, right):
+        left_root, right_root = find(left), find(right)
+        if left_root != right_root:
+            parent[left_root] = right_root
+
+    for source, target in edges:
+        if source in parent and target in parent:
+            union(source, target)
+
+    sizes: Dict[Any, int] = {}
+    for node_id in node_ids:
+        root = find(node_id)
+        sizes[root] = sizes.get(root, 0) + 1
+
+    return sorted(sizes.values(), reverse=True)
+
+
 cache_config = get_cache_config()
 if cache_config.shared_ladybug_lock:
     from cognee.infrastructure.databases.cache.get_cache_engine import get_cache_engine
@@ -2383,13 +2433,14 @@ class LadybugAdapter(GraphDBInterface):
             num_edges = edge_count_result[0][0] if edge_count_result else 0
 
             # Calculate mandatory metrics
+            component_sizes = await self._get_size_of_connected_components()
             mandatory_metrics = {
                 "num_nodes": num_nodes,
                 "num_edges": num_edges,
                 "mean_degree": (2 * num_edges) / num_nodes if num_nodes != 0 else None,
                 "edge_density": num_edges / (num_nodes * (num_nodes - 1)) if num_nodes > 1 else 0,
-                "num_connected_components": await self._get_num_connected_components(),
-                "sizes_of_connected_components": await self._get_size_of_connected_components(),
+                "num_connected_components": len(component_sizes),
+                "sizes_of_connected_components": component_sizes,
             }
 
             if include_optional:
@@ -2429,32 +2480,24 @@ class LadybugAdapter(GraphDBInterface):
                 "avg_clustering": -1,
             }
 
+    async def _get_size_of_connected_components(self) -> List[int]:
+        """Get the sizes of all connected components in the graph, largest first.
+
+        The previous Cypher walked a bounded ``[:EDGE*1..3]`` neighborhood per node
+        and counted those per-node neighborhoods as "components", so it ignored
+        connectivity beyond 3 hops, never collapsed a component to a single entry,
+        and dropped isolated nodes. Instead, fetch every node id and edge endpoint
+        pair and compute true weakly-connected components with union-find.
+        """
+        node_rows = await self.query("MATCH (n:Node) RETURN n.id")
+        edge_rows = await self.query("MATCH (a:Node)-[:EDGE]->(b:Node) RETURN a.id, b.id")
+        node_ids = [row[0] for row in node_rows] if node_rows else []
+        edges = [(row[0], row[1]) for row in edge_rows] if edge_rows else []
+        return _weakly_connected_component_sizes(node_ids, edges)
+
     async def _get_num_connected_components(self) -> int:
         """Get the number of connected components in the graph."""
-        query = """
-        MATCH (n:Node)
-        WITH n, n.id AS node_id
-        MATCH path = (n)-[:EDGE*1..3]-(m)
-        WITH node_id, COLLECT(DISTINCT m.id) AS connected_nodes
-        WITH COLLECT(DISTINCT connected_nodes + [node_id]) AS components
-        RETURN SIZE(components) AS num_components
-        """
-        result = await self.query(query)
-        return result[0][0] if result else 0
-
-    async def _get_size_of_connected_components(self) -> List[int]:
-        """Get the sizes of all connected components in the graph."""
-        query = """
-        MATCH (n:Node)
-        WITH n, n.id AS node_id
-        MATCH path = (n)-[:EDGE*1..3]-(m)
-        WITH node_id, COLLECT(DISTINCT m.id) AS connected_nodes
-        WITH COLLECT(DISTINCT connected_nodes + [node_id]) AS components
-        UNWIND components AS component
-        RETURN SIZE(component) AS component_size
-        """
-        result = await self.query(query)
-        return [row[0] for row in result] if result else []
+        return len(await self._get_size_of_connected_components())
 
     async def _get_shortest_path_lengths(self) -> List[int]:
         """Get the lengths of shortest paths between all pairs of nodes."""

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_graph_metrics.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_graph_metrics.py
@@ -1,0 +1,125 @@
+"""Tests for LadybugAdapter graph-metrics connected-component computation.
+
+Regression coverage for the bug where ``_get_num_connected_components`` /
+``_get_size_of_connected_components`` walked a bounded ``[:EDGE*1..3]`` neighborhood
+per node and counted those per-node neighborhoods as components — so they ignored
+connectivity beyond 3 hops, never collapsed a component to one entry, and dropped
+isolated nodes.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.ladybug.adapter import (
+    LadybugAdapter,
+    _weakly_connected_component_sizes,
+)
+
+
+# --------------------------------------------------------------------------- #
+# _weakly_connected_component_sizes (pure)
+# --------------------------------------------------------------------------- #
+
+
+def test_component_sizes_pairs_chain_and_isolated():
+    # Three 2-node pairs, a 5-node chain (spans 4 hops), and one isolated node.
+    node_ids = ["A", "B", "C", "D", "E", "F", "G", "P1", "P2", "P3", "P4", "P5"]
+    edges = [
+        ("A", "B"),
+        ("C", "D"),
+        ("E", "F"),
+        ("P1", "P2"),
+        ("P2", "P3"),
+        ("P3", "P4"),
+        ("P4", "P5"),
+    ]
+    assert _weakly_connected_component_sizes(node_ids, edges) == [5, 2, 2, 2, 1]
+
+
+def test_component_sizes_chain_beyond_three_hops_is_one_component():
+    # A 6-node chain is a single component even though endpoints are 5 hops apart.
+    node_ids = ["n0", "n1", "n2", "n3", "n4", "n5"]
+    edges = [("n0", "n1"), ("n1", "n2"), ("n2", "n3"), ("n3", "n4"), ("n4", "n5")]
+    assert _weakly_connected_component_sizes(node_ids, edges) == [6]
+
+
+def test_component_sizes_all_isolated():
+    assert _weakly_connected_component_sizes(["a", "b", "c"], []) == [1, 1, 1]
+
+
+def test_component_sizes_edges_are_undirected():
+    assert _weakly_connected_component_sizes(["a", "b"], [("b", "a")]) == [2]
+
+
+def test_component_sizes_empty():
+    assert _weakly_connected_component_sizes([], []) == []
+
+
+def test_component_sizes_ignores_unknown_endpoints():
+    assert _weakly_connected_component_sizes(["a", "b"], [("a", "missing")]) == [1, 1]
+
+
+def test_component_sizes_self_loop_stays_singleton():
+    assert _weakly_connected_component_sizes(["a", "b"], [("a", "a")]) == [1, 1]
+
+
+# --------------------------------------------------------------------------- #
+# adapter methods (DB I/O mocked)
+# --------------------------------------------------------------------------- #
+
+
+def _adapter_with_graph(node_ids, edge_pairs):
+    """A LadybugAdapter whose query() returns a fixed node/edge graph."""
+    adapter = LadybugAdapter.__new__(LadybugAdapter)
+
+    async def fake_query(query, params=None):
+        if "RETURN n.id" in query:
+            return [[node_id] for node_id in node_ids]
+        if "a.id, b.id" in query:
+            return [[source, target] for source, target in edge_pairs]
+        if "COUNT(n)" in query:
+            return [[len(node_ids)]]
+        if "COUNT(r)" in query:
+            return [[len(edge_pairs)]]
+        return []
+
+    adapter.query = AsyncMock(side_effect=fake_query)
+    return adapter
+
+
+_GRAPH = (
+    ["A", "B", "C", "D", "E", "F", "G", "P1", "P2", "P3", "P4", "P5"],
+    [
+        ("A", "B"),
+        ("C", "D"),
+        ("E", "F"),
+        ("P1", "P2"),
+        ("P2", "P3"),
+        ("P3", "P4"),
+        ("P4", "P5"),
+    ],
+)
+
+
+@pytest.mark.asyncio
+async def test_get_size_of_connected_components_uses_full_graph():
+    adapter = _adapter_with_graph(*_GRAPH)
+    assert await adapter._get_size_of_connected_components() == [5, 2, 2, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_get_num_connected_components_matches_sizes():
+    adapter = _adapter_with_graph(*_GRAPH)
+    assert await adapter._get_num_connected_components() == 5
+
+
+@pytest.mark.asyncio
+async def test_get_graph_metrics_reports_correct_components():
+    adapter = _adapter_with_graph(*_GRAPH)
+    metrics = await adapter.get_graph_metrics()
+
+    assert metrics["num_nodes"] == 12
+    assert metrics["num_edges"] == 7
+    assert metrics["num_connected_components"] == 5
+    assert metrics["sizes_of_connected_components"] == [5, 2, 2, 2, 1]


### PR DESCRIPTION
### Description
On the default graph backend, `get_graph_metrics()` reported the wrong number and sizes of connected components. The helpers walked a bounded `[:EDGE*1..3]` neighborhood for each node and counted those per-node neighborhoods as "components", which (a) ignored connectivity beyond 3 hops, (b) returned roughly one component per node instead of the real component count, and (c) dropped isolated nodes (the `*1..3` minimum-one-hop match skips degree-0 nodes).

I verified it on a graph whose true components are `[5, 2, 2, 2, 1]` (3 pairs, a 5-node chain that spans 4 hops, and 1 isolated node): before the fix it reported `num_connected_components = 11` with sizes `[6, 6, 6, 5, 5, 3, 3, 3, 3, 3, 3]`; after the fix it reports `5` and `[5, 2, 2, 2, 1]`.

The fix fetches all node ids and edge endpoint pairs and computes weakly-connected components with a small union-find helper (undirected; isolated nodes count as singletons; unknown endpoints ignored). This is the same in-process approach the Neptune (PR #3171) and spanner/turingdb adapters use. `get_graph_metrics` now computes the sizes once and derives `num_connected_components` from them, so the count and the size list can never disagree.

Closes #3491

### Acceptance Criteria
- `num_connected_components` equals the real number of weakly-connected components, including isolated nodes as singletons.
- `sizes_of_connected_components` lists the true component sizes (largest first), independent of how far apart nodes are.
- A single connected graph of any diameter reports exactly one component.
- Existing graph adapter tests keep passing.

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

### Screenshots
<!-- Screenshot of the command below passing -->
```
python -m pytest cognee/tests/unit/infrastructure/databases/graph/test_ladybug_graph_metrics.py
# 10 passed
```
<img width="1626" height="700" alt="image" src="https://github.com/user-attachments/assets/26d30730-ba03-44e0-9365-2485390dba15" />


### Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

### DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
