### PR TITLE
feat(auth): add asymmetric JWKS token validation backend

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -253,6 +253,14 @@ FASTAPI_USERS_JWT_SECRET="super_secret"
 # Default: 3600 (1 hour)
 JWT_LIFETIME_SECONDS=3600
 
+# -- JWKS Asymmetric Token Authentication (Optional) --------------------------
+# Set COGNEE_JWKS_URL to validate external tokens (e.g. Teleport, Auth0, Keycloak)
+#COGNEE_JWKS_URL="https://your-idp.example.com/.well-known/jwks.json"
+#COGNEE_JWKS_AUDIENCE="cognee_api"
+#COGNEE_JWKS_ISSUER="https://your-idp.example.com/"
+# Auto-provision users if they don't exist in local DB (default: True)
+#COGNEE_JWKS_AUTO_PROVISION=True
+
 # -- API Key Authentication ---------------------------------------------------
 # When HASH_API_KEY=true, API keys are hashed with SHA-256 before being stored in the database.
 # This means the raw key is shown to the user only once at creation time and cannot be recovered.

--- a/cognee/modules/users/authentication/jwks/get_jwks_auth_backend.py
+++ b/cognee/modules/users/authentication/jwks/get_jwks_auth_backend.py
@@ -1,0 +1,29 @@
+import os
+from functools import lru_cache
+from typing import Optional
+
+from fastapi_users.authentication import AuthenticationBackend
+
+from cognee.modules.users.authentication.api_bearer import api_bearer_transport
+from .jwks_jwt_strategy import JWKSJWTStrategy
+
+
+@lru_cache
+def get_jwks_auth_backend() -> Optional[AuthenticationBackend]:
+    """
+    Returns the JWKS authentication backend if COGNEE_JWKS_URL is set.
+    Otherwise, returns None.
+    """
+    if not os.getenv("COGNEE_JWKS_URL"):
+        return None
+
+    def get_strategy() -> JWKSJWTStrategy:
+        return JWKSJWTStrategy()
+
+    auth_backend = AuthenticationBackend(
+        name="jwks_bearer",
+        transport=api_bearer_transport,
+        get_strategy=get_strategy,
+    )
+
+    return auth_backend

--- a/cognee/modules/users/authentication/jwks/jwks_jwt_strategy.py
+++ b/cognee/modules/users/authentication/jwks/jwks_jwt_strategy.py
@@ -1,0 +1,92 @@
+import os
+import uuid
+import secrets
+from typing import Optional
+
+import jwt
+from fastapi import HTTPException, status
+from fastapi_users.authentication.strategy.base import Strategy
+from fastapi_users.exceptions import UserNotExists
+
+from cognee.modules.users.get_user_manager import UserManager
+from cognee.modules.users.models import User
+from cognee.modules.users.methods.create_user import create_user
+
+
+class JWKSJWTStrategy(Strategy[User, uuid.UUID]):
+    def __init__(self):
+        self.jwks_url = os.getenv("COGNEE_JWKS_URL")
+        self.audience = os.getenv("COGNEE_JWKS_AUDIENCE")
+        self.issuer = os.getenv("COGNEE_JWKS_ISSUER")
+        self.auto_provision = os.getenv("COGNEE_JWKS_AUTO_PROVISION", "True").lower() in ("true", "1", "yes")
+
+        # PyJWKClient automatically fetches and caches the JWKS based on cache configuration.
+        self.jwk_client = jwt.PyJWKClient(self.jwks_url)
+
+    async def read_token(self, token: Optional[str], user_manager: UserManager) -> Optional[User]:
+        if not token:
+            return None
+
+        try:
+            # Fetch the matching signing key from the cached JWKS
+            # PyJWKClient internally decodes the unverified header to get the 'kid' (Key ID)
+            signing_key = self.jwk_client.get_signing_key_from_jwt(token)
+            
+            # Build dynamic options to safely handle optional claims
+            decode_options = {
+                "verify_aud": bool(self.audience),
+                "verify_iss": bool(self.issuer),
+            }
+
+            # Verify the token signature and standard claims
+            payload = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256", "ES256"],
+                audience=self.audience,
+                issuer=self.issuer,
+                options=decode_options,
+            )
+
+            # Try to resolve user by email, or fallback to sub claim if no email is provided
+            user_identifier = payload.get("email") or payload.get("sub")
+            
+            if not user_identifier:
+                return None
+
+            try:
+                user = await user_manager.get_by_email(user_identifier)
+                return user
+            except UserNotExists:
+                if self.auto_provision:
+                    # Auto-provision the missing user
+                    # Generate a secure random password since the user relies on the external IdP
+                    random_password = secrets.token_urlsafe(32)
+                    new_user = await create_user(
+                        email=user_identifier,
+                        password=random_password,
+                        is_active=True,
+                        is_verified=True,
+                    )
+                    return new_user
+                
+                return None
+
+        except jwt.PyJWKClientConnectionError as e:
+            # 503 Service Unavailable if the JWKS endpoint itself is unreachable
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"JWKS endpoint unreachable: {str(e)}",
+            )
+        except (jwt.PyJWTError, jwt.PyJWKClientError):
+            # Failed signature, expired token, wrong issuer/audience, missing kid, etc.
+            # Return None to trigger fastapi-users default 401 Unauthorized behavior
+            return None
+
+    async def write_token(self, user: User) -> str:
+        # This strategy is read-only (tokens are minted by the external IdP)
+        raise NotImplementedError("JWKS JWT Strategy is read-only.")
+
+    async def destroy_token(self, token: str, user: User) -> None:
+        # External IdPs handle their own token destruction/invalidation
+        pass

