### PR TITLE
feat: add Turso(libSQL) as relational backend

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,6 +29,15 @@ LLM_API_KEY="your_api_key"
 #DB_PASSWORD=cognee
 #DB_NAME=cognee_db
 
+# -- Turso (libSQL) -----------------------------------------------------------
+# Requires: pip install cognee[turso]
+#DB_PROVIDER="turso"
+# Remote Turso database:
+#TURSO_URL="libsql://your-db-org.turso.io"
+#TURSO_AUTH_TOKEN="your-turso-auth-token"
+# Local embedded libSQL (no URL/token needed, uses DB_PATH/DB_NAME like SQLite):
+#DB_PROVIDER="turso"
+
 #GRAPH_DATABASE_PROVIDER="neo4j"
 #VECTOR_DB_PROVIDER="lancedb"
 

--- a/cognee/infrastructure/databases/relational/config.py
+++ b/cognee/infrastructure/databases/relational/config.py
@@ -21,6 +21,8 @@ class RelationalConfig(BaseSettings):
     db_username: Union[str, None] = None  # "cognee"
     db_password: Union[str, None] = None  # "cognee"
     db_provider: str = "sqlite"
+    turso_url: Union[str, None] = None
+    turso_auth_token: Union[str, None] = None
     database_connect_args: Union[str, None] = None
     pool_args: Union[str, None] = None
 
@@ -77,6 +79,8 @@ class RelationalConfig(BaseSettings):
             "db_username": self.db_username,
             "db_password": self.db_password,
             "db_provider": self.db_provider,
+            "turso_url": self.turso_url,
+            "turso_auth_token": self.turso_auth_token,
             "database_connect_args": self.database_connect_args,
             "pool_args": self.pool_args,
         }

--- a/cognee/infrastructure/databases/relational/create_relational_engine.py
+++ b/cognee/infrastructure/databases/relational/create_relational_engine.py
@@ -15,6 +15,8 @@ def create_relational_engine(
     db_username: str,
     db_password: str,
     db_provider: str,
+    turso_url: str = None,
+    turso_auth_token: str = None,
     database_connect_args: tuple = None,
     pool_args: tuple = None,
 ) -> SQLAlchemyAdapter:
