### PR TITLE
fix(observability): replace misleading 'Pipeline run started' log with per-item and per-pipeline messages

### DIFF
--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -87,6 +87,8 @@ async def run_tasks(
         payload=data,
     )
 
+    logger.info("Pipeline run started: `%s` (run: `%s`)", pipeline_name, pipeline_run_id)
+
     # Note: Setting of global context has to be done after yielding PipelineRunStarted due to running in
     #       background mode requiring the pipeline run started yield.
     async with set_database_global_context_variables(
@@ -175,6 +177,7 @@ async def run_tasks(
                 pipeline_run_id, pipeline_id, pipeline_name, dataset.id, data
             )
 
+            logger.info("Pipeline run completed: `%s` (run: `%s`)", pipeline_name, pipeline_run_id)
             yield PipelineRunCompleted(
                 pipeline_run_id=pipeline_run_id,
                 dataset_id=dataset.id,
@@ -202,6 +205,13 @@ async def run_tasks(
                 pipeline_run_id, pipeline_id, pipeline_name, dataset.id, data, error
             )
 
+            logger.error(
+                "Pipeline run errored: `%s` (run: `%s`)\n%s\n",
+                pipeline_name,
+                pipeline_run_id,
+                str(error),
+                exc_info=True,
+            )
             yield PipelineRunErrored(
                 pipeline_run_id=pipeline_run_id,
                 payload=repr(error),

--- a/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
+++ b/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
@@ -19,16 +19,19 @@ async def run_tasks_with_telemetry(
     tasks: list[Task], data, user: User, pipeline_name: str, ctx: Optional[PipelineContext] = None
 ):
     config = get_current_settings()
+    run_id = ctx.pipeline_run_id if ctx else "N/A"
+    pname = ctx.pipeline_name if ctx else pipeline_name
 
     logger.debug("\nRunning pipeline with configuration:\n%s\n", json.dumps(config, indent=1))
 
     try:
-        logger.info("Pipeline run started: `%s`", pipeline_name)
+        logger.info("Processing data item for pipeline `%s` (run: `%s`)", pname, run_id)
         send_telemetry(
-            "Pipeline Run Started",
+            "Processing Data Item",
             user.id,
             additional_properties={
-                "pipeline_name": str(pipeline_name),
+                "pipeline_name": str(pname),
+                "pipeline_run_id": str(run_id),
                 "cognee_version": cognee_version,
                 "tenant_id": str(user.tenant_id) if user.tenant_id else "Single User Tenant",
             }
@@ -38,12 +41,13 @@ async def run_tasks_with_telemetry(
         async for result in run_tasks_base(tasks, data, user, ctx):
             yield result
 
-        logger.info("Pipeline run completed: `%s`", pipeline_name)
+        logger.info("Finished processing data item for pipeline `%s` (run: `%s`)", pname, run_id)
         send_telemetry(
-            "Pipeline Run Completed",
+            "Data Item Processed",
             user.id,
             additional_properties={
-                "pipeline_name": str(pipeline_name),
+                "pipeline_name": str(pname),
+                "pipeline_run_id": str(run_id),
                 "cognee_version": cognee_version,
                 "tenant_id": str(user.tenant_id) if user.tenant_id else "Single User Tenant",
             }
@@ -51,16 +55,18 @@ async def run_tasks_with_telemetry(
         )
     except Exception as error:
         logger.error(
-            "Pipeline run errored: `%s`\n%s\n",
-            pipeline_name,
+            "Error processing data item for pipeline `%s` (run: `%s`)\n%s\n",
+            pname,
+            run_id,
             str(error),
             exc_info=True,
         )
         send_telemetry(
-            "Pipeline Run Errored",
+            "Data Item Errored",
             user.id,
             additional_properties={
-                "pipeline_name": str(pipeline_name),
+                "pipeline_name": str(pname),
+                "pipeline_run_id": str(run_id),
                 "cognee_version": cognee_version,
                 "tenant_id": str(user.tenant_id) if user.tenant_id else "Single User Tenant",
             }


### PR DESCRIPTION
## Description

`Pipeline run started` was logged inside `run_tasks_with_telemetry()`, which runs **once per data item** — but it used `pipeline_id` (a deterministic UUID hash of user + dataset + pipeline_name). With N data items in a dataset, N identical log lines appeared with the same UUID, falsely suggesting the pipeline was looping.

## Root cause

`pipeline_id` is deterministic — same user + same dataset + same pipeline = same UUID every time. It identifies the pipeline, not the execution. `pipeline_run_id` is the true unique identifier per execution, but it was never logged.

## Changes

1. **`run_tasks.py`** — log `Pipeline run started/completed/errored` once per actual pipeline execution, including the unique `pipeline_run_id`.
2. **`run_tasks_with_telemetry.py`** — rename internal logs to `Processing data item / Finished processing data item / Error processing data item`. Include both `pipeline_name` and `pipeline_run_id` from `PipelineContext`.

## Log diff

### Before (2 data items)
```
Pipeline run started: abc123
Pipeline run started: abc123
```

### After (2 data items)
```
Pipeline run started: add_pipeline (run: 382e7b83-...)
Processing data item for pipeline add_pipeline (run: 382e7b83-...)
Finished processing data item for pipeline add_pipeline (run: 382e7b83-...)
Processing data item for pipeline add_pipeline (run: 382e7b83-...)
Finished processing data item for pipeline add_pipeline (run: 382e7b83-...)
Pipeline run completed: add_pipeline (run: 382e7b83-...)
```

## Closes
Closes #3724