### PR TITLE
fix(ingestion): persist importance_weight on re-ingest update path

### DIFF
--- a/cognee/tasks/ingestion/ingest_data.py
+++ b/cognee/tasks/ingestion/ingest_data.py
@@ -188,6 +188,7 @@ async def ingest_data(
                 data_point.node_set = json.dumps(node_set) if node_set else None
                 data_point.tenant_id = user.tenant_id if user.tenant_id else None
                 data_point.label = current_label
+                data_point.importance_weight = importance_weight
 
                 if content_changed:
                     data_point.pipeline_status = {}


### PR DESCRIPTION
## What

`store_data_to_dataset` (in `cognee/tasks/ingestion/ingest_data.py`) has separate **create** and **update** branches. The create branch sets `importance_weight`, but the **update** branch — run when re-ingesting an already-existing `Data` row — set every other field and omitted `importance_weight`. As a result, re-ingesting a file with a new `importance_weight` silently kept the previously stored value.

This is the same class of bug as #3160 (a field missing/incorrect in the same update branch), but for a different field.

## Fix

Add the missing assignment in the update branch:

```python
data_point.importance_weight = importance_weight
```

`importance_weight` is a mapped `Column(Float)` on the `Data` model, so the value now persists on flush — matching the behavior of the create branch.

## Reproduction

```python
import asyncio, cognee

async def main():
    await cognee.add("Paris is the capital of France.", importance_weight=0.9)
    # Re-ingest identical content with a new weight -> update path runs
    await cognee.add("Paris is the capital of France.", importance_weight=0.1)
    # Before this fix: stored importance_weight is still 0.9
    # After this fix:  stored importance_weight is 0.1

asyncio.run(main())
```

Fixes #3372
