### PR TITLE
fix(neo4j): make DatabaseUnavailable retry reachable and consistent (#3757)

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
@@ -35,8 +35,8 @@ def deadlock_retry(max_retries=10):
             async def wait():
                 backoff_time = calculate_backoff(attempt)
                 logger.warning(
-                    f"Neo4j rate limit hit, retrying in {backoff_time:.2f}s "
-                    f"Attempt {attempt}/{max_retries}"
+                    f"Neo4j transient error, retrying in {backoff_time:.2f}s "
+                    f"(attempt {attempt}/{max_retries})"
                 )
                 await asyncio.sleep(backoff_time)
 

--- a/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
@@ -10,16 +10,16 @@ logger = get_logger("deadlock_retry")
 
 def deadlock_retry(max_retries=10):
     """
-    Decorator that automatically retries an asynchronous function when rate limit errors occur.
+    Decorator that automatically retries an asynchronous Neo4j operation on
+    transient failures.
 
-    This decorator implements an exponential backoff strategy with jitter
-    to handle rate limit errors efficiently.
+    Retries when the wrapped call raises ``DatabaseUnavailable`` or a Neo4j
+    deadlock/transient error (``DeadlockDetected`` / ``Neo.TransientError``),
+    using an exponential backoff with jitter between attempts. Any other
+    ``Neo4jError`` is re-raised immediately.
 
     Args:
-        max_retries: Maximum number of retry attempts.
-        initial_backoff: Initial backoff time in seconds.
-        backoff_factor: Multiplier for exponential backoff.
-        jitter: Jitter factor to avoid the thundering herd problem.
+        max_retries: Maximum number of retry attempts after the initial call.
 
     Returns:
         The decorated async function.
@@ -44,6 +44,16 @@ def deadlock_retry(max_retries=10):
                 try:
                     attempt += 1
                     return await func(self, *args, **kwargs)
+                except DatabaseUnavailable:
+                    # DatabaseUnavailable subclasses Neo4jError, so this handler
+                    # must precede the `except Neo4jError` below — otherwise the
+                    # broader handler catches it first and this branch is dead
+                    # code. Use the same `attempt > max_retries` bound as the
+                    # Neo4jError branch so both retry the same number of times.
+                    if attempt > max_retries:
+                        raise  # Re-raise the original error
+
+                    await wait()
                 except Neo4jError as error:
                     if attempt > max_retries:
                         raise  # Re-raise the original error
@@ -53,11 +63,6 @@ def deadlock_retry(max_retries=10):
                         await wait()
                     else:
                         raise  # Re-raise the original error
-                except DatabaseUnavailable:
-                    if attempt >= max_retries:
-                        raise  # Re-raise the original error
-
-                    await wait()
 
         return wrapper
 

--- a/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
@@ -1,8 +1,15 @@
 import pytest
 import asyncio
-from unittest.mock import MagicMock
-from neo4j.exceptions import Neo4jError
+from unittest.mock import MagicMock, patch
+from neo4j.exceptions import Neo4jError, DatabaseUnavailable
 from cognee.infrastructure.databases.graph.neo4j_driver.deadlock_retry import deadlock_retry
+
+# DatabaseUnavailable retries hit ``asyncio.sleep`` via ``calculate_backoff``.
+# Patch the backoff to 0 so these tests stay fast and deterministic.
+_no_backoff = patch(
+    "cognee.infrastructure.databases.graph.neo4j_driver.deadlock_retry.calculate_backoff",
+    return_value=0,
+)
 
 
 @pytest.mark.asyncio
@@ -45,11 +52,60 @@ async def test_deadlock_retry_exhaustive():
     assert result, "Function should have succeded on second time"
 
 
+@pytest.mark.asyncio
+async def test_database_unavailable_is_retried():
+    """DatabaseUnavailable must be retried, not raised on the first failure.
+
+    Regression test: DatabaseUnavailable subclasses Neo4jError, so with the
+    handlers ordered ``except Neo4jError`` first, the DatabaseUnavailable
+    branch was unreachable and the error surfaced immediately (0 retries).
+    """
+    mock_return = asyncio.Future()
+    mock_return.set_result(True)
+    mock_function = MagicMock(side_effect=[DatabaseUnavailable("unavailable"), mock_return])
+
+    wrapped_function = deadlock_retry(max_retries=1)(mock_function)
+
+    with _no_backoff:
+        result = await wrapped_function(self=None)
+
+    assert result, "DatabaseUnavailable should be retried and then succeed"
+    assert mock_function.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_database_unavailable_retry_count_matches_neo4jerror():
+    """DatabaseUnavailable is retried the same number of times as Neo4jError.
+
+    With max_retries=1 both allow exactly one retry (two calls total) before
+    re-raising — previously DatabaseUnavailable used ``>=`` and raised one
+    attempt earlier than the Neo4jError branch.
+    """
+    mock_return = asyncio.Future()
+    mock_return.set_result(True)
+    mock_function = MagicMock(
+        side_effect=[
+            DatabaseUnavailable("unavailable"),
+            DatabaseUnavailable("unavailable"),
+            mock_return,
+        ]
+    )
+
+    wrapped_function = deadlock_retry(max_retries=1)(mock_function)
+
+    with _no_backoff, pytest.raises(DatabaseUnavailable):
+        await wrapped_function(self=None)
+
+    assert mock_function.call_count == 2
+
+
 if __name__ == "__main__":
 
     async def main():
         await test_deadlock_retry()
         await test_deadlock_retry_errored()
         await test_deadlock_retry_exhaustive()
+        await test_database_unavailable_is_retried()
+        await test_database_unavailable_retry_count_matches_neo4jerror()
 
     asyncio.run(main())

--- a/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
@@ -35,7 +35,7 @@ async def test_deadlock_retry():
     wrapped_function = deadlock_retry(max_retries=2)(mock_function)
 
     result = await wrapped_function(self=None)
-    assert result, "Function should have succeded on second time"
+    assert result, "Function should have succeeded on second time"
 
 
 @pytest.mark.asyncio
@@ -49,7 +49,7 @@ async def test_deadlock_retry_exhaustive():
     wrapped_function = deadlock_retry(max_retries=2)(mock_function)
 
     result = await wrapped_function(self=None)
-    assert result, "Function should have succeded on second time"
+    assert result, "Function should have succeeded on second time"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes #3757. The `deadlock_retry` decorator in
`cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py` had two
problems: an inaccurate docstring, and a `DatabaseUnavailable` retry path that
never actually ran.

## Root cause (the important part)

`DatabaseUnavailable` is a **subclass** of `Neo4jError`
(`DatabaseUnavailable → TransientError → Neo4jError`). The handlers were ordered:

```python
except Neo4jError as error:
    ...
except DatabaseUnavailable:   # unreachable — superclass already caught it
    if attempt >= max_retries:
        raise
    await wait()
```

Because `except Neo4jError` comes first and `DatabaseUnavailable` is a subclass,
**the `DatabaseUnavailable` branch is dead code** — it can never execute. A real
`DatabaseUnavailable` is caught by the `Neo4jError` branch, and since
`str(error)` is only the message (the `Neo.TransientError...` text lives on
`error.code`, not in `str()`), it fails the `"DeadlockDetected"/"Neo.TransientError"`
check and is **re-raised immediately with zero retries**.

So the previously-reported `>=` vs `>` inconsistency is real, but simply changing
`>=` to `>` fixes nothing — it edits unreachable code. The handler has to be made
reachable first.

## Fix

- **Reorder** the handlers so the more specific `DatabaseUnavailable` is caught
  **before** `Neo4jError`, making the retry path reachable.
- Use the same `attempt > max_retries` bound in both branches so
  `DatabaseUnavailable` and `Neo4jError` retry the **same** number of times
  (previously `DatabaseUnavailable` used `>=`, one retry short).
- **Docstring:** removed three documented parameters (`initial_backoff`,
  `backoff_factor`, `jitter`) that are not in the signature, and corrected the
  description (it retries Neo4j transient/deadlock + `DatabaseUnavailable`, not
  generic "rate limit" errors).

## Verification

Reproduced against the real `neo4j` package. With `max_retries=1` and a function
that raises `DatabaseUnavailable` once then succeeds:

- **Before:** raises after **1 call** (no retry).
- **After:** succeeds after **2 calls** (retried).

Added two regression tests to
`cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py`:

- `test_database_unavailable_is_retried` — fails on the old code, passes now.
- `test_database_unavailable_retry_count_matches_neo4jerror` — pins the retry
  count to match the `Neo4jError` path.

The three existing tests are unchanged and still pass (deadlock errors are plain
`Neo4jError` and still take the `Neo4jError` branch).
