### PR TITLE
[hackathon] test(deployment): Helm/kind golden_flow e2e + chart fixes (T7 #3365)

### DIFF
--- a/.github/workflows/helm_kind_test.yml
+++ b/.github/workflows/helm_kind_test.yml
@@ -1,0 +1,97 @@
+name: test | helm kind e2e
+
+on:
+  workflow_call:
+
+jobs:
+  helm-kind-e2e:
+    name: Helm chart deploy + golden flow on kind
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # ── Build the images the cluster will run ─────────────────────────────
+      - name: Build cognee image (from this PR's code)
+        run: docker build -t cognee/cognee:ci-test .
+
+      - name: Build mock LLM image
+        run: docker build -t mock-llm:ci-test cognee/tests/deployment/mock_llm
+
+      # ── Create the kind cluster and load the local images into it ─────────
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: cognee-test
+          node_image: kindest/node:v1.31.2
+
+      - name: Load images into kind
+        run: |
+          kind load docker-image cognee/cognee:ci-test --name cognee-test
+          kind load docker-image mock-llm:ci-test --name cognee-test
+
+      # ── Deploy the mock, then the chart pointed at it ─────────────────────
+      - name: Deploy in-cluster mock LLM
+        run: kubectl apply -f cognee/tests/deployment/mock_llm/k8s.yml
+
+      - name: Helm install cognee (mock LLM, dummy key)
+        run: |
+          helm install cognee deployment/helm \
+            --set cognee.image.repository=cognee/cognee \
+            --set cognee.image.tag=ci-test \
+            --set cognee.image.pullPolicy=IfNotPresent \
+            --set cognee.env.LLM_ENDPOINT=http://mock-llm:11434 \
+            --set cognee.env.LLM_API_KEY=mock \
+            --set cognee.env.EMBEDDING_PROVIDER=openai \
+            --set cognee.env.EMBEDDING_MODEL=text-embedding-3-small \
+            --set cognee.env.EMBEDDING_DIMENSIONS=1536 \
+            --set cognee.env.EMBEDDING_ENDPOINT=http://mock-llm:11434
+
+      # ── Wait for readiness (Postgres up, cognee rolled out) ───────────────
+      - name: Wait for mock LLM
+        run: kubectl rollout status deployment/mock-llm --timeout=120s
+
+      - name: Wait for Postgres ready
+        run: kubectl wait --for=condition=ready pod -l app=cognee-postgres --timeout=180s
+
+      - name: Wait for cognee deployment
+        run: kubectl wait --for=condition=available deployment/cognee-cognee --timeout=300s
+
+      # ── Port-forward and run the golden flow ──────────────────────────────
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test deps
+        run: python -m pip install httpx pytest pytest-asyncio
+
+      - name: Port-forward cognee service
+        run: |
+          kubectl port-forward svc/cognee-cognee 8000:8000 &
+          echo "PF_PID=$!" >> "$GITHUB_ENV"
+          # give the forward a moment; the test also polls /health itself
+          sleep 5
+
+      - name: Run deployment golden flow
+        env:
+          COGNEE_BASE_URL: http://localhost:8000
+        run: python -m pytest -m deployment_graph cognee/tests/deployment/test_helm_kind.py -v
+
+      # ── Diagnostics on failure + teardown ──────────────────────
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== pods ===";        kubectl get pods -o wide || true
+          echo "=== pvc ===";         kubectl get pvc || true
+          echo "=== cognee logs ==="; kubectl logs -l app=cognee-cognee --tail=200 || true
+          echo "=== postgres logs ==="; kubectl logs -l app=cognee-postgres --tail=100 || true
+          echo "=== mock logs ===";   kubectl logs -l app=mock-llm --tail=100 || true
+
+      - name: Stop port-forward
+        if: always()
+        run: kill "${PF_PID}" 2>/dev/null || true

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -221,6 +221,10 @@ jobs:
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
+  helm-kind-test:
+    name: Helm Kind E2E Test
+    uses: ./.github/workflows/helm_kind_test.yml
+    secrets: inherit
   temporal-graph-tests:
     name: Temporal Graph Test
     needs: [ build-ci-env ]
@@ -293,6 +297,7 @@ jobs:
       search-db-tests,
       relational-db-migration-tests,
       db-examples-tests,
+      helm-kind-test,
     ]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
@@ -319,7 +324,8 @@ jobs:
                 "${{ needs.temporal-graph-tests.result }}" == "success" &&
                 "${{ needs.search-db-tests.result }}" == "success" &&
                 "${{ needs.relational-db-migration-tests.result }}" == "success" &&
-                "${{ needs.db-examples-tests.result }}" == "success" ]]; then
+                "${{ needs.db-examples-tests.result }}" == "success" &&
+                "${{ needs.helm-kind-test.result }}" == "success" ]]; then
             echo "All test suites completed successfully!"
           else
             echo "One or more test suites failed."

