### PR TITLE
fix(mcp): stop duplicating the ~9GB /app layer (COPY --chown)

### DIFF
--- a/cognee-mcp/Dockerfile
+++ b/cognee-mcp/Dockerfile
@@ -62,18 +62,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Run as a non-root user. Create the user *before* copying /app so the copy can
+# set ownership inline via `--chown`. A separate `chown -R /app` after the COPY
+# would rewrite metadata on every file, forcing overlayfs to copy up the entire
+# ~9 GB /app tree into a second layer — storing the venv twice. Doing it in the
+# COPY keeps it to a single layer.
+RUN groupadd --system --gid 1000 cognee \
+    && useradd --system --uid 1000 --gid cognee --no-create-home --shell /usr/sbin/nologin cognee
+
 # Copy the virtual environment from the uv stage
 COPY --from=uv /usr/local /usr/local
-COPY --from=uv /app /app
+COPY --from=uv --chown=cognee:cognee /app /app
 
 # Strip Windows carriage returns (fixes "no such file" on Windows Docker)
 RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
-
-# Run as a non-root user. Create the user before copying ownership so the
-# /app tree (which already exists from the COPY above) is readable.
-RUN groupadd --system --gid 1000 cognee \
-    && useradd --system --uid 1000 --gid cognee --no-create-home --shell /usr/sbin/nologin cognee \
-    && chown -R cognee:cognee /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
## What

Fixes **Issue 1** of #3691: the `cognee-mcp` image stores the ~9 GB `/app` venv tree **twice**.

The final stage did:
```dockerfile
COPY --from=uv /app /app
...
RUN groupadd ... && useradd ... && chown -R cognee:cognee /app
```
The `chown -R /app` runs in its own layer and rewrites metadata on every file, so overlayfs copies up the entire `/app` tree into a second layer. The maintainer's `docker history` in the issue shows it directly:
```
9.02GB  COPY /app /app # buildkit
9.02GB  RUN ... chown -R cognee:cognee /app # buildkit
```

## Fix

Create the `cognee` user **before** the copy, and set ownership inline:
```dockerfile
RUN groupadd ... && useradd ...
COPY --from=uv --chown=cognee:cognee /app /app
```
Single layer, ~9 GB smaller, **no behavior change** (same files, same ownership, same user).

## Evidence

Building the real 27.8 GB image locally is impractical (and disk-risky — the issue notes it filled a 78 GB disk). Instead, a minimal synthetic repro of the **exact mechanic** — a 294 MB stand-in for the venv, old pattern vs fix:

| image | pattern | total size |
| --- | --- | --- |
| `chown-before` | `COPY` + `RUN chown -R` | **1.34 GB** |
| `chown-after` | `COPY --chown` | **736 MB** |

`docker history` — the old pattern produces a duplicate payload-sized layer; the fix does not:
```
# BEFORE
300MB   RUN ... groupadd ... chown -R ...      <-- duplicate
300MB   COPY ctx/bigfile.bin /app/bigfile.bin

# AFTER
300MB   COPY --chown=... ctx/bigfile.bin ...
 41kB   RUN ... groupadd ...                   <-- no duplication
```
The duplicated layer equals the payload size, so on the real image the `chown -R` over the ~9 GB venv costs ~9 GB — recovered in full here.

## Scope

Issue 1 only (the free, universal, no-behavior-change win). **Issue 2** (`cognee[docs]` → torch/CUDA ~6.6 GB) is left as a separate follow-up: it touches the frozen `uv.lock` / the `docs` extra and needs a CPU-index or opt-out decision that affects non-proxy deployments.

Refs #3691 (Issue 1).
