### PR TITLE
[HACKATHON] fix: truncate_text() returns a string longer than limit when limit < 3

### DIFF
--- a/cognee/modules/agent_memory/sanitization.py
+++ b/cognee/modules/agent_memory/sanitization.py
@@ -8,9 +8,17 @@ MAX_TRACE_CONTAINER_ITEMS = 20
 
 
 def truncate_text(value: str, limit: int) -> str:
-    """Bound stored trace strings so unusually large params/returns do not create oversized trace payloads."""
+    """Bound stored trace strings so unusually large params/returns do not create oversized trace payloads.
+
+    The returned string never exceeds ``limit`` characters.
+    """
     if len(value) <= limit:
         return value
+    if limit < 3:
+        # Fewer than 3 characters leaves no room for the "..." marker, and
+        # value[: limit - 3] would be a negative slice that returns a string
+        # LONGER than limit. Hard-truncate instead.
+        return value[: max(limit, 0)]
     return value[: limit - 3] + "..."
 
 

--- a/cognee/tests/unit/modules/agent_memory/test_truncate_text.py
+++ b/cognee/tests/unit/modules/agent_memory/test_truncate_text.py
@@ -1,0 +1,42 @@
+"""Tests for truncate_text length-bounding contract.
+
+Regression: for ``limit < 3`` the implementation used ``value[: limit - 3]``,
+a negative slice that returned a string *longer* than ``limit`` (e.g.
+``truncate_text("hello world", 2)`` returned 13 characters). truncate_text must
+never return more than ``limit`` characters.
+"""
+
+import pytest
+
+from cognee.modules.agent_memory.sanitization import truncate_text
+
+
+@pytest.mark.parametrize("limit", [0, 1, 2, 3, 4, 5, 10, 50, 1000])
+def test_never_exceeds_limit(limit):
+    value = "hello world, this is a reasonably long string to truncate"
+    assert len(truncate_text(value, limit)) <= limit
+
+
+def test_short_value_returned_unchanged():
+    assert truncate_text("hi", 100) == "hi"
+
+
+def test_long_value_uses_ellipsis_and_hits_limit_exactly():
+    # For limit >= 3, truncation appends "..." and fills the limit exactly.
+    result = truncate_text("x" * 100, 10)
+    assert result == "x" * 7 + "..."
+    assert len(result) == 10
+
+
+@pytest.mark.parametrize(
+    "value,limit,expected",
+    [
+        ("hello world", 0, ""),
+        ("hello world", 1, "h"),
+        ("hello world", 2, "he"),
+        ("hello world", 3, "..."),
+        ("hello world", 4, "h..."),
+    ],
+)
+def test_small_limits(value, limit, expected):
+    assert truncate_text(value, limit) == expected


### PR DESCRIPTION
### What

Fixes `truncate_text` returning a string longer than `limit` when `limit < 3`, and adds tests.

Fixes #3734.

### Why

`truncate_text` used `value[: limit - 3] + "..."`. For `limit < 3`, `limit - 3` is negative, so the slice runs from the end and the result is far longer than `limit`:

```python
truncate_text("hello world", 2)  # was "hello worl..." (13 chars, limit 2)
```

`truncate_text` is a shared helper (used by `cache/models.py` and `agent_memory/runtime.py`), and `normalize_optional_text(value, limit=...)` exposes an arbitrary `limit`, so this path is reachable.

### Changes

- `sanitization.py`: when `limit < 3` there is no room for the `"..."` marker, so hard-truncate to `value[: max(limit, 0)]`. Behavior for `limit >= 3` is unchanged (still fills the limit exactly with an ellipsis).
- New `test_truncate_text.py`: a length invariant (`len(result) <= limit` across many limits), the unchanged ellipsis behavior, and explicit small-limit cases.

### Verification

- New tests **pass with this change** and **fail on `dev`** (6 failing cases on `dev`, all limit < 3).
- Existing agent-memory + cache suites pass (208 passed, 2 skipped).
- `ruff format --check` and `ruff check` clean.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
