### PR TITLE
docs(lru_cache): correct documented default (128 -> 6) to match code

### DIFF
--- a/cognee/shared/lru_cache.py
+++ b/cognee/shared/lru_cache.py
@@ -2,7 +2,7 @@
 Shared cache size setting for Cognee database adapters.
 
 Set DATABASE_MAX_LRU_CACHE_SIZE in the environment to control the maxsize of the
-lru_cache used by the graph, vector, and relational DB engine factories (default: 128).
+lru_cache used by the graph, vector, and relational DB engine factories (default: 6).
 """
 
 import os


### PR DESCRIPTION
## What

The module docstring for `cognee/shared/lru_cache.py` documents the default
value of `DATABASE_MAX_LRU_CACHE_SIZE` as **128**, but the code has always
defaulted to **6**:

```python
DATABASE_MAX_LRU_CACHE_SIZE: int = int(os.getenv("DATABASE_MAX_LRU_CACHE_SIZE", "6"))
```

## Why

This value is not only an `lru_cache` maxsize for the graph/vector/relational
engine factories — `cognee/infrastructure/databases/dataset_queue/queue.py`
also reuses it as the default for `DATASET_QUEUE_MAX_CONCURRENT` ("safe
baseline"). A reader tuning DB connection / concurrency behavior from the
docstring would expect a default of 128 concurrent engine instances / queue
slots, when the real default is 6. The docstring is the only in-code
documentation of this setting, so the mismatch is actively misleading.

## Changes

- `cognee/shared/lru_cache.py`: docstring `(default: 128)` -> `(default: 6)`.

## Notes

Documentation-only change; no runtime behavior is affected.
