### PR TITLE
fix(cognee-mcp): re-lock cognee to match the released library version

### DIFF
--- a/cognee-mcp/uv.lock
+++ b/cognee-mcp/uv.lock
@@ -868,7 +868,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.1.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -882,6 +882,7 @@ dependencies = [
     { name = "fakeredis", extra = ["lua"] },
     { name = "fastapi" },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
+    { name = "filelock" },
     { name = "filetype" },
     { name = "gunicorn" },
     { name = "instructor" },
@@ -907,6 +908,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "rdflib" },
     { name = "sqlalchemy" },
+    { name = "starlette" },
     { name = "structlog" },
     { name = "tenacity" },
     { name = "tiktoken" },
@@ -915,9 +917,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/ec/ab50531c89628c2d4f5abd63a35f320b13a2d8d940722ab2987a756d1ce9/cognee-1.1.0.tar.gz", hash = "sha256:41505ae5afcfc43e5f017992b9d9b1c7b5dd77ec057e9c95b722afd781a07ab4", size = 18833971, upload-time = "2026-05-16T18:55:54.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/f1/7eca21f6bb468a86d0f57cefcae642382b614b3af3da8b7c83f90a3f1aa4/cognee-1.2.1.tar.gz", hash = "sha256:c527d3b58978759a73079fbb7e081620499f2bd8d80dc01dd4466971123b9a81", size = 19272567, upload-time = "2026-06-21T18:30:04.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/c1/f29421b5dc16f6eb92c4e4461a04a48ed14808e7944e9b32d81f24586529/cognee-1.1.0-py3-none-any.whl", hash = "sha256:559e0e610304d5d4bdf6fcb6d17d0e3036f464b7da3b1db1d4ffefb3588a6384", size = 2338066, upload-time = "2026-05-16T18:55:57.898Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4a/ccdb4b5a6256559cf8bcdb13b483cade9a5c7432a2a65d01dd13c1ccb56d/cognee-1.2.1-py3-none-any.whl", hash = "sha256:4d3248d7551ae07b5248dd82ca2756e75e2c8891404e8823e524c0d00cf718d1", size = 2830094, upload-time = "2026-06-21T18:30:00.918Z" },
 ]
 
 [package.optional-dependencies]
@@ -5138,16 +5140,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
When I deployed both  cognee's MCP server (`cognee-mcp:1.2.1`) and the API (`cognee/cognee:1.2.1`)
against a shared Postgres database, the MCP crashed on startup with message
`alembic ... Can't locate revision identified by 'aa753a730673'`.

Investigating, I found that `cognee-mcp:1.2.1` actually bundles the cognee *library*
`1.1.0`, not `1.2.1` — the image tag is decoupled from the bundled library.
Root cause: `cognee-mcp/uv.lock` pins cognee to `1.1.0` (from PyPI), and the
Dockerfile installs with `uv sync --frozen`, which uses the locked version and
never re-resolves the `>=1.1.0,<2.0.0` range. So when the 1.2.x API migrates the
shared DB forward, the 1.1.0 MCP can't find the new Alembic revision and fails.

This PR re-locks `cognee-mcp/uv.lock` so cognee resolves to the current release,
making the MCP's library match the API.

## Acceptance Criteria
- `cognee-mcp/uv.lock` resolves `cognee` to the current release (was `1.1.0`, now `1.2.1`).
- A rebuilt `cognee-mcp` image reports the matching cognee version.
- `cognee/tests/test_library.py` passes locally: full add → cognify → search →
  recall cycle, with relational migrations reaching head.

## Type of Change
<!-- Please check the relevant option -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<img width="768" height="263" alt="1" src="https://github.com/user-attachments/assets/e2f2bc7c-6781-4528-83a8-33f87ca3b75b" />
<img width="768" height="395" alt="2" src="https://github.com/user-attachments/assets/b1db87b0-8073-4ee6-9c13-1524f49789ec" />
<img width="1906" height="979" alt="3" src="https://github.com/user-attachments/assets/8c0a261c-11c9-45a6-976d-085e0fb7cd90" />
<img width="1902" height="902" alt="4" src="https://github.com/user-attachments/assets/b5a23f72-8006-4b1a-8928-b13f53c98187" />
<img width="1896" height="903" alt="5" src="https://github.com/user-attachments/assets/b49d8890-5b13-4135-9920-eb9c55a8bfdb" />
<img width="1891" height="903" alt="6" src="https://github.com/user-attachments/assets/2620724a-f6ed-4933-990a-b3dd02f25b8d" />
<img width="1898" height="912" alt="7" src="https://github.com/user-attachments/assets/8182f9f3-41b1-4f16-bcdc-9846d0b5018e" />
<img width="1906" height="911" alt="8" src="https://github.com/user-attachments/assets/1d21525d-1f48-4713-9e03-2e2bc03bbe68" />
<img width="1894" height="915" alt="9" src="https://github.com/user-attachments/assets/aed24036-5bac-4466-b297-b8b3f3df55be" />
<img width="1901" height="910" alt="11" src="https://github.com/user-attachments/assets/46d2b9a0-6e76-4e1c-9d02-989b5761f956" />
<img width="1912" height="908" alt="12" src="https://github.com/user-attachments/assets/96289e6f-7d06-42a4-8c9f-6036c596e75d" />
<img width="1896" height="896" alt="13" src="https://github.com/user-attachments/assets/7ed35861-2241-4855-ac6b-1329d3036754" />
<img width="1899" height="887" alt="14" src="https://github.com/user-attachments/assets/e85bb5dc-da5c-4e33-a90e-4a748a7dea27" />



## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [X] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [X] **This PR contains minimal changes necessary to address the issue/feature**
- [X] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [X] All new and existing tests pass
- [X] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [X] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
