### PR TITLE
feat(ingestion): Slack export dlt connector + table-scoped orphan cleanup

### DIFF
--- a/cognee/tasks/ingestion/connectors/__init__.py
+++ b/cognee/tasks/ingestion/connectors/__init__.py
@@ -1,0 +1,5 @@
+"""DLT connectors for structured external data sources."""
+
+from .slack_export import iter_slack_export_messages, slack_export_source
+
+__all__ = ["iter_slack_export_messages", "slack_export_source"]

--- a/cognee/tasks/ingestion/connectors/slack_export.py
+++ b/cognee/tasks/ingestion/connectors/slack_export.py
@@ -1,0 +1,151 @@
+"""Slack workspace export → dlt source for Cognee ingestion.
+
+Parses the standard Slack export layout (channels.json, users.json, and
+per-channel daily JSON message files) and yields flat message rows suitable
+for DLT ingestion with ``primary_key="id"``.
+
+Each message row uses ``id = "{channel_id}:{ts}"`` so re-syncs and orphan
+cleanup can track individual messages across export snapshots.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+try:
+    import dlt
+except ImportError:
+    dlt = None
+
+
+def _load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _build_user_lookup(users: List[dict]) -> Dict[str, str]:
+    lookup: Dict[str, str] = {}
+    for user in users:
+        user_id = user.get("id")
+        if not user_id:
+            continue
+        display = (
+            user.get("real_name")
+            or user.get("profile", {}).get("real_name")
+            or user.get("name")
+            or user_id
+        )
+        lookup[user_id] = display
+    return lookup
+
+
+def _build_channel_lookup(channels: List[dict]) -> Dict[str, dict]:
+    """Map channel folder name (``name`` field) → channel metadata."""
+    lookup: Dict[str, dict] = {}
+    for channel in channels:
+        name = channel.get("name")
+        if name:
+            lookup[name] = channel
+    return lookup
+
+
+def _message_text(message: dict, user_name: Optional[str], channel_name: str) -> str:
+    """Build searchable text, folding thread context when present."""
+    raw_text = message.get("text") or ""
+    parts: List[str] = []
+
+    thread_ts = message.get("thread_ts")
+    msg_ts = message.get("ts")
+    if thread_ts and msg_ts and thread_ts != msg_ts:
+        parts.append(f"[thread reply in #{channel_name}]")
+
+    if user_name:
+        parts.append(f"{user_name}:")
+    parts.append(raw_text)
+    return " ".join(part for part in parts if part).strip()
+
+
+def iter_slack_export_messages(export_path: str | os.PathLike) -> Iterator[dict]:
+    """Yield flat Slack message dicts from a workspace export directory.
+
+    Skips non-message events (joins, topic changes, etc.) and messages
+    without a ``ts`` timestamp.
+    """
+    root = Path(export_path)
+    if not root.is_dir():
+        raise FileNotFoundError(f"Slack export directory not found: {root}")
+
+    channels_path = root / "channels.json"
+    users_path = root / "users.json"
+    if not channels_path.is_file():
+        raise FileNotFoundError(f"Missing channels.json in Slack export: {root}")
+
+    channels = _load_json(channels_path)
+    users = _load_json(users_path) if users_path.is_file() else []
+    channel_lookup = _build_channel_lookup(channels)
+    user_lookup = _build_user_lookup(users)
+
+    for channel_dir in sorted(root.iterdir()):
+        if not channel_dir.is_dir():
+            continue
+
+        channel_meta = channel_lookup.get(channel_dir.name)
+        if channel_meta is None:
+            continue
+
+        channel_id = channel_meta.get("id", channel_dir.name)
+        channel_name = channel_meta.get("name", channel_dir.name)
+
+        for message_file in sorted(channel_dir.glob("*.json")):
+            day_messages = _load_json(message_file)
+            if not isinstance(day_messages, list):
+                continue
+
+            for message in day_messages:
+                if not isinstance(message, dict):
+                    continue
+                if message.get("type") != "message":
+                    continue
+
+                ts = message.get("ts")
+                if not ts:
+                    continue
+
+                user_id = message.get("user") or message.get("bot_id")
+                user_name = user_lookup.get(user_id) if user_id else None
+                text = _message_text(message, user_name, channel_name)
+                ts_no_dot = ts.replace(".", "")
+
+                yield {
+                    "id": f"{channel_id}:{ts}",
+                    "channel_id": channel_id,
+                    "channel_name": channel_name,
+                    "ts": ts,
+                    "thread_ts": message.get("thread_ts"),
+                    "user_id": user_id,
+                    "user_name": user_name,
+                    "text": text,
+                    "subtype": message.get("subtype"),
+                    # Reconstructable permalink for citable recall (#3604).
+                    "slack_permalink": f"https://slack.com/archives/{channel_id}/p{ts_no_dot}",
+                }
+
+
+def slack_export_source(export_path: str | os.PathLike):
+    """Return a dlt resource over a Slack workspace export directory."""
+    if dlt is None:
+        raise ImportError(
+            "The 'dlt' package is required for slack_export_source. "
+            "Install cognee with dlt extras or `pip install dlt`."
+        )
+
+    path = str(export_path)
+
+    @dlt.resource(name="slack_messages", write_disposition="replace")
+    def slack_messages():
+        yield from iter_slack_export_messages(path)
+
+    return slack_messages()

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -196,9 +196,12 @@ async def resolve_dlt_sources(
     orphan_cleanup: Optional[Callable[[], Any]] = None
     if write_disposition != "append":
         fresh_data_ids: Set[UUID] = set(row_id_lookup.values())
+        fresh_table_names: Set[str] = {row.table_name for row in all_rows}
 
         async def _cleanup() -> None:
-            await _delete_dlt_orphans(dataset_name, user, fresh_data_ids)
+            await _delete_dlt_orphans(
+                dataset_name, user, fresh_data_ids, fresh_table_names
+            )
 
         orphan_cleanup = _cleanup
 
@@ -312,13 +315,34 @@ def _resolve_fk_references(
     return references
 
 
+def _is_dlt_orphan_candidate(
+    external_metadata: dict,
+    data_id: UUID,
+    fresh_data_ids: Set[UUID],
+    fresh_table_names: Set[str],
+) -> bool:
+    """Return True if a Data row should be removed during DLT orphan cleanup."""
+    if external_metadata.get("source") != "dlt":
+        return False
+    table_name = external_metadata.get("table_name")
+    if table_name not in fresh_table_names:
+        return False
+    if data_id in fresh_data_ids:
+        return False
+    return True
+
+
 async def _delete_dlt_orphans(
     dataset_name: str,
     user: User,
     fresh_data_ids: Set[UUID],
+    fresh_table_names: Set[str],
 ) -> None:
     """Delete dlt-sourced Data records (and their graph/vector artifacts) that
     are no longer present in the freshly-ingested dlt source.