--- a/cognee/tests/deployment/mock_llm/Dockerfile
+++ b/cognee/tests/deployment/mock_llm/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+RUN pip install --no-cache-dir fastapi uvicorn
+
+COPY server.py /app/server.py
+
+EXPOSE 11434
+CMD ["python", "server.py"]

--- a/cognee/tests/deployment/mock_llm/k8s.yml
+++ b/cognee/tests/deployment/mock_llm/k8s.yml
@@ -1,0 +1,47 @@
+# In-cluster deterministic mock LLM for the Helm/kind e2e test.
+# Applied by the CI workflow (and local dry-run) BEFORE `helm install`, so the
+# cognee pod can reach it at http://mock-llm:11434 via LLM_ENDPOINT/EMBEDDING_ENDPOINT.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mock-llm
+  labels:
+    app: mock-llm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mock-llm
+  template:
+    metadata:
+      labels:
+        app: mock-llm
+    spec:
+      containers:
+        - name: mock-llm
+          image: mock-llm:ci-test
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 11434
+          env:
+            - name: MOCK_ENTITY
+              value: "Alice"
+            - name: MOCK_EMBED_DIM
+              value: "1536"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 11434
+            initialDelaySeconds: 2
+            periodSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mock-llm
+spec:
+  selector:
+    app: mock-llm
+  ports:
+    - port: 11434
+      targetPort: 11434

