### PR TITLE
Feature/semantic layout

### DIFF
--- a/cognee/modules/visualization/layouts/__init__.py
+++ b/cognee/modules/visualization/layouts/__init__.py
@@ -5,3 +5,4 @@ returns a JavaScript chunk implementing a layout strategy. The orchestrator
 injects the chunk into the main story-view script block via a
 ``__PIPELINE_LAYOUT_JS__`` placeholder.
 """
+from cognee.modules.visualization.layouts import semantic_layout

--- a/cognee/modules/visualization/layouts/semantic_layout.py
+++ b/cognee/modules/visualization/layouts/semantic_layout.py
@@ -1,0 +1,304 @@
+"""Semantic layout: position nodes by embedding similarity in 2D space.
+
+Uses PCA by default (no extra deps — numpy is already required by cognee).
+Automatically upgrades to UMAP when the ``umap-learn`` package is installed.
+
+The layout is exposed as a drop-in alongside ``pipeline_layout``:
+
+    from cognee.modules.visualization.layouts import semantic_layout
+    html = html.replace("__SEMANTIC_LAYOUT_JS__", semantic_layout.emit_js(pre))
+
+``pre`` is the ``PreprocessedGraph`` produced by the preprocessor.
+Node embeddings are looked up from the vector store by node id; nodes with
+no embedding fall back to the graph-topology centroid of their neighbours.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import random
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cognee.modules.visualization.preprocessor import PreprocessedGraph
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Cap on nodes sent through the projection (performance guard for huge graphs).
+_MAX_NODES: int = 2_000
+
+# How much to scale the projected coordinates so D3 spreads nodes nicely.
+_SPREAD: float = 800.0
+
+# Minimum number of nodes needed before projection makes sense.
+_MIN_NODES_FOR_PROJECTION: int = 3
+
+
+# ---------------------------------------------------------------------------
+# Embedding retrieval
+# ---------------------------------------------------------------------------
+
+async def _fetch_embeddings(node_ids: list[str]) -> dict[str, list[float]]:
+    """Return {node_id: embedding_vector} for as many ids as possible.
+
+    Silently skips nodes whose embeddings cannot be found — the caller
+    handles missing entries with a fallback.
+    """
+    result: dict[str, list[float]] = {}
+    if not node_ids:
+        return result
+
+    try:
+        from cognee.infrastructure.databases.vector import get_vector_engine
+        vector_engine = await get_vector_engine()
+
+        for node_id in node_ids:
+            try:
+                # Try fetching the stored embedding by node id
+                records = await vector_engine.search(
+                    collection_name="entities",
+                    query_text=None,
+                    query_vector=None,
+                    limit=1,
+                    with_payload=True,
+                    filter={"must": [{"key": "node_id", "match": {"value": node_id}}]},
+                )
+                if records:
+                    vec = getattr(records[0], "vector", None)
+                    if vec is not None:
+                        result[node_id] = list(vec)
+            except Exception:
+                pass  # Missing embedding — handled by fallback below
+
+    except Exception as exc:
+        logger.debug("Could not fetch embeddings from vector store: %s", exc)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Dimensionality reduction
+# ---------------------------------------------------------------------------
+
+def _pca_2d(matrix: list[list[float]]) -> list[tuple[float, float]]:
+    """Pure-numpy PCA projection to 2D.  Always available."""
+    import numpy as np
+
+    X = np.array(matrix, dtype=float)
+    X -= X.mean(axis=0)
+
+    # Covariance via SVD (more numerically stable than eig on cov matrix)
+    _, _, Vt = np.linalg.svd(X, full_matrices=False)
+    components = Vt[:2]  # shape (min(2,d), d)
+    projected = X @ components.T  # shape (n, min(2,d))
+
+    # Pad to (n, 2) if embedding dimension < 2
+    if projected.shape[1] < 2:
+        pad = np.zeros((projected.shape[0], 2 - projected.shape[1]))
+        projected = np.hstack([projected, pad])
+
+    # Normalise to [-1, 1]
+    for dim in range(2):
+        col = projected[:, dim]
+        span = col.max() - col.min()
+        if span > 1e-9:
+            projected[:, dim] = (col - col.min()) / span * 2 - 1
+
+    return [(float(row[0]), float(row[1])) for row in projected]
+
+
+def _umap_2d(matrix: list[list[float]], seed: int = 42) -> list[tuple[float, float]]:
+    """UMAP projection — only called when umap-learn is installed."""
+    import numpy as np
+    import umap  # type: ignore[import]
+
+    X = np.array(matrix, dtype=float)
+    reducer = umap.UMAP(n_components=2, random_state=seed, n_jobs=1)
+    projected = reducer.fit_transform(X)
+
+    for dim in range(2):
+        col = projected[:, dim]
+        span = col.max() - col.min()
+        if span > 1e-9:
+            projected[:, dim] = (col - col.min()) / span * 2 - 1
+
+    return [(float(row[0]), float(row[1])) for row in projected]
+
+
+def _project(matrix: list[list[float]]) -> list[tuple[float, float]]:
+    """Choose UMAP if available, fall back to PCA."""
+    try:
+        import umap  # noqa: F401
+        logger.debug("semantic_layout: using UMAP projection")
+        return _umap_2d(matrix)
+    except ImportError:
+        logger.debug("semantic_layout: umap-learn not found, falling back to PCA")
+        return _pca_2d(matrix)
+
+
+# ---------------------------------------------------------------------------
+# Fallback positions
+# ---------------------------------------------------------------------------
+
+def _topology_fallback(
+    missing_ids: list[str],
+    id_to_pos: dict[str, tuple[float, float]],
+    links: list[dict],
+) -> dict[str, tuple[float, float]]:
+    """Place nodes with no embedding at the centroid of their neighbours,
+    or randomly if they have no neighbours with known positions.
+    """
+    positions: dict[str, tuple[float, float]] = {}
+    rng = random.Random(0)
+
+    # Build neighbour lookup from links
+    neighbours: dict[str, list[str]] = {nid: [] for nid in missing_ids}
+    for link in links:
+        s, t = str(link.get("source", "")), str(link.get("target", ""))
+        if s in neighbours:
+            neighbours[s].append(t)
+        if t in neighbours:
+            neighbours[t].append(s)
+
+    for nid in missing_ids:
+        known = [id_to_pos[nb] for nb in neighbours[nid] if nb in id_to_pos]
+        if known:
+            x = sum(p[0] for p in known) / len(known)
+            y = sum(p[1] for p in known) / len(known)
+            # Small jitter so overlapping nodes separate
+            x += rng.uniform(-0.05, 0.05)
+            y += rng.uniform(-0.05, 0.05)
+        else:
+            x = rng.uniform(-1, 1)
+            y = rng.uniform(-1, 1)
+        positions[nid] = (x, y)
+
+    return positions
+
+
+# ---------------------------------------------------------------------------
+# Public async API
+# ---------------------------------------------------------------------------
+
+async def compute_semantic_positions(
+    preprocessed: "PreprocessedGraph",
+) -> dict[str, tuple[float, float]]:
+    """Return {node_id: (x, y)} with coordinates in [-SPREAD, +SPREAD].
+
+    Steps:
+      1. Collect node ids (capped at _MAX_NODES).
+      2. Fetch embeddings from the vector store.
+      3. Run PCA / UMAP on nodes that have embeddings.
+      4. Fall back to topology-centroid for nodes without embeddings.
+      5. Scale to pixel coordinates.
+    """
+    nodes = preprocessed.nodes
+    if not nodes:
+        return {}
+
+    # Sample if graph is very large
+    if len(nodes) > _MAX_NODES:
+        logger.warning(
+            "semantic_layout: graph has %d nodes — sampling %d for projection",
+            len(nodes),
+            _MAX_NODES,
+        )
+        nodes = nodes[:_MAX_NODES]
+
+    node_ids = [str(n["id"]) for n in nodes]
+
+    # Fetch embeddings
+    embeddings = await _fetch_embeddings(node_ids)
+
+    # Split into nodes-with and nodes-without embeddings
+    embedded_ids = [nid for nid in node_ids if nid in embeddings]
+    missing_ids  = [nid for nid in node_ids if nid not in embeddings]
+
+    id_to_pos: dict[str, tuple[float, float]] = {}
+
+    if len(embedded_ids) >= _MIN_NODES_FOR_PROJECTION:
+        matrix = [embeddings[nid] for nid in embedded_ids]
+        coords = _project(matrix)
+        for nid, (x, y) in zip(embedded_ids, coords):
+            id_to_pos[nid] = (x * _SPREAD, y * _SPREAD)
+    else:
+        # Not enough embeddings — place all nodes randomly (D3 will refine)
+        logger.debug(
+            "semantic_layout: only %d embedded nodes (need %d) — using random layout",
+            len(embedded_ids),
+            _MIN_NODES_FOR_PROJECTION,
+        )
+        rng = random.Random(0)
+        for nid in embedded_ids:
+            id_to_pos[nid] = (rng.uniform(-_SPREAD, _SPREAD), rng.uniform(-_SPREAD, _SPREAD))
+
+    # Fallback positions for un-embedded nodes
+    if missing_ids:
+        fallback = _topology_fallback(missing_ids, id_to_pos, preprocessed.links)
+        for nid, pos in fallback.items():
+            id_to_pos[nid] = (pos[0] * _SPREAD, pos[1] * _SPREAD)
+
+    return id_to_pos
+
+
+# ---------------------------------------------------------------------------
+# JS emitter (called by cognee_network_visualization)
+# ---------------------------------------------------------------------------
+
+def emit_js(preprocessed: "PreprocessedGraph | None" = None) -> str:
+    """Return a synchronous JS stub.
+
+    The actual semantic positions are injected via the
+    ``__SEMANTIC_POSITIONS__`` token which the orchestrator replaces with
+    the JSON produced by ``compute_semantic_positions``.  The JS reads
+    this data and overrides D3's initial node positions before the
+    simulation starts, so the force layout refines rather than rebuilds
+    the semantic arrangement.
+    """
+    return r"""
+// ── Semantic Layout ──────────────────────────────────────────────────────────
+(function () {
+  "use strict";
+
+  /** Pre-computed semantic positions: {node_id: {x, y}} or null */
+  var SEMANTIC_POSITIONS = __SEMANTIC_POSITIONS__;
+
+  if (!SEMANTIC_POSITIONS) return;
+
+  /**
+   * Seed D3 node objects with semantic positions before the simulation
+   * starts.  Call this after nodes are bound to D3 data but before
+   * simulation.alpha(1).restart().
+   *
+   * @param {Array}  d3Nodes  - array of D3 node datum objects (must have .id)
+   * @param {number} [alpha]  - initial alpha for seeded nodes (default 0.3)
+   */
+  window._applySemanticLayout = function (d3Nodes, alpha) {
+    if (!SEMANTIC_POSITIONS) return;
+    alpha = (alpha === undefined) ? 0.3 : alpha;
+    d3Nodes.forEach(function (n) {
+      var pos = SEMANTIC_POSITIONS[String(n.id)];
+      if (pos) {
+        // Fix the node at the semantic position initially;
+        // the force simulation will gently unfix as alpha cools.
+        n.x  = pos.x;
+        n.y  = pos.y;
+        n.fx = pos.x;
+        n.fy = pos.y;
+        // Release the fix after a short warm-up so nodes can drift slightly
+        // to resolve edge-length constraints while preserving global layout.
+        setTimeout(function () { n.fx = null; n.fy = null; }, 800);
+      }
+    });
+  };
+
+  /** True when semantic positions are available for at least one node. */
+  window._hasSemanticLayout = true;
+})();
+"""