+
+    Only rows whose ``table_name`` appears in the current ingest run are
+    considered for deletion. Tables not loaded in this run are left untouched.
 
     This handles the case where rows are deleted from the upstream database
     and the user re-ingests.  dlt cleans its own staging DB, but cognee's
@@ -346,10 +370,11 @@ async def _delete_dlt_orphans(
     orphans = []
     for data_item in all_data:
         ext = data_item.external_metadata
-        if not isinstance(ext, dict) or ext.get("source") != "dlt":
+        if not isinstance(ext, dict):
             continue
-        if data_item.id not in fresh_data_ids:
-            orphans.append(data_item)
+        if not _is_dlt_orphan_candidate(ext, data_item.id, fresh_data_ids, fresh_table_names):
+            continue
+        orphans.append(data_item)
 
     if not orphans:
         return

--- a/cognee/tests/unit/tasks/ingestion/test_orphan_cleanup_table_scope.py
+++ b/cognee/tests/unit/tasks/ingestion/test_orphan_cleanup_table_scope.py
@@ -1,0 +1,49 @@
+"""Unit tests for table-scoped DLT orphan cleanup."""
+
+from uuid import UUID
+
+from cognee.tasks.ingestion.resolve_dlt_sources import _is_dlt_orphan_candidate
+
+
+def _meta(table_name: str) -> dict:
+    return {"source": "dlt", "table_name": table_name}
+
+
+def test_orphan_candidate_when_table_in_run_and_id_missing():
+    fresh_ids = {UUID("11111111-1111-1111-1111-111111111111")}
+    stale_id = UUID("22222222-2222-2222-2222-222222222222")
+
+    assert _is_dlt_orphan_candidate(_meta("slack_messages"), stale_id, fresh_ids, {"slack_messages"})
+
+
+def test_not_orphan_when_table_not_in_current_run():
+    stale_id = UUID("22222222-2222-2222-2222-222222222222")
+
+    assert not _is_dlt_orphan_candidate(
+        _meta("employees"),
+        stale_id,
+        set(),
+        {"slack_messages"},
+    )
+
+
+def test_not_orphan_when_id_still_fresh():
+    data_id = UUID("11111111-1111-1111-1111-111111111111")
+
+    assert not _is_dlt_orphan_candidate(
+        _meta("slack_messages"),
+        data_id,
+        {data_id},
+        {"slack_messages"},
+    )
+
+
+def test_not_orphan_for_non_dlt_source():
+    stale_id = UUID("22222222-2222-2222-2222-222222222222")
+
+    assert not _is_dlt_orphan_candidate(
+        {"source": "file"},
+        stale_id,
+        set(),
+        {"slack_messages"},
+    )

--- a/cognee/tests/unit/tasks/ingestion/test_slack_export_connector.py
+++ b/cognee/tests/unit/tasks/ingestion/test_slack_export_connector.py
@@ -1,0 +1,104 @@
+"""Unit tests for the Slack workspace export DLT connector."""
+
+import os
+
+import pytest
+
+from cognee.tasks.ingestion.connectors.slack_export import (
+    iter_slack_export_messages,
+    slack_export_source,
+)
+
+FIXTURES = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "..",
+        "..",
+        "examples",
+        "demos",
+        "test_data",
+        "slack_export",
+    )
+)
+
+
+def _fixture(name: str) -> str:
+    return os.path.normpath(os.path.join(FIXTURES, name))
+
+
+def test_iter_messages_v1_yields_expected_rows():
+    rows = list(iter_slack_export_messages(_fixture("v1")))
+
+    assert len(rows) == 4
+    ids = {row["id"] for row in rows}
+    assert "C001:1717200000.000100" in ids
+    assert "C002:1717200100.000100" in ids
+
+
+def test_message_ids_use_channel_id_and_ts():
+    rows = list(iter_slack_export_messages(_fixture("v1")))
+    for row in rows:
+        channel_id, ts = row["id"].split(":", 1)
+        assert channel_id == row["channel_id"]
+        assert ts == row["ts"]
+
+
+def test_thread_reply_text_includes_thread_marker():
+    rows = list(iter_slack_export_messages(_fixture("v1")))
+    reply = next(row for row in rows if row["ts"] == "1717200001.000200")
+
+    assert reply["thread_ts"] == "1717200000.000100"
+    assert "[thread reply" in reply["text"]
+    assert "Bob" in reply["text"]
+
+
+def test_v2_deleted_message_would_be_orphan_on_resync():
+    from cognee.tasks.ingestion.resolve_dlt_sources import _is_dlt_orphan_candidate
+
+    v1_ids = {row["id"] for row in iter_slack_export_messages(_fixture("v1"))}
+    v2_ids = {row["id"] for row in iter_slack_export_messages(_fixture("v2"))}
+    deleted_ids = v1_ids - v2_ids
+
+    assert deleted_ids == {"C001:1717200002.000300"}
+    fresh_table_names = {"slack_messages"}
+    for deleted_id in deleted_ids:
+        assert _is_dlt_orphan_candidate(
+            {"source": "dlt", "table_name": "slack_messages"},
+            "00000000-0000-0000-0000-000000000001",
+            set(),
+            fresh_table_names,
+        )
+
+
+def test_large_export_has_more_than_default_row_cap():
+    rows = list(iter_slack_export_messages(_fixture("large")))
+    assert len(rows) == 65
+
+
+def test_missing_channels_json_raises(tmp_path):
+    with pytest.raises(FileNotFoundError, match="channels.json"):
+        list(iter_slack_export_messages(tmp_path))
+
+
+pytest.importorskip("dlt")
+
+
+def test_slack_export_source_is_dlt_resource():
+    resource = slack_export_source(_fixture("v1"))
+    rows = list(resource)
+
+    assert len(rows) == 4
+    assert all("id" in row for row in rows)
+
+
+def test_large_fixture_exceeds_default_dlt_row_cap():
+    from cognee.tasks.ingestion.config import get_ingestion_config
+
+    rows = list(iter_slack_export_messages(_fixture("large")))
+    default_cap = get_ingestion_config().dlt_max_rows_per_table
+
+    assert default_cap == 50
+    assert len(rows) > default_cap

