### PR TITLE
fix(api): standardize error responses in improve, forget, recall routers

### DIFF
--- a/cognee/api/v1/forget/routers/get_forget_router.py
+++ b/cognee/api/v1/forget/routers/get_forget_router.py
@@ -1,16 +1,18 @@
 from uuid import UUID
 from typing import Optional, Union, Literal
 from pydantic import ConfigDict, Field
-from fastapi import Depends, APIRouter
+from fastapi import Depends, APIRouter, status
 from fastapi.responses import JSONResponse
 
-from cognee.api.DTO import InDTO
+from cognee.api.DTO import InDTO, ErrorResponse
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.shared.utils import send_telemetry
 from cognee.shared.usage_logger import log_usage
 from cognee import __version__ as cognee_version
 from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
 
 
 class ForgetPayloadDTO(InDTO):
@@ -53,7 +55,13 @@ class ForgetPayloadDTO(InDTO):
 def get_forget_router() -> APIRouter:
     router = APIRouter()
 
-    @router.post("")
+    @router.post(
+        "",
+        responses={
+            422: {"model": ErrorResponse},
+            500: {"model": ErrorResponse},
+        },
+    )
     @log_usage(function_name="POST /v1/forget", log_type="api_endpoint")
     async def forget_endpoint(
         payload: ForgetPayloadDTO, user: User = Depends(get_authenticated_user)
@@ -110,17 +118,20 @@ def get_forget_router() -> APIRouter:
             return result
         except ValueError:
             return JSONResponse(
-                status_code=422,
-                content={
-                    "error": "Invalid request parameters. Specify dataset or dataset_id, data_id+dataset, or everything=True."
-                },
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                content=ErrorResponse(
+                    error="Invalid request parameters.",
+                    detail="Specify dataset or dataset_id, data_id+dataset, or everything=True.",
+                ).model_dump(),
             )
         except Exception as error:
-            logger = get_logger()
             logger.error("Forget endpoint error: %s", error, exc_info=True)
             return JSONResponse(
-                status_code=500,
-                content={"error": "An error occurred during deletion."},
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content=ErrorResponse(
+                    error="An error occurred during deletion.",
+                    detail=str(error),
+                ).model_dump(),
             )
 
     return router

--- a/cognee/api/v1/improve/routers/get_improve_router.py
+++ b/cognee/api/v1/improve/routers/get_improve_router.py
@@ -1,12 +1,12 @@
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import JSONResponse
 from fastapi import Depends
 from pydantic import Field
 from typing import List, Optional, Union, Literal
 
-from cognee.api.DTO import InDTO
+from cognee.api.DTO import InDTO, ErrorResponse
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.shared.utils import send_telemetry
@@ -37,7 +37,14 @@ class ImprovePayloadDTO(InDTO):
 def get_improve_router() -> APIRouter:
     router = APIRouter()
 
-    @router.post("", response_model=dict)
+    @router.post(
+        "",
+        response_model=dict,
+        responses={
+            400: {"model": ErrorResponse},
+            500: {"model": ErrorResponse},
+        },
+    )
     @log_usage(function_name="POST /v1/improve", log_type="api_endpoint")
     async def improve(payload: ImprovePayloadDTO, user: User = Depends(get_authenticated_user)):
         """
@@ -60,7 +67,7 @@ def get_improve_router() -> APIRouter:
 
         ## Error Codes
         - **400 Bad Request**: Neither dataset_id nor dataset_name provided
-        - **409 Conflict**: Error during processing
+        - **500 Internal Server Error**: Error during processing
         """
         send_telemetry(
             "Improve API Endpoint Invoked",
@@ -93,13 +100,23 @@ def get_improve_router() -> APIRouter:
             )
 
             if isinstance(improve_run, PipelineRunErrored):
-                return JSONResponse(status_code=420, content=improve_run)
+                detail = getattr(improve_run, "error", None) or str(improve_run)
+                return JSONResponse(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    content=ErrorResponse(
+                        error="Pipeline run errored",
+                        detail=detail,
+                    ).model_dump(),
+                )
             return improve_run
         except Exception as error:
             logger.error("Improve endpoint error: %s", error, exc_info=True)
             return JSONResponse(
-                status_code=409,
-                content={"error": "An error occurred during graph improvement."},
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content=ErrorResponse(
+                    error="Internal server error",
+                    detail=str(error),
+                ).model_dump(),
             )
 
     return router

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -2,13 +2,13 @@ from datetime import datetime
 from typing import List, Optional, Union
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import Field
 
 from cognee import __version__ as cognee_version
-from cognee.api.DTO import InDTO, OutDTO
+from cognee.api.DTO import InDTO, OutDTO, ErrorResponse
 from cognee.api.v1.recall.recall import RecallResponse
 from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
@@ -104,7 +104,13 @@ def get_recall_router() -> APIRouter:
         user: str
         created_at: datetime
 
-    @router.get("", response_model=list[RecallHistoryItem])
+    @router.get(
+        "",
+        response_model=list[RecallHistoryItem],
+        responses={
+            500: {"model": ErrorResponse},
+        },
+    )
     async def get_recall_history(user: User = Depends(get_authenticated_user)):
         """Get search/recall history for the authenticated user."""
         send_telemetry(
@@ -120,11 +126,21 @@ def get_recall_router() -> APIRouter:
             logger = get_logger()
             logger.error("Recall history error: %s", error, exc_info=True)
             return JSONResponse(
-                status_code=500,
-                content={"error": "An error occurred while fetching recall history."},
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content=ErrorResponse(
+                    error="An error occurred while fetching recall history.",
+                ).model_dump(),
             )
 
-    @router.post("", response_model=list[RecallResponse])
+    @router.post(
+        "",
+        response_model=list[RecallResponse],
+        responses={
+            403: {"model": ErrorResponse},
+            422: {"model": ErrorResponse},
+            500: {"model": ErrorResponse},
+        },
+    )
     @log_usage(function_name="POST /v1/recall", log_type="api_endpoint")
     async def recall(payload: RecallPayloadDTO, user: User = Depends(get_authenticated_user)):
         """
@@ -157,7 +173,7 @@ def get_recall_router() -> APIRouter:
           (default: "auto" — session first when session_id is set, else graph)
 
         ## Error Codes
-        - **409 Conflict**: Error during recall
+        - **500 Internal Server Error**: Error during recall
         - **403 Forbidden**: Permission denied (returns empty list)
         - **422 Unprocessable Entity**: Recall prerequisites not met — ingest data
           first (POST /v1/remember or /v1/add followed by /v1/cognify)
@@ -198,10 +214,10 @@ def get_recall_router() -> APIRouter:
             status_code = getattr(e, "status_code", 422)
             return JSONResponse(
                 status_code=status_code,
-                content={
-                    "error": "Recall prerequisites not met",
-                    "hint": "Run `await cognee.remember(...)` or `await cognee.add(...)` then `await cognee.cognify()` before recalling.",
-                },
+                content=ErrorResponse(
+                    error="Recall prerequisites not met",
+                    detail="Run `await cognee.remember(...)` or `await cognee.add(...)` then `await cognee.cognify()` before recalling.",
+                ).model_dump(),
             )
         except PermissionDeniedError:
             return []
@@ -209,8 +225,11 @@ def get_recall_router() -> APIRouter:
             logger = get_logger()
             logger.error("Recall endpoint error: %s", error, exc_info=True)
             return JSONResponse(
-                status_code=409,
-                content={"error": "An error occurred during recall."},
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content=ErrorResponse(
+                    error="An error occurred during recall.",
+                    detail=str(error),
+                ).model_dump(),
             )
 
     return router


### PR DESCRIPTION
While looking through the API routers in cognee/api/v1/, I noticed that commit 62d294c83 ("Standardized API error responses") had updated 5 of the 8 routers to use the canonical ErrorResponse DTO, but the improve, forget, and recall routers were left as-is. They were still returning raw dicts, using non-standard status codes like 420 and 409 for generic errors, and missing the responses={...} decorator parameter — which meant Swagger docs had no error schemas for these endpoints.

This PR brings those three routers in line with the rest of the API:

- Replaced HTTP 420 and 409 status codes with standard 500 Internal Server Error
- Converted all raw {"error": ...} dict returns and raw PipelineRunErrored objects to ErrorResponse(...).model_dump()
- Moved the undocumented hint field in recall into the standard detail field
- Added responses={...} to all router decorators so Swagger UI generates error schemas
- Moved the forget router logger to module level to match the pattern in other routers
- Updated docstrings that still referenced 409

The changes follow the exact same pattern already established in add, cognify, memify, search, and update routers.

Acceptance Criteria:
- improve, forget, and recall return ErrorResponse schema on errors
- Non-standard status codes (420, 409) replaced with 500
- responses={...} added to decorators for Swagger/OpenAPI generation
- All 52 existing unit tests pass (20 API error response tests + 32 router-specific tests)

Type of Change:
- [x] Bug fix
- [ ] New feature
- [x] Code refactoring
- [ ] Other (specify)

Screenshots:
<!-- Drag and drop your screenshots here -->
<img width="1464" height="842" alt="SCR-20260701-slzv" src="https://github.com/user-attachments/assets/bc939afd-2854-491f-9630-7ccd8331f35f" />
<img width="1466" height="753" alt="SCR-20260701-smge" src="https://github.com/user-attachments/assets/ba734067-37f7-48a8-acd8-16d156b39e9a" />
<img width="1465" height="809" alt="SCR-20260701-smii" src="https://github.com/user-attachments/assets/61b0e186-8011-4c89-8ab2-e45b23339427" />



Pre-submission Checklist:
- [x] Tested changes thoroughly
- [x] Contains minimal changes necessary
- [x] Code follows project standards
- [ ] Added tests for fix/feature (existing tests cover these paths)
- [ ] Added documentation (if applicable) (Swagger docs auto-generated via responses={})
- [x] All new and existing tests pass
- [x] Searched existing PRs for duplicates
- [x] Linked relevant issues: Closes #3748
- [x] Clear commit messages

DCO Affirmation:
I affirm that all code in every commit of this pull request conforms to the
terms of the Topoteretes Developer Certificate of Origin.