### PR TITLE
fix(ingestion): keep WHERE clause for schema-qualified tables in DLT SQL parser

### DIFF
--- a/cognee/tasks/ingestion/create_dlt_source.py
+++ b/cognee/tasks/ingestion/create_dlt_source.py
@@ -76,7 +76,7 @@ def _parse_sql_query(query: str) -> tuple:
     """Extract table name and WHERE clause from a SELECT query.
     Returns (table_name, where_clause) or raises ValueError."""
     match = re.match(
-        r"SELECT\s+.+?\s+FROM\s+(\w+)(?:\s+WHERE\s+(.+))?",
+        r"SELECT\s+.+?\s+FROM\s+(\w+(?:\.\w+)*)(?:\s+WHERE\s+(.+))?",
         query.strip(),
         re.IGNORECASE | re.DOTALL,
     )

--- a/cognee/tests/unit/tasks/test_parse_sql_query.py
+++ b/cognee/tests/unit/tasks/test_parse_sql_query.py
@@ -1,0 +1,87 @@
+"""Unit tests for ``cognee.tasks.ingestion.create_dlt_source._parse_sql_query``.
+
+The parser feeds ``dlt``'s ``sql_database`` adapter: the captured ``table_name``
+selects which table to load and the ``where_clause`` filters rows. A silent
+mispin (wrong table or dropped WHERE) means the user gets back the whole table
+instead of the slice they asked for. These tests pin the parser against:
+
+  - bare table names (the original happy path)
+  - schema-qualified table names (regression for #3663)
+  - WHERE clauses with subqueries / quoted literals
+  - non-SELECT statements (must raise so the caller surfaces the bad input)
+"""
+
+import pytest
+
+from cognee.tasks.ingestion.create_dlt_source import _parse_sql_query
+
+
+def test_bare_table_name_no_where():
+    assert _parse_sql_query("SELECT * FROM users") == ("users", "1=1")
+
+
+def test_bare_table_name_with_where():
+    assert _parse_sql_query("SELECT * FROM users WHERE age > 18") == (
+        "users",
+        "age > 18",
+    )
+
+
+def test_schema_qualified_table_name_no_where():
+    # Regression for #3663: previously captured "public" and dropped ".users".
+    assert _parse_sql_query("SELECT * FROM public.users") == ("public.users", "1=1")
+
+
+def test_schema_qualified_table_name_with_where():
+    # Regression for #3663: the WHERE clause was silently dropped when the
+    # table name contained a dot, because the (\w+) capture ended at the dot
+    # and the trailing ".users WHERE ..." no longer matched the WHERE group.
+    assert _parse_sql_query("SELECT * FROM public.users WHERE age > 18") == (
+        "public.users",
+        "age > 18",
+    )
+
+
+def test_catalog_schema_table_name():
+    assert _parse_sql_query("SELECT id FROM analytics.events") == (
+        "analytics.events",
+        "1=1",
+    )
+
+
+def test_where_clause_with_quoted_string_containing_from():
+    # The non-greedy "FROM" splitter must not trip on "FROM" appearing inside
+    # a quoted literal in the WHERE clause.
+    assert _parse_sql_query(
+        "SELECT * FROM users WHERE note = 'imported FROM legacy'"
+    ) == ("users", "note = 'imported FROM legacy'")
+
+
+def test_where_clause_with_subquery():
+    assert _parse_sql_query(
+        "SELECT * FROM orders WHERE customer_id IN (SELECT id FROM vip_customers)"
+    ) == (
+        "orders",
+        "customer_id IN (SELECT id FROM vip_customers)",
+    )
+
+
+def test_case_insensitive_keywords():
+    assert _parse_sql_query("select id from public.users where active = true") == (
+        "public.users",
+        "active = true",
+    )
+
+
+def test_leading_trailing_whitespace_is_tolerated():
+    assert _parse_sql_query("  SELECT * FROM users\n") == ("users", "1=1")
+
+
+def test_non_select_query_raises():
+    with pytest.raises(ValueError):
+        _parse_sql_query("UPDATE users SET active = false")
+
+
+def test_missing_from_raises():
+    with pytest.raises(ValueError):
+        _parse_sql_query("SELECT 1 + 1")


### PR DESCRIPTION
## What Problem This Solves

Fixes #3663.

`_parse_sql_query` extracts the table name and WHERE clause from a user-supplied SQL string so the DLT `sql_database` adapter knows which table to read and how to filter rows. The table-name capture group was `(\w+)`, which stops at the first dot. For a schema-qualified name like `public.users`, the regex captured only `public`, and the trailing `.users WHERE ...` no longer matched the optional WHERE group — so the WHERE clause was silently dropped (fell back to `1=1`) and the wrong table name (`public`) was passed downstream.

End result: the user's row filter was ignored and the whole table was ingested instead of the requested slice.

## Why This Change Was Made

`(\w+)` could not represent SQL schema-qualified identifiers (`schema.table`, `catalog.schema.table`). Switching to `(\w+(?:\.\w+)*)` lets the capture span dotted identifiers cleanly without ever consuming a trailing dot, so the WHERE group matches again.

Bare table names and queries without a WHERE clause continue to behave exactly as before — `\w+(?:\.\w+)*` matches `users` identically to `\w+` when no dot is present.

The non-greedy `.+?` for the SELECT column list plus `re.DOTALL` means WHERE clauses containing quoted literals with embedded `FROM` or subqueries still parse correctly, as the unit tests pin.

## User Impact

- Schema-qualified SQL filters (e.g. `SELECT * FROM public.users WHERE age > 18`) now ingest only the matching rows instead of every row in `public`.
- DLT ingestion with filters against any non-default schema (`analytics.events`, ` reporting.fact_orders`) works as documented instead of silently swallowing the filter.
- Affected users: anyone passing a SQL query string with a schema-qualified table to `create_dlt_source_from_connection_string`.

## Evidence

- Pure-function regression tests added in `cognee/tests/unit/tasks/test_parse_sql_query.py` covering bare and schema-qualified table names, WHERE with quoted literals containing `FROM`, WHERE with subqueries, case-insensitive keywords, leading/trailing whitespace tolerance, and the `ValueError` path for non-SELECT / missing-FROM input.
- Verified the regex change directly against the repro cases from the issue:

```python
from cognee.tasks.ingestion.create_dlt_source import _parse_sql_query
_parse_sql_query("SELECT * FROM users")                       # ('users', '1=1')
_parse_sql_query("SELECT * FROM public.users WHERE age > 18") # ('public.users', 'age > 18')
_parse_sql_query("SELECT id FROM analytics.events")           # ('analytics.events', '1=1')
```

- No DB/LLM/network in the test path — the parser is pure string handling.