--- a/examples/demos/slack_export_ingestion.py
+++ b/examples/demos/slack_export_ingestion.py
@@ -1,0 +1,55 @@
+"""Ingest a Slack workspace export via the dlt connector.
+
+Slack exports can contain thousands of messages. Cognee caps DLT table reads
+at 50 rows by default (``dlt_max_rows_per_table`` / ``DLT_MAX_ROWS_PER_TABLE``).
+Pass ``max_rows_per_table=0`` to ingest the full export.
+
+Use a dedicated ``dataset_name`` per workspace so orphan cleanup only touches
+tables from the current ingest run.
+"""
+
+import asyncio
+import os
+
+import cognee
+
+try:
+    import dlt
+except ImportError:
+    dlt = None
+
+from cognee.tasks.ingestion.connectors.slack_export import slack_export_source
+
+SLACK_REMEMBER_KWARGS = {
+    "primary_key": "id",
+    "write_disposition": "replace",
+    "max_rows_per_table": 0,
+    "incremental_loading": False,
+    "self_improvement": False,
+}
+
+
+async def main():
+    export_path = os.path.join(
+        os.path.dirname(__file__),
+        "test_data",
+        "slack_export",
+        "v1",
+    )
+
+    await cognee.forget(everything=True)
+
+    await cognee.remember(
+        slack_export_source(export_path),
+        dataset_name="team-slack-export",
+        **SLACK_REMEMBER_KWARGS,
+    )
+
+    result = await cognee.recall("What did Bob say about the connector demo?")
+    print("Recall results:", result)
+
+
+if __name__ == "__main__":
+    if dlt is None:
+        raise SystemExit("Install dlt to run this example: pip install dlt")
+    asyncio.run(main())

