### PR TITLE
Use model context window for chunk size calculation

### DIFF
--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -4,6 +4,7 @@ import os
 import litellm
 
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
+from cognee.infrastructure.llm.config import get_llm_context_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client import (
     get_llm_client,
 )
@@ -36,12 +37,42 @@ def get_max_chunk_tokens() -> int:
     embedding_engine = get_vector_engine().embedding_engine
     llm_client = get_llm_client(raise_api_key_error=False)
 
-    # We need to make sure chunk size won't take more than half of LLM max context token size
-    # but it also can't be bigger than the embedding engine max token size
-    llm_cutoff_point = llm_client.max_completion_tokens // 2  # Round down the division
+    llm_config = get_llm_context_config()
+    llm_context_window = get_model_max_context_tokens(llm_config.llm_model)
+    if llm_context_window is None:
+        llm_context_window = llm_client.max_completion_tokens
+
+    # We need to make sure chunk size won't take more than half of the LLM context token size
+    # but it also can't be bigger than the embedding engine max token size.
+    llm_cutoff_point = llm_context_window // 2  # Round down the division
     max_chunk_tokens = min(embedding_engine.max_completion_tokens, llm_cutoff_point)
 
     return max_chunk_tokens
+
+
+def get_model_max_context_tokens(model_name: str) -> int | None:
+    """
+    Retrieve the maximum context-window size for a specified model if it exists.
+
+    Uses LiteLLM model metadata when available and falls back to the legacy model-cost entry.
+    """
+    try:
+        model_info = litellm.get_model_info(model_name)
+    except Exception as exc:
+        logger.debug("Failed to resolve model info for %s: %s", model_name, exc)
+        model_info = {}
+
+    max_context_tokens = model_info.get("max_input_tokens") or model_info.get("max_tokens")
+    if max_context_tokens is None:
+        if model_name in litellm.model_cost and "max_tokens" in litellm.model_cost[model_name]:
+            max_context_tokens = litellm.model_cost[model_name]["max_tokens"]
+
+    if max_context_tokens is None:
+        logger.debug("Model context window not found for %s.", model_name)
+    else:
+        logger.debug("Model context window for %s: %s", model_name, max_context_tokens)
+
+    return max_context_tokens
 
 
 def get_model_max_completion_tokens(model_name: str) -> int | None:

--- a/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
+++ b/cognee/tests/unit/infrastructure/llm/test_get_llm_client.py
@@ -3,6 +3,7 @@ from dataclasses import asdict
 import pytest
 from pydantic import BaseModel
 
+from cognee.infrastructure.llm import utils as llm_utils
 from cognee.infrastructure.llm.config import LLMConfig
 from cognee.infrastructure.llm.exceptions import LLMAPIKeyNotSetError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api import (
@@ -52,6 +53,30 @@ def _llm_config(**overrides):
 
 def test_llm_client_cache_is_bounded_lru():
     assert _get_llm_client_cached.cache_parameters()["maxsize"] == _LLM_CLIENT_CACHE_MAXSIZE
+
+
+def test_get_max_chunk_tokens_prefers_model_context_window(monkeypatch):
+    class FakeEmbeddingEngine:
+        max_completion_tokens = 4096
+
+    class FakeVectorEngine:
+        embedding_engine = FakeEmbeddingEngine()
+
+    class FakeLLMClient:
+        max_completion_tokens = 1024
+
+    class FakeLLMConfig:
+        llm_model = "test-model"
+
+    monkeypatch.setattr(
+        "cognee.infrastructure.databases.vector.get_vector_engine",
+        lambda: FakeVectorEngine(),
+    )
+    monkeypatch.setattr(llm_utils, "get_llm_client", lambda raise_api_key_error=False: FakeLLMClient())
+    monkeypatch.setattr(llm_utils, "get_llm_context_config", lambda: FakeLLMConfig())
+    monkeypatch.setattr(llm_utils, "get_model_max_context_tokens", lambda model_name: 32768)
+
+    assert llm_utils.get_max_chunk_tokens() == 4096
 
 
 def test_llm_client_cache_key_covers_adapter_configuration_fields():


### PR DESCRIPTION
## Description

This PR updates chunk size calculation to prefer the model context window instead of the completion token limit when context metadata is available.
A helper was added to retrieve the model context window from LiteLLM metadata while preserving the existing fallback behavior when the context window cannot be determined.
A regression test was added to verify that chunk size calculation prefers the model context window.

Closes #3436


## Acceptance Criteria

Chunk size calculation prefers the model context window when available.
Existing fallback behavior is preserved when context metadata is unavailable.
Added a regression test covering the new behavior.
Relevant unit tests pass locally.


## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):


## Screenshots
<img width="1042" height="353" alt="image" src="https://github.com/user-attachments/assets/087160d3-8ee4-4c94-936f-abac5b8b78f9" />


## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages


## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
