### PR TITLE
fix(graph/ladybug): filter edge_type neighborhood in Python to avoid Kuzu RECURSIVE_REL assertion (#3585)

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -2003,18 +2003,36 @@ class LadybugAdapter(GraphDBInterface):
                 logger.warning("No node IDs provided for neighborhood retrieval.")
                 return [], []
 
-            # Use variable-length path to find all nodes within depth hops
-            path_query = f"""
-            MATCH (seed:Node)-[r*1..{depth}]-(neighbor:Node)
-            WHERE seed.id IN $node_ids{" AND ALL(rel IN r WHERE rel.relationship_name IN $edge_types)" if edge_types else ""}
-            RETURN DISTINCT neighbor.id
-            """
-            params = {"node_ids": node_ids}
+            # Use variable-length path to find all nodes within depth hops.
+            # Kuzu's `r` from `-[r*1..N]-` is a RECURSIVE_REL, not a LIST, so the
+            # engine rejects `ALL(rel IN r WHERE ...)` with a binder error (and an
+            # internal assertion when combined with a parameter reference). When
+            # edge_types is set, fetch paths unfiltered and discard neighbors whose
+            # every path crosses a disallowed edge type (#3585).
             if edge_types:
-                params["edge_types"] = edge_types
-
-            neighbor_rows = await self.query(path_query, params)
-            neighbor_ids = [row[0] for row in neighbor_rows if row[0]]
+                path_query = f"""
+                MATCH (seed:Node)-[r*1..{depth}]-(neighbor:Node)
+                WHERE seed.id IN $node_ids
+                RETURN neighbor.id, r
+                """
+                path_rows = await self.query(path_query, {"node_ids": node_ids})
+                allowed = set(edge_types)
+                neighbor_ids_set: set = set()
+                for neighbor_id, path in path_rows:
+                    if not neighbor_id or neighbor_id in neighbor_ids_set:
+                        continue
+                    rels = path.get("_RELS", []) if isinstance(path, dict) else []
+                    if rels and all(rel.get("relationship_name") in allowed for rel in rels):
+                        neighbor_ids_set.add(neighbor_id)
+                neighbor_ids = list(neighbor_ids_set)
+            else:
+                path_query = f"""
+                MATCH (seed:Node)-[r*1..{depth}]-(neighbor:Node)
+                WHERE seed.id IN $node_ids
+                RETURN DISTINCT neighbor.id
+                """
+                neighbor_rows = await self.query(path_query, {"node_ids": node_ids})
+                neighbor_ids = [row[0] for row in neighbor_rows if row[0]]
 
             # Combine seed nodes and neighbor nodes
             all_ids = list(set(node_ids) | set(neighbor_ids))

--- a/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
+++ b/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
@@ -295,6 +295,75 @@ async def test_get_filtered_graph_data(adapter):
 
 
 # ---------------------------------------------------------------------------
+# get_neighborhood with edge_types filter
+# Regression for #3585: ALL(rel IN r WHERE ...) over a variable-length path
+# binding crashes Kuzu (RECURSIVE_REL vs LIST). Filter in Python instead.
+# ---------------------------------------------------------------------------
+
+
+class _NeighborhoodNode:
+    """Minimal pydantic-shaped payload compatible with add_nodes."""
+
+    def __init__(self, node_id: str, name: str = "", type: str = ""):
+        self._d = {"id": str(node_id), "name": name, "type": type}
+
+    def model_dump(self):
+        return dict(self._d)
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_unfiltered_returns_all_reachable(adapter):
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "D"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "B", "KNOWS", {}),
+            ("A", "D", "WORKS_AT", {}),
+        ]
+    )
+
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2)
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "B", "D"]
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_edge_type_filter_excludes_other_edges(adapter):
+    """Regression for #3585: edge_types filter must not crash and must exclude
+    neighbors reachable only via disallowed edge types."""
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "D"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "B", "KNOWS", {}),
+            ("A", "D", "WORKS_AT", {}),
+        ]
+    )
+
+    # Filter to KNOWS only — D (reachable only via WORKS_AT) must be excluded.
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2, edge_types=["KNOWS"])
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "B"]
+
+    # Symmetric: filter to WORKS_AT only — B must be excluded.
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2, edge_types=["WORKS_AT"])
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "D"]
+
+    # Both allowed — full neighborhood.
+    rows, _ = await adapter.get_neighborhood(
+        node_ids=["A"], depth=2, edge_types=["KNOWS", "WORKS_AT"]
+    )
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "B", "D"]
+
+    # No matching edge type — only the seed itself is in the neighborhood.
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2, edge_types=["NONEXISTENT"])
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A"]
+
+
+# ---------------------------------------------------------------------------
 # get_predecessors / get_successors
 # Known adapter bug: RETURN properties(m) fails with current Kuzu version.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`LadybugAdapter.get_neighborhood(node_ids=..., depth=..., edge_types=[...])` crashed with a Kuzu internal assertion (`UNREACHABLE_CODE` in `parsed_parameter_expression.h:21`) whenever `edge_types` was supplied. Unfiltered calls worked; only the edge-type allow-list path was broken. Since Ladybug is the default graph backend, edge-filtered neighborhood queries were unusable out of the box. Surfaced via `SearchType.NEIGHBORHOOD` (#3376).

