### PR TITLE
feat: add Turso (libSQL) as a vector database option

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -153,13 +153,22 @@ GRAPH_DATASET_DATABASE_HANDLER="kuzu"
 #  Provider-specific connection details.
 ################################################################################
 
-# Supported (built-in): pgvector | lancedb
+# Supported (built-in): pgvector | lancedb | turso
 # Community adapters (separate packages): qdrant | weaviate | milvus | chromadb
 VECTOR_DB_PROVIDER="lancedb"
 #VECTOR_DB_URL=
 #VECTOR_DB_KEY=
 # Handler for multi-user access control (per-dataset DB creation).
 VECTOR_DATASET_DATABASE_HANDLER="lancedb"
+
+# Turso / libSQL (requires the turso extra: pip install cognee"[turso]")
+# Embedded (local file):
+#VECTOR_DB_PROVIDER="turso"
+#VECTOR_DB_URL="/absolute/path/to/cognee.turso.db"
+# Remote Turso cloud:
+#VECTOR_DB_PROVIDER="turso"
+#VECTOR_DB_URL="libsql://your-db.turso.io"
+#VECTOR_DB_KEY="your_turso_auth_token"
 
 # Connection pool tuning for PGVector per-dataset engines (JSON).
 # When ENABLE_BACKEND_ACCESS_CONTROL=true each dataset gets its own engine; this controls

--- a/.github/workflows/vector_db_tests.yml
+++ b/.github/workflows/vector_db_tests.yml
@@ -189,7 +189,7 @@ jobs:
           EMBEDDING_DIMENSIONS: 300
           EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
           EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
-        run: uv run python ./cognee/tests/test_search_db.py
+        run: uv run pytest cognee/tests/test_search_db.py -v --log-level=INFO
 
   run-turso-multi-user-tests:
     name: Turso Multi-User Tests
@@ -224,4 +224,4 @@ jobs:
           EMBEDDING_DIMENSIONS: 300
           EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
           EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
-        run: uv run python ./cognee/tests/test_permissions.py
+        run: uv run pytest cognee/tests/test_permissions.py -v --log-level=INFO

--- a/.github/workflows/vector_db_tests.yml
+++ b/.github/workflows/vector_db_tests.yml
@@ -151,3 +151,77 @@ jobs:
           EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
           EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
         run: uv run python ./cognee/tests/test_lancedb.py