--- a/cognee/tests/deployment/mock_llm/server.py
+++ b/cognee/tests/deployment/mock_llm/server.py
@@ -1,0 +1,154 @@
+"""
+Minimal OpenAI-compatible mock LLM + embedding server for deterministic CI.
+
+Lets cognee run add -> cognify -> search with no real API key. It returns a
+fixed entity ("Alice") for chat and a fixed vector for embeddings, so results
+are deterministic.
+
+cognee uses `instructor` tool-calling, so chat replies must be a tool_call whose
+arguments fit the schema cognee sends. We reflect that schema and return a
+minimal valid instance. Arrays are returned empty — this keeps models with
+custom validators / unions (e.g. SessionTurnAnalysis) valid while still filling
+the required fields the extraction models need.
+"""
+import json
+import os
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+FIXED_ENTITY = os.environ.get("MOCK_ENTITY", "Einstein")
+EMBED_DIM = int(os.environ.get("MOCK_EMBED_DIM", "1536"))
+
+
+def _instance_from_schema(schema: dict):
+    """Minimal deterministic instance satisfying a JSON schema.
+
+    Strategy that stays valid across cognee's many models:
+      - resolve $ref / allOf / anyOf / oneOf
+      - honor const / enum (covers many constrained strings)
+      - objects: fill ONLY required properties
+      - arrays: emit [] (empty list satisfies min-less list fields and dodges
+        discriminated-union / custom-validator item constraints)
+      - scalars: deterministic placeholders; free strings -> FIXED_ENTITY
+    """
+    defs = schema.get("$defs", {}) or schema.get("definitions", {})
+
+    def resolve(node, depth=0):
+        if depth > 40 or not isinstance(node, dict):
+            return FIXED_ENTITY
+
+        if "const" in node:
+            return node["const"]
+        if node.get("enum"):
+            return node["enum"][0]
+
+        if "$ref" in node:
+            ref = node["$ref"].split("/")[-1]
+            return resolve(defs.get(ref, {}), depth + 1)
+        if node.get("allOf"):
+            return resolve(node["allOf"][0], depth + 1)
+        for key in ("anyOf", "oneOf"):
+            if node.get(key):
+                non_null = [o for o in node[key] if o.get("type") != "null"]
+                chosen = non_null[0] if non_null else node[key][0]
+                return resolve(chosen, depth + 1)
+
+        t = node.get("type")
+        if isinstance(t, list):
+            t = next((x for x in t if x != "null"), "string")
+
+        if t == "object" or ("properties" in node and t is None):
+            out = {}
+            props = node.get("properties", {})
+            required = node.get("required", [])
+            for k in required:
+                if k in props:
+                    out[k] = resolve(props[k], depth + 1)
+            return out
+        if t == "array":
+            # Empty list: satisfies optional/zero-min arrays and avoids
+            # inventing items for discriminated unions / validated item models.
+            return []
+        if t == "integer":
+            return 1
+        if t == "number":
+            return 1.0
+        if t == "boolean":
+            return True
+        return FIXED_ENTITY
+
+    return resolve(schema)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/v1/chat/completions")
+@app.post("/chat/completions")
+async def chat_completions(request: Request):
+    body = await request.json()
+    model = body.get("model", "gpt-4o-mini")
+    tools = body.get("tools") or []
+
+    if tools:
+        fn = (tools[0] or {}).get("function", {})
+        name = fn.get("name", "extract")
+        schema = fn.get("parameters", {}) or {}
+        args = _instance_from_schema(schema)
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_mock",
+                    "type": "function",
+                    "function": {"name": name, "arguments": json.dumps(args)},
+                }
+            ],
+        }
+        finish = "tool_calls"
+    else:
+        message = {"role": "assistant", "content": FIXED_ENTITY}
+        finish = "stop"
+
+    return JSONResponse(
+        {
+            "id": "chatcmpl-mock",
+            "object": "chat.completion",
+            "model": model,
+            "choices": [{"index": 0, "message": message, "finish_reason": finish}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+    )
+
+
+@app.post("/v1/embeddings")
+@app.post("/embeddings")
+async def embeddings(request: Request):
+    body = await request.json()
+    inp = body.get("input", "")
+    items = inp if isinstance(inp, list) else [inp]
+    vector = [0.001] * EMBED_DIM
+    data = [
+        {"object": "embedding", "index": i, "embedding": vector}
+        for i, _ in enumerate(items)
+    ]
+    return JSONResponse(
+        {
+            "object": "list",
+            "model": body.get("model", "text-embedding-3-small"),
+            "data": data,
+            "usage": {"prompt_tokens": 1, "total_tokens": 1},
+        }
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "11434")))

