### PR TITLE
fix(cli): guide first run next steps

### DIFF
--- a/cognee/cli/api_dispatch.py
+++ b/cognee/cli/api_dispatch.py
@@ -13,6 +13,13 @@ import os
 
 import cognee.cli.echo as fmt
 from cognee.cli.api_client import CogneeApiClient
+from cognee.cli.first_run import (
+    echo_after_add,
+    echo_after_cognify,
+    echo_after_forget,
+    echo_after_remember,
+    echo_empty_query_hint,
+)
 
 SUPPORTED_COMMANDS = {
     "add",
@@ -98,6 +105,7 @@ def _dispatch_add(client: CogneeApiClient, args: argparse.Namespace) -> None:
     fmt.success(f"Successfully added data to dataset '{args.dataset_name}'")
     if result:
         fmt.echo(json.dumps(result, indent=2, default=str))
+    echo_after_add(args.dataset_name)
 
 
 def _dispatch_cognify(client: CogneeApiClient, args: argparse.Namespace) -> None:
@@ -114,6 +122,7 @@ def _dispatch_cognify(client: CogneeApiClient, args: argparse.Namespace) -> None
         fmt.success("Cognification completed successfully!")
     if result:
         fmt.echo(json.dumps(result, indent=2, default=str))
+    echo_after_cognify(datasets, background=getattr(args, "background", False))
 
 
 def _dispatch_search(client: CogneeApiClient, args: argparse.Namespace) -> None:
@@ -130,6 +139,7 @@ def _dispatch_search(client: CogneeApiClient, args: argparse.Namespace) -> None:
         fmt.echo(json.dumps(results, indent=2, default=str))
     elif not results:
         fmt.warning("No results found for your query.")
+        echo_empty_query_hint("search")
     else:
         fmt.echo(f"\nFound {len(results)} result(s):")
         fmt.echo("=" * 60)
@@ -274,6 +284,12 @@ def _dispatch_remember(client: CogneeApiClient, args: argparse.Namespace) -> Non
             value = result.get(key)
             if value is not None:
                 fmt.echo(f"  {key}: {value}")
+    dataset_id = result.get("dataset_id") if isinstance(result, dict) else None
+    echo_after_remember(
+        args.dataset_name,
+        dataset_id=str(dataset_id) if dataset_id else None,
+        background=getattr(args, "background", False),
+    )
 
 
 def _dispatch_recall(client: CogneeApiClient, args: argparse.Namespace) -> None:
@@ -309,6 +325,7 @@ def _dispatch_recall(client: CogneeApiClient, args: argparse.Namespace) -> None:
 
     if not results:
         fmt.warning("No results found for your query.")
+        echo_empty_query_hint("recall")
         return
 
     is_session = isinstance(results[0], dict) and results[0].get("_source") == "session"
@@ -381,3 +398,4 @@ def _dispatch_forget(client: CogneeApiClient, args: argparse.Namespace) -> None:
         everything=everything,
     )
     fmt.success(f"Done: {result}")
+    echo_after_forget()

--- a/cognee/cli/commands/add_command.py
+++ b/cognee/cli/commands/add_command.py
@@ -6,6 +6,7 @@ from cognee.cli.reference import SupportsCliCommand
 from cognee.cli import DEFAULT_DOCS_URL
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.first_run import echo_after_add, with_first_run_error_hint
 
 
 class AddCommand(SupportsCliCommand):
@@ -74,11 +75,14 @@ After adding data, use `cognee cognify` to process it into knowledge graphs.
                     await cognee.add(data=data_to_add, dataset_name=args.dataset_name, user=user)
                     fmt.success(f"Successfully added data to dataset '{args.dataset_name}'")
                 except Exception as e:
-                    raise CliCommandInnerException(f"Failed to add data: {str(e)}") from e
+                    message = with_first_run_error_hint(f"Failed to add data: {str(e)}")
+                    raise CliCommandInnerException(message) from e
 
             asyncio.run(run_add())
+            echo_after_add(args.dataset_name)
 
         except Exception as e:
             if isinstance(e, CliCommandInnerException):
                 raise CliCommandException(str(e), error_code=1) from e
-            raise CliCommandException(f"Failed to add data: {str(e)}", error_code=1) from e
+            message = with_first_run_error_hint(f"Failed to add data: {str(e)}")
+            raise CliCommandException(message, error_code=1) from e

