### PR TITLE
fix(migration): declare e_relationship_name key in GraphML export

### DIFF
--- a/cognee/modules/migration/formats.py
+++ b/cognee/modules/migration/formats.py
@@ -49,6 +49,13 @@ def write_graphml(nodes: List[Node], edges: List[Edge], destination: Path) -> No
     for _, properties in nodes:
         for key in properties or {}:
             node_keys.setdefault(key)
+    # Every edge emits a "relationship_name" datum below. It comes from the edge
+    # tuple rather than the per-edge properties dict, so the loop below would never
+    # register it; declare it explicitly whenever edges are present, otherwise the
+    # emitted <data key="e_relationship_name"> has no matching <key> declaration and
+    # strict GraphML readers (e.g. networkx.read_graphml) reject the file.
+    if edges:
+        edge_keys.setdefault("relationship_name")
     for _, _, _, properties in edges:
         for key in properties or {}:
             if key not in _SKIP_EDGE_KEYS:

--- a/cognee/tests/unit/migration/test_migration.py
+++ b/cognee/tests/unit/migration/test_migration.py
@@ -478,6 +478,32 @@ class TestFormatEmitters:
         assert len(graph.findall(f"{namespace}node")) == 2
         assert len(graph.findall(f"{namespace}edge")) == 1
 
+    def test_graphml_data_keys_are_all_declared(self, tmp_path):
+        # Every <data key="..."> must reference a declared <key id="...">. The edge
+        # relationship_name datum was emitted without a matching <key> declaration,
+        # which strict GraphML readers reject even though the XML is well-formed.
+        destination = tmp_path / "graph.graphml"
+        write_graphml(self.NODES, self.EDGES, destination)
+        root = ET.parse(destination).getroot()
+        namespace = "{http://graphml.graphdrawing.org/xmlns}"
+        declared = {key.get("id") for key in root.findall(f"{namespace}key")}
+        used = {data.get("key") for data in root.iter(f"{namespace}data")}
+        assert used <= declared, f"undeclared data keys: {used - declared}"
+        assert "e_relationship_name" in declared
+
+    def test_graphml_round_trips_through_networkx(self, tmp_path):
+        import networkx as nx
+
+        destination = tmp_path / "graph.graphml"
+        write_graphml(self.NODES, self.EDGES, destination)
+        graph = nx.read_graphml(destination)
+        assert graph.number_of_nodes() == 2
+        assert graph.number_of_edges() == 1
+        source, target, data = next(iter(graph.edges(data=True)))
+        assert (source, target) == ("id-1", "id-2")
+        assert data["relationship_name"] == "lives_in"
+        assert data["edge_text"] == "Alice lives in Berlin"
+
     def test_cypher(self, tmp_path):
         destination = tmp_path / "graph.cypher"
         write_cypher(self.NODES, self.EDGES, destination)


### PR DESCRIPTION
## Problem

`write_graphml` (`cognee/modules/migration/formats.py`) emits a `<data key="e_relationship_name">` element on every edge, but never declares that key. The edge `<key>` declarations are built only from each edge's *properties* dict, whereas `relationship_name` comes from the edge tuple `(source, target, relationship_name, properties)` — so it is never registered.

GraphML requires every `<data key="X">` to have a matching `<key id="X">` declaration. The output is well-formed XML (so the existing `test_graphml_is_valid_xml`, which only checks XML validity via `ElementTree`, passes), but strict GraphML readers reject it:

```
networkx.exception.NetworkXError: Bad GraphML data: no key e_relationship_name
```

Since virtually every edge carries a relationship name, essentially every export containing edges is unreadable by NetworkX — one of the interop targets named in the module docstring ("GraphML for Gephi/yEd/NetworkX interop").

## Fix

Declare the `relationship_name` edge key whenever edges are present, so the `<data key="e_relationship_name">` emitted per edge has a matching `<key>` declaration.

## Tests

Added two regression tests to `TestFormatEmitters` (both fail before this change, pass after):
- `test_graphml_data_keys_are_all_declared` — every `<data key>` references a declared `<key id>`.
- `test_graphml_round_trips_through_networkx` — `networkx.read_graphml` reads the export and preserves `relationship_name`.

Fixes #3527
