### PR TITLE
fix: resolve runtime deprecation warnings in observability, API route…

### DIFF
--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -54,7 +54,7 @@ def get_add_router() -> APIRouter:
                 "Providing dataset ID is mandatory for sharing a dataset between users. Datasets provided by name will only be resolvable by dataset owner."
             ),
         ),
-        node_set: Optional[List[str]] = Form(default=[""], example=[""]),
+        node_set: Optional[List[str]] = Form(default=[""], examples=[""]),
         run_in_background: Optional[bool] = Form(default=False),
         user: User = Depends(get_authenticated_user),
     ):

--- a/cognee/modules/observability/get_observe.py
+++ b/cognee/modules/observability/get_observe.py
@@ -62,9 +62,9 @@ def _wrap_with_otel(inner_decorator):
                         span.set_attribute(COGNEE_SPAN_CATEGORY, category)
                         return wrapped(*args, **kwargs)
 
-                import asyncio
+                import inspect
 
-                if asyncio.iscoroutinefunction(func):
+                if inspect.iscoroutinefunction(func):
                     return async_wrapper
                 return sync_wrapper
 
@@ -106,9 +106,9 @@ def _wrap_with_otel(inner_decorator):
             with tracer.start_as_current_span(f"cognee.observe.{func.__name__}"):
                 return wrapped(*args, **kwargs)
 
-        import asyncio
+        import inspect
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             return async_wrapper
         return sync_wrapper
 

--- a/cognee/modules/pipelines/models/PipelineRunInfo.py
+++ b/cognee/modules/pipelines/models/PipelineRunInfo.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, List, Union
 from uuid import UUID
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from cognee.modules.data.models.Data import Data
 
 
@@ -16,9 +16,15 @@ class PipelineRunInfo(BaseModel):
     model_config = {
         "arbitrary_types_allowed": True,
         "from_attributes": True,
-        # Add custom encoding handler for Data ORM model
-        "json_encoders": {Data: lambda d: d.to_json()},
     }
+
+    @field_serializer("payload")
+    def serialize_payload(self, value: Any, _info) -> Any:
+        if isinstance(value, Data):
+            return value.to_json()
+        if isinstance(value, list):
+            return [item.to_json() if isinstance(item, Data) else item for item in value]
+        return value
 
 
 class PipelineRunStarted(PipelineRunInfo):

--- a/cognee/modules/pipelines/operations/run_tasks_base.py
+++ b/cognee/modules/pipelines/operations/run_tasks_base.py
@@ -89,7 +89,7 @@ def _stamp_provenance(
             data.source_content_hash = current_hash
 
         # Recurse into DataPoint model fields to stamp nested DataPoints
-        for field_name in data.model_fields:
+        for field_name in type(data).model_fields:
             field_value = getattr(data, field_name, None)
             if field_value is not None:
                 _stamp_provenance(

--- a/cognee/tests/unit/modules/pipelines/test_provenance_stamping.py
+++ b/cognee/tests/unit/modules/pipelines/test_provenance_stamping.py
@@ -52,7 +52,7 @@ def _stamp_provenance(data, pipeline_name, task_name, visited=None):
         if data.source_task is None:
             data.source_task = task_name
 
-        for field_name in data.model_fields:
+        for field_name in type(data).model_fields:
             field_value = getattr(data, field_name, None)
             if field_value is not None:
                 _stamp_provenance(field_value, pipeline_name, task_name, visited)

--- a/cognee/tests/unit/modules/pipelines/test_topological_rank_stamping.py
+++ b/cognee/tests/unit/modules/pipelines/test_topological_rank_stamping.py
@@ -59,7 +59,7 @@ def _stamp_provenance(
             if current_rank is None or current_rank == 0:
                 data.topological_rank = task_index
 
-        for field_name in data.model_fields:
+        for field_name in type(data).model_fields:
             field_value = getattr(data, field_name, None)
             if field_value is not None:
                 _stamp_provenance(


### PR DESCRIPTION
…r, and Pydantic models

Running the unit test suite generated 185,000+ DeprecationWarnings from cognee's own code. Three are on hard removal timelines:

- Replace asyncio.iscoroutinefunction with inspect.iscoroutinefunction in get_observe.py. asyncio.iscoroutinefunction was deprecated in Python 3.12 and is removed in Python 3.16.
- Replace FastAPI example= with examples= in get_add_router.py.
- Replace json_encoders config with @field_serializer decorator in PipelineRunInfo.py (Pydantic V2 migration).
- Fix model_fields instance access to class access in run_tasks_base.py (production code) and two test files.

Fixes #3508

<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