--- a/cognee/cli/commands/cognify_command.py
+++ b/cognee/cli/commands/cognify_command.py
@@ -7,6 +7,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import CHUNKER_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.first_run import echo_after_cognify, with_first_run_error_hint
 
 
 class CognifyCommand(SupportsCliCommand):
@@ -125,7 +126,8 @@ After successful cognify processing, use `cognee search` to query the knowledge 
                     )
                     return result
                 except Exception as e:
-                    raise CliCommandInnerException(f"Failed to cognify: {str(e)}") from e
+                    message = with_first_run_error_hint(f"Failed to cognify: {str(e)}")
+                    raise CliCommandInnerException(message) from e
 
             result = asyncio.run(run_cognify())
 
@@ -139,8 +141,10 @@ After successful cognify processing, use `cognee search` to query the knowledge 
                 fmt.success("Cognification completed successfully!")
                 if args.verbose and result:
                     fmt.echo(f"Processing results: {result}")
+            echo_after_cognify(datasets, background=args.background)
 
         except Exception as e:
             if isinstance(e, CliCommandInnerException):
                 raise CliCommandException(str(e), error_code=1) from e
-            raise CliCommandException(f"Error during cognification: {str(e)}", error_code=1) from e
+            message = with_first_run_error_hint(f"Error during cognification: {str(e)}")
+            raise CliCommandException(message, error_code=1) from e

--- a/cognee/cli/commands/forget_command.py
+++ b/cognee/cli/commands/forget_command.py
@@ -6,6 +6,7 @@ from cognee.cli.reference import SupportsCliCommand
 from cognee.cli import DEFAULT_DOCS_URL
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.first_run import echo_after_forget
 
 
 class ForgetCommand(SupportsCliCommand):
@@ -68,6 +69,7 @@ to delete a dataset, or dataset + --data-id to delete a single item.
 
             result = asyncio.run(run_forget())
             fmt.success(f"Done: {result}")
+            echo_after_forget()
 
         except Exception as e:
             if isinstance(e, CliCommandInnerException):

--- a/cognee/cli/commands/recall_command.py
+++ b/cognee/cli/commands/recall_command.py
@@ -7,6 +7,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import SEARCH_TYPE_CHOICES, OUTPUT_FORMAT_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.first_run import echo_empty_query_hint, with_first_run_error_hint
 
 
 class RecallCommand(SupportsCliCommand):
@@ -117,7 +118,8 @@ Otherwise, this is a memory-oriented alias for `cognee search`.
                         results = await cognee.recall(**recall_kwargs)
                     return results
                 except Exception as e:
-                    raise CliCommandInnerException(f"Failed to recall: {str(e)}") from e
+                    message = with_first_run_error_hint(f"Failed to recall: {str(e)}")
+                    raise CliCommandInnerException(message) from e
 
             results = asyncio.run(run_recall())
 
@@ -129,6 +131,7 @@ Otherwise, this is a memory-oriented alias for `cognee search`.
             else:
                 if not results:
                     fmt.warning("No results found for your query.")
+                    echo_empty_query_hint("recall")
                     return
 
                 # Detect session results by _source tag
@@ -169,4 +172,5 @@ Otherwise, this is a memory-oriented alias for `cognee search`.
         except Exception as e:
             if isinstance(e, CliCommandInnerException):
                 raise CliCommandException(str(e), error_code=1) from e
-            raise CliCommandException(f"Error recalling: {str(e)}", error_code=1) from e
+            message = with_first_run_error_hint(f"Error recalling: {str(e)}")
+            raise CliCommandException(message, error_code=1) from e

--- a/cognee/cli/commands/remember_command.py
+++ b/cognee/cli/commands/remember_command.py
@@ -6,6 +6,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import CHUNKER_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.first_run import echo_after_remember, with_first_run_error_hint
 
 
 class RememberCommand(SupportsCliCommand):
@@ -94,7 +95,8 @@ After completion, use `cognee recall` (or `cognee search`) to query the graph.
                     )
                     return result
                 except Exception as e:
-                    raise CliCommandInnerException(f"Failed to remember: {str(e)}") from e
+                    message = with_first_run_error_hint(f"Failed to remember: {str(e)}")
+                    raise CliCommandInnerException(message) from e
 
             result = asyncio.run(run_remember())
 