### Root cause

Two compounding issues in the existing query, both in the `ALL()` predicate:

```cypher
MATCH (seed:Node)-[r*1..{depth}]-(neighbor:Node)
WHERE seed.id IN $node_ids AND ALL(rel IN r WHERE rel.relationship_name IN $edge_types)
RETURN DISTINCT neighbor.id
```

1. **Binder type mismatch** — Kuzu 0.17 emits a clean binder error if you replace `$edge_types` with a literal list, but the engine still rejects the construct: `r` from a variable-length path is `RECURSIVE_REL`, and `ALL()` expects `LIST`. Confirmed by direct experimentation:

   ```
   Binder exception: Function ALL did not receive correct arguments:
   Actual:   (RECURSIVE_REL,ANY)
   Expected: (LIST,ANY) -> BOOL
   ```

2. **Internal assertion when parameterized** — combining the `ALL(RECURSIVE_REL, ...)` shape with the `$edge_types` parameter reference drives the engine past the binder into a `RuntimeError: Assertion failed ... UNREACHABLE_CODE` in `parsed_parameter_expression.h`.

Edge-type filtering works on the Neo4j and Postgres backends because they accept the same Cypher; only Kuzu/Ladybug hits this engine limitation.

### Why pattern matching isn't an alternative

All Ladybug edges live under the single `:EDGE` label with `relationship_name` as a property (see `add_edges` at `adapter.py:1291`: `MERGE (from)-[r:EDGE {relationship_name: ...}]->(to)`). So `:KNOWS|WORKS_AT*1..N` pattern matching would not match anything — those labels don't exist in the schema.

### Fix

Drop the `ALL()` predicate. When `edge_types` is supplied, fetch paths unfiltered and discard neighbors whose every path crosses a disallowed edge type:

```python
if edge_types:
    path_query = f"""
    MATCH (seed:Node)-[r*1..{depth}]-(neighbor:Node)
    WHERE seed.id IN $node_ids
    RETURN neighbor.id, r
    """
    path_rows = await self.query(path_query, {"node_ids": node_ids})
    allowed = set(edge_types)
    neighbor_ids_set: set = set()
    for neighbor_id, path in path_rows:
        if not neighbor_id or neighbor_id in neighbor_ids_set:
            continue
        rels = path.get("_RELS", []) if isinstance(path, dict) else []
        if rels and all(rel.get("relationship_name") in allowed for rel in rels):
            neighbor_ids_set.add(neighbor_id)
    neighbor_ids = list(neighbor_ids_set)
else:
    # unchanged: RETURN DISTINCT neighbor.id
```

The no-`edge_types` path is byte-identical to before. Kuzu returns each path row as a dict with `_RELS` containing each edge's `relationship_name`, so the post-filter is a one-line `all(...)` over a list that is already materialized by the engine for the result set.

### Performance note

The post-filter materializes all paths up to depth N, even those the engine would have pruned. For typical cognee knowledge graphs (thousands of edges, depth ≤ 2–3) this is fine. If neighborhood queries on dense subgraphs become hot, the next step would be iterative single-hop traversal with the existing single-hop `relationship_name = $edge_type` filter — but that's a larger refactor and out of scope for this bug fix.

## Acceptance Criteria

- `get_neighborhood(node_ids=["A"], depth=2, edge_types=["KNOWS"])` no longer raises; returns `{A, B}` when the graph has `A—KNOWS—>B` and `A—WORKS_AT—>D`, excluding `D`.
- Symmetric for `edge_types=["WORKS_AT"]` (excludes `B`).
- `edge_types=["KNOWS", "WORKS_AT"]` returns the full unfiltered set.
- `edge_types=["NONEXISTENT"]` returns just the seed.
- Unfiltered `get_neighborhood(depth=2)` is unchanged.

### Proof

Direct terminal session against a real Kuzu 0.17.1 instance via `LadybugAdapter`:

```
$ .venv/bin/python -c '...'   # issue #3585 repro script, patched code
Unfiltered:                  ['A', 'B', 'D']
Filtered (KNOWS):            ['A', 'B']      # was: RuntimeError (assertion)
Filtered (WORKS_AT):         ['A', 'D']
Filtered (KNOWS+WORKS_AT):   ['A', 'B', 'D']
Filtered (NONEXISTENT):      ['A']
```

Full regression test suite (direct + subprocess-proxy modes):

```
$ .venv/bin/python -m pytest cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
46 passed, 4 xfailed, 2 xpassed in 15.92s
```

Including the two new tests:
- `test_get_neighborhood_unfiltered_returns_all_reachable` (baseline)
- `test_get_neighborhood_edge_type_filter_excludes_other_edges` (parametrized over `KNOWS` / `WORKS_AT` / both / neither)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines (`ruff check` + `ruff format` clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (inline comments where the post-filter lives; no public docs change)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Fixes #3585
