### PR TITLE
fix(llm): fail fast on quota exhaustion

### DIFF
--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -1,3 +1,5 @@
+from fastapi import status
+
 from cognee.exceptions.exceptions import CogneeValidationError
 
 
@@ -12,6 +14,25 @@ class LLMAPIKeyNotSetError(CogneeValidationError):
 
     def __init__(self, message: str = "LLM API key is not set.") -> None:
         super().__init__(message=message, name="LLMAPIKeyNotSetError")
+
+
+class LLMQuotaExceededError(CogneeValidationError):
+    """
+    Raised when the configured LLM provider reports exhausted quota or billing.
+    """
+
+    def __init__(
+        self,
+        message: str = (
+            "LLM provider quota or billing limit was exhausted. "
+            "Check provider credits, billing limits, or use a different model/API key before retrying."
+        ),
+    ) -> None:
+        super().__init__(
+            message=message,
+            name="LLMQuotaExceededError",
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        )
 
 
 class UnsupportedLLMProviderError(CogneeValidationError):

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
@@ -1,26 +1,24 @@
-import asyncio
 import logging
 from typing import Any
 
 import anthropic  # ty:ignore[unresolved-import]
 import instructor
-import litellm
 from instructor.core.patch import AsyncInstructorChatCompletionCreate
 from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     wait_exponential_jitter,
 )
 
 from cognee.infrastructure.llm.retry_config import (
     llm_retry_stop_condition,
 )
-
-from cognee.infrastructure.llm.config import get_llm_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
     GenericAPIAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    retry_if_retryable_llm_error,
 )
 from cognee.modules.observability.get_observe import get_observe
 from cognee.shared.logging_utils import get_logger
@@ -74,13 +72,7 @@ class AnthropicAdapter(GenericAPIAdapter):
     @retry(
         stop=llm_retry_stop_condition,
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/azure_openai/adapter.py
@@ -1,6 +1,5 @@
 """Adapter for Azure OpenAI with managed identity and API key support."""
 
-import asyncio
 import logging
 from typing import Any
 
@@ -19,7 +18,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     wait_exponential_jitter,
 )
 
@@ -30,6 +28,9 @@ from cognee.infrastructure.llm.retry_config import (
 from cognee.infrastructure.llm.exceptions import ContentPolicyFilterError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai.adapter import (
     OpenAIAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    retry_if_retryable_llm_error,
 )
 from cognee.modules.observability.get_observe import get_observe
 from cognee.shared.logging_utils import get_logger
@@ -185,13 +186,7 @@ class AzureOpenAIAdapter(OpenAIAdapter):
     @retry(
         stop=llm_retry_stop_condition,
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
@@ -1,6 +1,5 @@
 """Adapter for Gemini API LLM provider"""
 
-import asyncio
 import logging
 from typing import Any
 
@@ -13,7 +12,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     wait_exponential_jitter,
 )
 
@@ -24,6 +22,9 @@ from cognee.infrastructure.llm.retry_config import (
 from cognee.infrastructure.llm.exceptions import ContentPolicyFilterError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
     GenericAPIAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    retry_if_retryable_llm_error,
 )
 from cognee.modules.observability.get_observe import get_observe
 from cognee.shared.logging_utils import get_logger
@@ -87,13 +88,7 @@ class GeminiAdapter(GenericAPIAdapter):
     @retry(
         stop=llm_retry_stop_condition,
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
 )
@@ -27,6 +26,9 @@ from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.llm.exceptions import ContentPolicyFilterError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    retry_if_retryable_llm_error,
 )
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
@@ -139,9 +141,7 @@ class GenericAPIAdapter(LLMInterface):
     @retry(
         stop=llm_retry_stop_condition,
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -261,9 +261,7 @@ class GenericAPIAdapter(LLMInterface):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -319,9 +317,7 @@ class GenericAPIAdapter(LLMInterface):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/llama_cpp/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/llama_cpp/adapter.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     wait_exponential_jitter,
 )
 
@@ -25,6 +24,9 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
 
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    retry_if_retryable_llm_error,
 )
 from cognee.modules.observability.get_observe import get_observe
 from cognee.shared.logging_utils import get_logger
