### PR TITLE
fix(neo4j): add missing await in has_node and fix has_edge return type

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -176,7 +176,7 @@ class Neo4jAdapter(GraphDBInterface):
 
             - bool: True if the node exists, otherwise False.
         """
-        results = self.query(
+        results = await self.query(
             f"""
                 MATCH (n:`{BASE_LABEL}`)
                 WHERE n.id = $node_id
@@ -460,9 +460,9 @@ class Neo4jAdapter(GraphDBInterface):
             - bool: True if the edge exists, otherwise False.
         """
         query = f"""
-            MATCH (from_node: `{BASE_LABEL}`)-[:`{edge_label}`]->(to_node: `{BASE_LABEL}`)
+            MATCH (from_node: `{BASE_LABEL}`)-[r:`{edge_label}`]->(to_node: `{BASE_LABEL}`)
             WHERE from_node.id = $from_node_id AND to_node.id = $to_node_id
-            RETURN COUNT(relationship) > 0 AS edge_exists
+            RETURN COUNT(r) > 0 AS edge_exists
         """
 
         params = {
@@ -470,8 +470,8 @@ class Neo4jAdapter(GraphDBInterface):
             "to_node_id": str(to_node),
         }
 
-        edge_exists = await self.query(query, params)
-        return edge_exists
+        results = await self.query(query, params)
+        return results[0]["edge_exists"] if results else False
 
     async def has_edges(self, edges):
         """


### PR DESCRIPTION
Two bug fixes in the Neo4j adapter:

1. has_node() - Missing await before self.query(). Fixed by adding await.
2. has_edge() - Cypher used COUNT(relationship) on unbound variable, and returned raw List[Dict] instead of bool. Fixed by binding relationship var and extracting bool from result.