### PR TITLE
fix(graphiti): copy metadata dict before mutation in index_graphiti_o…

### DIFF
--- a/cognee/tasks/temporal_awareness/index_graphiti_objects.py
+++ b/cognee/tasks/temporal_awareness/index_graphiti_objects.py
@@ -63,6 +63,7 @@ async def index_and_transform_graphiti_nodes_and_edges():
 
             if getattr(graphiti_node, field_name, None) is not None:
                 indexed_data_point = graphiti_node.model_copy()
+                indexed_data_point.metadata = indexed_data_point.metadata.copy()
                 indexed_data_point.metadata["index_fields"] = [field_name]
                 index_points[index_name].append(indexed_data_point)
 
@@ -90,6 +91,7 @@ async def index_and_transform_graphiti_nodes_and_edges():
                 index_points[index_name] = []
 
             indexed_data_point = edge.model_copy()
+            indexed_data_point.metadata = indexed_data_point.metadata.copy()
             indexed_data_point.metadata["index_fields"] = [field_name]
             index_points[index_name].append(indexed_data_point)
 


### PR DESCRIPTION
…bjects

index_and_transform_graphiti_nodes_and_edges was mutating the metadata dict shared across all GraphitiNode and EdgeType instances. Both models use a class-level mutable default dict for metadata, so model_copy() only shallow-copies the Pydantic fields — the metadata dict reference is still shared.

When indexed_data_point.metadata['index_fields'] was overwritten, it corrupted the class default for all subsequent instances.

Added .copy() on the metadata dict after model_copy() so each indexed data point works on its own isolated copy.

Fixes #3292

<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