--- a/cognee/tests/deployment/test_helm_kind.py
+++ b/cognee/tests/deployment/test_helm_kind.py
@@ -1,0 +1,102 @@
+"""
+End-to-end deployment test for the Helm chart on a kind cluster (T7 #3365).
+
+Deploys the chart and runs the golden flow (add-cognify-search) over HTTP
+against the live cognee Service, using an in-cluster mock LLM so no real API key
+is needed and the result is deterministic (the mock always returns "Alice").
+
+Uses a local golden_flow() for now; will switch to the shared harness flow
+(#3358 / #3596) once that merges.
+
+Run with: pytest -m deployment_graph
+"""
+import os
+import time
+
+import httpx
+import pytest
+
+pytestmark = [pytest.mark.deployment, pytest.mark.deployment_graph]
+
+BASE_URL = os.environ.get("COGNEE_BASE_URL", "http://localhost:8000")
+DATASET = os.environ.get("COGNEE_TEST_DATASET", "helm_kind_e2e")
+MOCK_ENTITY = os.environ.get("MOCK_ENTITY", "Alice")
+DOC_TEXT = f"{MOCK_ENTITY} works at Cognee and manages the AI memory platform."
+
+# cognify + embedding over the mock is quick, but pod scheduling/boot is not.
+# keep timeouts generous so CI on a small runner isnt flaky.
+REQUEST_TIMEOUT = 120.0
+
+
+def wait_for_health(url: str, timeout: float = 300.0, interval: float = 3.0) -> None:
+    """Poll GET <url> until it returns 200, or raise on timeout.
+
+    Local mirror of the harness health poller; dropped for the shared
+    helpers/health.py once T0 (#3596) lands.
+    """
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            r = httpx.get(url, timeout=10.0)
+            if r.status_code == 200:
+                return
+            last_err = f"status {r.status_code}"
+        except Exception as e:
+            last_err = str(e)
+        time.sleep(interval)
+    raise TimeoutError(f"health not ready at {url} after {timeout}s (last: {last_err})")
+
+
+async def golden_flow(api_client: httpx.AsyncClient) -> bool:
+    """Deployed golden flow: add -> cognify -> search, asserting the seeded entity.
+    Signature mirrors the frozen harness flow (#3596): takes an async httpx
+    client bound to the cognee base URL. Kept intentionally minimal and matched
+    to the endpoint shapes verified against the running container:
+      - add: multipart/form-data with `data` as an uploaded file
+      - cognify: blocking (returns PipelineRunCompleted synchronously), so no
+        status polling is needed for the mock path
+      - search: GRAPH_COMPLETION, asserting the deterministic mock entity
+    """
+    # 1. add (multipart file upload)
+    files = {"data": ("doc.txt", DOC_TEXT.encode("utf-8"), "text/plain")}
+    add_resp = await api_client.post(
+        "/api/v1/add", files=files, data={"datasetName": DATASET}
+    )
+    assert add_resp.status_code == 200, f"add failed: {add_resp.status_code} {add_resp.text}"
+    assert "PipelineRunCompleted" in add_resp.text, f"add did not complete: {add_resp.text}"
+
+    # 2. cognify (blocking)
+    cognify_resp = await api_client.post("/api/v1/cognify", json={"datasets": [DATASET]})
+    assert cognify_resp.status_code == 200, (
+        f"cognify failed: {cognify_resp.status_code} {cognify_resp.text}"
+    )
+    assert "PipelineRunCompleted" in cognify_resp.text, (
+        f"cognify did not complete: {cognify_resp.text}"
+    )
+
+    # 3. search (GRAPH_COMPLETION)
+    search_resp = await api_client.post(
+        "/api/v1/search",
+        json={
+            "search_type": "GRAPH_COMPLETION",
+            "query": "Who works at Cognee?",
+            "datasets": [DATASET],
+        },
+    )
+    assert search_resp.status_code == 200, (
+        f"search failed: {search_resp.status_code} {search_resp.text}"
+    )
+
+    results = search_resp.json()
+    flat = " ".join(map(str, results)) if isinstance(results, list) else str(results)
+    assert MOCK_ENTITY in flat, f"expected '{MOCK_ENTITY}' in search results, got: {results}"
+    return True
+
+
+@pytest.mark.asyncio
+async def test_golden_flow_on_helm_kind():
+    """Full deployed golden flow against the Helm/kind deployment."""
+    wait_for_health(f"{BASE_URL}/health")
+    async with httpx.AsyncClient(base_url=BASE_URL, timeout=REQUEST_TIMEOUT) as client:
+        assert await golden_flow(client) is True

--- a/deployment/helm/templates/cognee_deployment.yaml
+++ b/deployment/helm/templates/cognee_deployment.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       containers:
         - name: cognee
-          image: {{ .Values.cognee.image }}
+          image: "{{ .Values.cognee.image.repository }}:{{ .Values.cognee.image.tag }}"
+          imagePullPolicy: {{ .Values.cognee.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.cognee.port }}
           env:
@@ -47,7 +48,24 @@ spec:
               value: {{ .Values.cognee.env.LLM_MODEL }}
             - name: LLM_PROVIDER
               value: {{ .Values.cognee.env.LLM_PROVIDER }}