@@ -155,9 +157,7 @@ class LlamaCppAPIAdapter(LLMInterface):
     @retry(
         stop=llm_retry_stop_condition,
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import Any
 
@@ -10,7 +9,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
 )
@@ -23,6 +21,9 @@ from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.llm.config import get_llm_config
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
     GenericAPIAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    retry_if_retryable_llm_error,
 )
 from cognee.modules.observability.get_observe import get_observe
 from cognee.shared.logging_utils import get_logger
@@ -81,13 +82,7 @@ class MistralAdapter(GenericAPIAdapter):
     @retry(
         stop=llm_retry_stop_condition,
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -152,13 +147,7 @@ class MistralAdapter(GenericAPIAdapter):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -1,16 +1,13 @@
-import asyncio
 import base64
 import logging
 from typing import Any
 
 import instructor
-import litellm
 from openai import AsyncOpenAI
 from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
 )
@@ -22,6 +19,9 @@ from cognee.infrastructure.llm.retry_config import (
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    retry_if_retryable_llm_error,
 )
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
@@ -89,13 +89,7 @@ class OllamaAPIAdapter(LLMInterface):
     @retry(
         stop=llm_retry_stop_condition,
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -162,13 +156,7 @@ class OllamaAPIAdapter(LLMInterface):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -207,13 +195,7 @@ class OllamaAPIAdapter(LLMInterface):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (
-                litellm.exceptions.NotFoundError,
-                litellm.exceptions.AuthenticationError,
-                asyncio.CancelledError,
-            )
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
 )
@@ -25,6 +24,9 @@ from cognee.infrastructure.llm.exceptions import (
 )
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.generic_llm_api.adapter import (
     GenericAPIAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    retry_if_retryable_llm_error,
 )
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
@@ -114,9 +116,7 @@ class OpenAIAdapter(GenericAPIAdapter):
     @retry(
         stop=llm_retry_stop_condition,
         wait=wait_exponential_jitter(8, 128),
-        retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )
@@ -217,9 +217,7 @@ class OpenAIAdapter(GenericAPIAdapter):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential_jitter(2, 128),
-        retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, litellm.exceptions.AuthenticationError)
-        ),
+        retry=retry_if_retryable_llm_error,
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
     )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/rate_limiter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/rate_limiter.py
@@ -51,6 +51,10 @@ from limits import RateLimitItemPerMinute, storage
 from limits.strategies import MovingWindowRateLimiter
 
 from cognee.infrastructure.llm.config import get_llm_config
