### PR TITLE
Fix: Call super().__init__() in EntityNotFoundError and NodesetFilterNotSupportedError

### DIFF
--- a/cognee/infrastructure/databases/exceptions/exceptions.py
+++ b/cognee/infrastructure/databases/exceptions/exceptions.py
@@ -43,10 +43,7 @@ class EntityNotFoundError(CogneeValidationError):
         name: str = "EntityNotFoundError",
         status_code=status.HTTP_404_NOT_FOUND,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
-        # super().__init__(message, name, status_code) :TODO: This is not an error anymore with the dynamic exception handling therefore we shouldn't log error
+        super().__init__(message, name, status_code, log=False)
 
 
 class EntityAlreadyExistsError(CogneeValidationError):
@@ -81,9 +78,7 @@ class NodesetFilterNotSupportedError(CogneeConfigurationError):
         name: str = "NodeSetFilterNotSupportedError",
         status_code=status.HTTP_404_NOT_FOUND,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
+        super().__init__(message, name, status_code, log=False)
 
 
 class EmbeddingException(CogneeConfigurationError):


### PR DESCRIPTION
**Fixes: #3749**
**Description: **
**EntityNotFoundError** and **NodesetFilterNotSupportedError** in `cognee/infrastructure/databases/exceptions/exceptions.py` were `overriding __init__()` without calling `super().__init__()`, which:
1. Left self.args as an empty tuple () — breaking repr(), str(), and exception chaining
2. Skipped the centralized logging in CogneeApiError.__init__(), so these errors were never logged

**Fix:**
Added `super().__init__(message, name, status_code, log=False)` to both classes — consistent with all other exceptions in the file. `log=False` is used since these are validation/configuration errors that shouldn't produce log noise.

**Changes:**
- `cognee/infrastructure/databases/exceptions/exceptions.py:46 `— EntityNotFoundError.__init__ now calls super().__init__
- `cognee/infrastructure/databases/exceptions/exceptions.py:81` — **NodesetFilterNotSupportedError.__init__** now calls `super().__init__`

**Testing:**
- uv run python `test_exceptions_fix.py` — all 6 checks pass (args, repr, chaining, consistency)
- Existing unit tests using **EntityNotFoundError** pass unchanged
<img width="2880" height="1774" alt="image" src="https://github.com/user-attachments/assets/67628424-e8ed-4d1f-803f-08ef044fff19" />
<img width="2274" height="1086" alt="image" src="https://github.com/user-attachments/assets/95b08f12-ca51-450f-bf11-993278bba581" />
