### PR TITLE
test(deployment): add Fly.io deploy e2e (nightly/manual) [#3363]

### DIFF
--- a/.github/workflows/fly_deploy_e2e.yml
+++ b/.github/workflows/fly_deploy_e2e.yml
@@ -1,0 +1,46 @@
+name: Fly.io Deploy E2E
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 3 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fly-deploy-e2e:
+    name: Deploy to Fly.io and run golden_flow
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      FLY_VOLUME_SIZE: '1'
+      FLY_REGION: 'iad'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Run Fly.io deploy e2e
+        run: uv run pytest cognee/tests/deployment/test_fly_deploy.py -m deployment -v
+
+      - name: Ensure ephemeral app is destroyed
+        if: always()
+        run: |
+          APP_NAME="cognee-ci-${GITHUB_RUN_ID}"
+          if [ -n "${FLY_API_TOKEN}" ]; then
+            fly apps destroy "${APP_NAME}" --yes || true
+          fi

--- a/cognee/tests/deployment/fly_harness.py
+++ b/cognee/tests/deployment/fly_harness.py
@@ -1,0 +1,160 @@
+"""Local deployment harness for the Fly.io end-to-end test in ``test_fly_deploy.py``."""
+
+import os
+import time
+import asyncio
+import subprocess
+from uuid import uuid4
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+import httpx
+import requests
+
+# Repo root is four levels up: cognee/tests/deployment/fly_harness.py -> repo root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEPLOY_SCRIPT = REPO_ROOT / "distributed" / "deploy" / "fly-deploy.sh"
+
+
+def wait_for_health(url: str, timeout: int = 600, interval: int = 10) -> bool:
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            response = requests.get(url, timeout=10)
+            if response.status_code == 200:
+                return True
+        except requests.RequestException as error:
+            last_error = error
+        time.sleep(interval)
+    raise TimeoutError(
+        f"Service at {url} did not become healthy within {timeout}s (last error: {last_error})"
+    )
+
+
+def deploy_fly_app(
+    app_name: str,
+    *,
+    region: str = "iad",
+    volume_size: int = 1,
+    llm_env: dict | None = None,
+) -> str:
+    """Deploy a throwaway app via fly-deploy.sh (run from repo root) and return its URL."""
+    if not DEPLOY_SCRIPT.exists():
+        raise FileNotFoundError(f"Deploy script not found: {DEPLOY_SCRIPT}")
+
+    env = os.environ.copy()
+    env["FLY_APP_NAME"] = app_name
+    env["FLY_REGION"] = region
+    env["FLY_VOLUME_SIZE"] = str(volume_size)
+    for key, value in (llm_env or {}).items():
+        if value is not None:
+            env[key] = str(value)
+
+    if not env.get("LLM_API_KEY"):
+        raise RuntimeError("LLM_API_KEY must be set; fly-deploy.sh requires it.")
+
+    subprocess.run(["bash", str(DEPLOY_SCRIPT)], cwd=str(REPO_ROOT), env=env, check=True)
+
+    return f"https://{app_name}.fly.dev"
+
+
+def destroy_fly_app(app_name: str) -> None:
+    """Destroy the Fly app and its volume. Never raises (cleanup must not mask failures)."""
+    try:
+        subprocess.run(
+            ["fly", "apps", "destroy", app_name, "--yes"],
+            check=False,
+            timeout=300,
+        )
+    except Exception as error:  # noqa: BLE001 - cleanup must never raise
+        print(f"Failed to destroy Fly app {app_name}: {error}")
+
+
+@asynccontextmanager
+async def authed_client(
+    base_url: str,
+    email: str | None = None,
+    password: str = "cognee-ci-pass-123!",
+):
+    """Yield an httpx client authenticated (register + login) against the deployed app."""
+    email = email or f"ci-{uuid4().hex[:8]}@example.com"
+    client = httpx.AsyncClient(base_url=base_url, timeout=300.0)
+    try:
+        await client.post("/api/v1/auth/register", json={"email": email, "password": password})
+        login = await client.post(
+            "/api/v1/auth/login",
+            data={"username": email, "password": password},
+        )
+        login.raise_for_status()
+        client.headers["Authorization"] = f"Bearer {login.json()['access_token']}"
+        yield client
+    finally:
+        await client.aclose()
+
+
+async def golden_flow(
+    api_client: httpx.AsyncClient,
+    *,
+    dataset_name: str | None = None,
+    expected_entity: str = "Alice",
+    poll_attempts: int = 60,
+    poll_interval: int = 5,
+) -> bool:
+    """Run add -> cognify -> search against a live Cognee API; assert the seeded entity returns.
+
+    Signature-compatible with the shared ``golden_flow`` in #3596 (swap in once T0 merges).
+    """
+    dataset_name = dataset_name or f"fly_ci_{uuid4().hex[:8]}"
+    known_doc = f"{expected_entity} works at Cognee and manages the AI memory platform."
+
+    # 1. Add the known document (synchronous ingest by default).
+    files = {"data": ("doc.txt", known_doc.encode("utf-8"), "text/plain")}
+    add_response = await api_client.post(
+        "/api/v1/add", files=files, data={"datasetName": dataset_name}
+    )
+    add_response.raise_for_status()
+    dataset_id = add_response.json()["dataset_id"]
+
+    # 2. Cognify by dataset id (a real UUID from the add response).
+    cognify_response = await api_client.post("/api/v1/cognify", json={"dataset_ids": [dataset_id]})
+    cognify_response.raise_for_status()
+
+    # 3. Poll status until the cognify pipeline completes.
+    status = None
+    for _ in range(poll_attempts):
+        status_response = await api_client.get(
+            "/api/v1/datasets/status", params={"dataset": dataset_id}
+        )
+        status_response.raise_for_status()
+        status = str(status_response.json().get(str(dataset_id), ""))
+        if status == "DATASET_PROCESSING_COMPLETED":
+            break
+        if status == "DATASET_PROCESSING_ERRORED":
+            raise RuntimeError(f"Cognify errored for dataset {dataset_id}")
+        await asyncio.sleep(poll_interval)
+    else:
+        raise TimeoutError(
+            f"Cognify did not complete within {poll_attempts * poll_interval}s "
+            f"(last status: {status!r})"
+        )
+
+    # 4. Search the graph.
+    search_response = await api_client.post(
+        "/api/v1/search",
+        json={
+            "query": "Who works at Cognee?",
+            "search_type": "GRAPH_COMPLETION",
+            "dataset_ids": [dataset_id],
+        },
+    )
+    search_response.raise_for_status()
+
+    # 5. Assert the seeded entity is present in the results.
+    payload = search_response.json()
+    results = payload if isinstance(payload, list) else payload.get("results", payload)
+    if expected_entity not in str(results):
+        raise AssertionError(
+            f"Expected entity {expected_entity!r} not found in search results: {results}"
+        )
+    return True

--- a/cognee/tests/deployment/test_fly_deploy.py
+++ b/cognee/tests/deployment/test_fly_deploy.py
@@ -1,0 +1,49 @@
+"""Fly.io deployment end-to-end test."""
+
+import os
+import uuid
+
+import pytest
+
+from cognee.tests.deployment.fly_harness import (
+    authed_client,
+    deploy_fly_app,
+    destroy_fly_app,
+    golden_flow,
+    wait_for_health,
+)
+
+REQUIRED_SECRETS = ("FLY_API_TOKEN", "LLM_API_KEY")
+HEALTH_TIMEOUT = int(os.getenv("FLY_HEALTH_TIMEOUT", "600"))
+
+
+def _missing_secrets() -> list[str]:
+    return [name for name in REQUIRED_SECRETS if not os.getenv(name)]
+
+
+@pytest.mark.deployment
+@pytest.mark.asyncio
+async def test_fly_deploy_golden_flow():
+    missing = _missing_secrets()
+    if missing:
+        pytest.skip(f"Missing required secret(s): {', '.join(missing)}")
+
+    run_id = os.getenv("GITHUB_RUN_ID") or uuid.uuid4().hex[:8]
+    app_name = f"cognee-ci-{run_id}"
+
+    llm_env = {"LLM_API_KEY": os.getenv("LLM_API_KEY")}
+
+    try:
+        url = deploy_fly_app(
+            app_name,
+            region=os.getenv("FLY_REGION", "iad"),
+            volume_size=int(os.getenv("FLY_VOLUME_SIZE", "1")),
+            llm_env=llm_env,
+        )
+
+        wait_for_health(f"{url}/health", timeout=HEALTH_TIMEOUT, interval=10)
+
+        async with authed_client(url) as client:
+            assert await golden_flow(client) is True
+    finally:
+        destroy_fly_app(app_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,3 +282,8 @@ dev = [
     "pytest-split>=0.11.0,<0.12",
     "ruff>=0.13.1",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "deployment: Deployment end-to-end tests (opt-in, not in default run)"
+]


### PR DESCRIPTION
## Description
Closes #3363 (T5). Adds the first automated test of the Fly.io deployment path (`distributed/deploy/fly.toml` + `distributed/deploy/fly-deploy.sh`), which currently has **zero coverage**. This is a nightly/manual fidelity test: it deploys a real throwaway app, verifies it actually works end-to-end, and tears it down.

**How it works**
1. **Deploy** — installs `flyctl` and runs the existing `fly-deploy.sh` with a unique `FLY_APP_NAME=cognee-ci-<run_id>` and `FLY_VOLUME_SIZE=1`. Reuses the script via its env knobs instead of duplicating deploy logic; runs from the repo root so `fly.toml`'s root `Dockerfile` resolves.
2. **Health** — polls `https://<app>.fly.dev/health` with a generous timeout. `fly.toml` sets `auto_stop_machines = "stop"` / `min_machines_running = 0`, so the first request cold-starts the machine — the poll tolerates that boot.
3. **golden_flow** — runs `add → cognify → search` against the public URL and asserts the seeded entity comes back.
4. **Teardown** — `fly apps destroy --yes` in the test `finally` **and** an `if: always()` workflow step; destroying the app drops its volume too, so no cost leak on failure.

**Relationship to #3358 / #3596 (T0 harness):** T5 depends on the T0 deployment harness, which is not merged yet. So, the Fly-specific helpers are kept local in `fly_harness.py`, and `golden_flow` / `wait_for_health` are kept signature compatible with the shared harness in #3596 for a drop-in swap once T0 lands.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->
- [x] **First coverage of the Fly.io deploy path** — new `test_fly_deploy.py` deploys from `fly.toml` + `fly-deploy.sh` with a unique ephemeral app name.
- [x] **Gated on a Fly token secret; never blocks PRs** — no `pull_request` trigger; scheduled workflows don't run on forks; the test `pytest.skip`s when `FLY_API_TOKEN` / `LLM_API_KEY` are absent, so the job stays green.
- [x] **`workflow_dispatch` + nightly `schedule`** in `fly_deploy_e2e.yml`.
- [x] **Health poll tolerates cold start** — generous timeout absorbs auto-stop/auto-start boot latency on top of the `grace_period`.
- [x] **`golden_flow()` runs against the public URL** — real LLM via secret (script default `openai/gpt-4o-mini`).
- [x] **Always tears down** — `fly apps destroy` in test `finally` + `always()` workflow step; drops the app and its volume together.

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.