+from cognee.infrastructure.llm.exceptions import LLMQuotaExceededError
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    is_quota_exceeded_error,
+)
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
@@ -437,6 +441,9 @@ def sleep_and_retry_sync(
                     return func(*args, **kwargs)
                 except Exception as e:
                     attempt += 1
+                    if is_quota_exceeded_error(e):
+                        raise LLMQuotaExceededError() from e
+
                     if not is_rate_limit_error(e) or attempt > max_retries:
                         raise
 
@@ -522,6 +529,9 @@ def sleep_and_retry_async(
                     return await func(*args, **kwargs)
                 except Exception as e:
                     attempt += 1
+                    if is_quota_exceeded_error(e):
+                        raise LLMQuotaExceededError() from e
+
                     if not is_rate_limit_error(e) or attempt > max_retries:
                         raise
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/retry_predicates.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/retry_predicates.py
@@ -1,0 +1,117 @@
+import asyncio
+from collections.abc import Iterator
+from typing import Any
+
+import litellm
+from tenacity import retry_if_exception
+
+from cognee.infrastructure.llm.exceptions import LLMQuotaExceededError
+
+
+_NON_RETRYABLE_LLM_ERRORS = (
+    litellm.exceptions.NotFoundError,
+    litellm.exceptions.AuthenticationError,
+    asyncio.CancelledError,
+    LLMQuotaExceededError,
+)
+
+_QUOTA_EXHAUSTED_MARKERS = (
+    "insufficient_quota",
+    "quota_exceeded",
+    "quota exceeded",
+    "quota has been exceeded",
+    "exceeded your current quota",
+    "exceeded your quota",
+    "billing hard limit",
+    "billing limit",
+    "billing quota",
+    "payment required",
+    "credit balance",
+    "credits exhausted",
+    "free quota",
+)
+
+_ERROR_TEXT_ATTRS = (
+    "message",
+    "body",
+    "error",
+    "code",
+    "type",
+    "status_code",
+    "litellm_debug_info",
+)
+
+
+def _iter_exception_chain(error: BaseException) -> Iterator[BaseException]:
+    seen: set[int] = set()
+    current: BaseException | None = error
+
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _iter_response_text(response: Any) -> Iterator[str]:
+    if response is None:
+        return
+
+    text = getattr(response, "text", None)
+    if text:
+        yield str(text)
+
+    content = getattr(response, "content", None)
+    if content:
+        yield str(content)
+
+    json_body = None
+    try:
+        json_body = response.json()
+    except Exception:
+        json_body = None
+
+    if json_body is not None:
+        yield repr(json_body)
+
+
+def _iter_error_text(error: BaseException) -> Iterator[str]:
+    for current in _iter_exception_chain(error):
+        yield current.__class__.__name__
+        yield str(current)
+
+        for attr_name in _ERROR_TEXT_ATTRS:
+            attr = getattr(current, attr_name, None)
+            if attr:
+                yield repr(attr)
+
+        yield from _iter_response_text(getattr(current, "response", None))
+
+        attr_dict = getattr(current, "__dict__", {})
+        yield from _iter_response_text(attr_dict.get("response"))
+
+        for attr_name in _ERROR_TEXT_ATTRS:
+            attr = attr_dict.get(attr_name)
+            if attr:
+                yield repr(attr)
+
+
+def is_quota_exceeded_error(error: BaseException) -> bool:
+    error_text = "\n".join(_iter_error_text(error)).lower()
+    return any(marker in error_text for marker in _QUOTA_EXHAUSTED_MARKERS)
+
+
+def is_non_retryable_llm_error(error: BaseException) -> bool:
+    return isinstance(error, _NON_RETRYABLE_LLM_ERRORS) or is_quota_exceeded_error(error)
+
+
+def should_retry_llm_error(error: BaseException) -> bool:
+    if isinstance(error, LLMQuotaExceededError):
+        return False
+
+    if is_quota_exceeded_error(error):
+        raise LLMQuotaExceededError() from error
+
+    return not isinstance(error, _NON_RETRYABLE_LLM_ERRORS)
+
+
+retry_if_retryable_llm_error = retry_if_exception(should_retry_llm_error)

--- a/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
@@ -49,7 +49,7 @@ async def test_acreate_structured_output_awaits_async_client():
 
     with (
         patch(f"{_MODULE}.llm_rate_limiter_context_manager", _null_rate_limiter),
-        patch(f"{_MODULE}.asyncio.to_thread", wraps=asyncio.to_thread) as to_thread_spy,
+        patch("asyncio.to_thread", wraps=asyncio.to_thread) as to_thread_spy,
     ):
         result = await adapter.acreate_structured_output("hello", "system prompt", _Resp)
 

--- a/cognee/tests/unit/infrastructure/llm/test_retry_predicates.py
+++ b/cognee/tests/unit/infrastructure/llm/test_retry_predicates.py
@@ -1,0 +1,138 @@
+import asyncio
+
+import httpx
+import litellm
+import pytest
+from tenacity import retry, stop_after_attempt, wait_none
+
+from cognee.infrastructure.llm.exceptions import LLMQuotaExceededError
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.rate_limiter import (
+    sleep_and_retry_async,
+    sleep_and_retry_sync,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.retry_predicates import (
+    is_quota_exceeded_error,
+    retry_if_retryable_llm_error,
+    should_retry_llm_error,
+)
+
+
+def _rate_limit_error(message: str, response: httpx.Response | None = None):
+    return litellm.exceptions.RateLimitError(
+        message,
+        llm_provider="openai",
+        model="openai/gpt-5-mini",
+        response=response,
+    )
+
+
+def test_quota_exhaustion_is_detected_from_message():
+    error = _rate_limit_error("429: You exceeded your current quota. Code: insufficient_quota.")
+
+    assert is_quota_exceeded_error(error)
+
+
+def test_quota_exhaustion_is_detected_from_response_body():
+    class ProviderError(Exception):
+        pass
+
+    response = httpx.Response(
+        status_code=429,
+        json={
+            "error": {
+                "code": "insufficient_quota",
+                "message": "Your billing quota has been exceeded.",
+            }
+        },
+        request=httpx.Request("POST", "https://api.openai.test/v1/chat/completions"),
+    )
+    error = ProviderError("429 provider error")
+    error.response = response
+
+    assert is_quota_exceeded_error(error)
+
+
+def test_transient_rate_limit_is_still_retryable():
+    assert not is_quota_exceeded_error(_rate_limit_error("429: rate limit exceeded"))
+
+
+def test_quota_exhaustion_is_not_retried():
+    attempts = 0
+    error = _rate_limit_error("429: quota_exceeded; billing limit reached")
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_none(),
+        retry=retry_if_retryable_llm_error,
+        reraise=True,
+    )
+    def always_fails():
+        nonlocal attempts
+        attempts += 1
+        raise error
+
+    with pytest.raises(LLMQuotaExceededError) as error_info:
+        always_fails()
+
+    assert attempts == 1
+    assert "quota or billing limit was exhausted" in str(error_info.value)
+
+
+def test_project_quota_error_is_not_wrapped_again():
+    assert not should_retry_llm_error(LLMQuotaExceededError())
+
+
+def test_cancellation_is_not_retried():
+    assert not should_retry_llm_error(asyncio.CancelledError())
+
+
+def test_transient_rate_limit_still_retries_until_stop_condition():
+    attempts = 0
+    error = _rate_limit_error("429: rate limit exceeded")
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_none(),
+        retry=retry_if_retryable_llm_error,
+        reraise=True,
+    )
+    def always_fails():
+        nonlocal attempts
+        attempts += 1
+        raise error
+
+    with pytest.raises(litellm.exceptions.RateLimitError):
+        always_fails()
+
+    assert attempts == 3
+
+
+def test_sleep_and_retry_quota_exhaustion_is_not_retried():
+    attempts = 0
+
+    @sleep_and_retry_sync(max_retries=3, initial_backoff=0)
+    def always_fails():
+        nonlocal attempts
+        attempts += 1
+        raise Exception("429: insufficient_quota; billing limit reached")
+
+    with pytest.raises(LLMQuotaExceededError):
+        always_fails()
+
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_async_sleep_and_retry_quota_exhaustion_is_not_retried():
+    attempts = 0
+
+    @sleep_and_retry_async(max_retries=3, initial_backoff=0)
+    async def always_fails():
+        nonlocal attempts
+        attempts += 1
+        raise Exception("429: insufficient_quota; billing limit reached")
+
+    with pytest.raises(LLMQuotaExceededError):
+        await always_fails()
+
+    assert attempts == 1


### PR DESCRIPTION
## Description

Related to #3643.

Quota and billing exhaustion are terminal failures, but the structured-output retry path treated them like transient provider errors. That can add latency and extra attempted requests even though retrying cannot succeed.

This adds a shared retry predicate for LLM calls that keeps ordinary transient rate limits retryable while failing fast on quota/billing exhaustion with a clear project-level error. The predicate is wired through the LiteLLM/instructor adapters and the Bedrock sleep-and-retry wrapper.

The dry-run token estimator from #3643 is not included here; this PR only covers the quota fail-fast behavior.

## Acceptance Criteria

- Quota and billing exhaustion are classified as non-retryable.
- Transient rate limits remain retryable.
- Provider-specific chained exceptions and response payloads are handled by one shared predicate.
- Existing cancellation, auth, and not-found behavior remains non-retryable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Local checks run:

```text
python -m pytest cognee/tests/unit/infrastructure/llm -q
ruff check <changed Python files>
ruff format --check <changed Python files>
git diff --check origin/dev...HEAD
gitleaks git --log-opts=origin/dev..HEAD --redact --no-banner
```

The LLM unit suite passed: `30 passed`.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