--- a/examples/demos/test_data/slack_export/large/channels.json
+++ b/examples/demos/test_data/slack_export/large/channels.json
@@ -1,0 +1,1 @@
+[{"id": "C001", "name": "general", "created": 1600000000}]

--- a/examples/demos/test_data/slack_export/large/general/2024-06-01.json
+++ b/examples/demos/test_data/slack_export/large/general/2024-06-01.json
@@ -1,0 +1,392 @@
+[
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 0",
+    "ts": "1717200000.000000"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 1",
+    "ts": "1717200000.000001"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 2",
+    "ts": "1717200000.000002"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 3",
+    "ts": "1717200000.000003"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 4",
+    "ts": "1717200000.000004"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 5",
+    "ts": "1717200000.000005"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 6",
+    "ts": "1717200000.000006"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 7",
+    "ts": "1717200000.000007"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 8",
+    "ts": "1717200000.000008"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 9",
+    "ts": "1717200000.000009"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 10",
+    "ts": "1717200000.000010"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 11",
+    "ts": "1717200000.000011"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 12",
+    "ts": "1717200000.000012"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 13",
+    "ts": "1717200000.000013"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 14",
+    "ts": "1717200000.000014"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 15",
+    "ts": "1717200000.000015"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 16",
+    "ts": "1717200000.000016"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 17",
+    "ts": "1717200000.000017"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 18",
+    "ts": "1717200000.000018"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 19",
+    "ts": "1717200000.000019"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 20",
+    "ts": "1717200000.000020"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 21",
+    "ts": "1717200000.000021"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 22",
+    "ts": "1717200000.000022"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 23",
+    "ts": "1717200000.000023"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 24",
+    "ts": "1717200000.000024"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 25",
+    "ts": "1717200000.000025"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 26",
+    "ts": "1717200000.000026"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 27",
+    "ts": "1717200000.000027"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 28",
+    "ts": "1717200000.000028"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 29",
+    "ts": "1717200000.000029"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 30",
+    "ts": "1717200000.000030"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 31",
+    "ts": "1717200000.000031"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 32",
+    "ts": "1717200000.000032"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 33",
+    "ts": "1717200000.000033"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 34",
+    "ts": "1717200000.000034"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 35",
+    "ts": "1717200000.000035"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 36",
+    "ts": "1717200000.000036"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 37",
+    "ts": "1717200000.000037"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 38",
+    "ts": "1717200000.000038"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 39",
+    "ts": "1717200000.000039"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 40",
+    "ts": "1717200000.000040"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 41",
+    "ts": "1717200000.000041"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 42",
+    "ts": "1717200000.000042"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 43",
+    "ts": "1717200000.000043"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 44",
+    "ts": "1717200000.000044"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 45",
+    "ts": "1717200000.000045"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 46",
+    "ts": "1717200000.000046"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 47",
+    "ts": "1717200000.000047"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 48",
+    "ts": "1717200000.000048"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 49",
+    "ts": "1717200000.000049"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 50",
+    "ts": "1717200000.000050"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 51",
+    "ts": "1717200000.000051"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 52",
+    "ts": "1717200000.000052"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 53",
+    "ts": "1717200000.000053"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 54",
+    "ts": "1717200000.000054"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 55",
+    "ts": "1717200000.000055"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 56",
+    "ts": "1717200000.000056"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 57",
+    "ts": "1717200000.000057"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 58",
+    "ts": "1717200000.000058"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 59",
+    "ts": "1717200000.000059"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 60",
+    "ts": "1717200000.000060"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 61",
+    "ts": "1717200000.000061"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 62",
+    "ts": "1717200000.000062"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 63",
+    "ts": "1717200000.000063"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "message 64",
+    "ts": "1717200000.000064"
+  }
+]

