### PR TITLE
fix: Ingestion pipeline crashes on markdown (.md), JSON, or case-preserved file extensions

### DIFF
--- a/cognee/tasks/documents/classify_documents.py
+++ b/cognee/tasks/documents/classify_documents.py
@@ -19,6 +19,14 @@ from cognee.tasks.ingestion.dlt_utils import is_dlt_sourced
 EXTENSION_TO_DOCUMENT_CLASS = {
     "pdf": PdfDocument,  # Text documents
     "txt": TextDocument,
+    "md": TextDocument,
+    "markdown": TextDocument,
+    "json": TextDocument,
+    "xml": TextDocument,
+    "yaml": TextDocument,
+    "yml": TextDocument,
+    "log": TextDocument,
+    "html": TextDocument,
     "csv": CsvDocument,
     "docx": UnstructuredDocument,
     "doc": UnstructuredDocument,
@@ -127,7 +135,8 @@ async def classify_documents(data_documents: list[Data]) -> list[Document]:
         if is_dlt_sourced(data_item):
             doc_class = DltRowDocument
         else:
-            doc_class = EXTENSION_TO_DOCUMENT_CLASS[data_item.extension]
+            extension = data_item.extension.lower() if data_item.extension else "txt"
+            doc_class = EXTENSION_TO_DOCUMENT_CLASS.get(extension, TextDocument)
 
         document = doc_class(
             id=data_item.id,


### PR DESCRIPTION
### Description
This PR resolves a document classification KeyError/crash during the ingestion pipeline when processing text-based extensions (like `.md`, `.json`, `.yaml`, `.xml`, `.log`, or `.html`) and case-preserved extensions (like `.PDF` or `.CSV`).

### Changes
1. Added explicit mappings for common text file extensions (`md`, `markdown`, `json`, `xml`, `yaml`, `yml`, `log`, `html`) to `TextDocument`.
2. Normalized input extension strings to lowercase in `classify_documents()` to handle case-preserved suffixes safely.
3. Substituted direct key lookup (`EXTENSION_TO_DOCUMENT_CLASS[ext]`) with a safe `.get(ext, TextDocument)` fallback logic to avoid crashes on unknown formats.