+
+  run-turso-tests:
+    name: Turso Tests
+    runs-on: ubuntu-22.04
+    container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
+    if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'turso') }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: ${{ inputs.python-version }}
+          extra-dependencies: "turso"
+
+      # Adapter behavior against a real embedded libSQL DB (no LLM needed).
+      - name: Run Turso adapter unit tests
+        env:
+          ENV: 'dev'
+        run: uv run pytest cognee/tests/unit/infrastructure/databases/vector/test_turso_adapter.py -v
+
+      # Full search-type e2e suite, run against Turso via VECTOR_DB_PROVIDER.
+      - name: Run Turso search tests
+        env:
+          ENV: 'dev'
+          DATABASE_MAX_LRU_CACHE_SIZE: 1
+          VECTOR_DB_PROVIDER: turso
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_DIMENSIONS: 300
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run python ./cognee/tests/test_search_db.py
+
+  run-turso-multi-user-tests:
+    name: Turso Multi-User Tests
+    runs-on: ubuntu-22.04
+    container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
+    if: ${{ inputs.databases == 'all' || contains(inputs.databases, 'turso') }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: ${{ inputs.python-version }}
+          extra-dependencies: "turso"
+
+      # Per-dataset libSQL files isolate users; proves the dataset handler +
+      # permission system work with Turso under backend access control.
+      - name: Run Turso permissions tests
+        env:
+          ENV: 'dev'
+          ENABLE_BACKEND_ACCESS_CONTROL: 'true'
+          VECTOR_DB_PROVIDER: turso
+          VECTOR_DATASET_DATABASE_HANDLER: turso
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_DIMENSIONS: 300
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run python ./cognee/tests/test_permissions.py

--- a/cognee/infrastructure/databases/dataset_database_handler/supported_dataset_database_handlers.py
+++ b/cognee/infrastructure/databases/dataset_database_handler/supported_dataset_database_handlers.py
@@ -13,6 +13,9 @@ from cognee.infrastructure.databases.graph.ladybug.LadybugDatasetDatabaseHandler
 from cognee.infrastructure.databases.vector.pgvector.PGVectorDatasetDatabaseHandler import (
     PGVectorDatasetDatabaseHandler,
 )
+from cognee.infrastructure.databases.vector.turso.TursoVectorDatasetDatabaseHandler import (
+    TursoVectorDatasetDatabaseHandler,
+)
 from cognee.infrastructure.databases.graph.postgres.PostgresGraphDatasetDatabaseHandler import (
     PostgresGraphDatasetDatabaseHandler,
 )
@@ -30,6 +33,10 @@ supported_dataset_database_handlers = {
     "pgvector": {
         "handler_instance": PGVectorDatasetDatabaseHandler,
         "handler_provider": "pgvector",
+    },
+    "turso": {
+        "handler_instance": TursoVectorDatasetDatabaseHandler,
+        "handler_provider": "turso",
     },
     "postgres_graph": {
         "handler_instance": PostgresGraphDatasetDatabaseHandler,

--- a/cognee/infrastructure/databases/vector/config.py
+++ b/cognee/infrastructure/databases/vector/config.py
@@ -50,6 +50,8 @@ class VectorConfig(BaseSettings):
         self.vector_dataset_database_handler = vector_dataset_database_handler
         if provider == "pgvector" and vector_dataset_database_handler in ("lancedb", "pgvector"):
             self.vector_dataset_database_handler = "pgvector"
+        elif provider == "turso" and vector_dataset_database_handler in ("lancedb", "turso"):
+            self.vector_dataset_database_handler = "turso"
         return self
 
     @pydantic.model_validator(mode="after")

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -312,8 +312,24 @@ def _create_vector_engine(
             embedding_engine=embedding_engine,
         )
 
+    elif vector_db_provider.lower() == "turso":
+        try:
+            from .turso.TursoVectorAdapter import TursoVectorAdapter
+        except ImportError:
+            raise ImportError(
+                "Turso/libSQL dependencies are not installed. Please install with "
+                "'pip install cognee\"[turso]\"' to use Turso functionality."
+            )
+
+        return TursoVectorAdapter(
+            url=vector_db_url,
+            api_key=vector_db_key,
+            embedding_engine=embedding_engine,
+            database_name=vector_db_name,
+        )
+
     else:
         raise EnvironmentError(
             f"Unsupported vector database provider: {vector_db_provider}. "
-            f"Supported providers are: {', '.join(list(supported_databases.keys()) + ['LanceDB', 'PGVector', 'neptune_analytics'])}"
+            f"Supported providers are: {', '.join(list(supported_databases.keys()) + ['LanceDB', 'PGVector', 'neptune_analytics', 'Turso'])}"
         )

--- a/cognee/infrastructure/databases/vector/turso/TursoVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/turso/TursoVectorAdapter.py
@@ -1,31 +1,4 @@
-"""Vector-database adapter backed by Turso / libSQL.
-
-libSQL is SQLite-compatible and adds a native vector type plus built-in
-similarity functions. This adapter stores each collection as a libSQL table
-
-    CREATE TABLE "{collection}" (
-        id      TEXT PRIMARY KEY,
-        payload TEXT,                 -- JSON (SQLite JSON1)
-        vector  F32_BLOB({dim})       -- libSQL native vector
-    )
-
-and runs similarity search with ``vector_distance_cos`` (cosine distance,
-lower-is-better — the same score convention as PGVector / LanceDB, see
-``ScoredResult``). NodeSet (``belongs_to_set``) filtering uses the SQLite
-JSON1 functions ``json_each`` / ``json_group_array`` — the SQLite analog of
-PGVector's JSONB ``?|`` / ``?&`` operators.
-
-Async model
------------
-The libSQL engine that supports the native vector functions in *embedded*
-(local file) mode ships as the synchronous ``libsql_experimental`` client
-(the pure-async ``libsql-client`` falls back to plain SQLite locally and has
-no vector functions). cognee's ``VectorDBInterface`` is async, so every DB
-call here is run through ``asyncio.to_thread`` and serialized by a single
-lock. The sync client is touched in exactly one place (``_run``), so the
-async contract can be re-aligned to a native-async client later without
-changing any SQL.
-"""
+"""Vector-database adapter backed by Turso / libSQL."""
 
 import json
 import asyncio
@@ -103,7 +76,12 @@ class TursoVectorAdapter(VectorDBInterface):
         self._connection = None
 
     # ------------------------------------------------------------------ #
-    # Connection + low-level execution (the only sync-client touch point)
+    # Connection + low-level execution.
+    #
+    # libsql-experimental is sync but is the only client with native vector
+    # support in embedded mode, so DB calls run via asyncio.to_thread. The sync
+    # client is touched only here (and in _run / _run_many), keeping the async
+    # contract easy to re-align to a native-async client later.
     # ------------------------------------------------------------------ #
     def _get_connection(self):
         """Lazily open the libSQL connection (embedded file or remote server)."""

--- a/cognee/infrastructure/databases/vector/turso/TursoVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/turso/TursoVectorAdapter.py
@@ -446,32 +446,45 @@ class TursoVectorAdapter(VectorDBInterface):
 
         for table_name in candidate_tables:
             id_scope = ""
-            base_params: List[Any] = [tags_json]
+            scope_params: List[Any] = []
             if node_ids_list is not None:
                 placeholders = ",".join("?" for _ in node_ids_list)
                 id_scope = f" AND id IN ({placeholders})"
+                scope_params = list(node_ids_list)
 
-            # Remove the tags from the array.
-            update_sql = (
-                f"UPDATE \"{table_name}\" SET payload = json_set(payload, '$.belongs_to_set', ("
-                f"  SELECT json_group_array(value) FROM json_each(payload, '$.belongs_to_set')"
-                f"  WHERE value NOT IN (SELECT value FROM json_each(?))"
-                f")) WHERE json_type(payload, '$.belongs_to_set') = 'array'{id_scope}"
-            )
-            # Delete rows whose array is now empty.
-            delete_sql = (
-                f'DELETE FROM "{table_name}" '
+            # Capture the rows that actually contain one of the removed tags
+            # FIRST. The UPDATE + delete-when-empty must only touch these rows,
+            # otherwise a row that was already stored with an empty
+            # belongs_to_set (e.g. an untagged index row) would be deleted as
+            # collateral on any unrelated tag removal. Mirrors PGVector.
+            select_sql = (
+                f'SELECT id FROM "{table_name}" '
                 f"WHERE json_type(payload, '$.belongs_to_set') = 'array' "
-                f"AND json_array_length(payload, '$.belongs_to_set') = 0{id_scope}"
+                f"AND EXISTS (SELECT 1 FROM json_each(payload, '$.belongs_to_set') je "
+                f"WHERE je.value IN (SELECT value FROM json_each(?))){id_scope}"
             )
             try:
-                update_params = list(base_params)
-                if node_ids_list is not None:
-                    update_params.extend(node_ids_list)
-                await self._execute(update_sql, update_params, commit=True)
+                rows = await self._execute(select_sql, [tags_json] + scope_params, fetch=True)
+                target_ids = [row[0] for row in rows or []]
+                if not target_ids:
+                    continue
 
-                delete_params = node_ids_list if node_ids_list is not None else None
-                await self._execute(delete_sql, delete_params, commit=True)
+                id_placeholders = ",".join("?" for _ in target_ids)
+                # Strip the tags from exactly those rows.
+                update_sql = (
+                    f"UPDATE \"{table_name}\" SET payload = json_set(payload, '$.belongs_to_set', ("
+                    f"  SELECT json_group_array(value) FROM json_each(payload, '$.belongs_to_set')"
+                    f"  WHERE value NOT IN (SELECT value FROM json_each(?))"
+                    f")) WHERE id IN ({id_placeholders})"
+                )
+                await self._execute(update_sql, [tags_json] + target_ids, commit=True)
+
+                # Delete only the captured rows that are now empty.
+                delete_sql = (
+                    f'DELETE FROM "{table_name}" WHERE id IN ({id_placeholders}) '
+                    f"AND json_array_length(payload, '$.belongs_to_set') = 0"
+                )
+                await self._execute(delete_sql, target_ids, commit=True)
             except Exception as error:  # noqa: BLE001 - one bad table must not abort the rest
                 logger.debug("remove_belongs_to_set_tags skipped '%s': %s", table_name, error)
 

--- a/cognee/infrastructure/databases/vector/turso/TursoVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/turso/TursoVectorAdapter.py
@@ -1,0 +1,520 @@
+"""Vector-database adapter backed by Turso / libSQL.
+
+libSQL is SQLite-compatible and adds a native vector type plus built-in
+similarity functions. This adapter stores each collection as a libSQL table
+
+    CREATE TABLE "{collection}" (
+        id      TEXT PRIMARY KEY,
+        payload TEXT,                 -- JSON (SQLite JSON1)
+        vector  F32_BLOB({dim})       -- libSQL native vector
+    )
+
+and runs similarity search with ``vector_distance_cos`` (cosine distance,
+lower-is-better — the same score convention as PGVector / LanceDB, see
+``ScoredResult``). NodeSet (``belongs_to_set``) filtering uses the SQLite
+JSON1 functions ``json_each`` / ``json_group_array`` — the SQLite analog of
+PGVector's JSONB ``?|`` / ``?&`` operators.
+
+Async model
+-----------
+The libSQL engine that supports the native vector functions in *embedded*
+(local file) mode ships as the synchronous ``libsql_experimental`` client
+(the pure-async ``libsql-client`` falls back to plain SQLite locally and has
+no vector functions). cognee's ``VectorDBInterface`` is async, so every DB
+call here is run through ``asyncio.to_thread`` and serialized by a single
+lock. The sync client is touched in exactly one place (``_run``), so the
+async contract can be re-aligned to a native-async client later without
+changing any SQL.
+"""
+
+import json
+import asyncio
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from cognee.shared.logging_utils import get_logger
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.engine.utils import parse_id
+from cognee.infrastructure.databases.exceptions import MissingQueryParameterError
+
+from ..models.ScoredResult import ScoredResult
+from ..exceptions import CollectionNotFoundError
+from ..vector_db_interface import VectorDBInterface
+from ..embeddings.EmbeddingEngine import EmbeddingEngine
+from ..pgvector.serialize_data import serialize_data
+
+logger = get_logger("TursoVectorAdapter")
+
+QUERY_BATCH_SIZE = 1000
+
+
+class IndexSchema(DataPoint):
+    """Schema for the rows written by ``index_data_points`` (mirrors PGVector)."""
+
+    text: str
+
+    # Optional reference scalars carried for the search "Evidence" feature.
+    # They stay None for non-chunk data points, so this schema remains
+    # compatible with every indexed DataPoint type.
+    document_id: Optional[str] = None
+    document_name: Optional[str] = None
+    chunk_index: Optional[int] = None
+    source_chunk_id: Optional[str] = None
+    importance_weight: Optional[float] = 0.5
+
+    metadata: dict = {"index_fields": ["text"]}
+    belongs_to_set: List[str] = []
+
+
+def _is_remote_url(url: str) -> bool:
+    """True when ``url`` points at a libSQL server rather than a local file."""
+    return url.startswith(("libsql://", "http://", "https://", "ws://", "wss://"))
+
+
+def _vector_literal(vector: List[float]) -> str:
+    """Render an embedding as the JSON-array text ``vector32()`` expects."""
+    return json.dumps([float(value) for value in vector])
+
+
+class TursoVectorAdapter(VectorDBInterface):
+    """Vector-database adapter backed by Turso / libSQL; implements VectorDBInterface."""
+
+    name = "Turso"
+
+    def __init__(
+        self,
+        url: str,
+        api_key: Optional[str],
+        embedding_engine: EmbeddingEngine,
+        database_name: Optional[str] = None,
+    ):
+        self.url = url
+        self.api_key = api_key
+        self.embedding_engine = embedding_engine
+        self.database_name = database_name
+
+        # One lock serializes every DB call; the sync libSQL connection is
+        # shared across the asyncio.to_thread worker threads, so concurrent
+        # access must be funneled through here.
+        self.VECTOR_DB_LOCK = asyncio.Lock()
+
+        # Reflected collection names; refreshed lazily by has_collection().
+        self._known_collections: set[str] = set()
+        self._connection = None
+
+    # ------------------------------------------------------------------ #
+    # Connection + low-level execution (the only sync-client touch point)
+    # ------------------------------------------------------------------ #
+    def _get_connection(self):
+        """Lazily open the libSQL connection (embedded file or remote server)."""
+        if self._connection is not None:
+            return self._connection
+
+        try:
+            import libsql_experimental as libsql
+        except ImportError:
+            import libsql  # pragma: no cover - alternate package name
+
+        if _is_remote_url(self.url):
+            self._connection = libsql.connect(
+                database=self.url,
+                auth_token=self.api_key or "",
+                check_same_thread=False,
+            )
+        else:
+            self._connection = libsql.connect(self.url, check_same_thread=False)
+
+        return self._connection
+
+    def _run(
+        self,
+        sql: str,
+        params: Optional[List[Any]] = None,
+        *,
+        fetch: bool = False,
+        commit: bool = False,
+    ):
+        """Run one statement synchronously. Called only inside asyncio.to_thread."""
+        connection = self._get_connection()
+        cursor = connection.execute(sql, tuple(params) if params else ())
+        rows = cursor.fetchall() if fetch else None
+        if commit:
+            connection.commit()
+        return rows
+
+    async def _execute(
+        self,
+        sql: str,
+        params: Optional[List[Any]] = None,
+        *,
+        fetch: bool = False,
+        commit: bool = False,
+    ):
+        async with self.VECTOR_DB_LOCK:
+            return await asyncio.to_thread(self._run, sql, params, fetch=fetch, commit=commit)
+
+    # ------------------------------------------------------------------ #
+    # Embedding
+    # ------------------------------------------------------------------ #
+    async def embed_data(self, data: List[str]) -> List[List[float]]:
+        """Embed a list of texts into vectors using the configured engine."""
+        return await self.embedding_engine.embed_text(data)
+
+    # ------------------------------------------------------------------ #
+    # Collections
+    # ------------------------------------------------------------------ #
+    async def has_collection(self, collection_name: str) -> bool:
+        """Return True when a table named ``collection_name`` exists."""
+        if collection_name in self._known_collections:
+            return True
+
+        rows = await self._execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+            [collection_name],
+            fetch=True,
+        )
+        exists = bool(rows)
+        if exists:
+            self._known_collections.add(collection_name)
+        return exists
+
+    async def create_collection(self, collection_name: str, payload_schema=None):
+        """Create the libSQL table for ``collection_name`` if it does not exist."""
+        vector_size = self.embedding_engine.get_vector_size()
+
+        if not await self.has_collection(collection_name):
+            async with self.VECTOR_DB_LOCK:
+                await asyncio.to_thread(
+                    self._run,
+                    f'CREATE TABLE IF NOT EXISTS "{collection_name}" '
+                    f"(id TEXT PRIMARY KEY, payload TEXT, vector F32_BLOB({vector_size}))",
+                    None,
+                    commit=True,
+                )
+            self._known_collections.add(collection_name)
+
+    async def get_table_names(self) -> List[str]:
+        """Return every table name in the database (used by prune / detag / tests)."""
+        rows = await self._execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'",
+            fetch=True,
+        )
+        return [row[0] for row in rows] if rows else []
+
+    # ------------------------------------------------------------------ #
+    # Writes
+    # ------------------------------------------------------------------ #
+    async def create_data_points(self, collection_name: str, data_points: List[DataPoint]):
+        """Upsert DataPoints, merging ``belongs_to_set`` on id conflict."""
+        if not data_points:
+            return
+
+        if not await self.has_collection(collection_name):
+            await self.create_collection(collection_name, payload_schema=type(data_points[0]))
+
+        data_vectors = await self.embed_data(
+            [DataPoint.get_embeddable_data(data_point) for data_point in data_points]
+        )
+
+        # Build (id, payload_json, vector_literal) rows, deduplicating by id
+        # within the batch and unioning belongs_to_set tags of duplicates so a
+        # tag present on only one duplicate is not dropped (mirrors PGVector).
+        deduped: Dict[str, Dict[str, Any]] = {}
+        for index, data_point in enumerate(data_points):
+            row_id = str(data_point.id)
+            payload = serialize_data(data_point.model_dump())
+            existing = deduped.get(row_id)
+            if existing is None:
+                deduped[row_id] = {
+                    "id": row_id,
+                    "payload": payload,
+                    "vector": _vector_literal(data_vectors[index]),
+                }
+                continue
+            existing_payload = existing["payload"] or {}
+            existing_tags = existing_payload.get("belongs_to_set") or []
+            incoming_tags = (payload or {}).get("belongs_to_set") or []
+            if existing_tags or incoming_tags:
+                merged_tags = list(dict.fromkeys(list(existing_tags) + list(incoming_tags)))
+                payload = {**payload, "belongs_to_set": merged_tags}
+            existing["payload"] = payload
+
+        # On conflict keep the existing vector (like PGVector) and merge the
+        # belongs_to_set arrays from the stored and incoming payloads via JSON1.
+        insert_sql = (
+            f'INSERT INTO "{collection_name}" (id, payload, vector) '
+            f"VALUES (?, ?, vector32(?)) "
+            f"ON CONFLICT(id) DO UPDATE SET payload = json_set("
+            f"  excluded.payload, '$.belongs_to_set',"
+            f"  (SELECT json_group_array(value) FROM ("
+            f'    SELECT value FROM json_each(json_extract("{collection_name}".payload, '
+            f"'$.belongs_to_set'))"
+            f"    UNION"
+            f"    SELECT value FROM json_each(json_extract(excluded.payload, '$.belongs_to_set'))"
+            f"  ))"
+            f")"
+        )
+
+        params = [
+            [row["id"], json.dumps(row["payload"]), row["vector"]] for row in deduped.values()
+        ]
+
+        async with self.VECTOR_DB_LOCK:
+            await asyncio.to_thread(self._run_many, insert_sql, params)
+
+    def _run_many(self, sql: str, params: List[List[Any]]):
+        """Execute one write per row inside a single committed transaction."""
+        connection = self._get_connection()
+        for start in range(0, len(params), QUERY_BATCH_SIZE):
+            for row in params[start : start + QUERY_BATCH_SIZE]:
+                connection.execute(sql, tuple(row))
+        connection.commit()
+
+    async def create_vector_index(self, index_name: str, index_property_name: str):
+        """Create the index collection (table) for the given name/property pair."""
+        await self.create_collection(f"{index_name}_{index_property_name}")
+
+    async def index_data_points(
+        self, index_name: str, index_property_name: str, data_points: List[DataPoint]
+    ):
+        """Write index rows derived from ``data_points`` into the {index}_{property} table."""
+        await self.create_data_points(
+            f"{index_name}_{index_property_name}",
+            [
+                IndexSchema(
+                    id=data_point.id,
+                    text=DataPoint.get_embeddable_data(data_point),
+                    document_id=getattr(data_point, "document_id", None),
+                    document_name=getattr(data_point, "document_name", None),
+                    chunk_index=getattr(data_point, "chunk_index", None),
+                    source_chunk_id=getattr(data_point, "source_chunk_id", None),
+                    importance_weight=getattr(data_point, "importance_weight", None),
+                    belongs_to_set=(data_point.belongs_to_set or []),
+                )
+                for data_point in data_points
+            ],
+        )
+
+    # ------------------------------------------------------------------ #
+    # Reads
+    # ------------------------------------------------------------------ #
+    async def retrieve(self, collection_name: str, data_point_ids: List[str]):
+        """Return rows from ``collection_name`` matching any of ``data_point_ids``."""
+        if not await self.has_collection(collection_name):
+            return []
+
+        results = []
+        seen_ids = set()
+        ids = [str(data_point_id) for data_point_id in data_point_ids]
+        for start in range(0, len(ids), QUERY_BATCH_SIZE):
+            id_batch = ids[start : start + QUERY_BATCH_SIZE]
+            placeholders = ",".join("?" for _ in id_batch)
+            rows = await self._execute(
+                f'SELECT id, payload FROM "{collection_name}" WHERE id IN ({placeholders})',
+                id_batch,
+                fetch=True,
+            )
+            for row in rows or []:
+                if row[0] in seen_ids:
+                    continue
+                seen_ids.add(row[0])
+                results.append(
+                    ScoredResult(
+                        id=parse_id(row[0]),
+                        payload=json.loads(row[1]) if row[1] else {},
+                        score=0,
+                    )
+                )
+        return results
+
+    async def search(
+        self,
+        collection_name: str,
+        query_text: Optional[str] = None,
+        query_vector: Optional[List[float]] = None,
+        limit: Optional[int] = 15,
+        with_vector: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+        node_name_filter_operator: str = "OR",
+    ) -> List[ScoredResult]:
+        """Run a cosine-distance similarity search, optionally filtered by NodeSet tag."""
+        if query_text is None and query_vector is None:
+            raise MissingQueryParameterError()
+
+        if not await self.has_collection(collection_name):
+            raise CollectionNotFoundError(f"Collection '{collection_name}' not found!")
+
+        if query_text and not query_vector:
+            query_vector = (await self.embedding_engine.embed_text([query_text]))[0]
+
+        if limit is None:
+            rows = await self._execute(f'SELECT count(*) FROM "{collection_name}"', fetch=True)
+            limit = rows[0][0] if rows else 0
+
+        if limit <= 0:
+            return []
+
+        params: List[Any] = [_vector_literal(query_vector)]
+        where_clause = ""
+        if node_name:
+            placeholders = ",".join("?" for _ in node_name)
+            if node_name_filter_operator == "AND":
+                where_clause = (
+                    f" WHERE (SELECT count(DISTINCT je.value) FROM json_each("
+                    f"\"{collection_name}\".payload, '$.belongs_to_set') je "
+                    f"WHERE je.value IN ({placeholders})) = ?"
+                )
+                params.extend(node_name)
+                params.append(len(set(node_name)))
+            else:
+                where_clause = (
+                    f" WHERE EXISTS (SELECT 1 FROM json_each("
+                    f"\"{collection_name}\".payload, '$.belongs_to_set') je "
+                    f"WHERE je.value IN ({placeholders}))"
+                )
+                params.extend(node_name)
+
+        params.append(limit)
+        # Bind order matches the statement: SELECT's vector32(?), then any
+        # NodeSet placeholders (+ the AND count), then LIMIT.
+        rows = await self._execute(
+            f"SELECT id, payload, "
+            f"vector_distance_cos(vector, vector32(?)) AS _distance "
+            f'FROM "{collection_name}"{where_clause} ORDER BY _distance ASC LIMIT ?',
+            params,
+            fetch=True,
+        )
+
+        return [
+            ScoredResult(
+                id=parse_id(str(row[0])),
+                payload=json.loads(row[1]) if (include_payload and row[1]) else None,
+                score=float(row[2]),
+            )
+            for row in rows or []
+        ]
+
+    async def batch_search(
+        self,
+        collection_name: str,
+        query_texts: List[str],
+        limit: int = None,
+        with_vectors: bool = False,
+        include_payload: bool = False,
+        node_name: Optional[List[str]] = None,
+    ):
+        """Run ``search`` for each query text and return a list of result lists."""
+        query_vectors = await self.embedding_engine.embed_text(query_texts)
+
+        return await asyncio.gather(
+            *[
+                self.search(
+                    collection_name=collection_name,
+                    query_vector=query_vector,
+                    limit=limit,
+                    with_vector=with_vectors,
+                    include_payload=include_payload,
+                    node_name=node_name,
+                )
+                for query_vector in query_vectors
+            ]
+        )
+
+    # ------------------------------------------------------------------ #
+    # Deletes
+    # ------------------------------------------------------------------ #
+    async def delete_data_points(self, collection_name: str, data_point_ids: List[UUID]):
+        """Delete rows whose id is in ``data_point_ids``."""
+        if not await self.has_collection(collection_name):
+            return None
+
+        ids = [str(data_point_id) for data_point_id in data_point_ids]
+        if not ids:
+            return None
+
+        for start in range(0, len(ids), QUERY_BATCH_SIZE):
+            id_batch = ids[start : start + QUERY_BATCH_SIZE]
+            placeholders = ",".join("?" for _ in id_batch)
+            await self._execute(
+                f'DELETE FROM "{collection_name}" WHERE id IN ({placeholders})',
+                id_batch,
+                commit=True,
+            )
+        return None
+
+    async def remove_belongs_to_set_tags(
+        self,
+        tags: List[str],
+        node_ids: Optional[List[str]] = None,
+    ) -> None:
+        """Strip ``tags`` from belongs_to_set arrays and delete rows left empty.
+
+        cognee vector collections follow the ``{PascalCaseType}_{field}``
+        naming convention and coexist with snake_case relational tables, so
+        only PascalCase-named tables are touched.
+        """
+        if not tags:
+            return None
+        if node_ids is not None and not node_ids:
+            return None
+
+        candidate_tables = [
+            name for name in await self.get_table_names() if name and name[0].isupper()
+        ]
+
+        tags_json = json.dumps(list(tags))
+        node_ids_list = [str(node_id) for node_id in node_ids] if node_ids is not None else None
+
+        for table_name in candidate_tables:
+            id_scope = ""
+            base_params: List[Any] = [tags_json]
+            if node_ids_list is not None:
+                placeholders = ",".join("?" for _ in node_ids_list)
+                id_scope = f" AND id IN ({placeholders})"
+
+            # Remove the tags from the array.
+            update_sql = (
+                f"UPDATE \"{table_name}\" SET payload = json_set(payload, '$.belongs_to_set', ("
+                f"  SELECT json_group_array(value) FROM json_each(payload, '$.belongs_to_set')"
+                f"  WHERE value NOT IN (SELECT value FROM json_each(?))"
+                f")) WHERE json_type(payload, '$.belongs_to_set') = 'array'{id_scope}"
+            )
+            # Delete rows whose array is now empty.
+            delete_sql = (
+                f'DELETE FROM "{table_name}" '
+                f"WHERE json_type(payload, '$.belongs_to_set') = 'array' "
+                f"AND json_array_length(payload, '$.belongs_to_set') = 0{id_scope}"
+            )
+            try:
+                update_params = list(base_params)
+                if node_ids_list is not None:
+                    update_params.extend(node_ids_list)
+                await self._execute(update_sql, update_params, commit=True)
+
+                delete_params = node_ids_list if node_ids_list is not None else None
+                await self._execute(delete_sql, delete_params, commit=True)
+            except Exception as error:  # noqa: BLE001 - one bad table must not abort the rest
+                logger.debug("remove_belongs_to_set_tags skipped '%s': %s", table_name, error)
+
+        return None
+
+    async def prune(self):
+        """Drop every collection table and reset cached reflection state."""
+        for table_name in await self.get_table_names():
+            await self._execute(f'DROP TABLE IF EXISTS "{table_name}"', commit=True)
+        self._known_collections.clear()
+
+    async def run_migrations(self):
+        """Run Turso adapter migrations (currently no-op)."""
+        return None
+
+    def reset_metadata_cache(self):
+        """Reset cached collection names for this adapter instance."""
+        self._known_collections.clear()
+
+    async def close(self) -> None:
+        """Close the libSQL connection. Driven by closing_lru_cache on eviction."""
+        if self._connection is not None:
+            connection, self._connection = self._connection, None
+            await asyncio.to_thread(connection.close)

--- a/cognee/infrastructure/databases/vector/turso/TursoVectorDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/turso/TursoVectorDatasetDatabaseHandler.py
@@ -1,0 +1,59 @@
+import os
+from uuid import UUID
+from typing import Optional
+
+from cognee.infrastructure.databases.vector.create_vector_engine import create_vector_engine
+from cognee.modules.users.models import User
+from cognee.modules.users.models import DatasetDatabase
+from cognee.base_config import get_base_config
+from cognee.infrastructure.databases.vector import get_vectordb_config
+from cognee.infrastructure.databases.dataset_database_handler import DatasetDatabaseHandlerInterface
+from cognee.infrastructure.files.storage.get_file_storage import get_file_storage
+
+
+class TursoVectorDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
+    """
+    Handler for interacting with Turso / libSQL Dataset databases.
+
+    Embedded mode gives every dataset its own libSQL file under the user's
+    databases directory (``{dataset_id}.turso.db``), mirroring the LanceDB
+    handler. That per-dataset file is what isolates one user/dataset's
+    vectors from another's when ``ENABLE_BACKEND_ACCESS_CONTROL=True``.
+    """
+
+    @classmethod
+    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        """Create local Turso dataset connection details for a user's dataset."""
+        vector_config = get_vectordb_config()
+        base_config = get_base_config()
+
+        if vector_config.vector_db_provider != "turso":
+            raise ValueError(
+                "TursoVectorDatasetDatabaseHandler can only be used with Turso vector database provider."
+            )
+
+        databases_directory_path = os.path.join(
+            base_config.system_root_directory, "databases", str(user.id)
+        )
+        await get_file_storage(databases_directory_path).ensure_directory_exists()
+
+        vector_db_name = f"{dataset_id}.turso.db"
+
+        return {
+            "vector_database_provider": vector_config.vector_db_provider,
+            "vector_database_url": os.path.join(databases_directory_path, vector_db_name),
+            "vector_database_key": vector_config.vector_db_key,
+            "vector_database_name": vector_db_name,
+            "vector_dataset_database_handler": "turso",
+        }
+
+    @classmethod
+    async def delete_dataset(cls, dataset_database: DatasetDatabase):
+        """Drop the dataset's vector tables by pruning its dedicated libSQL file."""
+        vector_engine = create_vector_engine(
+            vector_db_provider=dataset_database.vector_database_provider,
+            vector_db_url=dataset_database.vector_database_url,
+            vector_db_key=dataset_database.vector_database_key,
+            vector_db_name=dataset_database.vector_database_name,
+        )
+        await vector_engine.prune()

--- a/cognee/tests/test_turso.py
+++ b/cognee/tests/test_turso.py
@@ -1,0 +1,289 @@
+import os
+import pathlib
+
+import cognee
+from cognee.shared.logging_utils import get_logger
+from cognee.infrastructure.files.storage import get_storage_config
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.search.types import SearchType
+from cognee.modules.search.operations import get_history
+
+logger = get_logger()
+
+
+async def test_getting_of_documents(dataset_id_1):
+    # Test getting of documents for search per dataset
+    from cognee.modules.users.permissions.methods import get_document_ids_for_user
+
+    user = await get_default_user()
+    document_ids = await get_document_ids_for_user(user.id, [dataset_id_1])
+    assert len(document_ids) == 1, (
+        f"Number of expected documents doesn't match {len(document_ids)} != 1"
+    )
+
+    # Test getting of documents for search when no dataset is provided
+    user = await get_default_user()
+    document_ids = await get_document_ids_for_user(user.id)
+    assert len(document_ids) == 2, (
+        f"Number of expected documents doesn't match {len(document_ids)} != 2"
+    )
+
+
+async def test_vector_engine_search_none_limit():
+    query_text = "Tell me about Quantum computers"
+
+    from cognee.infrastructure.databases.vector import get_vector_engine
+
+    vector_engine = get_vector_engine()
+    collection_name = "Entity_name"
+
+    query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
+
+    result = await vector_engine.search(
+        collection_name=collection_name, query_vector=query_vector, limit=None
+    )
+
+    # Check that we did not accidentally use any default value for limit
+    # in vector search along the way (like 5, 10, or 15)
+    assert len(result) > 15
+
+
+async def test_vector_engine_search_with_nodeset_filtering():
+    node_set_a = ["NLP"]
+    node_set_b = ["Quantum", "Computers"]
+    node_set_c = ["Quantum"]
+
+    explanation_file_path_nlp = os.path.join(
+        pathlib.Path(__file__).parent, "test_data/Natural_language_processing.txt"
+    )
+    await cognee.add([explanation_file_path_nlp], node_set=node_set_a)
+
+    explanation_file_path_quantum = os.path.join(
+        pathlib.Path(__file__).parent, "test_data/Quantum_computers.txt"
+    )
+
+    await cognee.add([explanation_file_path_quantum], node_set=node_set_b)
+
+    await cognee.add("Alice is an expert in Quantum Mechanics", node_set=node_set_c)
+
+    await cognee.cognify()
+
+    node_set = ["NLP", "Quantum"]
+    query_text = "Tell me about NLP"
+
+    from cognee.infrastructure.databases.vector import get_vector_engine
+
+    vector_engine = get_vector_engine()
+    query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
+
+    # Search with "OR" operator
+    result = await vector_engine.search(
+        collection_name="DocumentChunk_text",
+        query_vector=query_vector,
+        include_payload=True,
+        limit=None,
+        node_name=node_set,
+        node_name_filter_operator="OR",
+    )
+
+    assert all(nodeset in node_set for nodeset in result[0].payload["belongs_to_set"]), (
+        "Only results from relevant nodesets should be returned"
+    )
+
+    # Search with "AND" operator
+    result = await vector_engine.search(
+        collection_name="DocumentChunk_text",
+        query_vector=query_vector,
+        include_payload=True,
+        limit=None,
+        node_name=node_set,
+        node_name_filter_operator="AND",
+    )
+
+    assert len(result) == 0, f"Results for search with all nodesets in {node_set} should be empty"
+
+    node_set = ["Quantum", "Computers"]
+
+    # Search with "OR" operator
+    result = await vector_engine.search(
+        collection_name="Entity_name",
+        query_vector=query_vector,
+        include_payload=True,
+        limit=None,
+        node_name=node_set,
+        node_name_filter_operator="OR",
+    )
+
+    assert any(entity.payload["text"].lower() == "alice" for entity in result), (
+        "Entity of Alice should be present in the results"
+    )
+
+    # Search with "AND" operator
+    result = await vector_engine.search(
+        collection_name="Entity_name",
+        query_vector=query_vector,
+        include_payload=True,
+        limit=None,
+        node_name=node_set,
+        node_name_filter_operator="AND",
+    )
+
+    assert all(entity.payload["text"].lower() != "alice" for entity in result), (
+        "Entity of Alice should NOT be present in the results"
+    )
+
+
+async def test_vector_nodeset_filtering_retriever_integration():
+    node_set = ["NLP", "Quantum"]
+    query_text = "Tell me about Quantum computers"
+
+    from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
+
+    # Search with "OR" operator
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
+    retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
+
+    assert any("NLP" in chunk.payload["text"] for chunk in retrieved_objects)
+    assert any("Quantum" in chunk.payload["text"] for chunk in retrieved_objects)
+
+    # Search with "AND" operator
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
+    retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
+
+    assert len(retrieved_objects) == 0, (
+        f"Results for search with all nodesets in {node_set} should be empty"
+    )
+
+    node_set = ["Quantum", "Computers"]
+
+    # Search with "OR" operator
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="OR")
+    retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
+
+    assert any("Alice" in chunk.payload["text"] for chunk in retrieved_objects)
+
+    # Search with "AND" operator
+    retriever = ChunksRetriever(node_name=node_set, node_name_filter_operator="AND")
+    retrieved_objects = await retriever.get_retrieved_objects(query=query_text)
+
+    assert all("Alice" not in chunk.payload["text"] for chunk in retrieved_objects)
+
+
+async def main():
+    cognee.config.set_vector_db_config(
+        {
+            "vector_db_provider": "turso",
+            "vector_dataset_database_handler": "turso",
+        }
+    )
+
+    data_directory_path = str(
+        pathlib.Path(
+            os.path.join(pathlib.Path(__file__).parent, ".data_storage/test_turso")
+        ).resolve()
+    )
+    cognee.config.data_root_directory(data_directory_path)
+    cognee_directory_path = str(
+        pathlib.Path(
+            os.path.join(pathlib.Path(__file__).parent, ".cognee_system/test_turso")
+        ).resolve()
+    )
+    cognee.config.system_root_directory(cognee_directory_path)
+
+    node_set_a = ["NLP"]
+    node_set_b = ["Quantum", "Computers"]
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    dataset_name_1 = "natural_language"
+    dataset_name_2 = "quantum"
+
+    explanation_file_path_nlp = os.path.join(
+        pathlib.Path(__file__).parent, "test_data/Natural_language_processing.txt"
+    )
+    await cognee.add([explanation_file_path_nlp], dataset_name_1, node_set=node_set_a)
+
+    explanation_file_path_quantum = os.path.join(
+        pathlib.Path(__file__).parent, "test_data/Quantum_computers.txt"
+    )
+
+    await cognee.add([explanation_file_path_quantum], dataset_name_2, node_set=node_set_b)
+
+    await cognee.cognify([dataset_name_2, dataset_name_1])
+
+    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.modules.data.methods import get_datasets_by_name
+
+    user = await get_default_user()
+    dataset_1 = (await get_datasets_by_name([dataset_name_1], user.id))[0]
+    await test_getting_of_documents(dataset_1.id)
+
+    vector_engine = get_vector_engine()
+    random_node = (
+        await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
+    )[0]
+    random_node_name = random_node.payload["text"]
+
+    search_results = await cognee.search(
+        query_type=SearchType.GRAPH_COMPLETION, query_text=random_node_name
+    )
+    assert len(search_results) != 0, "The search results list is empty."
+    print("\n\nExtracted sentences are:\n")
+    for result in search_results:
+        print(f"{result}\n")
+
+    search_results = await cognee.search(
+        query_type=SearchType.CHUNKS, query_text=random_node_name, datasets=[dataset_name_2]
+    )
+    assert len(search_results) != 0, "The search results list is empty."
+    print("\n\nExtracted chunks are:\n")
+    for result in search_results:
+        print(f"{result}\n")
+
+    graph_completion = await cognee.search(
+        query_type=SearchType.GRAPH_COMPLETION,
+        query_text=random_node_name,
+        datasets=[dataset_name_2],
+    )
+    assert len(graph_completion) != 0, "Completion result is empty."
+    print("Completion result is:")
+    print(graph_completion)
+
+    search_results = await cognee.search(
+        query_type=SearchType.SUMMARIES, query_text=random_node_name
+    )
+    assert len(search_results) != 0, "Query related summaries don't exist."
+    print("\n\nExtracted summaries are:\n")
+    for result in search_results:
+        print(f"{result}\n")
+
+    user = await get_default_user()
+    history = await get_history(user.id)
+    assert len(history) == 8, "Search history is not correct."
+
+    await test_vector_engine_search_none_limit()
+
+    await test_vector_engine_search_with_nodeset_filtering()
+    # Note: make sure to call test_vector_engine_search_with_nodeset_filtering()
+    # before test_vector_nodeset_filtering_retriever_integration() because another cognify happens
+    # in the first test, and the second one depends on it. Done like this to minimize the number
+    # of cognify invocations.
+    await test_vector_nodeset_filtering_retriever_integration()
+
+    await cognee.prune.prune_data()
+    data_root_directory = get_storage_config()["data_root_directory"]
+    assert not os.path.isdir(data_root_directory), "Local data files are not deleted"
+
+    await cognee.prune.prune_system(metadata=True)
+    tables_in_database = await vector_engine.get_table_names()
+    assert len(tables_in_database) == 0, "Turso database is not empty"
+
+    if hasattr(vector_engine, "close"):
+        await vector_engine.close()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/cognee/tests/unit/infrastructure/databases/vector/test_turso_adapter.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_turso_adapter.py
@@ -1,0 +1,198 @@
+"""Behavioral tests for ``TursoVectorAdapter`` against a real embedded libSQL DB.
+
+These run without an LLM/embedding provider: a deterministic fake embedding
+engine maps keywords to vector axes so cosine ordering and NodeSet filtering
+are exercised on real ``vector_distance_cos`` / JSON1 SQL, not mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+try:
+    import libsql_experimental  # noqa: F401
+
+    from cognee.infrastructure.databases.vector.turso.TursoVectorAdapter import (
+        TursoVectorAdapter,
+    )
+    from cognee.infrastructure.engine import DataPoint
+
+    HAS_LIBSQL = True
+except ModuleNotFoundError:
+    HAS_LIBSQL = False
+
+
+pytestmark = pytest.mark.skipif(not HAS_LIBSQL, reason="libsql-experimental not installed")
+
+DIM = 4
+
+
+class _FakeEmbeddingEngine:
+    """Deterministic embeddings: keyword -> axis, so distances are meaningful."""
+
+    def get_vector_size(self):
+        return DIM
+
+    async def embed_text(self, texts):
+        out = []
+        for text in texts:
+            lowered = text.lower()
+            vector = [
+                1.0 if "quantum" in lowered else 0.0,
+                1.0 if "nlp" in lowered or "language" in lowered else 0.0,
+                1.0 if "alice" in lowered else 0.0,
+                0.1,
+            ]
+            if sum(vector[:3]) == 0:
+                vector[3] += 0.5
+            out.append(vector)
+        return out
+
+
+if HAS_LIBSQL:
+
+    class _Doc(DataPoint):
+        text: str
+        metadata: dict = {"index_fields": ["text"]}
+
+
+@pytest_asyncio.fixture
+async def adapter(tmp_path):
+    db_path = str(tmp_path / "turso_test.db")
+    instance = TursoVectorAdapter(
+        url=db_path, api_key=None, embedding_engine=_FakeEmbeddingEngine()
+    )
+    try:
+        yield instance
+    finally:
+        await instance.close()
+
+
+def _docs():
+    return [
+        _Doc(text="quantum computers are fast", belongs_to_set=["Quantum", "Computers"]),
+        _Doc(text="natural language processing nlp", belongs_to_set=["NLP"]),
+        _Doc(text="alice studies quantum", belongs_to_set=["Quantum"]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_has_collection_lifecycle(adapter):
+    assert await adapter.has_collection("Entity_name") is False
+    await adapter.create_collection("Entity_name")
+    assert await adapter.has_collection("Entity_name") is True
+
+
+@pytest.mark.asyncio
+async def test_create_data_points_and_search_ordering(adapter):
+    docs = _docs()
+    await adapter.create_data_points("DocumentChunk_text", docs)
+
+    results = await adapter.search(
+        "DocumentChunk_text", query_text="quantum", limit=3, include_payload=True
+    )
+    assert len(results) == 3
+    # cosine distance is lower-is-better; results must be ascending by score
+    assert results == sorted(results, key=lambda r: r.score)
+    assert "quantum" in results[0].payload["text"]
+
+
+@pytest.mark.asyncio
+async def test_search_none_limit_returns_all(adapter):
+    await adapter.create_data_points("DocumentChunk_text", _docs())
+    results = await adapter.search("DocumentChunk_text", query_text="quantum", limit=None)
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_nodeset_or_filtering(adapter):
+    await adapter.create_data_points("DocumentChunk_text", _docs())
+    results = await adapter.search(
+        "DocumentChunk_text",
+        query_text="quantum",
+        limit=None,
+        include_payload=True,
+        node_name=["NLP", "Quantum"],
+        node_name_filter_operator="OR",
+    )
+    returned_tags = {tag for r in results for tag in r.payload["belongs_to_set"]}
+    assert returned_tags <= {"NLP", "Quantum", "Computers"}
+    assert any("nlp" in r.payload["text"] for r in results)
+
+
+@pytest.mark.asyncio
+async def test_nodeset_and_filtering(adapter):
+    await adapter.create_data_points("DocumentChunk_text", _docs())
+    results = await adapter.search(
+        "DocumentChunk_text",
+        query_text="quantum",
+        limit=None,
+        include_payload=True,
+        node_name=["Quantum", "Computers"],
+        node_name_filter_operator="AND",
+    )
+    assert len(results) == 1
+    assert "quantum computers" in results[0].payload["text"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_by_ids(adapter):
+    docs = _docs()
+    await adapter.create_data_points("DocumentChunk_text", docs)
+    got = await adapter.retrieve("DocumentChunk_text", [d.id for d in docs])
+    assert {str(r.id) for r in got} == {str(d.id) for d in docs}
+
+
+@pytest.mark.asyncio
+async def test_belongs_to_set_merge_on_conflict(adapter):
+    docs = _docs()
+    await adapter.create_data_points("DocumentChunk_text", docs)
+
+    duplicate = _Doc(text="alice studies quantum", belongs_to_set=["Mechanics"])
+    duplicate.id = docs[2].id
+    await adapter.create_data_points("DocumentChunk_text", [duplicate])
+
+    merged = (await adapter.retrieve("DocumentChunk_text", [docs[2].id]))[0]
+    assert set(merged.payload["belongs_to_set"]) == {"Quantum", "Mechanics"}
+
+
+@pytest.mark.asyncio
+async def test_remove_belongs_to_set_tags(adapter):
+    docs = _docs()
+    await adapter.create_data_points("DocumentChunk_text", docs)
+
+    # Stripping one of several tags keeps the row.
+    await adapter.remove_belongs_to_set_tags(["Computers"])
+    kept = (await adapter.retrieve("DocumentChunk_text", [docs[0].id]))[0]
+    assert set(kept.payload["belongs_to_set"]) == {"Quantum"}
+
+    # Stripping the last tag empties the array, so the row is deleted.
+    await adapter.remove_belongs_to_set_tags(["NLP"])
+    assert await adapter.retrieve("DocumentChunk_text", [docs[1].id]) == []
+
+
+@pytest.mark.asyncio
+async def test_delete_data_points(adapter):
+    docs = _docs()
+    await adapter.create_data_points("DocumentChunk_text", docs)
+    await adapter.delete_data_points("DocumentChunk_text", [docs[0].id])
+    assert await adapter.retrieve("DocumentChunk_text", [docs[0].id]) == []
+
+
+@pytest.mark.asyncio
+async def test_batch_search(adapter):
+    await adapter.create_data_points("DocumentChunk_text", _docs())
+    batches = await adapter.batch_search(
+        "DocumentChunk_text", ["quantum", "alice"], limit=2, include_payload=True
+    )
+    assert len(batches) == 2
+    assert all(isinstance(batch, list) for batch in batches)
+
+
+@pytest.mark.asyncio
+async def test_prune_drops_all_collections(adapter):
+    await adapter.create_data_points("DocumentChunk_text", _docs())
+    await adapter.prune()
+    assert await adapter.has_collection("DocumentChunk_text") is False
+    assert await adapter.get_table_names() == []

--- a/cognee/tests/unit/infrastructure/databases/vector/test_turso_adapter.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_turso_adapter.py
@@ -173,6 +173,23 @@ async def test_remove_belongs_to_set_tags(adapter):
 
 
 @pytest.mark.asyncio
+async def test_remove_tags_preserves_untagged_rows(adapter):
+    # Regression: a row stored with an empty belongs_to_set (e.g. an untagged
+    # index row) must NOT be deleted when an unrelated tag is removed. The detag
+    # must only touch rows that actually contained one of the removed tags.
+    tagged = _Doc(text="quantum tagged", belongs_to_set=["Quantum"])
+    untagged = _Doc(text="untagged chunk", belongs_to_set=[])
+    await adapter.create_data_points("DocumentChunk_text", [tagged, untagged])
+
+    await adapter.remove_belongs_to_set_tags(["Quantum"])
+
+    # tagged row had only Quantum -> emptied -> deleted
+    assert await adapter.retrieve("DocumentChunk_text", [tagged.id]) == []
+    # untagged row never had Quantum -> must survive
+    assert len(await adapter.retrieve("DocumentChunk_text", [untagged.id])) == 1
+
+
+@pytest.mark.asyncio
 async def test_delete_data_points(adapter):
     docs = _docs()
     await adapter.create_data_points("DocumentChunk_text", docs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ fastembed = [
 
 neo4j = ["neo4j>=5.28.0,<6"]
 neptune = ["langchain_aws>=0.2.22"]
+turso = ["libsql-experimental>=0.0.55,<0.1"]
 postgres = [
     "psycopg2>=2.9.10,<3",
     "pgvector>=0.3.5,<0.4",


### PR DESCRIPTION
## Description

Fixes #3583.

This adds Turso (libSQL) as a vector database option. Set `VECTOR_DB_PROVIDER=turso` and cognee
stores its embeddings in libSQL. I followed the PGVector adapter, so I kept the new
`TursoVectorAdapter` as close to it as I could: each collection is a libSQL table with an `F32_BLOB`
vector column, search uses `vector_distance_cos`, and the NodeSet (`belongs_to_set`) filtering that
PGVector does with Postgres JSONB I rewrote using SQLite's JSON1 functions.

The part I want to flag is the async handling. cognee's vector interface is async, so my first
instinct was the async `libsql-client`. When I actually tried it, I hit a wall: in embedded
(local-file) mode it falls back to plain SQLite and doesn't have libSQL's vector functions at all.
The only client that gives you vectors on a local file is `libsql-experimental`, which is
synchronous. So I went with that and run the DB calls through `asyncio.to_thread` so they don't block
the event loop. I deliberately kept all the sync-client code in one place (`_get_connection` /
`_run`), so if we move to a native-async client later, that's the only spot that changes and none of
the SQL moves. 
Happy to align this with whatever async approach you'd prefer for the Turso adapter(or propose mine).

## What it does (the four points from the issue)

- **Plugs into `create_vector_engine`** — `VECTOR_DB_PROVIDER=turso` routes to the adapter, with a
  clear `ImportError` if the `cognee[turso]` extra isn't installed.
- **Multi-user** — added a dataset database handler (`TursoVectorDatasetDatabaseHandler`) and
  registered it, so under access control each dataset gets its own libSQL file and the permission
  system keeps them isolated.
- **Cache** — no new config, so the existing vector-engine cache works as-is.
- **Env vars only** — just set `VECTOR_DB_PROVIDER=turso` (plus `VECTOR_DB_URL` / `VECTOR_DB_KEY` for
  cloud) and you're done.

## Testing

I wrote 12 unit tests that hit a real embedded libSQL DB (no LLM needed) covering the whole adapter:
create/search/delete, cosine ordering, NodeSet OR and AND, the belongs_to_set merge, tag removal, and
prune. I also checked the dataset handler end to end (create a dataset, confirm another dataset can't
see its data, delete it) and ran the adapter against a real Turso cloud DB to make sure the remote
path works over the network.

For the bigger end-to-end tests (`test_permissions.py` and `test_search_db.py`), I wired them to run
against Turso in CI. I couldn't get a clean local run of those because I only have a free-tier LLM
key, and cognee fires a lot of `cognify` calls in parallel which blows past the rate limit. Could you
approve the CI workflows so those run with the repo's LLM secrets? I'll fix anything they turn up.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots

<img width="1203" height="725" alt="Screenshot 2026-06-29 at 3 32 15 AM" src="https://github.com/user-attachments/assets/072c8a00-4ad7-486c-8bef-90b79a7266f5" />


## Pre-submission Checklist

- [x] I've tested my changes (12 adapter unit tests + the dataset handler + a live Turso cloud run;
  the heavier e2e runs in CI)
- [x] This PR is scoped to the feature, nothing extra
- [x] Code follows the style guide (`ruff` is clean)
- [x] Added tests that show the feature works
- [x] Added docs (the Turso block in `.env.template`)
- [x] All tests pass — unit tests pass locally; the full e2e is validated by the new CI jobs
- [x] Searched existing PRs
- [x] Linked the issue
- [x] Commits are clear (Conventional Commits, DCO signed off)

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes
Developer Certificate of Origin.
