### PR TITLE
[hackathon]test(deployment): single-container API e2e golden flow with mock LLM (T1) #3359

### DIFF
--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -221,6 +221,27 @@ jobs:
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
+  deployment-test:
+    name: Deployment Test
+    needs: [ pre-test ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Build local Docker image
+        run: docker build -t cognee:local .
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Run Deployment Tests
+        env:
+          COGNEE_DOCKER_IMAGE: cognee:local
+        run: uv run pytest cognee/tests/deployment/ -v -m deployment --timeout=300
+
   temporal-graph-tests:
     name: Temporal Graph Test
     needs: [ build-ci-env ]
@@ -289,6 +310,7 @@ jobs:
       mcp-test,
       docker-compose-test,
       docker-ci-test,
+      deployment-test,
       temporal-graph-tests,
       search-db-tests,
       relational-db-migration-tests,
@@ -316,6 +338,7 @@ jobs:
                 "${{ needs.mcp-test.result }}" == "success" &&
                 "${{ needs.docker-compose-test.result }}" == "success" &&
                 "${{ needs.docker-ci-test.result }}" == "success" &&
+                "${{ needs.deployment-test.result }}" == "success" &&
                 "${{ needs.temporal-graph-tests.result }}" == "success" &&
                 "${{ needs.search-db-tests.result }}" == "success" &&
                 "${{ needs.relational-db-migration-tests.result }}" == "success" &&

--- a/cognee/tests/deployment/conftest.py
+++ b/cognee/tests/deployment/conftest.py
@@ -1,0 +1,187 @@
+"""Pytest fixtures for deployment end-to-end tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from cognee.tests.deployment.golden_flow import run_golden_flow
+from cognee.tests.deployment.helpers import (
+    build_api_container_cmd,
+    build_mcp_container_cmd,
+    get_free_port,
+    resolve_docker_image,
+    stop_container,
+    stream_container_logs,
+    wait_for_health,
+)
+from cognee.tests.deployment.mock_llm import start_mock_llm_server, stop_mock_llm_server
+
+pytestmark = pytest.mark.deployment
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--image",
+        action="store",
+        default=None,
+        help="Docker image for API deployment tests: build, pull, or an image name",
+    )
+    parser.addoption(
+        "--mcp-image",
+        action="store",
+        default=None,
+        help="Docker image for MCP deployment tests: build, pull, or an image name",
+    )
+
+
+def _use_real_llm() -> bool:
+    return os.getenv("DEPLOYMENT_USE_REAL_LLM", "").lower() in ("true", "1", "yes")
+
+
+@pytest.fixture(scope="session")
+def mock_llm_server():
+    if _use_real_llm():
+        yield None
+        return
+
+    server, _thread, port = start_mock_llm_server()
+    url = f"http://127.0.0.1:{port}/v1"
+    yield url
+    stop_mock_llm_server(server)
+
+
+@pytest.fixture(scope="session")
+def image_name(request):
+    return resolve_docker_image(
+        image_option=request.config.getoption("--image"),
+        env_var="COGNEE_DOCKER_IMAGE",
+        local_tag="cognee:local",
+        published_image="cognee/cognee:latest",
+        build_cmd=["docker", "build", "-t", "cognee:local", "."],
+    )
+
+
+@pytest.fixture(scope="session")
+def mcp_image_name(request):
+    return resolve_docker_image(
+        image_option=request.config.getoption("--mcp-image"),
+        env_var="COGNEE_MCP_IMAGE",
+        local_tag="cognee-mcp:local",
+        published_image="cognee/cognee-mcp:latest",
+        build_cmd=[
+            "docker",
+            "build",
+            "-t",
+            "cognee-mcp:local",
+            "-f",
+            "cognee-mcp/Dockerfile",
+            ".",
+        ],
+    )
+
+
+@pytest.fixture
+def running_container(request, mock_llm_server, image_name):
+    if _use_real_llm() and mock_llm_server is None:
+        pytest.skip("Real LLM mode requires DEPLOYMENT_USE_REAL_LLM secrets to be configured.")
+
+    host_port = get_free_port()
+    container_name = f"cognee-test-{uuid.uuid4().hex[:8]}"
+    cmd = build_api_container_cmd(
+        image_name=image_name,
+        container_name=container_name,
+        host_port=host_port,
+        mock_llm_url=mock_llm_server or "",
+    )
+
+    print(f"Starting container {container_name} on port {host_port} with image {image_name}...")
+    proc = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
+    if proc.returncode != 0:
+        raise RuntimeError(f"docker run failed to start: {proc.stderr}")
+
+    url = f"http://127.0.0.1:{host_port}"
+    failed = False
+
+    try:
+        wait_for_health(f"{url}/health", timeout=120.0)
+        yield {"url": url, "port": host_port, "container_name": container_name}
+    except Exception:
+        failed = True
+        raise
+    finally:
+        test_failed = getattr(getattr(request.node, "rep_call", None), "failed", False)
+        if failed or test_failed:
+            print(f"\n--- CONTAINER LOGS FOR {container_name} ---")
+            stream_container_logs(container_name)
+        stop_container(container_name)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"rep_{rep.when}", rep)
+
+
+@pytest_asyncio.fixture
+async def api_client(running_container):
+    async with httpx.AsyncClient(base_url=running_container["url"], timeout=60.0) as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def mcp_client(mcp_image_name):
+    host_port = get_free_port()
+    container_name = f"cognee-mcp-test-{uuid.uuid4().hex[:8]}"
+    cmd = build_mcp_container_cmd(
+        image_name=mcp_image_name,
+        container_name=container_name,
+        host_port=host_port,
+    )
+
+    print(f"Starting MCP container {container_name} on port {host_port}...")
+    proc = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
+    if proc.returncode != 0:
+        raise RuntimeError(f"docker run for MCP failed to start: {proc.stderr}")
+
+    url = f"http://127.0.0.1:{host_port}"
+
+    class MCPAsyncClient(httpx.AsyncClient):
+        async def call_tool(self, tool_name: str, arguments: dict) -> dict:
+            payload = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            }
+            resp = await self.post("/mcp", json=payload)
+            resp.raise_for_status()
+            result = resp.json()
+            if "error" in result:
+                raise RuntimeError(f"MCP tool error: {result['error']}")
+            return result["result"]
+
+    failed = False
+    try:
+        wait_for_health(f"{url}/health", timeout=120.0)
+        async with MCPAsyncClient(base_url=url, timeout=60.0) as client:
+            yield client
+    except Exception:
+        failed = True
+        raise
+    finally:
+        if failed:
+            print(f"\n--- MCP CONTAINER LOGS FOR {container_name} ---")
+            stream_container_logs(container_name)
+        stop_container(container_name)
+
+
+@pytest.fixture
+def golden_flow():
+    return run_golden_flow

--- a/cognee/tests/deployment/golden_flow.py
+++ b/cognee/tests/deployment/golden_flow.py
@@ -1,0 +1,117 @@
+"""Reusable add → cognify → search flow for deployment e2e tests."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import httpx
+
+from cognee.tests.deployment.mock_llm import GOLDEN_DOCUMENT, GOLDEN_ENTITY
+
+PIPELINE_COMPLETED = "DATASET_PROCESSING_COMPLETED"
+PIPELINE_ERRORED = "DATASET_PROCESSING_ERRORED"
+
+
+async def register_and_login(
+    client: httpx.AsyncClient,
+    email: str | None = None,
+    password: str = "test_password",
+) -> str:
+    if email is None:
+        email = f"deploy_test_{uuid.uuid4().hex[:8]}@example.com"
+
+    reg_payload = {
+        "email": email,
+        "password": password,
+        "is_active": True,
+        "is_superuser": False,
+        "is_verified": False,
+    }
+    try:
+        await client.post("/api/v1/auth/register", json=reg_payload)
+    except Exception:
+        pass
+
+    resp = await client.post(
+        "/api/v1/auth/login",
+        data={"username": email, "password": password},
+    )
+    resp.raise_for_status()
+    token = resp.json()["access_token"]
+    client.headers["Authorization"] = f"Bearer {token}"
+    return token
+
+
+async def run_golden_flow(client: httpx.AsyncClient, dataset_name: str | None = None) -> str:
+    """Drive add → cognify → poll → search and assert the golden entity is retrievable."""
+    if dataset_name is None:
+        dataset_name = f"deploy_golden_{uuid.uuid4().hex[:8]}"
+
+    await register_and_login(client)
+
+    files = {
+        "data": ("document.txt", GOLDEN_DOCUMENT.encode("utf-8"), "text/plain"),
+    }
+    resp = await client.post("/api/v1/add", data={"datasetName": dataset_name}, files=files)
+    resp.raise_for_status()
+
+    resp = await client.get("/api/v1/datasets")
+    resp.raise_for_status()
+    datasets = resp.json()
+
+    dataset_id = next((ds["id"] for ds in datasets if ds["name"] == dataset_name), None)
+    assert dataset_id is not None, f"Dataset {dataset_name} not found in: {datasets}"
+
+    resp = await client.post(
+        "/api/v1/cognify",
+        json={"datasets": [dataset_name], "run_in_background": True},
+    )
+    resp.raise_for_status()
+
+    status_completed = False
+    for _ in range(120):
+        resp = await client.get(f"/api/v1/datasets/status?dataset={dataset_id}")
+        resp.raise_for_status()
+        status_data = resp.json()
+        status = status_data.get(str(dataset_id))
+        if status == PIPELINE_COMPLETED:
+            status_completed = True
+            break
+        if status == PIPELINE_ERRORED:
+            raise RuntimeError(
+                f"Cognify pipeline failed for dataset {dataset_id}. Status payload: {status_data}"
+            )
+        await asyncio.sleep(1)
+
+    assert status_completed, f"Cognify pipeline did not complete in time for dataset {dataset_id}"
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "search_type": "GRAPH_COMPLETION",
+            "query": "Who developed relativity?",
+            "dataset_ids": [dataset_id],
+        },
+    )
+    resp.raise_for_status()
+    results_gc = resp.json()
+    assert any(GOLDEN_ENTITY in str(item) for item in results_gc), (
+        f"{GOLDEN_ENTITY} not found in GRAPH_COMPLETION results: {results_gc}"
+    )
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "search_type": "CHUNKS",
+            "query": GOLDEN_ENTITY,
+            "dataset_ids": [dataset_id],
+        },
+    )
+    resp.raise_for_status()
+    results_chunks = resp.json()
+    assert any(GOLDEN_ENTITY in str(item) for item in results_chunks), (
+        f"{GOLDEN_ENTITY} not found in CHUNKS results: {results_chunks}"
+    )
+
+    return dataset_id

