### PR TITLE
feat(ingestion): Notion connector (dlt, incremental + forget-on-delete)

### DIFF
--- a/cognee/tasks/ingestion/notion_source.py
+++ b/cognee/tasks/ingestion/notion_source.py
@@ -1,0 +1,258 @@
+"""DLT source for Notion pages (incremental re-sync + forget-on-delete).
+
+Fetches Notion pages and renders their block children to markdown, then yields
+them as a dlt resource for cognee's ingestion pipeline.
+
+Unlike the relational dlt path (SQL/CSV), Notion pages are ingested as *normal
+documents*: rows are tagged ``external_metadata["source"] = "notion"`` (not
+``"dlt"``), so ``is_dlt_sourced`` returns False and each page flows through the
+standard cognify entity-extraction pipeline instead of the deterministic
+dlt-row path.
+
+Incremental re-sync uses ``last_edited_time`` as the dlt cursor and the Notion
+page id as the primary key, so re-runs only process changed pages. Archived or
+trashed pages are flagged with dlt's ``hard_delete`` column hint: they drop out
+of the staging table on the next sync, which makes them orphans that cognee's
+existing ``orphan_cleanup`` removes from the graph and vector stores.
+"""
+
+import os
+from typing import Any, Optional
+from uuid import UUID
+
+from cognee.modules.data.methods.get_unique_data_id import get_unique_data_id
+from cognee.modules.users.models import User
+
+from .data_item import DataItem
+from .dlt_row_data import DltRowData
+
+# dlt resource / staging-table name for Notion pages. resolve_dlt_sources keys
+# off the source name to route Notion rows through the document path.
+NOTION_TABLE_NAME = "notion_pages"
+NOTION_SOURCE_NAME = "notion"
+_DEFAULT_NOTION_VERSION = "2022-06-28"
+
+# Notion rows are read back in full each sync so orphan cleanup can spot pages
+# that dropped out of staging (archived/deleted). Use a high cap so the default
+# per-table limit doesn't truncate the read and orphan live pages.
+NOTION_MAX_ROWS = 100_000
+
+# Notion block types whose rich_text renders as a plain markdown paragraph.
+_TEXT_BLOCKS = {"paragraph", "quote", "callout", "toggle"}
+_HEADING_PREFIX = {"heading_1": "# ", "heading_2": "## ", "heading_3": "### "}
+
+
+def notion_source(
+    token: Optional[str] = None,
+    page_ids: Optional[list[str]] = None,
+    database_ids: Optional[list[str]] = None,
+    notion_version: Optional[str] = None,
+):
+    """Create a dlt source that yields Notion pages as markdown documents.
+
+    Args:
+        token: Notion integration token. Falls back to ``NOTION_API_KEY``.
+        page_ids: Restrict ingestion to these page ids. When omitted (and no
+            ``database_ids``), all pages the integration can see are searched.
+        database_ids: Restrict ingestion to pages in these databases.
+        notion_version: Notion API version header. Defaults to ``2022-06-28``.
+
+    Returns:
+        A dlt source suitable for ``cognee.add(...)`` / ``resolve_dlt_sources``.
+    """
+    import dlt
+    from notion_client import Client
+
+    resolved_token = token or os.environ.get("NOTION_API_KEY")
+    if not resolved_token:
+        raise ValueError("Notion integration token required: pass token= or set NOTION_API_KEY.")
+
+    client = Client(
+        auth=resolved_token,
+        notion_version=notion_version or _DEFAULT_NOTION_VERSION,
+    )
+
+    @dlt.resource(
+        name=NOTION_TABLE_NAME,
+        primary_key="id",
+        write_disposition="merge",
+        # Archiving/trashing a page bumps last_edited_time, so it comes through
+        # the incremental window; the hard_delete hint then removes it from
+        # staging, making it an orphan that cognee's orphan_cleanup deletes.
+        columns={"archived": {"hard_delete": True}},
+    )
+    def notion_pages(
+        last_edited=dlt.sources.incremental("last_edited_time"),
+    ):
+        for page in _iter_pages(client, page_ids, database_ids):
+            yield _page_to_row(client, page)
+
+    @dlt.source(name=NOTION_SOURCE_NAME)
+    def _notion():
+        return notion_pages
+
+    return _notion()
+
+
+async def expand_notion_rows(
+    rows: list[DltRowData],
+    user: User,
+) -> tuple[list[DataItem], set[UUID]]:
+    """Turn Notion dlt rows into document DataItems for the standard pipeline.
+
+    Returns ``(data_items, fresh_data_ids)``. ``fresh_data_ids`` feeds the
+    deferred orphan cleanup so pages that vanished from the source (archived /
+    deleted, dropped from staging via ``hard_delete``) are removed downstream.
+    """
+    data_items: list[DataItem] = []
+    fresh_data_ids: set[UUID] = set()
+
+    for row in rows:
+        row_identifier = f"dlt:{row.table_name}:{row.primary_key_value}:{row.content_hash}"
+        data_id = await get_unique_data_id(row_identifier, user)
+        fresh_data_ids.add(data_id)
+        data_items.append(_build_notion_data_item(row, data_id))
+
+    return data_items, fresh_data_ids
+
+
+def _build_notion_data_item(row: DltRowData, data_id: UUID) -> DataItem:
+    """Build a document DataItem from a Notion page row (source ``"notion"``)."""
+    row_data = row.row_data
+    title = _clean(row_data.get("title"))
+    content = _clean(row_data.get("content"))
+    text = f"# {title}\n\n{content}".strip() if title else content
+
+    external_metadata = {
+        "source": "notion",
+        "notion_page_id": row_data.get("id"),
+        "notion_url": row_data.get("url"),
+        "title": title,
+        "last_edited_time": row_data.get("last_edited_time"),
+        "content_hash": row.content_hash,
+    }
+
+    return DataItem(
+        data=text,
+        label=title or str(row_data.get("id")),
+        external_metadata=external_metadata,
+        data_id=data_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Notion API helpers (module-private)
+# ---------------------------------------------------------------------------
+
+
+def _iter_pages(client, page_ids, database_ids):
+    """Yield raw Notion page objects for the configured scope."""
+    if page_ids:
+        for page_id in page_ids:
+            yield client.pages.retrieve(page_id=page_id)
+        return
+
+    if database_ids:
+        for database_id in database_ids:
+            yield from _paginate(client.databases.query, database_id=database_id)
+        return
+
+    # No explicit scope: search every page the integration can see.
+    yield from _paginate(
+        client.search,
+        filter={"property": "object", "value": "page"},
+        sort={"timestamp": "last_edited_time", "direction": "ascending"},
+    )
+
+
+def _paginate(method, **kwargs):
+    """Yield results across Notion's cursor-based pagination."""
+    cursor = None
+    while True:
+        response = method(start_cursor=cursor, **kwargs) if cursor else method(**kwargs)
+        for item in response.get("results", []):
+            yield item
+        if not response.get("has_more"):
+            return
+        cursor = response.get("next_cursor")
+
+
+def _page_to_row(client, page: dict) -> dict:
+    """Flatten a Notion page + its block children into a dlt row."""
+    return {
+        "id": page.get("id"),
+        "last_edited_time": page.get("last_edited_time"),
+        # in_trash is the newer flag; archived is the legacy one. Either means
+        # the page should be forgotten, so the hard_delete hint fires on both.
+        "archived": bool(page.get("archived") or page.get("in_trash")),
+        "url": page.get("url"),
+        "title": _page_title(page),
+        "content": _render_blocks(client, page.get("id")),
+    }
+
+
+def _page_title(page: dict) -> str:
+    """Extract the page title from its title property."""
+    properties = page.get("properties") or {}
+    for prop in properties.values():
+        if isinstance(prop, dict) and prop.get("type") == "title":
+            return _rich_text(prop.get("title"))
+    return ""
+
+
+def _render_blocks(client, block_id: Optional[str], depth: int = 0) -> str:
+    """Render a block's children to markdown, recursing into nested blocks."""
+    # Guard against pathological nesting / cycles.
+    if not block_id or depth > 10:
+        return ""
+
+    lines: list[str] = []
+    for block in _paginate(client.blocks.children.list, block_id=block_id):
+        rendered = _render_block(block)
+        if rendered:
+            lines.append(rendered)
+        if block.get("has_children"):
+            nested = _render_blocks(client, block.get("id"), depth + 1)
+            if nested:
+                lines.append(nested)
+
+    return "\n".join(lines)
+
+
+def _render_block(block: dict) -> str:
+    """Render a single Notion block to a markdown line."""
+    block_type = block.get("type")
+    if not block_type:
+        return ""
+
+    payload = block.get(block_type) or {}
+    text = _rich_text(payload.get("rich_text"))
+
+    if block_type in _HEADING_PREFIX:
+        return f"{_HEADING_PREFIX[block_type]}{text}" if text else ""
+    if block_type == "bulleted_list_item":
+        return f"- {text}" if text else ""
+    if block_type == "numbered_list_item":
+        return f"1. {text}" if text else ""
+    if block_type == "to_do":
+        checked = "x" if payload.get("checked") else " "
+        return f"- [{checked}] {text}" if text else ""
+    if block_type == "code":
+        language = payload.get("language") or ""
+        return f"```{language}\n{text}\n```" if text else ""
+    if block_type in _TEXT_BLOCKS:
+        return text
+
+    return text
+
+
+def _rich_text(rich_text: Any) -> str:
+    """Concatenate the plain_text of a Notion rich_text array."""
+    if not isinstance(rich_text, list):
+        return ""
+    return "".join(part.get("plain_text", "") for part in rich_text if isinstance(part, dict))
+
+
+def _clean(value: Any) -> str:
+    """Coerce a possibly-None cell value to a stripped string."""
+    return str(value).strip() if value is not None else ""

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -21,6 +21,7 @@ from .create_dlt_source import (
 from .data_item import DataItem
 from .dlt_row_data import DltRowData
 from .ingest_dlt_source import ingest_dlt_source
+from .notion_source import NOTION_MAX_ROWS, NOTION_SOURCE_NAME, expand_notion_rows
 
 logger = get_logger("resolve_dlt_sources")
 
@@ -79,9 +80,15 @@ async def resolve_dlt_sources(
         # Nothing to expand — return original data unchanged
         return data, None
 
+    # Notion sources take the document path (each page → a text document that
+    # goes through normal cognify); every other dlt source takes the relational
+    # schema-context path below.
+    notion_items = [i for i in dlt_items if getattr(i, "name", None) == NOTION_SOURCE_NAME]
+    relational_items = [i for i in dlt_items if getattr(i, "name", None) != NOTION_SOURCE_NAME]
+
     # --- Run DLT pipelines and collect rows ---------------------------------
     all_rows: List[DltRowData] = []
-    for dlt_item in dlt_items:
+    for dlt_item in relational_items:
         rows = await ingest_dlt_source(
             dlt_item,
             dataset_name,
@@ -90,6 +97,20 @@ async def resolve_dlt_sources(
             max_rows_per_table=max_rows_per_table,
         )
         all_rows.extend(rows)
+
+    # Notion always merges on page id and reads the full current staging state
+    # back, so orphan cleanup can detect pages that were archived/deleted
+    # (dropped from staging via the resource's hard_delete hint).
+    notion_rows: List[DltRowData] = []
+    for dlt_item in notion_items:
+        rows = await ingest_dlt_source(
+            dlt_item,
+            dataset_name,
+            primary_key="id",
+            write_disposition="merge",
+            max_rows_per_table=NOTION_MAX_ROWS,
+        )
+        notion_rows.extend(rows)
 
     # --- Phase 1: compute stable data_ids for all rows (for FK resolution) --
     # Primary lookup uses content_hash for uniqueness (handles tables with
@@ -184,6 +205,12 @@ async def resolve_dlt_sources(
             sample,
         )
 
+    # --- Expand Notion rows into document DataItems -------------------------
+    # Notion pages skip the schema-context treatment above: each becomes a text
+    # document (source "notion") that flows through normal cognify.
+    notion_expanded, notion_fresh_ids = await expand_notion_rows(notion_rows, user)
+    expanded_items.extend(notion_expanded)
+
     # --- Phase 3: prepare deferred orphan cleanup ---------------------------
     # Deletion of orphaned dlt rows is deferred to *after* the fresh rows are
     # committed by the add pipeline, to avoid a data-loss window: if ingestion
@@ -191,14 +218,23 @@ async def resolve_dlt_sources(
     # replacements never stored. We return a cleanup coroutine for the caller
     # to await post-commit instead of deleting here.
     #
-    # Skip orphan deletion for "append" disposition — each run intentionally
-    # adds new rows, so prior batches should not be treated as orphans.
+    # Relational sources skip cleanup for "append" (each run intentionally adds
+    # new rows). Notion always reconciles: it reads the full current page set
+    # back, so pages missing from it (archived/deleted) must be forgotten. The
+    # two paths are cleaned separately so an append relational run never treats
+    # Notion pages as orphans, or vice versa.
+    relational_fresh: Set[UUID] = set(row_id_lookup.values())
+    do_relational_cleanup = write_disposition != "append" and bool(relational_fresh)
+    do_notion_cleanup = bool(notion_items)
+
     orphan_cleanup: Optional[Callable[[], Any]] = None
-    if write_disposition != "append":
-        fresh_data_ids: Set[UUID] = set(row_id_lookup.values())
+    if do_relational_cleanup or do_notion_cleanup:
 
         async def _cleanup() -> None:
-            await _delete_dlt_orphans(dataset_name, user, fresh_data_ids)
+            if do_relational_cleanup:
+                await _delete_dlt_orphans(dataset_name, user, relational_fresh, sources=("dlt",))
+            if do_notion_cleanup:
+                await _delete_dlt_orphans(dataset_name, user, notion_fresh_ids, sources=("notion",))
 
         orphan_cleanup = _cleanup
 
@@ -316,6 +352,7 @@ async def _delete_dlt_orphans(
     dataset_name: str,
     user: User,
     fresh_data_ids: Set[UUID],
+    sources: tuple[str, ...] = ("dlt",),
 ) -> None:
     """Delete dlt-sourced Data records (and their graph/vector artifacts) that
     are no longer present in the freshly-ingested dlt source.
@@ -323,6 +360,11 @@ async def _delete_dlt_orphans(
     This handles the case where rows are deleted from the upstream database
     and the user re-ingests.  dlt cleans its own staging DB, but cognee's
     relational, graph, and vector stores still hold stale data.
+
+    ``sources`` restricts cleanup to Data whose ``external_metadata["source"]``
+    is one of the given tags (e.g. ``("dlt",)`` for relational rows or
+    ``("notion",)`` for Notion pages), so reconciling one source never removes
+    the other's records.
     """
     from cognee.modules.data.methods.get_dataset_data import get_dataset_data
     from cognee.modules.data.methods import get_authorized_existing_datasets
@@ -346,7 +388,7 @@ async def _delete_dlt_orphans(
     orphans = []
     for data_item in all_data:
         ext = data_item.external_metadata
-        if not isinstance(ext, dict) or ext.get("source") != "dlt":
+        if not isinstance(ext, dict) or ext.get("source") not in sources:
             continue
         if data_item.id not in fresh_data_ids:
             orphans.append(data_item)

--- a/cognee/tests/unit/tasks/test_notion_source.py
+++ b/cognee/tests/unit/tasks/test_notion_source.py
@@ -1,0 +1,306 @@
+"""Unit tests for the Notion dlt connector.
+
+Two layers, all runnable in CI without a live Notion token:
+
+* DB-free tests for block→markdown rendering, page→row flattening, and the
+  document DataItem tagging (``source="notion"``) that routes pages through
+  normal cognify.
+* dlt-pipeline tests (mocked notion-client, temp sqlite destination) covering
+  the acceptance criteria: incremental re-sync reflects edits, and archiving a
+  page removes it from staging (forget-on-delete) via the ``hard_delete`` hint.
+"""
+
+from types import SimpleNamespace
+from uuid import NAMESPACE_OID, uuid5
+
+import pytest
+
+from cognee.tasks.ingestion.notion_source import (
+    NOTION_SOURCE_NAME,
+    _build_notion_data_item,
+    _page_title,
+    _page_to_row,
+    _render_block,
+    _render_blocks,
+    _rich_text,
+    expand_notion_rows,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+def _rt(text):
+    """A minimal Notion rich_text array with one plain_text span."""
+    return [{"plain_text": text}]
+
+
+def _block(block_type, text=None, **payload):
+    body = dict(payload)
+    if text is not None:
+        body["rich_text"] = _rt(text)
+    return {"type": block_type, block_type: body, "has_children": False}
+
+
+def _page(page_id, last_edited, title, archived=False, url=None):
+    return {
+        "id": page_id,
+        "last_edited_time": last_edited,
+        "archived": archived,
+        "url": url or f"https://notion.so/{page_id}",
+        "properties": {"Name": {"type": "title", "title": _rt(title)}},
+    }
+
+
+class FakeNotionClient:
+    """Stand-in for notion_client.Client backed by in-memory fixtures."""
+
+    def __init__(self, pages, blocks=None):
+        self._pages = pages
+        self._blocks = blocks or {}
+        self.blocks = SimpleNamespace(children=SimpleNamespace(list=self._blocks_list))
+        self.pages = SimpleNamespace(retrieve=self._pages_retrieve)
+        self.databases = SimpleNamespace(query=self._db_query)
+
+    def search(self, **kwargs):
+        return {"results": self._pages, "has_more": False}
+
+    def _db_query(self, **kwargs):
+        return {"results": self._pages, "has_more": False}
+
+    def _pages_retrieve(self, page_id=None):
+        return next(p for p in self._pages if p["id"] == page_id)
+
+    def _blocks_list(self, block_id=None, start_cursor=None, **kwargs):
+        return {"results": self._blocks.get(block_id, []), "has_more": False}
+
+
+# ---------------------------------------------------------------------------
+# Rendering (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_rich_text_concatenates_plain_text():
+    rich = [{"plain_text": "Hello "}, {"plain_text": "world"}]
+    assert _rich_text(rich) == "Hello world"
+
+
+def test_rich_text_handles_non_list():
+    assert _rich_text(None) == ""
+
+
+def test_render_block_covers_common_types():
+    assert _render_block(_block("heading_1", "Title")) == "# Title"
+    assert _render_block(_block("heading_2", "Sub")) == "## Sub"
+    assert _render_block(_block("bulleted_list_item", "point")) == "- point"
+    assert _render_block(_block("numbered_list_item", "step")) == "1. step"
+    assert _render_block(_block("to_do", "task", checked=True)) == "- [x] task"
+    assert _render_block(_block("to_do", "task", checked=False)) == "- [ ] task"
+    assert _render_block(_block("paragraph", "prose")) == "prose"
+    assert _render_block(_block("code", "print(1)", language="python")) == (
+        "```python\nprint(1)\n```"
+    )
+
+
+def test_render_blocks_recurses_into_children():
+    client = FakeNotionClient(
+        pages=[],
+        blocks={
+            "root": [
+                {
+                    "type": "paragraph",
+                    "paragraph": {"rich_text": _rt("parent")},
+                    "has_children": True,
+                    "id": "child",
+                },
+            ],
+            "child": [_block("bulleted_list_item", "nested")],
+        },
+    )
+    rendered = _render_blocks(client, "root")
+    assert "parent" in rendered
+    assert "- nested" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Page → row / DataItem (DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_page_title_reads_title_property():
+    assert _page_title(_page("p1", "2024-01-01T00:00:00.000Z", "My Page")) == "My Page"
+
+
+def test_page_to_row_flattens_page_and_flags_archive():
+    client = FakeNotionClient(pages=[], blocks={"p1": [_block("paragraph", "body text")]})
+    page = _page("p1", "2024-01-01T00:00:00.000Z", "My Page")
+    page["in_trash"] = True  # newer trash flag should also mark it archived
+
+    row = _page_to_row(client, page)
+
+    assert row["id"] == "p1"
+    assert row["title"] == "My Page"
+    assert row["last_edited_time"] == "2024-01-01T00:00:00.000Z"
+    assert row["archived"] is True
+    assert "body text" in row["content"]
+
+
+def test_build_notion_data_item_tags_source_notion():
+    row = SimpleNamespace(
+        row_data={
+            "id": "p1",
+            "url": "https://notion.so/p1",
+            "title": "My Page",
+            "last_edited_time": "2024-01-01T00:00:00.000Z",
+            "content": "body text",
+        },
+        content_hash="abc123",
+    )
+    data_id = uuid5(NAMESPACE_OID, "p1")
+
+    item = _build_notion_data_item(row, data_id)
+
+    # source="notion" (not "dlt") is what routes the page through normal cognify.
+    assert item.external_metadata["source"] == "notion"
+    assert item.external_metadata["notion_page_id"] == "p1"
+    assert item.external_metadata["notion_url"] == "https://notion.so/p1"
+    assert item.data_id == data_id
+    assert item.data.startswith("# My Page")
+    assert "body text" in item.data
+
+
+@pytest.mark.asyncio
+async def test_expand_notion_rows_builds_items_and_fresh_ids(monkeypatch):
+    async def fake_unique_id(identifier, user):
+        return uuid5(NAMESPACE_OID, identifier)
+
+    monkeypatch.setattr("cognee.tasks.ingestion.notion_source.get_unique_data_id", fake_unique_id)
+
+    rows = [
+        SimpleNamespace(
+            table_name="notion_pages",
+            primary_key_value="p1",
+            content_hash="h1",
+            row_data={"id": "p1", "title": "A", "content": "one", "url": "u1"},
+        ),
+        SimpleNamespace(
+            table_name="notion_pages",
+            primary_key_value="p2",
+            content_hash="h2",
+            row_data={"id": "p2", "title": "B", "content": "two", "url": "u2"},
+        ),
+    ]
+
+    items, fresh_ids = await expand_notion_rows(rows, user=SimpleNamespace(id="u"))
+
+    assert len(items) == 2
+    assert len(fresh_ids) == 2
+    assert all(i.external_metadata["source"] == "notion" for i in items)
+    # fresh_ids must match the items' data_ids so orphan cleanup keeps them.
+    assert {i.data_id for i in items} == fresh_ids
+
+
+def test_notion_source_name_constant():
+    # resolve_dlt_sources routes on this name; keep it stable.
+    assert NOTION_SOURCE_NAME == "notion"
+
+
+# ---------------------------------------------------------------------------
+# dlt pipeline: incremental + hard_delete (needs dlt + notion-client)
+# ---------------------------------------------------------------------------
+
+
+def _run_sync(dlt, tmp_path, monkeypatch, pages, blocks):
+    """Run notion_source through a dlt pipeline into a temp sqlite destination."""
+    import notion_client
+
+    from cognee.tasks.ingestion.notion_source import notion_source
+
+    monkeypatch.setattr(notion_client, "Client", lambda *a, **k: FakeNotionClient(pages, blocks))
+
+    db_path = (tmp_path / "notion.db").as_posix()
+    pipeline = dlt.pipeline(
+        pipeline_name="notion_test",
+        destination=dlt.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+        dataset_name="notion_ds",
+        pipelines_dir=str(tmp_path / "state"),
+    )
+    pipeline.run(notion_source(token="test-token"))
+    return pipeline
+
+
+def _read_pages(pipeline):
+    """Return {id: row-dict} for the notion_pages table.
+
+    Reads positionally (the SELECT fixes the column order) since dlt's
+    sqlalchemy cursor exposes a SQLAlchemy Result without DB-API ``description``.
+    """
+    with pipeline.sql_client() as client:
+        with client.execute_query(
+            "SELECT id, title, content, archived FROM notion_pages"
+        ) as cursor:
+            rows = cursor.fetchall()
+    return {
+        row[0]: {"id": row[0], "title": row[1], "content": row[2], "archived": row[3]}
+        for row in rows
+    }
+
+
+@pytest.fixture
+def dlt_mod():
+    return pytest.importorskip("dlt")
+
+
+@pytest.fixture(autouse=True)
+def _need_notion_client():
+    pytest.importorskip("notion_client")
+
+
+def test_first_sync_loads_pages_with_rendered_content(dlt_mod, tmp_path, monkeypatch):
+    pages = [_page("p1", "2024-01-01T00:00:00.000Z", "Alpha")]
+    blocks = {"p1": [_block("paragraph", "alpha body")]}
+
+    pipeline = _run_sync(dlt_mod, tmp_path, monkeypatch, pages, blocks)
+
+    rows = _read_pages(pipeline)
+    assert set(rows) == {"p1"}
+    assert "alpha body" in rows["p1"]["content"]
+
+
+def test_edit_is_reflected_on_resync(dlt_mod, tmp_path, monkeypatch):
+    pages = [_page("p1", "2024-01-01T00:00:00.000Z", "Alpha")]
+    _run_sync(dlt_mod, tmp_path, monkeypatch, pages, {"p1": [_block("paragraph", "v1")]})
+
+    # Edit bumps last_edited_time so the incremental cursor picks it up.
+    edited = [_page("p1", "2024-02-01T00:00:00.000Z", "Alpha")]
+    pipeline = _run_sync(
+        dlt_mod, tmp_path, monkeypatch, edited, {"p1": [_block("paragraph", "v2")]}
+    )
+
+    rows = _read_pages(pipeline)
+    assert "v2" in rows["p1"]["content"]
+    assert "v1" not in rows["p1"]["content"]
+
+
+def test_archived_page_is_removed_on_resync(dlt_mod, tmp_path, monkeypatch):
+    pages = [
+        _page("p1", "2024-01-01T00:00:00.000Z", "Alpha"),
+        _page("p2", "2024-01-01T00:00:00.000Z", "Beta"),
+    ]
+    blocks = {"p1": [_block("paragraph", "a")], "p2": [_block("paragraph", "b")]}
+    _run_sync(dlt_mod, tmp_path, monkeypatch, pages, blocks)
+
+    # p1 archived (with a bumped timestamp so it comes through the window).
+    resync = [
+        _page("p1", "2024-03-01T00:00:00.000Z", "Alpha", archived=True),
+        _page("p2", "2024-01-01T00:00:00.000Z", "Beta"),
+    ]
+    pipeline = _run_sync(dlt_mod, tmp_path, monkeypatch, resync, blocks)
+
+    rows = _read_pages(pipeline)
+    # hard_delete drops the archived page from staging → orphan cleanup would
+    # then forget it downstream.
+    assert "p1" not in rows
+    assert "p2" in rows

--- a/examples/README.md
+++ b/examples/README.md
@@ -163,6 +163,9 @@ Same scripts, indexed by what they demonstrate.
 - [`demos/simple_relational_database_migration_example/simple_relational_database_migration_example.py`](demos/simple_relational_database_migration_example/simple_relational_database_migration_example.py)
 - [`demos/complex_relational_database_migration_example/complex_relational_database_migration_example.py`](demos/complex_relational_database_migration_example/complex_relational_database_migration_example.py)
 
+### External connectors (dlt)
+- [`python/notion_connector_example.py`](python/notion_connector_example.py) — Notion pages with incremental sync + forget-on-delete (needs `cognee[notion]` and `NOTION_API_KEY`)
+
 ### Custom pipelines / tasks
 - [`custom_pipelines/custom_cognify_pipeline_example.py`](custom_pipelines/custom_cognify_pipeline_example.py)
 - [`custom_pipelines/agentic_reasoning_procurement_example.py`](custom_pipelines/agentic_reasoning_procurement_example.py)

--- a/examples/python/notion_connector_example.py
+++ b/examples/python/notion_connector_example.py
@@ -1,0 +1,59 @@
+"""Example: ingest Notion pages into cognee with incremental sync + forget-on-delete.
+
+The Notion connector is a dlt source: pages are fetched via the Notion API,
+rendered to markdown, and ingested as normal documents (so they go through the
+full cognify entity-extraction pipeline). Re-running syncs incrementally on
+``last_edited_time``, and pages you archive/trash in Notion are removed from
+cognee automatically (dlt's hard_delete hint → cognee's orphan cleanup).
+
+Setup:
+    1. Create an internal Notion integration and copy its token:
+       https://www.notion.so/my-integrations
+    2. Share the pages/databases you want to ingest with that integration.
+    3. Export the token (and your LLM key) before running:
+           export NOTION_API_KEY="secret_..."
+           export LLM_API_KEY="sk-..."
+
+Run:
+    python examples/python/notion_connector_example.py
+
+Re-run after editing or archiving a page in Notion to see incremental sync and
+forget-on-delete in action.
+"""
+
+import asyncio
+import os
+
+import cognee
+from cognee.tasks.ingestion.notion_source import notion_source
+
+DATASET_NAME = "notion"
+
+
+async def main() -> None:
+    if not os.environ.get("NOTION_API_KEY"):
+        print("Set NOTION_API_KEY (and share pages with your integration) to run this example.")
+        return
+
+    # Scope the sync with page_ids=[...] or database_ids=[...]; omit both to
+    # ingest every page the integration can see.
+    source = notion_source()
+
+    print("Syncing Notion pages into cognee ...")
+    await cognee.add(source, dataset_name=DATASET_NAME)
+    await cognee.cognify(datasets=[DATASET_NAME])
+
+    results = await cognee.search(
+        query_text="Summarize what these Notion pages are about.",
+        datasets=[DATASET_NAME],
+    )
+    print("\nSearch result:\n", results[0] if results else "<no results>")
+
+    print(
+        "\nEdit or archive a page in Notion, then re-run: edits re-sync incrementally "
+        "and archived pages are forgotten."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ graphiti = ["graphiti-core>=0.28.0"]
 # Always use comaptible fixed versions of these two dependencies
 aws = ["s3fs[boto3]==2025.3.2"]
 dlt = ["dlt[sqlalchemy]>=1.9.0,<2"]
+notion = ["dlt[sqlalchemy]>=1.9.0,<2", "notion-client>=2.2.1,<3"]
 baml = ["baml-py (==0.206.0)"]
 dev = [
     "pytest>=7.4.0,<8",


### PR DESCRIPTION
## Summary

A dlt-based Notion connector that ingests pages into cognee memory, extending
the existing DLT ingestion subsystem (`cognee/tasks/ingestion/`) rather than
adding a parallel path.

Closes #3617

## Design

- **`notion_source()`** — fetches pages via `notion-client`, renders block
  children to markdown. Incremental on `last_edited_time`, primary key = page id,
  `write_disposition="merge"`.
- **Pages are documents, not relational rows.** Rows are tagged
  `external_metadata["source"] = "notion"` (not `"dlt"`), so `is_dlt_sourced`
  returns False and each page flows through normal cognify entity extraction
  instead of the deterministic dlt-row path. No changes to `classify_documents`.
- **Forget-on-delete.** Archiving/trashing a page bumps `last_edited_time`, so it
  comes through the incremental window with `archived=true`; dlt's `hard_delete`
  column hint drops it from staging, and the existing `orphan_cleanup` removes it
  from the graph + vector stores. `_delete_dlt_orphans` gains a `sources` filter
  so Notion and relational rows reconcile independently.

## Tests

Mocked `notion-client`, no live token:
- block→markdown rendering, page→row flattening, `source="notion"` tagging
- a real dlt pipeline (temp sqlite) covering first sync, edit re-sync, and archive removal
- here is the screen shots of passed tests.
<img width="1293" height="345" alt="image" src="https://github.com/user-attachments/assets/5b53013c-a700-44d0-8562-ae720a34f345" />


## Notes

- Adds a `notion` extra (`dlt` + `notion-client`), a runnable example
  (`examples/python/notion_connector_example.py`), and an examples index entry.
- Integrations Hub entry pending #3616's registry location.