@@ -112,8 +114,14 @@ After completion, use `cognee recall` (or `cognee search`) to query the graph.
                     fmt.echo(f"  Content hash: {result.content_hash}")
                 if result.elapsed_seconds is not None:
                     fmt.echo(f"  Elapsed: {result.elapsed_seconds:.1f}s")
+            echo_after_remember(
+                args.dataset_name,
+                dataset_id=str(result.dataset_id) if result and result.dataset_id else None,
+                background=args.background,
+            )
 
         except Exception as e:
             if isinstance(e, CliCommandInnerException):
                 raise CliCommandException(str(e), error_code=1) from e
-            raise CliCommandException(f"Failed to remember: {str(e)}", error_code=1) from e
+            message = with_first_run_error_hint(f"Failed to remember: {str(e)}")
+            raise CliCommandException(message, error_code=1) from e

--- a/cognee/cli/commands/search_command.py
+++ b/cognee/cli/commands/search_command.py
@@ -8,6 +8,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import SEARCH_TYPE_CHOICES, OUTPUT_FORMAT_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.first_run import echo_empty_query_hint, with_first_run_error_hint
 
 
 class SearchCommand(SupportsCliCommand):
@@ -110,7 +111,8 @@ Search Types & Use Cases:
                     )
                     return results
                 except Exception as e:
-                    raise CliCommandInnerException(f"Failed to search: {str(e)}") from e
+                    message = with_first_run_error_hint(f"Failed to search: {str(e)}")
+                    raise CliCommandInnerException(message) from e
 
             results = asyncio.run(run_search())
 
@@ -123,6 +125,7 @@ Search Types & Use Cases:
             else:  # pretty format
                 if not results:
                     fmt.warning("No results found for your query.")
+                    echo_empty_query_hint("search")
                     return
 
                 fmt.echo(f"\nFound {len(results)} result(s) using {args.query_type}:")
@@ -148,4 +151,5 @@ Search Types & Use Cases:
         except Exception as e:
             if isinstance(e, CliCommandInnerException):
                 raise CliCommandException(str(e), error_code=1) from e
-            raise CliCommandException(f"Error searching: {str(e)}", error_code=1) from e
+            message = with_first_run_error_hint(f"Error searching: {str(e)}")
+            raise CliCommandException(message, error_code=1) from e