--- a/cognee/tests/deployment/helpers.py
+++ b/cognee/tests/deployment/helpers.py
@@ -1,0 +1,154 @@
+"""Shared helpers for deployment end-to-end tests."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from urllib.parse import urlparse
+
+import httpx
+
+
+def get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def wait_for_health(url: str, timeout: float = 60.0) -> None:
+    """Poll until the service health endpoint reports ready."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            resp = httpx.get(url, timeout=5.0)
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("status") in ("ready", "ok") or data.get("health") == "healthy":
+                    return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise TimeoutError(f"Service at {url} not ready after {timeout}s")
+
+
+def resolve_docker_image(
+    image_option: str | None,
+    env_var: str,
+    local_tag: str,
+    published_image: str,
+    build_cmd: list[str],
+) -> str:
+    image = image_option or os.environ.get(env_var)
+    if not image:
+        image = "build"
+
+    if image == "build":
+        print(f"Building local Docker image '{local_tag}'...")
+        proc = subprocess.run(build_cmd, capture_output=True, text=True, errors="replace")
+        if proc.returncode == 0:
+            print(f"Successfully built local image '{local_tag}'.")
+            return local_tag
+        print(f"Failed to build local Docker image: {proc.stderr}")
+        print(f"Falling back to published image '{published_image}'.")
+        return published_image
+
+    if image == "pull":
+        return published_image
+
+    return image
+
+
+def mock_llm_endpoint_for_container(mock_llm_url: str) -> str:
+    parsed = urlparse(mock_llm_url)
+    mock_llm_port = parsed.port
+    if sys.platform.startswith("linux"):
+        return f"http://127.0.0.1:{mock_llm_port}/v1"
+    return f"http://host.docker.internal:{mock_llm_port}/v1"
+
+
+def build_api_container_cmd(
+    *,
+    image_name: str,
+    container_name: str,
+    host_port: int,
+    mock_llm_url: str,
+) -> list[str]:
+    llm_endpoint = mock_llm_endpoint_for_container(mock_llm_url)
+    env = [
+        "ENV=local",
+        "DB_PROVIDER=sqlite",
+        "COGNEE_SKIP_CONNECTION_TEST=true",
+        "LLM_PROVIDER=openai",
+        "LLM_MODEL=gpt-5-mini",
+        f"LLM_ENDPOINT={llm_endpoint}",
+        "LLM_API_KEY=mock-key",
+        "EMBEDDING_PROVIDER=openai",
+        "EMBEDDING_MODEL=text-embedding-3-small",
+        "EMBEDDING_DIMENSIONS=1536",
+        f"EMBEDDING_ENDPOINT={llm_endpoint}",
+        "EMBEDDING_API_KEY=mock-key",
+    ]
+
+    cmd = ["docker", "run", "-d", "--name", container_name]
+    if sys.platform.startswith("linux"):
+        cmd.extend(["--network", "host", "-e", f"HTTP_PORT={host_port}"])
+    else:
+        cmd.extend(
+            [
+                "-p",
+                f"{host_port}:8000",
+                "--add-host",
+                "host.docker.internal:host-gateway",
+            ]
+        )
+
+    for entry in env:
+        cmd.extend(["-e", entry])
+
+    cmd.append(image_name)
+    return cmd
+
+
+def fetch_container_logs(container_name: str) -> tuple[str, str]:
+    proc = subprocess.run(
+        ["docker", "logs", container_name],
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    return proc.stdout, proc.stderr
+
+
+def stream_container_logs(container_name: str) -> None:
+    stdout, stderr = fetch_container_logs(container_name)
+    sys.stdout.buffer.write(stdout.encode("utf-8", errors="replace"))
+    sys.stdout.buffer.write(b"\n")
+    sys.stderr.buffer.write(stderr.encode("utf-8", errors="replace"))
+    sys.stderr.buffer.write(b"\n")
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+
+def stop_container(container_name: str) -> None:
+    subprocess.run(["docker", "stop", container_name], capture_output=True)
+    subprocess.run(["docker", "rm", container_name], capture_output=True)
+
+
+def assert_no_tracebacks_in_logs(stdout: str, stderr: str) -> None:
+    assert "Traceback" not in stdout, f"Traceback found in container stdout logs:\n{stdout}"
+    assert "Traceback" not in stderr, f"Traceback found in container stderr logs:\n{stderr}"
+
+
+def build_mcp_container_cmd(*, image_name: str, container_name: str, host_port: int) -> list[str]:
+    cmd = ["docker", "run", "-d", "--name", container_name]
+    if sys.platform.startswith("linux"):
+        cmd.extend(
+            ["--network", "host", "-e", f"HTTP_PORT={host_port}", "-e", "TRANSPORT_MODE=http"]
+        )
+    else:
+        cmd.extend(["-p", f"{host_port}:8000", "-e", "TRANSPORT_MODE=http"])
+    cmd.append(image_name)
+    return cmd

--- a/cognee/tests/deployment/mock_llm.py
+++ b/cognee/tests/deployment/mock_llm.py
@@ -1,0 +1,167 @@
+"""In-process OpenAI-compatible mock for deployment e2e tests."""
+
+from __future__ import annotations
+
+import json
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+
+GOLDEN_DOCUMENT = "Albert Einstein developed the theory of relativity."
+GOLDEN_ENTITY = "Albert Einstein"
+GOLDEN_ANSWER = "Albert Einstein developed the theory of relativity."
+
+
+def _resolve_schema_name(req: dict) -> str:
+    response_format = req.get("response_format") or {}
+    json_schema = response_format.get("json_schema") or {}
+    schema_name = json_schema.get("name", "")
+    if schema_name:
+        return schema_name
+
+    tools = req.get("tools") or []
+    if tools and isinstance(tools, list):
+        schema_name = tools[0].get("function", {}).get("name", "")
+        if schema_name:
+            return schema_name
+
+    functions = req.get("functions") or []
+    if functions and isinstance(functions, list):
+        schema_name = functions[0].get("name", "")
+        if schema_name:
+            return schema_name
+
+    return ""
+
+
+def build_chat_completion_content(req: dict) -> str:
+    schema_name = _resolve_schema_name(req)
+
+    if schema_name == "DefaultContentPrediction":
+        return json.dumps(
+            {
+                "label": {
+                    "type": "TEXTUAL_DOCUMENTS_USED_FOR_GENERAL_PURPOSES",
+                    "subclass": ["News stories and blog posts"],
+                }
+            }
+        )
+
+    if schema_name == "SummarizedContent":
+        return json.dumps(
+            {
+                "summary": (
+                    "This document covers Albert Einstein and his development of "
+                    "the theory of relativity."
+                ),
+                "description": "",
+            }
+        )
+
+    if schema_name == "KnowledgeGraph":
+        return json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "einstein",
+                        "name": GOLDEN_ENTITY,
+                        "type": "Person",
+                        "description": "A theoretical physicist.",
+                    }
+                ],
+                "edges": [
+                    {
+                        "source_node_id": "einstein",
+                        "target_node_id": "relativity",
+                        "relationship_name": "developed",
+                        "description": GOLDEN_ANSWER,
+                    }
+                ],
+            }
+        )
+
+    if schema_name == "Answer":
+        return json.dumps({"answer": GOLDEN_ANSWER})
+
+    # Plain string completions (GRAPH_COMPLETION with response_model=str).
+    return GOLDEN_ANSWER
+
+
+def build_embeddings_response(req: dict) -> dict:
+    model = req.get("model", "")
+    dim = 3072 if "text-embedding-3-large" in model else 1536
+    inputs = req.get("input", [])
+
+    if isinstance(inputs, list):
+        data_list = [
+            {"object": "embedding", "index": idx, "embedding": [0.1] * dim}
+            for idx in range(len(inputs))
+        ]
+    else:
+        data_list = [{"object": "embedding", "index": 0, "embedding": [0.1] * dim}]
+
+    return {"object": "list", "data": data_list, "model": model}
+
+
+class MockLLMHandler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args) -> None:
+        return
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length).decode("utf-8")
+        try:
+            req = json.loads(body)
+        except json.JSONDecodeError:
+            req = {}
+
+        if self.path.endswith("/chat/completions"):
+            content = build_chat_completion_content(req)
+            resp = {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": req.get("model", "gpt-5-mini"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+            payload = json.dumps(resp).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        if self.path.endswith("/embeddings"):
+            payload = json.dumps(build_embeddings_response(req)).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+def start_mock_llm_server() -> tuple[HTTPServer, Thread, int]:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        port = sock.getsockname()[1]
+
+    server = HTTPServer(("0.0.0.0", port), MockLLMHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, port
+
+
+def stop_mock_llm_server(server: HTTPServer) -> None:
+    server.shutdown()
+    server.server_close()

--- a/cognee/tests/deployment/test_harness.py
+++ b/cognee/tests/deployment/test_harness.py
@@ -1,0 +1,72 @@
+"""Lightweight harness self-tests (no Docker required)."""
+
+import json
+
+import httpx
+import pytest
+
+from cognee.tests.deployment.helpers import wait_for_health
+from cognee.tests.deployment.mock_llm import (
+    GOLDEN_ANSWER,
+    GOLDEN_ENTITY,
+    build_chat_completion_content,
+    build_embeddings_response,
+    start_mock_llm_server,
+    stop_mock_llm_server,
+)
+
+
+@pytest.mark.deployment
+def test_mock_llm_schema_responses():
+    kg_content = build_chat_completion_content(
+        {
+            "response_format": {"json_schema": {"name": "KnowledgeGraph"}},
+        }
+    )
+    kg = json.loads(kg_content)
+    assert any(node["name"] == GOLDEN_ENTITY for node in kg["nodes"])
+
+    summary_content = build_chat_completion_content(
+        {
+            "response_format": {"json_schema": {"name": "SummarizedContent"}},
+        }
+    )
+    summary = json.loads(summary_content)
+    assert "summary" in summary
+    assert GOLDEN_ENTITY in summary["summary"]
+
+    plain_answer = build_chat_completion_content({})
+    assert plain_answer == GOLDEN_ANSWER
+
+
+@pytest.mark.deployment
+def test_mock_llm_embeddings():
+    resp = build_embeddings_response({"model": "text-embedding-3-small", "input": ["hello"]})
+    assert len(resp["data"]) == 1
+    assert len(resp["data"][0]["embedding"]) == 1536
+
+
+@pytest.mark.deployment
+def test_mock_llm_http_server():
+    server, _thread, port = start_mock_llm_server()
+    try:
+        resp = httpx.post(
+            f"http://127.0.0.1:{port}/v1/chat/completions",
+            json={
+                "model": "gpt-5-mini",
+                "messages": [{"role": "user", "content": "test"}],
+                "response_format": {"json_schema": {"name": "KnowledgeGraph"}},
+            },
+            timeout=5.0,
+        )
+        resp.raise_for_status()
+        content = resp.json()["choices"][0]["message"]["content"]
+        assert GOLDEN_ENTITY in content
+    finally:
+        stop_mock_llm_server(server)
+
+
+@pytest.mark.deployment
+def test_wait_for_health_times_out_on_dead_port():
+    with pytest.raises(TimeoutError):
+        wait_for_health("http://127.0.0.1:1/health", timeout=2.0)

--- a/cognee/tests/deployment/test_t1_single_container.py
+++ b/cognee/tests/deployment/test_t1_single_container.py
@@ -1,0 +1,14 @@
+"""T1 — single-container API e2e golden flow over HTTP."""
+
+import pytest
+
+from cognee.tests.deployment.helpers import assert_no_tracebacks_in_logs, fetch_container_logs
+
+
+@pytest.mark.deployment
+@pytest.mark.asyncio
+async def test_t1_single_container_golden_flow(running_container, api_client, golden_flow):
+    await golden_flow(api_client)
+
+    stdout, stderr = fetch_container_logs(running_container["container_name"])
+    assert_no_tracebacks_in_logs(stdout, stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,3 +282,8 @@ dev = [
     "pytest-split>=0.11.0,<0.12",
     "ruff>=0.13.1",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "deployment: Deployment end-to-end integration tests (require Docker; opt-in via -m deployment)",
+]


### PR DESCRIPTION
Closes #3359

## Summary
Adds a deployment pytest harness and T1 single-container e2e that runs the `cognee/cognee` image and drives add → cognify → poll → search (GRAPH_COMPLETION + CHUNKS) over HTTP using a mock LLM (no API key).

## Changes
- `cognee/tests/deployment/` — harness, mock LLM, `golden_flow`, T1 test
- `pyproject.toml` — `@pytest.mark.deployment`
- `.github/workflows/test_suites.yml` — PR-blocking `deployment-test` job

## How to test
docker build -t cognee:local .
uv run pytest cognee/tests/deployment/ -v -m deployment --timeout=300

## Checklist
- [x] Mock LLM, no real key required
- [x] CI wired into test_suites notify gate
- [x] Harness self-tests pass without Docker