### PR TITLE
fix: resolve runtime deprecation warnings in observability, API router, and Pydantic models

### DIFF
--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -54,7 +54,7 @@ def get_add_router() -> APIRouter:
                 "Providing dataset ID is mandatory for sharing a dataset between users. Datasets provided by name will only be resolvable by dataset owner."
             ),
         ),
-        node_set: Optional[List[str]] = Form(default=[""], example=[""]),
+        node_set: Optional[List[str]] = Form(default=[""], examples=[[""]]),
         run_in_background: Optional[bool] = Form(default=False),
         user: User = Depends(get_authenticated_user),
     ):

--- a/cognee/modules/observability/get_observe.py
+++ b/cognee/modules/observability/get_observe.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 
 from cognee.base_config import get_base_config
 from .observers import Observer
@@ -64,7 +65,7 @@ def _wrap_with_otel(inner_decorator):
 
                 import asyncio
 
-                if asyncio.iscoroutinefunction(func):
+                if inspect.iscoroutinefunction(func):
                     return async_wrapper
                 return sync_wrapper
 
@@ -108,7 +109,7 @@ def _wrap_with_otel(inner_decorator):
 
         import asyncio
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             return async_wrapper
         return sync_wrapper
 

--- a/cognee/modules/pipelines/models/PipelineRunInfo.py
+++ b/cognee/modules/pipelines/models/PipelineRunInfo.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, List, Union
 from uuid import UUID
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from cognee.modules.data.models.Data import Data
 
 
@@ -16,10 +16,16 @@ class PipelineRunInfo(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "from_attributes": True,
-        # Add custom encoding handler for Data ORM model
-        "json_encoders": {Data: lambda d: d.to_json()},
+     
     }
 
+    @field_serializer("payload")
+    def serialize_payload(self, payload, _info):
+        if isinstance(payload, list):
+            return [item.to_json() if isinstance(item, Data) else item for item in payload]
+        if isinstance(payload, Data):
+            return payload.to_json()
+        return payload
 
 class PipelineRunStarted(PipelineRunInfo):
     status: str = "PipelineRunStarted"

--- a/cognee/tests/unit/modules/pipelines/test_provenance_stamping.py
+++ b/cognee/tests/unit/modules/pipelines/test_provenance_stamping.py
@@ -52,7 +52,7 @@ def _stamp_provenance(data, pipeline_name, task_name, visited=None):
         if data.source_task is None:
             data.source_task = task_name
 
-        for field_name in data.model_fields:
+        for field_name in type(data).model_fields:
             field_value = getattr(data, field_name, None)
             if field_value is not None:
                 _stamp_provenance(field_value, pipeline_name, task_name, visited)

--- a/cognee/tests/unit/modules/pipelines/test_topological_rank_stamping.py
+++ b/cognee/tests/unit/modules/pipelines/test_topological_rank_stamping.py
@@ -59,7 +59,7 @@ def _stamp_provenance(
             if current_rank is None or current_rank == 0:
                 data.topological_rank = task_index
 
-        for field_name in data.model_fields:
+        for field_name in type(data).model_fields:
             field_value = getattr(data, field_name, None)
             if field_value is not None:
                 _stamp_provenance(


### PR DESCRIPTION
## Description

Fixes four categories of runtime deprecation warnings identified by auditing the full unit test suite output (`uv run pytest cognee/tests/unit/`). Each warning is on a hard removal timeline in upcoming Python or library versions.

Fixes #3508

### Changes

**1. `cognee/modules/observability/get_observe.py`**
Replace `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`. The asyncio version is deprecated and scheduled for removal in Python 3.16.

**2. `cognee/api/v1/add/routers/get_add_router.py`**
Replace deprecated `example=` with `examples=` on FastAPI `Form()` field. Affects Swagger UI documentation generation.

**3. `cognee/modules/pipelines/models/PipelineRunInfo.py`**
Replace deprecated Pydantic V2 `json_encoders` in `model_config` with `@field_serializer` decorator on the `payload` field.

**4. `cognee/tests/unit/modules/pipelines/test_provenance_stamping.py` and `test_topological_rank_stamping.py`**
Access `model_fields` on the class (`type(data).model_fields`) instead of the instance, as required by Pydantic V2.11+.

## Acceptance Criteria

- [x] No behaviour change — all fixes are drop-in replacements
- [x] `ruff format` and `ruff check` pass clean
- [x] 2430 unit tests pass (11 pre-existing failures unrelated to this change)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

<img width="1600" height="226" alt="WhatsApp Image 2026-06-26 at 11 55 09 PM" src="https://github.com/user-attachments/assets/d158caef-4d2e-4fca-b921-c1eaded2f927" />

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

## AI Disclosure

I used Claude (Anthropic) to help understand the deprecation patterns and verify the fixes. The bug identification (via test suite audit), code changes, and testing were done by me.