### PR TITLE
feat(search): expose retrieved subgraph stub via include_subgraph (#3…

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -382,6 +382,7 @@ async def recall(
     neighborhood_depth: int | None = None,
     neighborhood_seed_top_k: int | None = None,
     include_references: bool = False,
+    include_subgraph: bool = False,
     user: object | None = None,
     llm_config: LLMConfig | None = None,
     embedding_config: EmbeddingConfig | None = None,
@@ -613,13 +614,16 @@ async def recall(
                 neighborhood_depth=neighborhood_depth,
                 neighborhood_seed_top_k=neighborhood_seed_top_k,
                 include_references=include_references,
+                include_subgraph=include_subgraph,
                 llm_config=llm_config,
                 embedding_config=embedding_config,
             )
 
             tagged = []
             for r in graph_results:
-                items: list[SearchResultItem] = normalize_search_payload(r)
+                items: list[SearchResultItem] = normalize_search_payload(
+                    r, include_subgraph=include_subgraph
+                )
                 tagged.extend(
                     [ResponseGraphEntry(**item.model_dump(), source="graph") for item in items]
                 )

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -68,6 +68,13 @@ class RecallPayloadDTO(InDTO):
         default=False,
         description="Include source/provenance references in completion results.",
     )
+    include_subgraph: bool = Field(
+        default=False,
+        description=(
+            "Include a lightweight stub of the retrieved graph subgraph "
+            "(nodes + edges) in graph search results."
+        ),
+    )
     session_id: Optional[str] = Field(
         default=None,
         examples=[None],
@@ -190,6 +197,7 @@ def get_recall_router() -> APIRouter:
                 scope=payload.scope,
                 context_profile=payload.context_profile,
                 include_references=payload.include_references,
+                include_subgraph=payload.include_subgraph,
             )
             return jsonable_encoder(results)
         except (DatabaseNotCreatedError, UserNotFoundError, CogneeValidationError) as e:

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -95,6 +95,13 @@ class SearchPayloadDTO(InDTO):
         default=False,
         description="Attach source references to completion-type results.",
     )
+    include_subgraph: bool = Field(
+        default=False,
+        description=(
+            "Include a lightweight stub of the retrieved graph subgraph "
+            "(nodes + edges) in the response for graph-based search types."
+        ),
+    )
 
 
 def get_search_router() -> APIRouter:
@@ -215,6 +222,7 @@ def get_search_router() -> APIRouter:
                 "tools": payload.tools,
                 "max_iter": payload.max_iter,
                 "include_references": payload.include_references,
+                "include_subgraph": payload.include_subgraph,
                 "cognee_version": cognee_version,
             },
         )
@@ -239,6 +247,7 @@ def get_search_router() -> APIRouter:
                 tools=payload.tools,
                 max_iter=payload.max_iter,
                 include_references=payload.include_references,
