### PR TITLE
feat(memify): add consolidate_entities pipeline to merge near-duplicate entities

### DIFF
--- a/cognee/memify_pipelines/consolidate_entities.py
+++ b/cognee/memify_pipelines/consolidate_entities.py
@@ -59,6 +59,20 @@ async def consolidate_entities_pipeline(
             message="similarity_threshold must be in the range (0, 1]", log=False
         )
 
+    # top_k drives the top-k neighbor optimization in clustering; a non-positive
+    # or non-int value would silently fall back to an all-pairs scan, so reject
+    # it up front. (bool is an int subclass — exclude it explicitly.)
+    if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k <= 0:
+        raise CogneeValidationError(message="top_k must be a positive integer", log=False)
+
+    if protect_node_types is not None and (
+        not isinstance(protect_node_types, list)
+        or not all(isinstance(item, str) and item.strip() for item in protect_node_types)
+    ):
+        raise CogneeValidationError(
+            message="protect_node_types must be a list of non-empty strings", log=False
+        )
+
     if user is None:
         user = await get_default_user()
 

--- a/cognee/memify_pipelines/consolidate_entities.py
+++ b/cognee/memify_pipelines/consolidate_entities.py
@@ -1,0 +1,101 @@
+"""Memify pipeline that merges near-duplicate ``Entity`` nodes into one.
+
+Mirrors the structure of the sibling graph-mutating enrichment pipelines (e.g.
+``apply_feedback_weights``): it resolves the target dataset, enters that
+dataset's database context, and runs a single detect (extraction) task followed
+by a single merge (enrichment) task. The shared configuration is bound onto
+both tasks so detection and merge agree on thresholds and on ``dry_run``.
+"""
+
+from typing import List, Optional
+
+from cognee import memify
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.exceptions import CogneeValidationError
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.pipelines.tasks.task import Task
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.users.models import User
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.memify.consolidate_entities import (
+    detect_entity_duplicates,
+    merge_entity_duplicates,
+)
+
+logger = get_logger("consolidate_entities_pipeline")
+
+
+async def consolidate_entities_pipeline(
+    similarity_threshold: float = 0.85,
+    dry_run: bool = False,
+    protect_node_types: Optional[List[str]] = None,
+    name_match: bool = True,
+    top_k: int = 10,
+    allow_cross_type: bool = False,
+    user: Optional[User] = None,
+    dataset: str = "main_dataset",
+    run_in_background: bool = False,
+):
+    """Merge near-duplicate ``Entity`` nodes in an existing graph.
+
+    Args:
+        similarity_threshold: Minimum cosine similarity between two entity-name
+            embeddings for them to be treated as the same entity.
+        dry_run: When True, compute and log the merge plan but mutate nothing.
+        protect_node_types: EntityType names that must never be merged.
+        name_match: Also merge entities whose normalized names are identical.
+        top_k: Max neighbors considered per entity during similarity clustering.
+        allow_cross_type: When True, allow merging entities of different
+            EntityTypes (off by default for safety).
+        user: Acting user; the default user is used when omitted.
+        dataset: Dataset name (or id) whose graph to consolidate.
+        run_in_background: Forwarded to ``memify``.
+
+    Returns:
+        The ``memify`` pipeline result.
+    """
+    if not isinstance(similarity_threshold, (int, float)) or not 0 < similarity_threshold <= 1:
+        raise CogneeValidationError(
+            message="similarity_threshold must be in the range (0, 1]", log=False
+        )
+
+    if user is None:
+        user = await get_default_user()
+
+    datasets = await get_authorized_existing_datasets([dataset], "write", user)
+    if not datasets:
+        raise CogneeValidationError(
+            message=f"User (id: {user.id}) has no write access to dataset: {dataset}",
+            log=False,
+        )
+    target = datasets[0]
+
+    config = {
+        "similarity_threshold": similarity_threshold,
+        "dry_run": dry_run,
+        "protect_node_types": protect_node_types or [],
+        "name_match": name_match,
+        "top_k": top_k,
+        "allow_cross_type": allow_cross_type,
+    }
+
+    async with set_database_global_context_variables(target.id, target.owner_id):
+        extraction_tasks = [Task(detect_entity_duplicates, config=config)]
+        enrichment_tasks = [Task(merge_entity_duplicates, config=config)]
+
+        result = await memify(
+            extraction_tasks=extraction_tasks,
+            enrichment_tasks=enrichment_tasks,
+            data=[{}],  # placeholder seed; the tasks read entities from the graph
+            dataset=target.id,
+            user=user,
+            run_in_background=run_in_background,
+        )
+
+    logger.info(
+        "consolidate_entities pipeline finished (dataset=%s, dry_run=%s, threshold=%.2f).",
+        target.id,
+        dry_run,
+        similarity_threshold,
+    )
+    return result

--- a/cognee/tasks/memify/__init__.py
+++ b/cognee/tasks/memify/__init__.py
@@ -14,3 +14,4 @@ from .extract_agent_trace_feedbacks import extract_agent_trace_feedbacks
 from .extract_user_sessions import extract_user_sessions
 from .extract_feedback_qas import extract_feedback_qas
 from .apply_feedback_weights import apply_feedback_weights
+from .consolidate_entities import detect_entity_duplicates, merge_entity_duplicates

