### PR TITLE
fix: remove deprecated pydantic Field(env=...) from GraphConfig

### DIFF
--- a/cognee/infrastructure/databases/graph/config.py
+++ b/cognee/infrastructure/databases/graph/config.py
@@ -40,9 +40,11 @@ class GraphConfig(BaseSettings):
     - model_config
     """
 
-    # Using Field we are able to dynamically load current GRAPH_DATABASE_PROVIDER value in the model validator part
-    # and determine default graph db file and path based on this parameter if no values are provided
-    graph_database_provider: str = Field("ladybug", env="GRAPH_DATABASE_PROVIDER")
+    # pydantic-settings binds each field from its upper-cased name (e.g.
+    # GRAPH_DATABASE_PROVIDER) automatically, so no explicit env= is needed. The
+    # value is read here and the derived graph file/path are filled in the model
+    # validator below when no explicit values are provided.
+    graph_database_provider: str = Field("ladybug")
 
     graph_database_url: str = ""
     graph_database_name: str = ""
@@ -59,10 +61,11 @@ class GraphConfig(BaseSettings):
     graph_dataset_database_handler: str = "ladybug"
     graph_database_subprocess_enabled: bool = True
 
-    # Kuzu tuning. 0 means "use Kuzu's default" (one thread per CPU).
-    kuzu_num_threads: int = Field(0, env="KUZU_NUM_THREADS")
-    kuzu_buffer_pool_size: int = Field(DEFAULT_KUZU_BUFFER_POOL_SIZE, env="KUZU_BUFFER_POOL_SIZE")
-    kuzu_max_db_size: int = Field(DEFAULT_KUZU_MAX_DB_SIZE, env="KUZU_MAX_DB_SIZE")
+    # Kuzu tuning. 0 means "use Kuzu's default" (one thread per CPU). These bind
+    # from KUZU_NUM_THREADS / KUZU_BUFFER_POOL_SIZE / KUZU_MAX_DB_SIZE by field name.
+    kuzu_num_threads: int = Field(0)
+    kuzu_buffer_pool_size: int = Field(DEFAULT_KUZU_BUFFER_POOL_SIZE)
+    kuzu_max_db_size: int = Field(DEFAULT_KUZU_MAX_DB_SIZE)
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow", populate_by_name=True)
 

--- a/cognee/tests/unit/infrastructure/databases/graph/test_graph_config_env_binding.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_graph_config_env_binding.py
@@ -1,0 +1,54 @@
+"""Regression tests for GraphConfig environment-variable binding.
+
+GraphConfig previously declared fields with the deprecated pydantic
+``Field(..., env="...")`` keyword. pydantic-settings ignores ``env=`` (it binds
+each field from its upper-cased name), so the keyword only emitted
+``PydanticDeprecatedSince20`` warnings. These tests pin that:
+
+1. fields still bind from their environment variables by name, and
+2. importing the config module emits no ``env=`` deprecation warning.
+"""
+
+import importlib
+import warnings
+
+import pytest
+
+
+ENV_FIELDS = [
+    ("GRAPH_DATABASE_PROVIDER", "graph_database_provider", "neo4j", "neo4j"),
+    ("KUZU_NUM_THREADS", "kuzu_num_threads", "7", 7),
+    ("KUZU_BUFFER_POOL_SIZE", "kuzu_buffer_pool_size", "12345", 12345),
+    ("KUZU_MAX_DB_SIZE", "kuzu_max_db_size", "67890", 67890),
+]
+
+
+@pytest.mark.parametrize("env_name,field_name,raw_value,expected", ENV_FIELDS)
+def test_fields_bind_from_environment(monkeypatch, env_name, field_name, raw_value, expected):
+    """Each field still reads its value from the upper-cased env var by name."""
+    monkeypatch.setenv(env_name, raw_value)
+
+    from cognee.infrastructure.databases.graph.config import GraphConfig
+
+    config = GraphConfig()
+
+    # graph_database_provider is lower-cased by the model validator.
+    actual = getattr(config, field_name)
+    if isinstance(expected, str):
+        assert actual == expected.lower()
+    else:
+        assert actual == expected
+
+
+def test_no_field_env_deprecation_warning_on_import():
+    """Reloading the config module must not emit a Field(env=) deprecation warning."""
+    import cognee.infrastructure.databases.graph.config as config_module
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.reload(config_module)
+
+    offending = [w for w in caught if "extra keys: 'env'" in str(w.message).lower()]
+    assert not offending, (
+        f"unexpected env= deprecation warning(s): {[str(w.message) for w in offending]}"
+    )


### PR DESCRIPTION
### What

Removes the deprecated `Field(..., env="...")` keyword from the four `GraphConfig` fields in `cognee/infrastructure/databases/graph/config.py` and adds a regression test.

Fixes #3702.

### Why

`pydantic-settings` v2 binds each field from its upper-cased name, so `Field(env=...)` is ignored and only emits `PydanticDeprecatedSince20: ... (Extra keys: 'env')`. Every `env=` value here already equals the field name upper-cased, so removing it preserves behavior and eliminates the warning (which is on a hard-removal path in pydantic).

### Changes

- `config.py`: `Field("ladybug", env="GRAPH_DATABASE_PROVIDER")` → `Field("ladybug")` (and the three `kuzu_*` fields likewise); comments updated to explain name-based binding.
- New `test_graph_config_env_binding.py`:
  - parametrized test that each field still binds from its env var by name, and
  - a test that reloading the config module emits no `env=` deprecation warning.

### Verification

- `pytest cognee/tests/unit/infrastructure/databases/graph/test_graph_config_env_binding.py` → **5 passed**.
- The new deprecation test **fails on `dev`** and **passes with this change** (real regression coverage).
- `graph/config.py` deprecation warnings no longer appear under `-W always::DeprecationWarning`.
- Existing graph unit tests pass (23 passed; excludes neo4j/postgres extras not installed locally).
- `ruff format --check` and `ruff check` clean.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
