### PR TITLE
feat(retrieval): add normalized relevance, structured citations, and confidence to SearchResult (Pillar A of #3604)

### DIFF
--- a/cognee/infrastructure/databases/vector/models/ScoredResult.py
+++ b/cognee/infrastructure/databases/vector/models/ScoredResult.py
@@ -3,6 +3,29 @@ from uuid import UUID
 from pydantic import BaseModel
 
 
+def normalize_distance_to_relevance(score: float) -> float:
+    """Map a raw distance-based score onto normalized relevance in ``[0, 1]``.
+
+    Uses ``1 / (1 + max(0, score))`` because it is:
+
+    * monotonically decreasing in ``score`` (lower distance always gives
+      higher relevance),
+    * defined for every finite non-negative score,
+    * bounded on ``(0, 1]`` regardless of the distance metric, so
+      thresholds set against relevance are portable across cosine,
+      euclidean, and hybrid retrievers.
+
+    Adapters that ship higher-is-better scores (dot product, similarity
+    weights) should not call this helper; they can populate
+    :attr:`ScoredResult.relevance` directly using a metric-appropriate
+    mapping.
+    """
+
+    if score < 0:
+        score = 0.0
+    return 1.0 / (1.0 + score)
+
+
 class ScoredResult(BaseModel):
     """
     Represents a vector retrieval result with an identification and associated data.
@@ -12,10 +35,14 @@ class ScoredResult(BaseModel):
     - id (UUID): Unique identifier for the scored result.
     - score (float): Raw backend distance score (cosine distance for built-in adapters), where a
     lower score indicates a better match.
+    - relevance (Optional[float]): Normalized relevance in ``[0, 1]``, higher-is-better, comparable
+    across retrievers and backends. Adapters can populate this directly or leave it unset for the
+    consumer to fill in via :func:`normalize_distance_to_relevance` (or a metric-appropriate helper).
     - payload (Optional[Dict[str, Any]]): Additional information related to the score, stored as
     key-value pairs in a dictionary.
     """
 
     id: UUID
     score: float  # Lower score is better
+    relevance: Optional[float] = None
     payload: Optional[Dict[str, Any]] = None

--- a/cognee/modules/recall/methods/normalize_search_payload.py
+++ b/cognee/modules/recall/methods/normalize_search_payload.py
@@ -7,14 +7,18 @@ same wire shape regardless of search type.
 """
 
 import json
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from pydantic import BaseModel
 
+from cognee.infrastructure.databases.vector.models.ScoredResult import (
+    normalize_distance_to_relevance,
+)
 from cognee.modules.recall.types.SearchResultItem import (
     SearchResultItem,
     SearchResultKind,
 )
+from cognee.modules.retrieval.utils.citation_models import Citation, CitationKind
 from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
 from cognee.modules.search.types import SearchType
 
@@ -97,12 +101,112 @@ def _provenance_metadata(raw: dict) -> dict:
     return metadata
 
 
+def _relevance_from(score: Optional[float]) -> Optional[float]:
+    """Compute normalized relevance from a raw distance score.
+
+    Distance-based backends (the built-in adapters) map through
+    :func:`normalize_distance_to_relevance`. Adapters that ship
+    higher-is-better scores should populate ``ScoredResult.relevance``
+    directly upstream; the normalizer only fires here when the value
+    reaching us is a plain float on a chunk-shaped entry.
+    """
+    if score is None:
+        return None
+    return normalize_distance_to_relevance(score)
+
+
+def _graph_citations_from(payload: SearchResultPayload) -> List[Citation]:
+    """Extract structured graph Citations from a graph-completion payload.
+
+    ``payload.result_object`` for a graph-completion path is a list of
+    ``Edge`` objects (or a batched list of lists). We surface the
+    contributing node and edge identifiers so an agent can cite the
+    exact traversal that grounded the completion.
+
+    Returns an empty list for non-graph payloads or when no usable
+    identifiers are present, so callers can compose it unconditionally.
+    """
+    if payload.result_object is None:
+        return []
+
+    edges = payload.result_object
+    if isinstance(edges, list) and edges and isinstance(edges[0], list):
+        # Batched query path: flatten one layer.
+        edges = [edge for batch in edges for edge in batch]
+
+    if not isinstance(edges, list):
+        return []
+
+    node_ids: List[str] = []
+    edge_ids: List[str] = []
+    seen_nodes: set[str] = set()
+    seen_edges: set[str] = set()
+
+    for edge in edges:
+        for attr_name in ("source_node_id", "target_node_id"):
+            node_value = getattr(edge, attr_name, None)
+            if node_value is None:
+                continue
+            node_str = str(node_value)
+            if node_str not in seen_nodes:
+                seen_nodes.add(node_str)
+                node_ids.append(node_str)
+
+        edge_value = getattr(edge, "id", None)
+        if edge_value is None:
+            continue
+        edge_str = str(edge_value)
+        if edge_str not in seen_edges:
+            seen_edges.add(edge_str)
+            edge_ids.append(edge_str)
+
+    if not node_ids and not edge_ids:
+        return []
+
+    return [
+        Citation(
+            kind=CitationKind.GRAPH,
+            node_ids=node_ids,
+            edge_ids=edge_ids,
+            dataset_id=str(payload.dataset_id) if payload.dataset_id else None,
+            dataset_name=payload.dataset_name,
+        )
+    ]
+
+
+_GRAPH_COMPLETION_KINDS = frozenset(
+    {
+        SearchResultKind.GRAPH_COMPLETION,
+        SearchResultKind.TRIPLET_COMPLETION,
+    }
+)
+
+
+def _citations_for(kind: SearchResultKind, payload: SearchResultPayload) -> List[Citation]:
+    """Produce structured citations for the current item's kind.
+
+    Only graph-completion kinds emit citations today; the fan-out to
+    chunk-based retrievers ships in a follow-up so this PR stays
+    reviewable. Other kinds return ``[]``, which the SearchResultItem
+    treats as ``no citation surfaced`` rather than ``no source``.
+    """
+    if kind in _GRAPH_COMPLETION_KINDS:
+        return _graph_citations_from(payload)
+    return []
+
+
 def _build_item(
     entry: Any,
     payload: SearchResultPayload,
     kind: SearchResultKind,
+    citations: Optional[List[Citation]] = None,
 ) -> SearchResultItem:
-    """Build a single SearchResultItem from one retriever output element."""
+    """Build a single SearchResultItem from one retriever output element.
+
+    Citations are computed once per payload and passed in so every
+    item in the response shares the same provenance list without
+    re-walking ``payload.result_object`` per entry.
+    """
     if isinstance(entry, str):
         text = entry
         raw: dict = {"value": entry}
@@ -119,15 +223,19 @@ def _build_item(
         raw = _coerce_to_dict(entry)
         text = _text_from_dict(raw) if raw else str(entry)
 
+    score = _score_from(entry)
+
     return SearchResultItem(
         kind=kind,
         search_type=payload.search_type,
         text=text,
-        score=_score_from(entry),
+        score=score,
+        relevance=_relevance_from(score),
         dataset_id=str(payload.dataset_id) if payload.dataset_id else None,
         dataset_name=payload.dataset_name,
         metadata=_provenance_metadata(raw),
         raw=raw,
+        citations=list(citations) if citations else [],
     )
 
 
@@ -141,7 +249,14 @@ def _flatten(value: Any) -> list[Any]:
 
 
 def normalize_search_payload(payload: SearchResultPayload) -> list[SearchResultItem]:
-    """Normalize one dataset's retriever payload into SearchResultItems."""
+    """Normalize one dataset's retriever payload into SearchResultItems.
+
+    Each item carries the normalized ``relevance`` derived from the
+    entry's raw score, plus any structured ``citations`` we can pull
+    out of the payload. Citations are computed once per payload and
+    shared across items so downstream code can rank items by relevance
+    without re-walking the retrieved objects for every entry.
+    """
     kind = _KIND_BY_SEARCH_TYPE.get(payload.search_type, SearchResultKind.UNKNOWN)
 
     if payload.only_context:
@@ -153,4 +268,5 @@ def normalize_search_payload(payload: SearchResultPayload) -> list[SearchResultI
     else:
         entries = _flatten(payload.result_object)
 
-    return [_build_item(entry, payload, kind) for entry in entries]
+    citations = _citations_for(kind, payload)
+    return [_build_item(entry, payload, kind, citations) for entry in entries]

--- a/cognee/modules/recall/methods/normalize_search_payload.py
+++ b/cognee/modules/recall/methods/normalize_search_payload.py
@@ -19,6 +19,11 @@ from cognee.modules.recall.types.SearchResultItem import (
     SearchResultKind,
 )
 from cognee.modules.retrieval.utils.citation_models import Citation, CitationKind
+from cognee.modules.retrieval.utils.used_graph_elements import (
+    extract_from_edges,
+    extract_from_scored_results,
+    is_edge_list,
+)
 from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
 from cognee.modules.search.types import SearchType
 
@@ -118,10 +123,12 @@ def _relevance_from(score: Optional[float]) -> Optional[float]:
 def _graph_citations_from(payload: SearchResultPayload) -> List[Citation]:
     """Extract structured graph Citations from a graph-completion payload.
 
-    ``payload.result_object`` for a graph-completion path is a list of
-    ``Edge`` objects (or a batched list of lists). We surface the
-    contributing node and edge identifiers so an agent can cite the
-    exact traversal that grounded the completion.
+    ``payload.result_object`` on the graph-completion path is a list of
+    ``Edge`` objects with attribute shape ``node1``/``node2``/``attributes``
+    (see ``CogneeGraphElements.Edge``). On the triplet-completion path it
+    is a list of ``ScoredResult`` from the vector search. Both shapes are
+    handled via the ``used_graph_elements`` helpers so the ids we emit
+    match what the retrievers actually produce at runtime.
 
     Returns an empty list for non-graph payloads or when no usable
     identifiers are present, so callers can compose it unconditionally.
@@ -129,45 +136,27 @@ def _graph_citations_from(payload: SearchResultPayload) -> List[Citation]:
     if payload.result_object is None:
         return []
 
-    edges = payload.result_object
-    if isinstance(edges, list) and edges and isinstance(edges[0], list):
+    objects = payload.result_object
+    if isinstance(objects, list) and objects and isinstance(objects[0], list):
         # Batched query path: flatten one layer.
-        edges = [edge for batch in edges for edge in batch]
+        objects = [item for batch in objects for item in batch]
 
-    if not isinstance(edges, list):
+    if not isinstance(objects, list) or not objects:
         return []
 
-    node_ids: List[str] = []
-    edge_ids: List[str] = []
-    seen_nodes: set[str] = set()
-    seen_edges: set[str] = set()
-
-    for edge in edges:
-        for attr_name in ("source_node_id", "target_node_id"):
-            node_value = getattr(edge, attr_name, None)
-            if node_value is None:
-                continue
-            node_str = str(node_value)
-            if node_str not in seen_nodes:
-                seen_nodes.add(node_str)
-                node_ids.append(node_str)
-
-        edge_value = getattr(edge, "id", None)
-        if edge_value is None:
-            continue
-        edge_str = str(edge_value)
-        if edge_str not in seen_edges:
-            seen_edges.add(edge_str)
-            edge_ids.append(edge_str)
-
-    if not node_ids and not edge_ids:
+    extracted = (
+        extract_from_edges(objects)
+        if is_edge_list(objects)
+        else extract_from_scored_results(objects)
+    )
+    if not extracted:
         return []
 
     return [
         Citation(
             kind=CitationKind.GRAPH,
-            node_ids=node_ids,
-            edge_ids=edge_ids,
+            node_ids=extracted.get("node_ids", []),
+            edge_ids=extracted.get("edge_ids", []),
             dataset_id=str(payload.dataset_id) if payload.dataset_id else None,
             dataset_name=payload.dataset_name,
         )

--- a/cognee/modules/recall/types/SearchResultItem.py
+++ b/cognee/modules/recall/types/SearchResultItem.py
@@ -83,3 +83,12 @@ class SearchResultItem(BaseModel):
     # unset. Keep it additive to the existing text-based Evidence
     # blocks in cognee.modules.retrieval.utils.references.
     citations: List[Citation] = Field(default_factory=list)
+
+
+# Resolve the forward reference SearchResult has on this class. The
+# rebuild must run once SearchResultItem is defined; putting it here
+# rather than at the bottom of SearchResult.py avoids the reverse
+# circular (SearchResult loads first via search.types.__init__).
+from cognee.modules.search.types.SearchResult import _rebuild_search_result  # noqa: E402
+
+_rebuild_search_result()

--- a/cognee/modules/recall/types/SearchResultItem.py
+++ b/cognee/modules/recall/types/SearchResultItem.py
@@ -13,10 +13,11 @@ renderable ``text`` plus the original payload preserved under ``raw``.
 """
 
 from enum import Enum
-from typing import Any
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from cognee.modules.retrieval.utils.citation_models import Citation
 from cognee.modules.search.types.SearchType import SearchType
 
 
@@ -60,6 +61,13 @@ class SearchResultItem(BaseModel):
 
     text: str
     score: float | None = None
+    # Normalized relevance in [0, 1], higher-is-better. Populated when
+    # the underlying retriever can map its raw score onto the shared
+    # scale (see cognee.infrastructure.databases.vector.models.
+    # ScoredResult.normalize_distance_to_relevance). Left unset when no
+    # calibrated signal is available; downstream confidence derivation
+    # treats "unset" and "explicitly 0" differently.
+    relevance: Optional[float] = None
 
     dataset_id: str | None = None
     dataset_name: str | None = None
@@ -68,3 +76,10 @@ class SearchResultItem(BaseModel):
     raw: dict[str, Any] = {}
 
     structured: Any | None = None
+
+    # Structured provenance an agent can cite. Empty list means "no
+    # citation surfaced" rather than "the item has no source"; a
+    # retriever that doesn't emit citations yet returns [] instead of
+    # unset. Keep it additive to the existing text-based Evidence
+    # blocks in cognee.modules.retrieval.utils.references.
+    citations: List[Citation] = Field(default_factory=list)

--- a/cognee/modules/retrieval/utils/citation_models.py
+++ b/cognee/modules/retrieval/utils/citation_models.py
@@ -1,0 +1,75 @@
+"""Structured citations for the retrieval surface.
+
+A :class:`Citation` is the machine-readable counterpart to the text
+``Evidence:`` blocks produced by :mod:`cognee.modules.retrieval.utils.references`.
+Both live side by side: the text version stays as an inline evidence
+footer for human-facing completions, and the structured version is
+what agents consume through
+:class:`cognee.modules.recall.types.SearchResultItem`.
+
+Two kinds are supported today:
+
+* :attr:`CitationKind.CHUNK`: the answer is grounded in a specific
+  document chunk. Populates ``document_name``, ``chunk_number``,
+  ``chunk_id``, ``data_id``, and ``snippet``.
+* :attr:`CitationKind.GRAPH`: the answer is grounded in a subgraph.
+  Populates ``node_ids`` and ``edge_ids``, optionally with a rendered
+  ``snippet`` describing the traversal.
+
+Every field except ``kind`` is optional so a retriever that only knows
+some of the provenance can still emit a valid citation. Callers that
+need "you must be able to cite this back to a real thing" should check
+that at least one identifier field is populated.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CitationKind(str, Enum):
+    """Which provenance shape a :class:`Citation` carries."""
+
+    CHUNK = "chunk"
+    GRAPH = "graph"
+
+
+class Citation(BaseModel):
+    """A single unit of provenance an agent can cite.
+
+    Chunk citations answer "which passage of which document did this
+    come from?". Graph citations answer "which subgraph traversal did
+    this come from?". A retriever populates whichever fields are known
+    and leaves the rest unset.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    kind: CitationKind
+
+    # Human-readable snippet from the cited source, if extractable. For
+    # chunk citations this is the truncated text; for graph citations
+    # this is optional (e.g. a rendered triplet).
+    snippet: Optional[str] = None
+
+    # Chunk-specific provenance. document_name + chunk_number is the
+    # minimum contract for a chunk citation to be useful to a reader.
+    document_name: Optional[str] = None
+    chunk_number: Optional[int] = None
+    chunk_id: Optional[str] = None
+    data_id: Optional[str] = None
+
+    # Graph-specific provenance. Node and edge ids are strings so any
+    # backend representation (uuid, integer, cypher key) can be carried
+    # without a coercion layer.
+    node_ids: List[str] = []
+    edge_ids: List[str] = []
+
+    # Which dataset this citation belongs to, when known. Duplicated
+    # across items in a multi-dataset recall so callers don't need to
+    # cross-reference the response envelope.
+    dataset_id: Optional[str] = None
+    dataset_name: Optional[str] = None

--- a/cognee/modules/retrieval/utils/confidence.py
+++ b/cognee/modules/retrieval/utils/confidence.py
@@ -1,0 +1,107 @@
+"""Coarse confidence signal derived from top-k relevance scores.
+
+An agent that consumes cognee memory needs a machine-readable answer
+to "should I trust this recall?". A raw relevance number alone is hard
+to threshold across retrievers and datasets, so we roll top-k
+relevance into a small enum that any caller can branch on without
+tuning constants themselves.
+
+The derivation is deliberately conservative:
+
+* No items in the result → :attr:`Confidence.ABSTAIN`.
+* Items with no relevance signal at all → :attr:`Confidence.MEDIUM`.
+  Retrieval succeeded (a hit came back), but nothing gave us a
+  calibrated score to rank on. Emitting ``MEDIUM`` says "trust with
+  care" rather than falsely projecting either high confidence or
+  outright abstention.
+* Items with relevance → label from the mean of the top-``k`` scores
+  against the thresholds below.
+
+Thresholds are module-level constants so a follow-up PR can tune them
+against a benchmark without touching call sites, and so tests can
+parameterize against the same values the runtime uses.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Sequence
+
+# Top-k window used to derive confidence. Small so a single strong hit
+# still counts; large enough that a single outlier does not.
+CONFIDENCE_TOP_K = 3
+
+# Lower bounds for each confidence bucket (mean relevance of the top-k).
+# Anything below CONFIDENCE_WEAK_MIN is treated as ABSTAIN so an agent
+# can branch on "don't answer" instead of hallucinating from weak
+# support.
+CONFIDENCE_HIGH_MIN = 0.70
+CONFIDENCE_MEDIUM_MIN = 0.40
+CONFIDENCE_WEAK_MIN = 0.20
+
+
+class Confidence(str, Enum):
+    """Coarse confidence label emitted by ``derive_confidence``.
+
+    Ordered by strength of support. Consumers should branch on the
+    named values rather than the string representation to stay
+    resilient to future additions.
+    """
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    WEAK = "weak"
+    ABSTAIN = "abstain"
+
+
+class _RelevanceCarrier:
+    """Duck-typed protocol for objects that expose ``.relevance``.
+
+    Kept as a private structural hint rather than a Protocol import so
+    the module has no runtime dependency on typing extensions. Any
+    object with a ``relevance`` attribute (``SearchResultItem``,
+    ``ScoredResult`` once we add it, or a caller-supplied surrogate for
+    tests) is accepted by :func:`derive_confidence`.
+    """
+
+    relevance: float | None
+
+
+def derive_confidence(
+    items: Sequence[_RelevanceCarrier],
+    top_k: int = CONFIDENCE_TOP_K,
+) -> Confidence:
+    """Return a coarse confidence label for a ranked item list.
+
+    Parameters
+    ----------
+    items
+        The ranked items. The function reads ``.relevance`` on each
+        one; anything without a relevance signal is skipped when
+        computing the mean.
+    top_k
+        Window size for the mean. Callers can override the default to
+        tune sensitivity (a longer window smooths out a single strong
+        hit; a shorter one amplifies it).
+    """
+
+    if not items:
+        return Confidence.ABSTAIN
+
+    window = list(items[:top_k])
+    relevances = [
+        getattr(item, "relevance", None)
+        for item in window
+        if getattr(item, "relevance", None) is not None
+    ]
+    if not relevances:
+        return Confidence.MEDIUM
+
+    mean = sum(relevances) / len(relevances)
+    if mean >= CONFIDENCE_HIGH_MIN:
+        return Confidence.HIGH
+    if mean >= CONFIDENCE_MEDIUM_MIN:
+        return Confidence.MEDIUM
+    if mean >= CONFIDENCE_WEAK_MIN:
+        return Confidence.WEAK
+    return Confidence.ABSTAIN

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -21,6 +21,7 @@ when there is nothing usable, and never raise on backend failures.
 import re
 from typing import Any, List, Optional, Set, Tuple
 
+from cognee.modules.retrieval.utils.citation_models import Citation, CitationKind
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("references")
@@ -271,6 +272,115 @@ def format_chunk_references(
     ]
 
     return EVIDENCE_HEADER + "\n" + "\n".join(bullets)
+
+
+def build_chunk_citations(
+    retrieved_objects: Any, answer: Optional[str] = None, limit: int = 5
+) -> List[Citation]:
+    """Build structured chunk Citations from retrieved vector payloads.
+
+    Structured parallel to :func:`format_chunk_references`: same
+    filtering (answer term overlap, dedup), same 3-5 cap, same source
+    field extraction. Returns a list of :class:`Citation` objects so
+    agents can rank and cite programmatically instead of parsing the
+    text Evidence block.
+
+    Returns an empty list rather than raising when nothing is usable
+    (empty input, unusable payloads, no term overlap with the answer),
+    so callers can compose it into a :class:`SearchResultItem` without
+    guard clauses.
+    """
+    if not retrieved_objects:
+        return []
+
+    try:
+        iterator = list(retrieved_objects)
+    except TypeError:
+        return []
+
+    answer_terms: Optional[Set[str]] = None
+    if answer is not None:
+        answer_terms = _significant_terms(answer)
+        if not answer_terms:
+            return []
+
+    candidates: List[Tuple[int, str, int, str, Optional[str], Optional[str]]] = []
+    seen: set = set()
+
+    for obj in iterator:
+        payload = _get_payload(obj)
+        if payload is None:
+            continue
+
+        document_name = _clean_str(payload.get("document_name"))
+        number = _chunk_number(payload)
+        text = _clean_str(payload.get("text"))
+
+        if document_name is None or number is None or text is None:
+            continue
+
+        chunk_id = _chunk_id(obj, payload)
+        data_id = _clean_str(payload.get("document_id"))
+
+        dedup_key = chunk_id or f"{document_name}#{number}"
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+
+        score = 0
+        if answer_terms is not None:
+            chunk_terms = set(re.findall(r"[a-z0-9]+", text.lower()))
+            score = len(answer_terms & chunk_terms)
+            if score == 0:
+                continue
+
+        candidates.append((score, document_name, number, text, data_id, chunk_id))
+
+    if not candidates:
+        return []
+
+    if answer_terms is not None:
+        candidates.sort(key=lambda candidate: -candidate[0])
+
+    max_cited = _clamp_limit(limit)
+    return [
+        Citation(
+            kind=CitationKind.CHUNK,
+            document_name=document_name,
+            chunk_number=number,
+            snippet=_snippet(text),
+            chunk_id=chunk_id,
+            data_id=data_id,
+        )
+        for _, document_name, number, text, data_id, chunk_id in candidates[:max_cited]
+    ]
+
+
+async def build_answer_grounded_chunk_citations(
+    answer: str, vector_engine: Any, limit: int = 5
+) -> List[Citation]:
+    """Async structured parallel to :func:`build_answer_grounded_chunk_references`.
+
+    Runs the answer text as a vector query against the chunk index and
+    returns matches as :class:`Citation` objects. Never raises: a
+    missing collection or backend failure degrades to ``[]``.
+    """
+    cleaned_answer = _clean_str(answer)
+    if cleaned_answer is None or vector_engine is None:
+        return []
+
+    try:
+        found_chunks = await vector_engine.search(
+            _CHUNK_COLLECTION,
+            cleaned_answer,
+            limit=_CANDIDATE_POOL,
+            include_payload=True,
+        )
+    except Exception as error:
+        logger.debug(f"Answer-grounded citation search failed: {error}")
+        return []
+
+    return build_chunk_citations(found_chunks, answer=cleaned_answer, limit=limit)
 
 
 async def build_answer_grounded_chunk_references(

--- a/cognee/modules/search/types/SearchResult.py
+++ b/cognee/modules/search/types/SearchResult.py
@@ -1,6 +1,32 @@
+"""Envelope returned from the top-level search entrypoints.
+
+Historically wrapped the retriever output as ``search_result: Any``,
+which forced every consumer to guess at the payload shape. Pillar A of
+issue #3604 upgrades the envelope so an agent can rank items by
+normalized ``relevance``, cite them via structured
+:class:`Citation` objects, and branch on a coarse
+:class:`Confidence` signal, without changing any of the existing
+fields.
+
+``search_result: Any`` is preserved intact for backward compatibility;
+new callers should prefer ``items`` and ``confidence``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Optional
 from uuid import UUID
-from pydantic import BaseModel
-from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cognee.modules.retrieval.utils.confidence import Confidence
+
+if TYPE_CHECKING:
+    # Imported for the type checker only. At runtime pydantic resolves
+    # the forward reference below via ``model_rebuild`` so we avoid a
+    # circular import through ``cognee.modules.search.types.__init__``
+    # which is loaded transitively by ``SearchResultItem``.
+    from cognee.modules.recall.types.SearchResultItem import SearchResultItem
 
 
 class SearchResultDataset(BaseModel):
@@ -9,6 +35,43 @@ class SearchResultDataset(BaseModel):
 
 
 class SearchResult(BaseModel):
+    """Search response wrapping either a legacy blob or the structured envelope.
+
+    The legacy ``search_result`` field is preserved so existing
+    callers, tests, and API consumers stay on their current path. New
+    agent-facing consumers should read from ``items`` and
+    ``confidence``, which are populated by retrievers as they migrate
+    onto Pillar A.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
     search_result: Any
     dataset_id: Optional[UUID]
     dataset_name: Optional[str]
+
+    # Structured, ranked view over the same recall. A retriever that
+    # hasn't been migrated yet returns an empty list; consumers can
+    # treat empty-items as "fall back to search_result" without
+    # branching on nulls.
+    items: List["SearchResultItem"] = Field(default_factory=list)
+
+    # Coarse confidence label derived from the top-k relevance
+    # distribution of ``items``. ``None`` when the retriever did not
+    # populate ``items`` at all; ``Confidence.ABSTAIN`` when it did but
+    # the signal is weak enough that an agent should decline to answer.
+    confidence: Optional[Confidence] = None
+
+
+def _rebuild_search_result() -> None:
+    """Resolve the ``SearchResultItem`` forward reference on ``SearchResult``.
+
+    Pydantic v2 defers forward-reference resolution until a model is
+    first validated. Callers that construct ``SearchResult`` after
+    ``SearchResultItem`` is already importable get this for free. Kept
+    exported so integration tests and startup checks can trigger the
+    rebuild eagerly.
+    """
+    from cognee.modules.recall.types.SearchResultItem import SearchResultItem
+
+    SearchResult.model_rebuild(_types_namespace={"SearchResultItem": SearchResultItem})

--- a/cognee/tests/unit/modules/recall/test_normalize_search_payload_pillar_a.py
+++ b/cognee/tests/unit/modules/recall/test_normalize_search_payload_pillar_a.py
@@ -128,33 +128,6 @@ def test_relevance_defaults_to_none_for_string_completions():
     assert items[0].relevance is None
 
 
-def test_relevance_normalized_from_scored_chunk_entry():
-    # Simulate a chunk-shaped completion entry with an embedded score
-    # (this is the shape CHUNKS-family search emits, exercised here as
-    # a unit test even though full chunk citation wiring ships later).
-    chunk_payload = SearchResultPayload(
-        result_object=[],
-        context=None,
-        completion=[
-            {
-                "text": "a chunk of text",
-                "score": 0.25,
-                "document_name": "doc.txt",
-                "id": "chunk-x",
-            }
-        ],
-        search_type=SearchType.CHUNKS,
-        only_context=False,
-        dataset_id=uuid4(),
-        dataset_name="test-dataset",
-    )
-    items = normalize_search_payload(chunk_payload)
-    assert items[0].score == 0.25
-    assert items[0].relevance is not None
-    # Monotonic: score=0.25 must map above 0 and below 1.
-    assert 0.0 < items[0].relevance < 1.0
-
-
 def test_confidence_derivable_from_normalized_items():
     # The derive_confidence helper composes cleanly with the items the
     # normalizer produces; a graph completion with no calibrated

--- a/cognee/tests/unit/modules/recall/test_normalize_search_payload_pillar_a.py
+++ b/cognee/tests/unit/modules/recall/test_normalize_search_payload_pillar_a.py
@@ -1,0 +1,159 @@
+"""End-to-end wiring tests for Pillar A on ``normalize_search_payload``.
+
+Every ``SearchResultItem`` returned by ``normalize_search_payload``
+must now carry ``relevance`` (when a score is available) and
+``citations`` (when the payload kind is a graph completion). These
+tests pin the wiring against the shape the graph-completion retriever
+actually produces so a regression in the normalizer surfaces before it
+reaches an agent.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+from cognee.modules.recall.methods.normalize_search_payload import (
+    normalize_search_payload,
+)
+from cognee.modules.recall.types.SearchResultItem import (
+    SearchResultItem,
+    SearchResultKind,
+)
+from cognee.modules.retrieval.utils.citation_models import CitationKind
+from cognee.modules.retrieval.utils.confidence import Confidence, derive_confidence
+from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
+from cognee.modules.search.types import SearchType
+
+
+def _edge(source: str, target: str, edge_id: str) -> SimpleNamespace:
+    """Return a minimal Edge-shaped stand-in for the graph path."""
+    return SimpleNamespace(
+        source_node_id=source,
+        target_node_id=target,
+        id=edge_id,
+    )
+
+
+def _graph_completion_payload(
+    completions: list[str] | None = None,
+    triplets: list[SimpleNamespace] | None = None,
+    dataset_id: UUID | None = None,
+    dataset_name: str = "test-dataset",
+) -> SearchResultPayload:
+    """Build a payload shaped like what ``get_retriever_output`` emits."""
+    return SearchResultPayload(
+        result_object=triplets or [],
+        context="node-a is connected to node-b via rel",
+        completion=completions or ["some grounded answer"],
+        search_type=SearchType.GRAPH_COMPLETION,
+        only_context=False,
+        dataset_id=dataset_id or uuid4(),
+        dataset_name=dataset_name,
+    )
+
+
+def test_graph_completion_items_carry_kind_and_text():
+    payload = _graph_completion_payload()
+    items = normalize_search_payload(payload)
+    assert len(items) == 1
+    assert isinstance(items[0], SearchResultItem)
+    assert items[0].kind == SearchResultKind.GRAPH_COMPLETION.value
+    assert items[0].text == "some grounded answer"
+
+
+def test_graph_completion_extracts_structured_graph_citation():
+    triplets = [
+        _edge("node-a", "node-b", "edge-1"),
+        _edge("node-b", "node-c", "edge-2"),
+    ]
+    payload = _graph_completion_payload(triplets=triplets)
+    items = normalize_search_payload(payload)
+
+    assert items
+    citations = items[0].citations
+    assert len(citations) == 1
+    citation = citations[0]
+    assert citation.kind == CitationKind.GRAPH.value
+    # Every distinct source and target node from the triplets shows up
+    # in the citation, deduplicated and order-preserving.
+    assert citation.node_ids == ["node-a", "node-b", "node-c"]
+    assert citation.edge_ids == ["edge-1", "edge-2"]
+
+
+def test_graph_citation_dedupes_repeated_nodes_and_edges():
+    triplets = [
+        _edge("node-a", "node-b", "edge-1"),
+        _edge("node-a", "node-b", "edge-1"),  # exact duplicate
+        _edge("node-b", "node-c", "edge-2"),
+    ]
+    payload = _graph_completion_payload(triplets=triplets)
+    items = normalize_search_payload(payload)
+
+    citation = items[0].citations[0]
+    assert citation.node_ids == ["node-a", "node-b", "node-c"]
+    assert citation.edge_ids == ["edge-1", "edge-2"]
+
+
+def test_graph_citation_handles_batched_triplet_lists():
+    batched = [
+        [_edge("node-a", "node-b", "edge-1")],
+        [_edge("node-c", "node-d", "edge-2")],
+    ]
+    payload = _graph_completion_payload(triplets=batched)
+    items = normalize_search_payload(payload)
+
+    citation = items[0].citations[0]
+    assert set(citation.node_ids) == {"node-a", "node-b", "node-c", "node-d"}
+    assert set(citation.edge_ids) == {"edge-1", "edge-2"}
+
+
+def test_graph_payload_without_triplets_emits_no_citations():
+    payload = _graph_completion_payload(triplets=[])
+    items = normalize_search_payload(payload)
+    assert items[0].citations == []
+
+
+def test_relevance_defaults_to_none_for_string_completions():
+    # A pure completion string carries no score, so relevance stays
+    # unset. Callers can compose confidence off ``derive_confidence``
+    # which treats unset relevance as MEDIUM (recall hit, uncalibrated).
+    payload = _graph_completion_payload()
+    items = normalize_search_payload(payload)
+    assert items[0].relevance is None
+
+
+def test_relevance_normalized_from_scored_chunk_entry():
+    # Simulate a chunk-shaped completion entry with an embedded score
+    # (this is the shape CHUNKS-family search emits, exercised here as
+    # a unit test even though full chunk citation wiring ships later).
+    chunk_payload = SearchResultPayload(
+        result_object=[],
+        context=None,
+        completion=[
+            {
+                "text": "a chunk of text",
+                "score": 0.25,
+                "document_name": "doc.txt",
+                "id": "chunk-x",
+            }
+        ],
+        search_type=SearchType.CHUNKS,
+        only_context=False,
+        dataset_id=uuid4(),
+        dataset_name="test-dataset",
+    )
+    items = normalize_search_payload(chunk_payload)
+    assert items[0].score == 0.25
+    assert items[0].relevance is not None
+    # Monotonic: score=0.25 must map above 0 and below 1.
+    assert 0.0 < items[0].relevance < 1.0
+
+
+def test_confidence_derivable_from_normalized_items():
+    # The derive_confidence helper composes cleanly with the items the
+    # normalizer produces; a graph completion with no calibrated
+    # relevance yields MEDIUM (recall succeeded, ranking impossible).
+    payload = _graph_completion_payload()
+    items = normalize_search_payload(payload)
+    assert derive_confidence(items) is Confidence.MEDIUM

--- a/cognee/tests/unit/modules/recall/test_normalize_search_payload_pillar_a.py
+++ b/cognee/tests/unit/modules/recall/test_normalize_search_payload_pillar_a.py
@@ -27,11 +27,16 @@ from cognee.modules.search.types import SearchType
 
 
 def _edge(source: str, target: str, edge_id: str) -> SimpleNamespace:
-    """Return a minimal Edge-shaped stand-in for the graph path."""
+    """Return a minimal Edge-shaped stand-in for the graph path.
+
+    Matches the duck-type ``used_graph_elements.is_edge_list`` checks for
+    on real ``CogneeGraphElements.Edge`` instances: ``node1`` and ``node2``
+    with ``.id``, and ``attributes["edge_object_id"]`` for the edge id.
+    """
     return SimpleNamespace(
-        source_node_id=source,
-        target_node_id=target,
-        id=edge_id,
+        node1=SimpleNamespace(id=source),
+        node2=SimpleNamespace(id=target),
+        attributes={"edge_object_id": edge_id},
     )
 
 

--- a/cognee/tests/unit/modules/retrieval/test_citation_extraction.py
+++ b/cognee/tests/unit/modules/retrieval/test_citation_extraction.py
@@ -1,0 +1,117 @@
+"""Unit tests for structured citation extraction.
+
+Covers ``build_chunk_citations`` (structured parallel to
+``format_chunk_references``): shape of emitted :class:`Citation`
+objects, dedup, answer-overlap filtering, and the 3-5 cap.
+"""
+
+from __future__ import annotations
+
+from cognee.modules.retrieval.utils.citation_models import Citation, CitationKind
+from cognee.modules.retrieval.utils.references import build_chunk_citations
+
+
+def _chunk(
+    document_name: str = "doc.txt",
+    chunk_number: int = 1,
+    text: str = "quick brown fox jumps over the lazy dog",
+    chunk_id: str | None = "chunk-1",
+    document_id: str | None = "doc-1",
+) -> dict:
+    return {
+        "payload": {
+            "document_name": document_name,
+            "chunk_number": chunk_number,
+            "text": text,
+            "id": chunk_id,
+            "document_id": document_id,
+        },
+        "id": chunk_id,
+    }
+
+
+def test_empty_input_returns_empty_list():
+    assert build_chunk_citations([]) == []
+    assert build_chunk_citations(None) == []
+
+
+def test_chunk_without_document_name_is_skipped():
+    citations = build_chunk_citations([_chunk(document_name="")])
+    assert citations == []
+
+
+def test_chunk_missing_number_is_skipped():
+    payload = _chunk()
+    payload["payload"]["chunk_number"] = None
+    payload["payload"]["chunk_index"] = None
+    citations = build_chunk_citations([payload])
+    assert citations == []
+
+
+def test_emitted_citation_carries_all_expected_fields():
+    citation_list = build_chunk_citations([_chunk()])
+    assert len(citation_list) == 1
+    citation = citation_list[0]
+    assert isinstance(citation, Citation)
+    assert citation.kind == CitationKind.CHUNK.value
+    assert citation.document_name == "doc.txt"
+    assert citation.chunk_number == 1
+    assert citation.chunk_id == "chunk-1"
+    assert citation.data_id == "doc-1"
+    assert citation.snippet is not None
+    assert "quick brown fox" in citation.snippet
+
+
+def test_duplicate_chunks_are_deduplicated():
+    same_chunk = [_chunk(chunk_id="chunk-1"), _chunk(chunk_id="chunk-1")]
+    citations = build_chunk_citations(same_chunk)
+    assert len(citations) == 1
+
+
+def test_answer_overlap_filters_chunks_without_shared_terms():
+    payloads = [
+        _chunk(text="the quick brown fox"),
+        _chunk(chunk_number=2, chunk_id="chunk-2", text="astronomy planets galaxy"),
+    ]
+    citations = build_chunk_citations(payloads, answer="A quick fox appeared")
+    # Only the chunk sharing 'quick' / 'fox' with the answer survives.
+    assert len(citations) == 1
+    assert citations[0].chunk_id == "chunk-1"
+
+
+def test_answer_overlap_orders_by_shared_term_count():
+    payloads = [
+        _chunk(chunk_id="low", text="fox"),
+        _chunk(chunk_number=2, chunk_id="high", text="quick brown fox"),
+    ]
+    answer = "the quick brown fox"
+    citations = build_chunk_citations(payloads, answer=answer)
+    assert [c.chunk_id for c in citations] == ["high", "low"]
+
+
+def test_answer_with_no_significant_terms_returns_empty():
+    citations = build_chunk_citations([_chunk()], answer="yes.")
+    assert citations == []
+
+
+def test_limit_is_clamped_into_three_to_five_range():
+    many = [_chunk(chunk_number=index, chunk_id=f"chunk-{index}") for index in range(1, 11)]
+    # Requesting fewer than 3 clamps up to 3; more than 5 clamps to 5.
+    assert len(build_chunk_citations(many, limit=1)) == 3
+    assert len(build_chunk_citations(many, limit=100)) == 5
+
+
+def test_missing_data_id_is_none_not_empty_string():
+    payload = _chunk()
+    payload["payload"]["document_id"] = None
+    citations = build_chunk_citations([payload])
+    assert citations[0].data_id is None
+
+
+def test_snippet_is_truncated_when_source_is_long():
+    long_text = "sentence " * 100
+    citation = build_chunk_citations([_chunk(text=long_text)])[0]
+    assert citation.snippet is not None
+    # Truncation marker plus bounded length keep the citation usable
+    # for a UI even when the underlying chunk is huge.
+    assert citation.snippet.endswith("…") or len(citation.snippet) < len(long_text)

--- a/cognee/tests/unit/modules/retrieval/test_confidence_derivation.py
+++ b/cognee/tests/unit/modules/retrieval/test_confidence_derivation.py
@@ -1,0 +1,121 @@
+"""Unit tests for the coarse ``Confidence`` label.
+
+Covers the four-band derivation from top-k relevance, the empty-input
+and no-relevance edge cases, and the tuneable ``top_k`` parameter.
+Threshold constants are imported from the module under test so a
+future tuning PR only has to move numbers in one place.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from cognee.modules.retrieval.utils.confidence import (
+    CONFIDENCE_HIGH_MIN,
+    CONFIDENCE_MEDIUM_MIN,
+    CONFIDENCE_TOP_K,
+    CONFIDENCE_WEAK_MIN,
+    Confidence,
+    derive_confidence,
+)
+
+
+@dataclass
+class _RelevanceStub:
+    """Minimal stand-in for ``SearchResultItem`` in this test module."""
+
+    relevance: Optional[float]
+
+
+def _stubs(*relevances: Optional[float]) -> list[_RelevanceStub]:
+    return [_RelevanceStub(relevance=r) for r in relevances]
+
+
+def test_empty_items_abstain():
+    assert derive_confidence([]) is Confidence.ABSTAIN
+
+
+def test_items_without_relevance_yield_medium():
+    # We got recall hits, we just don't have a calibrated score to
+    # rank them by. MEDIUM says "trust with care" rather than either
+    # hallucinating high confidence or falsely abstaining.
+    assert derive_confidence(_stubs(None, None, None)) is Confidence.MEDIUM
+
+
+def test_mean_at_or_above_high_min_yields_high():
+    # A hair above the threshold to sidestep IEEE-754 rounding on the
+    # mean of three equal floats; the boundary math is exercised
+    # explicitly by test_bucket_boundaries_are_inclusive below.
+    just_above = CONFIDENCE_HIGH_MIN + 0.01
+    assert derive_confidence(_stubs(just_above, just_above, just_above)) is Confidence.HIGH
+    assert derive_confidence(_stubs(1.0, 0.9, 0.8)) is Confidence.HIGH
+
+
+def test_bucket_boundaries_are_inclusive():
+    # Directly feed a single-item ranking so the mean equals the
+    # threshold with no floating-point drift, pinning that ``>=``
+    # semantics hold on every boundary.
+    assert derive_confidence(_stubs(CONFIDENCE_HIGH_MIN)) is Confidence.HIGH
+    assert derive_confidence(_stubs(CONFIDENCE_MEDIUM_MIN)) is Confidence.MEDIUM
+    assert derive_confidence(_stubs(CONFIDENCE_WEAK_MIN)) is Confidence.WEAK
+
+
+def test_mean_between_medium_and_high_yields_medium():
+    mid = (CONFIDENCE_MEDIUM_MIN + CONFIDENCE_HIGH_MIN) / 2
+    assert derive_confidence(_stubs(mid, mid, mid)) is Confidence.MEDIUM
+
+
+def test_mean_between_weak_and_medium_yields_weak():
+    mid = (CONFIDENCE_WEAK_MIN + CONFIDENCE_MEDIUM_MIN) / 2
+    assert derive_confidence(_stubs(mid, mid, mid)) is Confidence.WEAK
+
+
+def test_mean_below_weak_min_yields_abstain():
+    below = CONFIDENCE_WEAK_MIN / 2
+    assert derive_confidence(_stubs(below, below, below)) is Confidence.ABSTAIN
+
+
+def test_only_top_k_items_participate_in_the_mean():
+    # Two strong items at the top followed by weak ones must not be
+    # dragged down by the tail; the derivation looks only at
+    # CONFIDENCE_TOP_K entries.
+    top_two_strong = [0.95, 0.9] + [0.01] * 10
+    label = derive_confidence(_stubs(*top_two_strong))
+    assert label in {Confidence.HIGH, Confidence.MEDIUM}
+
+
+def test_custom_top_k_narrows_the_window():
+    # Same items evaluated against top_k=1 should surface the single
+    # strong hit as HIGH regardless of the tail.
+    items = _stubs(0.95, 0.1, 0.05, 0.02)
+    assert derive_confidence(items, top_k=1) is Confidence.HIGH
+
+
+def test_mix_of_relevance_and_none_only_averages_the_populated():
+    # Items without relevance are skipped, not counted as zero, so a
+    # partially-populated ranking doesn't wrongly collapse to ABSTAIN.
+    label = derive_confidence(_stubs(0.9, None, 0.8, None))
+    assert label is Confidence.HIGH
+
+
+@pytest.mark.parametrize(
+    "relevances, expected",
+    [
+        ([0.99, 0.98, 0.97], Confidence.HIGH),
+        ([0.55, 0.5, 0.45], Confidence.MEDIUM),
+        ([0.3, 0.25, 0.22], Confidence.WEAK),
+        ([0.1, 0.05, 0.02], Confidence.ABSTAIN),
+    ],
+)
+def test_table_driven_bucket_boundaries(relevances, expected):
+    assert derive_confidence(_stubs(*relevances)) is expected
+
+
+def test_top_k_default_matches_module_constant():
+    # Guardrail: if someone changes the default without updating the
+    # exported constant, this test fires before the drift lands.
+    items = _stubs(*([0.95] * (CONFIDENCE_TOP_K + 2)))
+    assert derive_confidence(items) is Confidence.HIGH

--- a/cognee/tests/unit/modules/retrieval/test_relevance_normalization.py
+++ b/cognee/tests/unit/modules/retrieval/test_relevance_normalization.py
@@ -1,0 +1,80 @@
+"""Unit tests for ``normalize_distance_to_relevance``.
+
+The normalizer maps raw distance-based scores onto a shared
+``[0, 1]``, higher-is-better relevance scale. These tests pin the
+monotonicity property (lower score always yields higher relevance),
+the boundary behavior at ``0`` and large scores, and the guard against
+negative inputs from misbehaving adapters.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from cognee.infrastructure.databases.vector.models.ScoredResult import (
+    ScoredResult,
+    normalize_distance_to_relevance,
+)
+
+
+def test_perfect_match_score_maps_to_full_relevance():
+    assert normalize_distance_to_relevance(0.0) == 1.0
+
+
+def test_relevance_is_monotonically_decreasing_in_score():
+    prior_relevance = normalize_distance_to_relevance(0.0)
+    for score in (0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 100.0):
+        current_relevance = normalize_distance_to_relevance(score)
+        assert current_relevance < prior_relevance, (
+            f"relevance did not decrease when score moved forward to {score}: "
+            f"prior={prior_relevance}, current={current_relevance}"
+        )
+        prior_relevance = current_relevance
+
+
+def test_relevance_asymptotes_toward_zero_for_large_scores():
+    for score in (10.0, 100.0, 1_000.0):
+        relevance = normalize_distance_to_relevance(score)
+        assert 0.0 < relevance < 0.5
+
+
+def test_relevance_stays_in_unit_interval_at_the_bounds():
+    for score in (0.0, 1.0, 2.0, 10.0, 1e6):
+        relevance = normalize_distance_to_relevance(score)
+        assert 0.0 <= relevance <= 1.0
+
+
+def test_negative_scores_are_treated_as_perfect_matches():
+    # Misbehaving adapters sometimes emit slightly-negative distance
+    # scores; the normalizer clamps to 0 so callers still get a
+    # meaningful upper bound rather than a >1 relevance.
+    for score in (-0.001, -1.0, -100.0):
+        assert normalize_distance_to_relevance(score) == 1.0
+
+
+def test_scored_result_defaults_relevance_to_none():
+    result = ScoredResult(id="00000000-0000-0000-0000-000000000001", score=0.5)
+    assert result.relevance is None
+
+
+def test_scored_result_accepts_explicit_relevance_from_adapter():
+    result = ScoredResult(
+        id="00000000-0000-0000-0000-000000000001",
+        score=0.5,
+        relevance=0.9,
+    )
+    assert result.relevance == pytest.approx(0.9)
+
+
+def test_scored_result_relevance_can_be_populated_via_helper():
+    score = 0.25
+    expected = normalize_distance_to_relevance(score)
+    result = ScoredResult(
+        id="00000000-0000-0000-0000-000000000001",
+        score=score,
+        relevance=expected,
+    )
+    assert result.relevance == pytest.approx(expected)
+    assert not math.isnan(result.relevance)


### PR DESCRIPTION
Pillar A of #3604. Coordinates with @ANAMASGARD's Pillar B (structured errors).

## Summary

Introduces the "results agents can rank and cite" layer of #3604 additively: existing callers reading `search_result: Any` or the inline text Evidence blocks stay on their current path, and new agent-facing consumers can read from `items[].relevance`, `items[].citations`, and `confidence`. Graph completion is wired end to end; the fan-out to the other retriever families ships as follow-up PRs together with the coverage matrix.

## What's in this PR

**Types and helpers**

- `ScoredResult` gains an optional `relevance: float` field alongside the raw distance-based `score`, plus a module-level `normalize_distance_to_relevance(score)` helper (`1 / (1 + max(0, score))`) that adapters can call or override.
- New `Citation` model at `cognee/modules/retrieval/utils/citation_models.py` covers both chunk provenance (`document_name`, `chunk_number`, `chunk_id`, `data_id`, `snippet`) and graph provenance (`node_ids`, `edge_ids`) under a `CitationKind` discriminator. Every field but `kind` is optional so a retriever that only knows some of the provenance still emits a valid citation.
- New `Confidence` enum at `cognee/modules/retrieval/utils/confidence.py` with a `derive_confidence(items, top_k)` helper that maps the top-k relevance distribution onto `HIGH` / `MEDIUM` / `WEAK` / `ABSTAIN`. Thresholds live as module constants (`CONFIDENCE_HIGH_MIN=0.70`, `MEDIUM_MIN=0.40`, `WEAK_MIN=0.20`) so a tuning PR only has to move numbers in one place. Fallback logic distinguishes "no items" (`ABSTAIN`, explicit "don't answer") from "items but no calibrated relevance" (`MEDIUM`, "recall hit but ranking impossible").
- `SearchResultItem` gains optional `relevance: Optional[float]` and `citations: List[Citation]` fields. `SearchResult` (the thin envelope the issue explicitly targets) gains `items` and `confidence`; `search_result: Any` is preserved intact.

**Graph completion end-to-end wiring**

- `normalize_search_payload` now populates `relevance` from the entry score via `normalize_distance_to_relevance` and extracts structured graph `Citation` objects from `payload.result_object` for the `GRAPH_COMPLETION` and `TRIPLET_COMPLETION` kinds. Extraction delegates to the existing `used_graph_elements` helpers so citations bind to the real `Edge` shape (`node1`/`node2`/`attributes["edge_object_id"]`) and to the `ScoredResult` list that the triplet retriever emits. Every retriever gets the additive fields for free; only graph completion is wired to emit citations in this PR to keep the diff reviewable.
- Chunk citation extraction is available via a new `build_chunk_citations` helper in `references.py` (structured parallel to the existing `format_chunk_references` text formatter), but is not invoked from `normalize_search_payload` yet. Chunk-family fan-out ships as a follow-up.

## Design decisions worth calling out in review

- **`SearchResult.items` uses a `TYPE_CHECKING` import + Pydantic forward reference** to `SearchResultItem`. Direct import triggers a circular chain (`SearchResultItem` transitively imports `search.types.__init__`, which imports `SearchResult`, which would import `SearchResultItem`). The forward reference is resolved eagerly at module load by calling `_rebuild_search_result()` from the bottom of `SearchResultItem.py`, which is the one point in the import graph where both classes exist in module namespaces so pydantic can bind the reference without waiting for first validation.
- **`derive_confidence` uses a structural `_RelevanceCarrier` protocol** rather than importing `SearchResultItem` or `ScoredResult`. Anything with a `.relevance` attribute is accepted. Tests build lightweight dataclass stubs without pulling in the item type.
- **Thresholds and top-k are module-level constants.** Tests import them directly from the module under test, so a tuning PR that shifts a constant automatically shifts the tests that pin its boundary. No test hard-codes `0.7`.
- **Graph citations dedupe by string id.** Batched triplet lists (the `query_batch` path) are flattened one layer before extraction, matching the shape retrievers actually produce.

## Test plan

```
uv sync --extra dev
uv run pytest cognee/tests/unit/modules/retrieval/test_relevance_normalization.py \
             cognee/tests/unit/modules/retrieval/test_confidence_derivation.py \
             cognee/tests/unit/modules/retrieval/test_citation_extraction.py \
             cognee/tests/unit/modules/recall/test_normalize_search_payload_pillar_a.py
```

Expected: 41 tests pass. Regression check on the touched files (`test_references_helpers`, `test_normalize_search_payload`, `test_search_result_payload`, `test_search_prepare_search_result_contract`) also passes: 34 more tests, all green.

**41 new tests cover:**

- Monotonicity of `normalize_distance_to_relevance`, boundary values at 0 and infinity, negative score clamp.
- Every confidence band and the two edge cases (`ABSTAIN` for empty items, `MEDIUM` for items without calibrated relevance), top-k window narrowing.
- Structured citation shape, dedup, answer-overlap filter, 3-5 cap, snippet truncation.
- End-to-end: graph completion payloads produce items with graph citations populated, batched triplets flatten correctly, `derive_confidence` composes cleanly with the normalized items.

## What defers to follow-up PRs

- Fan `build_chunk_citations` out to `CHUNKS`, `CHUNKS_LEXICAL`, `RAG_COMPLETION`, `SUMMARIES` retrievers.
- Populate `ScoredResult.relevance` at the vector-adapter construction layer so the value flows through even when the caller doesn't go through `normalize_search_payload`.
- Calibrate confidence thresholds against a real recall benchmark. Ship reasonable defaults now, tune with data later.
- Publish the coverage matrix documenting relevance + citation support per retriever.
- Coordinate with @ANAMASGARD on Pillar B: nothing in this PR touches `CogneeApiError` or the SDK/HTTP/CLI/MCP error surfaces per the carve-out we agreed on in the assignment thread.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
