### PR TITLE
fix(api): support singular dataset fields and enforce dataset isolation in search/recall

### DIFF
--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from cognee import __version__ as cognee_version
 from cognee.api.DTO import InDTO, OutDTO
@@ -49,6 +49,36 @@ class RecallPayloadDTO(InDTO):
             "when both are provided. Leave empty to resolve by name."
         ),
     )
+    dataset_name: Optional[str] = Field(
+        default=None,
+        description="Optional singular dataset name to search. Added to datasets list.",
+    )
+    dataset_id: Optional[UUID] = Field(
+        default=None,
+        description="Optional singular dataset UUID to search. Added to dataset_ids list.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def map_singular_dataset_fields(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            dataset_name = data.get("dataset_name")
+            if dataset_name is not None:
+                datasets = data.get("datasets")
+                if datasets is None:
+                    data["datasets"] = [dataset_name]
+                elif isinstance(datasets, list) and dataset_name not in datasets:
+                    data["datasets"].append(dataset_name)
+
+            dataset_id = data.get("dataset_id")
+            if dataset_id is not None:
+                dataset_ids = data.get("dataset_ids")
+                if dataset_ids is None:
+                    data["dataset_ids"] = [dataset_id]
+                elif isinstance(dataset_ids, list) and dataset_id not in dataset_ids:
+                    data["dataset_ids"].append(dataset_id)
+        return data
+
     query: str = Field(default="What is in the document?")
     system_prompt: Optional[str] = Field(
         default="Answer the question using the provided context. Be as brief as possible."

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from cognee import __version__ as cognee_version
 from cognee.api.DTO import ErrorResponse, InDTO, OutDTO
@@ -47,6 +47,36 @@ class SearchPayloadDTO(InDTO):
             " When provided, the datasets name list is ignored."
         ),
     )