--- a/cognee/modules/users/get_fastapi_users.py
+++ b/cognee/modules/users/get_fastapi_users.py
@@ -5,6 +5,7 @@ from fastapi_users import FastAPIUsers
 from .authentication.get_api_auth_backend import get_api_auth_backend
 from .authentication.get_client_auth_backend import get_client_auth_backend
 from .authentication.get_api_key_backend import get_api_key_backend
+from .authentication.jwks.get_jwks_auth_backend import get_jwks_auth_backend
 
 from .get_user_manager import get_user_manager
 from .models.User import User
@@ -12,12 +13,19 @@ from .models.User import User
 
 @lru_cache
 def get_fastapi_users():
+    jwks_auth_backend = get_jwks_auth_backend()
     api_auth_backend = get_api_auth_backend()
     client_auth_backend = get_client_auth_backend()
     api_key_backend = get_api_key_backend()
 
+    backends = []
+    if jwks_auth_backend is not None:
+        backends.append(jwks_auth_backend)
+        
+    backends.extend([api_key_backend, api_auth_backend, client_auth_backend])
+
     fastapi_users = FastAPIUsers[User, uuid.UUID](
-        get_user_manager, [api_key_backend, api_auth_backend, client_auth_backend]
+        get_user_manager, backends
     )
 
     return fastapi_users

