### PR TITLE
fix(classify): use os.path.basename() to correctly extract filename o…

### DIFF
--- a/cognee/modules/ingestion/classify.py
+++ b/cognee/modules/ingestion/classify.py
@@ -14,7 +14,7 @@ def classify(
         return TextData(data)
 
     if isinstance(data, BufferedReader) or isinstance(data, SpooledTemporaryFile):
-        return BinaryData(data, filename if filename else str(data.name).split("/")[-1])
+        return BinaryData(data, filename if filename else path.basename(str(data.name)))
 
     try:
         from s3fs import S3File


### PR DESCRIPTION
…n Windows

The code used split('/') to extract filenames from paths, which only works on Unix. On Windows, backslash-separated paths were not split correctly, causing the full path to be stored as the document name instead of just the filename.

os.path.basename() correctly handles both Unix '/' and Windows '\\' path separators on all platforms.

Fixes #3341

<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