--- a/cognee/cli/first_run.py
+++ b/cognee/cli/first_run.py
@@ -1,0 +1,101 @@
+"""First-run guidance shared by local and API-backed CLI commands."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Iterable
+
+import cognee.cli.echo as fmt
+
+
+def quote_cli_value(value: object) -> str:
+    return shlex.quote(str(value))
+
+
+def format_dataset_options(datasets: Iterable[str] | None) -> str:
+    if not datasets:
+        return ""
+
+    quoted = " ".join(quote_cli_value(dataset) for dataset in datasets)
+    return f" --datasets {quoted}"
+
+
+def recall_command(dataset_name: str | None = None) -> str:
+    dataset_options = format_dataset_options([dataset_name] if dataset_name else None)
+    return f'cognee-cli recall "What should I remember?"{dataset_options}'
+
+
+def remember_command() -> str:
+    return 'cognee-cli remember "Cognee turns documents into AI memory."'
+
+
+def echo_after_add(dataset_name: str) -> None:
+    dataset = quote_cli_value(dataset_name)
+    fmt.note(
+        "Next: run "
+        f"`cognee-cli cognify --datasets {dataset}`, then "
+        f"`{recall_command(dataset_name)}`."
+    )
+
+
+def echo_after_cognify(datasets: Iterable[str] | None, background: bool = False) -> None:
+    dataset_names = list(datasets or [])
+    dataset_options = format_dataset_options(dataset_names)
+    prefix = "When background processing finishes, run" if background else "Next: run"
+    fmt.note(f'{prefix} `cognee-cli search "What is in this data?"{dataset_options}`.')
+
+
+def echo_after_remember(
+    dataset_name: str,
+    dataset_id: str | None = None,
+    background: bool = False,
+) -> None:
+    if background:
+        if dataset_id:
+            fmt.note(
+                "Next: track progress with "
+                f"`cognee-cli datasets status {quote_cli_value(dataset_id)}`. "
+                f"When it finishes, run `{recall_command(dataset_name)}`."
+            )
+            return
+        fmt.note(f"Next: when processing finishes, run `{recall_command(dataset_name)}`.")
+        return
+
+    fmt.note(f"Next: run `{recall_command(dataset_name)}`.")
+
+
+def echo_after_forget() -> None:
+    fmt.note(
+        f"Next: add new memory with `{remember_command()}` or retry recall to confirm removal."
+    )
+
+
+def echo_empty_query_hint(command_name: str) -> None:
+    query = "What is in this data?" if command_name == "search" else "What should I remember?"
+    fmt.note(
+        "Next: if this is your first run, create memory with "
+        f'`{remember_command()}`, then retry `cognee-cli {command_name} "{query}"`.'
+    )
+
+
+_KEY_ERROR_PATTERN = re.compile(
+    r"(llm_api_key|api[_ -]?key|authentication|unauthorized|invalid key)",
+    re.IGNORECASE,
+)
+
+
+def with_first_run_error_hint(message: str) -> str:
+    if not _KEY_ERROR_PATTERN.search(message):
+        return message
+
+    hint = (
+        "Set LLM_API_KEY before running LLM-backed commands: "
+        '`export LLM_API_KEY="..."`. '
+        "If you only want to stage data first, run `cognee-cli add ...` before `cognee-cli cognify`."
+    )
+
+    if hint in message:
+        return message
+
+    return f"{message}\n{hint}"

--- a/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from cognee.cli import api_dispatch
 from cognee.cli.api_dispatch import can_dispatch, dispatch, SUPPORTED_COMMANDS
 
 
@@ -126,3 +127,37 @@ class TestUserIdHeader:
         call_kwargs = MockClient.call_args
         headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
         assert "X-User-Id" not in headers
+
+
+class TestFirstRunApiDispatch:
+    @patch("cognee.cli.first_run.fmt.note")
+    def test_add_dispatch_prints_next_step(self, mock_note):
+        client = MagicMock()
+        client.add.return_value = {"status": "ok"}
+        args = argparse.Namespace(data=["first note"], dataset_name="first_run")
+
+        api_dispatch._dispatch_add(client, args)
+
+        note_text = mock_note.call_args.args[0]
+        assert "cognee-cli cognify --datasets first_run" in note_text
+        assert 'cognee-cli recall "What should I remember?" --datasets first_run' in note_text
+
+    @patch("cognee.cli.first_run.fmt.note")
+    def test_recall_dispatch_empty_results_prints_first_run_hint(self, mock_note):
+        client = MagicMock()
+        client.recall.return_value = []
+        args = argparse.Namespace(
+            query_text="What does Cognee do?",
+            query_type="GRAPH_COMPLETION",
+            datasets=None,
+            top_k=10,
+            system_prompt=None,
+            session_id=None,
+            output_format="pretty",
+        )
+
+        api_dispatch._dispatch_recall(client, args)
+
+        note_text = mock_note.call_args.args[0]
+        assert 'cognee-cli remember "Cognee turns documents into AI memory."' in note_text
+        assert 'retry `cognee-cli recall "What should I remember?"`' in note_text

--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
@@ -7,12 +7,15 @@ import pytest
 import sys
 import argparse
 import asyncio
+from types import SimpleNamespace
 from uuid import uuid4
 from unittest.mock import patch, MagicMock, AsyncMock, ANY
 import cognee
 from cognee.cli.commands.add_command import AddCommand
 from cognee.cli.commands.search_command import SearchCommand
 from cognee.cli.commands.cognify_command import CognifyCommand
+from cognee.cli.commands.remember_command import RememberCommand
+from cognee.cli.commands.recall_command import RecallCommand
 from cognee.cli.commands.delete_command import DeleteCommand
 from cognee.cli.commands.config_command import ConfigCommand
 from cognee.cli.exceptions import CliCommandException
@@ -284,6 +287,101 @@ class TestCognifyCommand:
 
         with pytest.raises(CliCommandException):
             command.execute(args)
+
+
+class TestFirstRunGuidance:
+    @patch("cognee.cli.first_run.fmt.note")
+    @patch(_RESOLVE_USER_PATCH, new_callable=lambda: AsyncMock(return_value=_mock_user()))
+    @patch("cognee.cli.commands.add_command.asyncio.run", side_effect=_mock_run)
+    def test_add_prints_cognify_and_recall_next_step(
+        self, _mock_asyncio_run, _mock_resolve, mock_note
+    ):
+        mock_cognee = MagicMock()
+        mock_cognee.add = AsyncMock()
+
+        with patch.dict(sys.modules, {"cognee": mock_cognee}):
+            command = AddCommand()
+            args = argparse.Namespace(data=["first note"], dataset_name="first_run")
+            command.execute(args)
+
+        note_text = mock_note.call_args.args[0]
+        assert "cognee-cli cognify --datasets first_run" in note_text
+        assert 'cognee-cli recall "What should I remember?" --datasets first_run' in note_text
+
+    @patch("cognee.cli.first_run.fmt.note")
+    @patch("cognee.cli.commands.remember_command.asyncio.run", side_effect=_mock_run)
+    def test_remember_prints_recall_next_step(self, _mock_asyncio_run, mock_note):
+        mock_cognee = MagicMock()
+        mock_cognee.remember = AsyncMock(
+            return_value=SimpleNamespace(
+                dataset_id=uuid4(),
+                items_processed=1,
+                content_hash=None,
+                elapsed_seconds=1.2,
+            )
+        )
+
+        with patch.dict(sys.modules, {"cognee": mock_cognee}):
+            command = RememberCommand()
+            args = argparse.Namespace(
+                data=["Cognee turns documents into AI memory."],
+                dataset_name="main_dataset",
+                chunk_size=None,
+                chunker="TextChunker",
+                background=False,
+                chunks_per_batch=None,
+            )
+            command.execute(args)
+
+        note_text = mock_note.call_args.args[0]
+        assert note_text == (
+            'Next: run `cognee-cli recall "What should I remember?" --datasets main_dataset`.'
+        )
+
+    @patch("cognee.cli.commands.remember_command.asyncio.run", side_effect=_mock_run)
+    def test_remember_missing_key_error_is_actionable(self, _mock_asyncio_run):
+        mock_cognee = MagicMock()
+        mock_cognee.remember = AsyncMock(side_effect=RuntimeError("LLM_API_KEY is not set"))
+
+        with patch.dict(sys.modules, {"cognee": mock_cognee}):
+            command = RememberCommand()
+            args = argparse.Namespace(
+                data=["first note"],
+                dataset_name="main_dataset",
+                chunk_size=None,
+                chunker="TextChunker",
+                background=False,
+                chunks_per_batch=None,
+            )
+            with pytest.raises(CliCommandException) as exc:
+                command.execute(args)
+
+        message = str(exc.value)
+        assert "LLM_API_KEY is not set" in message
+        assert 'export LLM_API_KEY="..."' in message
+
+    @patch("cognee.cli.first_run.fmt.note")
+    @patch("cognee.cli.commands.recall_command.asyncio.run", side_effect=_mock_run)
+    def test_recall_empty_results_prints_first_run_hint(self, _mock_asyncio_run, mock_note):
+        mock_cognee = MagicMock()
+        mock_cognee.recall = AsyncMock(return_value=[])
+
+        with patch.dict(sys.modules, {"cognee": mock_cognee}):
+            command = RecallCommand()
+            args = argparse.Namespace(
+                query_text="What does Cognee do?",
+                query_type="GRAPH_COMPLETION",
+                datasets=None,
+                top_k=10,
+                system_prompt=None,
+                session_id=None,
+                output_format="pretty",
+            )
+            command.execute(args)
+
+        note_text = mock_note.call_args.args[0]
+        assert 'cognee-cli remember "Cognee turns documents into AI memory."' in note_text
+        assert 'retry `cognee-cli recall "What should I remember?"`' in note_text
 
 
 class TestDeleteCommand:

--- a/docs/first-run-onboarding-audit.md
+++ b/docs/first-run-onboarding-audit.md
@@ -1,0 +1,58 @@
+# Calm, honest first run audit
+
+This audit covers the first-run paths from issue #3605 and focuses on low-risk changes that
+help a new user reach a first result without guessing the next command.
+
+## Scope
+
+Checked the README quickstart, CLI command help, local CLI command behavior, and Docker/UI
+setup notes. This pass did not run a live token-consuming LLM recall; the quick wins below
+target the no-key and empty-result friction that can be tested without external services.
+
+## Path snapshot
+
+| Path | First result path | Decisions before step 1 | Main first-run risk |
+| --- | --- | --- | --- |
+| Python SDK | Install, set `LLM_API_KEY`, call `remember`, then `recall`. | Package tool, API key/provider, session vs dataset memory. | Missing or invalid key appears only when the user reaches LLM-backed work. |
+| CLI | `remember` is the shortest path; `add` + `cognify` is the lower-level path. | Which command to start with, dataset name, background or foreground processing. | Success and empty-result output did not consistently say what to do next. |
+| Local UI | `cognee-cli -ui`. | Docker/Colima availability and local service startup. | Docker is required before the UI path can work. |
+| Docker Compose | Copy `.env.template`, set `LLM_API_KEY`, choose profiles, run Compose. | Which profile, which backing services, local image vs prebuilt image. | More choices before the user sees a memory result. |
+| Prebuilt image | Pull and run with env configuration. | Env file/API key and exposed services. | Fast to start, but still needs honest key/service prerequisites. |
+
+## Findings
+
+| Rank | Path | Friction | Impact |
+| --- | --- | --- | --- |
+| 1 | CLI `add` / `cognify` / `remember` | Successful commands ended without a concrete next command. | A new user can ingest data and still not know how to ask the first question. |
+| 2 | CLI `search` / `recall` | Empty results only said that nothing was found. | First-run users cannot tell whether they used the wrong query or skipped ingestion. |
+| 3 | CLI LLM-backed commands | Provider or API-key failures surfaced as raw provider text. | The fix is usually simple, but users have to infer that `LLM_API_KEY` is required. |
+| 4 | CLI `remember --background` | Background processing could imply recall is ready immediately. | Users may query too early and interpret empty results as product failure. |
+| 5 | UI / Docker | `cognee-cli -ui` needs Docker or Colima; Compose adds profile choices. | Users can spend time on infrastructure before seeing a memory result. |
+
+## Proposal
+
+The calm CLI path should be:
+
+1. `cognee-cli remember "Cognee turns documents into AI memory."`
+2. `cognee-cli recall "What should I remember?"`
+3. If the user chooses the lower-level path, `add` should point to `cognify`, and `cognify`
+   should point to `search`.
+
+The CLI should also keep failure states actionable:
+
+- Empty `search` and `recall` output should say how to create memory first.
+- API-key and authentication failures should mention `LLM_API_KEY`.
+- Background runs should say to wait for processing before recall.
+
+## Quick wins implemented
+
+- Added next-step hints after local `add`, `cognify`, `remember`, and `forget`.
+- Added matching next-step hints for `--api-url` dispatch paths.
+- Added first-run guidance after empty local/API `search` and `recall`.
+- Added API-key guidance to local command failures that mention API-key or authentication errors.
+
+## Follow-ups
+
+- Add `cognee doctor` for Python version, Docker, API key, and backend reachability checks.
+- Add a no-key sample-data path if the project supports an offline model or mocked local mode.
+- Split UI and Docker onboarding into a separate checklist with exact Docker/Colima diagnostics.


### PR DESCRIPTION
## Description

Related to #3605.

This adds small first-run CLI guidance so new users are not left at a dead end after common commands. Successful ingestion/processing paths now point to the next useful command, and empty search/recall output tells first-run users how to create memory before retrying.

The change is intentionally limited to CLI output and an audit/proposal doc. It does not add `cognee doctor`, Docker/UI diagnostics, or a no-key sample path.

## Acceptance Criteria

- `add`, `cognify`, `remember`, and `forget` print concrete next-step hints.
- Empty `search` and `recall` output includes a runnable first-run command path.
- API-dispatched CLI paths get matching guidance.
- API-key/authentication failures include `LLM_API_KEY` guidance.
- CLI behavior and command arguments remain unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [x] Other (please specify): first-run CLI UX polish

## Screenshots

Local checks run:

```text
python -m pytest cognee/tests/cli_tests/cli_unit_tests -q
ruff check <changed Python files>
ruff format --check <changed Python files>
git diff --check origin/dev...HEAD
gitleaks git --log-opts=origin/dev..HEAD --redact --no-banner
semgrep scan --config p/default --metrics=off --config p/security-audit cognee/cli docs/first-run-onboarding-audit.md
```

The CLI unit suite passed: `122 passed`.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