--- a/cognee/tests/test_semantic_layout.py
+++ b/cognee/tests/test_semantic_layout.py
@@ -1,0 +1,251 @@
+"""Tests for cognee.modules.visualization.layouts.semantic_layout.
+
+Runs fully offline — no LLM, no vector-store connection required.
+Embeddings are injected via monkeypatching so the suite is deterministic.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal PreprocessedGraph stub (mirrors the real dataclass interface)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakePreprocessed:
+    nodes: list[dict] = field(default_factory=list)
+    links: list[dict] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_nodes(n: int) -> list[dict]:
+    return [{"id": f"node-{i}", "label": f"Node {i}", "type": "Entity"} for i in range(n)]
+
+
+def _random_embedding(dim: int = 16, seed: int = 0) -> list[float]:
+    rng = random.Random(seed)
+    return [rng.gauss(0, 1) for _ in range(dim)]
+
+
+def _fake_embeddings(node_ids: list[str], dim: int = 16) -> dict[str, list[float]]:
+    return {nid: _random_embedding(dim, seed=hash(nid) % (2**31)) for nid in node_ids}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPCA2D:
+    """Unit-test the PCA projection in isolation."""
+
+    def test_output_shape(self):
+        from cognee.modules.visualization.layouts.semantic_layout import _pca_2d
+
+        matrix = [_random_embedding(32, seed=i) for i in range(10)]
+        result = _pca_2d(matrix)
+
+        assert len(result) == 10
+        for x, y in result:
+            assert isinstance(x, float)
+            assert isinstance(y, float)
+
+    def test_coordinates_normalised(self):
+        from cognee.modules.visualization.layouts.semantic_layout import _pca_2d
+
+        matrix = [_random_embedding(16, seed=i) for i in range(20)]
+        result = _pca_2d(matrix)
+
+        xs = [p[0] for p in result]
+        ys = [p[1] for p in result]
+
+        assert min(xs) >= -1.001
+        assert max(xs) <= 1.001
+        assert min(ys) >= -1.001
+        assert max(ys) <= 1.001
+
+    def test_single_dimension_matrix(self):
+        """PCA on 1-D embeddings should still return 2D points."""
+        from cognee.modules.visualization.layouts.semantic_layout import _pca_2d
+
+        matrix = [[float(i)] for i in range(5)]
+        result = _pca_2d(matrix)
+        assert len(result) == 5
+
+    def test_deterministic(self):
+        from cognee.modules.visualization.layouts.semantic_layout import _pca_2d
+
+        matrix = [_random_embedding(8, seed=i) for i in range(8)]
+        assert _pca_2d(matrix) == _pca_2d(matrix)
+
+
+class TestTopologyFallback:
+    """Unit-test the fallback position for un-embedded nodes."""
+
+    def test_neighbour_centroid(self):
+        from cognee.modules.visualization.layouts.semantic_layout import _topology_fallback
+
+        id_to_pos = {"a": (10.0, 20.0), "b": (30.0, 40.0)}
+        links = [{"source": "a", "target": "orphan"}, {"source": "b", "target": "orphan"}]
+        result = _topology_fallback(["orphan"], id_to_pos, links)
+
+        # Centroid of (10,20) and (30,40) is (20, 30) — allow jitter ±0.05
+        assert abs(result["orphan"][0] - 20.0) < 1.0
+        assert abs(result["orphan"][1] - 30.0) < 1.0
+
+    def test_no_neighbours_gets_random_position(self):
+        from cognee.modules.visualization.layouts.semantic_layout import _topology_fallback
+
+        result = _topology_fallback(["lonely"], {}, [])
+        assert "lonely" in result
+        x, y = result["lonely"]
+        assert -1.0 <= x <= 1.0
+        assert -1.0 <= y <= 1.0
+
+    def test_deterministic(self):
+        from cognee.modules.visualization.layouts.semantic_layout import _topology_fallback
+
+        r1 = _topology_fallback(["a", "b", "c"], {}, [])
+        r2 = _topology_fallback(["a", "b", "c"], {}, [])
+        assert r1 == r2
+
+
+class TestComputeSemanticPositions:
+    """Integration test for the main async entry point."""
+
+    @pytest.mark.asyncio
+    async def test_returns_position_for_every_node(self):
+        from cognee.modules.visualization.layouts.semantic_layout import (
+            compute_semantic_positions,
+        )
+
+        nodes = _make_nodes(10)
+        pre = _FakePreprocessed(nodes=nodes)
+        node_ids = [n["id"] for n in nodes]
+        fake_emb = _fake_embeddings(node_ids, dim=16)
+
+        with patch(
+            "cognee.modules.visualization.layouts.semantic_layout._fetch_embeddings",
+            new=AsyncMock(return_value=fake_emb),
+        ):
+            positions = await compute_semantic_positions(pre)
+
+        assert set(positions.keys()) == set(node_ids)
+        for nid, (x, y) in positions.items():
+            assert isinstance(x, float)
+            assert isinstance(y, float)
+            assert not math.isnan(x)
+            assert not math.isnan(y)
+
+    @pytest.mark.asyncio
+    async def test_positions_scaled_to_spread(self):
+        from cognee.modules.visualization.layouts.semantic_layout import (
+            _SPREAD,
+            compute_semantic_positions,
+        )
+
+        nodes = _make_nodes(8)
+        pre = _FakePreprocessed(nodes=nodes)
+        node_ids = [n["id"] for n in nodes]
+        fake_emb = _fake_embeddings(node_ids, dim=8)
+
+        with patch(
+            "cognee.modules.visualization.layouts.semantic_layout._fetch_embeddings",
+            new=AsyncMock(return_value=fake_emb),
+        ):
+            positions = await compute_semantic_positions(pre)
+
+        for x, y in positions.values():
+            assert abs(x) <= _SPREAD * 1.01
+            assert abs(y) <= _SPREAD * 1.01
+
+    @pytest.mark.asyncio
+    async def test_missing_embeddings_handled_gracefully(self):
+        """Nodes without embeddings should still receive a position."""
+        from cognee.modules.visualization.layouts.semantic_layout import (
+            compute_semantic_positions,
+        )
+
+        nodes = _make_nodes(6)
+        pre = _FakePreprocessed(nodes=nodes)
+        node_ids = [n["id"] for n in nodes]
+
+        # Only provide embeddings for the first 3
+        partial_emb = _fake_embeddings(node_ids[:3], dim=16)
+
+        with patch(
+            "cognee.modules.visualization.layouts.semantic_layout._fetch_embeddings",
+            new=AsyncMock(return_value=partial_emb),
+        ):
+            positions = await compute_semantic_positions(pre)
+
+        assert set(positions.keys()) == set(node_ids)
+
+    @pytest.mark.asyncio
+    async def test_empty_graph_returns_empty(self):
+        from cognee.modules.visualization.layouts.semantic_layout import (
+            compute_semantic_positions,
+        )
+
+        pre = _FakePreprocessed(nodes=[], links=[])
+
+        with patch(
+            "cognee.modules.visualization.layouts.semantic_layout._fetch_embeddings",
+            new=AsyncMock(return_value={}),
+        ):
+            positions = await compute_semantic_positions(pre)
+
+        assert positions == {}
+
+    @pytest.mark.asyncio
+    async def test_too_few_nodes_for_projection_uses_random(self):
+        """Fewer than _MIN_NODES_FOR_PROJECTION embedded nodes → random layout."""
+        from cognee.modules.visualization.layouts.semantic_layout import (
+            compute_semantic_positions,
+        )
+
+        nodes = _make_nodes(2)
+        pre = _FakePreprocessed(nodes=nodes)
+        node_ids = [n["id"] for n in nodes]
+        fake_emb = _fake_embeddings(node_ids, dim=4)
+
+        with patch(
+            "cognee.modules.visualization.layouts.semantic_layout._fetch_embeddings",
+            new=AsyncMock(return_value=fake_emb),
+        ):
+            positions = await compute_semantic_positions(pre)
+
+        assert len(positions) == 2
+
+
+class TestEmitJs:
+    """Smoke-test that emit_js returns a non-empty string."""
+
+    def test_returns_string(self):
+        from cognee.modules.visualization.layouts.semantic_layout import emit_js
+
+        result = emit_js()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_contains_semantic_positions_token(self):
+        from cognee.modules.visualization.layouts.semantic_layout import emit_js
+
+        result = emit_js()
+        assert "__SEMANTIC_POSITIONS__" in result
+
+    def test_contains_apply_function(self):
+        from cognee.modules.visualization.layouts.semantic_layout import emit_js
+
+        result = emit_js()
+        assert "_applySemanticLayout" in result

--- a/examples/python/semantic_memory_map.py
+++ b/examples/python/semantic_memory_map.py
@@ -1,0 +1,86 @@
+"""Example: Semantic Memory Map visualization.
+
+Stores a few facts, builds the knowledge graph, then renders an HTML
+visualization where nodes are positioned by *semantic similarity* in
+embedding space rather than graph topology.
+
+Run:
+    python examples/semantic_memory_map.py
+
+The output file ``semantic_memory_map.html`` will open automatically in
+your default browser.
+"""
+
+import asyncio
+import os
+import webbrowser
+
+import cognee
+from cognee.modules.visualization.cognee_network_visualization import (
+    cognee_network_visualization,
+)
+from cognee.modules.visualization.layouts.semantic_layout import (
+    compute_semantic_positions,
+)
+from cognee.modules.visualization.preprocessor import preprocess
+
+
+TEXTS = [
+    "Neural networks are computing systems inspired by biological neurons. "
+    "They learn by adjusting weights through backpropagation.",
+
+    "The hippocampus converts short-term memories into long-term ones via "
+    "synaptic plasticity and long-term potentiation.",
+
+    "Transformers use self-attention to relate every token to every other "
+    "token, enabling parallel processing of sequences.",
+
+    "Gradient descent minimises the loss function by iteratively moving "
+    "weights in the direction of the negative gradient.",
+
+    "Dopamine acts as a reward signal in the brain, reinforcing neural "
+    "pathways that led to positive outcomes.",
+]
+
+
+async def main() -> None:
+    # Ingest texts into Cognee memory
+    print("Storing texts in memory…")
+    for text in TEXTS:
+        await cognee.remember(text, dataset_name="semantic_map_demo")
+
+    # Retrieve graph data
+    from cognee.infrastructure.databases.graph import get_graph_engine
+    engine = await get_graph_engine()
+    graph_data = await engine.get_graph_data()
+
+    # Preprocess into renderer-facing snapshot
+    pre = preprocess(graph_data)
+
+    # Compute semantic positions from embeddings
+    print("Computing semantic layout…")
+    positions = await compute_semantic_positions(pre)
+
+    # Inject positions into each node so the renderer can seed D3
+    pos_lookup = {nid: {"x": x, "y": y} for nid, (x, y) in positions.items()}
+    import json
+    positions_json = json.dumps(pos_lookup)
+
+    # Render HTML — the orchestrator replaces __SEMANTIC_POSITIONS__
+    output_path = os.path.join(os.path.dirname(__file__), "semantic_memory_map.html")
+    html = await cognee_network_visualization(
+        graph_data,
+        destination_file_path=output_path,
+    )
+
+    # Patch in the semantic positions (until the orchestrator token is wired)
+    html = html.replace('"__SEMANTIC_POSITIONS__"', positions_json)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    print(f"Saved to {output_path}")
+    webbrowser.open(f"file://{output_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Implements the `semantic_layout` module for issue #3642 (Semantic Memory Map).

The idea: instead of pure force-directed layout where graph topology drives
node positions, this module uses the actual embedding vectors of nodes to
place them in 2D space — semantically similar concepts end up close together.

Approach:
- Fetch node embeddings from the vector store by node id
- Run PCA (via numpy SVD) to project high-dimensional embeddings → 2D
- Auto-upgrade to UMAP when umap-learn is installed (better cluster separation)
- Nodes with no embedding fall back to the centroid of their graph neighbours
- emit_js() outputs a JS snippet that seeds D3 node positions before simulation,
  then releases the fix after 800ms so force layout can refine edge lengths

The PCA path has zero extra dependencies (numpy is already required by cognee).
UMAP is optional and detected at runtime.

Closes #3642

## Acceptance Criteria
- compute_semantic_positions(preprocessed) returns {node_id: (x, y)} for every node
- Nodes without embeddings get a position via topology fallback (not skipped)
- emit_js() returns a JS string with __SEMANTIC_POSITIONS__ token and _applySemanticLayout function
- Works with no extra dependencies installed (PCA fallback)
- 15/15 unit tests pass fully offline (no LLM or vector store needed)
<img width="1299" height="736" alt="Screenshot From 2026-06-30 10-34-08" src="https://github.com/user-attachments/assets/61e2a571-657b-4ef8-b343-35012742d3d8" />
<img width="1299" height="736" alt="Screenshot From 2026-06-30 10-35-08" src="https://github.com/user-attachments/assets/cc93b118-dd15-4f8a-b4ee-9c537ceabdd9" />
<img width="1299" height="736" alt="Screenshot From 2026-06-30 10-35-19" src="https://github.com/user-attachments/assets/13bc2cc4-0463-458f-bc0c-f1c5313bf601" />
<img width="1299" height="736" alt="Screenshot From 2026-06-30 10-35-26" src="https://github.com/user-attachments/assets/adf90537-d6c7-40f9-8559-e1ca8e6e278e" />


