### PR TITLE
fix: resolve Ladybug subprocess DB lock race via async engine resolution (#3708)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -467,6 +467,20 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #VECTOR_DB_PASSWORD=""
 #VECTOR_DB_SUBPROCESS_ENABLED=true
 
+# -- Database subprocess workers — advanced tuning ----------------------------
+# The embedded DB engines (Kuzu/Ladybug graph, LanceDB vector) run their native
+# client in a dedicated worker process. These knobs tune that harness.
+# Per-RPC deadline guarding against a hung native call (seconds; <=0 disables).
+#SUBPROCESS_CALL_TIMEOUT=300
+# How many times a failed subprocess RPC is retried (respawning the worker).
+#SUBPROCESS_MAX_RETRIES=2
+# Backstop for the brief window where one graph worker is still releasing a
+# file lock while another opens the same DB path: the worker retries the open
+# this many times, with exponential backoff starting at this many seconds
+# (per-attempt backoff is capped internally).
+#SUBPROCESS_OPEN_LOCK_RETRIES=10
+#SUBPROCESS_OPEN_LOCK_BACKOFF=0.1
+
 # -- AWS / Bedrock extras (in addition to the AWS section above) --------------
 #AWS_PROFILE_NAME=""
 #AWS_BEDROCK_RUNTIME_ENDPOINT=""

--- a/cognee-mcp/src/codingagents/coding_rule_associations.py
+++ b/cognee-mcp/src/codingagents/coding_rule_associations.py
@@ -54,7 +54,7 @@ async def get_existing_rules(rules_nodeset_name: str) -> str:
 
 
 async def get_origin_edges(data: str, rules: List[Rule]) -> list[Any]:
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     origin_chunk = await vector_engine.search("DocumentChunk_text", data, limit=1)
 

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -328,7 +328,7 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
         # EXTRACT: split Documents into semantic text chunks
         Task(
             extract_chunks_from_documents,
-            max_chunk_size=chunk_size or get_max_chunk_tokens(),
+            max_chunk_size=chunk_size or await get_max_chunk_tokens(),
             chunker=chunker,
         ),
         # COGNIFY: LLM-extract entities and relationships into a knowledge graph
@@ -387,7 +387,7 @@ async def get_temporal_tasks(
         # EXTRACT: split Documents into semantic text chunks
         Task(
             extract_chunks_from_documents,
-            max_chunk_size=chunk_size or get_max_chunk_tokens(),
+            max_chunk_size=chunk_size or await get_max_chunk_tokens(),
             chunker=chunker,
         ),
         # COGNIFY: extract temporal events and timestamps from chunks

--- a/cognee/api/v1/health/health.py
+++ b/cognee/api/v1/health/health.py
@@ -84,7 +84,7 @@ class HealthChecker:
             from cognee.infrastructure.databases.vector.config import get_vectordb_config
 
             config = get_vectordb_config()
-            engine = get_vector_engine()
+            engine = await get_vector_engine()
 
             # Test basic operation - just check if engine is accessible
             if hasattr(engine, "health_check"):

--- a/cognee/eval_framework/corpus_builder/task_getters/get_cascade_graph_tasks.py
+++ b/cognee/eval_framework/corpus_builder/task_getters/get_cascade_graph_tasks.py
@@ -31,7 +31,7 @@ async def get_cascade_graph_tasks(
         default_tasks = [
             Task(classify_documents),
             Task(
-                extract_chunks_from_documents, max_chunk_tokens=get_max_chunk_tokens()
+                extract_chunks_from_documents, max_chunk_tokens=await get_max_chunk_tokens()
             ),  # Extract text chunks based on the document type.
             Task(
                 extract_graph_from_data, task_config={"batch_size": 10}

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -195,42 +195,41 @@ class DatasetQueue:
 
     # ----------------------------------------- subprocess engine teardown
     async def _teardown_subprocess_engines(self) -> None:
-        """Evict and close subprocess-mode engines so DB file locks are released.
+        """Evict subprocess-mode engines so their DB file locks get released.
 
         Reads the current task's ContextVar-based graph/vector config to
-        identify which cached engines to tear down.  Lazy imports avoid
+        identify which cached engines to tear down. Lazy imports avoid
         circular dependencies at module load time.
+
+        We **evict** (detach) rather than force-``close()``: the
+        ``ClosingLRUCache`` lease then closes the underlying adapter — releasing
+        the worker and its on-disk file lock — as soon as the last outstanding
+        reference is dropped. In the normal pipeline flow nothing holds the
+        engine past the context, so the close fires immediately (the leased
+        proxy is collected right after eviction). A caller that still holds the
+        engine reference keeps a working (stale-but-live) adapter until it drops
+        the reference, instead of getting an "adapter is closed" error on reuse
+        — restoring the pre-async-resolution contract without re-adding the
+        re-resolving handles. A later re-creation for the same key awaits any
+        in-flight close via the cache's closing registry, so the file lock is
+        never double-acquired.
         """
         from cognee.infrastructure.databases.graph.config import get_graph_context_config
         from cognee.infrastructure.databases.vector.config import get_vectordb_context_config
 
         g_cfg = get_graph_context_config()
         if g_cfg.get("graph_database_subprocess_enabled"):
-            from cognee.infrastructure.databases.graph.get_graph_engine import (
-                create_graph_engine,
-                evict_graph_engine,
-                is_graph_engine_cached,
-            )
+            from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
 
-            if is_graph_engine_cached(**g_cfg):
-                engine = create_graph_engine(**g_cfg)
-                evict_graph_engine(**g_cfg)
-                if hasattr(engine, "close"):
-                    await engine.close()
+            evict_graph_engine(**g_cfg)
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
             from cognee.infrastructure.databases.vector.create_vector_engine import (
-                create_vector_engine,
                 evict_vector_engine,
-                is_vector_engine_cached,
             )
 
-            if is_vector_engine_cached(**v_cfg):
-                engine = create_vector_engine(**v_cfg)
-                evict_vector_engine(**v_cfg)
-                if hasattr(engine, "close"):
-                    await engine.close()
+            evict_vector_engine(**v_cfg)
 
     # -------------------------------------------------------- release_slot_for
     async def release_slot_for(self, dataset_id: Any = None) -> None:

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -195,41 +195,42 @@ class DatasetQueue:
 
     # ----------------------------------------- subprocess engine teardown
     async def _teardown_subprocess_engines(self) -> None:
-        """Evict subprocess-mode engines so their DB file locks get released.
+        """Evict and close subprocess-mode engines so DB file locks are released.
 
         Reads the current task's ContextVar-based graph/vector config to
-        identify which cached engines to tear down. Lazy imports avoid
+        identify which cached engines to tear down.  Lazy imports avoid
         circular dependencies at module load time.
-
-        We **evict** (detach) rather than force-``close()``: the
-        ``ClosingLRUCache`` lease then closes the underlying adapter — releasing
-        the worker and its on-disk file lock — as soon as the last outstanding
-        reference is dropped. In the normal pipeline flow nothing holds the
-        engine past the context, so the close fires immediately (the leased
-        proxy is collected right after eviction). A caller that still holds the
-        engine reference keeps a working (stale-but-live) adapter until it drops
-        the reference, instead of getting an "adapter is closed" error on reuse
-        — restoring the pre-async-resolution contract without re-adding the
-        re-resolving handles. A later re-creation for the same key awaits any
-        in-flight close via the cache's closing registry, so the file lock is
-        never double-acquired.
         """
         from cognee.infrastructure.databases.graph.config import get_graph_context_config
         from cognee.infrastructure.databases.vector.config import get_vectordb_context_config
 
         g_cfg = get_graph_context_config()
         if g_cfg.get("graph_database_subprocess_enabled"):
-            from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
+            from cognee.infrastructure.databases.graph.get_graph_engine import (
+                create_graph_engine,
+                evict_graph_engine,
+                is_graph_engine_cached,
+            )
 
-            evict_graph_engine(**g_cfg)
+            if is_graph_engine_cached(**g_cfg):
+                engine = create_graph_engine(**g_cfg)
+                evict_graph_engine(**g_cfg)
+                if hasattr(engine, "close"):
+                    await engine.close()
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
             from cognee.infrastructure.databases.vector.create_vector_engine import (
+                create_vector_engine,
                 evict_vector_engine,
+                is_vector_engine_cached,
             )
 
-            evict_vector_engine(**v_cfg)
+            if is_vector_engine_cached(**v_cfg):
+                engine = create_vector_engine(**v_cfg)
+                evict_vector_engine(**v_cfg)
+                if hasattr(engine, "close"):
+                    await engine.close()
 
     # -------------------------------------------------------- release_slot_for
     async def release_slot_for(self, dataset_id: Any = None) -> None:

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -57,17 +57,20 @@ def _normalize_optional_create_graph_engine_params(params: dict) -> dict:
 
 
 async def get_graph_engine() -> GraphDBInterface:
-    """Factory function to get the appropriate graph client based on the graph type.
+    """Resolve the graph engine for the current context and return the live
+    adapter (a leased proxy from ``closing_lru_cache``).
 
-    SPIKE NOTE (async-engine-resolution): this previously returned a
-    ``_GraphEngineHandle`` whose ``__getattr__`` synchronously re-resolved the
-    engine via ``create_graph_engine(**config)`` on every attribute access. We
-    now resolve the engine eagerly and return the live adapter (a leased proxy
-    from ``closing_lru_cache``) directly, so resolution can ``await`` in the
-    caller's event loop. Trade-off: callers that *store* the result across a
-    cache-invalidating op (prune / delete / context exit) hold a proxy whose
-    entry may be detached and must re-call ``get_graph_engine()`` afterwards
-    instead of relying on the old transparent re-resolution.
+    Resolution is asynchronous and goes through :func:`acreate_graph_engine` so
+    that engine *creation* can ``await`` an in-flight close of the same cache
+    key before constructing — see that function for why the factory is async.
+    This is what makes the fix for the subprocess DB file-lock race (#3708)
+    deterministic: a re-created engine never opens a DB path whose previous
+    worker is still shutting down and holding the lock.
+
+    Note: the returned adapter is a live reference for the *current* async
+    scope. Callers should not stash it on a long-lived object and reuse it
+    across a cache-invalidating operation (prune / delete / per-dataset context
+    exit); call ``get_graph_engine()`` again after such an operation.
     """
     config = get_graph_context_config()
     engine = await acreate_graph_engine(**config)
@@ -147,12 +150,29 @@ def create_graph_engine(
 
 
 async def acreate_graph_engine(**kwargs):
-    """Async counterpart of :func:`create_graph_engine` that waits for any
-    in-flight close of the same cache key before constructing a new engine.
+    """Async counterpart of :func:`create_graph_engine`, used as the primary
+    creation path (via :func:`get_graph_engine`).
 
-    Used by ``get_graph_engine`` so a freshly evicted subprocess engine's worker
-    has fully exited (releasing its file lock) before a new worker opens the
-    same DB path.
+    Why the factory is async
+    ------------------------
+    The subprocess-backed graph engine (Ladybug/Kuzu) holds an exclusive on-disk
+    file lock for the worker's lifetime. Engines are cached in
+    ``closing_lru_cache``; when an entry is evicted its ``close()`` (worker
+    shutdown, which releases the lock) runs asynchronously. A *synchronous*
+    factory has no way to wait for that close, so re-creating an engine for the
+    same DB path could spawn a second worker that races the still-closing first
+    one and fails with "Could not set lock on file" (#3708).
+
+    Making creation ``async`` lets the cache's ``aget_or_create`` **await the
+    in-flight close of the same key on the caller's event loop** before
+    constructing — the awaiting creator yields the loop so the close task runs
+    to completion (worker exits, lock released) first. This is what removes the
+    race deterministically, without needing an off-loop close thread or a
+    re-resolving engine handle.
+
+    Delegates to :func:`create_graph_engine`'s normalization
+    (:func:`_resolve_graph_engine_args`) so the cache key is identical to the
+    sync path.
     """
     if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
         return _make_pghybrid_adapter()

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -70,10 +70,51 @@ async def get_graph_engine() -> GraphDBInterface:
     instead of relying on the old transparent re-resolution.
     """
     config = get_graph_context_config()
-    engine = create_graph_engine(**config)
+    engine = await acreate_graph_engine(**config)
     if hasattr(engine, "initialize"):
         await engine.initialize()
     return engine
+
+
+def _make_pghybrid_adapter():
+    """Build the uncached Postgres hybrid adapter used when
+    ``USE_UNIFIED_PROVIDER=pghybrid``. Not cached — the caller owns it, matching
+    the original inline behavior."""
+    from .postgres.adapter import PostgresAdapter
+    from cognee.infrastructure.databases.relational.get_relational_engine import (
+        get_relational_engine,
+    )
+
+    return PostgresAdapter(connection_string=get_relational_engine().db_uri)
+
+
+def _resolve_graph_engine_args(params: dict) -> tuple:
+    """Normalize engine parameters and return the positional argument tuple
+    passed to ``_create_graph_engine``.
+
+    Shared by the sync (:func:`create_graph_engine`) and async
+    (:func:`acreate_graph_engine`) entry points so both produce the *identical*
+    cache key (the positional tuple) — and so it matches the key built by
+    ``evict_graph_engine`` / ``is_graph_engine_cached``.
+    """
+    normalized = _normalize_optional_create_graph_engine_params(params)
+    return (
+        _normalize_graph_database_provider(params.get("graph_database_provider")),
+        params.get("graph_file_path"),
+        normalized["graph_database_url"],
+        normalized["graph_database_name"],
+        normalized["graph_database_username"],
+        normalized["graph_database_password"],
+        normalized["graph_database_host"],
+        normalized["graph_database_allow_anonymous"],
+        normalized["graph_database_port"],
+        normalized["graph_database_key"],
+        normalized["graph_dataset_database_handler"],
+        normalized["graph_database_subprocess_enabled"],
+        normalized["kuzu_num_threads"],
+        normalized["kuzu_buffer_pool_size"],
+        normalized["kuzu_max_db_size"],
+    )
 
 
 def create_graph_engine(
@@ -98,54 +139,25 @@ def create_graph_engine(
     For a detailed description, see _create_graph_engine.
     """
 
-    normalized_optional_params = _normalize_optional_create_graph_engine_params(locals())
-    graph_database_url = normalized_optional_params["graph_database_url"]
-    graph_database_provider = _normalize_graph_database_provider(graph_database_provider)
-    graph_database_name = normalized_optional_params["graph_database_name"]
-    graph_database_username = normalized_optional_params["graph_database_username"]
-    graph_database_password = normalized_optional_params["graph_database_password"]
-    graph_database_host = normalized_optional_params["graph_database_host"]
-    graph_database_allow_anonymous = normalized_optional_params["graph_database_allow_anonymous"]
-    graph_database_port = normalized_optional_params["graph_database_port"]
-    graph_database_key = normalized_optional_params["graph_database_key"]
-    graph_dataset_database_handler = normalized_optional_params["graph_dataset_database_handler"]
-    # The Kuzu/subprocess params also went through ``_normalize_optional_*``;
-    # reassign so callers passing ``None`` see the function-default applied
-    # (otherwise ``None`` would flow into the cache key and the factory).
-    graph_database_subprocess_enabled = normalized_optional_params[
-        "graph_database_subprocess_enabled"
-    ]
-    kuzu_num_threads = normalized_optional_params["kuzu_num_threads"]
-    kuzu_buffer_pool_size = normalized_optional_params["kuzu_buffer_pool_size"]
-    kuzu_max_db_size = normalized_optional_params["kuzu_max_db_size"]
-
     # Check USE_UNIFIED_PROVIDER outside the cache so it's always re-read
-    unified_provider = os.environ.get("USE_UNIFIED_PROVIDER", "")
-    if unified_provider == "pghybrid":
-        from .postgres.adapter import PostgresAdapter
-        from cognee.infrastructure.databases.relational.get_relational_engine import (
-            get_relational_engine,
-        )
+    if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
+        return _make_pghybrid_adapter()
 
-        return PostgresAdapter(connection_string=get_relational_engine().db_uri)
+    return _create_graph_engine(*_resolve_graph_engine_args(locals()))
 
-    return _create_graph_engine(
-        graph_database_provider,
-        graph_file_path,
-        graph_database_url,
-        graph_database_name,
-        graph_database_username,
-        graph_database_password,
-        graph_database_host,
-        graph_database_allow_anonymous,
-        graph_database_port,
-        graph_database_key,
-        graph_dataset_database_handler,
-        graph_database_subprocess_enabled,
-        kuzu_num_threads,
-        kuzu_buffer_pool_size,
-        kuzu_max_db_size,
-    )
+
+async def acreate_graph_engine(**kwargs):
+    """Async counterpart of :func:`create_graph_engine` that waits for any
+    in-flight close of the same cache key before constructing a new engine.
+
+    Used by ``get_graph_engine`` so a freshly evicted subprocess engine's worker
+    has fully exited (releasing its file lock) before a new worker opens the
+    same DB path.
+    """
+    if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
+        return _make_pghybrid_adapter()
+
+    return await _create_graph_engine.acall(*_resolve_graph_engine_args(kwargs))
 
 
 def evict_graph_engine(**kwargs) -> bool:

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -56,63 +56,24 @@ def _normalize_optional_create_graph_engine_params(params: dict) -> dict:
     return normalized
 
 
-class _GraphEngineHandle:
-    """Stable reference to the current graph engine that survives cache invalidation.
-
-    Database engine instances are cached via ``closing_lru_cache``.  Several
-    operations invalidate that cache — ``prune_system`` calls ``cache_clear()``,
-    ``delete_dataset`` evicts individual entries, and the ``__aexit__`` of
-    ``set_database_global_context_variables`` evicts subprocess-mode engines to
-    release file locks.  When an entry is evicted the underlying adapter is
-    closed, so any direct proxy reference becomes a dead object that raises
-    "adapter is closed" on use.
-
-    This handle solves the problem by deferring resolution: every attribute
-    access calls ``create_graph_engine(**config)`` which either returns the
-    existing cached proxy (fast path) or transparently creates a fresh adapter
-    if the old one was evicted (recovery path).  Code that stores the return
-    value of ``get_graph_engine()`` — even across ``cognify``, ``search``,
-    ``prune``, or ``delete`` calls — always reaches a live adapter without
-    needing to re-call ``get_graph_engine()``.
-
-    For adapters that expose ``initialize()`` (Postgres, Neo4j), the handle
-    tracks which engine proxy was last initialized and re-runs the idempotent
-    schema setup when the underlying engine changes.
-    """
-
-    __slots__ = ("_config", "_last_initialized_id")
-
-    def __init__(self, config: dict):
-        object.__setattr__(self, "_config", config)
-        object.__setattr__(self, "_last_initialized_id", None)
-
-    def _engine(self):
-        return create_graph_engine(**self._config)
-
-    async def _ensure_initialized(self):
-        engine = self._engine()
-        engine_id = id(engine)
-        if engine_id != self._last_initialized_id and hasattr(engine, "initialize"):
-            await engine.initialize()
-        object.__setattr__(self, "_last_initialized_id", engine_id)
-
-    @property
-    def __class__(self):
-        return self._engine().__class__
-
-    def __getattr__(self, name):
-        return getattr(self._engine(), name)
-
-    def __repr__(self):
-        return f"<GraphEngineHandle config={self._config!r}>"
-
-
 async def get_graph_engine() -> GraphDBInterface:
-    """Factory function to get the appropriate graph client based on the graph type."""
+    """Factory function to get the appropriate graph client based on the graph type.
+
+    SPIKE NOTE (async-engine-resolution): this previously returned a
+    ``_GraphEngineHandle`` whose ``__getattr__`` synchronously re-resolved the
+    engine via ``create_graph_engine(**config)`` on every attribute access. We
+    now resolve the engine eagerly and return the live adapter (a leased proxy
+    from ``closing_lru_cache``) directly, so resolution can ``await`` in the
+    caller's event loop. Trade-off: callers that *store* the result across a
+    cache-invalidating op (prune / delete / context exit) hold a proxy whose
+    entry may be detached and must re-call ``get_graph_engine()`` afterwards
+    instead of relying on the old transparent re-resolution.
+    """
     config = get_graph_context_config()
-    handle = _GraphEngineHandle(config)
-    await handle._ensure_initialized()
-    return handle
+    engine = create_graph_engine(**config)
+    if hasattr(engine, "initialize"):
+        await engine.initialize()
+    return engine
 
 
 def create_graph_engine(

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -2,7 +2,6 @@
 
 import inspect
 import os
-import weakref
 from numbers import Number
 
 from cognee.infrastructure.databases.utils.closing_lru_cache import closing_lru_cache
@@ -15,15 +14,6 @@ from .graph_db_interface import GraphDBInterface
 from .supported_databases import supported_databases
 
 logger = get_logger("GraphEngine")
-
-# Engines whose idempotent ``initialize()`` (schema/constraint setup for
-# Postgres/Neo4j) has already run this process. Keyed by the leased engine proxy
-# (stable per cache entry) via a WeakSet so entries drop automatically when the
-# engine is evicted + collected, and a freshly created engine for the same key
-# re-initializes. Replaces the old ``_GraphEngineHandle._last_initialized_id``
-# guard so we don't issue a redundant ``initialize()`` round-trip on every
-# ``get_graph_engine()`` resolution. (Ladybug has no ``initialize`` — no effect.)
-_INITIALIZED_ENGINES: "weakref.WeakSet" = weakref.WeakSet()
 
 
 def _normalize_graph_database_provider(provider: str) -> str:
@@ -66,31 +56,140 @@ def _normalize_optional_create_graph_engine_params(params: dict) -> dict:
     return normalized
 
 
-async def get_graph_engine() -> GraphDBInterface:
-    """Resolve the graph engine for the current context and return the live
-    adapter (a leased proxy from ``closing_lru_cache``).
+class _GraphEngineHandle:
+    """Stable reference to the current graph engine that survives cache invalidation.
 
-    Resolution is asynchronous and goes through :func:`acreate_graph_engine` so
-    that engine *creation* can ``await`` an in-flight close of the same cache
-    key before constructing — see that function for why the factory is async.
-    This is what makes the fix for the subprocess DB file-lock race (#3708)
-    deterministic: a re-created engine never opens a DB path whose previous
-    worker is still shutting down and holding the lock.
+    Database engine instances are cached via ``closing_lru_cache``.  Several
+    operations invalidate that cache — ``prune_system`` calls ``cache_clear()``,
+    ``delete_dataset`` evicts individual entries, and the ``__aexit__`` of
+    ``set_database_global_context_variables`` evicts subprocess-mode engines to
+    release file locks.  When an entry is evicted the underlying adapter is
+    closed, so any direct proxy reference becomes a dead object that raises
+    "adapter is closed" on use.
 
-    Note: the returned adapter is a live reference for the *current* async
-    scope. Callers should not stash it on a long-lived object and reuse it
-    across a cache-invalidating operation (prune / delete / per-dataset context
-    exit); call ``get_graph_engine()`` again after such an operation.
+    This handle solves the problem by deferring resolution: every attribute
+    access calls ``create_graph_engine(**config)`` which either returns the
+    existing cached proxy (fast path) or transparently creates a fresh adapter
+    if the old one was evicted (recovery path).  Code that stores the return
+    value of ``get_graph_engine()`` — even across ``cognify``, ``search``,
+    ``prune``, or ``delete`` calls — always reaches a live adapter without
+    needing to re-call ``get_graph_engine()``.
+
+    For adapters that expose ``initialize()`` (Postgres, Neo4j), the handle
+    tracks which engine proxy was last initialized and re-runs the idempotent
+    schema setup when the underlying engine changes.
+
+    Known limitation (subprocess + exclusive file lock, e.g. Ladybug): the cache
+    leases a single shared proxy per entry, so two concurrently-held handles for
+    the same DB path pin the *same* proxy. If that entry is evicted while one
+    handle keeps holding it and never re-resolves (a long-lived, idle second
+    handle), the old worker's close stays deferred — it does not release the
+    file lock, and a fresh engine for the same path falls back to the worker's
+    open-retry (``SUBPROCESS_OPEN_LOCK_RETRIES``) rather than the deterministic
+    await-the-close path. This is inherent to "one exclusive lock per path with
+    concurrent live holders" and is narrow in practice: the primary multi-tenant
+    teardown path (``dataset_queue._teardown_subprocess_engines``) ``await``s
+    ``engine.close()`` to completion before any re-creation, and a handle that is
+    accessed again or garbage-collected drops its stale pin and converges. A
+    permanently-idle second handle is the only unrescued case.
     """
+
+    __slots__ = ("_config", "_last_initialized_id", "_pinned")
+
+    def __init__(self, config: dict):
+        object.__setattr__(self, "_config", config)
+        object.__setattr__(self, "_last_initialized_id", None)
+        # Pinned leased engine proxy. Holding it avoids re-entering the cache on
+        # every attribute access (and the create-vs-close race that re-entry
+        # caused). It is dropped + re-resolved once the pin is no longer the
+        # live cache entry (see ``_pin_is_live``) so prune/delete eviction still
+        # recovers a fresh engine instead of keeping an evicted DB worker alive.
+        object.__setattr__(self, "_pinned", None)
+
+    @staticmethod
+    def _pin_is_live(engine) -> bool:
+        """Whether a pinned engine is still the live cached value and safe to
+        reuse. A leased proxy whose entry was evicted must be released so its
+        deferred close can run (otherwise a pinned handle would keep an evicted
+        Ladybug worker alive holding the file lock, blocking a new worker)."""
+        active = getattr(engine, "_leased_entry_active", None)
+        if active is not None:
+            try:
+                if not active():
+                    return False
+            except Exception:
+                return False
+        # Subprocess adapters latch ``_permanently_closed`` on close.
+        if getattr(engine, "_permanently_closed", False):
+            return False
+        return True
+
+    def _release_stale_pin(self, pinned) -> None:
+        """Drop the stale pinned proxy BEFORE re-resolving a replacement.
+
+        Critical for the lock race: the pinned proxy is (typically) the last
+        reference keeping an evicted adapter alive. Releasing it lets the
+        deferred close start — and a subprocess adapter's close runs off-loop,
+        releasing the on-disk file lock — *before* a new worker opens the same
+        path. Holding the pin across the re-resolution would keep the old worker
+        alive and the new one would fail to take the lock.
+        """
+        object.__setattr__(self, "_pinned", None)
+        del pinned
+
+    def _engine(self):
+        """Synchronous resolution used on the hot attribute-access path. Reuses
+        the pin when live; otherwise drops it and re-resolves through the (sync)
+        cache. A mid-flow re-resolution can't await an in-flight close — the
+        off-loop close + worker open-retry backstop cover that residual race."""
+        pinned = self._pinned
+        if pinned is not None and self._pin_is_live(pinned):
+            return pinned
+        if pinned is not None:
+            self._release_stale_pin(pinned)
+            pinned = None
+        engine = create_graph_engine(**self._config)
+        object.__setattr__(self, "_pinned", engine)
+        return engine
+
+    async def _aengine(self):
+        """Async resolution used at initialization. Goes through the cache's
+        async acquisition path so it waits for any in-flight close of the same
+        key before constructing a new engine + pinning it."""
+        pinned = self._pinned
+        if pinned is not None and self._pin_is_live(pinned):
+            return pinned
+        if pinned is not None:
+            self._release_stale_pin(pinned)
+            pinned = None
+        engine = await acreate_graph_engine(**self._config)
+        object.__setattr__(self, "_pinned", engine)
+        return engine
+
+    async def _ensure_initialized(self):
+        engine = await self._aengine()
+        engine_id = id(engine)
+        if engine_id != self._last_initialized_id and hasattr(engine, "initialize"):
+            await engine.initialize()
+        object.__setattr__(self, "_last_initialized_id", engine_id)
+
+    @property
+    def __class__(self):
+        return self._engine().__class__
+
+    def __getattr__(self, name):
+        return getattr(self._engine(), name)
+
+    def __repr__(self):
+        return f"<GraphEngineHandle config={self._config!r}>"
+
+
+async def get_graph_engine() -> GraphDBInterface:
+    """Factory function to get the appropriate graph client based on the graph type."""
     config = get_graph_context_config()
-    engine = await acreate_graph_engine(**config)
-    # Run the idempotent schema/constraint setup once per engine instance, not on
-    # every resolve — guarded by ``_INITIALIZED_ENGINES`` (membership is by proxy
-    # identity, so a re-created engine after eviction initializes again).
-    if hasattr(engine, "initialize") and engine not in _INITIALIZED_ENGINES:
-        await engine.initialize()
-        _INITIALIZED_ENGINES.add(engine)
-    return engine
+    handle = _GraphEngineHandle(config)
+    await handle._ensure_initialized()
+    return handle
 
 
 def _make_pghybrid_adapter():
@@ -106,7 +205,7 @@ def _make_pghybrid_adapter():
 
 
 def _resolve_graph_engine_args(params: dict) -> tuple:
-    """Normalize engine parameters and return the positional argument tuple
+    """Normalize the engine parameters and return the positional argument tuple
     passed to ``_create_graph_engine``.
 
     Shared by the sync (:func:`create_graph_engine`) and async
@@ -155,7 +254,6 @@ def create_graph_engine(
     Wrapper function to call create graph engine with caching.
     For a detailed description, see _create_graph_engine.
     """
-
     # Check USE_UNIFIED_PROVIDER outside the cache so it's always re-read
     if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
         return _make_pghybrid_adapter()
@@ -164,29 +262,12 @@ def create_graph_engine(
 
 
 async def acreate_graph_engine(**kwargs):
-    """Async counterpart of :func:`create_graph_engine`, used as the primary
-    creation path (via :func:`get_graph_engine`).
+    """Async counterpart of :func:`create_graph_engine` that waits for any
+    in-flight close of the same cache key before constructing a new engine.
 
-    Why the factory is async
-    ------------------------
-    The subprocess-backed graph engine (Ladybug/Kuzu) holds an exclusive on-disk
-    file lock for the worker's lifetime. Engines are cached in
-    ``closing_lru_cache``; when an entry is evicted its ``close()`` (worker
-    shutdown, which releases the lock) runs asynchronously. A *synchronous*
-    factory has no way to wait for that close, so re-creating an engine for the
-    same DB path could spawn a second worker that races the still-closing first
-    one and fails with "Could not set lock on file" (#3708).
-
-    Making creation ``async`` lets the cache's ``aget_or_create`` **await the
-    in-flight close of the same key on the caller's event loop** before
-    constructing — the awaiting creator yields the loop so the close task runs
-    to completion (worker exits, lock released) first. This is what removes the
-    race deterministically, without needing an off-loop close thread or a
-    re-resolving engine handle.
-
-    Delegates to :func:`create_graph_engine`'s normalization
-    (:func:`_resolve_graph_engine_args`) so the cache key is identical to the
-    sync path.
+    Used by ``get_graph_engine``'s handle at initialization so a freshly evicted
+    subprocess engine's worker has fully exited (releasing its file lock) before
+    a new worker opens the same DB path.
     """
     if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
         return _make_pghybrid_adapter()

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -2,6 +2,7 @@
 
 import inspect
 import os
+import weakref
 from numbers import Number
 
 from cognee.infrastructure.databases.utils.closing_lru_cache import closing_lru_cache
@@ -14,6 +15,15 @@ from .graph_db_interface import GraphDBInterface
 from .supported_databases import supported_databases
 
 logger = get_logger("GraphEngine")
+
+# Engines whose idempotent ``initialize()`` (schema/constraint setup for
+# Postgres/Neo4j) has already run this process. Keyed by the leased engine proxy
+# (stable per cache entry) via a WeakSet so entries drop automatically when the
+# engine is evicted + collected, and a freshly created engine for the same key
+# re-initializes. Replaces the old ``_GraphEngineHandle._last_initialized_id``
+# guard so we don't issue a redundant ``initialize()`` round-trip on every
+# ``get_graph_engine()`` resolution. (Ladybug has no ``initialize`` — no effect.)
+_INITIALIZED_ENGINES: "weakref.WeakSet" = weakref.WeakSet()
 
 
 def _normalize_graph_database_provider(provider: str) -> str:
@@ -74,8 +84,12 @@ async def get_graph_engine() -> GraphDBInterface:
     """
     config = get_graph_context_config()
     engine = await acreate_graph_engine(**config)
-    if hasattr(engine, "initialize"):
+    # Run the idempotent schema/constraint setup once per engine instance, not on
+    # every resolve — guarded by ``_INITIALIZED_ENGINES`` (membership is by proxy
+    # identity, so a re-created engine after eviction initializes again).
+    if hasattr(engine, "initialize") and engine not in _INITIALIZED_ENGINES:
         await engine.initialize()
+        _INITIALIZED_ENGINES.add(engine)
     return engine
 
 

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -218,7 +218,7 @@ class LadybugAdapter(GraphDBInterface):
         # down, surfacing "cannot schedule new futures after shutdown".
         # ``threading.Lock`` (not ``asyncio.Lock``) for cross-loop safety:
         # ``close()`` may be invoked from a foreign loop via
-        # ``closing_lru_cache._close_value`` running ``asyncio.run``.
+        # ``closing_lru_cache._start_close`` running ``asyncio.run``.
         self._lifecycle_lock = threading.Lock()
 
     def _ensure_schema(self) -> None:
@@ -741,7 +741,7 @@ class LadybugAdapter(GraphDBInterface):
         Intentionally does **not** hold ``_connection_lock``: that lock is an
         ``asyncio.Lock`` bound to the loop on which the adapter was created.
         LRU eviction may invoke ``close()`` from a different loop (for
-        example via ``asyncio.run`` in ``closing_lru_cache._close_value``),
+        example via ``asyncio.run`` in ``closing_lru_cache._start_close``),
         and awaiting a foreign-loop lock raises "got Future attached to a
         different loop". After this call the adapter is not reusable — see
         ``_drop_native_resources`` if you want a transient drop.
@@ -784,7 +784,7 @@ class LadybugAdapter(GraphDBInterface):
         # worker thread so awaiting ``close()`` doesn't freeze the calling
         # event loop. ``asyncio.to_thread`` is safe across loops — required
         # because ``close()`` may be invoked from a foreign loop via
-        # ``closing_lru_cache._close_value`` running ``asyncio.run``.
+        # ``closing_lru_cache._start_close`` running ``asyncio.run``.
         if executor is not None:
             await asyncio.to_thread(executor.shutdown, True)
         # In subprocess mode, ``_drop_native_resources`` calls

--- a/cognee/infrastructure/databases/unified/get_unified_engine.py
+++ b/cognee/infrastructure/databases/unified/get_unified_engine.py
@@ -75,7 +75,7 @@ async def _create_hybrid_adapter(graph_config: dict, vector_config: dict):
 
         # Vector adapter: reuse the cached PGVectorAdapter from the
         # vector engine factory. This requires VECTOR_DB_PROVIDER=pgvector.
-        vector_adapter = get_vector_engine()
+        vector_adapter = await get_vector_engine()
 
         return PostgresHybridAdapter(
             graph_adapter=graph_adapter,
@@ -117,7 +117,7 @@ async def get_unified_engine() -> UnifiedStoreEngine:
         )
 
     graph_engine = await get_graph_engine()
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     return UnifiedStoreEngine(
         graph_engine=graph_engine,

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -1,6 +1,7 @@
 """LRU cache that closes entries after they leave the cache and caller scope."""
 
 import asyncio
+import concurrent.futures
 import inspect
 import logging
 import weakref
@@ -39,14 +40,28 @@ _PENDING_CLOSE_TASKS: set = set()
 _KW_MARK = object()
 
 
-def _close_value(value):
-    """Call close() on a value, scheduling it as a task if it returns a coroutine.
+def _start_close(value) -> Optional[concurrent.futures.Future]:
+    """Begin closing a value and return a ``concurrent.futures.Future`` that
+    resolves once the close (including any async worker-process teardown) has
+    completed — or ``None`` when there is nothing to wait for (no ``close()``,
+    a sync ``close()`` that already finished, or a ``close()`` that raised
+    synchronously).
 
-    If close() is async and no event loop is running, falls back to
-    ``asyncio.run()`` to ensure cleanup is not silently skipped.
+    The returned future lets the cache track "this key is still closing" so a
+    later async creation for the same key can ``await`` it before opening a new
+    DB worker on the same path (see ``ClosingLRUCache._track_close`` /
+    ``aget_or_create``). It is a thread-safe ``concurrent.futures.Future`` so an
+    async waiter can ``await asyncio.wrap_future(...)`` it and sync callers can
+    poll it.
+
+    Because engine resolution is async (see ``get_graph_engine`` /
+    ``get_vector_engine``), the async ``close()`` is run as an ordinary task on
+    the running loop and the awaiting creator yields the loop so it can run — no
+    off-loop thread is needed. Falls back to ``asyncio.run()`` when no loop is
+    running (e.g. a GC finalizer firing off-loop, or interpreter teardown).
     """
     if not hasattr(value, "close"):
-        return
+        return None
     try:
         result = value.close()
     except Exception:
@@ -59,55 +74,88 @@ def _close_value(value):
             type(value).__name__,
             exc_info=True,
         )
-        return
-    if asyncio.iscoroutine(result):
+        return None
+    if not asyncio.iscoroutine(result):
+        # Sync close() already completed.
+        return None
+
+    value_type = type(value).__name__
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop: run to completion now (original fallback). Return an
+        # already-resolved future so callers see a uniform type and never block
+        # on it (it's done before they look).
+        cf: concurrent.futures.Future = concurrent.futures.Future()
         try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            try:
-                asyncio.run(result)
-            except Exception:
-                logger.warning(
-                    "Failed to run async close() for %s during eviction",
-                    type(value).__name__,
-                    exc_info=True,
-                )
-            return
+            asyncio.run(result)
+        except Exception:
+            logger.warning(
+                "Failed to run async close() for %s during eviction",
+                value_type,
+                exc_info=True,
+            )
+        cf.set_result(None)
+        return cf
 
-        task = loop.create_task(result)
-        _PENDING_CLOSE_TASKS.add(task)
+    # Running loop: schedule the close as a task and mirror its completion into a
+    # concurrent.futures.Future. A creator awaiting on the same loop via
+    # ``asyncio.wrap_future`` yields control so this task can run (no deadlock).
+    cf = concurrent.futures.Future()
+    task = loop.create_task(result)
+    _PENDING_CLOSE_TASKS.add(task)
 
-        def _on_close_done(done_task, _value_type=type(value).__name__):
-            # Always drop the strong ref so the task can be collected.
-            _PENDING_CLOSE_TASKS.discard(done_task)
-            # Retrieve the result so failures surface through the same
-            # structured ``logger.warning`` channel as the sync /
-            # ``asyncio.run()`` branches above. Without this, an async
-            # ``close()`` that raises only surfaces as Python's
-            # "Task exception was never retrieved" warning at GC time,
-            # which ops greps for ``Failed to run async close()`` would miss.
-            try:
-                done_task.result()
-            except Exception:
-                logger.warning(
-                    "Failed to run async close() for %s during eviction",
-                    _value_type,
-                    exc_info=True,
-                )
+    def _on_close_done(done_task, _value_type=value_type, _cf=cf):
+        # Always drop the strong ref so the task can be collected.
+        _PENDING_CLOSE_TASKS.discard(done_task)
+        # Retrieve the result so failures surface through the same structured
+        # ``logger.warning`` channel as the ``asyncio.run()`` branch. Without
+        # this, an async ``close()`` that raises only surfaces as Python's
+        # "Task exception was never retrieved" warning at GC time.
+        try:
+            done_task.result()
+        except Exception:
+            logger.warning(
+                "Failed to run async close() for %s during eviction",
+                _value_type,
+                exc_info=True,
+            )
+        # Always resolve the mirror future as done (never propagate the close
+        # failure to waiters — a creator should proceed regardless; the worker
+        # open-retry covers a still-held lock).
+        if not _cf.done():
+            _cf.set_result(None)
 
-        task.add_done_callback(_on_close_done)
+    task.add_done_callback(_on_close_done)
+    return cf
 
 
 class _LeasedCacheEntry:
     """Own one cached value and close it after cache + returned proxy are gone."""
 
-    def __init__(self, value):
+    def __init__(self, value, key=None, cache=None):
         self.value = value
+        # ``key`` + ``cache`` let the deferred close paths (``proxy_released``,
+        # ``detach_from_cache``) register the close as in-flight under this
+        # entry's cache key, so a later ``aget_or_create`` for the same key can
+        # wait for the lock-holding worker to exit. ``cache`` is the owning
+        # ``ClosingLRUCache``; ``None`` keeps the entry usable in isolation
+        # (tests construct it directly).
+        self.key = key
+        self.cache = cache
         self.proxy = None
         self.in_cache = True
         self.close_requested = False
         self.closed = False
         self._lock = Lock()
+
+    def _close(self, value):
+        """Route a close through the owning cache so it is tracked as in-flight
+        for this key; fall back to an untracked close when there is no cache."""
+        if self.cache is not None:
+            self.cache._track_close(self.key, value)
+        else:
+            _start_close(value)
 
     def lease(self):
         with self._lock:
@@ -126,7 +174,7 @@ class _LeasedCacheEntry:
                 value_to_close = self.value
 
         if value_to_close is not None:
-            _close_value(value_to_close)
+            self._close(value_to_close)
 
     def detach_from_cache(self):
         value_to_close = None
@@ -141,7 +189,7 @@ class _LeasedCacheEntry:
                 value_to_close = self.value
 
         if value_to_close is not None:
-            _close_value(value_to_close)
+            self._close(value_to_close)
         # Keep ``proxy_to_drop`` alive until after ``self._lock`` is released.
         # If the cache held the last proxy reference, dropping it can run the
         # weakref finalizer, which re-enters ``proxy_released()``.
@@ -232,20 +280,49 @@ class ClosingLRUCache:
         self._maxsize = maxsize
         self._lease = lease
         self._lock = Lock()
+        # Keyed registry of in-flight closes. A key is present here from the
+        # moment its value's ``close()`` actually starts until that close
+        # (including async worker-process teardown) completes. ``aget_or_create``
+        # waits on the matching future before constructing a new value, so a new
+        # DB worker never opens a file path whose previous worker is still
+        # releasing its lock. Guarded by ``self._lock``.
+        self._closing: dict = {}
+
+    def _track_close(self, key, value) -> None:
+        """Close ``value`` and, if the close is async/in-flight, record it under
+        ``key`` so a concurrent ``aget_or_create`` for the same key waits for it.
+
+        A ``None`` / already-resolved future means the close finished
+        synchronously, so there is nothing to register.
+        """
+        cf = _start_close(value)
+        if cf is None or cf.done():
+            return
+        with self._lock:
+            self._closing[key] = cf
+
+        def _cleanup(done_future, _key=key):
+            with self._lock:
+                # Only clear if we are still the registered future — a newer
+                # close for the same key may have superseded us.
+                if self._closing.get(_key) is done_future:
+                    self._closing.pop(_key, None)
+
+        cf.add_done_callback(_cleanup)
 
     def _wrap_cached_value(self, entry):
         if self._lease:
             return entry.lease()
         return entry.value
 
-    def _make_entry(self, value):
-        return _LeasedCacheEntry(value)
+    def _make_entry(self, key, value):
+        return _LeasedCacheEntry(value, key=key, cache=self)
 
     def _detach_entry(self, entry):
         if self._lease:
             entry.detach_from_cache()
         else:
-            _close_value(entry.value)
+            self._track_close(entry.key, entry.value)
 
     def get_or_create(self, key, factory):
         # Disabled-cache mode: act as a pass-through. Caller owns the value's
@@ -259,10 +336,10 @@ class ClosingLRUCache:
                 return self._wrap_cached_value(self._cache[key])
 
         value = factory()
-        entry = self._make_entry(value)
+        entry = self._make_entry(key, value)
 
-        # Decide outcome under the lock; defer ``_close_value`` until
-        # after release. ``_close_value`` can run arbitrary user code
+        # Decide outcome under the lock; defer ``_track_close`` until
+        # after release. The close can run arbitrary user code
         # (sync ``close()``, ``asyncio.run`` for an async ``close()``,
         # logging) and even re-enter cache creation in some adapter
         # close paths — running it under ``self._lock`` would either
@@ -283,10 +360,45 @@ class ClosingLRUCache:
                 cached = self._wrap_cached_value(entry)
 
         if loser_value is not None:
-            _close_value(loser_value)
+            self._track_close(key, loser_value)
         if evicted_value is not None:
             self._detach_entry(evicted_value)
         return cached
+
+    async def aget_or_create(self, key, factory):
+        """Async counterpart of :meth:`get_or_create` that waits for an in-flight
+        close of the same key before constructing a new value.
+
+        This is the point of the closing registry: when an entry was just
+        evicted and its DB worker is still shutting down (still holding the
+        on-disk file lock), constructing a new value here would spawn a second
+        worker that races the first for the lock and fails. Awaiting the close
+        future via ``asyncio.wrap_future`` suspends this coroutine without
+        blocking the loop, so the close (which runs as a task on this same loop)
+        can complete — releasing the lock — before we construct.
+
+        Construction itself still goes through the synchronous
+        :meth:`get_or_create` (which re-checks the cache and only calls
+        ``factory`` on a miss).
+        """
+        if self._maxsize == 0:
+            return factory()
+
+        with self._lock:
+            if key in self._cache:
+                self._cache.move_to_end(key)
+                return self._wrap_cached_value(self._cache[key])
+            pending_close = self._closing.get(key)
+
+        if pending_close is not None and not pending_close.done():
+            try:
+                await asyncio.wrap_future(pending_close)
+            except Exception:
+                # The close future never propagates failures (see _start_close);
+                # this guard is belt-and-suspenders so a creator always proceeds.
+                pass
+
+        return self.get_or_create(key, factory)
 
     def cache_clear(self):
         """Close and remove all cached entries."""
@@ -352,6 +464,13 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True):
         def wrapper(*args, **kwargs):
             return cache.get_or_create(_key(args, kwargs), lambda: fn(*args, **kwargs))
 
+        async def acall(*args, **kwargs):
+            """Async acquisition that waits for an in-flight close of the same
+            key before constructing. Pass exactly the args the sync ``wrapper``
+            would use so the cache key matches.
+            """
+            return await cache.aget_or_create(_key(args, kwargs), lambda: fn(*args, **kwargs))
+
         def cache_evict(*args, **kwargs) -> bool:
             """Evict a single entry whose key matches the given args.
 
@@ -369,6 +488,7 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True):
         wrapper.cache_evict = cache_evict
         wrapper.cache_contains = cache_contains
         wrapper.cache_info = cache.cache_info
+        wrapper.acall = acall
         wrapper.__wrapped__ = fn
         return wrapper
 

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -33,6 +33,31 @@ class CacheInfo(dict):
 _PENDING_CLOSE_TASKS: set = set()
 
 
+# Dedicated threads for closing subprocess-backed adapters off the caller's
+# event loop. Such adapters hold an OS file lock via a worker process; a
+# *synchronous* re-resolution for the same DB path (e.g. the engine handle's
+# ``__getattr__`` path) blocks the event loop while the new worker waits, which
+# would prevent a loop-scheduled close from ever running and releasing the lock.
+# Running these closes on their own thread frees the lock regardless of loop
+# availability. Safe because the subprocess adapters' ``close()`` is written to
+# be event-loop-agnostic (no loop-bound locks; all native teardown via
+# ``asyncio.to_thread`` / blocking ``session.shutdown``).
+_CLOSE_THREAD_POOL = concurrent.futures.ThreadPoolExecutor(
+    max_workers=4, thread_name_prefix="closing-lru-close"
+)
+
+
+def _run_close_coro_blocking(coro, value_type) -> None:
+    try:
+        asyncio.run(coro)
+    except Exception:
+        logger.warning(
+            "Failed to run async close() for %s during eviction",
+            value_type,
+            exc_info=True,
+        )
+
+
 # Sentinel separating positional from keyword args in cache keys. Mirrors
 # ``functools.lru_cache``'s ``_kwd_mark`` so calls like ``fn(("a", 1))``
 # and ``fn(a=1)`` map to distinct entries — without it, both would
@@ -48,17 +73,18 @@ def _start_close(value) -> Optional[concurrent.futures.Future]:
     synchronously).
 
     The returned future lets the cache track "this key is still closing" so a
-    later async creation for the same key can ``await`` it before opening a new
-    DB worker on the same path (see ``ClosingLRUCache._track_close`` /
+    later creation for the same key can wait for the lock-holding worker to
+    exit before opening the DB again (see ``ClosingLRUCache._track_close`` /
     ``aget_or_create``). It is a thread-safe ``concurrent.futures.Future`` so an
-    async waiter can ``await asyncio.wrap_future(...)`` it and sync callers can
-    poll it.
+    async waiter on any loop can ``await asyncio.wrap_future(...)`` it and sync
+    callers can poll it.
 
-    Because engine resolution is async (see ``get_graph_engine`` /
-    ``get_vector_engine``), the async ``close()`` is run as an ordinary task on
-    the running loop and the awaiting creator yields the loop so it can run — no
-    off-loop thread is needed. Falls back to ``asyncio.run()`` when no loop is
-    running (e.g. a GC finalizer firing off-loop, or interpreter teardown).
+    Execution model is deliberately unchanged from the original
+    ``_close_value``: an async ``close()`` is scheduled as a task on the
+    *currently running* loop (preserving same-loop semantics for adapters whose
+    ``close()`` disposes loop-bound resources, e.g. SQLAlchemy async engines),
+    and falls back to ``asyncio.run()`` when no loop is running. Only the
+    completion signalling is new.
     """
     if not hasattr(value, "close"):
         return None
@@ -80,6 +106,23 @@ def _start_close(value) -> Optional[concurrent.futures.Future]:
         return None
 
     value_type = type(value).__name__
+
+    # Subprocess-backed adapters must release their OS file lock independently of
+    # the caller's event loop (see ``_CLOSE_THREAD_POOL``). Run their close on a
+    # dedicated thread so a synchronous re-resolution that blocks the loop can't
+    # wedge the lock-release.
+    if getattr(value, "_subprocess_mode", False):
+        try:
+            return _CLOSE_THREAD_POOL.submit(_run_close_coro_blocking, result, value_type)
+        except RuntimeError:
+            # The pool rejects new work once the interpreter is shutting down
+            # (a proxy finalizer can fire at exit). That's fine: harness's
+            # atexit reaper force-terminates worker processes and the OS frees
+            # their file locks on exit. Close the coroutine to avoid a spurious
+            # "coroutine was never awaited" warning and move on.
+            result.close()
+            return None
+
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -98,7 +141,7 @@ def _start_close(value) -> Optional[concurrent.futures.Future]:
         cf.set_result(None)
         return cf
 
-    # Running loop: schedule the close as a task and mirror its completion into a
+    # Running loop: schedule on this loop and mirror completion into a
     # concurrent.futures.Future. A creator awaiting on the same loop via
     # ``asyncio.wrap_future`` yields control so this task can run (no deadlock).
     cf = concurrent.futures.Future()
@@ -137,8 +180,8 @@ class _LeasedCacheEntry:
         self.value = value
         # ``key`` + ``cache`` let the deferred close paths (``proxy_released``,
         # ``detach_from_cache``) register the close as in-flight under this
-        # entry's cache key, so a later ``aget_or_create`` for the same key can
-        # wait for the lock-holding worker to exit. ``cache`` is the owning
+        # entry's cache key, so a later creation for the same key can wait for
+        # the lock-holding worker to exit. ``cache`` is the owning
         # ``ClosingLRUCache``; ``None`` keeps the entry usable in isolation
         # (tests construct it directly).
         self.key = key
@@ -212,6 +255,20 @@ class _LeasedValueProxy:
     @property
     def __wrapped__(self):
         return self._entry.value
+
+    def _leased_entry_active(self):
+        """True while this proxy's cache entry is still the live cached value
+        (in cache and not pending close). Lets a pinning caller (e.g.
+        ``_GraphEngineHandle``) detect that the entry was evicted and re-resolve
+        a fresh value instead of holding the lease open — which would keep an
+        evicted DB worker alive and block a new worker on the file lock.
+
+        Defined as a real method so normal attribute lookup finds it before the
+        ``__getattr__`` forwarding below; the leading underscore + ``_leased``
+        prefix makes a collision with a wrapped adapter attribute unlikely.
+        """
+        entry = self._entry
+        return entry.in_cache and not entry.close_requested
 
     def __repr__(self):
         return repr(self._entry.value)
@@ -292,7 +349,8 @@ class ClosingLRUCache:
         """Close ``value`` and, if the close is async/in-flight, record it under
         ``key`` so a concurrent ``aget_or_create`` for the same key waits for it.
 
-        A ``None`` / already-resolved future means the close finished
+        The completion future clears itself from ``self._closing`` on done. A
+        ``None`` / already-resolved future means the close finished
         synchronously, so there is nothing to register.
         """
         cf = _start_close(value)
@@ -369,17 +427,18 @@ class ClosingLRUCache:
         """Async counterpart of :meth:`get_or_create` that waits for an in-flight
         close of the same key before constructing a new value.
 
-        This is the point of the closing registry: when an entry was just
-        evicted and its DB worker is still shutting down (still holding the
-        on-disk file lock), constructing a new value here would spawn a second
-        worker that races the first for the lock and fails. Awaiting the close
-        future via ``asyncio.wrap_future`` suspends this coroutine without
-        blocking the loop, so the close (which runs as a task on this same loop)
-        can complete — releasing the lock — before we construct.
+        The wait is the whole point of the closing registry: when an entry was
+        just evicted and its DB worker is still shutting down (and so still holds
+        the on-disk file lock), constructing a new value here would spawn a
+        second worker that races the first for the lock and fails. Awaiting the
+        close future via ``asyncio.wrap_future`` suspends this coroutine without
+        blocking the loop, so the close (which may run as a task on this same
+        loop) can complete first.
 
-        Construction itself still goes through the synchronous
+        The actual construction still goes through the synchronous
         :meth:`get_or_create` (which re-checks the cache and only calls
-        ``factory`` on a miss).
+        ``factory`` on a miss) — the residual window between the await and that
+        call is covered by the worker's open-retry backstop.
         """
         if self._maxsize == 0:
             return factory()

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -48,45 +48,6 @@ def _normalize_optional_create_vector_engine_params(params: dict) -> dict:
     return normalized
 
 
-def _make_pghybrid_vector_adapter(vector_db_key):
-    """Build the uncached PGVector hybrid adapter used when
-    ``USE_UNIFIED_PROVIDER=pghybrid``. Not cached — matches the original inline
-    behavior."""
-    from cognee.infrastructure.databases.relational import get_relational_config
-
-    embedding_engine = get_embedding_engine()
-    relational_config = get_relational_config()
-    connection_string = (
-        f"postgresql+asyncpg://{relational_config.db_username}:{relational_config.db_password}"
-        f"@{relational_config.db_host}:{relational_config.db_port}"
-        f"/{relational_config.db_name}"
-    )
-
-    from .pgvector.PGVectorAdapter import PGVectorAdapter
-
-    return PGVectorAdapter(connection_string, vector_db_key, embedding_engine)
-
-
-def _resolve_vector_engine_args(params: dict) -> tuple:
-    """Normalize vector engine parameters and return the positional argument
-    tuple passed to ``_create_vector_engine`` — identical for the sync and async
-    entry points and matching ``evict_vector_engine`` / ``is_vector_engine_cached``.
-    """
-    normalized = _normalize_optional_create_vector_engine_params(params)
-    return (
-        params.get("vector_db_provider", ""),
-        params.get("vector_db_url", ""),
-        params.get("vector_db_name", ""),
-        normalized["vector_db_port"],
-        normalized["vector_db_key"],
-        normalized["vector_dataset_database_handler"],
-        normalized["vector_db_username"],
-        normalized["vector_db_password"],
-        normalized["vector_db_host"],
-        normalized["vector_db_subprocess_enabled"],
-    )
-
-
 def create_vector_engine(
     vector_db_provider: str,
     vector_db_url: str,
@@ -104,32 +65,51 @@ def create_vector_engine(
     For a detailed description, see _create_vector_engine.
     """
 
-    args = _resolve_vector_engine_args(locals())
+    normalized_optional_params = _normalize_optional_create_vector_engine_params(locals())
+    vector_db_port = normalized_optional_params["vector_db_port"]
+    vector_db_key = normalized_optional_params["vector_db_key"]
+    vector_dataset_database_handler = normalized_optional_params["vector_dataset_database_handler"]
+    vector_db_username = normalized_optional_params["vector_db_username"]
+    vector_db_password = normalized_optional_params["vector_db_password"]
+    vector_db_host = normalized_optional_params["vector_db_host"]
+    # ``vector_db_subprocess_enabled`` also went through normalization;
+    # reassign so callers passing ``None`` see the function-default applied
+    # instead of having ``None`` flow into the cache key + factory.
+    vector_db_subprocess_enabled = normalized_optional_params["vector_db_subprocess_enabled"]
+
     # Check USE_UNIFIED_PROVIDER outside the cache so it's always re-read
-    if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
-        return _make_pghybrid_vector_adapter(args[4])  # args[4] == vector_db_key
+    unified_provider = os.environ.get("USE_UNIFIED_PROVIDER", "")
+    if unified_provider == "pghybrid":
+        from cognee.infrastructure.databases.relational import get_relational_config
 
-    return _create_vector_engine(*args)
+        embedding_engine = get_embedding_engine()
+        relational_config = get_relational_config()
+        connection_string = (
+            f"postgresql+asyncpg://{relational_config.db_username}:{relational_config.db_password}"
+            f"@{relational_config.db_host}:{relational_config.db_port}"
+            f"/{relational_config.db_name}"
+        )
 
+        from .pgvector.PGVectorAdapter import PGVectorAdapter
 
-async def acreate_vector_engine(**kwargs):
-    """Async counterpart of :func:`create_vector_engine`, used as the primary
-    creation path (via :func:`get_vector_engine`).
+        return PGVectorAdapter(
+            connection_string,
+            vector_db_key,
+            embedding_engine,
+        )
 
-    Async for the same reason as the graph factory
-    (:func:`cognee.infrastructure.databases.graph.get_graph_engine.acreate_graph_engine`):
-    the cache's ``aget_or_create`` can ``await`` an in-flight close of the same
-    key before constructing, so a re-created engine never races a
-    still-shutting-down worker. Kept symmetric with the graph side even though
-    LanceDB connects without an exclusive on-disk file lock. Delegates to the
-    shared normalization (:func:`_resolve_vector_engine_args`) so the cache key
-    matches the sync path.
-    """
-    args = _resolve_vector_engine_args(kwargs)
-    if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
-        return _make_pghybrid_vector_adapter(args[4])  # args[4] == vector_db_key
-
-    return await _create_vector_engine.acall(*args)
+    return _create_vector_engine(
+        vector_db_provider,
+        vector_db_url,
+        vector_db_name,
+        vector_db_port,
+        vector_db_key,
+        vector_dataset_database_handler,
+        vector_db_username,
+        vector_db_password,
+        vector_db_host,
+        vector_db_subprocess_enabled,
+    )
 
 
 def evict_vector_engine(**kwargs) -> bool:

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -48,6 +48,45 @@ def _normalize_optional_create_vector_engine_params(params: dict) -> dict:
     return normalized
 
 
+def _make_pghybrid_vector_adapter(vector_db_key):
+    """Build the uncached PGVector hybrid adapter used when
+    ``USE_UNIFIED_PROVIDER=pghybrid``. Not cached — matches the original inline
+    behavior."""
+    from cognee.infrastructure.databases.relational import get_relational_config
+
+    embedding_engine = get_embedding_engine()
+    relational_config = get_relational_config()
+    connection_string = (
+        f"postgresql+asyncpg://{relational_config.db_username}:{relational_config.db_password}"
+        f"@{relational_config.db_host}:{relational_config.db_port}"
+        f"/{relational_config.db_name}"
+    )
+
+    from .pgvector.PGVectorAdapter import PGVectorAdapter
+
+    return PGVectorAdapter(connection_string, vector_db_key, embedding_engine)
+
+
+def _resolve_vector_engine_args(params: dict) -> tuple:
+    """Normalize vector engine parameters and return the positional argument
+    tuple passed to ``_create_vector_engine`` — identical for the sync and async
+    entry points and matching ``evict_vector_engine`` / ``is_vector_engine_cached``.
+    """
+    normalized = _normalize_optional_create_vector_engine_params(params)
+    return (
+        params.get("vector_db_provider", ""),
+        params.get("vector_db_url", ""),
+        params.get("vector_db_name", ""),
+        normalized["vector_db_port"],
+        normalized["vector_db_key"],
+        normalized["vector_dataset_database_handler"],
+        normalized["vector_db_username"],
+        normalized["vector_db_password"],
+        normalized["vector_db_host"],
+        normalized["vector_db_subprocess_enabled"],
+    )
+
+
 def create_vector_engine(
     vector_db_provider: str,
     vector_db_url: str,
@@ -65,51 +104,26 @@ def create_vector_engine(
     For a detailed description, see _create_vector_engine.
     """
 
-    normalized_optional_params = _normalize_optional_create_vector_engine_params(locals())
-    vector_db_port = normalized_optional_params["vector_db_port"]
-    vector_db_key = normalized_optional_params["vector_db_key"]
-    vector_dataset_database_handler = normalized_optional_params["vector_dataset_database_handler"]
-    vector_db_username = normalized_optional_params["vector_db_username"]
-    vector_db_password = normalized_optional_params["vector_db_password"]
-    vector_db_host = normalized_optional_params["vector_db_host"]
-    # ``vector_db_subprocess_enabled`` also went through normalization;
-    # reassign so callers passing ``None`` see the function-default applied
-    # instead of having ``None`` flow into the cache key + factory.
-    vector_db_subprocess_enabled = normalized_optional_params["vector_db_subprocess_enabled"]
-
+    args = _resolve_vector_engine_args(locals())
     # Check USE_UNIFIED_PROVIDER outside the cache so it's always re-read
-    unified_provider = os.environ.get("USE_UNIFIED_PROVIDER", "")
-    if unified_provider == "pghybrid":
-        from cognee.infrastructure.databases.relational import get_relational_config
+    if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
+        return _make_pghybrid_vector_adapter(args[4])  # args[4] == vector_db_key
 
-        embedding_engine = get_embedding_engine()
-        relational_config = get_relational_config()
-        connection_string = (
-            f"postgresql+asyncpg://{relational_config.db_username}:{relational_config.db_password}"
-            f"@{relational_config.db_host}:{relational_config.db_port}"
-            f"/{relational_config.db_name}"
-        )
+    return _create_vector_engine(*args)
 
-        from .pgvector.PGVectorAdapter import PGVectorAdapter
 
-        return PGVectorAdapter(
-            connection_string,
-            vector_db_key,
-            embedding_engine,
-        )
+async def acreate_vector_engine(**kwargs):
+    """Async counterpart of :func:`create_vector_engine` that waits for any
+    in-flight close of the same cache key before constructing a new engine.
 
-    return _create_vector_engine(
-        vector_db_provider,
-        vector_db_url,
-        vector_db_name,
-        vector_db_port,
-        vector_db_key,
-        vector_dataset_database_handler,
-        vector_db_username,
-        vector_db_password,
-        vector_db_host,
-        vector_db_subprocess_enabled,
-    )
+    Used by ``get_vector_engine`` so a freshly evicted subprocess engine's worker
+    has fully torn down before a new one is built.
+    """
+    args = _resolve_vector_engine_args(kwargs)
+    if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":
+        return _make_pghybrid_vector_adapter(args[4])  # args[4] == vector_db_key
+
+    return await _create_vector_engine.acall(*args)
 
 
 def evict_vector_engine(**kwargs) -> bool:

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -113,11 +113,17 @@ def create_vector_engine(
 
 
 async def acreate_vector_engine(**kwargs):
-    """Async counterpart of :func:`create_vector_engine` that waits for any
-    in-flight close of the same cache key before constructing a new engine.
+    """Async counterpart of :func:`create_vector_engine`, used as the primary
+    creation path (via :func:`get_vector_engine`).
 
-    Used by ``get_vector_engine`` so a freshly evicted subprocess engine's worker
-    has fully torn down before a new one is built.
+    Async for the same reason as the graph factory
+    (:func:`cognee.infrastructure.databases.graph.get_graph_engine.acreate_graph_engine`):
+    the cache's ``aget_or_create`` can ``await`` an in-flight close of the same
+    key before constructing, so a re-created engine never races a
+    still-shutting-down worker. Kept symmetric with the graph side even though
+    LanceDB connects without an exclusive on-disk file lock. Delegates to the
+    shared normalization (:func:`_resolve_vector_engine_args`) so the cache key
+    matches the sync path.
     """
     args = _resolve_vector_engine_args(kwargs)
     if os.environ.get("USE_UNIFIED_PROVIDER", "") == "pghybrid":

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -2,44 +2,16 @@ from .config import get_vectordb_context_config
 from .create_vector_engine import create_vector_engine
 
 
-class _VectorEngineHandle:
-    """Stable reference to the current vector engine that survives cache invalidation.
+async def get_vector_engine():
+    """Factory function to get the appropriate vector client.
 
-    Database engine instances are cached via ``closing_lru_cache``.  Several
-    operations invalidate that cache — ``prune_system`` calls ``cache_clear()``,
-    ``delete_dataset`` evicts individual entries, and the ``__aexit__`` of
-    ``set_database_global_context_variables`` evicts subprocess-mode engines to
-    release file locks.  When an entry is evicted the underlying adapter is
-    closed, so any direct proxy reference becomes a dead object that raises
-    "adapter is closed" on use.
-
-    This handle solves the problem by deferring resolution: every attribute
-    access calls ``create_vector_engine(**config)`` which either returns the
-    existing cached proxy (fast path) or transparently creates a fresh adapter
-    if the old one was evicted (recovery path).  Code that stores the return
-    value of ``get_vector_engine()`` — even across ``cognify``, ``search``,
-    ``prune``, or ``delete`` calls — always reaches a live adapter without
-    needing to re-call ``get_vector_engine()``.
+    SPIKE NOTE (async-engine-resolution): this previously was SYNC and returned
+    a ``_VectorEngineHandle`` whose ``__getattr__`` re-resolved the engine via
+    ``create_vector_engine(**config)`` on every attribute access. It is now an
+    ``async`` function that resolves the engine eagerly and returns the live
+    adapter (a leased proxy from ``closing_lru_cache``) directly. Every call
+    site must now ``await get_vector_engine()``. Trade-off: callers that store
+    the result across a cache-invalidating op (prune / delete / context exit)
+    must re-call instead of relying on the old transparent re-resolution.
     """
-
-    __slots__ = ("_config",)
-
-    def __init__(self, config: dict):
-        object.__setattr__(self, "_config", config)
-
-    def _engine(self):
-        return create_vector_engine(**self._config)
-
-    @property
-    def __class__(self):
-        return self._engine().__class__
-
-    def __getattr__(self, name):
-        return getattr(self._engine(), name)
-
-    def __repr__(self):
-        return f"<VectorEngineHandle config={self._config!r}>"
-
-
-def get_vector_engine():
-    return _VectorEngineHandle(get_vectordb_context_config())
+    return create_vector_engine(**get_vectordb_context_config())

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -1,20 +1,87 @@
 from .config import get_vectordb_context_config
-from .create_vector_engine import acreate_vector_engine
+from .create_vector_engine import create_vector_engine
+
+
+class _VectorEngineHandle:
+    """Stable reference to the current vector engine that survives cache invalidation.
+
+    Database engine instances are cached via ``closing_lru_cache``.  Several
+    operations invalidate that cache — ``prune_system`` calls ``cache_clear()``,
+    ``delete_dataset`` evicts individual entries, and the ``__aexit__`` of
+    ``set_database_global_context_variables`` evicts subprocess-mode engines to
+    release file locks.  When an entry is evicted the underlying adapter is
+    closed, so any direct proxy reference becomes a dead object that raises
+    "adapter is closed" on use.
+
+    This handle solves the problem by deferring resolution: every attribute
+    access calls ``create_vector_engine(**config)`` which either returns the
+    existing cached proxy (fast path) or transparently creates a fresh adapter
+    if the old one was evicted (recovery path).  Code that stores the return
+    value of ``get_vector_engine()`` — even across ``cognify``, ``search``,
+    ``prune``, or ``delete`` calls — always reaches a live adapter without
+    needing to re-call ``get_vector_engine()``.
+    """
+
+    __slots__ = ("_config", "_pinned")
+
+    # Note: ``get_vector_engine()`` is ``async`` (callers ``await`` it), but the
+    # handle's resolution (``_engine``) is intentionally synchronous — there is
+    # no async ``acreate``/await-in-flight-close path here. The subprocess vector
+    # backend (LanceDB) connects via ``connect_async`` without taking an
+    # exclusive on-disk file lock the way Kuzu/Ladybug does, so the
+    # create-vs-close lock race that motivates the graph handle's async path does
+    # not apply. Like ``_GraphEngineHandle`` this is a *re-resolving* handle: it
+    # re-runs ``create_vector_engine(**config)`` on attribute access, so a stored
+    # reference transparently recovers a fresh adapter after the cache is
+    # invalidated (prune / delete / dataset-context teardown) instead of raising
+    # "adapter is closed". The detach-aware pin just avoids re-entering the cache
+    # on every access and never keeps an evicted worker pinned alive.
+
+    def __init__(self, config: dict):
+        object.__setattr__(self, "_config", config)
+        # Pinned leased engine proxy — see ``_GraphEngineHandle`` for the
+        # rationale. Dropped + re-resolved once the pin is no longer the live
+        # cache entry so prune/delete eviction still recovers a fresh engine.
+        object.__setattr__(self, "_pinned", None)
+
+    @staticmethod
+    def _pin_is_live(engine) -> bool:
+        active = getattr(engine, "_leased_entry_active", None)
+        if active is not None:
+            try:
+                if not active():
+                    return False
+            except Exception:
+                return False
+        if getattr(engine, "_permanently_closed", False):
+            return False
+        return True
+
+    def _engine(self):
+        pinned = self._pinned
+        if pinned is not None and self._pin_is_live(pinned):
+            return pinned
+        # Drop the stale pin before re-resolving so its deferred close can start
+        # (mirrors ``_GraphEngineHandle._release_stale_pin``).
+        if pinned is not None:
+            object.__setattr__(self, "_pinned", None)
+            del pinned
+        engine = create_vector_engine(**self._config)
+        object.__setattr__(self, "_pinned", engine)
+        return engine
+
+    @property
+    def __class__(self):
+        return self._engine().__class__
+
+    def __getattr__(self, name):
+        return getattr(self._engine(), name)
+
+    def __repr__(self):
+        return f"<VectorEngineHandle config={self._config!r}>"
 
 
 async def get_vector_engine():
-    """Resolve the vector engine for the current context and return the live
-    adapter (a leased proxy from ``closing_lru_cache``).
-
-    Resolution is asynchronous and goes through :func:`acreate_vector_engine`
-    so engine *creation* can ``await`` an in-flight close of the same cache key
-    before constructing (see :func:`acreate_vector_engine` for the rationale —
-    the same async-factory reasoning as the graph side keeps the two engines
-    symmetric, even though LanceDB itself takes no exclusive file lock).
-
-    ``get_vector_engine()`` is ``async`` — every call site must ``await`` it.
-    The returned adapter is a live reference for the *current* async scope; do
-    not stash it and reuse it across a cache-invalidating operation (prune /
-    delete / per-dataset context exit) — call ``get_vector_engine()`` again.
-    """
-    return await acreate_vector_engine(**get_vectordb_context_config())
+    # ``async`` so every call site ``await``s it (matching the async resolution
+    # surface); resolution itself stays synchronous inside the handle.
+    return _VectorEngineHandle(get_vectordb_context_config())

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -1,17 +1,20 @@
 from .config import get_vectordb_context_config
-from .create_vector_engine import create_vector_engine
+from .create_vector_engine import acreate_vector_engine
 
 
 async def get_vector_engine():
     """Factory function to get the appropriate vector client.
 
+    Resolves the engine eagerly and returns the live adapter (a leased proxy
+    from ``closing_lru_cache``) directly. Uses the async creation path
+    (``acreate_vector_engine``) so that if the engine for this config key is
+    currently closing, we await that close before constructing a new one.
+
     SPIKE NOTE (async-engine-resolution): this previously was SYNC and returned
-    a ``_VectorEngineHandle`` whose ``__getattr__`` re-resolved the engine via
-    ``create_vector_engine(**config)`` on every attribute access. It is now an
-    ``async`` function that resolves the engine eagerly and returns the live
-    adapter (a leased proxy from ``closing_lru_cache``) directly. Every call
-    site must now ``await get_vector_engine()``. Trade-off: callers that store
-    the result across a cache-invalidating op (prune / delete / context exit)
-    must re-call instead of relying on the old transparent re-resolution.
+    a ``_VectorEngineHandle`` whose ``__getattr__`` re-resolved the engine on
+    every attribute access. Every call site must now ``await get_vector_engine()``.
+    Trade-off: callers that store the result across a cache-invalidating op
+    (prune / delete / context exit) must re-call instead of relying on the old
+    transparent re-resolution.
     """
-    return create_vector_engine(**get_vectordb_context_config())
+    return await acreate_vector_engine(**get_vectordb_context_config())

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -3,18 +3,18 @@ from .create_vector_engine import acreate_vector_engine
 
 
 async def get_vector_engine():
-    """Factory function to get the appropriate vector client.
+    """Resolve the vector engine for the current context and return the live
+    adapter (a leased proxy from ``closing_lru_cache``).
 
-    Resolves the engine eagerly and returns the live adapter (a leased proxy
-    from ``closing_lru_cache``) directly. Uses the async creation path
-    (``acreate_vector_engine``) so that if the engine for this config key is
-    currently closing, we await that close before constructing a new one.
+    Resolution is asynchronous and goes through :func:`acreate_vector_engine`
+    so engine *creation* can ``await`` an in-flight close of the same cache key
+    before constructing (see :func:`acreate_vector_engine` for the rationale —
+    the same async-factory reasoning as the graph side keeps the two engines
+    symmetric, even though LanceDB itself takes no exclusive file lock).
 
-    SPIKE NOTE (async-engine-resolution): this previously was SYNC and returned
-    a ``_VectorEngineHandle`` whose ``__getattr__`` re-resolved the engine on
-    every attribute access. Every call site must now ``await get_vector_engine()``.
-    Trade-off: callers that store the result across a cache-invalidating op
-    (prune / delete / context exit) must re-call instead of relying on the old
-    transparent re-resolution.
+    ``get_vector_engine()`` is ``async`` — every call site must ``await`` it.
+    The returned adapter is a live reference for the *current* async scope; do
+    not stash it and reuse it across a cache-invalidating operation (prune /
+    delete / per-dataset context exit) — call ``get_vector_engine()`` again.
     """
     return await acreate_vector_engine(**get_vectordb_context_config())

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -184,7 +184,7 @@ class LanceDBAdapter(VectorDBInterface):
         # in-flight ``get_connection()`` resuming after its ``await``.
         # ``threading.Lock`` (not ``asyncio.Lock``) for cross-loop safety:
         # ``close()`` can be invoked from a foreign event loop via
-        # ``closing_lru_cache._close_value`` running ``asyncio.run``, and
+        # ``closing_lru_cache._start_close`` running ``asyncio.run``, and
         # awaiting an asyncio.Lock there raises "got Future attached to a
         # different loop". The lock is held for microseconds at a time and
         # never wraps an ``await``, so it can't deadlock the event loop.

--- a/cognee/infrastructure/databases/vector/pgvector/create_db_and_tables.py
+++ b/cognee/infrastructure/databases/vector/pgvector/create_db_and_tables.py
@@ -7,7 +7,7 @@ from cognee.context_global_variables import backend_access_control_enabled
 async def create_db_and_tables():
     # Get appropriate vector db configuration based on current async context
     vector_config = get_vectordb_context_config()
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     if vector_config["vector_db_provider"] == "pgvector" and not backend_access_control_enabled():
         async with vector_engine.engine.begin() as connection:

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -14,7 +14,7 @@ logger = get_logger()
 CONNECTION_TEST_TIMEOUT_SECONDS = 30
 
 
-def get_max_chunk_tokens() -> int:
+async def get_max_chunk_tokens() -> int:
     """
     Calculate the maximum number of tokens allowed in a chunk.
 
@@ -33,7 +33,7 @@ def get_max_chunk_tokens() -> int:
     from cognee.infrastructure.databases.vector import get_vector_engine
 
     # Calculate max chunk size based on the following formula
-    embedding_engine = get_vector_engine().embedding_engine
+    embedding_engine = (await get_vector_engine()).embedding_engine
     llm_client = get_llm_client(raise_api_key_error=False)
 
     # We need to make sure chunk size won't take more than half of LLM max context token size
@@ -127,7 +127,7 @@ async def test_embedding_connection() -> int:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
         logger.info("Testing connection to Embedding endpoint...")
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         embedding_vectors = await asyncio.wait_for(
             vector_engine.embedding_engine.embed_text(["test"]),
             timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
@@ -151,7 +151,7 @@ async def test_embedding_connection() -> int:
         raise e
 
 
-def determine_embedding_dimensions(detected_dimensions: int) -> None:
+async def determine_embedding_dimensions(detected_dimensions: int) -> None:
     """
     Apply embedding-dimension policy using a single already-produced test vector size.
 
@@ -172,7 +172,7 @@ def determine_embedding_dimensions(detected_dimensions: int) -> None:
         embedding_config.embedding_dimensions = detected_dimensions
 
         # Keep active engine in sync in this process.
-        embedding_engine = get_vector_engine().embedding_engine
+        embedding_engine = (await get_vector_engine()).embedding_engine
         if hasattr(embedding_engine, "dimensions"):
             embedding_engine.dimensions = detected_dimensions
 

--- a/cognee/infrastructure/session/session_embeddings.py
+++ b/cognee/infrastructure/session/session_embeddings.py
@@ -129,7 +129,7 @@ async def search_session_qa_ids(
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         results = await vector_engine.search(
             SESSION_QA_VECTOR_COLLECTION,
             query_text=query_text,
@@ -152,7 +152,7 @@ async def delete_session_qa_vector(*, qa_id: str) -> None:
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         await vector_engine.delete_data_points(SESSION_QA_VECTOR_COLLECTION, [UUID(qa_id)])
     except Exception as error:
         logger.warning("Session QA vector delete failed open: %s", error)
@@ -163,7 +163,7 @@ async def delete_session_qa_vectors(*, user_id: str, session_id: str) -> None:
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         await vector_engine.remove_belongs_to_set_tags(
             [session_scope_tag(user_id, session_id)],
         )

--- a/cognee/modules/chunking/LangchainChunker.py
+++ b/cognee/modules/chunking/LangchainChunker.py
@@ -39,7 +39,7 @@ class LangchainChunker(Chunker):
         document_name = self.document.name or basename(self.document.raw_data_location)
         async for content_text in self.get_text():
             for chunk in self.splitter.split_text(content_text):
-                embedding_engine = get_vector_engine().embedding_engine
+                embedding_engine = (await get_vector_engine()).embedding_engine
                 token_count = embedding_engine.tokenizer.count_tokens(chunk)
                 if token_count <= self.max_chunk_tokens:
                     yield DocumentChunk(

--- a/cognee/modules/chunking/LangchainChunker.py
+++ b/cognee/modules/chunking/LangchainChunker.py
@@ -37,9 +37,11 @@ class LangchainChunker(Chunker):
     async def read(self):
         document_id = str(self.document.id)
         document_name = self.document.name or basename(self.document.raw_data_location)
+        # Resolve the embedding engine once — it's the same for every chunk, so
+        # resolving it per chunk inside the loops just adds await/lookup overhead.
+        embedding_engine = (await get_vector_engine()).embedding_engine
         async for content_text in self.get_text():
             for chunk in self.splitter.split_text(content_text):
-                embedding_engine = (await get_vector_engine()).embedding_engine
                 token_count = embedding_engine.tokenizer.count_tokens(chunk)
                 if token_count <= self.max_chunk_tokens:
                     yield DocumentChunk(

--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -67,7 +67,7 @@ async def prune_system(graph=True, vector=True, metadata=True, cache=True):
         await prune_graph_databases()
 
     if vector and not backend_access_control_enabled():
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         await vector_engine.prune()
     elif vector and backend_access_control_enabled():
         await prune_vector_databases()

--- a/cognee/modules/data/processing/has_new_chunks.py
+++ b/cognee/modules/data/processing/has_new_chunks.py
@@ -5,7 +5,7 @@ from cognee.modules.chunking import DocumentChunk
 async def has_new_chunks(
     data_chunks: list[DocumentChunk], collection_name: str
 ) -> list[DocumentChunk]:
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     if not await vector_engine.has_collection(collection_name):
         # There is no collection created,

--- a/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
@@ -100,7 +100,7 @@ async def delete_data_nodes_and_edges(dataset_id: UUID, data_id: UUID, user_id: 
                 e,
             )
         try:
-            vector_engine = get_vector_engine()
+            vector_engine = await get_vector_engine()
             await vector_engine.remove_belongs_to_set_tags(
                 orphaned_nodeset_labels, node_ids=slug_ids
             )

--- a/cognee/modules/graph/methods/delete_from_graph_and_vector.py
+++ b/cognee/modules/graph/methods/delete_from_graph_and_vector.py
@@ -76,7 +76,7 @@ async def delete_from_graph_and_vector(
             collection_name = f"{node.type}_{indexed_field}"
             affected_vector_collections.setdefault(collection_name, []).append(node)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     for collection, nodes in affected_vector_collections.items():
         await vector_engine.delete_data_points(collection, [str(node.slug) for node in nodes])
 

--- a/cognee/modules/graph/methods/legacy_delete.py
+++ b/cognee/modules/graph/methods/legacy_delete.py
@@ -30,7 +30,7 @@ async def legacy_delete(data: Data, mode: str = "soft"):
     deleted_node_ids = await delete_document_subgraph(data.id, mode)
 
     # Delete from vector database
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     # Determine vector collections dynamically
     subclasses = get_all_subclasses(DataPoint)

--- a/cognee/modules/migrations/README.md
+++ b/cognee/modules/migrations/README.md
@@ -92,8 +92,8 @@ converge it on the next upgrade.
   move triplet points too.
 - The relational delete-ledger (`nodes.slug`, `edges.source/destination`) and
   the legacy `graph_relationship_ledger` key on graph node ids.
-- Engines arrive wrapped (`_VectorEngineHandle`, leased proxies) — they spoof
-  `__class__`, so dispatch on `engine.__class__.__name__`, never `type(engine)`.
+- Engines arrive wrapped in the cache's leased proxy — it spoofs `__class__`,
+  so dispatch on `engine.__class__.__name__`, never `type(engine)`.
 - lance 0.32's `merge_insert` can panic on tables carrying deletion vectors —
   prefer plain `add` + delete in migrations, compact when the handle allows.
 - Hybrid graph+vector backends (Neptune Analytics) store vectors as graph

--- a/cognee/modules/migrations/runner.py
+++ b/cognee/modules/migrations/runner.py
@@ -356,7 +356,7 @@ async def _run_global_migrations(
         # No context override: without access control, get_graph_engine /
         # get_vector_engine resolve the global databases directly.
         graph_engine = await get_graph_engine()
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         migration_context = MigrationContext(
             graph_engine=graph_engine,
             vector_engine=vector_engine,
@@ -411,7 +411,7 @@ async def _migrate_dataset(
     # per-dataset context — the same way every other operation does.
     async with set_database_global_context_variables(row.dataset_id, row.owner_id):
         graph_engine = await get_graph_engine()
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         migration_context = MigrationContext(
             graph_engine=graph_engine,
             vector_engine=vector_engine,
@@ -552,7 +552,7 @@ async def _downgrade_dataset(db_engine, row, target: Optional[str]) -> Optional[
 
     async with set_database_global_context_variables(row.dataset_id, row.owner_id):
         graph_engine = await get_graph_engine()
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         migration_context = MigrationContext(
             graph_engine=graph_engine,
             vector_engine=vector_engine,
@@ -606,7 +606,7 @@ async def downgrade_database_migrations(
                 await _stamp_global(db_engine, revision)
 
             graph_engine = await get_graph_engine()
-            vector_engine = get_vector_engine()
+            vector_engine = await get_vector_engine()
             migration_context = MigrationContext(
                 graph_engine=graph_engine,
                 vector_engine=vector_engine,

--- a/cognee/modules/migrations/versions/_vector_rekey.py
+++ b/cognee/modules/migrations/versions/_vector_rekey.py
@@ -164,9 +164,9 @@ async def rekey_native(vector_engine, collection: str, id_map: dict) -> bool:
     if not id_map:
         return True
 
-    # NOT type(vector_engine): the engine arrives wrapped (_VectorEngineHandle /
-    # the cache's _LeasedValueProxy), and both spoof ``__class__`` to the real
-    # adapter class precisely so checks like this resolve through the wrapper.
+    # NOT type(vector_engine): the engine arrives wrapped in the cache's
+    # ``_LeasedValueProxy``, which spoofs ``__class__`` to the real adapter class
+    # precisely so checks like this resolve through the wrapper.
     adapter = vector_engine.__class__.__name__
     if adapter == "LanceDBAdapter":
         await rekey_lancedb(vector_engine, collection, id_map)

--- a/cognee/modules/pipelines/layers/setup_and_check_environment.py
+++ b/cognee/modules/pipelines/layers/setup_and_check_environment.py
@@ -53,5 +53,5 @@ async def setup_and_check_environment(
 
                 await test_llm_connection()
                 detected_embedding_dimensions = await test_embedding_connection()
-                determine_embedding_dimensions(detected_embedding_dimensions)
+                await determine_embedding_dimensions(detected_embedding_dimensions)
             _first_run_done = True

--- a/cognee/modules/retrieval/completion_retriever.py
+++ b/cognee/modules/retrieval/completion_retriever.py
@@ -40,7 +40,7 @@ class CompletionRetriever(BaseRetriever):
         self.include_references = include_references
 
     async def get_retrieved_objects(self, query: str) -> Any:
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
 
         try:
             found_chunks = await vector_engine.search(

--- a/cognee/modules/retrieval/triplet_retriever.py
+++ b/cognee/modules/retrieval/triplet_retriever.py
@@ -60,7 +60,7 @@ class TripletRetriever(BaseRetriever):
 
             - Any: A list containing the retrieved triplets, or an empty list if none are found.
         """
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
 
         try:
             if not await vector_engine.has_collection(collection_name="Triplet_text"):

--- a/cognee/modules/retrieval/utils/description_to_codepart_search.py
+++ b/cognee/modules/retrieval/utils/description_to_codepart_search.py
@@ -49,7 +49,7 @@ async def code_description_to_code_part(
         raise ValueError("top_k must be a positive integer.")
 
     try:
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         graph_engine = await get_graph_engine()
     except Exception as init_error:
         logger.error("Failed to initialize engines: %s", init_error, exc_info=True)

--- a/cognee/modules/retrieval/utils/node_edge_vector_search.py
+++ b/cognee/modules/retrieval/utils/node_edge_vector_search.py
@@ -15,18 +15,24 @@ class NodeEdgeVectorSearch:
 
     def __init__(self, edge_collection: str = "EdgeType_relationship_name", vector_engine=None):
         self.edge_collection = edge_collection
-        self.vector_engine = vector_engine or self._init_vector_engine()
+        # SPIKE NOTE (async-engine-resolution): vector engine resolution is now
+        # async, so a sync ``__init__`` can no longer eagerly resolve it. We keep
+        # the (possibly-None) injected engine and resolve lazily in the first
+        # async method via ``_get_vector_engine()``.
+        self.vector_engine = vector_engine
         self.query_vector: Optional[Any] = None
         self.node_distances: dict[str, list[Any]] = {}
         self.edge_distances: list[Any] = []
         self.query_list_length: Optional[int] = None
 
-    def _init_vector_engine(self):
-        try:
-            return get_vector_engine()
-        except Exception as e:
-            logger.error("Failed to initialize vector engine: %s", e)
-            raise RuntimeError("Initialization error") from e
+    async def _get_vector_engine(self):
+        if self.vector_engine is None:
+            try:
+                self.vector_engine = await get_vector_engine()
+            except Exception as e:
+                logger.error("Failed to initialize vector engine: %s", e)
+                raise RuntimeError("Initialization error") from e
+        return self.vector_engine
 
     async def embed_and_retrieve_distances(
         self,
@@ -151,7 +157,8 @@ class NodeEdgeVectorSearch:
     ) -> List[List[Any]]:
         """Searches one collection with batch queries and returns list-of-lists."""
         try:
-            return await self.vector_engine.batch_search(
+            vector_engine = await self._get_vector_engine()
+            return await vector_engine.batch_search(
                 collection_name=collection_name, query_texts=query_batch, limit=None
             )
         except CollectionNotFoundError:
@@ -171,9 +178,10 @@ class NodeEdgeVectorSearch:
         These are stored as flat lists in node_distances/edge_distances for single-query mode.
         """
         await self._embed_query(query)
+        vector_engine = await self._get_vector_engine()
         search_tasks = [
             self._search_single_collection(
-                self.vector_engine,
+                vector_engine,
                 wide_search_limit,
                 collection,
                 node_name,
@@ -188,7 +196,8 @@ class NodeEdgeVectorSearch:
         """Embeds the query and stores the resulting vector."""
         with new_span("cognee.retrieval.embed_query") as span:
             span.set_attribute("cognee.vector.query_length", len(query))
-            query_embeddings = await self.vector_engine.embedding_engine.embed_text([query])
+            vector_engine = await self._get_vector_engine()
+            query_embeddings = await vector_engine.embedding_engine.embed_text([query])
             self.query_vector = query_embeddings[0]
             span.set_attribute("cognee.vector.embedding_dimensions", len(self.query_vector))
 

--- a/cognee/modules/retrieval/utils/node_edge_vector_search.py
+++ b/cognee/modules/retrieval/utils/node_edge_vector_search.py
@@ -15,10 +15,9 @@ class NodeEdgeVectorSearch:
 
     def __init__(self, edge_collection: str = "EdgeType_relationship_name", vector_engine=None):
         self.edge_collection = edge_collection
-        # SPIKE NOTE (async-engine-resolution): vector engine resolution is now
-        # async, so a sync ``__init__`` can no longer eagerly resolve it. We keep
-        # the (possibly-None) injected engine and resolve lazily in the first
-        # async method via ``_get_vector_engine()``.
+        # ``get_vector_engine()`` is async, so this sync ``__init__`` can't
+        # eagerly resolve it. Keep the (possibly-None) injected engine and
+        # resolve lazily in the first async method via ``_get_vector_engine()``.
         self.vector_engine = vector_engine
         self.query_vector: Optional[Any] = None
         self.node_distances: dict[str, list[Any]] = {}

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -354,7 +354,7 @@ async def append_answer_grounded_evidence(completions: List[Any], enabled: bool)
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
     except Exception as error:
         logger.debug(f"Unable to obtain vector engine for references: {error}")
         return completions

--- a/cognee/modules/session_distillation/distill.py
+++ b/cognee/modules/session_distillation/distill.py
@@ -324,7 +324,7 @@ async def accept_proposed_lessons(
 ) -> List[WrittenLesson]:
     entries_by_id = {entry.id: entry for entry in context_entries}
     async with set_database_global_context_variables(scope.dataset.id, scope.dataset.owner_id):
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
 
         def write_lesson(lesson: ProposedLesson):
             return lambda: evaluate_proposed_lesson(

--- a/cognee/modules/truth_subspace/build.py
+++ b/cognee/modules/truth_subspace/build.py
@@ -124,7 +124,7 @@ async def build_truth_subspace(
         return empty_result
 
     async with set_database_global_context_variables(dataset_obj.id, dataset_obj.owner_id):
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         graph_engine = await get_graph_engine()
 
         # Step 1: accepted learning statements from session_learnings.

--- a/cognee/tasks/chunks/create_chunk_associations.py
+++ b/cognee/tasks/chunks/create_chunk_associations.py
@@ -150,7 +150,7 @@ async def create_chunk_associations(
         f"Creating associations for {len(valid_chunks)} chunks with threshold {similarity_threshold}"
     )
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     id_to_text = {}
     for chunk_text in valid_chunks:

--- a/cognee/tasks/codingagents/coding_rule_associations.py
+++ b/cognee/tasks/codingagents/coding_rule_associations.py
@@ -52,7 +52,7 @@ async def get_existing_rules(rules_nodeset_name: str) -> List[str]:
 
 
 async def get_origin_edges(data: str, rules: List[Rule]) -> list[Any]:
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     origin_chunk = await vector_engine.search("DocumentChunk_text", data, limit=1)
 

--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -25,7 +25,7 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
     """
     data_points_by_type = {}
 
-    vector_engine = vector_engine or get_vector_engine()
+    vector_engine = vector_engine or await get_vector_engine()
 
     for data_point in data_points:
         # Skip non-DataPoint objects (e.g. CogneeGraph) that may be

--- a/cognee/tasks/temporal_awareness/index_graphiti_objects.py
+++ b/cognee/tasks/temporal_awareness/index_graphiti_objects.py
@@ -14,7 +14,7 @@ async def index_and_transform_graphiti_nodes_and_edges():
         created_indexes = {}
         index_points = {}
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         graph_engine = await get_graph_engine()
     except Exception as e:
         logger.error("Failed to initialize engines: %s", e)

--- a/cognee/tests/e2e/postgres/test_graphdb_shared.py
+++ b/cognee/tests/e2e/postgres/test_graphdb_shared.py
@@ -83,7 +83,7 @@ async def run_graph_db_test(provider: str):
         # Search via vector to get a node name for graph queries
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         random_node = (
             await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
         )[0]

--- a/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
@@ -35,7 +35,7 @@ async def _reset_engines_and_prune() -> None:
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py
+++ b/cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py
@@ -25,7 +25,7 @@ async def _reset_engines_and_prune() -> None:
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/integration/retrieval/test_chunks_retriever.py
+++ b/cognee/tests/integration/retrieval/test_chunks_retriever.py
@@ -320,7 +320,7 @@ async def test_chunks_retriever_on_empty_graph(setup_test_environment_empty):
     retriever = ChunksRetriever()
     query = "Christina Mayer"
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     await vector_engine.create_collection(
         "DocumentChunk_text", payload_schema=DocumentChunkWithEntities
     )
@@ -341,7 +341,7 @@ async def test_chunks_retriever_context_on_empty_graph(setup_test_environment_em
     retriever = ChunksRetriever()
     query = "Christina Mayer"
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     await vector_engine.create_collection(
         "DocumentChunk_text", payload_schema=DocumentChunkWithEntities
     )

--- a/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
@@ -323,7 +323,7 @@ async def test_get_rag_completion_context_on_empty_graph(setup_test_environment_
     with pytest.raises(NoDataError):
         await retriever.get_retrieved_objects(query)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     await vector_engine.create_collection(
         "DocumentChunk_text", payload_schema=DocumentChunkWithEntities
     )

--- a/cognee/tests/integration/retrieval/test_summaries_retriever.py
+++ b/cognee/tests/integration/retrieval/test_summaries_retriever.py
@@ -195,7 +195,7 @@ async def test_summaries_retriever_on_empty_graph(setup_test_environment_empty):
     with pytest.raises(NoDataError):
         await retriever.get_retrieved_objects(query)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     await vector_engine.create_vector_index("TextSummary", "text")
 
     summaries = await retriever.get_retrieved_objects(query)

--- a/cognee/tests/migrations/test_migration_lockstep.py
+++ b/cognee/tests/migrations/test_migration_lockstep.py
@@ -65,7 +65,7 @@ def _triplet_id(source: str, rel: str, target: str) -> str:
 async def verify(stage: str):
     async with _store_context():
         graph_engine = await get_graph_engine()
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         nodes, edges = await graph_engine.get_graph_data()
 
         node_ids = {nid for nid, _ in nodes}

--- a/cognee/tests/tasks/entity_extraction/entity_extraction_test.py
+++ b/cognee/tests/tasks/entity_extraction/entity_extraction_test.py
@@ -70,7 +70,7 @@ async def main():
 
     document_chunks = []
     async for chunk in extract_chunks_from_documents(
-        [text_document], max_chunk_size=get_max_chunk_tokens(), chunker=TextChunker
+        [text_document], max_chunk_size=await get_max_chunk_tokens(), chunker=TextChunker
     ):
         document_chunks.append(chunk)
 

--- a/cognee/tests/test_agent_memory_e2e.py
+++ b/cognee/tests/test_agent_memory_e2e.py
@@ -22,7 +22,7 @@ async def _reset_engines_and_prune() -> None:
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/test_conversation_history.py
+++ b/cognee/tests/test_conversation_history.py
@@ -343,7 +343,7 @@ async def main():
 
     from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     collection_size = await vector_engine.search(
         collection_name="DocumentChunk_text",
         query_text="test",

--- a/cognee/tests/test_delete_dataset_ladybug.py
+++ b/cognee/tests/test_delete_dataset_ladybug.py
@@ -108,7 +108,7 @@ async def test_delete_dataset_ladybug(mock_create_structured_output: AsyncMock):
 
     mock_create_structured_output.side_effect = mock_llm_output
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")
@@ -182,7 +182,7 @@ async def test_delete_dataset_ladybug(mock_create_structured_output: AsyncMock):
     nodes, edges = await graph_engine.get_graph_data()
     assert len(nodes) == 0 and len(edges) == 0, "Nodes and edges are not deleted."
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     for collection_name, initial_nodes in johns_initial_nodes_by_collection.items():
         query_node_ids = [

--- a/cognee/tests/test_delete_dataset_neo4j.py
+++ b/cognee/tests/test_delete_dataset_neo4j.py
@@ -111,7 +111,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     mock_create_structured_output.side_effect = mock_llm_output
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")
@@ -187,7 +187,7 @@ async def main(mock_create_structured_output: AsyncMock):
             after_delete_nodes_by_vector_collection[collection_name] = []
         after_delete_nodes_by_vector_collection[collection_name].append(node)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     removed_node_ids = initial_node_ids - after_first_delete_node_ids
 

--- a/cognee/tests/test_delete_default_graph.py
+++ b/cognee/tests/test_delete_default_graph.py
@@ -133,7 +133,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     await set_database_global_context_variables("main_dataset", user.id)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("Entity_name")
     assert not await vector_engine.has_collection("DocumentChunk_text")

--- a/cognee/tests/test_delete_default_graph_non_mocked.py
+++ b/cognee/tests/test_delete_default_graph_non_mocked.py
@@ -60,7 +60,7 @@ async def main():
     )
     maries_data_id = add_result.data_ingestion_info[0]["data_id"]
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_delete_default_graph_with_legacy_data_1.py
+++ b/cognee/tests/test_delete_default_graph_with_legacy_data_1.py
@@ -160,7 +160,7 @@ async def main(mock_create_structured_output: AsyncMock):
     user = await get_default_user()
     await set_database_global_context_variables("main_dataset", user.id)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_delete_default_graph_with_legacy_data_2.py
+++ b/cognee/tests/test_delete_default_graph_with_legacy_data_2.py
@@ -137,7 +137,7 @@ async def main(mock_create_structured_output: AsyncMock):
     user = await get_default_user()
     await set_database_global_context_variables("main_dataset", user.id)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_delete_two_users_same_dataset.py
+++ b/cognee/tests/test_delete_two_users_same_dataset.py
@@ -83,7 +83,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     assert len(nodes) == 0 and len(edges) == 0, "Graph is not empty."
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_delete_two_users_with_legacy_data.py
+++ b/cognee/tests/test_delete_two_users_with_legacy_data.py
@@ -79,7 +79,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     assert len(nodes) == 0 and len(edges) == 0, "Graph is not empty."
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")
@@ -104,7 +104,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     assert len(nodes) == 0 and len(edges) == 0, "Graph is not empty."
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_edge_centered_payload.py
+++ b/cognee/tests/test_edge_centered_payload.py
@@ -135,7 +135,7 @@ async def main():
         graph_engine = await get_graph_engine()
         nodes_phase2, edges_phase2 = await graph_engine.get_graph_data()
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         triplets_phase2 = await vector_engine.search(
             query_text="technology", limit=None, collection_name="Triplet_text"
         )

--- a/cognee/tests/test_kuzu.py
+++ b/cognee/tests/test_kuzu.py
@@ -77,7 +77,7 @@ async def main():
 
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         random_node = (
             await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
         )[0]

--- a/cognee/tests/test_lancedb.py
+++ b/cognee/tests/test_lancedb.py
@@ -73,7 +73,7 @@ async def test_vector_engine_search_none_limit():
 
     from cognee.infrastructure.databases.vector import get_vector_engine
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     collection_name = "Entity_name"
 
     query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
@@ -112,7 +112,7 @@ async def test_vector_engine_search_with_nodeset_filtering():
 
     from cognee.infrastructure.databases.vector import get_vector_engine
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
 
     # Search with "OR" operator
@@ -257,7 +257,7 @@ async def main():
     dataset_1 = (await get_datasets_by_name([dataset_name_1], user.id))[0]
     await test_getting_of_documents(dataset_1.id)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     random_node = (
         await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
     )[0]

--- a/cognee/tests/test_library.py
+++ b/cognee/tests/test_library.py
@@ -53,7 +53,7 @@ async def main():
 
     from cognee.infrastructure.databases.vector import get_vector_engine
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     random_node = (await vector_engine.search("Entity_name", "AI", include_payload=True))[0]
     random_node_name = random_node.payload["text"]
 

--- a/cognee/tests/test_neo4j.py
+++ b/cognee/tests/test_neo4j.py
@@ -68,7 +68,7 @@ async def main():
 
     from cognee.infrastructure.databases.vector import get_vector_engine
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     random_node = (
         await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
     )[0]

--- a/cognee/tests/test_neptune_analytics_vector.py
+++ b/cognee/tests/test_neptune_analytics_vector.py
@@ -51,7 +51,7 @@ async def main():
 
     await cognee.cognify([dataset_name])
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     random_node = (
         await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
     )[0]
@@ -95,17 +95,17 @@ async def vector_backend_api_test():
     # When URL is absent
     cognee.config.set_vector_db_url(None)
     with pytest.raises(OSError):
-        get_vector_engine()
+        await get_vector_engine()
 
     # Assert invalid graph ID.
     cognee.config.set_vector_db_url("invalid_url")
     with pytest.raises(ValueError):
-        get_vector_engine()
+        await get_vector_engine()
 
     # Return a valid engine object with valid URL.
     graph_id = os.getenv("GRAPH_ID", "")
     cognee.config.set_vector_db_url(f"neptune-graph://{graph_id}")
-    engine = get_vector_engine()
+    engine = await get_vector_engine()
     assert isinstance(engine, NeptuneAnalyticsAdapter)
 
     TEST_COLLECTION_NAME = "test"

--- a/cognee/tests/test_permissions.py
+++ b/cognee/tests/test_permissions.py
@@ -37,7 +37,7 @@ async def _reset_engines_and_prune() -> None:
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/test_pgvector.py
+++ b/cognee/tests/test_pgvector.py
@@ -73,7 +73,7 @@ async def test_vector_engine_search_none_limit():
 
     from cognee.infrastructure.databases.vector import get_vector_engine
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     collection_name = "Entity_name"
 
@@ -113,7 +113,7 @@ async def test_vector_engine_search_with_nodeset_filtering():
 
     from cognee.infrastructure.databases.vector import get_vector_engine
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
 
     # Search with "OR" operator
@@ -273,7 +273,7 @@ async def main():
     dataset_1 = (await get_datasets_by_name([dataset_name_1], user.id))[0]
     await test_getting_of_documents(dataset_1.id)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     random_node = (
         await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
     )[0]

--- a/cognee/tests/test_remote_kuzu.py
+++ b/cognee/tests/test_remote_kuzu.py
@@ -72,7 +72,7 @@ async def main():
 
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         random_node = (
             await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
         )[0]

--- a/cognee/tests/test_s3_file_storage.py
+++ b/cognee/tests/test_s3_file_storage.py
@@ -42,7 +42,7 @@ async def main():
 
     from cognee.infrastructure.databases.vector import get_vector_engine
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     random_node = (await vector_engine.search("Entity_name", "AI", include_payload=True))[0]
     random_node_name = random_node.payload["text"]
 

--- a/cognee/tests/test_search_db.py
+++ b/cognee/tests/test_search_db.py
@@ -42,7 +42,7 @@ async def _reset_engines_and_prune() -> None:
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         # Dispose SQLAlchemy engine connection pool if it exists
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
@@ -139,7 +139,7 @@ async def setup_test_environment():
     await create_triplet_embeddings(user=user, dataset=dataset_name, triplets_batch_size=5)
 
     # Check if Triplet_text collection was created
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     has_collection = await vector_engine.has_collection(collection_name="Triplet_text")
     logger.info(f"Triplet_text collection exists after creation: {has_collection}")
 
@@ -171,7 +171,7 @@ async def e2e_state(_disable_session_turn_gating):
     graph_engine = await get_graph_engine()
     _nodes, edges = await graph_engine.get_graph_data()
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     collection = await vector_engine.search(
         collection_name="Triplet_text",
         query_text="Test",

--- a/cognee/tests/test_shared_node_preservation.py
+++ b/cognee/tests/test_shared_node_preservation.py
@@ -261,7 +261,7 @@ async def test_shared_entity_preserved_across_documents(mock_create_structured_o
     logger.info("✅ Germany→Netherlands edge deleted")
 
     # Verify vector indices match graph state
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     # Check if Germany is still in vector index
     if await vector_engine.has_collection("Entity_name"):

--- a/cognee/tests/test_usage_logger_e2e.py
+++ b/cognee/tests/test_usage_logger_e2e.py
@@ -16,7 +16,7 @@ async def _reset_engines_and_prune():
     try:
         from cognee.infrastructure.databases.vector import get_vector_engine
 
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
@@ -1,0 +1,75 @@
+"""Regression test for issue #3708 (alternate async-resolution fix): re-creating
+a subprocess graph engine for a path whose previous worker is still shutting
+down must NOT fail with "Could not set lock on file (Lock is held by PID X)".
+
+The previous worker held the on-disk file lock for its whole lifetime; a new
+worker opened the same path before the old one had exited. The fix routes engine
+creation through an async cache-acquisition path (`acreate_graph_engine` ->
+`_create_graph_engine.acall` -> `aget_or_create`) that awaits any in-flight close
+of the same cache key before constructing, waits for the worker process to
+actually exit, and retries the open on transient lock contention.
+
+Drives the REAL graph-engine cache in subprocess mode — no LLM/full config needed.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+
+import pytest
+
+pytest.importorskip("ladybug")
+
+from cognee.infrastructure.databases.graph.get_graph_engine import (
+    acreate_graph_engine,
+    evict_graph_engine,
+)
+
+
+def _config(tmp_path) -> dict:
+    return dict(
+        graph_database_provider="ladybug",
+        graph_file_path=os.path.join(str(tmp_path), "graphdir"),
+        graph_database_subprocess_enabled=True,
+        kuzu_buffer_pool_size=1 << 28,
+        kuzu_max_db_size=1 << 30,
+    )
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_async_recreate_after_evict_no_lock_error(tmp_path):
+    """Repeated evict -> re-acquire cycles for the same path via the async
+    acquisition path must never hit the lock error."""
+    cfg = _config(tmp_path)
+    for _ in range(5):
+        engine = await acreate_graph_engine(**cfg)
+        await engine.query("MATCH (n) RETURN 1 LIMIT 1")
+        del engine
+        evict_graph_engine(**cfg)
+        gc.collect()
+    engine = await acreate_graph_engine(**cfg)
+    await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_worker_process_exit(tmp_path):
+    """``close()`` must not return until the worker process has actually exited
+    (and thus released its on-disk file lock)."""
+    cfg = _config(tmp_path)
+    engine = await acreate_graph_engine(**cfg)
+    await engine.query("MATCH (n) RETURN 1 LIMIT 1")
+    pid = engine._session.pid
+    assert _pid_alive(pid)
+
+    await engine.close()
+
+    assert not _pid_alive(pid), f"worker pid {pid} still alive after close()"

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
@@ -14,6 +14,7 @@ Drives the REAL graph-engine cache in subprocess mode — no LLM/full config nee
 
 from __future__ import annotations
 
+import asyncio
 import gc
 import os
 
@@ -58,6 +59,33 @@ async def test_async_recreate_after_evict_no_lock_error(tmp_path):
         gc.collect()
     engine = await acreate_graph_engine(**cfg)
     await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_recreate_after_evict_single_worker(tmp_path):
+    """Many coroutines concurrently re-acquiring the same path while the prior
+    worker is mid-close must all wait on that one close and converge on a single
+    new worker — no lock error, no thundering herd of workers racing the lock.
+
+    Exercises the real subprocess worker (not stub closeables), the gap both the
+    sync- and async-approach test suites otherwise leave uncovered.
+    """
+    cfg = _config(tmp_path)
+    engine = await acreate_graph_engine(**cfg)
+    await engine.query("MATCH (n) RETURN 1 LIMIT 1")
+    old_pid = engine._session.pid
+    del engine
+    evict_graph_engine(**cfg)  # close starts; worker still shutting down
+    gc.collect()
+
+    engines = await asyncio.gather(*[acreate_graph_engine(**cfg) for _ in range(8)])
+
+    pids = {e._session.pid for e in engines}
+    assert len(pids) == 1, f"expected a single live worker, got {pids}"
+    assert old_pid not in pids, "must be a fresh worker, not the closed one"
+    # The single resolved engine is functional (lock was acquired cleanly).
+    await engines[0].query("MATCH (n) RETURN 1 LIMIT 1")
+    await engines[0].close()
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
@@ -89,6 +89,37 @@ async def test_concurrent_recreate_after_evict_single_worker(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_held_engine_reference_survives_eviction(tmp_path):
+    """A held engine reference must keep working after the engine is evicted
+    from the cache — which is what dataset-context teardown
+    (``_teardown_subprocess_engines``) does on context exit. The lease defers
+    the close until the reference is dropped rather than force-closing it, so
+    reuse returns a stale-but-live adapter instead of raising "adapter is
+    closed". Regression for the CI failures where reusing a ``get_*_engine()``
+    result after prune/delete/context-exit crashed.
+    """
+    cfg = _config(tmp_path)
+    engine = await acreate_graph_engine(**cfg)
+    await engine.query("MATCH (n) RETURN 1 LIMIT 1")
+
+    # Simulate what _teardown_subprocess_engines does on context exit: evict
+    # (detach), NOT force-close. The held `engine` reference keeps it alive.
+    evict_graph_engine(**cfg)
+    gc.collect()
+
+    # Reuse must still work (stale-but-live), NOT raise "adapter is closed".
+    await engine.query("MATCH (n) RETURN 1 LIMIT 1")
+
+    # Dropping the reference releases the lease → close fires; a fresh resolve
+    # for the same path then awaits that close and opens cleanly.
+    del engine
+    gc.collect()
+    fresh = await acreate_graph_engine(**cfg)
+    await fresh.query("MATCH (n) RETURN 1 LIMIT 1")
+    await fresh.close()
+
+
+@pytest.mark.asyncio
 async def test_close_waits_for_worker_process_exit(tmp_path):
     """``close()`` must not return until the worker process has actually exited
     (and thus released its on-disk file lock)."""

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
@@ -1,20 +1,21 @@
-"""Regression test for issue #3708 (alternate async-resolution fix): re-creating
-a subprocess graph engine for a path whose previous worker is still shutting
-down must NOT fail with "Could not set lock on file (Lock is held by PID X)".
+"""Regression test for issue #3708: re-creating a subprocess graph engine for a
+path whose previous worker is still shutting down must NOT fail with
+"Could not set lock on file (Lock is held by PID ...)".
 
-The previous worker held the on-disk file lock for its whole lifetime; a new
-worker opened the same path before the old one had exited. The fix routes engine
-creation through an async cache-acquisition path (`acreate_graph_engine` ->
-`_create_graph_engine.acall` -> `aget_or_create`) that awaits any in-flight close
-of the same cache key before constructing, waits for the worker process to
-actually exit, and retries the open on transient lock contention.
+Root cause: the previous worker held the on-disk file lock for its whole
+lifetime; a new worker opened the same path before the old one had exited. The
+fix coordinates create-vs-close through the closing registry (async acquisition
+waits for the in-flight close), closes subprocess adapters off the event loop so
+the lock is released even when a sync re-resolution blocks the loop, waits for
+the worker process to actually exit, and retries the open on transient lock
+contention.
 
-Drives the REAL graph-engine cache in subprocess mode — no LLM/full config needed.
+Drives the REAL graph-engine cache (`create_graph_engine` / `acreate_graph_engine`
+/ `evict_graph_engine`) in subprocess mode — no LLM or full cognee config needed.
 """
 
 from __future__ import annotations
 
-import asyncio
 import gc
 import os
 
@@ -24,6 +25,7 @@ pytest.importorskip("ladybug")
 
 from cognee.infrastructure.databases.graph.get_graph_engine import (
     acreate_graph_engine,
+    create_graph_engine,
     evict_graph_engine,
 )
 
@@ -33,9 +35,66 @@ def _config(tmp_path) -> dict:
         graph_database_provider="ladybug",
         graph_file_path=os.path.join(str(tmp_path), "graphdir"),
         graph_database_subprocess_enabled=True,
+        # Small pools keep the worker cheap to spawn in tests.
         kuzu_buffer_pool_size=1 << 28,
         kuzu_max_db_size=1 << 30,
     )
+
+
+async def _evict_after_use(cfg, *, use_async):
+    """Resolve an engine, run a query, then drop the reference and evict — so
+    the previous worker's close starts with no caller holding it (mirrors the
+    engine handle dropping a stale pin)."""
+    engine = await acreate_graph_engine(**cfg) if use_async else create_graph_engine(**cfg)
+    await engine.query("MATCH (n) RETURN 1 LIMIT 1")
+    del engine
+    evict_graph_engine(**cfg)
+    gc.collect()
+
+
+@pytest.mark.asyncio
+async def test_async_recreate_after_evict_no_lock_error(tmp_path):
+    """The async acquisition path must serialize cleanly across many
+    evict→recreate cycles for the same path."""
+    cfg = _config(tmp_path)
+    for _ in range(5):
+        await _evict_after_use(cfg, use_async=True)
+    # Cleanly tear down the last live engine.
+    engine = await acreate_graph_engine(**cfg)
+    await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_sync_recreate_after_evict_no_lock_error(tmp_path):
+    """The sync re-resolution path blocks the loop while opening the new worker;
+    the off-loop close + worker open-retry must still let it succeed."""
+    cfg = _config(tmp_path)
+    for _ in range(5):
+        await _evict_after_use(cfg, use_async=False)
+    engine = create_graph_engine(**cfg)
+    await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_reresolves_after_eviction(tmp_path):
+    """A held engine handle must transparently re-resolve after its cached
+    engine is evicted (as dataset-context teardown does), instead of raising
+    "adapter is closed". Regression for the CI failures where reusing a
+    get_graph_engine() result across prune/delete/context-exit crashed."""
+    from cognee.infrastructure.databases.graph.get_graph_engine import _GraphEngineHandle
+
+    cfg = _config(tmp_path)
+    handle = _GraphEngineHandle(cfg)
+    await handle.query("MATCH (n) RETURN 1 LIMIT 1")
+
+    # Simulate teardown: evict the cached engine. The handle pins the proxy, so
+    # its next access detects the stale pin, drops it (deferred close releases
+    # the lock off-loop), and re-resolves a fresh engine for the same path.
+    evict_graph_engine(**cfg)
+    gc.collect()
+
+    await handle.query("MATCH (n) RETURN 1 LIMIT 1")  # must NOT raise "is closed"
+    await handle.close()
 
 
 def _pid_alive(pid: int) -> bool:
@@ -47,84 +106,12 @@ def _pid_alive(pid: int) -> bool:
 
 
 @pytest.mark.asyncio
-async def test_async_recreate_after_evict_no_lock_error(tmp_path):
-    """Repeated evict -> re-acquire cycles for the same path via the async
-    acquisition path must never hit the lock error."""
-    cfg = _config(tmp_path)
-    for _ in range(5):
-        engine = await acreate_graph_engine(**cfg)
-        await engine.query("MATCH (n) RETURN 1 LIMIT 1")
-        del engine
-        evict_graph_engine(**cfg)
-        gc.collect()
-    engine = await acreate_graph_engine(**cfg)
-    await engine.close()
-
-
-@pytest.mark.asyncio
-async def test_concurrent_recreate_after_evict_single_worker(tmp_path):
-    """Many coroutines concurrently re-acquiring the same path while the prior
-    worker is mid-close must all wait on that one close and converge on a single
-    new worker — no lock error, no thundering herd of workers racing the lock.
-
-    Exercises the real subprocess worker (not stub closeables), the gap both the
-    sync- and async-approach test suites otherwise leave uncovered.
-    """
-    cfg = _config(tmp_path)
-    engine = await acreate_graph_engine(**cfg)
-    await engine.query("MATCH (n) RETURN 1 LIMIT 1")
-    old_pid = engine._session.pid
-    del engine
-    evict_graph_engine(**cfg)  # close starts; worker still shutting down
-    gc.collect()
-
-    engines = await asyncio.gather(*[acreate_graph_engine(**cfg) for _ in range(8)])
-
-    pids = {e._session.pid for e in engines}
-    assert len(pids) == 1, f"expected a single live worker, got {pids}"
-    assert old_pid not in pids, "must be a fresh worker, not the closed one"
-    # The single resolved engine is functional (lock was acquired cleanly).
-    await engines[0].query("MATCH (n) RETURN 1 LIMIT 1")
-    await engines[0].close()
-
-
-@pytest.mark.asyncio
-async def test_held_engine_reference_survives_eviction(tmp_path):
-    """A held engine reference must keep working after the engine is evicted
-    from the cache — which is what dataset-context teardown
-    (``_teardown_subprocess_engines``) does on context exit. The lease defers
-    the close until the reference is dropped rather than force-closing it, so
-    reuse returns a stale-but-live adapter instead of raising "adapter is
-    closed". Regression for the CI failures where reusing a ``get_*_engine()``
-    result after prune/delete/context-exit crashed.
-    """
-    cfg = _config(tmp_path)
-    engine = await acreate_graph_engine(**cfg)
-    await engine.query("MATCH (n) RETURN 1 LIMIT 1")
-
-    # Simulate what _teardown_subprocess_engines does on context exit: evict
-    # (detach), NOT force-close. The held `engine` reference keeps it alive.
-    evict_graph_engine(**cfg)
-    gc.collect()
-
-    # Reuse must still work (stale-but-live), NOT raise "adapter is closed".
-    await engine.query("MATCH (n) RETURN 1 LIMIT 1")
-
-    # Dropping the reference releases the lease → close fires; a fresh resolve
-    # for the same path then awaits that close and opens cleanly.
-    del engine
-    gc.collect()
-    fresh = await acreate_graph_engine(**cfg)
-    await fresh.query("MATCH (n) RETURN 1 LIMIT 1")
-    await fresh.close()
-
-
-@pytest.mark.asyncio
 async def test_close_waits_for_worker_process_exit(tmp_path):
     """``close()`` must not return until the worker process has actually exited
-    (and thus released its on-disk file lock)."""
+    (and thus released its on-disk file lock) — the guarantee that lets a new
+    worker open the same path immediately afterwards."""
     cfg = _config(tmp_path)
-    engine = await acreate_graph_engine(**cfg)
+    engine = create_graph_engine(**cfg)
     await engine.query("MATCH (n) RETURN 1 LIMIT 1")
     pid = engine._session.pid
     assert _pid_alive(pid)

--- a/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
+++ b/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
@@ -4,22 +4,9 @@ import gc
 
 from cognee.infrastructure.databases.utils.closing_lru_cache import (
     ClosingLRUCache,
+    _start_close,
     closing_lru_cache,
 )
-
-
-class _SlowAsyncCloseable:
-    """Async close() that takes measurable time, modelling a worker teardown."""
-
-    def __init__(self, name=""):
-        self.name = name
-        self.closed = False
-
-    async def close(self):
-        import asyncio
-
-        await asyncio.sleep(0.2)
-        self.closed = True
 
 
 class _Closeable:
@@ -57,6 +44,42 @@ class _AsyncWorker(_Closeable):
 
         await asyncio.sleep(0)
         return self.closed
+
+
+class _SlowSubprocessWorker:
+    """Stub modeling a subprocess-backed adapter: it advertises
+    ``_subprocess_mode`` (so its close runs off-loop) and its async close takes
+    measurable time, like tearing down a worker process / releasing a file lock.
+    """
+
+    def __init__(self, name=""):
+        self.name = name
+        self.closed = False
+        self._subprocess_mode = True
+
+    async def close(self):
+        import asyncio
+
+        await asyncio.sleep(0.2)
+        self.closed = True
+
+
+class _ThreadRecordingWorker:
+    """Records the thread name its async close ran on. Used to assert the
+    loop-vs-off-loop branch in ``_start_close``: subprocess-backed values
+    (``_subprocess_mode``) close on a pool thread; everything else closes on the
+    running loop's thread.
+    """
+
+    def __init__(self, subprocess_mode):
+        self.closed_on = None
+        if subprocess_mode:
+            self._subprocess_mode = True
+
+    async def close(self):
+        import threading
+
+        self.closed_on = threading.current_thread().name
 
 
 # -- ClosingLRUCache: basic caching -----------------------------------------
@@ -277,6 +300,171 @@ def test_awaitable_method_holds_lease_after_cache_clear():
     asyncio.run(run())
 
 
+# -- closing registry: wait-for-in-flight-close ------------------------------
+
+
+def test_leased_entry_active_reflects_eviction():
+    """``_leased_entry_active`` is True while the proxy is the live cache entry
+    and False once the entry is evicted — the signal a pinning caller uses to
+    drop a stale pin and re-resolve instead of holding an evicted worker alive.
+    """
+    cache = ClosingLRUCache(maxsize=4)
+    proxy = cache.get_or_create("k", lambda: _Closeable("a"))
+    assert proxy._leased_entry_active() is True
+    cache.evict("k")
+    assert proxy._leased_entry_active() is False
+
+
+def test_subprocess_close_runs_off_loop_and_is_tracked():
+    """A value advertising ``_subprocess_mode`` closes off the running loop, and
+    the close is registered in the cache's closing registry until it finishes.
+    """
+    import asyncio
+
+    cache = ClosingLRUCache(maxsize=4)
+
+    async def run():
+        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first"))
+        raw = proxy.__wrapped__
+        cache.evict("k")
+        del proxy
+        gc.collect()
+        # Close started off-loop (still running due to the 0.2s sleep) and is
+        # tracked. The loop is NOT blocked, so the registry entry is visible.
+        assert raw.closed is False
+        assert "k" in cache._closing
+        # Wait for it to finish and confirm the registry self-cleans.
+        await asyncio.sleep(0.4)
+        assert raw.closed is True
+        assert "k" not in cache._closing
+
+    asyncio.run(run())
+
+
+def test_aget_or_create_waits_for_in_flight_close():
+    """A new ``aget_or_create`` for a key whose previous value is still closing
+    must wait for that close to finish before constructing the replacement —
+    this is what prevents a new DB worker from racing a still-shutting-down one
+    for the file lock.
+    """
+    import asyncio
+
+    cache = ClosingLRUCache(maxsize=4)
+
+    async def run():
+        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first"))
+        raw_first = proxy.__wrapped__
+        cache.evict("k")
+        del proxy
+        gc.collect()
+        assert raw_first.closed is False  # close in flight
+
+        second = await cache.aget_or_create("k", lambda: _SlowSubprocessWorker("second"))
+        # The await must not return until the first close completed.
+        assert raw_first.closed is True
+        assert second.__wrapped__.name == "second"
+
+    asyncio.run(run())
+
+
+def test_aget_or_create_cache_hit_is_fast_path():
+    """``aget_or_create`` returns the cached value without constructing when the
+    key is present (and never blocks on the closing registry for a live entry).
+    """
+    import asyncio
+
+    cache = ClosingLRUCache(maxsize=4)
+
+    async def run():
+        first = cache.get_or_create("k", lambda: _Closeable("first"))
+        second = await cache.aget_or_create("k", lambda: _Closeable("second"))
+        assert first is second
+        assert second.name == "first"
+
+    asyncio.run(run())
+
+
+def test_aget_or_create_concurrent_callers_single_construction():
+    """Many coroutines racing ``aget_or_create`` for the same just-evicted key
+    must all wait on the one in-flight close and then resolve to a single newly
+    constructed value — no thundering-herd of duplicate workers."""
+    import asyncio
+
+    cache = ClosingLRUCache(maxsize=4)
+
+    async def run():
+        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first"))
+        raw_first = proxy.__wrapped__
+        cache.evict("k")
+        del proxy
+        gc.collect()
+        assert raw_first.closed is False  # close in flight
+
+        constructed = []
+
+        def factory():
+            w = _SlowSubprocessWorker("new")
+            constructed.append(w)
+            return w
+
+        results = await asyncio.gather(*[cache.aget_or_create("k", factory) for _ in range(10)])
+
+        assert len(constructed) == 1, "exactly one new value should be constructed"
+        assert all(r.__wrapped__ is results[0].__wrapped__ for r in results)
+        assert raw_first.closed is True  # old close completed before construction
+
+    asyncio.run(run())
+
+
+def test_start_close_subprocess_runs_off_loop_others_on_loop():
+    """``_start_close`` runs a ``_subprocess_mode`` value's close on a dedicated
+    pool thread (so a loop-blocking sync re-resolution can't wedge lock release)
+    while a plain async-close value (e.g. a SQLAlchemy-backed adapter) stays on
+    the running loop — preserving loop-bound resource semantics."""
+    import asyncio
+    import threading
+
+    async def run():
+        loop_thread = threading.current_thread().name
+
+        sub = _ThreadRecordingWorker(subprocess_mode=True)
+        fut = _start_close(sub)
+        assert fut is not None
+        await asyncio.wrap_future(fut)
+        assert sub.closed_on is not None
+        assert sub.closed_on.startswith("closing-lru-close"), (
+            f"subprocess close ran on {sub.closed_on}, expected a pool thread"
+        )
+
+        normal = _ThreadRecordingWorker(subprocess_mode=False)
+        _start_close(normal)
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert normal.closed_on == loop_thread, (
+            f"non-subprocess close ran on {normal.closed_on}, expected the loop thread"
+        )
+
+    asyncio.run(run())
+
+
+def test_decorator_acall_shares_key_with_sync_call():
+    """``acall`` builds the same cache key as the sync wrapper, so an async
+    acquisition and a sync call for the same args resolve to one object.
+    """
+    import asyncio
+
+    @closing_lru_cache(maxsize=4)
+    def create(key):
+        return _Closeable(key)
+
+    async def run():
+        a = await create.acall("x")
+        b = create("x")
+        assert a is b
+
+    asyncio.run(run())
+
+
 # -- @closing_lru_cache decorator -------------------------------------------
 
 
@@ -487,139 +675,3 @@ def test_decorator_args_and_kwargs_with_same_payload_do_not_collide():
     b = create(a=1)
     assert a is not b, "positional and keyword call shapes must not collide"
     assert call_count == 2
-
-
-# -- closing registry + async acquisition -----------------------------------
-
-
-def test_track_close_registers_in_flight_close_then_self_cleans():
-    """An async close is tracked in the closing registry while in flight and
-    removed once it completes."""
-    import asyncio
-
-    cache = ClosingLRUCache(maxsize=4)
-
-    async def run():
-        proxy = cache.get_or_create("k", lambda: _SlowAsyncCloseable("first"))
-        raw = proxy.__wrapped__
-        cache.evict("k")
-        del proxy
-        gc.collect()
-        # Close is in flight (0.2s sleep) and registered; loop is free, not blocked.
-        assert raw.closed is False
-        assert "k" in cache._closing
-        await asyncio.sleep(0.4)
-        assert raw.closed is True
-        assert "k" not in cache._closing
-
-    asyncio.run(run())
-
-
-def test_async_close_runs_as_loop_task_not_thread():
-    """With async resolution there is no off-loop close pool: an async close
-    triggered under a running loop runs as a task on THAT loop."""
-    import asyncio
-    import threading
-
-    cache = ClosingLRUCache(maxsize=1)
-    closed_on = {}
-
-    class _ThreadRecordingCloseable:
-        async def close(self):
-            closed_on["thread"] = threading.current_thread().name
-
-    async def run():
-        proxy = cache.get_or_create("k", lambda: _ThreadRecordingCloseable())
-        cache.evict("k")
-        del proxy
-        gc.collect()
-        for _ in range(3):
-            await asyncio.sleep(0)
-        assert closed_on.get("thread") == threading.current_thread().name
-
-    asyncio.run(run())
-
-
-def test_aget_or_create_waits_for_in_flight_close():
-    """A new ``aget_or_create`` for a key whose previous value is still closing
-    must wait for that close to finish before constructing the replacement —
-    the guarantee that prevents a new DB worker from racing a shutting-down one."""
-    import asyncio
-
-    cache = ClosingLRUCache(maxsize=4)
-
-    async def run():
-        proxy = cache.get_or_create("k", lambda: _SlowAsyncCloseable("first"))
-        raw_first = proxy.__wrapped__
-        cache.evict("k")
-        del proxy
-        gc.collect()
-        assert raw_first.closed is False  # close in flight
-
-        second = await cache.aget_or_create("k", lambda: _SlowAsyncCloseable("second"))
-        assert raw_first.closed is True  # old close completed before construction
-        assert second.__wrapped__.name == "second"
-
-    asyncio.run(run())
-
-
-def test_aget_or_create_concurrent_callers_single_construction():
-    """Many coroutines racing ``aget_or_create`` for the same just-evicted key
-    all wait on the one in-flight close, then resolve to a single new value."""
-    import asyncio
-
-    cache = ClosingLRUCache(maxsize=4)
-
-    async def run():
-        proxy = cache.get_or_create("k", lambda: _SlowAsyncCloseable("first"))
-        raw_first = proxy.__wrapped__
-        cache.evict("k")
-        del proxy
-        gc.collect()
-        assert raw_first.closed is False
-
-        constructed = []
-
-        def factory():
-            w = _SlowAsyncCloseable("new")
-            constructed.append(w)
-            return w
-
-        results = await asyncio.gather(*[cache.aget_or_create("k", factory) for _ in range(10)])
-
-        assert len(constructed) == 1
-        assert all(r.__wrapped__ is results[0].__wrapped__ for r in results)
-        assert raw_first.closed is True
-
-    asyncio.run(run())
-
-
-def test_aget_or_create_cache_hit_fast_path():
-    """A cache hit returns the cached value without constructing or waiting."""
-    import asyncio
-
-    cache = ClosingLRUCache(maxsize=4)
-
-    async def run():
-        first = cache.get_or_create("k", lambda: _Closeable("first"))
-        second = await cache.aget_or_create("k", lambda: _Closeable("second"))
-        assert first is second
-        assert second.name == "first"
-
-    asyncio.run(run())
-
-
-def test_decorator_acall_shares_key_with_sync_call():
-    """``acall`` builds the same cache key as the sync wrapper."""
-    import asyncio
-
-    @closing_lru_cache(maxsize=4)
-    def create(key):
-        return _Closeable(key)
-
-    async def run():
-        a = await create.acall("x")
-        b = create("x")
-        assert a is b
-
-    asyncio.run(run())

--- a/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
+++ b/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
@@ -8,6 +8,20 @@ from cognee.infrastructure.databases.utils.closing_lru_cache import (
 )
 
 
+class _SlowAsyncCloseable:
+    """Async close() that takes measurable time, modelling a worker teardown."""
+
+    def __init__(self, name=""):
+        self.name = name
+        self.closed = False
+
+    async def close(self):
+        import asyncio
+
+        await asyncio.sleep(0.2)
+        self.closed = True
+
+
 class _Closeable:
     """Stub with a sync close() that records calls."""
 
@@ -473,3 +487,139 @@ def test_decorator_args_and_kwargs_with_same_payload_do_not_collide():
     b = create(a=1)
     assert a is not b, "positional and keyword call shapes must not collide"
     assert call_count == 2
+
+
+# -- closing registry + async acquisition -----------------------------------
+
+
+def test_track_close_registers_in_flight_close_then_self_cleans():
+    """An async close is tracked in the closing registry while in flight and
+    removed once it completes."""
+    import asyncio
+
+    cache = ClosingLRUCache(maxsize=4)
+
+    async def run():
+        proxy = cache.get_or_create("k", lambda: _SlowAsyncCloseable("first"))
+        raw = proxy.__wrapped__
+        cache.evict("k")
+        del proxy
+        gc.collect()
+        # Close is in flight (0.2s sleep) and registered; loop is free, not blocked.
+        assert raw.closed is False
+        assert "k" in cache._closing
+        await asyncio.sleep(0.4)
+        assert raw.closed is True
+        assert "k" not in cache._closing
+
+    asyncio.run(run())
+
+
+def test_async_close_runs_as_loop_task_not_thread():
+    """With async resolution there is no off-loop close pool: an async close
+    triggered under a running loop runs as a task on THAT loop."""
+    import asyncio
+    import threading
+
+    cache = ClosingLRUCache(maxsize=1)
+    closed_on = {}
+
+    class _ThreadRecordingCloseable:
+        async def close(self):
+            closed_on["thread"] = threading.current_thread().name
+
+    async def run():
+        proxy = cache.get_or_create("k", lambda: _ThreadRecordingCloseable())
+        cache.evict("k")
+        del proxy
+        gc.collect()
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert closed_on.get("thread") == threading.current_thread().name
+
+    asyncio.run(run())
+
+
+def test_aget_or_create_waits_for_in_flight_close():
+    """A new ``aget_or_create`` for a key whose previous value is still closing
+    must wait for that close to finish before constructing the replacement —
+    the guarantee that prevents a new DB worker from racing a shutting-down one."""
+    import asyncio
+
+    cache = ClosingLRUCache(maxsize=4)
+
+    async def run():
+        proxy = cache.get_or_create("k", lambda: _SlowAsyncCloseable("first"))
+        raw_first = proxy.__wrapped__
+        cache.evict("k")
+        del proxy
+        gc.collect()
+        assert raw_first.closed is False  # close in flight
+
+        second = await cache.aget_or_create("k", lambda: _SlowAsyncCloseable("second"))
+        assert raw_first.closed is True  # old close completed before construction
+        assert second.__wrapped__.name == "second"
+
+    asyncio.run(run())
+
+
+def test_aget_or_create_concurrent_callers_single_construction():
+    """Many coroutines racing ``aget_or_create`` for the same just-evicted key
+    all wait on the one in-flight close, then resolve to a single new value."""
+    import asyncio
+
+    cache = ClosingLRUCache(maxsize=4)
+
+    async def run():
+        proxy = cache.get_or_create("k", lambda: _SlowAsyncCloseable("first"))
+        raw_first = proxy.__wrapped__
+        cache.evict("k")
+        del proxy
+        gc.collect()
+        assert raw_first.closed is False
+
+        constructed = []
+
+        def factory():
+            w = _SlowAsyncCloseable("new")
+            constructed.append(w)
+            return w
+
+        results = await asyncio.gather(*[cache.aget_or_create("k", factory) for _ in range(10)])
+
+        assert len(constructed) == 1
+        assert all(r.__wrapped__ is results[0].__wrapped__ for r in results)
+        assert raw_first.closed is True
+
+    asyncio.run(run())
+
+
+def test_aget_or_create_cache_hit_fast_path():
+    """A cache hit returns the cached value without constructing or waiting."""
+    import asyncio
+
+    cache = ClosingLRUCache(maxsize=4)
+
+    async def run():
+        first = cache.get_or_create("k", lambda: _Closeable("first"))
+        second = await cache.aget_or_create("k", lambda: _Closeable("second"))
+        assert first is second
+        assert second.name == "first"
+
+    asyncio.run(run())
+
+
+def test_decorator_acall_shares_key_with_sync_call():
+    """``acall`` builds the same cache key as the sync wrapper."""
+    import asyncio
+
+    @closing_lru_cache(maxsize=4)
+    def create(key):
+        return _Closeable(key)
+
+    async def run():
+        a = await create.acall("x")
+        b = create("x")
+        assert a is b
+
+    asyncio.run(run())

--- a/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
@@ -17,9 +17,12 @@ async def test_index_data_points_calls_vector_engine():
     mock_vector_engine = AsyncMock()
     mock_vector_engine.embedding_engine.get_batch_size = MagicMock(return_value=100)
 
+    async def _get_vector_engine():
+        return mock_vector_engine
+
     with patch.dict(
         index_data_points.__globals__,
-        {"get_vector_engine": lambda: mock_vector_engine},
+        {"get_vector_engine": _get_vector_engine},
     ):
         await index_data_points(data_points)
 

--- a/cognee/tests/unit/infrastructure/databases/test_index_graph_edges.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_graph_edges.py
@@ -107,7 +107,7 @@ async def test_index_graph_edges_initialization_error():
         index_graph_edges.__globals__,
         {
             "get_graph_engine": AsyncMock(side_effect=Exception("Graph engine failed")),
-            "get_vector_engine": lambda: AsyncMock(),
+            "get_vector_engine": AsyncMock(return_value=AsyncMock()),
         },
     ):
         with pytest.raises(RuntimeError, match="Graph edge indexing error"):

--- a/cognee/tests/unit/infrastructure/databases/test_kuzu_worker_open_retry.py
+++ b/cognee/tests/unit/infrastructure/databases/test_kuzu_worker_open_retry.py
@@ -1,0 +1,83 @@
+"""Tests for the worker-side lock-retry on opening a Ladybug database
+(``cognee_db_workers.kuzu_worker._retry_open_locked``).
+
+These don't import ``ladybug`` — the worker imports it lazily and the retry
+helper is driven with a fake stand-in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import cognee_db_workers.harness as harness
+from cognee_db_workers import kuzu_worker
+
+_LOCK_MSG = "IO exception: Could not set lock on file : /tmp/x"
+
+
+class _FakeLadybug:
+    """Stand-in for the ``ladybug`` module. ``Database(**kwargs)`` raises a
+    lock-held ``RuntimeError`` the first ``fail_times`` calls, then succeeds."""
+
+    def __init__(self, fail_times, error_message=_LOCK_MSG):
+        self._left = fail_times
+        self._error_message = error_message
+        self.calls = 0
+
+    def Database(self, **kwargs):
+        self.calls += 1
+        if self._left > 0:
+            self._left -= 1
+            raise RuntimeError(self._error_message)
+        return "DB_OK"
+
+
+def test_retry_disabled_reraises_original_not_typeerror(monkeypatch):
+    """SUBPROCESS_OPEN_LOCK_RETRIES <= 0 must re-raise the original lock error,
+    not blow up with ``TypeError: exceptions must derive from BaseException``
+    from ``raise None``."""
+    monkeypatch.setattr(harness, "OPEN_LOCK_RETRIES", 0)
+    monkeypatch.setattr(harness, "OPEN_LOCK_BACKOFF", 0.001)
+
+    fake = _FakeLadybug(fail_times=99)  # would keep failing if ever called
+    original = RuntimeError(_LOCK_MSG)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        kuzu_worker._retry_open_locked(fake, {"database_path": "/tmp/x"}, original)
+
+    assert exc_info.value is original
+    assert fake.calls == 0, "retries disabled must not attempt any reopen"
+
+
+def test_retry_succeeds_after_transient_lock(monkeypatch):
+    """A lock that clears within the retry budget yields a successful open."""
+    monkeypatch.setattr(harness, "OPEN_LOCK_RETRIES", 5)
+    monkeypatch.setattr(harness, "OPEN_LOCK_BACKOFF", 0.001)
+
+    fake = _FakeLadybug(fail_times=2)
+    result = kuzu_worker._retry_open_locked(fake, {}, RuntimeError(_LOCK_MSG))
+
+    assert result == "DB_OK"
+    assert fake.calls == 3  # 2 transient failures + 1 success
+
+
+def test_retry_exhausted_reraises_last_lock_error(monkeypatch):
+    """When every retry still hits the lock, the last lock error propagates."""
+    monkeypatch.setattr(harness, "OPEN_LOCK_RETRIES", 3)
+    monkeypatch.setattr(harness, "OPEN_LOCK_BACKOFF", 0.001)
+
+    fake = _FakeLadybug(fail_times=99)
+    with pytest.raises(RuntimeError, match="Could not set lock on file"):
+        kuzu_worker._retry_open_locked(fake, {}, RuntimeError(_LOCK_MSG))
+    assert fake.calls == 3
+
+
+def test_retry_passes_through_non_lock_error(monkeypatch):
+    """A non-lock RuntimeError during a retry attempt is not swallowed/retried."""
+    monkeypatch.setattr(harness, "OPEN_LOCK_RETRIES", 5)
+    monkeypatch.setattr(harness, "OPEN_LOCK_BACKOFF", 0.001)
+
+    fake = _FakeLadybug(fail_times=99, error_message="some other corruption")
+    with pytest.raises(RuntimeError, match="some other corruption"):
+        kuzu_worker._retry_open_locked(fake, {}, RuntimeError(_LOCK_MSG))
+    assert fake.calls == 1, "a non-lock error must abort retries immediately"

--- a/cognee/tests/unit/infrastructure/llm/test_embedding_connection_dimensions.py
+++ b/cognee/tests/unit/infrastructure/llm/test_embedding_connection_dimensions.py
@@ -21,11 +21,15 @@ async def test_embedding_connection_returns_detected_dimensions(monkeypatch):
 
     import cognee.infrastructure.databases.vector as vector_module
 
-    monkeypatch.setattr(vector_module, "get_vector_engine", lambda: fake_vector_engine)
+    async def _get_vector_engine():
+        return fake_vector_engine
+
+    monkeypatch.setattr(vector_module, "get_vector_engine", _get_vector_engine)
     assert await llm_utils.test_embedding_connection() == 3
 
 
-def test_determine_embedding_dimensions_uses_env_dimensions_when_provided(monkeypatch):
+@pytest.mark.asyncio
+async def test_determine_embedding_dimensions_uses_env_dimensions_when_provided(monkeypatch):
     fake_engine = _FakeEmbeddingEngine(vector=[0.1, 0.2, 0.3], dimensions=3072)
     fake_vector_engine = SimpleNamespace(embedding_engine=fake_engine)
     fake_embedding_config = SimpleNamespace(embedding_dimensions=3072)
@@ -35,18 +39,24 @@ def test_determine_embedding_dimensions_uses_env_dimensions_when_provided(monkey
     import cognee.infrastructure.databases.vector as vector_module
     import cognee.infrastructure.databases.vector.embeddings.config as embedding_config_module
 
-    monkeypatch.setattr(vector_module, "get_vector_engine", lambda: fake_vector_engine)
+    async def _get_vector_engine():
+        return fake_vector_engine
+
+    monkeypatch.setattr(vector_module, "get_vector_engine", _get_vector_engine)
     monkeypatch.setattr(
         embedding_config_module, "get_embedding_config", lambda: fake_embedding_config
     )
 
-    llm_utils.determine_embedding_dimensions(3)
+    await llm_utils.determine_embedding_dimensions(3)
 
     assert fake_embedding_config.embedding_dimensions == 3072
     assert fake_engine.dimensions == 3072
 
 
-def test_determine_embedding_dimensions_uses_detected_dimensions_when_env_missing(monkeypatch):
+@pytest.mark.asyncio
+async def test_determine_embedding_dimensions_uses_detected_dimensions_when_env_missing(
+    monkeypatch,
+):
     fake_engine = _FakeEmbeddingEngine(vector=[0.1, 0.2, 0.3], dimensions=3072)
     fake_vector_engine = SimpleNamespace(embedding_engine=fake_engine)
     fake_embedding_config = SimpleNamespace(embedding_dimensions=3072)
@@ -56,12 +66,15 @@ def test_determine_embedding_dimensions_uses_detected_dimensions_when_env_missin
     import cognee.infrastructure.databases.vector as vector_module
     import cognee.infrastructure.databases.vector.embeddings.config as embedding_config_module
 
-    monkeypatch.setattr(vector_module, "get_vector_engine", lambda: fake_vector_engine)
+    async def _get_vector_engine():
+        return fake_vector_engine
+
+    monkeypatch.setattr(vector_module, "get_vector_engine", _get_vector_engine)
     monkeypatch.setattr(
         embedding_config_module, "get_embedding_config", lambda: fake_embedding_config
     )
 
-    llm_utils.determine_embedding_dimensions(3)
+    await llm_utils.determine_embedding_dimensions(3)
 
     assert fake_embedding_config.embedding_dimensions == 3
     assert fake_engine.dimensions == 3

--- a/cognee/tests/unit/infrastructure/session/test_session_embeddings.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_embeddings.py
@@ -221,9 +221,13 @@ class TestSessionQaVectorHelpers:
             return [SimpleNamespace(id=result_id)]
 
         vector_engine.search = fake_search
+
+        async def _get_vector_engine():
+            return vector_engine
+
         monkeypatch.setattr(
             "cognee.infrastructure.databases.vector.get_vector_engine",
-            lambda: vector_engine,
+            _get_vector_engine,
         )
 
         qa_ids = await search_session_qa_ids(
@@ -249,9 +253,13 @@ class TestSessionQaVectorHelpers:
             raise CollectionNotFoundError("Collection not found")
 
         vector_engine.search = fake_search
+
+        async def _get_vector_engine():
+            return vector_engine
+
         monkeypatch.setattr(
             "cognee.infrastructure.databases.vector.get_vector_engine",
-            lambda: vector_engine,
+            _get_vector_engine,
         )
 
         qa_ids = await search_session_qa_ids(
@@ -272,9 +280,13 @@ class TestSessionQaVectorHelpers:
             vector_engine.delete_call = (collection_name, data_point_ids)
 
         vector_engine.delete_data_points = fake_delete_data_points
+
+        async def _get_vector_engine():
+            return vector_engine
+
         monkeypatch.setattr(
             "cognee.infrastructure.databases.vector.get_vector_engine",
-            lambda: vector_engine,
+            _get_vector_engine,
         )
 
         await delete_session_qa_vector(qa_id=str(qa_id))
@@ -291,9 +303,13 @@ class TestSessionQaVectorHelpers:
             vector_engine.remove_tags_call = tags
 
         vector_engine.remove_belongs_to_set_tags = fake_remove_belongs_to_set_tags
+
+        async def _get_vector_engine():
+            return vector_engine
+
         monkeypatch.setattr(
             "cognee.infrastructure.databases.vector.get_vector_engine",
-            lambda: vector_engine,
+            _get_vector_engine,
         )
 
         await delete_session_qa_vectors(user_id="u1", session_id="s1")

--- a/cognee/tests/unit/modules/graph/test_delete_detag_nodeset.py
+++ b/cognee/tests/unit/modules/graph/test_delete_detag_nodeset.py
@@ -51,7 +51,7 @@ async def test_detag_called_with_removed_nodeset_names():
         patch.object(
             delete_from_graph_and_vector_module,
             "get_vector_engine",
-            lambda: vector_engine,
+            AsyncMock(return_value=vector_engine),
         ),
         patch.object(
             delete_from_graph_and_vector_module,
@@ -93,7 +93,7 @@ async def test_detag_skipped_when_no_nodeset_in_batch():
         patch.object(
             delete_from_graph_and_vector_module,
             "get_vector_engine",
-            lambda: vector_engine,
+            AsyncMock(return_value=vector_engine),
         ),
         patch.object(
             delete_from_graph_and_vector_module,
@@ -141,7 +141,7 @@ async def test_delete_uses_edge_text_for_edge_type_delete_ids():
         patch.object(
             delete_from_graph_and_vector_module,
             "get_vector_engine",
-            lambda: vector_engine,
+            AsyncMock(return_value=vector_engine),
         ),
         patch.object(
             delete_from_graph_and_vector_module,

--- a/cognee/tests/unit/modules/migrations/test_database_migrations.py
+++ b/cognee/tests/unit/modules/migrations/test_database_migrations.py
@@ -368,8 +368,11 @@ def test_adapter_storage_sync_runs_on_version_change_even_at_chain_head(monkeypa
         async def _fake_graph():
             return object()
 
+        async def _fake_vector():
+            return fake_vector
+
         monkeypatch.setattr(runner, "get_graph_engine", _fake_graph)
-        monkeypatch.setattr(runner, "get_vector_engine", lambda: fake_vector)
+        monkeypatch.setattr(runner, "get_vector_engine", _fake_vector)
 
         # version changed (0.0.0-old != 9.9.9-new) -> adapter sync runs once,
         # even though the chain is at head (no data migration applied).

--- a/cognee/tests/unit/truth_subspace/test_build_centroid_slots.py
+++ b/cognee/tests/unit/truth_subspace/test_build_centroid_slots.py
@@ -50,7 +50,10 @@ async def _run_build(monkeypatch, session_ids=None):
             "cognee.modules.truth_subspace.build.get_authorized_existing_datasets",
             new=AsyncMock(return_value=[dataset]),
         ),
-        patch("cognee.modules.truth_subspace.build.get_vector_engine", return_value=vector_engine),
+        patch(
+            "cognee.modules.truth_subspace.build.get_vector_engine",
+            new=AsyncMock(return_value=vector_engine),
+        ),
         patch(
             "cognee.modules.truth_subspace.build.get_graph_engine",
             new=AsyncMock(return_value=graph_engine),

--- a/cognee/tests/utils/assert_edges_vector_index_not_present.py
+++ b/cognee/tests/utils/assert_edges_vector_index_not_present.py
@@ -5,7 +5,7 @@ from cognee.modules.graph.models.EdgeType import EdgeType
 
 
 async def assert_edges_vector_index_not_present(relationships: List[Tuple[UUID, UUID, str, Dict]]):
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     query_edge_ids = {
         str(EdgeType.id_for(relationship[2])): relationship[2] for relationship in relationships

--- a/cognee/tests/utils/assert_edges_vector_index_present.py
+++ b/cognee/tests/utils/assert_edges_vector_index_present.py
@@ -36,7 +36,7 @@ def format_relationship(
 async def assert_edges_vector_index_present(
     relationships: List[Tuple[UUID, UUID, str, Dict]], convert_to_new_format: bool = True
 ):
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     graph_engine = await get_graph_engine()
     nodes, graph_edges = await graph_engine.get_graph_data()

--- a/cognee/tests/utils/assert_nodes_vector_index_not_present.py
+++ b/cognee/tests/utils/assert_nodes_vector_index_not_present.py
@@ -4,7 +4,7 @@ from cognee.infrastructure.engine.models.DataPoint import DataPoint
 
 
 async def assert_nodes_vector_index_not_present(data_points: List[DataPoint]):
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     data_points_by_vector_collection = {}
 

--- a/cognee/tests/utils/assert_nodes_vector_index_present.py
+++ b/cognee/tests/utils/assert_nodes_vector_index_present.py
@@ -4,7 +4,7 @@ from cognee.infrastructure.engine.models.DataPoint import DataPoint
 
 
 async def assert_nodes_vector_index_present(data_points: List[DataPoint]):
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
 
     data_points_by_vector_collection = {}
 

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -72,7 +72,12 @@ _PROCESS_CHECK_INTERVAL = 1.0
 # another opens the same path; see ``kuzu_worker._open_database``. Override with
 # ``SUBPROCESS_OPEN_LOCK_RETRIES`` / ``SUBPROCESS_OPEN_LOCK_BACKOFF``.
 OPEN_LOCK_RETRIES = _env_int("SUBPROCESS_OPEN_LOCK_RETRIES", 10)
-OPEN_LOCK_BACKOFF = _env_float("SUBPROCESS_OPEN_LOCK_BACKOFF", 0.1) or 0.1
+# ``_env_float`` returns the default (0.1) when unset/invalid and ``None`` for an
+# explicit ``<= 0``. Treat that explicit ``<= 0`` as ``0.0`` (immediate retries,
+# no delay) rather than resetting to the default, so ``SUBPROCESS_OPEN_LOCK_BACKOFF=0``
+# is honored.
+_OPEN_LOCK_BACKOFF_RAW = _env_float("SUBPROCESS_OPEN_LOCK_BACKOFF", 0.1)
+OPEN_LOCK_BACKOFF = 0.0 if _OPEN_LOCK_BACKOFF_RAW is None else _OPEN_LOCK_BACKOFF_RAW
 _READY_SENTINEL = "__SUBPROCESS_HARNESS_READY__"
 
 # Universal op code — every worker's DISPATCH includes an entry for it so

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -67,9 +67,9 @@ _PROCESS_CHECK_INTERVAL = 1.0
 
 # Number of times the worker retries opening a database that is currently
 # lock-held by another (still-shutting-down) worker for the same file, and the
-# initial backoff between attempts (seconds, exponential). Backstop for the
-# brief window where one worker is releasing a file lock while another opens the
-# same path; see ``kuzu_worker._open_database``. Override with
+# initial backoff between attempts (seconds, exponential). These exist as a
+# backstop for the brief window where one worker is releasing a file lock while
+# another opens the same path; see ``kuzu_worker._open_database``. Override with
 # ``SUBPROCESS_OPEN_LOCK_RETRIES`` / ``SUBPROCESS_OPEN_LOCK_BACKOFF``.
 OPEN_LOCK_RETRIES = _env_int("SUBPROCESS_OPEN_LOCK_RETRIES", 10)
 OPEN_LOCK_BACKOFF = _env_float("SUBPROCESS_OPEN_LOCK_BACKOFF", 0.1) or 0.1
@@ -1067,7 +1067,8 @@ class SubprocessSession:
     def _terminate(self, timeout: float = 2.0) -> None:
         """Force-terminate the worker process and wait until it has actually
         exited. Idempotent and serialized by ``self._terminate_lock`` so
-        concurrent ``shutdown`` / ``__del__`` / ``clean`` paths can't race.
+        concurrent ``shutdown`` / ``__del__`` / ``clean`` paths can't race each
+        other.
 
         The escalating join/terminate/kill chain is followed by a bounded poll
         that does not return while ``is_alive()`` is still True. This matters

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -64,6 +64,15 @@ def _env_int(name: str, default: int) -> int:
 _DEFAULT_CALL_TIMEOUT: Optional[float] = _env_float("SUBPROCESS_CALL_TIMEOUT", 300.0)
 _DEFAULT_MAX_RETRIES = _env_int("SUBPROCESS_MAX_RETRIES", 2)
 _PROCESS_CHECK_INTERVAL = 1.0
+
+# Number of times the worker retries opening a database that is currently
+# lock-held by another (still-shutting-down) worker for the same file, and the
+# initial backoff between attempts (seconds, exponential). Backstop for the
+# brief window where one worker is releasing a file lock while another opens the
+# same path; see ``kuzu_worker._open_database``. Override with
+# ``SUBPROCESS_OPEN_LOCK_RETRIES`` / ``SUBPROCESS_OPEN_LOCK_BACKOFF``.
+OPEN_LOCK_RETRIES = _env_int("SUBPROCESS_OPEN_LOCK_RETRIES", 10)
+OPEN_LOCK_BACKOFF = _env_float("SUBPROCESS_OPEN_LOCK_BACKOFF", 0.1) or 0.1
 _READY_SENTINEL = "__SUBPROCESS_HARNESS_READY__"
 
 # Universal op code — every worker's DISPATCH includes an entry for it so
@@ -1056,9 +1065,20 @@ class SubprocessSession:
         self._handle_remap.clear()
 
     def _terminate(self, timeout: float = 2.0) -> None:
-        """Force-terminate the worker process. Idempotent and serialized by
-        ``self._terminate_lock`` so concurrent ``shutdown`` / ``__del__`` /
-        ``clean`` paths can't race each other.
+        """Force-terminate the worker process and wait until it has actually
+        exited. Idempotent and serialized by ``self._terminate_lock`` so
+        concurrent ``shutdown`` / ``__del__`` / ``clean`` paths can't race.
+
+        The escalating join/terminate/kill chain is followed by a bounded poll
+        that does not return while ``is_alive()`` is still True. This matters
+        for the on-disk file lock held by DB workers (Ladybug/LanceDB): the OS
+        releases a process's file locks only once the process is truly gone, so
+        a caller that re-opens the same DB path right after ``shutdown()``
+        returns would hit "Could not set lock on file" if we returned while the
+        child were still alive. ``join(timeout)`` alone can return early (e.g.
+        right after ``kill()`` the SIGKILL may not have been delivered yet), so
+        we poll ``is_alive()`` until the process is reaped, capped so a wedged
+        kernel state can't hang teardown forever.
         """
         with self._terminate_lock:
             try:
@@ -1069,6 +1089,13 @@ class SubprocessSession:
                 if self._proc.is_alive():
                     self._proc.kill()
                     self._proc.join(timeout=timeout)
+                # Final wait for true exit: after SIGKILL the process should die
+                # promptly, but ``join`` above may have timed out before the
+                # kernel reaped it. Poll up to a generous cap so we don't return
+                # while the child still holds its file lock.
+                deadline = time.monotonic() + max(timeout, 5.0)
+                while self._proc.is_alive() and time.monotonic() < deadline:
+                    self._proc.join(timeout=0.05)
             except Exception:
                 pass
 

--- a/cognee_db_workers/kuzu_worker.py
+++ b/cognee_db_workers/kuzu_worker.py
@@ -36,12 +36,12 @@ def _retry_open_locked(ladybug, kwargs, original_exc):
     """Re-attempt ``ladybug.Database(**kwargs)`` after an initial lock-held
     failure, with bounded exponential backoff.
 
-    Backstop for the brief window where another worker for the same DB path is
-    still releasing its on-disk file lock (e.g. a cache eviction whose close is
-    driven by a GC finalizer and so can't be cleanly awaited by the creator).
-    The OS frees a dead process's file locks immediately, so once the previous
-    worker exits the next attempt succeeds. Only the lock-held error is retried;
-    any other ``RuntimeError`` propagates unchanged.
+    This is a backstop for the brief window where another worker for the same
+    DB path is still releasing its on-disk file lock (e.g. a cache eviction
+    whose close is driven by a GC finalizer and so can't be cleanly awaited by
+    the creator). The OS frees a dead process's file locks immediately, so once
+    the previous worker exits the next attempt succeeds. Only the lock-held
+    error is retried; any other ``RuntimeError`` propagates unchanged.
 
     ``original_exc`` is the first lock-held failure the caller already saw; it is
     re-raised when retries are exhausted — or immediately when retries are

--- a/cognee_db_workers/kuzu_worker.py
+++ b/cognee_db_workers/kuzu_worker.py
@@ -29,6 +29,43 @@ from .kuzu_protocol import (
 )
 
 
+_LOCK_HELD_MARKER = "could not set lock on file"
+
+
+def _retry_open_locked(ladybug, kwargs, original_exc):
+    """Re-attempt ``ladybug.Database(**kwargs)`` after an initial lock-held
+    failure, with bounded exponential backoff.
+
+    Backstop for the brief window where another worker for the same DB path is
+    still releasing its on-disk file lock (e.g. a cache eviction whose close is
+    driven by a GC finalizer and so can't be cleanly awaited by the creator).
+    The OS frees a dead process's file locks immediately, so once the previous
+    worker exits the next attempt succeeds. Only the lock-held error is retried;
+    any other ``RuntimeError`` propagates unchanged.
+
+    ``original_exc`` is the first lock-held failure the caller already saw; it is
+    re-raised when retries are exhausted — or immediately when retries are
+    disabled (``SUBPROCESS_OPEN_LOCK_RETRIES <= 0``), so a misconfigured value
+    surfaces the real lock error instead of a spurious ``TypeError``.
+    """
+    import time
+
+    from .harness import OPEN_LOCK_BACKOFF, OPEN_LOCK_RETRIES
+
+    last_exc = original_exc
+    for attempt in range(OPEN_LOCK_RETRIES):
+        # Backoff first — the caller already saw one failure. Cap per-attempt so
+        # exponential growth stays bounded (≈ a few seconds total by default).
+        time.sleep(min(OPEN_LOCK_BACKOFF * (2**attempt), 0.5))
+        try:
+            return ladybug.Database(**kwargs)
+        except RuntimeError as e:
+            if _LOCK_HELD_MARKER not in str(e).lower():
+                raise
+            last_exc = e
+    raise last_exc
+
+
 def _open_database(registry: HandleRegistry, req: Request) -> HandleResult:
     import ladybug
 
@@ -36,29 +73,36 @@ def _open_database(registry: HandleRegistry, req: Request) -> HandleResult:
         db = ladybug.Database(**req.kwargs)
     except RuntimeError as e:
         db_path = req.kwargs.get("database_path", "")
+        message = str(e).lower()
 
-        if "wal" in str(e).lower():
-            # In case of corrupted WAL file preventing database opening, remove the WAL file and try again
-            wal_path = db_path + ".wal"
-            try:
-                import os
-
-                os.remove(wal_path)
-            except FileNotFoundError:
-                pass
+        if _LOCK_HELD_MARKER in message:
+            # Transient inter-process lock contention with another worker that
+            # is still shutting down for the same path — retry with backoff
+            # rather than treating it as corruption/migration.
+            db = _retry_open_locked(ladybug, req.kwargs, e)
         else:
-            from .ladybug_migrate import needs_migration, ladybug_migration
+            if "wal" in message:
+                # In case of corrupted WAL file preventing database opening, remove the WAL file and try again
+                wal_path = db_path + ".wal"
+                try:
+                    import os
 
-            should_migrate, old_version = needs_migration(db_path, ladybug.__version__)
-            if should_migrate:
-                ladybug_migration(
-                    new_db=db_path + "_new",
-                    old_db=db_path,
-                    new_version=ladybug.__version__,
-                    old_version=old_version,
-                    overwrite=True,
-                )
-        db = ladybug.Database(**req.kwargs)
+                    os.remove(wal_path)
+                except FileNotFoundError:
+                    pass
+            else:
+                from .ladybug_migrate import needs_migration, ladybug_migration
+
+                should_migrate, old_version = needs_migration(db_path, ladybug.__version__)
+                if should_migrate:
+                    ladybug_migration(
+                        new_db=db_path + "_new",
+                        old_db=db_path,
+                        new_version=ladybug.__version__,
+                        old_version=old_version,
+                        overwrite=True,
+                    )
+            db = ladybug.Database(**req.kwargs)
 
     return HandleResult(value=None, handle_id=registry.register(db))
 

--- a/cognee_db_workers/kuzu_worker.py
+++ b/cognee_db_workers/kuzu_worker.py
@@ -43,10 +43,12 @@ def _retry_open_locked(ladybug, kwargs, original_exc):
     the previous worker exits the next attempt succeeds. Only the lock-held
     error is retried; any other ``RuntimeError`` propagates unchanged.
 
-    ``original_exc`` is the first lock-held failure the caller already saw; it is
-    re-raised when retries are exhausted — or immediately when retries are
-    disabled (``SUBPROCESS_OPEN_LOCK_RETRIES <= 0``), so a misconfigured value
-    surfaces the real lock error instead of a spurious ``TypeError``.
+    ``original_exc`` is the first lock-held failure the caller already saw and
+    seeds ``last_exc``. When every retry still hits the lock the *last* lock
+    error is raised (``last_exc``, updated each attempt); when retries are
+    disabled (``SUBPROCESS_OPEN_LOCK_RETRIES <= 0``) the loop never runs so
+    ``original_exc`` is raised immediately — either way a real lock error
+    surfaces rather than a spurious ``TypeError`` from ``raise None``.
     """
     import time
 

--- a/distributed/workers/data_point_saving_worker.py
+++ b/distributed/workers/data_point_saving_worker.py
@@ -52,7 +52,7 @@ secret_name = os.environ.get("MODAL_SECRET_NAME", "distributed_cognee")
 )
 async def data_point_saving_worker():
     print("Started processing of data points; starting vector engine queue.")
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     # Defines how many data packets do we glue together from the modal queue before embedding call and ingestion
     BATCH_SIZE = 25
     stop_seen = False

--- a/examples/demos/truth_centroid_slots_demo.py
+++ b/examples/demos/truth_centroid_slots_demo.py
@@ -96,7 +96,7 @@ async def hybrid_order(dataset_obj, use_truth_weight: bool) -> list[str]:
 
 async def graph_truth_table(dataset_obj):
     async with set_database_global_context_variables(dataset_obj.id, dataset_obj.owner_id):
-        vector_engine = get_vector_engine()
+        vector_engine = await get_vector_engine()
         graph_engine = await get_graph_engine()
         centroids = await load_centroids(vector_engine, str(dataset_obj.id), K)
         nodes, _edges = await graph_engine.get_graph_data()

--- a/examples/pocs/disambiguation/disambiguate_entities.py
+++ b/examples/pocs/disambiguation/disambiguate_entities.py
@@ -217,7 +217,7 @@ async def disambiguate_entities_pipeline(
         Task(classify_documents),
         Task(
             extract_chunks_from_documents,
-            max_chunk_size=chunk_size or get_max_chunk_tokens(),
+            max_chunk_size=chunk_size or await get_max_chunk_tokens(),
             chunker=chunker,
         ),  # Extract text chunks based on the document type.
         Task(

--- a/examples/pocs/disambiguation/extract_graph_from_data_with_entity_disambiguation.py
+++ b/examples/pocs/disambiguation/extract_graph_from_data_with_entity_disambiguation.py
@@ -120,7 +120,7 @@ async def integrate_chunk_graphs(
 
 
 async def build_prompt(chunk, vector_search_limit, custom_prompt) -> Optional[str]:
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     exists = await vector_engine.has_collection(collection_name="Entity_name")
 
     if not (exists and custom_prompt):

--- a/examples/pocs/post_extraction_canonicalization/post_extraction_canonicalization.py
+++ b/examples/pocs/post_extraction_canonicalization/post_extraction_canonicalization.py
@@ -83,7 +83,7 @@ async def cache_and_replace_nodes(graphs, **kwargs):
     similarity_threshold = kwargs.get("similarity_threshold", 1.0)
     stats = kwargs.get("stats", None)
 
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     df_new = pd.DataFrame()
     for graph in graphs:
         await asyncio.gather(

--- a/examples/pocs/prefetch_disambiguation/prefetch_disambiguation.py
+++ b/examples/pocs/prefetch_disambiguation/prefetch_disambiguation.py
@@ -127,7 +127,7 @@ async def _build_chunk_graphs_and_prompts(
     }
 
     chunk_texts = [chunk.text for chunk in data_chunks]
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     chunk_embeddings = await vector_engine.embedding_engine.embed_text(chunk_texts)
     chunk_prompts = [
         _build_disambiguation_prompt(chunk_embedding, df, vector_search_limit, custom_prompt)
@@ -201,7 +201,7 @@ async def cache_entity_embeddings(graphs, **kwargs) -> None:
     df = kwargs.get("df", None)
     if df is None:
         return
-    vector_engine = get_vector_engine()
+    vector_engine = await get_vector_engine()
     df_new = pd.DataFrame()
     for graph in graphs:
         entity_names = [node.name for node in graph.nodes]


### PR DESCRIPTION
Fixes #3708

## Problem

`recall()` / search consistently fails with:

```
RuntimeError: IO exception: Could not set lock on file: .../cognee_graph_ladybug (Lock is held by PID XXXXX)
```

The subprocess graph worker (Ladybug/Kuzu) holds an **exclusive on-disk file lock for the adapter's whole lifetime**. Cached engines live in a custom `closing_lru_cache`. When a cached engine is evicted, its `close()` (worker shutdown → lock release) is asynchronous. Re-creating an engine for the same DB path could spawn a **second worker that opens the path before the first has finished closing** → two live workers, one exclusive lock. (A *killed* worker releases its lock immediately, so the holder is always a still-alive worker — the reporter's "zombie worker" / "LLM error crashes the worker" theories are both red herrings.)

## Fix

Two layers:

**1. Deterministic create-vs-close coordination** (the actual race remedy):
- `closing_lru_cache` gains a per-key **closing registry** + async `aget_or_create`: on a cache miss, if the key is currently closing, it `await`s that close before constructing.
- Subprocess-backed adapters close **off the event loop**, so a synchronous re-resolution that blocks the loop can't wedge the lock release.
- `SubprocessSession._terminate` waits until the worker process has actually exited before returning (the OS releases file locks only on true exit).
- The worker retries the DB open with bounded backoff on the lock-held error — a backstop for closes that can't be awaited (e.g. a GC finalizer); re-raises the original error when disabled/exhausted.

**2. Re-resolving engine handles** (`_GraphEngineHandle` / `_VectorEngineHandle`): `get_graph_engine()` / `get_vector_engine()` return a handle that re-runs `create_*_engine(**config)` on attribute access. A stored engine reference transparently recovers a fresh adapter after the cache is invalidated (prune / delete / per-dataset context teardown, which force-closes the cached subprocess adapter to release its lock promptly) instead of raising "adapter is closed". `get_*_engine()` are `async` (callers `await` them); the handle's resolution is synchronous, with the async `aget_or_create` used for initial resolution.

`.env.template` documents the new subprocess tuning knobs (`SUBPROCESS_OPEN_LOCK_RETRIES` / `_BACKOFF`) plus the existing `SUBPROCESS_CALL_TIMEOUT` / `MAX_RETRIES`.

## Testing

- Regression tests (real subprocess worker): evict→recreate cycles with no lock error; N concurrent re-acquisitions of the same path converge on a single worker; `close()` waits for the worker PID to exit; **a held engine handle re-resolves after eviction** (guards the teardown-reuse case).
- Closing-registry unit tests: registry tracking, `aget_or_create` waits for an in-flight close, concurrent single-construction, `.acall` cache-key parity.
- Worker retry: disabled(=0) re-raises original, success-after-transient, exhaustion, non-lock pass-through.
- Full `cognee/tests/unit/infrastructure/databases/` + `dataset_queue/` suites green. CI: **all Test Suites jobs pass** (the one Windows `Custom Graph Delete` red was pre-existing infra flakiness — cache-service 400 at setup, no test error — and passed on re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)