### PR TITLE
docs: prefer canonical cognee cloud vars

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -304,8 +304,11 @@ ENABLE_BACKEND_ACCESS_CONTROL=True
 #  Cloud Sync
 ################################################################################
 
-COGNEE_CLOUD_API_URL="http://localhost:8001"
-COGNEE_CLOUD_AUTH_TOKEN="your-api-key"
+# Canonical vars shared by serve()/push()/MCP/sync.
+# Deprecated aliases COGNEE_CLOUD_API_URL / COGNEE_CLOUD_AUTH_TOKEN are still
+# accepted by the runtime, but prefer the names below for new setups.
+COGNEE_SERVICE_URL="http://localhost:8001"
+COGNEE_API_KEY="your-api-key"
 
 ################################################################################
 #  UI


### PR DESCRIPTION
Updates the Cognee template to use the canonical cloud sync env vars (COGNEE_SERVICE_URL / COGNEE_API_KEY) and notes the deprecated aliases that remain supported.