### PR TITLE
fix(web_scraper): accept a list of URLs in DefaultUrlCrawler.fetch_urls

### DIFF
--- a/cognee/tasks/web_scraper/default_url_crawler.py
+++ b/cognee/tasks/web_scraper/default_url_crawler.py
@@ -399,7 +399,7 @@ class DefaultUrlCrawler:
         """
         if isinstance(urls, str):
             urls = [urls]
-        else:
+        elif not isinstance(urls, list):
             raise ValueError(f"Invalid urls type: {type(urls)}")
 
         async def _task(url: str):

--- a/cognee/tests/integration/web_url_crawler/test_default_url_crawler.py
+++ b/cognee/tests/integration/web_url_crawler/test_default_url_crawler.py
@@ -11,3 +11,14 @@ async def test_fetch():
     assert isinstance(results, dict)
     html = results[url]
     assert isinstance(html, str)
+
+
+@pytest.mark.asyncio
+async def test_fetch_accepts_list():
+    crawler = DefaultUrlCrawler()
+    urls = ["http://example.com/"]
+    results = await crawler.fetch_urls(urls)
+    assert isinstance(results, dict)
+    assert len(results) == 1
+    html = results["http://example.com/"]
+    assert isinstance(html, str)


### PR DESCRIPTION
## Description

`DefaultUrlCrawler.fetch_urls` is typed `urls: Union[str, List[str]]` and is built to process multiple URLs: it logs `len(urls)`, creates one task per URL, drains them with `asyncio.as_completed`, and bounds concurrency with a semaphore. But the input guard only accepts a string and raises `ValueError` on anything else, including the `List[str]` the signature documents:

```python
if isinstance(urls, str):
    urls = [urls]
else:
    raise ValueError(f"Invalid urls type: {type(urls)}")
```

So `await crawler.fetch_urls(["http://a/", "http://b/"])` raises `ValueError` before any work runs. This is reachable through the public `fetch_page_content` helper too, which forwards a list straight into `fetch_urls`.

## Fix

Only raise for a type that is neither `str` nor `list`:

```python
if isinstance(urls, str):
    urls = [urls]
elif not isinstance(urls, list):
    raise ValueError(f"Invalid urls type: {type(urls)}")
```

## Tests

Added `test_fetch_accepts_list` next to the existing `test_fetch`, mirroring it but passing a single-element list. It raises `ValueError` on the current `dev` branch and passes with the fix. `ruff format` and `ruff check` pass on both changed files.
