### PR TITLE
fix(graph): validate importance_weight to prevent triplet ranking cor…

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -186,6 +186,16 @@ async def add(
         - TAVILY_API_KEY: YOUR_TAVILY_API_KEY
 
     """
+    import math
+
+    if importance_weight is not None:
+        if isinstance(importance_weight, bool) or not isinstance(importance_weight, (int, float)):
+            raise ValueError(f"importance_weight must be a numeric float between 0.0 and 2.0")
+        if math.isnan(importance_weight) or math.isinf(importance_weight):
+            raise ValueError(f"importance_weight must be a finite float between 0.0 and 2.0")
+        if not (0.0 <= importance_weight <= 2.0):
+            raise ValueError(f"importance_weight must be between 0.0 and 2.0")
+
     # Route to remote instance if connected via serve()
     from cognee.api.v1.serve.state import get_remote_client
 

--- a/cognee/modules/graph/cognee_graph/CogneeGraph.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraph.py
@@ -514,7 +514,10 @@ class CogneeGraph(CogneeAbstractGraph):
                 distances = element.attributes.get("vector_distance")
                 importance_weight = element.attributes.get("importance_weight")
                 try:
+                    import math
                     importance_weight = float(importance_weight)
+                    if math.isnan(importance_weight) or math.isinf(importance_weight) or not (0.0 <= importance_weight <= 2.0):
+                        importance_weight = 0.5
                 except (TypeError, ValueError):
                     importance_weight = 0.5
                 if not isinstance(distances, list) or query_index >= len(distances):

--- a/cognee/tests/unit/api/v1/test_add_importance_weight_validation.py
+++ b/cognee/tests/unit/api/v1/test_add_importance_weight_validation.py
@@ -1,0 +1,37 @@
+import pytest
+import math
+from cognee.api.v1.add import add
+
+@pytest.mark.asyncio
+async def test_add_rejects_importance_weight_above_range():
+    with pytest.raises(ValueError, match="between 0.0 and 2.0"):
+        await add("test data", importance_weight=2.1)
+
+@pytest.mark.asyncio
+async def test_add_rejects_importance_weight_below_range():
+    with pytest.raises(ValueError, match="between 0.0 and 2.0"):
+        await add("test data", importance_weight=-0.1)
+
+@pytest.mark.asyncio
+async def test_add_rejects_nan_importance_weight():
+    with pytest.raises(ValueError, match="between 0.0 and 2.0"):
+        await add("test data", importance_weight=float('nan'))
+
+@pytest.mark.asyncio
+async def test_add_rejects_infinite_importance_weight():
+    with pytest.raises(ValueError, match="between 0.0 and 2.0"):
+        await add("test data", importance_weight=float('inf'))
+
+@pytest.mark.asyncio
+async def test_add_rejects_non_numeric_importance_weight():
+    with pytest.raises(ValueError, match="between 0.0 and 2.0"):
+        await add("test data", importance_weight="high")
+    with pytest.raises(ValueError, match="between 0.0 and 2.0"):
+        await add("test data", importance_weight=True)
+
+@pytest.mark.asyncio
+async def test_importance_weight_validation_bounds_are_documented_in_message():
+    try:
+        await add("test data", importance_weight=3.0)
+    except ValueError as e:
+        assert "0.0 and 2.0" in str(e)

--- a/cognee/tests/unit/modules/graph/cognee_graph_test.py
+++ b/cognee/tests/unit/modules/graph/cognee_graph_test.py
@@ -1136,3 +1136,79 @@ def test_normalize_query_distance_lists_empty_list(setup_graph):
     result = graph._normalize_query_distance_lists([], query_list_length=None, name="test")
 
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_importance_weight_out_of_range_does_not_corrupt_ranking():
+    from cognee.modules.graph.cognee_graph.CogneeGraphElements import Node, Edge
+    from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
+    graph = CogneeGraph()
+
+    n1, n2 = Node("1"), Node("2")
+    n3, n4 = Node("3"), Node("4")
+    for n in (n1, n2, n3, n4):
+        graph.add_node(n)
+
+    edge_best  = Edge(n1, n2, attributes={"importance_weight": 0.5})
+    edge_worst = Edge(n3, n4, attributes={"importance_weight": 3.0})
+    graph.add_edge(edge_best)
+    graph.add_edge(edge_worst)
+
+    for node, dist in [(n1, 0.1), (n2, 0.1), (n3, 1.5), (n4, 1.5)]:
+        node.add_attribute("vector_distance", [dist])
+    edge_best.add_attribute("vector_distance",  [0.1])
+    edge_worst.add_attribute("vector_distance", [1.5])
+
+    ranked = await graph.calculate_top_triplet_importances(k=2, feedback_influence=0.0)
+    assert ranked[0] == edge_best
+
+
+@pytest.mark.asyncio
+async def test_importance_weight_nan_falls_back_to_neutral():
+    from cognee.modules.graph.cognee_graph.CogneeGraphElements import Node, Edge
+    from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
+    import math
+    graph = CogneeGraph()
+
+    n1, n2 = Node("1"), Node("2")
+    n3, n4 = Node("3"), Node("4")
+    for n in (n1, n2, n3, n4):
+        graph.add_node(n)
+
+    edge_best  = Edge(n1, n2, attributes={"importance_weight": 0.5})
+    edge_worst = Edge(n3, n4, attributes={"importance_weight": float('nan')})
+    graph.add_edge(edge_best)
+    graph.add_edge(edge_worst)
+
+    for node, dist in [(n1, 0.1), (n2, 0.1), (n3, 1.5), (n4, 1.5)]:
+        node.add_attribute("vector_distance", [dist])
+    edge_best.add_attribute("vector_distance",  [0.1])
+    edge_worst.add_attribute("vector_distance", [1.5])
+
+    ranked = await graph.calculate_top_triplet_importances(k=2, feedback_influence=0.0)
+    assert ranked[0] == edge_best
+
+
+@pytest.mark.asyncio
+async def test_importance_weight_within_range_preserves_ordering():
+    from cognee.modules.graph.cognee_graph.CogneeGraphElements import Node, Edge
+    from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
+    graph = CogneeGraph()
+
+    n1, n2 = Node("1"), Node("2")
+    n3, n4 = Node("3"), Node("4")
+    for n in (n1, n2, n3, n4):
+        graph.add_node(n)
+
+    edge_best  = Edge(n1, n2, attributes={"importance_weight": 0.5})
+    edge_worst = Edge(n3, n4, attributes={"importance_weight": 1.5})
+    graph.add_edge(edge_best)
+    graph.add_edge(edge_worst)
+
+    for node, dist in [(n1, 0.1), (n2, 0.1), (n3, 1.5), (n4, 1.5)]:
+        node.add_attribute("vector_distance", [dist])
+    edge_best.add_attribute("vector_distance",  [0.1])
+    edge_worst.add_attribute("vector_distance", [1.5])
+
+    ranked = await graph.calculate_top_triplet_importances(k=2, feedback_influence=0.0)
+    assert ranked[0] == edge_best


### PR DESCRIPTION
## Description

This PR fixes a bug (Issue #3498) where providing an out-of-bounds `importance_weight` (e.g., `>= 2.0` or `< 0.0`) could silently corrupt triplet rankings in the graph distance calculations by flipping the sign of the scoring formula. 

I've added validation in two places:
1. `cognee/api/v1/add/add.py`: Added upfront validation to ensure `importance_weight` is numeric, finite, and strictly between `0.0` and `2.0`.
2. `cognee/modules/graph/cognee_graph/CogneeGraph.py`: Added protective bounds checks during scoring. If a node or edge has an invalid or `NaN` `importance_weight`, it gracefully falls back to the neutral default of `0.5` instead of propagating NaN/Inf or inverting scores.

## Acceptance Criteria

* `importance_weight` provided via `cognee.add()` is validated and raises a `ValueError` if out of bounds or `NaN`.
* The core triplet scoring loop (`calculate_top_triplet_importances`) defaults to `0.5` if the attribute falls outside `[0.0, 2.0]` or is `NaN`, ensuring it doesn't corrupt ranking.
* I've added comprehensive unit tests for both the `add` validation API and the `CogneeGraph` ranking to prove the fix works effectively.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

*(You can omit screenshots or upload a screenshot of your terminal showing the tests passing)*

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description (Fixes #3498)
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.