+                include_subgraph=payload.include_subgraph,
             )
 
             return jsonable_encoder(results)

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -53,6 +53,7 @@ async def search(
     tools: Optional[List[str]] = None,
     max_iter: Optional[int] = None,
     include_references: bool = False,
+    include_subgraph: bool = False,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[SearchResult]:
@@ -330,6 +331,7 @@ async def search(
             neighborhood_depth=neighborhood_depth,
             neighborhood_seed_top_k=neighborhood_seed_top_k,
             include_references=include_references,
+            include_subgraph=include_subgraph,
             llm_config=llm_config,
             embedding_config=embedding_config,
         )

--- a/cognee/modules/recall/methods/normalize_search_payload.py
+++ b/cognee/modules/recall/methods/normalize_search_payload.py
@@ -101,6 +101,7 @@ def _build_item(
     entry: Any,
     payload: SearchResultPayload,
     kind: SearchResultKind,
+    include_subgraph: bool = False,
 ) -> SearchResultItem:
     """Build a single SearchResultItem from one retriever output element."""
     if isinstance(entry, str):
@@ -119,7 +120,7 @@ def _build_item(
         raw = _coerce_to_dict(entry)
         text = _text_from_dict(raw) if raw else str(entry)
 
-    return SearchResultItem(
+    item_kwargs = dict(
         kind=kind,
         search_type=payload.search_type,
         text=text,
@@ -129,6 +130,9 @@ def _build_item(
         metadata=_provenance_metadata(raw),
         raw=raw,
     )
+    if include_subgraph:
+        item_kwargs["retrieved_subgraph"] = payload.retrieved_subgraph
+    return SearchResultItem(**item_kwargs)
 
 
 def _flatten(value: Any) -> list[Any]:
@@ -140,7 +144,9 @@ def _flatten(value: Any) -> list[Any]:
     return [value]
 
 
-def normalize_search_payload(payload: SearchResultPayload) -> list[SearchResultItem]:
+def normalize_search_payload(
+    payload: SearchResultPayload, include_subgraph: bool = False
+) -> list[SearchResultItem]:
     """Normalize one dataset's retriever payload into SearchResultItems."""
     kind = _KIND_BY_SEARCH_TYPE.get(payload.search_type, SearchResultKind.UNKNOWN)
 
@@ -153,4 +159,6 @@ def normalize_search_payload(payload: SearchResultPayload) -> list[SearchResultI
     else:
         entries = _flatten(payload.result_object)
 
-    return [_build_item(entry, payload, kind) for entry in entries]
+    return [
+        _build_item(entry, payload, kind, include_subgraph=include_subgraph) for entry in entries
+    ]

--- a/cognee/modules/recall/types/SearchResultItem.py
+++ b/cognee/modules/recall/types/SearchResultItem.py
@@ -67,4 +67,6 @@ class SearchResultItem(BaseModel):
     metadata: dict[str, Any] = {}
     raw: dict[str, Any] = {}
 
+    retrieved_subgraph: Any | None = None
+
     structured: Any | None = None

--- a/cognee/modules/retrieval/utils/used_graph_elements.py
+++ b/cognee/modules/retrieval/utils/used_graph_elements.py
@@ -1,6 +1,23 @@
 """Helpers to extract used graph element IDs from retriever results for session QA."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
+
+from cognee.modules.search.types.SearchType import SearchType
+
+SUBGRAPH_SEARCH_TYPES = frozenset(
+    {
+        SearchType.GRAPH_COMPLETION,
+        SearchType.GRAPH_COMPLETION_DECOMPOSITION,
+        SearchType.GRAPH_COMPLETION_COT,
+        SearchType.GRAPH_COMPLETION_CONTEXT_EXTENSION,
+        SearchType.GRAPH_SUMMARY_COMPLETION,
+        SearchType.TRIPLET_COMPLETION,
+        SearchType.TEMPORAL,
+        SearchType.AGENTIC_COMPLETION,
+    }
+)
+
+_EMPTY_SUBGRAPH: Dict[str, List] = {"nodes": [], "edges": []}
 
 
 def is_edge_list(obj: Any) -> bool:
@@ -81,3 +98,190 @@ def extract_from_temporal_dict(obj: Dict[str, Any]) -> Optional[Dict[str, List[s
     if isinstance(scored_results, list) and scored_results:
         return extract_from_scored_results(scored_results)
     return None
+
+
+def supports_subgraph_search_type(query_type: SearchType) -> bool:
+    """Return True when the search type can expose a retrieved subgraph stub."""
+    return query_type in SUBGRAPH_SEARCH_TYPES
+
+
+def _node_display_name(node: Any) -> str:
+    attributes = getattr(node, "attributes", None) or {}
+    name = attributes.get("name")
+    if name:
+        return str(name)
+    text = attributes.get("text")
+    if text:
+        return str(text)[:120]
+    description = attributes.get("description")
+    if description:
+        return str(description)[:120]
+    return "Unnamed Node"
+
+
+def _node_type_label(node: Any) -> str:
+    attributes = getattr(node, "attributes", None) or {}
+    return str(attributes.get("type") or attributes.get("node_type") or "Entity")
+
+
+def _edge_relationship(edge: Any) -> str:
+    attributes = getattr(edge, "attributes", None) or {}
+    return str(
+        attributes.get("relationship_type")
+        or attributes.get("relationship_name")
+        or attributes.get("edge_text")
+        or ""
+    )
+
+
+def _vector_distance_score(element: Any, query_index: int = 0) -> Optional[float]:
+    attributes = getattr(element, "attributes", None) or {}
+    distances = attributes.get("vector_distance")
+    if not isinstance(distances, list) or query_index >= len(distances):
+        return None
+    try:
+        return float(distances[query_index])
+    except (TypeError, ValueError):
+        return None
+
+
+def _scored_result_score(result: Any) -> Optional[float]:
+    score = getattr(result, "score", None)
+    if isinstance(score, (int, float)):
+        return float(score)
+    return None
+
+
+def _node_stub(node: Any) -> Dict[str, str]:
+    return {
+        "id": str(node.id),
+        "type": _node_type_label(node),
+        "name": _node_display_name(node),
+    }
+
+
+def build_subgraph_stub_from_edges(
+    edges: List[Any], query_index: int = 0
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Build a compact subgraph stub from retrieved Edge objects."""
+    nodes_by_id: Dict[str, Dict[str, str]] = {}
+    edge_stubs: List[Dict[str, Any]] = []
+
+    for edge in edges:
+        try:
+            node1 = getattr(edge, "node1", None)
+            node2 = getattr(edge, "node2", None)
+            if node1 is None or node2 is None:
+                continue
+            if getattr(node1, "id", None) is not None:
+                nodes_by_id.setdefault(str(node1.id), _node_stub(node1))
+            if getattr(node2, "id", None) is not None:
+                nodes_by_id.setdefault(str(node2.id), _node_stub(node2))
+
+            edge_stub: Dict[str, Any] = {
+                "source": str(node1.id),
+                "target": str(node2.id),
+                "relationship": _edge_relationship(edge),
+            }
+            score = _vector_distance_score(edge, query_index)
+            if score is not None:
+                edge_stub["score"] = score
+            edge_stubs.append(edge_stub)
+        except (TypeError, AttributeError):
+            continue
+
+    return {"nodes": list(nodes_by_id.values()), "edges": edge_stubs}
+
+
+def build_subgraph_stub_from_scored_results(
+    results: List[Any],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Build a nodes-only subgraph stub from scored vector results (e.g. temporal events)."""
+    nodes_by_id: Dict[str, Dict[str, Any]] = {}
+
+    for result in results:
+        try:
+            payload = getattr(result, "payload", None)
+            if not isinstance(payload, dict):
+                payload = {}
+            node_id = payload.get("id") or getattr(result, "id", None)
+            if node_id is None:
+                continue
+            node_id = str(node_id)
+            if node_id in nodes_by_id:
+                continue
+            node_stub: Dict[str, Any] = {
+                "id": node_id,
+                "type": str(payload.get("type") or payload.get("node_type") or "Entity"),
+                "name": str(
+                    payload.get("name")
+                    or payload.get("description")
+                    or payload.get("text")
+                    or "Unnamed Node"
+                ),
+            }
+            score = _scored_result_score(result)
+            if score is not None:
+                node_stub["score"] = score
+            nodes_by_id[node_id] = node_stub
+        except (TypeError, AttributeError):
+            continue
+
+    return {"nodes": list(nodes_by_id.values()), "edges": []}
+
+
+def _is_batch_edge_lists(obj: Any) -> bool:
+    return (
+        isinstance(obj, list)
+        and bool(obj)
+        and isinstance(obj[0], list)
+        and (not obj[0] or is_edge_list(obj[0]))
+    )
+
+
+def build_retrieved_subgraph(
+    retrieved_objects: Any,
+    query_type: SearchType,
+    query_index: int = 0,
+) -> Union[Dict[str, List[Dict[str, Any]]], List[Dict[str, List[Dict[str, Any]]]]]:
+    """Build the API subgraph stub from in-memory retriever output."""
+    if not supports_subgraph_search_type(query_type):
+        return None  # type: ignore[return-value]
+
+    if retrieved_objects is None:
+        return dict(_EMPTY_SUBGRAPH)
+
+    if isinstance(retrieved_objects, dict):
+        triplets = retrieved_objects.get("triplets")
+        if triplets is not None:
+            if _is_batch_edge_lists(triplets):
+                return [
+                    build_subgraph_stub_from_edges(batch, query_index=query_index)
+                    for batch in triplets
+                ]
+            if is_edge_list(triplets):
+                return build_subgraph_stub_from_edges(triplets, query_index=query_index)
+            if isinstance(triplets, list) and not triplets:
+                return dict(_EMPTY_SUBGRAPH)
+
+        vector_search_results = retrieved_objects.get("vector_search_results")
+        if isinstance(vector_search_results, list):
+            if not vector_search_results:
+                return dict(_EMPTY_SUBGRAPH)
+            return build_subgraph_stub_from_scored_results(vector_search_results)
+
+        return dict(_EMPTY_SUBGRAPH)
+
+    if _is_batch_edge_lists(retrieved_objects):
+        return [
+            build_subgraph_stub_from_edges(batch, query_index=query_index)
+            for batch in retrieved_objects
+        ]
+
+    if is_edge_list(retrieved_objects):
+        return build_subgraph_stub_from_edges(retrieved_objects, query_index=query_index)
+
+    if isinstance(retrieved_objects, list) and not retrieved_objects:
+        return dict(_EMPTY_SUBGRAPH)
+
+    return dict(_EMPTY_SUBGRAPH)

--- a/cognee/modules/search/methods/get_retriever_output.py
+++ b/cognee/modules/search/methods/get_retriever_output.py
@@ -1,4 +1,5 @@
 from inspect import Parameter, signature
+from typing import Any
 
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.modules.observability import (
@@ -8,6 +9,10 @@ from cognee.modules.observability import (
     new_span,
 )
 from cognee.modules.retrieval.utils.access_tracking import update_node_access_timestamps
+from cognee.modules.retrieval.utils.used_graph_elements import (
+    build_retrieved_subgraph,
+    supports_subgraph_search_type,
+)
 from cognee.modules.search.methods.get_search_type_retriever_instance import (
     get_search_type_retriever_instance,
 )
@@ -26,6 +31,18 @@ def _method_accepts_kwarg(method, name: str) -> bool:
     )
 
 
+def _subgraph_counts(subgraph: Any) -> tuple[int, int]:
+    if subgraph is None:
+        return 0, 0
+    if isinstance(subgraph, list):
+        node_count = sum(len(item.get("nodes", [])) for item in subgraph if isinstance(item, dict))
+        edge_count = sum(len(item.get("edges", [])) for item in subgraph if isinstance(item, dict))
+        return node_count, edge_count
+    if isinstance(subgraph, dict):
+        return len(subgraph.get("nodes", [])), len(subgraph.get("edges", []))
+    return 0, 0
+
+
 async def get_retriever_output(
     query_type: SearchType, query_text: str, **kwargs
 ) -> SearchResultPayload:
@@ -41,13 +58,14 @@ async def get_retriever_output(
 
     retriever_class = type(retriever_instance).__name__
     only_context = kwargs.get("only_context", False)
+    include_subgraph = kwargs.get("include_subgraph", False)
     effective_query = query_text
     turn_preparation = None
 
     if not only_context:
         turn_preparation = await retriever_instance.prepare_session_turn_for_retrieval(query_text)
         if not turn_preparation.should_answer:
-            return SearchResultPayload(
+            payload_kwargs = dict(
                 result_object=None,
                 context=None,
                 completion=[turn_preparation.response_to_user or "Got it."],
@@ -59,9 +77,13 @@ async def get_retriever_output(
                 if kwargs.get("dataset")
                 else None,
             )
+            if include_subgraph:
+                payload_kwargs["retrieved_subgraph"] = None
+            return SearchResultPayload(**payload_kwargs)
         effective_query = turn_preparation.effective_query or query_text
 
     # Get raw result objects from retriever and forward to context and completion methods to avoid duplicate retrievals.
+    retrieved_subgraph = None
     with new_span("cognee.retrieval.get_objects") as span:
         span.set_attribute("cognee.retrieval.retriever", retriever_class)
         span.set_attribute(COGNEE_SEARCH_TYPE, query_type.value)
@@ -72,6 +94,17 @@ async def get_retriever_output(
             COGNEE_RESULT_SUMMARY,
             f"{retriever_class} retrieved {obj_count} object(s)",
         )
+        if include_subgraph:
+            retrieved_subgraph = (
+                build_retrieved_subgraph(retrieved_objects, query_type)
+                if supports_subgraph_search_type(query_type)
+                else None
+            )
+            node_count, edge_count = _subgraph_counts(retrieved_subgraph)
+            span.set_attribute("cognee.retrieval.subgraph_node_count", node_count)
+            span.set_attribute("cognee.retrieval.subgraph_edge_count", edge_count)
+        else:
+            retrieved_subgraph = None
 
     # Centralized access tracking for all retriever types
     if retrieved_objects:
@@ -120,6 +153,7 @@ async def get_retriever_output(
         dataset_name=kwargs.get("dataset").name if kwargs.get("dataset") else None,
         dataset_id=kwargs.get("dataset").id if kwargs.get("dataset") else None,
         dataset_tenant_id=kwargs.get("dataset").tenant_id if kwargs.get("dataset") else None,
+        retrieved_subgraph=retrieved_subgraph if include_subgraph else None,
     )
 
     return search_result

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -58,6 +58,7 @@ async def search(
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
     include_references: bool = False,
+    include_subgraph: bool = False,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[SearchResult]:
@@ -116,6 +117,7 @@ async def search(
             neighborhood_depth=neighborhood_depth,
             neighborhood_seed_top_k=neighborhood_seed_top_k,
             include_references=include_references,
+            include_subgraph=include_subgraph,
             llm_config=llm_config,
             embedding_config=embedding_config,
         )
@@ -147,7 +149,9 @@ async def search(
         user.id,
     )
 
-    return _backwards_compatible_search_results(search_results, verbose)
+    return _backwards_compatible_search_results(
+        search_results, verbose, include_subgraph=include_subgraph
+    )
 
 
 async def authorized_search(
@@ -170,6 +174,7 @@ async def authorized_search(
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
     include_references: bool = False,
+    include_subgraph: bool = False,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[SearchResultPayload]:
@@ -203,6 +208,7 @@ async def authorized_search(
         neighborhood_depth=neighborhood_depth,
         neighborhood_seed_top_k=neighborhood_seed_top_k,
         include_references=include_references,
+        include_subgraph=include_subgraph,
         llm_config=llm_config,
         embedding_config=embedding_config,
     )
@@ -230,6 +236,7 @@ async def search_in_datasets_context(
     neighborhood_depth: Optional[int] = None,
     neighborhood_seed_top_k: Optional[int] = None,
     include_references: bool = False,
+    include_subgraph: bool = False,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
 ) -> List[Tuple[Any, Union[str, List[Edge]], List[Dataset]]]:
@@ -257,6 +264,7 @@ async def search_in_datasets_context(
         neighborhood_depth: Optional[int] = None,
         neighborhood_seed_top_k: Optional[int] = None,
         include_references: bool = False,
+        include_subgraph: bool = False,
     ) -> SearchResultPayload:
         with new_span("cognee.search.dataset") as span:
             span.set_attribute("cognee.search.dataset_name", dataset.name or "")
@@ -310,6 +318,7 @@ async def search_in_datasets_context(
                     neighborhood_depth=neighborhood_depth,
                     neighborhood_seed_top_k=neighborhood_seed_top_k,
                     include_references=include_references,
+                    include_subgraph=include_subgraph,
                 )
 
     # Search every dataset async based on query and appropriate database configuration
@@ -336,6 +345,7 @@ async def search_in_datasets_context(
                     neighborhood_depth=neighborhood_depth,
                     neighborhood_seed_top_k=neighborhood_seed_top_k,
                     include_references=include_references,
+                    include_subgraph=include_subgraph,
                 )
             )
     else:
@@ -362,6 +372,7 @@ async def search_in_datasets_context(
             neighborhood_depth=neighborhood_depth,
             neighborhood_seed_top_k=neighborhood_seed_top_k,
             include_references=include_references,
+            include_subgraph=include_subgraph,
         )
 
         async def _search_without_context() -> SearchResultPayload:
@@ -382,10 +393,26 @@ async def search_in_datasets_context(
     return await asyncio.gather(*tasks)
 
 
-def _backwards_compatible_search_results(search_results, verbose: bool):
+def _backwards_compatible_search_results(
+    search_results, verbose: bool, include_subgraph: bool = False
+):
     """
     Prepares search results in a format compatible with previous versions of the API.
     """
+
+    def _maybe_attach_subgraph(result_dict: dict, search_result) -> dict:
+        if include_subgraph:
+            result_dict["retrieved_subgraph"] = search_result.retrieved_subgraph
+        return result_dict
+
+    def _wrap_result_with_subgraph(search_result):
+        if not include_subgraph:
+            return search_result.result
+        return {
+            "search_result": search_result.result,
+            "retrieved_subgraph": search_result.retrieved_subgraph,
+        }
+
     # This is for maintaining backwards compatibility
     if backend_access_control_enabled():
         return_value = []
@@ -405,7 +432,7 @@ def _backwards_compatible_search_results(search_results, verbose: bool):
                 # Result attribute handles returning appropriate result based on set flags and outputs
                 search_result_dict["search_result"] = search_result.result
 
-            return_value.append(search_result_dict)
+            return_value.append(_maybe_attach_subgraph(search_result_dict, search_result))
         return return_value
     else:
         return_value = []
@@ -417,16 +444,17 @@ def _backwards_compatible_search_results(search_results, verbose: bool):
                     "context_result": search_result.context,
                     "objects_result": search_result.result_object,
                 }
-                return_value.append(search_result_dict)
+                return_value.append(_maybe_attach_subgraph(search_result_dict, search_result))
             return return_value
         else:
             for search_result in search_results:
-                # Result attribute handles returning appropriate result based on set flags and outputs
-                return_value.append(search_result.result)
+                return_value.append(_wrap_result_with_subgraph(search_result))
 
             # For maintaining backwards compatibility
-            if len(return_value) == 1 and isinstance(return_value[0], list):
+            if len(return_value) == 1 and not include_subgraph and isinstance(return_value[0], list):
                 # If a single element list return the element directly
+                return return_value[0]
+            if len(return_value) == 1 and include_subgraph:
                 return return_value[0]
             else:
                 # Otherwise return the list of results

--- a/cognee/modules/search/models/SearchResultPayload.py
+++ b/cognee/modules/search/models/SearchResultPayload.py
@@ -28,6 +28,8 @@ class SearchResultPayload(BaseModel):
     dataset_id: Optional[UUID] = None
     dataset_tenant_id: Optional[UUID] = None
 
+    retrieved_subgraph: Optional[Any] = None
+
     @field_serializer("result_object")
     def serialize_complex_types(self, v: Any):
         """

--- a/cognee/tests/unit/modules/retrieval/test_build_subgraph_stub.py
+++ b/cognee/tests/unit/modules/retrieval/test_build_subgraph_stub.py
@@ -1,0 +1,97 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognee.modules.retrieval.utils.used_graph_elements import (
+    build_retrieved_subgraph,
+    build_subgraph_stub_from_edges,
+    supports_subgraph_search_type,
+)
+from cognee.modules.search.types.SearchType import SearchType
+
+
+def _edge(
+    source_id: str,
+    target_id: str,
+    *,
+    relationship: str = "discovered",
+    score: float = 0.83,
+    source_name: str = "Marie Curie",
+    target_name: str = "Radium",
+    source_type: str = "Entity",
+    target_type: str = "Entity",
+):
+    n1 = MagicMock()
+    n1.id = source_id
+    n1.attributes = {"name": source_name, "type": source_type, "vector_distance": [score]}
+    n2 = MagicMock()
+    n2.id = target_id
+    n2.attributes = {"name": target_name, "type": target_type, "vector_distance": [score]}
+    edge = MagicMock()
+    edge.node1 = n1
+    edge.node2 = n2
+    edge.attributes = {
+        "relationship_name": relationship,
+        "vector_distance": [score],
+    }
+    return edge
+
+
+def test_build_subgraph_stub_from_edges_populates_nodes_and_edges():
+    edge = _edge("node-a", "node-b")
+    subgraph = build_subgraph_stub_from_edges([edge])
+
+    assert len(subgraph["nodes"]) == 2
+    assert {node["id"] for node in subgraph["nodes"]} == {"node-a", "node-b"}
+    assert subgraph["nodes"][0]["type"] == "Entity"
+    assert subgraph["nodes"][0]["name"] == "Marie Curie"
+    assert subgraph["edges"] == [
+        {
+            "source": "node-a",
+            "target": "node-b",
+            "relationship": "discovered",
+            "score": 0.83,
+        }
+    ]
+
+
+def test_build_subgraph_stub_empty_edges():
+    assert build_subgraph_stub_from_edges([]) == {"nodes": [], "edges": []}
+
+
+def test_build_retrieved_subgraph_batch_returns_one_stub_per_query():
+    batch = [
+        [_edge("a1", "b1")],
+        [_edge("a2", "b2", source_name="Ada", target_name="Lovelace")],
+    ]
+    result = build_retrieved_subgraph(batch, SearchType.GRAPH_COMPLETION)
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]["edges"][0]["source"] == "a1"
+    assert result[1]["nodes"][0]["name"] == "Ada"
+
+
+def test_build_retrieved_subgraph_non_graph_search_type_returns_none():
+    assert build_retrieved_subgraph([], SearchType.CHUNKS) is None
+
+
+def test_build_subgraph_stub_edge_endpoints_exist_in_nodes():
+    edge = _edge("node-a", "node-b")
+    subgraph = build_subgraph_stub_from_edges([edge])
+    node_ids = {node["id"] for node in subgraph["nodes"]}
+    for edge_stub in subgraph["edges"]:
+        assert edge_stub["source"] in node_ids
+        assert edge_stub["target"] in node_ids
+
+
+def test_build_retrieved_subgraph_empty_hits_returns_empty_stub_not_error():
+    assert build_retrieved_subgraph([], SearchType.GRAPH_COMPLETION) == {
+        "nodes": [],
+        "edges": [],
+    }
+
+
+def test_supports_subgraph_search_type():
+    assert supports_subgraph_search_type(SearchType.GRAPH_COMPLETION) is True
+    assert supports_subgraph_search_type(SearchType.TEMPORAL) is True
+    assert supports_subgraph_search_type(SearchType.RAG_COMPLETION) is False

--- a/cognee/tests/unit/modules/search/test_include_subgraph_wiring.py
+++ b/cognee/tests/unit/modules/search/test_include_subgraph_wiring.py
@@ -1,0 +1,139 @@
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognee.modules.search.methods.get_retriever_output import get_retriever_output
+from cognee.modules.search.types import SearchType
+from cognee.modules.recall.methods.normalize_search_payload import normalize_search_payload
+from cognee.modules.search.models.SearchResultPayload import SearchResultPayload
+
+
+def test_get_retriever_output_attaches_subgraph_when_requested():
+    edge = MagicMock()
+    edge.node1 = MagicMock(id="n1", attributes={"name": "A", "type": "Entity"})
+    edge.node2 = MagicMock(id="n2", attributes={"name": "B", "type": "Entity"})
+    edge.attributes = {"relationship_name": "rel", "vector_distance": [0.5]}
+
+    retriever = MagicMock()
+    retriever.prepare_session_turn_for_retrieval = AsyncMock(
+        return_value=types.SimpleNamespace(should_answer=True, effective_query="q")
+    )
+    retriever.get_retrieved_objects = AsyncMock(return_value=[edge])
+    retriever.get_context_from_objects = AsyncMock(return_value="ctx")
+    retriever.get_completion_from_context = AsyncMock(return_value="answer")
+
+    async def _run():
+        with (
+            patch(
+                "cognee.modules.search.methods.get_retriever_output.get_search_type_retriever_instance",
+                AsyncMock(return_value=retriever),
+            ),
+            patch(
+                "cognee.modules.search.methods.get_retriever_output.get_graph_engine"
+            ) as graph_engine,
+            patch(
+                "cognee.modules.search.methods.get_retriever_output.update_node_access_timestamps",
+                AsyncMock(),
+            ),
+        ):
+            graph_engine.return_value.is_empty = AsyncMock(return_value=False)
+            return await get_retriever_output(
+                SearchType.GRAPH_COMPLETION,
+                "question",
+                include_subgraph=True,
+            )
+
+    payload = asyncio.run(_run())
+    assert payload.retrieved_subgraph is not None
+    assert payload.retrieved_subgraph["edges"][0]["source"] == "n1"
+    assert payload.retrieved_subgraph["edges"][0]["target"] == "n2"
+
+
+def test_get_retriever_output_omits_subgraph_by_default():
+    retriever = MagicMock()
+    retriever.prepare_session_turn_for_retrieval = AsyncMock(
+        return_value=types.SimpleNamespace(should_answer=True, effective_query="q")
+    )
+    retriever.get_retrieved_objects = AsyncMock(return_value=[])
+    retriever.get_context_from_objects = AsyncMock(return_value="")
+    retriever.get_completion_from_context = AsyncMock(return_value="answer")
+
+    async def _run():
+        with (
+            patch(
+                "cognee.modules.search.methods.get_retriever_output.get_search_type_retriever_instance",
+                AsyncMock(return_value=retriever),
+            ),
+            patch(
+                "cognee.modules.search.methods.get_retriever_output.get_graph_engine"
+            ) as graph_engine,
+            patch(
+                "cognee.modules.search.methods.get_retriever_output.update_node_access_timestamps",
+                AsyncMock(),
+            ),
+        ):
+            graph_engine.return_value.is_empty = AsyncMock(return_value=False)
+            return await get_retriever_output(
+                SearchType.GRAPH_COMPLETION,
+                "question",
+            )
+
+    payload = asyncio.run(_run())
+    assert payload.retrieved_subgraph is None
+
+
+def test_normalize_search_payload_non_graph_include_subgraph_explicit_null():
+    payload = SearchResultPayload(
+        completion="chunk text",
+        search_type=SearchType.CHUNKS,
+        retrieved_subgraph=None,
+    )
+    items = normalize_search_payload(payload, include_subgraph=True)
+    assert len(items) == 1
+    assert items[0].retrieved_subgraph is None
+
+
+def test_normalize_search_payload_default_excludes_subgraph_field():
+    payload = SearchResultPayload(
+        completion="answer",
+        search_type=SearchType.GRAPH_COMPLETION,
+        retrieved_subgraph={"nodes": [], "edges": []},
+    )
+    items = normalize_search_payload(payload, include_subgraph=False)
+    assert "retrieved_subgraph" not in items[0].model_fields_set
+
+
+def test_backwards_compatible_search_results_default_unchanged(search_mod, monkeypatch):
+    monkeypatch.setattr(search_mod, "backend_access_control_enabled", lambda: False)
+    payload = SearchResultPayload(
+        completion="answer",
+        search_type=SearchType.GRAPH_COMPLETION,
+    )
+    out = search_mod._backwards_compatible_search_results([payload], verbose=False)
+    out_with_flag = search_mod._backwards_compatible_search_results(
+        [payload], verbose=False, include_subgraph=False
+    )
+    assert out == out_with_flag
+    assert "retrieved_subgraph" not in (out if isinstance(out, dict) else {})
+
+
+def test_backwards_compatible_search_results_wraps_when_subgraph_requested(search_mod, monkeypatch):
+    monkeypatch.setattr(search_mod, "backend_access_control_enabled", lambda: False)
+    payload = SearchResultPayload(
+        completion="answer",
+        search_type=SearchType.GRAPH_COMPLETION,
+        retrieved_subgraph={"nodes": [], "edges": []},
+    )
+    out = search_mod._backwards_compatible_search_results(
+        [payload], verbose=False, include_subgraph=True
+    )
+    assert out == {"search_result": "answer", "retrieved_subgraph": {"nodes": [], "edges": []}}
+
+
+@pytest.fixture
+def search_mod():
+    import importlib
+
+    return importlib.import_module("cognee.modules.search.methods.search")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Closes #3701 

Adds opt-in `include_subgraph` to `cognee.search()`, `cognee.recall()`, and `POST /v1/search` / `POST /v1/recall`. 

When enabled, graph-based search types return a lightweight `retrieved_subgraph` stub (`{nodes, edges}`) built from retrieval results already in memory. This means that there will be no extra graph traversal, DB, or LLM calls.

Default is `False` everywhere, so existing callers are unchanged.


## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->
- [x] `include_subgraph=False` (default) → existing response shape unchanged
- [x] `GRAPH_COMPLETION` family + `TEMPORAL` + `AGENTIC_COMPLETION` + `include_subgraph=True` → populated stub; every edge `source`/`target` exists in `nodes`
- [x] Empty / no hits → `{"nodes": [], "edges": []}`, not an error
- [x] `query_batch` → one subgraph per query
- [x] Non-graph types (`CHUNKS`, `RAG_COMPLETION`, etc.) → `retrieved_subgraph: null`
- [x] `recall()` mirrors `search()` for the same flag
- [x] OTEL: `subgraph_node_count` / `subgraph_edge_count` on retrieval span


## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->
N/A — API/behavior change covered by unit tests.
Local tests run:
pytest cognee/tests/unit/modules/retrieval/test_build_subgraph_stub.py
cognee/tests/unit/modules/search/test_include_subgraph_wiring.py
cognee/tests/unit/modules/retrieval/test_used_graph_elements.py
cognee/tests/unit/modules/recall/test_normalize_search_payload.py
cognee/tests/unit/modules/search/test_search.py -q

50 passed

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
