### PR TITLE
Improve embedding configuration warnings

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -91,19 +91,17 @@ class EmbeddingConfig(BaseSettings):
             else:
                 logger.warning(
                     "Could not auto-derive embedding_dimensions for "
-                    "provider=%r model=%r. Falling back to %d. If your embedder "
-                    "produces vectors of a different size, set EMBEDDING_DIMENSIONS "
-                    "explicitly — otherwise the first write into the vector store "
-                    "will fail with a shape mismatch.",
+                    "provider=%r model=%r. Using fallback dimension %d. "
+                    "If your embedding model produces vectors of a different size, the first "
+                    "vector write may fail with a dimension mismatch. "
+                    "Configure EMBEDDING_DIMENSIONS explicitly to avoid this.",
                     self.embedding_provider,
                     self.embedding_model,
                     _FALLBACK_DIMENSIONS,
                 )
                 self.embedding_dimensions = _FALLBACK_DIMENSIONS
 
-        if not self.embedding_batch_size and self.embedding_provider.lower() == "openai":
-            self.embedding_batch_size = 36
-        elif not self.embedding_batch_size:
+        if not self.embedding_batch_size:
             self.embedding_batch_size = 36
 
     def to_dict(self) -> dict:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
## Summary

This PR improves the developer experience around embedding configuration by:

- Improving the warning message when embedding dimensions cannot be auto-derived, making it more actionable.
- Simplifying the redundant `embedding_batch_size` conditional without changing existing behavior.

## Testing

- Verified the project compiles successfully using:

  ```bash
  python -m compileall cognee

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
