### PR TITLE
[codex] add CLI next-step hints

### DIFF
--- a/cognee/cli/commands/_next_step.py
+++ b/cognee/cli/commands/_next_step.py
@@ -1,0 +1,31 @@
+"""Shared next-step hints for the CLI."""
+
+from __future__ import annotations
+
+
+def format_next_step_hint(command: str, dataset_name: str | None = None) -> str:
+    """Return a short, copy-pasteable next command for common happy paths."""
+    command = (command or "").strip().lower()
+    dataset = (dataset_name or "").strip()
+
+    if command == "add":
+        if dataset:
+            return f"Next: `cognee cognify --datasets {dataset}`"
+        return "Next: `cognee cognify`"
+
+    if command == "cognify":
+        if dataset:
+            return f"Next: `cognee recall \"What did I add?\" --datasets {dataset}`"
+        return "Next: `cognee recall \"What did I add?\"`"
+
+    if command == "remember":
+        if dataset:
+            return f"Next: `cognee recall \"What did I add?\" --datasets {dataset}`"
+        return "Next: `cognee recall \"What did I add?\"`"
+
+    if command == "recall":
+        if dataset:
+            return f"Try adding data first: `cognee remember \"...\" --dataset-name {dataset}`"
+        return "Try adding data first: `cognee remember \"...\"`"
+
+    return ""

--- a/cognee/cli/commands/add_command.py
+++ b/cognee/cli/commands/add_command.py
@@ -6,6 +6,7 @@ from cognee.cli.reference import SupportsCliCommand
 from cognee.cli import DEFAULT_DOCS_URL
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.commands._next_step import format_next_step_hint
 
 
 class AddCommand(SupportsCliCommand):
@@ -73,6 +74,9 @@ After adding data, use `cognee cognify` to process it into knowledge graphs.
                     fmt.echo("Processing data...")
                     await cognee.add(data=data_to_add, dataset_name=args.dataset_name, user=user)
                     fmt.success(f"Successfully added data to dataset '{args.dataset_name}'")
+                    hint = format_next_step_hint("add", args.dataset_name)
+                    if hint:
+                        fmt.note(hint)
                 except Exception as e:
                     raise CliCommandInnerException(f"Failed to add data: {str(e)}") from e
 

--- a/cognee/cli/commands/cognify_command.py
+++ b/cognee/cli/commands/cognify_command.py
@@ -7,6 +7,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import CHUNKER_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.commands._next_step import format_next_step_hint
 
 
 class CognifyCommand(SupportsCliCommand):
@@ -139,6 +140,10 @@ After successful cognify processing, use `cognee search` to query the knowledge 
                 fmt.success("Cognification completed successfully!")
                 if args.verbose and result:
                     fmt.echo(f"Processing results: {result}")
+
+            hint = format_next_step_hint("cognify", datasets[0] if datasets else None)
+            if hint:
+                fmt.note(hint)
 
         except Exception as e:
             if isinstance(e, CliCommandInnerException):

--- a/cognee/cli/commands/recall_command.py
+++ b/cognee/cli/commands/recall_command.py
@@ -7,6 +7,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import SEARCH_TYPE_CHOICES, OUTPUT_FORMAT_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.commands._next_step import format_next_step_hint
 
 
 class RecallCommand(SupportsCliCommand):
@@ -129,6 +130,11 @@ Otherwise, this is a memory-oriented alias for `cognee search`.
             else:
                 if not results:
                     fmt.warning("No results found for your query.")
+                    hint = format_next_step_hint(
+                        "recall", args.datasets[0] if args.datasets else None
+                    )
+                    if hint:
+                        fmt.note(hint)
                     return
 
                 # Detect session results by _source tag

--- a/cognee/cli/commands/remember_command.py
+++ b/cognee/cli/commands/remember_command.py
@@ -6,6 +6,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import CHUNKER_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.commands._next_step import format_next_step_hint
 
 
 class RememberCommand(SupportsCliCommand):
