### PR TITLE
fix: reject relative paths when local file ingestion is disabled

### DIFF
--- a/cognee/tasks/ingestion/save_data_item_to_storage.py
+++ b/cognee/tasks/ingestion/save_data_item_to_storage.py
@@ -85,6 +85,8 @@ async def save_data_item_to_storage(data_item: Union[BinaryIO, str, Any]) -> str
                 # Normalize path separators before creating file URL
                 normalized_path = os.path.normpath(abs_path)
                 return Path(normalized_path).as_uri()
+            else:
+                raise IngestionError(message="Local files are not accepted.")
 
         # data is text, save it to data storage and return the file path
         return await save_data_to_file(data_item)

--- a/cognee/tests/tasks/ingestion/test_save_data_item_to_storage.py
+++ b/cognee/tests/tasks/ingestion/test_save_data_item_to_storage.py
@@ -1,0 +1,39 @@
+import importlib
+
+import pytest
+
+from cognee.modules.ingestion.exceptions import IngestionError
+
+# Import the submodule explicitly: the package __init__ re-exports the function
+# under the same name, which would otherwise shadow the module object.
+mod = importlib.import_module("cognee.tasks.ingestion.save_data_item_to_storage")
+
+
+@pytest.mark.asyncio
+async def test_relative_path_rejected_when_local_files_disabled(tmp_path, monkeypatch):
+    """A real relative-path file must raise IngestionError (not be stored as text)
+    when local file ingestion is disabled, consistent with the file:// and
+    absolute-path branches."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("classified")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod.settings, "accept_local_file_path", False)
+
+    with pytest.raises(IngestionError):
+        await mod.save_data_item_to_storage("secret.txt")
+
+
+@pytest.mark.asyncio
+async def test_relative_path_accepted_when_local_files_enabled(tmp_path, monkeypatch):
+    """When local file ingestion is enabled, an existing relative-path file is
+    resolved to a file:// URI (unchanged behavior)."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("classified")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod.settings, "accept_local_file_path", True)
+
+    result = await mod.save_data_item_to_storage("secret.txt")
+    assert result.startswith("file:")
+    assert result.endswith("secret.txt")


### PR DESCRIPTION
## Description

While reviewing `save_data_item_to_storage`, I noticed the three local-path
branches don't treat the `accept_local_file_path` setting consistently. The
`file://` branch and the absolute-path branch both raise `IngestionError`
when local files are disabled, but the relative-path branch only had an `if`
with no `else`. So when `ACCEPT_LOCAL_FILE_PATH=False`, calling
`add("data/secret.txt")` for an existing relative-path file didn't raise and
didn't read the file — it silently fell through to the text-storage path and
stored the literal string "data/secret.txt" as document content.

That's surprising on two fronts: a security control that's turned on is
silently bypassed, and the graph ends up with a path string masquerading as
real content. I added the missing symmetric `else: raise IngestionError(...)`
so all three path types reject consistently. Behavior is unchanged when
`accept_local_file_path` is True.

## Acceptance Criteria

- With `ACCEPT_LOCAL_FILE_PATH=False`, an existing relative-path file raises
  `IngestionError` instead of being stored as text.
- With `ACCEPT_LOCAL_FILE_PATH=True`, an existing relative-path file still
  resolves to a `file://` URI (no behavior change).
- New unit tests cover both cases and pass.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1013" height="232" alt="image" src="https://github.com/user-attachments/assets/4c72df34-0a07-485c-b7b5-8c4fb9f4c249" />


## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass

- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