--- a/examples/demos/test_data/slack_export/large/users.json
+++ b/examples/demos/test_data/slack_export/large/users.json
@@ -1,0 +1,1 @@
+[{"id": "U001", "name": "alice", "real_name": "Alice"}]

--- a/examples/demos/test_data/slack_export/v1/channels.json
+++ b/examples/demos/test_data/slack_export/v1/channels.json
@@ -1,0 +1,4 @@
+[
+  {"id": "C001", "name": "general", "created": 1600000000},
+  {"id": "C002", "name": "random", "created": 1600000001}
+]

--- a/examples/demos/test_data/slack_export/v1/general/2024-06-01.json
+++ b/examples/demos/test_data/slack_export/v1/general/2024-06-01.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "Morning standup at 10am",
+    "ts": "1717200000.000100"
+  },
+  {
+    "type": "message",
+    "user": "U002",
+    "text": "I'll demo the new connector today",
+    "ts": "1717200001.000200",
+    "thread_ts": "1717200000.000100"
+  },
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "Great, looking forward to it",
+    "ts": "1717200002.000300"
+  }
+]

--- a/examples/demos/test_data/slack_export/v1/random/2024-06-01.json
+++ b/examples/demos/test_data/slack_export/v1/random/2024-06-01.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "message",
+    "user": "U002",
+    "text": "Anyone up for lunch?",
+    "ts": "1717200100.000100"
+  }
+]

--- a/examples/demos/test_data/slack_export/v1/users.json
+++ b/examples/demos/test_data/slack_export/v1/users.json
@@ -1,0 +1,4 @@
+[
+  {"id": "U001", "name": "alice", "real_name": "Alice"},
+  {"id": "U002", "name": "bob", "real_name": "Bob"}
+]

--- a/examples/demos/test_data/slack_export/v2/channels.json
+++ b/examples/demos/test_data/slack_export/v2/channels.json
@@ -1,0 +1,4 @@
+[
+  {"id": "C001", "name": "general", "created": 1600000000},
+  {"id": "C002", "name": "random", "created": 1600000001}
+]