+            - name: LLM_ENDPOINT
+              value: "{{ .Values.cognee.env.LLM_ENDPOINT }}"
+            - name: EMBEDDING_PROVIDER
+              value: "{{ .Values.cognee.env.EMBEDDING_PROVIDER }}"
+            - name: EMBEDDING_MODEL
+              value: "{{ .Values.cognee.env.EMBEDDING_MODEL }}"
+            - name: EMBEDDING_DIMENSIONS
+              value: "{{ .Values.cognee.env.EMBEDDING_DIMENSIONS }}"
+            - name: EMBEDDING_ENDPOINT
+              value: "{{ .Values.cognee.env.EMBEDDING_ENDPOINT }}"
           resources:
             limits:
               cpu: {{ .Values.cognee.resources.cpu }}
               memory: {{ .Values.cognee.resources.memory }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.cognee.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -1,13 +1,21 @@
 # Configuration for the 'cognee' application service
 cognee:
-  # Image name (using the local image we’ll build in Minikube)
-  image: "cognee/cognee:main"
+  image:
+    repository: "cognee/cognee"
+    tag: "main"
+    pullPolicy: "IfNotPresent"      # so kind-loaded images aren't re-pulled
   port: 8000
   env:
     ENV: "local"
     PYTHONPATH: "."
-    LLM_MODEL: "openai/gpt-4o-mini"
     LLM_PROVIDER: "openai"
+    LLM_MODEL: "openai/gpt-4o-mini"
+    LLM_ENDPOINT: ""                 # empty default = real behavior unchanged
+    LLM_API_KEY: ""                  # default so `helm install` doesn't fail at render
+    EMBEDDING_PROVIDER: ""
+    EMBEDDING_MODEL: ""
+    EMBEDDING_DIMENSIONS: ""
+    EMBEDDING_ENDPOINT: ""
   resources:
     cpu: "4.0"
     memory: "2Gi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,3 +282,10 @@ dev = [
     "pytest-split>=0.11.0,<0.12",
     "ruff>=0.13.1",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+markers = [
+    "deployment: opt-in deployment e2e tests (excluded from default unit run)",
+    "deployment_graph: deployment e2e exercising the cognify->search graph path via mock LLM",
+]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
### **Closes #3365.**

Right now the Helm chart in deployment/helm/ is only checked for valid YAML, nothing actually deploys it and confirms that it runs. So the chart can look fine but still be broken. This PR makes CI actually deploy the chart on a kind cluster and run the real add/ cognify/search flow against the running service.

While building the test I found the chart could not even helm install cleanly as it is. It was missing an LLM_API_KEY default (so install failed at render), had no pullPolicy for locally built images (so a PR-built image will not come up on kind) and no way to point cognee at a mock LLM. I fixed those and added a /health readiness probe so "ready" means the app is actually responding.

For the test itself: it spins up a kind cluster, builds and loads the image from this PR, deploys a tiny in-cluster fake LLM alongside cognee and then points cognee at it. The fake LLM means no real API key is needed and the result is always the same so the test is deterministic and free to run on every PR. Once everything is ready it port-forwards the service and runs add/cognify/search, checking the known result comes back. It is added in as a PR-blocking check and the cluster is torn down at the end.

I kept the fake LLM and the flow self-contained for now, since the shared harness (#3358 / #3596) is not merged yet. Once it is merged. I will switch to the shared golden_flow and wait_for_health. The signatures already match, so it is just swapping imports, not changing the test logic.

**How to test locally:** build the two images, kind load them, kubectl apply the mock, helm install the chart with the mock endpoints set, wait for pods ready, port-forward :8000, then pytest -m deployment_graph. (Full commands in .github/workflows/helm_kind_test.ymlworkflow file.)

**Result:** runs green end to end on kind and the golden flow passes with no real LLM key.

## Acceptance Criteria
1. kind cluster created in CI, chart deployed with helm install (cognee + postgres), pods wait for Ready (Postgres + cognee rollout).
2. Service port-forwarded on :8000, add/cognify/search run against the live pod, known result asserted.
3. Mock LLM by default. No real API key, deterministic.
4. Image tag parametrized so PR runs test the locally built image.
5. PR-blocking. Cluster torn down at the end.
6. Verified locally on kind: the golden flow passes end to end with no real LLM key. To reproduce, see the commands in .github/workflows/helm_kind_test.yml.

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [x] Other (please specify):  Deployment e2e coverage for the Helm chart on kind,  the chart fixes needed to make it deploy.

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->
<img width="1919" height="1079" alt="Screenshot 2026-07-01 223353" src="https://github.com/user-attachments/assets/2d55b031-aade-42d6-9a99-9b88828e7563" />
<img width="1919" height="1079" alt="Screenshot 2026-07-01 223348" src="https://github.com/user-attachments/assets/aa0e6da5-8dbd-470e-9a50-cc175811569c" />


## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