@@ -102,6 +103,10 @@ After completion, use `cognee recall` (or `cognee search`) to query the graph.
                 fmt.success("Data ingested and cognification started in background!")
             else:
                 fmt.success("Data ingested and knowledge graph built successfully!")
+
+            hint = format_next_step_hint("remember", args.dataset_name)
+            if hint:
+                fmt.note(hint)
 
             if result:
                 if result.dataset_id:

--- a/cognee/tests/unit/cli/test_next_step_hints.py
+++ b/cognee/tests/unit/cli/test_next_step_hints.py
@@ -1,0 +1,154 @@
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from cognee.cli.commands._next_step import format_next_step_hint
+
+add_module = pytest.importorskip("cognee.cli.commands.add_command")
+cognify_module = pytest.importorskip("cognee.cli.commands.cognify_command")
+remember_module = pytest.importorskip("cognee.cli.commands.remember_command")
+recall_module = pytest.importorskip("cognee.cli.commands.recall_command")
+
+
+def _capture_cli(monkeypatch):
+    captured = []
+
+    monkeypatch.setattr(add_module.fmt, "echo", lambda message: captured.append(message))
+    monkeypatch.setattr(add_module.fmt, "success", lambda message: captured.append(message))
+    monkeypatch.setattr(add_module.fmt, "note", lambda message: captured.append(message))
+    monkeypatch.setattr(add_module.fmt, "warning", lambda message: captured.append(message))
+
+    monkeypatch.setattr(cognify_module.fmt, "echo", lambda message: captured.append(message))
+    monkeypatch.setattr(cognify_module.fmt, "success", lambda message: captured.append(message))
+    monkeypatch.setattr(cognify_module.fmt, "note", lambda message: captured.append(message))
+    monkeypatch.setattr(cognify_module.fmt, "warning", lambda message: captured.append(message))
+
+    monkeypatch.setattr(remember_module.fmt, "echo", lambda message: captured.append(message))
+    monkeypatch.setattr(remember_module.fmt, "success", lambda message: captured.append(message))
+    monkeypatch.setattr(remember_module.fmt, "note", lambda message: captured.append(message))
+    monkeypatch.setattr(remember_module.fmt, "warning", lambda message: captured.append(message))
+
+    monkeypatch.setattr(recall_module.fmt, "echo", lambda message: captured.append(message))
+    monkeypatch.setattr(recall_module.fmt, "success", lambda message: captured.append(message))
+    monkeypatch.setattr(recall_module.fmt, "note", lambda message: captured.append(message))
+    monkeypatch.setattr(recall_module.fmt, "warning", lambda message: captured.append(message))
+
+    return captured
+
+
+def test_format_next_step_hint_uses_dataset_name():
+    assert format_next_step_hint("add", "main_dataset") == "Next: `cognee cognify --datasets main_dataset`"
+    assert format_next_step_hint("recall", "main_dataset") == (
+        "Try adding data first: `cognee remember \"...\" --dataset-name main_dataset`"
+    )
+
+
+def test_add_command_prints_next_step_hint(monkeypatch):
+    captured = _capture_cli(monkeypatch)
+
+    async def fake_add(**kwargs):
+        return None
+
+    async def fake_resolve_cli_user(_user_id, strict=False):
+        return SimpleNamespace(id="user-1")
+
+    import cognee
+
+    monkeypatch.setattr(cognee, "add", fake_add)
+    monkeypatch.setattr("cognee.cli.user_resolution.resolve_cli_user", fake_resolve_cli_user)
+
+    command = add_module.AddCommand()
+    parser = argparse.ArgumentParser()
+    command.configure_parser(parser)
+    args = parser.parse_args(["hello", "--dataset-name", "main_dataset"])
+
+    command.execute(args)
+
+    assert any("Successfully added data" in message for message in captured)
+    assert any("Next: `cognee cognify --datasets main_dataset`" in message for message in captured)
+
+
+def test_cognify_command_prints_next_step_hint(monkeypatch):
+    captured = _capture_cli(monkeypatch)
+
+    async def fake_cognify(**kwargs):
+        return True
+
+    async def fake_resolve_cli_user(_user_id, strict=False):
+        return SimpleNamespace(id="user-1")
+
+    class FakeTextChunker:
+        pass
+
+    import cognee
+
+    monkeypatch.setattr(cognee, "cognify", fake_cognify)
+    monkeypatch.setattr("cognee.cli.user_resolution.resolve_cli_user", fake_resolve_cli_user)
+    monkeypatch.setattr("cognee.modules.chunking.TextChunker.TextChunker", FakeTextChunker, raising=False)
+
+    command = cognify_module.CognifyCommand()
+    parser = argparse.ArgumentParser()
+    command.configure_parser(parser)
+    args = parser.parse_args(["--datasets", "main_dataset"])
+
+    command.execute(args)
+
+    assert any("Cognification completed successfully!" in message for message in captured)
+    assert any("Next: `cognee recall \"What did I add?\" --datasets main_dataset`" in message for message in captured)
+
+
+def test_remember_command_prints_next_step_hint(monkeypatch):
+    captured = _capture_cli(monkeypatch)
+
+    async def fake_remember(**kwargs):
+        return SimpleNamespace(
+            dataset_id="dataset-1",
+            items_processed=1,
+            content_hash="hash",
+            elapsed_seconds=1.2,
+        )
+
+    async def fake_resolve_cli_user(_user_id, strict=False):
+        return SimpleNamespace(id="user-1")
+
+    monkeypatch.setattr("cognee.modules.chunking.TextChunker.TextChunker", object, raising=False)
+    monkeypatch.setattr("cognee.cli.user_resolution.resolve_cli_user", fake_resolve_cli_user)
+    import cognee
+
+    monkeypatch.setattr(cognee, "remember", fake_remember)
+
+    command = remember_module.RememberCommand()
+    parser = argparse.ArgumentParser()
+    command.configure_parser(parser)
+    args = parser.parse_args(["hello", "--dataset-name", "main_dataset"])
+
+    command.execute(args)
+
+    assert any("Data ingested and knowledge graph built successfully!" in message for message in captured)
+    assert any("Next: `cognee recall \"What did I add?\" --datasets main_dataset`" in message for message in captured)
+
+
+def test_recall_command_prints_next_step_hint_when_empty(monkeypatch):
+    captured = _capture_cli(monkeypatch)
+
+    async def fake_recall(**kwargs):
+        return []
+
+    async def fake_resolve_cli_user(_user_id, strict=False):
+        return SimpleNamespace(id="user-1")
+
+    monkeypatch.setattr("cognee.cli.user_resolution.resolve_cli_user", fake_resolve_cli_user)
+    import cognee
+
+    monkeypatch.setattr(cognee, "recall", fake_recall)
+
+    command = recall_module.RecallCommand()
+    parser = argparse.ArgumentParser()
+    command.configure_parser(parser)
+    args = parser.parse_args(["hello", "--datasets", "main_dataset"])
+
+    command.execute(args)
+
+    assert any("No results found for your query." in message for message in captured)
+    assert any("Try adding data first: `cognee remember \"...\" --dataset-name main_dataset`" in message for message in captured)


### PR DESCRIPTION
## Summary
- add shared next-step hint formatting for common CLI happy paths
- show a copy-pasteable follow-up command after add, cognify, remember, and empty recall
- cover the new behavior with focused unit tests

## Verification
- uv run pytest cognee/tests/unit/cli/test_next_step_hints.py -q
- uv run python -m compileall cognee/cli/commands/_next_step.py cognee/cli/commands/add_command.py cognee/cli/commands/cognify_command.py cognee/cli/commands/remember_command.py cognee/cli/commands/recall_command.py cognee/tests/unit/cli/test_next_step_hints.py
