### PR TITLE
fix(retrieval): clamp importance_weight to prevent ranking corruption

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -1,6 +1,8 @@
 from uuid import UUID
 from typing import Union, BinaryIO, List, Optional, Any
+import math
 
+from cognee.exceptions import CogneeValidationError
 from cognee.modules.users.models import User
 from cognee.infrastructure.databases.vector.embeddings.config import EmbeddingConfig
 from cognee.infrastructure.llm.config import LLMConfig
@@ -186,6 +188,22 @@ async def add(
         - TAVILY_API_KEY: YOUR_TAVILY_API_KEY
 
     """
+    # Validate importance_weight early. The triplet scoring formula uses
+    # (2 - importance_weight) as a multiplier, which is only well-behaved for
+    # weights in [0.0, 2.0]: outside that range the ranking sign flips and the
+    # least-relevant triplets win retrieval. Non-finite values (NaN/inf) corrupt
+    # ranking entirely. Reject at the boundary so bad data is never persisted.
+    if importance_weight is not None and (
+        not isinstance(importance_weight, (int, float))
+        or not math.isfinite(float(importance_weight))
+        or not (0.0 <= float(importance_weight) <= 2.0)
+    ):
+        raise CogneeValidationError(
+            message="importance_weight must be a finite number in range [0.0, 2.0].",
+            name="InvalidImportanceWeightError",
+            log=False,
+        )
+
     # Route to remote instance if connected via serve()
     from cognee.api.v1.serve.state import get_remote_client
 

--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -1,3 +1,4 @@
+import math
 import time
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.graph.models.EdgeType import EdgeType
@@ -517,6 +518,15 @@ class CogneeGraph(CogneeAbstractGraph):
                     importance_weight = float(importance_weight)
                 except (TypeError, ValueError):
                     importance_weight = 0.5
+                # Guard the (2 - importance_weight) multiplier below: a weight >= 2.0
+                # would flip the ranking sign (making the least relevant triplet rank
+                # first), while NaN/inf corrupt heapq.nsmallest ordering. Treat
+                # non-finite values as neutral (weight 1.0) and clamp the rest to
+                # [0.0, 2.0] so the multiplier stays in [0.0, 2.0].
+                if not math.isfinite(importance_weight):
+                    importance_weight = 1.0
+                else:
+                    importance_weight = max(0.0, min(2.0, importance_weight))
                 if not isinstance(distances, list) or query_index >= len(distances):
                     raise ValueError(
                         f"{label}: vector_distance must be a list with length > {query_index} "

--- a/cognee/tests/unit/api/v1/test_add_importance_weight_validation.py
+++ b/cognee/tests/unit/api/v1/test_add_importance_weight_validation.py
@@ -1,0 +1,89 @@
+"""Unit tests for cognee.add() importance_weight input validation.
+
+The validation runs as the first statement in add() (before serve()/DB routing),
+so these tests exercise the pure boundary check without any database or LLM setup.
+"""
+
+import math
+
+import pytest
+
+from cognee.api.v1.add import add
+from cognee.exceptions import CogneeValidationError
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_importance_weight_above_range():
+    """importance_weight > 2.0 would flip the ranking sign in triplet scoring."""
+    with pytest.raises(CogneeValidationError, match="importance_weight"):
+        await add("some text", dataset_name="ds", importance_weight=3.0)
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_importance_weight_below_range():
+    """Negative importance_weight is not a meaningful weight."""
+    with pytest.raises(CogneeValidationError, match="importance_weight"):
+        await add("some text", dataset_name="ds", importance_weight=-0.1)
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_nan_importance_weight():
+    """NaN corrupts heapq.nsmallest ordering during triplet ranking."""
+    with pytest.raises(CogneeValidationError, match="importance_weight"):
+        await add("some text", dataset_name="ds", importance_weight=float("nan"))
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_infinite_importance_weight():
+    """inf/-inf corrupt ranking arithmetic."""
+    for bad in (float("inf"), float("-inf")):
+        with pytest.raises(CogneeValidationError, match="importance_weight"):
+            await add("some text", dataset_name="ds", importance_weight=bad)
+
+
+@pytest.mark.asyncio
+async def test_add_rejects_non_numeric_importance_weight():
+    """Non-numeric weights cannot be persisted to a Float column meaningfully."""
+    with pytest.raises(CogneeValidationError, match="importance_weight"):
+        await add("some text", dataset_name="ds", importance_weight="very")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_add_accepts_boundary_importance_weights():
+    """Weights at the [0.0, 2.0] boundaries pass validation.
+
+    Validation is the first statement, so a passing weight proceeds past it. We
+    patch the subsequent serve()/DB surface to avoid needing infrastructure: the
+    point is simply that no CogneeValidationError is raised for valid weights.
+    """
+    from unittest.mock import patch
+
+    # get_remote_client returns None -> falls through to local setup(); stub setup()
+    # so we don't touch the DB. We only care that validation did NOT raise.
+    with (
+        patch(
+            "cognee.api.v1.serve.state.get_remote_client",
+            return_value=None,
+        ),
+        patch("cognee.api.v1.add.add.setup", create=True),
+        patch(
+            "cognee.api.v1.add.add.resolve_authorized_user_dataset",
+            side_effect=RuntimeError("stop-after-validation"),
+        ),
+    ):
+        for good in (0.0, 1.0, 2.0, 0.5):
+            with pytest.raises(RuntimeError, match="stop-after-validation"):
+                # Raises RuntimeError from the stub, proving we got PAST validation.
+                await add("some text", dataset_name="ds", importance_weight=good)
+
+
+def test_importance_weight_validation_bounds_are_documented_in_message():
+    """Sanity: the error message names the valid range so callers can self-correct."""
+    import asyncio
+
+    try:
+        asyncio.run(add("x", dataset_name="ds", importance_weight=math.nan))
+    except CogneeValidationError as exc:
+        assert "[0.0, 2.0]" in str(exc)
+    else:
+        pytest.fail("expected CogneeValidationError")

--- a/cognee/tests/unit/modules/graph/cognee_graph_test.py
+++ b/cognee/tests/unit/modules/graph/cognee_graph_test.py
@@ -988,6 +988,116 @@ async def test_feedback_blend_preserves_distance_order_when_feedback_weights_mat
 
 
 @pytest.mark.asyncio
+async def test_importance_weight_out_of_range_does_not_corrupt_ranking(setup_graph):
+    """importance_weight >= 2.0 must not flip the ranking so the worst-match triplet wins.
+
+    Regression guard: the scoring formula uses (2 - importance_weight) as a distance
+    multiplier. Without clamping, a weight >= 2.0 makes the multiplier <= 0, so the
+    least-relevant triplet ends up with the lowest (best) score. See the linked issue.
+    """
+    graph = setup_graph
+
+    node1 = Node("1")
+    node2 = Node("2")
+    node3 = Node("3")
+    node4 = Node("4")
+    graph.add_node(node1)
+    graph.add_node(node2)
+    graph.add_node(node3)
+    graph.add_node(node4)
+
+    # edge_best is a genuine close match (distance 0.1); edge_worst is far (1.5) but
+    # carries an importance_weight (3.0) that would, unclamped, push its score negative.
+    edge_best = Edge(node1, node2, attributes={"importance_weight": 3.0})
+    edge_worst = Edge(node3, node4, attributes={"importance_weight": 0.5})
+    graph.add_edge(edge_best)
+    graph.add_edge(edge_worst)
+
+    node1.add_attribute("vector_distance", [0.1])
+    node2.add_attribute("vector_distance", [0.1])
+    node3.add_attribute("vector_distance", [1.5])
+    node4.add_attribute("vector_distance", [1.5])
+    edge_best.add_attribute("vector_distance", [0.1])
+    edge_worst.add_attribute("vector_distance", [1.5])
+
+    ranked = await graph.calculate_top_triplet_importances(k=2, feedback_influence=0.0)
+
+    # The genuinely-close triplet must still rank first despite its out-of-range weight.
+    assert ranked[0] == edge_best
+    assert ranked[1] == edge_worst
+
+
+@pytest.mark.asyncio
+async def test_importance_weight_nan_falls_back_to_neutral(setup_graph):
+    """NaN importance_weight must be treated as neutral (1.0), not corrupt heapq ordering.
+
+    heapq.nsmallest has undefined behavior when keys contain NaN, so a NaN weight must
+    never reach the score computation.
+    """
+    graph = setup_graph
+
+    node1 = Node("1")
+    node2 = Node("2")
+    node3 = Node("3")
+    node4 = Node("4")
+    graph.add_node(node1)
+    graph.add_node(node2)
+    graph.add_node(node3)
+    graph.add_node(node4)
+
+    edge_nan = Edge(node1, node2, attributes={"importance_weight": float("nan")})
+    edge_normal = Edge(node3, node4, attributes={"importance_weight": 0.5})
+    graph.add_edge(edge_nan)
+    graph.add_edge(edge_normal)
+
+    node1.add_attribute("vector_distance", [0.1])
+    node2.add_attribute("vector_distance", [0.1])
+    node3.add_attribute("vector_distance", [1.0])
+    node4.add_attribute("vector_distance", [1.0])
+    edge_nan.add_attribute("vector_distance", [0.1])
+    edge_normal.add_attribute("vector_distance", [1.0])
+
+    # Must not raise and must produce a deterministic, correct order.
+    ranked = await graph.calculate_top_triplet_importances(k=2, feedback_influence=0.0)
+
+    assert ranked[0] == edge_nan
+    assert ranked[1] == edge_normal
+
+
+@pytest.mark.asyncio
+async def test_importance_weight_within_range_preserves_ordering(setup_graph):
+    """importance_weight in [0.0, 2.0] must keep existing ranking behavior unchanged."""
+    graph = setup_graph
+
+    node1 = Node("1")
+    node2 = Node("2")
+    node3 = Node("3")
+    node4 = Node("4")
+    graph.add_node(node1)
+    graph.add_node(node2)
+    graph.add_node(node3)
+    graph.add_node(node4)
+
+    edge_low_weight = Edge(node1, node2, attributes={"importance_weight": 0.0})
+    edge_high_weight = Edge(node3, node4, attributes={"importance_weight": 2.0})
+    graph.add_edge(edge_low_weight)
+    graph.add_edge(edge_high_weight)
+
+    # Equal distances; higher importance_weight -> (2 - iw) smaller -> lower (better) score.
+    node1.add_attribute("vector_distance", [0.5])
+    node2.add_attribute("vector_distance", [0.5])
+    node3.add_attribute("vector_distance", [0.5])
+    node4.add_attribute("vector_distance", [0.5])
+    edge_low_weight.add_attribute("vector_distance", [0.5])
+    edge_high_weight.add_attribute("vector_distance", [0.5])
+
+    ranked = await graph.calculate_top_triplet_importances(k=2, feedback_influence=0.0)
+
+    assert ranked[0] == edge_high_weight
+    assert ranked[1] == edge_low_weight
+
+
+@pytest.mark.asyncio
 async def test_missing_distance_penalty_ranks_below_max_real_triplet(setup_graph):
     """Fallback penalty 6.5 must rank behind any fully-matched max-cosine triplet (<= 6.0)."""
     graph = setup_graph


### PR DESCRIPTION
## Description

The triplet scoring formula in \`CogneeGraph.py\` uses \`(2 - importance_weight) * distance\` as a multiplier. This only works correctly when \`importance_weight\` is in \`[0, 2]\`. Nothing in the codebase enforced this range, so passing a value like \`3.0\` makes the multiplier negative, flipping the ranking sign and the least-relevant triplets end up ranking above the best match. \`NaN\` and \`inf\` corrupt \`heapq.nsmallest\` ordering entirely. No error is raised in any of these cases.

Two-part fix: clamp at the scoring site in \`CogneeGraph.py\` (non-finite falls back to neutral 1.0, finite values are clamped to [0.0, 2.0]), which also covers bad values already in the DB. Added input validation in \`add.py\` that raises \`CogneeValidationError\` early, matching how \`feedback_influence\` is already validated in \`brute_force_triplet_search.py\`.

Closes #3498

## Acceptance Criteria

- \`importance_weight >= 2.0\` no longer flips the triplet ranking sign
- \`NaN\`/\`inf\` no longer corrupt \`heapq.nsmallest\` ordering
- Valid weights in \`[0.0, 2.0]\` behave identically to before
- \`cognee.add()\` raises \`CogneeValidationError\` with a clear message for invalid input

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

<img width="1858" height="785" alt="Screenshot 2026-06-26 at 4 50 38 pm" src="https://github.com/user-attachments/assets/3a8f5dfd-b1b2-402b-ba8b-5bc86efe46b5" />
<img width="1820" height="766" alt="Screenshot 2026-06-26 at 4 52 41 pm" src="https://github.com/user-attachments/assets/58ffe06d-ee75-459b-985b-1ac96e8a2cbb" />


## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.