--- a/cognee/tasks/memify/consolidate_entities.py
+++ b/cognee/tasks/memify/consolidate_entities.py
@@ -12,8 +12,8 @@ These two tasks back the ``consolidate_entities`` memify pipeline:
   embeddings. ``dry_run`` computes and logs the plan without mutating anything.
 
 The merge is backend-agnostic: it relies only on ``get_graph_data`` (directed
-edges), ``add_edge`` (an UPSERT/MERGE on every adapter), ``add_nodes`` (an
-upsert that updates existing node properties via ``ON MATCH SET``),
+edges), ``add_edges`` (a batched UPSERT/MERGE on every adapter), ``add_nodes``
+(an upsert that updates existing node properties via ``ON MATCH SET``),
 ``delete_nodes`` (a detach-delete that cascades the duplicates' old edges), and
 the vector engine's ``delete_data_points``. No per-edge delete primitive is
 required or used.
@@ -22,6 +22,7 @@ required or used.
 import json
 import re
 from typing import Any, Dict, List, Optional, Tuple
+from uuid import UUID
 
 import numpy as np
 
@@ -72,20 +73,62 @@ def _normalize_name(name: Any) -> str:
     return re.sub(r"[^a-z0-9]+", "", name.lower())
 
 
-def _cosine_similarity_matrix(vectors: List[List[float]]) -> np.ndarray:
-    """Return the full pairwise cosine-similarity matrix for ``vectors``.
+# Row-block size for the chunked similarity scan. Each block holds at most
+# ``_SIMILARITY_CHUNK_SIZE`` x N similarities at a time, so peak memory grows
+# with the chunk size rather than with N**2.
+_SIMILARITY_CHUNK_SIZE = 512
 
-    This materializes an N x N matrix, which is fine for the entity counts a
-    single dataset's graph typically holds. For very large graphs this should be
-    replaced with a chunked / ANN top-k search against the vector backend.
+
+def _normalize_rows(vectors: List[List[float]]) -> np.ndarray:
+    """L2-normalize each row so that a dot product equals cosine similarity.
+
+    Returns a 2-D float array, or an empty array when there is nothing to
+    normalize. Zero-length rows are left as zeros (cosine-similar to nothing).
     """
     matrix = np.asarray(vectors, dtype=float)
     if matrix.ndim != 2 or matrix.shape[0] == 0:
         return np.zeros((0, 0))
     norms = np.linalg.norm(matrix, axis=1, keepdims=True)
     norms = np.where(norms == 0, 1.0, norms)
-    normalized = matrix / norms
-    return normalized @ normalized.T
+    return matrix / norms
+
+
+def _iter_topk_similar_pairs(
+    normalized: np.ndarray,
+    threshold: float,
+    top_k: int,
+    chunk_size: int = _SIMILARITY_CHUNK_SIZE,
+):
+    """Yield ``(i, j)`` index pairs whose cosine similarity is ``>= threshold``.
+
+    Similarities are computed one row-block at a time (``chunk_size`` rows per
+    block), so the full N x N matrix is never materialized — peak memory is
+    ``chunk_size`` x N instead of N**2, which lets the pipeline scale past small
+    graphs. For each row only its ``top_k`` nearest neighbors are inspected,
+    selected with ``np.argpartition`` (O(n) per row) instead of a full sort.
+    When ``top_k`` is unset or not smaller than the candidate pool, every other
+    node is considered.
+    """
+    count = int(normalized.shape[0]) if normalized.size else 0
+    if count < 2:
+        return
+    bounded = bool(top_k) and 0 < top_k < count - 1
+    for start in range(0, count, chunk_size):
+        block = normalized[start : start + chunk_size] @ normalized.T
+        for offset, row in enumerate(block):
+            index = start + offset
+            if bounded:
+                # +1 because the row's own entry (similarity 1.0) is always picked.
+                k = min(top_k + 1, count)
+                candidate_indices = np.argpartition(row, -k)[-k:]
+            else:
+                candidate_indices = range(count)
+            for other in candidate_indices:
+                other = int(other)
+                if other == index:
+                    continue
+                if row[other] >= threshold:
+                    yield index, other
 
 
 def _cluster_entities(
@@ -107,7 +150,7 @@ def _cluster_entities(
     name_match = cfg["name_match"]
     allow_cross_type = cfg["allow_cross_type"]
 
-    similarity = _cosine_similarity_matrix(vectors)
+    normalized_vectors = _normalize_rows(vectors)
     normalized_names = [_normalize_name(member["name"]) for member in members]
 
     parent = list(range(count))
@@ -126,23 +169,13 @@ def _cluster_entities(
     def same_type(left: int, right: int) -> bool:
         return allow_cross_type or members[left]["type"] == members[right]["type"]
 
-    # Pass 1 — cosine similarity. For each node, take its top_k nearest
-    # neighbors with np.argpartition (O(n) per node instead of a full sort),
-    # then union the ones at or above the threshold.
-    if similarity.size:
-        for index in range(count):
-            row = similarity[index]
-            if top_k and top_k < count - 1:
-                # +1 because the node itself (similarity 1.0) is always selected.
-                k = min(top_k + 1, count)
-                candidate_indices = np.argpartition(row, -k)[-k:]
-            else:
-                candidate_indices = range(count)
-            for other in candidate_indices:
-                if other == index:
-                    continue
-                if row[other] >= threshold and same_type(index, other):
-                    union(index, other)
+    # Pass 1 — cosine similarity. Similarities are scanned in row-blocks (the
+    # full N x N matrix is never held) and only each node's top_k nearest
+    # neighbors are considered; union those at or above the threshold that also
+    # share an EntityType (unless allow_cross_type).
+    for index, other in _iter_topk_similar_pairs(normalized_vectors, threshold, top_k):
+        if same_type(index, other):
+            union(index, other)
 
     # Pass 2 — exact normalized-name match (not bounded by top_k).
     if name_match:
@@ -305,29 +338,91 @@ def _union_descriptions(members: List[Dict[str, Any]]) -> Optional[str]:
     return " ".join(descriptions) if descriptions else None
 
 
+def _belongs_to_set_tags(member: Dict[str, Any]) -> List[str]:
+    """Return a member's ``belongs_to_set`` tags as a list of strings.
+
+    Reads the member's top-level value (populated by the detect task) and falls
+    back to its raw stored ``props``. Each tag may be stored as a plain string,
+    a NodeSet-like mapping, or a DataPoint; all are reduced to a stable string
+    key (``name`` preferred, then ``id``).
+    """
+    value = member.get("belongs_to_set")
+    if value is None:
+        value = (member.get("props") or {}).get("belongs_to_set")
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple, set)):
+        value = [value]
+
+    tags: List[str] = []
+    for item in value:
+        if item is None:
+            continue
+        if isinstance(item, str):
+            tag: Any = item
+        elif isinstance(item, dict):
+            tag = item.get("name") or item.get("id")
+        else:
+            tag = getattr(item, "name", None) or getattr(item, "id", None)
+        if tag is not None:
+            tags.append(str(tag))
+    return tags
+
+
+def _union_belongs_to_set(members: List[Dict[str, Any]]) -> Optional[List[str]]:
+    """Union the ``belongs_to_set`` tags across members, preserving first-seen order.
+
+    ``belongs_to_set`` is a node property that scopes a node to one or more
+    datasets / node sets. The canonical must inherit the tags of every duplicate
+    it absorbs, otherwise a merge would silently narrow the node's dataset
+    scoping. Returns ``None`` when no member carries any tag, so the caller
+    leaves the property untouched.
+    """
+    unioned: List[str] = []
+    for member in members:
+        for tag in _belongs_to_set_tags(member):
+            if tag not in unioned:
+                unioned.append(tag)
+    return unioned or None
+
+
 def _build_canonical_entity(
     canonical: Dict[str, Any], duplicates: List[Dict[str, Any]]
 ) -> Optional[Entity]:
-    """Rebuild the canonical ``Entity`` with a unioned description.
+    """Rebuild the canonical ``Entity`` with unioned description and tags.
 
     The node is reconstructed faithfully from its stored properties so that
     ``add_nodes`` (which overwrites the property blob via ``ON MATCH SET``)
-    never drops existing data. The ``is_a`` relationship is preserved as a graph
-    edge and is not part of the node blob, so it is omitted here. Returns
-    ``None`` if reconstruction fails, in which case the caller leaves the
-    canonical node untouched (no data loss).
+    never drops existing data. Three things are enforced explicitly:
+
+    * the canonical's **actual graph id** is pinned onto the rebuilt node.
+      ``Entity`` ids are otherwise derived from the name, so a legacy- or
+      random-id canonical would be re-created under a different id by
+      ``add_nodes`` and orphaned from its edges;
+    * ``description`` is the union of the canonical's and the duplicates' text;
+    * ``belongs_to_set`` is the union of every member's dataset / node-set tags,
+      so a merge never narrows the canonical's scoping.
+
+    The ``is_a`` relationship is preserved as a graph edge (not part of the node
+    blob) and is omitted here. Returns ``None`` if reconstruction fails, in
+    which case the caller leaves the canonical node untouched (no data loss).
     """
     props = dict(canonical.get("props") or {})
     props.pop("is_a", None)
     props["name"] = canonical["name"]
+    props["id"] = canonical["id"]
 
     unioned = _union_descriptions([canonical] + duplicates)
     if unioned is not None:
         props["description"] = unioned
     props.setdefault("description", "")
 
+    unioned_tags = _union_belongs_to_set([canonical] + duplicates)
+    if unioned_tags is not None:
+        props["belongs_to_set"] = unioned_tags
+
     try:
-        return Entity.from_dict(props)
+        entity = Entity.from_dict(props)
     except Exception as error:  # noqa: BLE001 - reconstruction is best-effort
         logger.warning(
             "consolidate_entities: could not rebuild canonical %s (%s); "
@@ -336,6 +431,19 @@ def _build_canonical_entity(
             error,
         )
         return None
+
+    # Pin the canonical's real id regardless of name-based derivation, so
+    # add_nodes upserts the existing node in place instead of creating a new one.
+    canonical_id = canonical["id"]
+    try:
+        entity.id = canonical_id if isinstance(canonical_id, UUID) else UUID(str(canonical_id))
+    except (ValueError, AttributeError, TypeError):
+        logger.warning(
+            "consolidate_entities: canonical id %s is not a UUID; keeping derived id %s.",
+            canonical_id,
+            entity.id,
+        )
+    return entity
 
 
 async def merge_entity_duplicates(
@@ -400,15 +508,20 @@ async def merge_entity_duplicates(
     graph_engine = await get_graph_engine()
     vector_engine = get_vector_engine()
 
-    # 1. Re-point edges onto the canonicals. add_edge is called positionally
-    #    because adapters disagree on the 4th parameter's name
+    # 1. Re-point every duplicate edge onto its canonical in a single batched
+    #    call. add_edges is part of GraphDBInterface and implemented by every
+    #    adapter, so a large cluster costs one round-trip instead of one await
+    #    per edge. The 4-tuples (source, target, relationship, properties) are
+    #    passed positionally because adapters disagree on the 4th field's name
     #    (properties vs edge_properties); position is stable across all of them.
-    for source, target, relationship, properties in moved_edges:
-        await graph_engine.add_edge(source, target, relationship, properties or {})
+    if moved_edges:
+        await graph_engine.add_edges(moved_edges)
 
-    # 2. Persist unioned descriptions onto the canonicals (add_nodes upserts via
-    #    ON MATCH SET). Membership in node sets is already unioned at the edge
-    #    level by step 1, since belongs_to_set links are ordinary edges.
+    # 2. Persist the rebuilt canonicals (add_nodes upserts via ON MATCH SET).
+    #    Each rebuilt canonical carries the union of its cluster's descriptions
+    #    AND belongs_to_set tags (see _build_canonical_entity). belongs_to_set is
+    #    a node property, so it must be unioned here — edge re-pointing in step 1
+    #    cannot preserve it.
     updated_canonicals = [
         entity
         for canonical, duplicates in plans

--- a/cognee/tasks/memify/consolidate_entities.py
+++ b/cognee/tasks/memify/consolidate_entities.py
@@ -1,0 +1,440 @@
+"""Detect and merge semantically near-duplicate ``Entity`` nodes.
+
+These two tasks back the ``consolidate_entities`` memify pipeline:
+
+* :func:`detect_entity_duplicates` (extraction) loads every ``Entity`` node,
+  embeds its name, and clusters near-duplicates by cosine similarity and/or
+  normalized-name equality.
+* :func:`merge_entity_duplicates` (enrichment) collapses each cluster into one
+  canonical node: it re-points every edge from the duplicates onto the
+  canonical (direction preserved), unions the descriptions, records a
+  ``merged_from`` report, then deletes the duplicate nodes and their vector
+  embeddings. ``dry_run`` computes and logs the plan without mutating anything.
+
+The merge is backend-agnostic: it relies only on ``get_graph_data`` (directed
+edges), ``add_edge`` (an UPSERT/MERGE on every adapter), ``add_nodes`` (an
+upsert that updates existing node properties via ``ON MATCH SET``),
+``delete_nodes`` (a detach-delete that cascades the duplicates' old edges), and
+the vector engine's ``delete_data_points``. No per-edge delete primitive is
+required or used.
+"""
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import UUID
+
+import numpy as np
+
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.modules.engine.models.Entity import Entity
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("consolidate_entities")
+
+# The vector collection that holds Entity name embeddings. Cognee names vector
+# collections ``f"{type_name}_{index_field}"``; Entity declares
+# ``index_fields=["name"]`` so its collection is ``Entity_name``.
+ENTITY_VECTOR_COLLECTION = "Entity_name"
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    # Minimum cosine similarity between two entity-name embeddings to treat them
+    # as the same entity.
+    "similarity_threshold": 0.85,
+    # EntityType names (or node types) that must never be merged.
+    "protect_node_types": [],
+    # When True, compute and log the merge plan but perform zero mutations.
+    "dry_run": False,
+    # Also treat entities whose normalized names are identical as duplicates
+    # (catches e.g. "U.S.A." vs "USA", which hash to different node ids).
+    "name_match": True,
+    # Max neighbors per entity to consider during similarity clustering.
+    "top_k": 10,
+    # When False (default, conservative), only entities sharing the same
+    # EntityType are merged together.
+    "allow_cross_type": False,
+}
+
+
+def _resolve_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge the caller config over defaults and normalize derived fields."""
+    cfg = dict(DEFAULT_CONFIG)
+    if config:
+        cfg.update({key: value for key, value in config.items() if value is not None})
+    cfg["protect_node_types"] = set(cfg.get("protect_node_types") or [])
+    return cfg
+
+
+def _normalize_name(name: Any) -> str:
+    """Lower-case and strip every non-alphanumeric character from a name."""
+    if not isinstance(name, str):
+        return ""
+    return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+
+def _cosine_similarity_matrix(vectors: List[List[float]]) -> np.ndarray:
+    """Return the full pairwise cosine-similarity matrix for ``vectors``."""
+    matrix = np.asarray(vectors, dtype=float)
+    if matrix.ndim != 2 or matrix.shape[0] == 0:
+        return np.zeros((0, 0))
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1.0, norms)
+    normalized = matrix / norms
+    return normalized @ normalized.T
+
+
+def _cluster_entities(
+    members: List[Dict[str, Any]], vectors: List[List[float]], cfg: Dict[str, Any]
+) -> List[List[Dict[str, Any]]]:
+    """Group entities into duplicate clusters via union-find.
+
+    Two entities are united when their name embeddings are at least
+    ``similarity_threshold`` cosine-similar, or (when ``name_match`` is on) when
+    their normalized names are identical. Unless ``allow_cross_type`` is set,
+    entities are only united when they share the same EntityType.
+    """
+    count = len(members)
+    if count < 2:
+        return []
+
+    threshold = cfg["similarity_threshold"]
+    top_k = cfg["top_k"]
+    name_match = cfg["name_match"]
+    allow_cross_type = cfg["allow_cross_type"]
+
+    similarity = _cosine_similarity_matrix(vectors)
+    normalized_names = [_normalize_name(member["name"]) for member in members]
+
+    parent = list(range(count))
+
+    def find(node: int) -> int:
+        while parent[node] != node:
+            parent[node] = parent[parent[node]]
+            node = parent[node]
+        return node
+
+    def union(left: int, right: int) -> None:
+        left_root, right_root = find(left), find(right)
+        if left_root != right_root:
+            parent[max(left_root, right_root)] = min(left_root, right_root)
+
+    def same_type(left: int, right: int) -> bool:
+        return allow_cross_type or members[left]["type"] == members[right]["type"]
+
+    # Pass 1 — cosine similarity, bounded to the top_k nearest neighbors per node.
+    if similarity.size:
+        for index in range(count):
+            neighbors = sorted(
+                (other for other in range(count) if other != index),
+                key=lambda other: similarity[index][other],
+                reverse=True,
+            )
+            if top_k:
+                neighbors = neighbors[:top_k]
+            for other in neighbors:
+                if similarity[index][other] >= threshold and same_type(index, other):
+                    union(index, other)
+
+    # Pass 2 — exact normalized-name match (not bounded by top_k).
+    if name_match:
+        for index in range(count):
+            if not normalized_names[index]:
+                continue
+            for other in range(index + 1, count):
+                if normalized_names[index] == normalized_names[other] and same_type(index, other):
+                    union(index, other)
+
+    clusters: Dict[int, List[Dict[str, Any]]] = {}
+    for index in range(count):
+        clusters.setdefault(find(index), []).append(members[index])
+
+    return [cluster for cluster in clusters.values() if len(cluster) >= 2]
+
+
+def _entity_type_map(
+    entity_ids: set, edges: List[Tuple], nodes_by_id: Dict[str, Dict[str, Any]]
+) -> Dict[str, Optional[str]]:
+    """Map each entity id to its EntityType name.
+
+    Robust to the exact ``is_a`` relationship label: an entity's type is the
+    name of any neighbor node whose ``type`` is ``"EntityType"``.
+    """
+    type_of: Dict[str, Optional[str]] = {}
+    for edge in edges:
+        source, target = str(edge[0]), str(edge[1])
+        if source in entity_ids:
+            target_props = nodes_by_id.get(target)
+            if target_props and target_props.get("type") == "EntityType":
+                type_of[source] = target_props.get("name")
+    return type_of
+
+
+async def detect_entity_duplicates(
+    data: Any = None, config: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Find clusters of near-duplicate ``Entity`` nodes.
+
+    Returns a payload ``{"clusters": [...], "edges": [...]}`` consumed by
+    :func:`merge_entity_duplicates`. ``edges`` is the full directed edge list
+    from the graph, forwarded so the merge step re-points edges without a
+    second full scan. The ``data`` argument (the memify pipeline seed) is
+    intentionally ignored — the entities are read straight from the graph.
+    """
+    cfg = _resolve_config(config)
+    graph_engine = await get_graph_engine()
+    vector_engine = get_vector_engine()
+
+    nodes, edges = await graph_engine.get_graph_data()
+    nodes_by_id = {str(node_id): props for node_id, props in nodes}
+
+    entity_ids = {
+        str(node_id)
+        for node_id, props in nodes
+        if props.get("type") == "Entity" and props.get("name")
+    }
+    type_of = _entity_type_map(entity_ids, edges, nodes_by_id)
+
+    members: List[Dict[str, Any]] = []
+    for node_id, props in nodes:
+        node_id = str(node_id)
+        if node_id not in entity_ids:
+            continue
+        entity_type = type_of.get(node_id)
+        if (
+            entity_type in cfg["protect_node_types"]
+            or props.get("type") in cfg["protect_node_types"]
+        ):
+            continue
+        members.append(
+            {
+                "id": node_id,
+                "name": props.get("name"),
+                "type": entity_type,
+                "created_at": props.get("created_at"),
+                "description": props.get("description"),
+                "belongs_to_set": props.get("belongs_to_set"),
+                "props": props,
+            }
+        )
+
+    if len(members) < 2:
+        logger.info("consolidate_entities: fewer than 2 candidate entities; nothing to detect.")
+        return {"clusters": [], "edges": edges}
+
+    vectors = await vector_engine.embed_data([member["name"] for member in members])
+    clusters = _cluster_entities(members, vectors, cfg)
+
+    logger.info(
+        "consolidate_entities: detected %d duplicate cluster(s) among %d entities.",
+        len(clusters),
+        len(members),
+    )
+    return {"clusters": clusters, "edges": edges}
+
+
+def plan_edge_repointing(
+    edges: List[Tuple], remap: Dict[str, str]
+) -> List[Tuple[str, str, str, Dict[str, Any]]]:
+    """Compute the edges to (re)create on canonical nodes.
+
+    Given every directed graph edge and a ``{duplicate_id: canonical_id}`` map,
+    both endpoints are remapped to their canonical. Edges untouched by the remap
+    are skipped; edges that collapse into a self-loop on a canonical are dropped.
+    The duplicates' original edges are removed later by the detach-delete
+    cascade, so this function only needs to add the re-pointed copies. This is
+    the backend-agnostic edge-move helper (it does not call any per-edge delete).
+    """
+    moved: List[Tuple[str, str, str, Dict[str, Any]]] = []
+    for edge in edges:
+        source, target, relationship = str(edge[0]), str(edge[1]), edge[2]
+        properties = edge[3] if len(edge) > 3 and isinstance(edge[3], dict) else {}
+        new_source = remap.get(source, source)
+        new_target = remap.get(target, target)
+        if new_source == source and new_target == target:
+            continue  # neither endpoint is a duplicate
+        if new_source == new_target:
+            continue  # would become a self-loop on the canonical
+        moved.append((new_source, new_target, relationship, properties))
+    return moved
+
+
+def _node_degrees(edges: List[Tuple]) -> Dict[str, int]:
+    """Count incident edges (both directions) for every node id."""
+    degree: Dict[str, int] = {}
+    for edge in edges:
+        for endpoint in (str(edge[0]), str(edge[1])):
+            degree[endpoint] = degree.get(endpoint, 0) + 1
+    return degree
+
+
+def _pick_canonical(
+    cluster: List[Dict[str, Any]], degree: Dict[str, int]
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Pick the canonical member of a cluster.
+
+    Deterministic rule: highest graph degree wins (it is the most connected,
+    so re-pointing moves the fewest edges); ties break to the oldest
+    ``created_at``; remaining ties break lexicographically by normalized name.
+    """
+
+    def sort_key(member: Dict[str, Any]):
+        created_at = member.get("created_at")
+        created_at = created_at if isinstance(created_at, (int, float)) else float("inf")
+        return (-degree.get(member["id"], 0), created_at, _normalize_name(member["name"]))
+
+    ordered = sorted(cluster, key=sort_key)
+    return ordered[0], ordered[1:]
+
+
+def _union_descriptions(members: List[Dict[str, Any]]) -> Optional[str]:
+    """Concatenate distinct, non-empty descriptions in member order."""
+    descriptions: List[str] = []
+    for member in members:
+        description = (member.get("description") or "").strip()
+        if description and description not in descriptions:
+            descriptions.append(description)
+    return " ".join(descriptions) if descriptions else None
+
+
+def _build_canonical_entity(
+    canonical: Dict[str, Any], duplicates: List[Dict[str, Any]]
+) -> Optional[Entity]:
+    """Rebuild the canonical ``Entity`` with a unioned description.
+
+    The node is reconstructed faithfully from its stored properties so that
+    ``add_nodes`` (which overwrites the property blob via ``ON MATCH SET``)
+    never drops existing data. The ``is_a`` relationship is preserved as a graph
+    edge and is not part of the node blob, so it is omitted here. Returns
+    ``None`` if reconstruction fails, in which case the caller leaves the
+    canonical node untouched (no data loss).
+    """
+    props = dict(canonical.get("props") or {})
+    props.pop("is_a", None)
+    props["name"] = canonical["name"]
+
+    unioned = _union_descriptions([canonical] + duplicates)
+    if unioned is not None:
+        props["description"] = unioned
+    props.setdefault("description", "")
+
+    try:
+        return Entity.from_dict(props)
+    except Exception as error:  # noqa: BLE001 - reconstruction is best-effort
+        logger.warning(
+            "consolidate_entities: could not rebuild canonical %s (%s); "
+            "leaving its properties unchanged.",
+            canonical.get("id"),
+            error,
+        )
+        return None
+
+
+async def merge_entity_duplicates(
+    payload: Any, config: Optional[Dict[str, Any]] = None
+) -> List[Entity]:
+    """Collapse each detected cluster into a single canonical node.
+
+    Steps per run (skipped entirely when ``dry_run`` is set):
+      1. Re-point every duplicate's edges onto its canonical (direction kept).
+      2. Union descriptions onto the canonical and persist via ``add_nodes``.
+      3. Delete the duplicate nodes (cascading their old edges) and purge their
+         name embeddings from the vector store.
+
+    Returns the list of updated canonical entities (empty on ``dry_run`` or when
+    nothing was merged). The ``merged_from`` provenance is logged as the merge
+    report.
+    """
+    cfg = _resolve_config(config)
+    dry_run = cfg["dry_run"]
+    clusters, edges = _unwrap_payload(payload)
+
+    if not clusters:
+        logger.info("consolidate_entities: no duplicate clusters to merge.")
+        return []
+
+    degree = _node_degrees(edges)
+
+    remap: Dict[str, str] = {}
+    plans: List[Tuple[Dict[str, Any], List[Dict[str, Any]]]] = []
+    for cluster in clusters:
+        canonical, duplicates = _pick_canonical(cluster, degree)
+        for duplicate in duplicates:
+            remap[duplicate["id"]] = canonical["id"]
+        plans.append((canonical, duplicates))
+
+    moved_edges = plan_edge_repointing(edges, remap)
+    duplicate_ids = list(remap.keys())
+
+    report = [
+        {
+            "canonical_id": canonical["id"],
+            "canonical_name": canonical["name"],
+            "merged_from": [
+                {"id": duplicate["id"], "name": duplicate["name"]} for duplicate in duplicates
+            ],
+        }
+        for canonical, duplicates in plans
+    ]
+    logger.info(
+        "consolidate_entities plan: clusters=%d duplicates=%d edges_to_repoint=%d dry_run=%s",
+        len(plans),
+        len(duplicate_ids),
+        len(moved_edges),
+        dry_run,
+    )
+    logger.info("consolidate_entities merge report: %s", json.dumps(report, default=str))
+
+    if dry_run:
+        logger.info("consolidate_entities: dry_run=True — performing ZERO mutations.")
+        return []
+
+    graph_engine = await get_graph_engine()
+    vector_engine = get_vector_engine()
+
+    # 1. Re-point edges onto the canonicals. add_edge is called positionally
+    #    because adapters disagree on the 4th parameter's name
+    #    (properties vs edge_properties); position is stable across all of them.
+    for source, target, relationship, properties in moved_edges:
+        await graph_engine.add_edge(source, target, relationship, properties or {})
+
+    # 2. Persist unioned descriptions onto the canonicals (add_nodes upserts via
+    #    ON MATCH SET). Membership in node sets is already unioned at the edge
+    #    level by step 1, since belongs_to_set links are ordinary edges.
+    updated_canonicals = [
+        entity
+        for canonical, duplicates in plans
+        if duplicates
+        for entity in [_build_canonical_entity(canonical, duplicates)]
+        if entity is not None
+    ]
+    if updated_canonicals:
+        await graph_engine.add_nodes(updated_canonicals)
+
+    # 3. Delete the duplicates (detach-delete cascades their old edges) and
+    #    purge their name embeddings, or stale vectors resurface in later runs.
+    if duplicate_ids:
+        await graph_engine.delete_nodes(duplicate_ids)
+        await vector_engine.delete_data_points(
+            ENTITY_VECTOR_COLLECTION, [UUID(duplicate_id) for duplicate_id in duplicate_ids]
+        )
+
+    logger.info(
+        "consolidate_entities: merged %d duplicate(s) into %d canonical(s).",
+        len(duplicate_ids),
+        len(plans),
+    )
+    return updated_canonicals
+
+
+def _unwrap_payload(payload: Any) -> Tuple[List[List[Dict[str, Any]]], List[Tuple]]:
+    """Normalize the detect-task output into ``(clusters, edges)``.
+
+    Tolerates the payload being wrapped in a single-element list by the
+    pipeline runner.
+    """
+    if isinstance(payload, list) and len(payload) == 1 and isinstance(payload[0], dict):
+        payload = payload[0]
+    if not isinstance(payload, dict):
+        return [], []
+    return payload.get("clusters", []), payload.get("edges", [])

--- a/cognee/tasks/memify/consolidate_entities.py
+++ b/cognee/tasks/memify/consolidate_entities.py
@@ -22,7 +22,6 @@ required or used.
 import json
 import re
 from typing import Any, Dict, List, Optional, Tuple
-from uuid import UUID
 
 import numpy as np
 
@@ -74,7 +73,12 @@ def _normalize_name(name: Any) -> str:
 
 
 def _cosine_similarity_matrix(vectors: List[List[float]]) -> np.ndarray:
-    """Return the full pairwise cosine-similarity matrix for ``vectors``."""
+    """Return the full pairwise cosine-similarity matrix for ``vectors``.
+
+    This materializes an N x N matrix, which is fine for the entity counts a
+    single dataset's graph typically holds. For very large graphs this should be
+    replaced with a chunked / ANN top-k search against the vector backend.
+    """
     matrix = np.asarray(vectors, dtype=float)
     if matrix.ndim != 2 or matrix.shape[0] == 0:
         return np.zeros((0, 0))
@@ -122,18 +126,22 @@ def _cluster_entities(
     def same_type(left: int, right: int) -> bool:
         return allow_cross_type or members[left]["type"] == members[right]["type"]
 
-    # Pass 1 — cosine similarity, bounded to the top_k nearest neighbors per node.
+    # Pass 1 — cosine similarity. For each node, take its top_k nearest
+    # neighbors with np.argpartition (O(n) per node instead of a full sort),
+    # then union the ones at or above the threshold.
     if similarity.size:
         for index in range(count):
-            neighbors = sorted(
-                (other for other in range(count) if other != index),
-                key=lambda other: similarity[index][other],
-                reverse=True,
-            )
-            if top_k:
-                neighbors = neighbors[:top_k]
-            for other in neighbors:
-                if similarity[index][other] >= threshold and same_type(index, other):
+            row = similarity[index]
+            if top_k and top_k < count - 1:
+                # +1 because the node itself (similarity 1.0) is always selected.
+                k = min(top_k + 1, count)
+                candidate_indices = np.argpartition(row, -k)[-k:]
+            else:
+                candidate_indices = range(count)
+            for other in candidate_indices:
+                if other == index:
+                    continue
+                if row[other] >= threshold and same_type(index, other):
                     union(index, other)
 
     # Pass 2 — exact normalized-name match (not bounded by top_k).
@@ -415,9 +423,10 @@ async def merge_entity_duplicates(
     #    purge their name embeddings, or stale vectors resurface in later runs.
     if duplicate_ids:
         await graph_engine.delete_nodes(duplicate_ids)
-        await vector_engine.delete_data_points(
-            ENTITY_VECTOR_COLLECTION, [UUID(duplicate_id) for duplicate_id in duplicate_ids]
-        )
+        # Duplicate ids are already strings. Sibling deletion code (e.g.
+        # delete_from_graph_and_vector) likewise passes string ids, which keeps
+        # this adapter-agnostic and avoids a UUID() cast that could raise.
+        await vector_engine.delete_data_points(ENTITY_VECTOR_COLLECTION, duplicate_ids)
 
     logger.info(
         "consolidate_entities: merged %d duplicate(s) into %d canonical(s).",

--- a/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
+++ b/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
@@ -1,0 +1,157 @@
+"""Real-backend integration test for the consolidate_entities pipeline.
+
+Unlike the mocked unit tests in
+``cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py``,
+this exercises the whole pipeline against the real default stack (Kuzu graph +
+LanceDB vectors) with real embeddings produced by the configured embedding
+engine. It seeds two near-duplicate entities ("New York City" / "NYC") with
+distinct edges and asserts they collapse into one node, every edge is preserved
+on the survivor, and the duplicate's name embedding is removed from the
+``Entity_name`` collection.
+
+Runs in the secret-gated integration suite (CI provides the embedding backend).
+Locally it can be run against the offline fastembed embedder, e.g.::
+
+    EMBEDDING_PROVIDER=fastembed EMBEDDING_MODEL=BAAI/bge-small-en-v1.5 \
+    EMBEDDING_DIMENSIONS=384 COGNEE_SKIP_CONNECTION_TEST=true \
+    uv run pytest cognee/tests/integration/tasks/test_consolidate_entities_integration.py -v
+"""
+
+import pathlib
+
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.low_level import setup
+from cognee.memify_pipelines.consolidate_entities import consolidate_entities_pipeline
+from cognee.modules.engine.models.Entity import Entity
+from cognee.modules.engine.models.EntityType import EntityType
+from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
+    resolve_authorized_user_datasets,
+)
+from cognee.tasks.storage.index_data_points import index_data_points
+
+DATASET = "consolidate_entities_integration"
+DUPLICATE_NAMES = {"New York City", "NYC"}
+
+
+@pytest_asyncio.fixture
+async def clean_test_environment():
+    """Isolate this test in its own system/data directories and reset state."""
+    base_dir = pathlib.Path(__file__).parent.parent.parent.parent
+    cognee.config.system_root_directory(
+        str(base_dir / ".cognee_system/test_consolidate_entities_integration")
+    )
+    cognee.config.data_root_directory(
+        str(base_dir / ".data_storage/test_consolidate_entities_integration")
+    )
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await setup()
+
+    yield
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+async def _seed(graph):
+    """Seed two near-duplicate cities plus distinct neighbors and edges."""
+    city = EntityType(name="City", description="A populated urban place.")
+    country = EntityType(name="Country", description="A sovereign nation.")
+    park_type = EntityType(name="Park", description="A public green space.")
+
+    nycity = Entity(
+        name="New York City", is_a=city, description="The most populous US city."
+    )
+    nyc = Entity(name="NYC", is_a=city, description="Common abbreviation for New York City.")
+    usa = Entity(name="United States", is_a=country, description="A country in North America.")
+    central_park = Entity(
+        name="Central Park", is_a=park_type, description="A large urban park in Manhattan."
+    )
+
+    await graph.add_nodes([city, country, park_type, nycity, nyc, usa, central_park])
+    await graph.add_edges(
+        [
+            (str(nycity.id), str(city.id), "is_a", {}),
+            (str(nyc.id), str(city.id), "is_a", {}),
+            (str(usa.id), str(country.id), "is_a", {}),
+            (str(central_park.id), str(park_type.id), "is_a", {}),
+            (str(nycity.id), str(usa.id), "located_in", {}),  # canonical-side edge
+            (str(nyc.id), str(central_park.id), "contains", {}),  # duplicate-side edge
+        ]
+    )
+    await index_data_points([city, country, park_type, nycity, nyc, usa, central_park])
+    return {str(nycity.id), str(nyc.id)}
+
+
+@pytest.mark.asyncio
+async def test_consolidate_entities_merges_real_graph(clean_test_environment):
+    user, datasets = await resolve_authorized_user_datasets(DATASET, None)
+    target = datasets[0]
+
+    async with set_database_global_context_variables(target.id, target.owner_id):
+        graph = await get_graph_engine()
+        duplicate_ids = await _seed(graph)
+        nodes_before, _ = await graph.get_graph_data()
+        name_by_id_before = {str(node_id): props.get("name") for node_id, props in nodes_before}
+        # Both duplicates exist before consolidation.
+        assert {name_by_id_before[d] for d in duplicate_ids} == DUPLICATE_NAMES
+
+    await consolidate_entities_pipeline(similarity_threshold=0.6, dataset=DATASET, user=user)
+
+    async with set_database_global_context_variables(target.id, target.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        nodes_after, edges_after = await graph.get_graph_data()
+        entities_after = {
+            str(node_id): props
+            for node_id, props in nodes_after
+            if props.get("type") == "Entity"
+        }
+
+        # Exactly one of the duplicate pair remains.
+        survivors = [
+            node_id for node_id, props in entities_after.items() if props.get("name") in DUPLICATE_NAMES
+        ]
+        assert len(survivors) == 1, (
+            f"expected a single survivor, found "
+            f"{[entities_after[s]['name'] for s in survivors]}"
+        )
+        survivor_id = survivors[0]
+
+        # All original edges are preserved on the survivor (both directions /
+        # both the canonical-side and the duplicate-side edge).
+        name_by_id = {str(node_id): props.get("name") for node_id, props in nodes_after}
+        survivor_rels = {
+            (rel, name_by_id.get(str(target_id)))
+            for source_id, target_id, rel, _ in edges_after
+            if str(source_id) == survivor_id
+        }
+        assert ("located_in", "United States") in survivor_rels
+        assert ("contains", "Central Park") in survivor_rels
+
+        # Neighbors are untouched (no accidental over-merge).
+        names_after = {props.get("name") for props in entities_after.values()}
+        assert "United States" in names_after
+        assert "Central Park" in names_after
+
+        # The duplicate node is gone, and so is its name embedding: embed the
+        # deleted name and confirm its id is not among the nearest matches.
+        deleted_ids = duplicate_ids - {survivor_id}
+        assert deleted_ids and all(d not in entities_after for d in deleted_ids)
+        for deleted_id in deleted_ids:
+            probe_vector = (await vector.embed_data([name_by_id_before[deleted_id]]))[0]
+            results = await vector.search(
+                "Entity_name", query_text=None, query_vector=probe_vector, limit=50
+            )
+            present_ids = {str(getattr(result, "id", None)) for result in results}
+            assert deleted_id not in present_ids

--- a/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
+++ b/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
@@ -69,9 +69,7 @@ async def _seed(graph):
     country = EntityType(name="Country", description="A sovereign nation.")
     park_type = EntityType(name="Park", description="A public green space.")
 
-    nycity = Entity(
-        name="New York City", is_a=city, description="The most populous US city."
-    )
+    nycity = Entity(name="New York City", is_a=city, description="The most populous US city.")
     nyc = Entity(name="NYC", is_a=city, description="Common abbreviation for New York City.")
     usa = Entity(name="United States", is_a=country, description="A country in North America.")
     central_park = Entity(
@@ -113,18 +111,17 @@ async def test_consolidate_entities_merges_real_graph(clean_test_environment):
         vector = get_vector_engine()
         nodes_after, edges_after = await graph.get_graph_data()
         entities_after = {
-            str(node_id): props
-            for node_id, props in nodes_after
-            if props.get("type") == "Entity"
+            str(node_id): props for node_id, props in nodes_after if props.get("type") == "Entity"
         }
 
         # Exactly one of the duplicate pair remains.
         survivors = [
-            node_id for node_id, props in entities_after.items() if props.get("name") in DUPLICATE_NAMES
+            node_id
+            for node_id, props in entities_after.items()
+            if props.get("name") in DUPLICATE_NAMES
         ]
         assert len(survivors) == 1, (
-            f"expected a single survivor, found "
-            f"{[entities_after[s]['name'] for s in survivors]}"
+            f"expected a single survivor, found {[entities_after[s]['name'] for s in survivors]}"
         )
         survivor_id = survivors[0]
 

--- a/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
+++ b/cognee/tests/integration/tasks/test_consolidate_entities_integration.py
@@ -26,7 +26,7 @@ import cognee
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.databases.vector import get_vector_engine
-from cognee.low_level import setup
+from cognee.low_level import setup as cognee_setup
 from cognee.memify_pipelines.consolidate_entities import consolidate_entities_pipeline
 from cognee.modules.engine.models.Entity import Entity
 from cognee.modules.engine.models.EntityType import EntityType
@@ -52,7 +52,7 @@ async def clean_test_environment():
 
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
-    await setup()
+    await cognee_setup()
 
     yield
 

--- a/cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
+++ b/cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
@@ -1,0 +1,307 @@
+"""Unit tests for the consolidate_entities memify tasks and pipeline.
+
+Everything here is mocked: no graph backend, no vector backend, no network.
+The tests assert the consolidation *logic* (clustering, canonical selection,
+direction-preserving edge re-pointing, duplicate + embedding deletion, the
+dry_run no-op) and the pipeline *wiring* (tasks and config passed to memify).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from cognee.memify_pipelines.consolidate_entities import consolidate_entities_pipeline
+from cognee.modules.engine.models.Entity import Entity
+from cognee.tasks.memify.consolidate_entities import (
+    _node_degrees,
+    _pick_canonical,
+    detect_entity_duplicates,
+    merge_entity_duplicates,
+    plan_edge_repointing,
+)
+
+GRAPH = "cognee.tasks.memify.consolidate_entities.get_graph_engine"
+VECTOR = "cognee.tasks.memify.consolidate_entities.get_vector_engine"
+
+# Deterministic, valid-UUID entity ids (Entity.id_for hashes the name).
+ID_NYC = str(Entity.id_for("NYC"))
+ID_NYCITY = str(Entity.id_for("New York City"))
+ID_BANANA = str(Entity.id_for("Banana"))
+
+
+def _graph_mock():
+    graph = AsyncMock()
+    graph.add_edge = AsyncMock()
+    graph.add_nodes = AsyncMock()
+    graph.delete_nodes = AsyncMock()
+    return graph
+
+
+def _vector_mock():
+    vector = MagicMock()
+    vector.embed_data = AsyncMock()
+    vector.delete_data_points = AsyncMock()
+    return vector
+
+
+def _make_async_ctx_mock():
+    """A MagicMock that behaves as an async-context-manager factory."""
+    inner = MagicMock()
+    inner.__aenter__ = AsyncMock(return_value=inner)
+    inner.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=inner)
+
+
+# --------------------------------------------------------------------------- #
+# detect
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_detect_clusters_near_duplicate_entities():
+    nodes = [
+        (ID_NYC, {"name": "NYC", "type": "Entity"}),
+        (ID_NYCITY, {"name": "New York City", "type": "Entity"}),
+        (ID_BANANA, {"name": "Banana", "type": "Entity"}),
+    ]
+    edges = []  # no EntityType edges -> all entities share an (absent) type
+
+    graph = _graph_mock()
+    graph.get_graph_data = AsyncMock(return_value=(nodes, edges))
+    vector = _vector_mock()
+    # Returned in the same order as the names passed to embed_data.
+    # NYC vs New York City -> cosine 0.96; Banana -> orthogonal.
+    vector.embed_data = AsyncMock(
+        return_value=[[1.0, 0.0, 0.0], [0.96, 0.28, 0.0], [0.0, 0.0, 1.0]]
+    )
+
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        result = await detect_entity_duplicates(None, config={"similarity_threshold": 0.85})
+
+    clusters = result["clusters"]
+    assert len(clusters) == 1
+    assert {member["name"] for member in clusters[0]} == {"NYC", "New York City"}
+    # Edges are forwarded for the merge step to reuse.
+    assert result["edges"] == edges
+
+
+@pytest.mark.asyncio
+async def test_detect_respects_protect_node_types():
+    nodes = [
+        (ID_NYC, {"name": "NYC", "type": "Entity"}),
+        (ID_NYCITY, {"name": "New York City", "type": "Entity"}),
+        ("type-city", {"name": "City", "type": "EntityType"}),
+    ]
+    # Both entities are of EntityType "City" via an is_a-style edge.
+    edges = [
+        (ID_NYC, "type-city", "is_a", {}),
+        (ID_NYCITY, "type-city", "is_a", {}),
+    ]
+    graph = _graph_mock()
+    graph.get_graph_data = AsyncMock(return_value=(nodes, edges))
+    vector = _vector_mock()
+    vector.embed_data = AsyncMock(return_value=[[1.0, 0.0], [0.99, 0.14]])
+
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        result = await detect_entity_duplicates(None, config={"protect_node_types": ["City"]})
+
+    # "City" is protected, so neither entity is even considered.
+    assert result["clusters"] == []
+    vector.embed_data.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# canonical selection
+# --------------------------------------------------------------------------- #
+def test_pick_canonical_prefers_higher_degree():
+    cluster = [
+        {"id": ID_NYC, "name": "NYC", "created_at": 50},
+        {"id": ID_NYCITY, "name": "New York City", "created_at": 100},
+    ]
+    canonical, duplicates = _pick_canonical(cluster, {ID_NYC: 5, ID_NYCITY: 2})
+    # NYC wins on degree even though New York City is older.
+    assert canonical["id"] == ID_NYC
+    assert [d["id"] for d in duplicates] == [ID_NYCITY]
+
+
+def test_pick_canonical_breaks_degree_ties_by_age():
+    cluster = [
+        {"id": ID_NYC, "name": "NYC", "created_at": 200},
+        {"id": ID_NYCITY, "name": "New York City", "created_at": 100},
+    ]
+    canonical, duplicates = _pick_canonical(cluster, {ID_NYC: 3, ID_NYCITY: 3})
+    # Equal degree -> older created_at wins.
+    assert canonical["id"] == ID_NYCITY
+    assert [d["id"] for d in duplicates] == [ID_NYC]
+
+
+def test_node_degrees_counts_both_endpoints():
+    edges = [("a", "b", "r", {}), ("a", "c", "r", {}), ("d", "a", "r", {})]
+    assert _node_degrees(edges) == {"a": 3, "b": 1, "c": 1, "d": 1}
+
+
+# --------------------------------------------------------------------------- #
+# edge re-pointing helper
+# --------------------------------------------------------------------------- #
+def test_plan_edge_repointing_preserves_direction_and_drops_self_loops():
+    remap = {ID_NYC: ID_NYCITY}
+    edges = [
+        (ID_NYC, "country", "located_in", {}),  # duplicate as source
+        ("visitor", ID_NYC, "visited", {}),  # duplicate as target
+        (ID_NYCITY, "park", "has", {}),  # canonical edge, untouched
+        (ID_NYC, ID_NYCITY, "same_as", {}),  # intra-cluster -> self-loop
+    ]
+
+    moved = plan_edge_repointing(edges, remap)
+
+    assert (ID_NYCITY, "country", "located_in", {}) in moved  # source kept as source
+    assert ("visitor", ID_NYCITY, "visited", {}) in moved  # target kept as target
+    assert len(moved) == 2  # untouched canonical edge and the self-loop are excluded
+    assert all(source != target for source, target, _, _ in moved)
+
+
+# --------------------------------------------------------------------------- #
+# merge
+# --------------------------------------------------------------------------- #
+def _cluster_payload():
+    canonical = {
+        "id": ID_NYCITY,
+        "name": "New York City",
+        "created_at": 100,
+        "type": None,
+        "description": "Largest US city.",
+        "props": {
+            "id": ID_NYCITY,
+            "name": "New York City",
+            "type": "Entity",
+            "description": "Largest US city.",
+        },
+    }
+    duplicate = {
+        "id": ID_NYC,
+        "name": "NYC",
+        "created_at": 200,
+        "type": None,
+        "description": "The Big Apple.",
+        "props": {
+            "id": ID_NYC,
+            "name": "NYC",
+            "type": "Entity",
+            "description": "The Big Apple.",
+        },
+    }
+    edges = [
+        (ID_NYCITY, "country", "located_in", {}),  # canonical, untouched
+        (ID_NYCITY, "park", "has", {}),  # canonical, untouched (degree tie-breaker)
+        (ID_NYC, "subway", "operates", {}),  # duplicate as source
+        ("tourist", ID_NYC, "visited", {}),  # duplicate as target
+        (ID_NYC, ID_NYCITY, "same_as", {}),  # intra-cluster -> dropped
+    ]
+    return {"clusters": [[canonical, duplicate]], "edges": edges}
+
+
+@pytest.mark.asyncio
+async def test_merge_repoints_edges_and_deletes_duplicates():
+    payload = _cluster_payload()
+    graph = _graph_mock()
+    vector = _vector_mock()
+
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        result = await merge_entity_duplicates(payload, config={})
+
+    # New York City and NYC tie on degree (3 each); New York City is older -> canonical.
+    repointed = {
+        (call.args[0], call.args[1], call.args[2]) for call in graph.add_edge.await_args_list
+    }
+    assert (ID_NYCITY, "subway", "operates") in repointed  # source remapped, direction kept
+    assert ("tourist", ID_NYCITY, "visited") in repointed  # target remapped, direction kept
+    assert graph.add_edge.await_count == 2  # untouched + self-loop edges are not re-added
+
+    # Duplicate node and its embedding are removed.
+    graph.delete_nodes.assert_awaited_once_with([ID_NYC])
+    vector.delete_data_points.assert_awaited_once()
+    collection, ids = vector.delete_data_points.await_args.args
+    assert collection == "Entity_name"
+    assert ids == [UUID(ID_NYC)]
+
+    # Canonical persisted once, with a unioned description and unchanged id.
+    graph.add_nodes.assert_awaited_once()
+    persisted = graph.add_nodes.await_args.args[0]
+    assert [entity.id for entity in persisted] == [UUID(ID_NYCITY)]
+    assert "Largest US city." in persisted[0].description
+    assert "The Big Apple." in persisted[0].description
+
+    assert [entity.id for entity in result] == [UUID(ID_NYCITY)]
+
+
+@pytest.mark.asyncio
+async def test_merge_dry_run_performs_no_mutations():
+    payload = _cluster_payload()
+    graph = _graph_mock()
+    vector = _vector_mock()
+
+    graph_getter = AsyncMock(return_value=graph)
+    with patch(GRAPH, new=graph_getter), patch(VECTOR, return_value=vector):
+        result = await merge_entity_duplicates(payload, config={"dry_run": True})
+
+    assert result == []
+    # Not a single mutating call, and the engines are not even acquired.
+    graph_getter.assert_not_called()
+    graph.add_edge.assert_not_called()
+    graph.add_nodes.assert_not_called()
+    graph.delete_nodes.assert_not_called()
+    vector.delete_data_points.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_merge_without_clusters_is_noop():
+    graph = _graph_mock()
+    vector = _vector_mock()
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        result = await merge_entity_duplicates({"clusters": [], "edges": []}, config={})
+    assert result == []
+    graph.add_edge.assert_not_called()
+    graph.delete_nodes.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# pipeline wiring
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_pipeline_wires_memify_tasks_and_config():
+    user = MagicMock()
+    user.id = "u1"
+    dataset = SimpleNamespace(id="ds-1", owner_id="owner-1", name="main_dataset")
+
+    module = "cognee.memify_pipelines.consolidate_entities"
+    with (
+        patch(f"{module}.get_default_user", new=AsyncMock(return_value=user)),
+        patch(
+            f"{module}.get_authorized_existing_datasets",
+            new=AsyncMock(return_value=[dataset]),
+        ),
+        patch(f"{module}.set_database_global_context_variables", new=_make_async_ctx_mock()) as ctx,
+        patch(f"{module}.memify", new=AsyncMock(return_value={"status": "ok"})) as memify_mock,
+    ):
+        result = await consolidate_entities_pipeline(
+            similarity_threshold=0.9, dry_run=True, top_k=5, protect_node_types=["City"]
+        )
+
+    assert result == {"status": "ok"}
+    # The graph is consolidated within the target dataset's database context.
+    ctx.assert_called_once_with("ds-1", "owner-1")
+
+    kwargs = memify_mock.call_args.kwargs
+    assert kwargs["data"] == [{}]
+    assert kwargs["dataset"] == "ds-1"
+    assert len(kwargs["extraction_tasks"]) == 1
+    assert len(kwargs["enrichment_tasks"]) == 1
+
+    detect_config = kwargs["extraction_tasks"][0].default_params["kwargs"]["config"]
+    merge_config = kwargs["enrichment_tasks"][0].default_params["kwargs"]["config"]
+    assert detect_config["similarity_threshold"] == 0.9
+    assert detect_config["dry_run"] is True
+    assert detect_config["top_k"] == 5
+    assert detect_config["protect_node_types"] == ["City"]
+    # detect and merge receive the same config object.
+    assert merge_config == detect_config

--- a/cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
+++ b/cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
@@ -110,6 +110,71 @@ async def test_detect_respects_protect_node_types():
     vector.embed_data.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_detect_name_match_groups_punctuation_variants():
+    # "USA" and "U.S.A." are not cosine-similar here, but their normalized names
+    # are identical, so name_match (on by default) must still group them.
+    id_usa = str(Entity.id_for("USA"))
+    id_usa_dotted = str(Entity.id_for("U.S.A."))
+    nodes = [
+        (id_usa, {"name": "USA", "type": "Entity"}),
+        (id_usa_dotted, {"name": "U.S.A.", "type": "Entity"}),
+    ]
+
+    graph = _graph_mock()
+    graph.get_graph_data = AsyncMock(return_value=(nodes, []))
+    vector = _vector_mock()
+    vector.embed_data = AsyncMock(return_value=[[1.0, 0.0], [0.0, 1.0]])  # cosine 0
+
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        grouped = await detect_entity_duplicates(None, config={"similarity_threshold": 0.85})
+        separate = await detect_entity_duplicates(
+            None, config={"similarity_threshold": 0.85, "name_match": False}
+        )
+
+    assert len(grouped["clusters"]) == 1
+    assert {m["name"] for m in grouped["clusters"][0]} == {"USA", "U.S.A."}
+    # With name_match off and dissimilar vectors, they are left separate.
+    assert separate["clusters"] == []
+
+
+@pytest.mark.asyncio
+async def test_detect_allow_cross_type_controls_cross_type_merge():
+    # Two cosine-similar names that belong to DIFFERENT EntityTypes.
+    nodes = [
+        (ID_NYC, {"name": "NYC", "type": "Entity"}),
+        (ID_NYCITY, {"name": "New York City", "type": "Entity"}),
+        ("type-city", {"name": "City", "type": "EntityType"}),
+        ("type-borough", {"name": "Borough", "type": "EntityType"}),
+    ]
+    edges = [
+        (ID_NYC, "type-borough", "is_a", {}),
+        (ID_NYCITY, "type-city", "is_a", {}),
+    ]
+    vectors = [[1.0, 0.0], [0.97, 0.24]]  # cosine ~0.97
+
+    # Default: differing EntityTypes are NOT merged.
+    graph = _graph_mock()
+    graph.get_graph_data = AsyncMock(return_value=(nodes, edges))
+    vector = _vector_mock()
+    vector.embed_data = AsyncMock(return_value=vectors)
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        default_result = await detect_entity_duplicates(None, config={"similarity_threshold": 0.85})
+    assert default_result["clusters"] == []
+
+    # allow_cross_type=True merges across types.
+    graph = _graph_mock()
+    graph.get_graph_data = AsyncMock(return_value=(nodes, edges))
+    vector = _vector_mock()
+    vector.embed_data = AsyncMock(return_value=vectors)
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        cross = await detect_entity_duplicates(
+            None, config={"similarity_threshold": 0.85, "allow_cross_type": True}
+        )
+    assert len(cross["clusters"]) == 1
+    assert {m["name"] for m in cross["clusters"][0]} == {"NYC", "New York City"}
+
+
 # --------------------------------------------------------------------------- #
 # canonical selection
 # --------------------------------------------------------------------------- #
@@ -222,7 +287,8 @@ async def test_merge_repoints_edges_and_deletes_duplicates():
     vector.delete_data_points.assert_awaited_once()
     collection, ids = vector.delete_data_points.await_args.args
     assert collection == "Entity_name"
-    assert ids == [UUID(ID_NYC)]
+    # ids are passed as strings (matches sibling deletion code, adapter-agnostic).
+    assert ids == [ID_NYC]
 
     # Canonical persisted once, with a unioned description and unchanged id.
     graph.add_nodes.assert_awaited_once()

--- a/cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
+++ b/cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py
@@ -8,15 +8,17 @@ dry_run no-op) and the pipeline *wiring* (tasks and config passed to memify).
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
+from cognee.exceptions import CogneeValidationError
 from cognee.memify_pipelines.consolidate_entities import consolidate_entities_pipeline
 from cognee.modules.engine.models.Entity import Entity
 from cognee.tasks.memify.consolidate_entities import (
     _node_degrees,
     _pick_canonical,
+    _union_belongs_to_set,
     detect_entity_duplicates,
     merge_entity_duplicates,
     plan_edge_repointing,
@@ -34,6 +36,7 @@ ID_BANANA = str(Entity.id_for("Banana"))
 def _graph_mock():
     graph = AsyncMock()
     graph.add_edge = AsyncMock()
+    graph.add_edges = AsyncMock()
     graph.add_nodes = AsyncMock()
     graph.delete_nodes = AsyncMock()
     return graph
@@ -275,12 +278,14 @@ async def test_merge_repoints_edges_and_deletes_duplicates():
         result = await merge_entity_duplicates(payload, config={})
 
     # New York City and NYC tie on degree (3 each); New York City is older -> canonical.
-    repointed = {
-        (call.args[0], call.args[1], call.args[2]) for call in graph.add_edge.await_args_list
-    }
+    # Edges are re-pointed in a single batched add_edges call.
+    graph.add_edges.assert_awaited_once()
+    repointed_edges = graph.add_edges.await_args.args[0]
+    repointed = {(edge[0], edge[1], edge[2]) for edge in repointed_edges}
     assert (ID_NYCITY, "subway", "operates") in repointed  # source remapped, direction kept
     assert ("tourist", ID_NYCITY, "visited") in repointed  # target remapped, direction kept
-    assert graph.add_edge.await_count == 2  # untouched + self-loop edges are not re-added
+    assert len(repointed_edges) == 2  # untouched + self-loop edges are not re-added
+    graph.add_edge.assert_not_called()  # per-edge path is no longer used
 
     # Duplicate node and its embedding are removed.
     graph.delete_nodes.assert_awaited_once_with([ID_NYC])
@@ -313,7 +318,7 @@ async def test_merge_dry_run_performs_no_mutations():
     assert result == []
     # Not a single mutating call, and the engines are not even acquired.
     graph_getter.assert_not_called()
-    graph.add_edge.assert_not_called()
+    graph.add_edges.assert_not_called()
     graph.add_nodes.assert_not_called()
     graph.delete_nodes.assert_not_called()
     vector.delete_data_points.assert_not_called()
@@ -326,8 +331,111 @@ async def test_merge_without_clusters_is_noop():
     with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
         result = await merge_entity_duplicates({"clusters": [], "edges": []}, config={})
     assert result == []
-    graph.add_edge.assert_not_called()
+    graph.add_edges.assert_not_called()
     graph.delete_nodes.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# belongs_to_set union + canonical id preservation
+# --------------------------------------------------------------------------- #
+def test_union_belongs_to_set_handles_mixed_shapes_and_dedups():
+    members = [
+        {"belongs_to_set": ["a", "b"]},
+        {"belongs_to_set": [{"name": "b"}, {"id": "c"}]},  # dict tags; "b" is a dup
+        {"props": {"belongs_to_set": "d"}},  # scalar, read via the props fallback
+        {"belongs_to_set": None},  # contributes nothing
+    ]
+    # First-seen order preserved, duplicates collapsed.
+    assert _union_belongs_to_set(members) == ["a", "b", "c", "d"]
+    # Nothing to union -> None, so the caller leaves the property untouched.
+    assert _union_belongs_to_set([{"belongs_to_set": None}]) is None
+
+
+@pytest.mark.asyncio
+async def test_merge_unions_belongs_to_set_and_pins_canonical_id():
+    """A merge must keep the canonical's id and union every duplicate's
+    belongs_to_set tags, or dataset / node-set scoping is silently narrowed."""
+    payload = _cluster_payload()
+    canonical, duplicate = payload["clusters"][0]
+    # Canonical and duplicate are scoped to DIFFERENT node sets.
+    canonical["props"]["belongs_to_set"] = ["dataset_a"]
+    duplicate["props"]["belongs_to_set"] = ["dataset_b"]
+
+    graph = _graph_mock()
+    vector = _vector_mock()
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        await merge_entity_duplicates(payload, config={})
+
+    graph.add_nodes.assert_awaited_once()
+    persisted = graph.add_nodes.await_args.args[0][0]
+    # New York City is canonical (older on the degree tie-break) and keeps its id.
+    assert persisted.id == UUID(ID_NYCITY)
+    # Both scoping tags survive the merge — neither dataset is dropped.
+    assert set(persisted.belongs_to_set or []) == {"dataset_a", "dataset_b"}
+
+
+@pytest.mark.asyncio
+async def test_merge_preserves_legacy_canonical_id():
+    """If the canonical has a legacy / random id (not ``Entity.id_for(name)``),
+    the rebuilt node must upsert under that real id, not a name-derived one,
+    otherwise add_nodes creates a brand-new node and orphans the survivor."""
+    legacy_id = str(uuid4())
+    assert legacy_id != ID_NYCITY  # sanity: not the name-derived id
+    canonical = {
+        "id": legacy_id,
+        "name": "New York City",
+        "created_at": 100,  # older -> wins the degree tie-break
+        "type": None,
+        "description": "Largest US city.",
+        "props": {
+            "id": legacy_id,
+            "name": "New York City",
+            "type": "Entity",
+            "description": "Largest US city.",
+        },
+    }
+    duplicate = {
+        "id": ID_NYC,
+        "name": "NYC",
+        "created_at": 200,
+        "type": None,
+        "description": "The Big Apple.",
+        "props": {"id": ID_NYC, "name": "NYC", "type": "Entity", "description": "The Big Apple."},
+    }
+    edges = [
+        (legacy_id, "country", "located_in", {}),
+        (ID_NYC, "subway", "operates", {}),
+    ]
+    payload = {"clusters": [[canonical, duplicate]], "edges": edges}
+
+    graph = _graph_mock()
+    vector = _vector_mock()
+    with patch(GRAPH, new=AsyncMock(return_value=graph)), patch(VECTOR, return_value=vector):
+        result = await merge_entity_duplicates(payload, config={})
+
+    persisted = graph.add_nodes.await_args.args[0][0]
+    assert persisted.id == UUID(legacy_id)  # real id pinned...
+    assert persisted.id != Entity.id_for("New York City")  # ...not the name-derived id
+    graph.delete_nodes.assert_awaited_once_with([ID_NYC])
+    assert [entity.id for entity in result] == [UUID(legacy_id)]
+
+
+# --------------------------------------------------------------------------- #
+# pipeline input validation
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_top_k", [0, -1, 2.5, True])
+async def test_pipeline_rejects_invalid_top_k(bad_top_k):
+    # Invalid top_k is rejected before any user / dataset resolution.
+    with pytest.raises(CogneeValidationError):
+        await consolidate_entities_pipeline(top_k=bad_top_k)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_protect", [["ok", ""], ["ok", "   "], "City", [1, 2]])
+async def test_pipeline_rejects_invalid_protect_node_types(bad_protect):
+    with pytest.raises(CogneeValidationError):
+        await consolidate_entities_pipeline(protect_node_types=bad_protect)
 
 
 # --------------------------------------------------------------------------- #

--- a/examples/guides/consolidate_entities_example.py
+++ b/examples/guides/consolidate_entities_example.py
@@ -150,17 +150,20 @@ async def main():
             if str(source) == survivor_id:
                 survivor_rels.add((rel, neighbor_name.get(str(tgt))))
 
-        # Was the deleted duplicate's embedding purged from Entity_name?
+        # Verify the deleted duplicate's embedding is actually gone from
+        # Entity_name: embed its name and confirm its id is not among the
+        # nearest matches (a real query_vector search, not a no-op probe).
         deleted_ids = dup_ids - {survivor_id}
         purged = True
-        try:
+        for deleted_id in deleted_ids:
+            deleted_name = (entities_before.get(deleted_id) or {}).get("name") or survivor_name
+            probe_vector = (await vector.embed_data([deleted_name]))[0]
             results = await vector.search(
-                "Entity_name", query_text=None, query_vector=None, limit=1000
+                "Entity_name", query_text=None, query_vector=probe_vector, limit=50
             )
             present_ids = {str(getattr(r, "id", None)) for r in results}
-            purged = all(deleted_id not in present_ids for deleted_id in deleted_ids)
-        except Exception as error:  # pragma: no cover - search shape varies by adapter
-            print(f"  (note: vector search probe skipped: {error})")
+            if deleted_id in present_ids:
+                purged = False
 
         print(f"Surviving duplicate-pair node: {survivor_name} ({survivor_id})")
         print(f"Survivor outgoing relationships: {sorted(survivor_rels)}")

--- a/examples/guides/consolidate_entities_example.py
+++ b/examples/guides/consolidate_entities_example.py
@@ -1,0 +1,193 @@
+"""Runnable integration demo for the ``consolidate_entities`` memify pipeline.
+
+It seeds two near-duplicate entities — "New York City" and "NYC" — into the
+default local backends (Kuzu graph + LanceDB vectors) using the offline
+``fastembed`` embedder (no API key needed), then runs
+``consolidate_entities_pipeline`` and verifies the acceptance criteria:
+
+* the two entities collapse into a single canonical node, and
+* every original edge survives on the canonical (the canonical-side
+  ``located_in -> United States`` and the duplicate-side
+  ``contains -> Central Park``), and
+* the duplicate's name embedding is purged from the ``Entity_name`` collection.
+
+Run it with the offline embedder::
+
+    cd cognee
+    EMBEDDING_PROVIDER=fastembed \
+    EMBEDDING_MODEL=BAAI/bge-small-en-v1.5 \
+    EMBEDDING_DIMENSIONS=384 \
+    uv run python examples/guides/consolidate_entities_example.py
+
+The script exits non-zero if any assertion fails.
+"""
+
+import asyncio
+import os
+import sys
+
+# Default to the offline fastembed embedder so the demo needs no API key.
+os.environ.setdefault("EMBEDDING_PROVIDER", "fastembed")
+os.environ.setdefault("EMBEDDING_MODEL", "BAAI/bge-small-en-v1.5")
+os.environ.setdefault("EMBEDDING_DIMENSIONS", "384")
+# This pipeline never calls the LLM, so skip the pipeline's LLM connection
+# preflight (otherwise it requires an LLM API key even though it is unused).
+os.environ.setdefault("COGNEE_SKIP_CONNECTION_TEST", "true")
+
+import cognee  # noqa: E402
+from cognee.context_global_variables import (  # noqa: E402
+    set_database_global_context_variables,
+)
+from cognee.infrastructure.databases.graph import get_graph_engine  # noqa: E402
+from cognee.infrastructure.databases.vector import get_vector_engine  # noqa: E402
+from cognee.memify_pipelines.consolidate_entities import (  # noqa: E402
+    consolidate_entities_pipeline,
+)
+from cognee.modules.engine.models.Entity import Entity  # noqa: E402
+from cognee.modules.engine.models.EntityType import EntityType  # noqa: E402
+from cognee.modules.engine.operations.setup import setup  # noqa: E402
+from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (  # noqa: E402
+    resolve_authorized_user_datasets,
+)
+from cognee.tasks.storage.index_data_points import index_data_points  # noqa: E402
+
+DATASET = "consolidate_entities_demo"
+DUP_NAMES = {"New York City", "NYC"}
+
+
+async def _seed():
+    """Create the two near-duplicate entities plus distinct neighbors/edges."""
+    graph = await get_graph_engine()
+
+    city = EntityType(name="City", description="A populated urban place.")
+    country = EntityType(name="Country", description="A sovereign nation.")
+    park = EntityType(name="Park", description="A public green space.")
+
+    nycity = Entity(
+        name="New York City",
+        is_a=city,
+        description="The most populous city in the United States.",
+    )
+    nyc = Entity(name="NYC", is_a=city, description="Common abbreviation for New York City.")
+    usa = Entity(name="United States", is_a=country, description="A country in North America.")
+    central_park = Entity(
+        name="Central Park", is_a=park, description="A large urban park in Manhattan."
+    )
+
+    await graph.add_nodes([city, country, park, nycity, nyc, usa, central_park])
+    await graph.add_edges(
+        [
+            (str(nycity.id), str(city.id), "is_a", {}),
+            (str(nyc.id), str(city.id), "is_a", {}),
+            (str(usa.id), str(country.id), "is_a", {}),
+            (str(central_park.id), str(park.id), "is_a", {}),
+            # canonical-side edge
+            (str(nycity.id), str(usa.id), "located_in", {}),
+            # duplicate-side edge — must survive on the canonical after merge
+            (str(nyc.id), str(central_park.id), "contains", {}),
+        ]
+    )
+    # Index entity names so detection (cosine) and embedding purge are exercised.
+    await index_data_points([city, country, park, nycity, nyc, usa, central_park])
+    return {str(nycity.id), str(nyc.id)}
+
+
+async def _entities(graph):
+    nodes, edges = await graph.get_graph_data()
+    entities = {str(node_id): props for node_id, props in nodes if props.get("type") == "Entity"}
+    return entities, edges
+
+
+def _check(label, condition):
+    print(f"  [{'PASS' if condition else 'FAIL'}] {label}")
+    return condition
+
+
+async def main():
+    print("== consolidate_entities integration demo (Kuzu + fastembed) ==")
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    # Recreate the relational/graph/vector schema (and default user) that the
+    # prune above dropped, before resolving datasets.
+    await setup()
+
+    user, datasets = await resolve_authorized_user_datasets(DATASET, None)
+    target = datasets[0]
+
+    async with set_database_global_context_variables(target.id, target.owner_id):
+        dup_ids = await _seed()
+        graph = await get_graph_engine()
+        entities_before, edges_before = await _entities(graph)
+        dup_names_before = sorted(
+            props.get("name")
+            for props in entities_before.values()
+            if props.get("name") in DUP_NAMES
+        )
+        print(f"Seeded entities: {sorted(p.get('name') for p in entities_before.values())}")
+        print(f"Duplicate pair present before: {dup_names_before}")
+
+    # Run the real pipeline (no dry_run).
+    await consolidate_entities_pipeline(similarity_threshold=0.6, dataset=DATASET, user=user)
+
+    async with set_database_global_context_variables(target.id, target.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        entities_after, edges_after = await _entities(graph)
+
+        surviving = [
+            (eid, props) for eid, props in entities_after.items() if props.get("name") in DUP_NAMES
+        ]
+        survivor_id = surviving[0][0] if surviving else None
+        survivor_name = surviving[0][1].get("name") if surviving else None
+
+        # Edges incident to the survivor, by relationship -> neighbor name.
+        neighbor_name = {eid: p.get("name") for eid, p in entities_after.items()}
+        # include EntityType names too
+        for node_id, props in (await graph.get_graph_data())[0]:
+            neighbor_name.setdefault(str(node_id), props.get("name"))
+        survivor_rels = set()
+        for source, tgt, rel, _ in edges_after:
+            if str(source) == survivor_id:
+                survivor_rels.add((rel, neighbor_name.get(str(tgt))))
+
+        # Was the deleted duplicate's embedding purged from Entity_name?
+        deleted_ids = dup_ids - {survivor_id}
+        purged = True
+        try:
+            results = await vector.search(
+                "Entity_name", query_text=None, query_vector=None, limit=1000
+            )
+            present_ids = {str(getattr(r, "id", None)) for r in results}
+            purged = all(deleted_id not in present_ids for deleted_id in deleted_ids)
+        except Exception as error:  # pragma: no cover - search shape varies by adapter
+            print(f"  (note: vector search probe skipped: {error})")
+
+        print(f"Surviving duplicate-pair node: {survivor_name} ({survivor_id})")
+        print(f"Survivor outgoing relationships: {sorted(survivor_rels)}")
+
+        ok = True
+        ok &= _check("exactly one of {New York City, NYC} remains", len(surviving) == 1)
+        ok &= _check(
+            "canonical kept its located_in -> United States edge",
+            ("located_in", "United States") in survivor_rels,
+        )
+        ok &= _check(
+            "duplicate's contains -> Central Park edge moved to the canonical",
+            ("contains", "Central Park") in survivor_rels,
+        )
+        ok &= _check(
+            "United States entity still present",
+            any(p.get("name") == "United States" for p in entities_after.values()),
+        )
+        ok &= _check(
+            "Central Park entity still present",
+            any(p.get("name") == "Central Park" for p in entities_after.values()),
+        )
+        ok &= _check("deleted duplicate embedding purged from Entity_name", purged)
+
+    print("== RESULT:", "ALL CHECKS PASSED ==" if ok else "FAILURES PRESENT ==")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Description

Running `cognify` a few times (or pulling the same facts in from more than one
source) leaves the graph with duplicate `Entity` nodes for the same thing - the
classic example is "New York City" vs "NYC". Because the id is derived from the
name they never collapse on their own, so one real entity ends up with its edges
split across two or three nodes.

This adds a `memify` pipeline, `consolidate_entities`, that finds those
near-duplicates and merges each group down to a single node without losing any
edges.

How it works:

`detect_entity_duplicates` embeds each entity name and clusters the close ones -
cosine similarity over a threshold, plus an exact normalized-name match so things
like "U.S.A." and "USA" still group even when the vectors disagree. By default it
only groups entities of the same `EntityType`; you can flip that with
`allow_cross_type`, or skip whole types with `protect_node_types`.

`merge_entity_duplicates` then picks the canonical node (most connected, ties
broken by oldest, then name), moves every edge from the duplicates onto it
(keeping the original direction), unions the descriptions, and finally deletes
the duplicate nodes plus their leftover name embeddings. `dry_run=True` logs the
plan and touches nothing.

A couple of notes from building it:

- I read the edges from `get_graph_data()` so I know each edge's real direction,
  then re-point them onto the canonical. The duplicates' old edges disappear with
  the node's detach-delete, so there's no need for a per-edge delete.
- Deleting a node doesn't drop its vector, so I delete the duplicate embeddings
  explicitly — otherwise they reappear the next time detection runs.

Two follow-up commits address the automated review.

The first round: the example now actually verifies the embedding is gone (the
first probe was a no-op), `delete_data_points` is called with string ids to match
the rest of the codebase, neighbor selection uses `argpartition`, and I added
tests for the name-match and cross-type paths.

The second round (after the re-review) tightens correctness and scale:

- The rebuilt canonical now keeps its **real graph id**, so a legacy- or
  random-id node is upserted in place instead of being re-created under a
  name-derived id and orphaned from its edges.
- The canonical now inherits the **union of every duplicate's `belongs_to_set`**
  tags, so a merge never silently narrows a node's dataset / node-set scoping.
  (`belongs_to_set` is a node property, not an edge — I corrected a comment that
  implied otherwise.)
- Edges are re-pointed in a single batched `add_edges` call instead of one await
  per edge.
- The similarity scan runs in row-blocks (chunked top-k via `argpartition`), so
  the full N×N matrix is never materialized and the pipeline scales past small
  graphs.
- The pipeline validates `top_k` (positive int) and `protect_node_types` (list of
  non-empty strings) up front.

I added unit tests for each of these — `belongs_to_set` union, canonical-id
preservation (including a legacy, non-name-derived id), and the input validation.

> I used an AI assistant (Hyperagent) for part of this work. I've read, run, and
> tested everything myself and I'm confident in how it behaves.

## Acceptance Criteria

- Two entities that mean the same thing collapse into one node, with all the
  original edges on the survivor. ✅
- `dry_run=True` reports the proposed merges and changes nothing. ✅

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots

Local run — 23 unit tests, the real-backend integration test, the integration
example, and pre-commit all passing (exit code 0):

![Local verification: 23 unit tests + integration test + example + pre-commit passing](https://pub.hyperagent.com/api/published/pbf01KW49E1KZ_4YBHNBXK8QSPWBTY/Screenshot%202026-06-27%20at%2015.40.57.png)

Unit tests (mocked, no backend or network) —
`cognee/tests/unit/memify_pipelines/test_consolidate_entities_pipeline.py`:

```
23 passed
```

Real-backend integration test (Kuzu + LanceDB, real embeddings) —
`cognee/tests/integration/tasks/test_consolidate_entities_integration.py`:

```
1 passed
```

The example on the default local stack (Kuzu + LanceDB, fastembed for
embeddings) — `examples/guides/consolidate_entities_example.py`:

```
Seeded entities: ['Central Park', 'NYC', 'New York City', 'United States']
Surviving duplicate-pair node: New York City
Survivor outgoing relationships: [('contains', 'Central Park'), ('is_a', 'City'), ('located_in', 'United States')]
  [PASS] exactly one of {New York City, NYC} remains
  [PASS] canonical kept its located_in -> United States edge
  [PASS] duplicate's contains -> Central Park edge moved to the canonical
  [PASS] United States entity still present
  [PASS] Central Park entity still present
  [PASS] deleted duplicate embedding purged from Entity_name
== RESULT: ALL CHECKS PASSED ==
```

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines (ruff + pre-commit pass)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (docstrings + a runnable example)
- [x] All new tests pass. (The only failing unit tests in the repo are the pre-existing `*_retriever` ones that need an LLM API key — they fail the same way on a clean `dev`.)
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

Closes #3393

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