--- a/examples/demos/test_data/slack_export/v2/general/2024-06-01.json
+++ b/examples/demos/test_data/slack_export/v2/general/2024-06-01.json
@@ -1,0 +1,15 @@
+[
+  {
+    "type": "message",
+    "user": "U001",
+    "text": "Morning standup at 10am",
+    "ts": "1717200000.000100"
+  },
+  {
+    "type": "message",
+    "user": "U002",
+    "text": "I'll demo the new connector today",
+    "ts": "1717200001.000200",
+    "thread_ts": "1717200000.000100"
+  }
+]

--- a/examples/demos/test_data/slack_export/v2/random/2024-06-01.json
+++ b/examples/demos/test_data/slack_export/v2/random/2024-06-01.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "message",
+    "user": "U002",
+    "text": "Anyone up for lunch?",
+    "ts": "1717200100.000100"
+  }
+]

--- a/examples/demos/test_data/slack_export/v2/users.json
+++ b/examples/demos/test_data/slack_export/v2/users.json
@@ -1,0 +1,4 @@
+[
+  {"id": "U001", "name": "alice", "real_name": "Alice"},
+  {"id": "U002", "name": "bob", "real_name": "Bob"}
+]


### PR DESCRIPTION
Fixes #3621

## Summary

This PR adds a **DLT source for Slack workspace exports** using the existing `remember()` / DLT ingestion pipeline. Slack exports (`channels.json`, `users.json`, and per-channel daily JSON files) are ingested into flat message rows with stable `channel_id:ts` identifiers, avoiding a separate ingestion path.

It also scopes DLT orphan cleanup to only the tables processed in the current sync (per @siillee's feedback), preventing unrelated DLT tables from being removed during Slack re-syncs. The example and documentation now use `max_rows_per_table=0` to disable the default 50-row limit for full Slack exports.

---

## Changes

### Slack export connector (`cognee/tasks/ingestion/connectors/slack_export.py`)

- Added `slack_export_source(export_path)` factory
- Parses Slack workspace exports (`channels.json`, `users.json`, per-channel daily JSON)
- Stable row identifier: `id = "{channel_id}:{ts}"`
- Uses `primary_key="id"`
- Resolves usernames from `users.json`
- Includes thread replies in searchable message text
- Adds `slack_permalink` for citable recall
- Uses `write_disposition="replace"` for snapshot synchronization

### Table-scoped orphan cleanup (`resolve_dlt_sources.py`)

- Tracks `fresh_table_names` for the current ingestion
- `_delete_dlt_orphans()` now deletes only rows whose:
  - `table_name` belongs to the current ingest
  - `data_id` is absent from the fresh dataset

This ensures Slack re-syncs do not affect unrelated DLT tables in the same dataset.

### Examples, Fixtures & Tests

Added:

- `examples/demos/slack_export_ingestion.py`
- Slack export fixtures:
  - v1
  - v2 (message deletion)
  - large (65 messages)
- Unit tests under `cognee/tests/unit/tasks/ingestion/`

---

## Acceptance Criteria

- [x] DLT source for Slack export archives
- [x] Stable primary key using `channel_id:ts`
- [x] Snapshot synchronization via `write_disposition="replace"`
- [x] Deleted messages handled through orphan cleanup
- [x] `max_rows_per_table=0` documented for full exports
- [x] Table-scoped orphan cleanup
- [x] Runnable demo under `examples/demos/`
- [x] Unit tests covering parsing, deletion handling, row limits, and orphan cleanup

---

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Code refactoring
- [ ] Other

---

## Test Plan

### Automated

```bash
pytest cognee/tests/unit/tasks/ingestion/ -v
```

**Result**

```text
======================= 12 passed =======================
```

### Manual

```bash
uv run python examples/demos/slack_export_ingestion.py
```

---

## Checklist

- [x] Tested locally
- [x] Added unit tests
- [x] Added documentation where applicable
- [x] Existing tests pass
- [x] Linked the related issue
- [x] Commits are clear and descriptive

---

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.