### PR TITLE
fix(search): return empty result when knowledge graph is empty

### DIFF
--- a/cognee/modules/search/methods/get_retriever_output.py
+++ b/cognee/modules/search/methods/get_retriever_output.py
@@ -34,6 +34,16 @@ async def get_retriever_output(
 
     if is_empty:
         logger.warning("Search attempt on an empty knowledge graph")
+        return SearchResultPayload(
+            result_object=[],
+            context=None,
+            completion=[],
+            search_type=query_type,
+            only_context=kwargs.get("only_context", False),
+            dataset_name=kwargs.get("dataset").name if kwargs.get("dataset") else None,
+            dataset_id=kwargs.get("dataset").id if kwargs.get("dataset") else None,
+            dataset_tenant_id=kwargs.get("dataset").tenant_id if kwargs.get("dataset") else None,
+        )
 
     retriever_instance = await get_search_type_retriever_instance(
         query_type=query_type, query_text=query_text, **kwargs

--- a/cognee/tests/unit/search/test_get_retriever_output.py
+++ b/cognee/tests/unit/search/test_get_retriever_output.py
@@ -1,0 +1,45 @@
+import importlib
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cognee.modules.search.types import SearchType
+
+
+@pytest.fixture
+def retriever_output_mod():
+    return importlib.import_module("cognee.modules.search.methods.get_retriever_output")
+
+
+@pytest.mark.asyncio
+async def test_empty_graph_returns_empty_payload_without_llm_call(
+    monkeypatch, retriever_output_mod
+):
+    """Empty knowledge graph must return an empty result without calling the completion LLM
+    (regression for the phantom 'no context' answer)."""
+    mock_engine = MagicMock()
+    mock_engine.is_empty = AsyncMock(return_value=True)
+
+    async def mock_get_graph_engine():
+        return mock_engine
+
+    monkeypatch.setattr(retriever_output_mod, "get_graph_engine", mock_get_graph_engine)
+    monkeypatch.setattr(
+        retriever_output_mod,
+        "get_search_type_retriever_instance",
+        AsyncMock(
+            side_effect=AssertionError(
+                "get_search_type_retriever_instance must not be called on an empty graph"
+            )
+        ),
+    )
+
+    result = await retriever_output_mod.get_retriever_output(
+        query_type=SearchType.GRAPH_COMPLETION,
+        query_text="What database mistake did Jane make?",
+    )
+
+    assert result.result_object == []
+    assert result.completion == []
+    assert result.context is None
+    assert result.search_type == SearchType.GRAPH_COMPLETION


### PR DESCRIPTION
## What

`GRAPH_COMPLETION` search returned a phantom LLM non-answer (e.g. *"There is no context provided. Please provide the context to answer the question."*) instead of an empty result when the knowledge graph was empty — for example right after `forget()`, or before any data is ingested.

Because `search()` returned a non-empty list, callers doing `if results:` could not distinguish "no memory found" from a real answer.

## Root cause

In `get_retriever_output`, `graph_engine.is_empty()` was checked and the empty-graph warning was logged, but execution fell through instead of returning. It then called the retriever (which correctly returned `[]`), built empty context (`""`), and still passed that empty context to the completion LLM — whose polite "no context" reply became the search result.

## Fix

Early-return a `SearchResultPayload` with empty `result_object`/`completion` immediately after the `is_empty` warning, before any retriever instantiation or LLM call. This mirrors the existing early-return style used for the `turn_preparation.should_answer` branch.

`is_empty()` is a global, dataset-agnostic node check (`MATCH (n) ... LIMIT 1`), so this only short-circuits when the graph store is physically empty — it does not affect the separate case where a non-empty graph simply yields no results for a query (already handled by the retriever returning `[]`).

## Testing

- Manual repro: `add` + `cognify` → search returns a real answer → `forget()` → search now returns an empty result (no phantom answer), verified against the local KuzuDB/LanceDB backend.
- Added `cognee/tests/unit/search/test_get_retriever_output.py`: mocks `is_empty() -> True` and asserts the retriever is **never instantiated** and the payload is empty. Verified it **fails without the fix** (the retriever mock's `AssertionError` fires) and passes with it. `ruff format` and `ruff check` clean.

Fixes #3728

---

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.