@@ -34,7 +36,13 @@ def create_relational_engine(
           PostgreSQL.
         - db_password (str): The password for database authentication, required for
           PostgreSQL.
-        - db_provider (str): The type of database provider (e.g., 'sqlite' or 'postgres').
+        - db_provider (str): The type of database provider (e.g., 'sqlite', 'postgres',
+          or 'turso').
+        - turso_url (str, optional): The Turso database URL
+          (e.g., 'libsql://mydb-org.turso.io'). Required when db_provider is 'turso'
+          for remote databases.
+        - turso_auth_token (str, optional): The authentication token for Turso.
+          Required when db_provider is 'turso' for remote databases.
         - database_connect_args (dict, optional): Database driver connection arguments.
 
     Returns:
@@ -67,6 +75,24 @@ def create_relational_engine(
         except ImportError:
             raise ImportError(
                 "PostgreSQL dependencies are not installed. Please install with 'pip install cognee\"[postgres]\"' or 'pip install cognee\"[postgres-binary]\"' to use PostgreSQL functionality."
+            )
+
+    elif db_provider == "turso":
+        try:
+            import sqlalchemy_libsql  # noqa: F401  — registers the libsql dialect
+
+            if turso_url:
+                # Remote Turso database: libsql://host?authToken=xxx&secure=true
+                connection_string = f"{turso_url}?authToken={turso_auth_token}&secure=true"
+            else:
+                # Local embedded libSQL file (same as SQLite but via libsql driver)
+                connection_string = f"sqlite+libsql:///{db_path}/{db_name}"
+
+        except ImportError:
+            raise ImportError(
+                "Turso/libSQL dependencies are not installed. "
+                "Please install with 'pip install cognee\"[turso]\"' "
+                "to use Turso functionality."
             )
 
     else:

--- a/cognee/tests/unit/infrastructure/databases/relational/test_turso_engine.py
+++ b/cognee/tests/unit/infrastructure/databases/relational/test_turso_engine.py
@@ -1,0 +1,113 @@
+import sys
+import types
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from cognee.infrastructure.databases.relational.create_relational_engine import (
+    create_relational_engine,
+)
+
+
+TURSO_REMOTE_PARAMS = {
+    "db_path": "/tmp",
+    "db_name": "test_db",
+    "db_host": "localhost",
+    "db_port": "5432",
+    "db_username": "user",
+    "db_password": "pass",
+    "db_provider": "turso",
+    "turso_url": "libsql://mydb-myorg.turso.io",
+    "turso_auth_token": "my-secret-token",
+}
+
+TURSO_LOCAL_PARAMS = {
+    "db_path": "/tmp/cognee",
+    "db_name": "cognee_db",
+    "db_host": None,
+    "db_port": None,
+    "db_username": None,
+    "db_password": None,
+    "db_provider": "turso",
+    "turso_url": None,
+    "turso_auth_token": None,
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_lru_cache():
+    """create_relational_engine is wrapped with @lru_cache — clear between tests."""
+    create_relational_engine.cache_clear()
+    yield
+    create_relational_engine.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _fake_sqlalchemy_libsql():
+    """Inject a fake sqlalchemy_libsql module so the import inside the function succeeds."""
+    fake = types.ModuleType("sqlalchemy_libsql")
+    with patch.dict(sys.modules, {"sqlalchemy_libsql": fake}):
+        yield
+
+
+class TestTursoRemoteConnectionString:
+    """Verify that remote Turso builds the correct libsql:// connection string."""
+
+    @patch(
+        "cognee.infrastructure.databases.relational.create_relational_engine.SQLAlchemyAdapter"
+    )
+    def test_turso_remote_builds_correct_url(self, mock_adapter):
+        """Remote Turso should produce a libsql:// URL with authToken query param."""
+        create_relational_engine(**TURSO_REMOTE_PARAMS)
+
+        connection_string = mock_adapter.call_args[0][0]
+        assert "libsql://mydb-myorg.turso.io" in connection_string
+        assert "authToken=my-secret-token" in connection_string
+        assert "secure=true" in connection_string
+
+    @patch(
+        "cognee.infrastructure.databases.relational.create_relational_engine.SQLAlchemyAdapter"
+    )
+    def test_turso_remote_returns_sqlalchemy_adapter(self, mock_adapter):
+        """The factory should return a SQLAlchemyAdapter instance for Turso."""
+        result = create_relational_engine(**TURSO_REMOTE_PARAMS)
+        assert result == mock_adapter.return_value
+
+
+class TestTursoLocalConnectionString:
+    """Verify that local/embedded Turso builds a sqlite+libsql:// connection string."""
+
+    @patch(
+        "cognee.infrastructure.databases.relational.create_relational_engine.SQLAlchemyAdapter"
+    )
+    def test_turso_local_builds_sqlite_libsql_url(self, mock_adapter):
+        """Local Turso (no turso_url) should produce a sqlite+libsql:/// file path."""
+        create_relational_engine(**TURSO_LOCAL_PARAMS)
+
+        connection_string = mock_adapter.call_args[0][0]
+        assert connection_string == "sqlite+libsql:////tmp/cognee/cognee_db"
+
+
+class TestTursoMissingDependency:
+    """Verify that missing sqlalchemy-libsql raises an actionable ImportError."""
+
+    def test_turso_missing_driver_raises_import_error(self):
+        """When sqlalchemy_libsql is not installed, an ImportError with install instructions
+        should be raised."""
+        with patch.dict(sys.modules, {"sqlalchemy_libsql": None}):
+            with pytest.raises(ImportError, match=r"pip install cognee.*turso"):
+                create_relational_engine(**TURSO_REMOTE_PARAMS)
+
+
+class TestTursoConnectArgs:
+    """Verify that connect_args are forwarded to the SQLAlchemyAdapter."""
+
+    @patch(
+        "cognee.infrastructure.databases.relational.create_relational_engine.SQLAlchemyAdapter"
+    )
+    def test_turso_no_connect_args_passes_empty_dict(self, mock_adapter):
+        """When no connect_args are provided, an empty dict should be forwarded."""
+        create_relational_engine(**TURSO_REMOTE_PARAMS)
+
+        _, kwargs = mock_adapter.call_args
+        assert kwargs.get("connect_args") == {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ postgres-binary = [
     "pgvector>=0.3.5,<0.4",
     "asyncpg>=0.30.0,<1.0.0",
 ]
+turso = [
+    "sqlalchemy-libsql>=0.1.0,<1",
+]
 notebook = ["notebook>=7.1.0,<8"]
 langchain = [
     "langsmith>=0.2.3,<1.0.0",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Resolves topoteretes/cognee#3570

this PR adds Turso (libSQL) as a first-class relational database backend. Since libSQL is SQLite-compatible, it integrates seamlessly with the existing `SQLAlchemyAdapter` via the `sqlalchemy-libsql` dialect.

`create_relational_engine` now includes a `db_provider == "turso"` branch that builds a `libsql://****` connection string for remote databases or falls back to an embedded SQLite file. A new `turso` extras group was also added to `pyproject.toml`, mirroring the existing `postgres` pattern.

## Acceptance Criteria
* `DB_PROVIDER="turso"` correctly instantiates and returns a working `SQLAlchemyAdapter`.
* Missing `sqlalchemy-libsql` dependency raises an actionable `ImportError` requesting `pip install cognee[turso]`.
* Supports both remote (`libsql://***`) and local embedded (`sqlite+libsql:///***`) configurations.
* Added unit tests validating URL construction and caching logic.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<img width="1919" height="720" alt="image" src="https://github.com/user-attachments/assets/162f89f9-ec7a-4788-bae8-41edc3c0f087" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