--- a/cognee/tests/unit/modules/users/test_jwks_authentication.py
+++ b/cognee/tests/unit/modules/users/test_jwks_authentication.py
@@ -1,0 +1,191 @@
+import os
+import uuid
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import jwt
+from fastapi import HTTPException
+from fastapi_users.exceptions import UserNotExists
+
+from cognee.modules.users.models import User
+from cognee.modules.users.authentication.jwks.jwks_jwt_strategy import JWKSJWTStrategy
+
+
+@pytest.fixture
+def mock_env(monkeypatch):
+    monkeypatch.setenv("COGNEE_JWKS_URL", "https://mock-idp.example.com/.well-known/jwks.json")
+    monkeypatch.setenv("COGNEE_JWKS_AUDIENCE", "cognee_api")
+    monkeypatch.setenv("COGNEE_JWKS_ISSUER", "https://mock-idp.example.com/")
+    monkeypatch.setenv("COGNEE_JWKS_AUTO_PROVISION", "True")
+
+
+@pytest.fixture
+def strategy(mock_env):
+    return JWKSJWTStrategy()
+
+
+@pytest.fixture
+def mock_user_manager():
+    manager = AsyncMock()
+    
+    user = User(
+        id=uuid.uuid4(),
+        email="test@example.com",
+        is_active=True,
+    )
+    
+    async def get_by_email(email):
+        if email == "test@example.com":
+            return user
+        raise UserNotExists()
+
+    manager.get_by_email = AsyncMock(side_effect=get_by_email)
+    return manager
+
+
+@pytest.fixture
+def mock_jwk_client():
+    with patch("jwt.PyJWKClient") as mock_client_class:
+        client_instance = MagicMock()
+        mock_client_class.return_value = client_instance
+        yield client_instance
+
+
+@pytest.fixture
+def mock_jwt():
+    with patch("jwt.get_unverified_header") as mock_header, \
+         patch("jwt.decode") as mock_decode:
+        yield mock_header, mock_decode
+
+
+@pytest.mark.asyncio
+async def test_valid_token_existing_user(strategy, mock_user_manager, mock_jwt, mock_jwk_client):
+    mock_header, mock_decode = mock_jwt
+    
+    mock_header.return_value = {"kid": "key1"}
+    
+    mock_key = MagicMock()
+    mock_key.key = "mock_public_key"
+    strategy.jwk_client.get_signing_key_from_jwt = MagicMock(return_value=mock_key)
+    
+    mock_decode.return_value = {"email": "test@example.com", "iss": "https://mock-idp.example.com/", "aud": "cognee_api"}
+
+    user = await strategy.read_token("mock_token", mock_user_manager)
+    
+    assert user is not None
+    assert user.email == "test@example.com"
+    mock_decode.assert_called_once_with(
+        "mock_token",
+        "mock_public_key",
+        algorithms=["RS256", "ES256"],
+        audience="cognee_api",
+        issuer="https://mock-idp.example.com/",
+        options={"verify_aud": True, "verify_iss": True}
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_or_claims(strategy, mock_user_manager, mock_jwt):
+    mock_header, mock_decode = mock_jwt
+    
+    mock_header.return_value = {"kid": "key1"}
+    
+    mock_key = MagicMock()
+    mock_key.key = "mock_public_key"
+    strategy.jwk_client.get_signing_key_from_jwt = MagicMock(return_value=mock_key)
+    
+    # Simulate an expired token or invalid signature exception
+    mock_decode.side_effect = jwt.ExpiredSignatureError("Signature has expired")
+
+    user = await strategy.read_token("mock_token", mock_user_manager)
+    
+    # fastapi-users strategy must return None on invalid token
+    assert user is None
+
+
+@pytest.mark.asyncio
+@patch("cognee.modules.users.authentication.jwks.jwks_jwt_strategy.create_user")
+async def test_auto_provisioning(mock_create_user, strategy, mock_user_manager, mock_jwt):
+    mock_header, mock_decode = mock_jwt
+    
+    mock_header.return_value = {"kid": "key1"}
+    
+    mock_key = MagicMock()
+    mock_key.key = "mock_public_key"
+    strategy.jwk_client.get_signing_key_from_jwt = MagicMock(return_value=mock_key)
+    
+    # Return a sub that doesn't exist to trigger auto-provisioning
+    mock_decode.return_value = {"sub": "new_user@external.idp"}
+    
+    new_user = User(
+        id=uuid.uuid4(),
+        email="new_user@external.idp",
+        is_active=True,
+    )
+    mock_create_user.return_value = new_user
+
+    user = await strategy.read_token("mock_token", mock_user_manager)
+    
+    assert user is not None
+    assert user.email == "new_user@external.idp"
+    
+    # Ensure create_user was called
+    mock_create_user.assert_called_once()
+    args, kwargs = mock_create_user.call_args
+    assert kwargs["email"] == "new_user@external.idp"
+    assert "password" in kwargs  # Auto-generated password
+    assert kwargs["is_active"] is True
+    assert kwargs["is_verified"] is True
+
+
+@pytest.mark.asyncio
+async def test_unreachable_jwks(strategy, mock_user_manager, mock_jwt):
+    mock_header, mock_decode = mock_jwt
+    
+    mock_header.return_value = {"kid": "key1"}
+    
+    # Simulate a network error when trying to fetch the JWKS
+    strategy.jwk_client.get_signing_key_from_jwt = MagicMock(
+        side_effect=jwt.PyJWKClientConnectionError("Failed to fetch JWKS")
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await strategy.read_token("mock_token", mock_user_manager)
+    
+    assert excinfo.value.status_code == 503
+    assert "JWKS endpoint unreachable" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_kid(strategy, mock_user_manager, mock_jwt):
+    mock_header, mock_decode = mock_jwt
+    
+    mock_header.return_value = {"kid": "unknown_key"}
+    
+    # Simulate the key not being found in the JWKS
+    strategy.jwk_client.get_signing_key_from_jwt = MagicMock(
+        side_effect=jwt.PyJWKClientError("Unable to find a signing key that matches")
+    )
+
+    user = await strategy.read_token("mock_token", mock_user_manager)
+    
+    # Should safely return None (401) rather than crash
+    assert user is None
+
+
+@pytest.mark.asyncio
+async def test_missing_user_identifier(strategy, mock_user_manager, mock_jwt):
+    mock_header, mock_decode = mock_jwt
+    
+    mock_header.return_value = {"kid": "key1"}
+    
+    mock_key = MagicMock()
+    mock_key.key = "mock_public_key"
+    strategy.jwk_client.get_signing_key_from_jwt = MagicMock(return_value=mock_key)
+    
+    # Payload missing both 'email' and 'sub'
+    mock_decode.return_value = {"iss": "https://mock-idp.example.com/", "aud": "cognee_api"}
+
+    user = await strategy.read_token("mock_token", mock_user_manager)
+    
+    assert user is None


### PR DESCRIPTION
This adds an optional authentication backend that fetches a remote JWKS to validate JWTs signed with asymmetric keys (RS256/ES256) by an external IdP (like Teleport or Auth0).

### Description
Currently, document ingestion through `cognify()` or standard endpoints relies exclusively on a symmetric HS256 shared secret (`FASTAPI_USERS_JWT_SECRET`). This prevents integration with external identity providers that sign tokens with asymmetric keys and publish them via a standard JWKS endpoint.

This PR adds an optional zero-trust authentication backend that:
1. **Fetches & Caches JWKS:** Uses `PyJWKClient` to securely fetch and dynamically cache remote public keys.
2. **Validates Tokens:** Dynamically decodes incoming Bearer tokens using the correct `kid` and verifies standard claims (`exp`, `aud`, `iss`).
3. **Resolves & Auto-Provisions:** Looks up the local user by `email` (or `sub`) and optionally provisions missing identities with a 32-byte secure random password.
4. **Conditional Activation:** The IdP logic activates exclusively when `COGNEE_JWKS_URL` is set, preserving legacy flows safely.

### Acceptance Criteria
- [x] External IdP JWT tokens signed with asymmetric keys are properly validated if `COGNEE_JWKS_URL` is set.
- [x] Tokens with invalid signatures, expired lifetimes, or unrecognized audiences/issuers are safely rejected with a 401 Unauthorized.
- [x] Missing local users are auto-provisioned securely if `COGNEE_JWKS_AUTO_PROVISION` is true.
- [x] Unreachable IdP JWKS endpoints gracefully return a 503 Service Unavailable rather than failing silently.
- [x] Existing API key and symmetric JWT flows are completely unaffected and work as normal.

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

### Screenshots
*N/A*

### Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR (See `CONTRIBUTING.md`)
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

### DCO Affirmation
- [x] I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
#3499 