### PR TITLE
fix(api): replace HTTP 418 with HTTP 500 for server errors

### DIFF
--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -193,7 +193,7 @@ async def exception_handler(_: Request, exc: CogneeApiError) -> JSONResponse:
         logger.error("Improperly defined exception: %s", exc)
         # Provide a default error response
         detail["message"] = "An unexpected error occurred."
-        status_code = status.HTTP_418_IM_A_TEAPOT
+        status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
 
     # log the stack trace for easier serverside debugging
     logger.error(format_exc())

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -108,7 +108,7 @@ def get_datasets_router() -> APIRouter:
         - **owner_id**: ID of the dataset owner
 
         ## Error Codes
-        - **418 I'm a teapot**: Error retrieving datasets
+        - **500 Internal Server Error**: Error retrieving datasets
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
@@ -126,7 +126,7 @@ def get_datasets_router() -> APIRouter:
         except Exception as error:
             logger.error(f"Error retrieving datasets: {str(error)}")
             raise HTTPException(
-                status_code=status.HTTP_418_IM_A_TEAPOT,
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Error retrieving datasets: {str(error)}",
             ) from error
 
@@ -156,7 +156,7 @@ def get_datasets_router() -> APIRouter:
         - **owner_id**: ID of the dataset owner
 
         ## Error Codes
-        - **418 I'm a teapot**: Error creating dataset
+        - **500 Internal Server Error**: Error creating dataset
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
@@ -179,7 +179,7 @@ def get_datasets_router() -> APIRouter:
         except Exception as error:
             logger.error(f"Error creating dataset: {str(error)}")
             raise HTTPException(
-                status_code=status.HTTP_418_IM_A_TEAPOT,
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Error creating dataset: {str(error)}",
             ) from error
 

--- a/cognee/exceptions/exceptions.py
+++ b/cognee/exceptions/exceptions.py
@@ -11,7 +11,7 @@ class CogneeApiError(Exception):
         self,
         message: str = "Service is unavailable.",
         name: str = "Cognee",
-        status_code=status.HTTP_418_IM_A_TEAPOT,
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         log=True,
         log_level="ERROR",
     ):

--- a/cognee/tests/unit/test_exceptions.py
+++ b/cognee/tests/unit/test_exceptions.py
@@ -1,0 +1,7 @@
+from cognee.exceptions.exceptions import CogneeApiError
+
+
+def test_cognee_api_error_defaults_to_5xx_range():
+    """Ensure base API error defaults to a 5xx range for proper server-error monitoring."""
+    error = CogneeApiError()
+    assert 500 <= error.status_code < 600


### PR DESCRIPTION
While reviewing the API error handling, I noticed that the datasets router and the CogneeApiError base class return HTTP 418 (I'm a Teapot) for internal server errors. RFC 2324 defines 418 as an April Fools joke — it has no place in production error handling. This breaks monitoring because 418 is not in the 5xx range, so alerting systems and API clients don't catch these as server errors.

I replaced all 4 occurrences with HTTP 500 INTERNAL_SERVER_ERROR across 3 files:
- **cognee/exceptions/exceptions.py** — base class default
- **cognee/api/v1/datasets/routers/get_datasets_router.py** — GET and POST error handlers
- **cognee/api/client.py** — exception handler fallback

I also updated the docstrings to match and added a unit test (`test_cognee_api_error_defaults_to_5xx_range`) that asserts the base exception always falls in the 500-599 range. I also checked the frontend (`cognee-frontend/`) — no dependency on 418 anywhere.

I saw this was introduced during the UI migration (commit e7644f4b3). If the original intent was to distinguish datasets errors from other errors, I think custom headers or structured logging would be a better approach than using a joke status code that breaks monitoring.

Closes #3742

**Screenshots**

<img width="1078" height="213" alt="SCR-20260701-pjha" src="https://github.com/user-attachments/assets/9623a5a3-826b-4353-81a1-f11295b2cea7" />
<img width="1438" height="780" alt="SCR-20260701-pjof" src="https://github.com/user-attachments/assets/515b8165-a8a1-4f98-b7d7-03ace9a0808e" />