+    dataset_name: Optional[str] = Field(
+        default=None,
+        description="Optional singular dataset name to search. Added to datasets list.",
+    )
+    dataset_id: Optional[UUID] = Field(
+        default=None,
+        description="Optional singular dataset UUID to search. Added to dataset_ids list.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def map_singular_dataset_fields(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            dataset_name = data.get("dataset_name")
+            if dataset_name is not None:
+                datasets = data.get("datasets")
+                if datasets is None:
+                    data["datasets"] = [dataset_name]
+                elif isinstance(datasets, list) and dataset_name not in datasets:
+                    data["datasets"].append(dataset_name)
+
+            dataset_id = data.get("dataset_id")
+            if dataset_id is not None:
+                dataset_ids = data.get("dataset_ids")
+                if dataset_ids is None:
+                    data["dataset_ids"] = [dataset_id]
+                elif isinstance(dataset_ids, list) and dataset_id not in dataset_ids:
+                    data["dataset_ids"].append(dataset_id)
+        return data
+
     query: str = Field(default="What is in the document?")
     system_prompt: Optional[str] = Field(
         default="Answer the question using the provided context. Be as brief as possible."

--- a/cognee/modules/graph/methods/__init__.py
+++ b/cognee/modules/graph/methods/__init__.py
@@ -23,5 +23,7 @@ from .get_dataset_related_edges import get_dataset_related_edges, get_global_dat
 from .delete_dataset_related_nodes import delete_dataset_related_nodes
 from .delete_dataset_related_edges import delete_dataset_related_edges
 from .delete_dataset_nodes_and_edges import delete_dataset_nodes_and_edges
+from .get_dataset_node_ids import get_dataset_node_ids
 
 from .legacy_delete import legacy_delete
+

--- a/cognee/modules/graph/methods/get_dataset_node_ids.py
+++ b/cognee/modules/graph/methods/get_dataset_node_ids.py
@@ -1,0 +1,13 @@
+from uuid import UUID
+from sqlalchemy import select
+from cognee.modules.graph.models import Node
+from cognee.infrastructure.databases.relational import with_async_session
+
+
+@with_async_session
+async def get_dataset_node_ids(dataset_ids: list[UUID], session) -> set[str]:
+    if not dataset_ids:
+        return set()
+    stmt = select(Node.slug).where(Node.dataset_id.in_(dataset_ids))
+    result = await session.execute(stmt)
+    return {str(slug) for slug in result.scalars().all()}

--- a/cognee/modules/retrieval/utils/completion.py
+++ b/cognee/modules/retrieval/utils/completion.py
@@ -16,6 +16,9 @@ async def generate_completion(
     response_model: Type = str,
 ) -> Any:
     """Generates a completion using LLM with given context and prompts."""
+    if not context or not context.strip():
+        if response_model is str:
+            return "I don't have enough context to answer this query."
     args = {"question": query, "context": context}
     user_prompt = render_prompt(user_prompt_path, args)
     system_prompt = system_prompt if system_prompt else read_query_prompt(system_prompt_path)

--- a/cognee/modules/search/methods/get_retriever_output.py
+++ b/cognee/modules/search/methods/get_retriever_output.py
@@ -39,6 +39,23 @@ async def get_retriever_output(
         query_type=query_type, query_text=query_text, **kwargs
     )
 
+    dataset = kwargs.get("dataset")
+    allowed_node_ids = None
+    if "user" in kwargs:
+        from cognee.modules.data.methods import get_authorized_existing_datasets
+        from cognee.modules.graph.methods.get_dataset_node_ids import get_dataset_node_ids
+
+        if dataset is not None:
+            allowed_dataset_ids = [dataset.id]
+        else:
+            search_datasets = await get_authorized_existing_datasets(
+                datasets=None, permission_type="read", user=kwargs["user"]
+            )
+            allowed_dataset_ids = [ds.id for ds in search_datasets]
+
+        allowed_node_ids = await get_dataset_node_ids(allowed_dataset_ids)
+        retriever_instance.allowed_node_ids = allowed_node_ids
+
     retriever_class = type(retriever_instance).__name__
     only_context = kwargs.get("only_context", False)
     effective_query = query_text
@@ -66,6 +83,88 @@ async def get_retriever_output(
         span.set_attribute("cognee.retrieval.retriever", retriever_class)
         span.set_attribute(COGNEE_SEARCH_TYPE, query_type.value)
         retrieved_objects = await retriever_instance.get_retrieved_objects(query=effective_query)
+
+        # Enforce dataset isolation at the Python level
+        if allowed_node_ids is not None:
+            if isinstance(retrieved_objects, list):
+                if retrieved_objects and isinstance(retrieved_objects[0], list):
+                    # Batch mode (list-of-lists)
+                    filtered_outer = []
+                    for sublist in retrieved_objects:
+                        filtered_inner = []
+                        for item in sublist:
+                            if hasattr(item, "node1"):
+                                if (
+                                    str(item.node1.id) in allowed_node_ids
+                                    and str(item.node2.id) in allowed_node_ids
+                                ):
+                                    filtered_inner.append(item)
+                            else:
+                                item_id = str(
+                                    getattr(item, "id", None)
+                                    or (item.get("id") if isinstance(item, dict) else "")
+                                )
+                                if item_id in allowed_node_ids:
+                                    filtered_inner.append(item)
+                        filtered_outer.append(filtered_inner)
+                    retrieved_objects = filtered_outer
+                else:
+                    # Single query mode (flat list)
+                    filtered = []
+                    for item in retrieved_objects:
+                        if hasattr(item, "node1"):
+                            if (
+                                str(item.node1.id) in allowed_node_ids
+                                and str(item.node2.id) in allowed_node_ids
+                            ):
+                                filtered.append(item)
+                        else:
+                            item_id = str(
+                                getattr(item, "id", None)
+                                or (item.get("id") if isinstance(item, dict) else "")
+                            )
+                            if item_id in allowed_node_ids:
+                                filtered.append(item)
+                    retrieved_objects = filtered
+            elif isinstance(retrieved_objects, dict):
+                # HybridRetriever output structure
+                if "chunks" in retrieved_objects:
+                    retrieved_objects["chunks"] = [
+                        chunk
+                        for chunk in retrieved_objects["chunks"]
+                        if str(
+                            getattr(chunk, "id", None)
+                            or (chunk.get("id") if isinstance(chunk, dict) else "")
+                        )
+                        in allowed_node_ids
+                    ]
+                if "chunk_summaries" in retrieved_objects and isinstance(
+                    retrieved_objects["chunk_summaries"], dict
+                ):
+                    retrieved_objects["chunk_summaries"] = {
+                        chunk_id: summary
+                        for chunk_id, summary in retrieved_objects["chunk_summaries"].items()
+                        if str(chunk_id) in allowed_node_ids
+                    }
+                if "entities" in retrieved_objects:
+                    retrieved_objects["entities"] = [
+                        entity
+                        for entity in retrieved_objects["entities"]
+                        if str(
+                            entity.get("id")
+                            if isinstance(entity, dict)
+                            else getattr(entity, "id", "")
+                        )
+                        in allowed_node_ids
+                    ]
+                if "facts" in retrieved_objects:
+                    retrieved_objects["facts"] = [
+                        fact
+                        for fact in retrieved_objects["facts"]
+                        if str(fact.get("source_node_id")) in allowed_node_ids
+                        or str(fact.get("target_node_id")) in allowed_node_ids
+                    ]
+
         obj_count = _count_retrieved_objects(retrieved_objects)
         span.set_attribute(COGNEE_RESULT_COUNT, obj_count)
         span.set_attribute(

--- a/cognee/tests/unit/api/v1/recall/test_dataset_leakage_and_fields.py
+++ b/cognee/tests/unit/api/v1/recall/test_dataset_leakage_and_fields.py
@@ -1,0 +1,142 @@
+from uuid import uuid4
+import pytest
+from pydantic import ValidationError
+from cognee.api.v1.recall.routers.get_recall_router import RecallPayloadDTO
+from cognee.api.v1.search.routers.get_search_router import SearchPayloadDTO
+from cognee.modules.retrieval.utils.completion import generate_completion
+
+
+def test_recall_payload_dto_singular_fields_mapping():
+    # Test dataset_name mapping to datasets list
+    payload1 = RecallPayloadDTO(query="What is eldaa?", dataset_name="eldaa")
+    assert payload1.datasets == ["eldaa"]
+    assert payload1.dataset_ids is None
+
+    # Test dataset_id mapping to dataset_ids list
+    test_uuid = uuid4()
+    payload2 = RecallPayloadDTO(query="What is eldaa?", dataset_id=test_uuid)
+    assert payload2.dataset_ids == [test_uuid]
+    assert payload2.datasets is None
+
+    # Test combining datasets lists (singular and plural) without duplicates
+    payload3 = RecallPayloadDTO(query="What is eldaa?", datasets=["eldaa"], dataset_name="eldaa")
+    assert payload3.datasets == ["eldaa"]
+
+    payload4 = RecallPayloadDTO(query="What is eldaa?", datasets=["remember"], dataset_name="eldaa")
+    assert set(payload4.datasets) == {"remember", "eldaa"}
+
+
+def test_search_payload_dto_singular_fields_mapping():
+    # Test dataset_name mapping to datasets list
+    payload1 = SearchPayloadDTO(query="What is eldaa?", dataset_name="eldaa")
+    assert payload1.datasets == ["eldaa"]
+
+    # Test dataset_id mapping to dataset_ids list
+    test_uuid = uuid4()
+    payload2 = SearchPayloadDTO(query="What is eldaa?", dataset_id=test_uuid)
+    assert payload2.dataset_ids == [test_uuid]
+
+
+@pytest.mark.asyncio
+async def test_generate_completion_empty_context():
+    # Test generate_completion with empty and whitespace-only context
+    result1 = await generate_completion(
+        query="What is eldaa?",
+        context="",
+        user_prompt_path="context_for_question.txt",
+        system_prompt_path="answer_simple_question.txt",
+    )
+    assert result1 == "I don't have enough context to answer this query."
+
+    result2 = await generate_completion(
+        query="What is eldaa?",
+        context="   \n  ",
+        user_prompt_path="context_for_question.txt",
+        system_prompt_path="answer_simple_question.txt",
+    )
+    assert result2 == "I don't have enough context to answer this query."
+
+
+@pytest.mark.asyncio
+async def test_get_retriever_output_filters_by_dataset(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+    from cognee.modules.search.types import SearchType
+    import cognee.modules.search.methods.get_retriever_output as gr_output_mod
+
+    # Mocks
+    mock_retriever = MagicMock()
+    mock_retriever.prepare_session_turn_for_retrieval = AsyncMock(
+        return_value=MagicMock(should_answer=True, effective_query="What is eldaa?")
+    )
+
+    class DummyChunk:
+        def __init__(self, id):
+            self.id = id
+
+    matching_chunk = DummyChunk("matching-uuid")
+    non_matching_chunk = DummyChunk("other-uuid")
+
+    mock_retriever.get_retrieved_objects = AsyncMock(
+        return_value=[matching_chunk, non_matching_chunk]
+    )
+    mock_retriever.get_context_from_objects = AsyncMock(return_value="Context from matching chunk")
+
+    async def dummy_get_completion_from_context(context, query, **kwargs):
+        return ["Completion text"]
+
+    mock_retriever.get_completion_from_context = dummy_get_completion_from_context
+
+    # Monkeypatch factory and engine helpers via the actual module object in sys.modules
+    import sys
+    import importlib
+    import cognee.modules.search.methods.get_retriever_output
+
+    gr_mod = sys.modules["cognee.modules.search.methods.get_retriever_output"]
+    importlib.reload(gr_mod)
+
+    monkeypatch.setattr(
+        gr_mod, "get_search_type_retriever_instance", AsyncMock(return_value=mock_retriever)
+    )
+
+    monkeypatch.setattr(gr_mod, "get_graph_engine", AsyncMock())
+
+    monkeypatch.setattr(gr_mod, "update_node_access_timestamps", AsyncMock())
+
+    # Mock submodules in sys.modules using monkeypatch.setitem to guarantee they are resolved correctly during runtime imports
+    import sys
+    from unittest.mock import MagicMock
+
+    mock_graph_module = MagicMock()
+    mock_graph_module.get_dataset_node_ids = AsyncMock(return_value={"matching-uuid"})
+    monkeypatch.setitem(
+        sys.modules, "cognee.modules.graph.methods.get_dataset_node_ids", mock_graph_module
+    )
+    if "cognee.modules.graph.methods" in sys.modules:
+        monkeypatch.setattr(
+            sys.modules["cognee.modules.graph.methods"],
+            "get_dataset_node_ids",
+            mock_graph_module.get_dataset_node_ids,
+        )
+
+    mock_dataset = MagicMock()
+    mock_dataset.id = uuid4()
+    mock_data_module = MagicMock()
+    mock_data_module.get_authorized_existing_datasets = AsyncMock(return_value=[mock_dataset])
+    monkeypatch.setitem(
+        sys.modules,
+        "cognee.modules.data.methods.get_authorized_existing_datasets",
+        mock_data_module,
+    )
+    if "cognee.modules.data.methods" in sys.modules:
+        monkeypatch.setattr(
+            sys.modules["cognee.modules.data.methods"],
+            "get_authorized_existing_datasets",
+            mock_data_module.get_authorized_existing_datasets,
+        )
+
+    result = await gr_mod.get_retriever_output(
+        query_type=SearchType.CHUNKS, query_text="What is eldaa?", user=MagicMock()
+    )
+
+    # Verify that only the matching chunk is retained
+    assert result.result_object == [matching_chunk]


### PR DESCRIPTION
## Description
In environments where storage collections are shared or physical isolation is disabled, performing search/recall queries could retrieve context chunks from other datasets. Furthermore, if a dataset was empty or irrelevant context was retrieved, the completion engine still called the LLM with empty text, prompting it to hallucinate plausible-sounding completions. Lastly, singular `dataset_name` and `dataset_id` request payloads were ignored by the FastAPI DTO schemas.

To resolve these issues, the following changes were made:
1. **API Schema Payload Validator:** Added `dataset_name` and `dataset_id` to `RecallPayloadDTO` and `SearchPayloadDTO` along with a pre-validator (`map_singular_dataset_fields`) to map them into their list equivalents for backwards compatibility.
2. **Relational Database Fetching:** Created a new helper `get_dataset_node_ids` to query node UUID slugs associated with dataset IDs inside the relational `Node` model mapping table.
3. **Application-level Filtering:** Plumbed allowed node IDs into `get_retriever_output` to discard chunks, summaries, entities, and facts not belonging to the authorized datasets before generating context.
4. **Hallucination Prevention:** Added an early intercept inside `generate_completion` to return a standard fallback response when context is empty/whitespace, rather than invoking the LLM.

## Acceptance Criteria
* Singular payload fields map correctly to datasets list.
* Retriever filters out results not associated with target datasets at the application level.
* LLM returns context fallback message instead of hallucinating on empty context.
* Unit tests verify singular fields parsing, output filtering, and completion fallback.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

Fixes #3520