### PR TITLE
feat: detect contradictions between new and existing graph facts

### DIFF
--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -27,6 +27,9 @@ from cognee.tasks.documents import (
     extract_chunks_from_documents,
 )
 from cognee.tasks.graph.extract_graph_and_summarize import extract_graph_and_summarize
+from cognee.tasks.graph.detect_contradictions import (
+    detect_contradictions as detect_contradictions_task,
+)
 from cognee.tasks.storage import add_data_points
 from cognee.tasks.ingestion.extract_dlt_fk_edges import extract_dlt_fk_edges
 from cognee.modules.pipelines.layers.pipeline_execution_mode import get_pipeline_executor
@@ -54,6 +57,7 @@ async def cognify(
     incremental_loading: bool = True,
     custom_prompt: Optional[str] = None,
     temporal_cognify: bool = False,
+    detect_contradictions: bool = False,
     data_per_batch: int = 20,
     llm_config: Optional[LLMConfig] = None,
     embedding_config: Optional[EmbeddingConfig] = None,
@@ -122,6 +126,11 @@ async def cognify(
                       If provided, this prompt will be used instead of the default prompts for
                       knowledge graph extraction. The prompt should guide the LLM on how to
                       extract entities and relationships from the text content.
+        detect_contradictions: If True, after the graph is built, compare the newly ingested
+                      facts against the facts already stored in the graph and flag any
+                      contradictions. Each contradiction is logged and recorded as a
+                      "contradicts" edge (with the reason and both facts) so it can be
+                      reviewed instead of silently coexisting. Defaults to False.
 
     Returns:
         Union[dict, list[PipelineRunInfo]]:
@@ -255,6 +264,7 @@ async def cognify(
                 config=config,
                 custom_prompt=custom_prompt,
                 chunks_per_batch=chunks_per_batch,
+                detect_contradictions=detect_contradictions,
                 **kwargs,
             )
 
@@ -295,6 +305,7 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
     config: Config = None,
     custom_prompt: Optional[str] = None,
     chunks_per_batch: int = None,
+    detect_contradictions: bool = False,
     **kwargs,
 ) -> list[Task]:
     if config is None:
@@ -349,6 +360,14 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
         ),
         Task(extract_dlt_fk_edges),
     ]
+
+    # OPTIONAL: flag facts in this ingestion that contradict facts already in the graph.
+    # Runs last so both new and existing facts are persisted and comparable; disabled by
+    # default to preserve existing behaviour.
+    if detect_contradictions:
+        default_tasks.append(
+            Task(detect_contradictions_task, task_config={"batch_size": chunks_per_batch})
+        )
 
     return default_tasks
 

--- a/cognee/infrastructure/llm/prompts/detect_contradictions_system.txt
+++ b/cognee/infrastructure/llm/prompts/detect_contradictions_system.txt
@@ -1,0 +1,28 @@
+You are a contradiction detection system for a knowledge graph (the "brain").
+
+You are given a set of facts drawn from the graph. These facts are connected to information
+that was just ingested, so some of them are new and some were already stored. Each fact is
+written as a simple subject-relationship-object statement and is prefixed with a unique
+identifier in square brackets (for example [F0] or [F3]).
+
+Your task is to identify pairs of facts that directly contradict each other.
+
+Two facts contradict each other only when they cannot both be true at the same time about the
+same subject. Typical cases are mutually exclusive values, direct negations, or logically
+incompatible statements.
+
+Do NOT report:
+- facts that are merely different but compatible (for example additional, unrelated information),
+- facts that are a more or less specific version of one another but still consistent,
+- duplicates or paraphrases of the same fact.
+
+For every genuine contradiction you find, report:
+- first_fact_id: the identifier of the first conflicting fact (for example "F0").
+- second_fact_id: the identifier of the second conflicting fact (for example "F3").
+- first_fact: the text of the first conflicting fact.
+- second_fact: the text of the second conflicting fact.
+- reason: a short explanation of why the two facts are incompatible.
+- confidence: your confidence that this is a genuine contradiction, from 0.0 to 1.0.
+
+Only use identifiers that appear in the provided facts, and never pair a fact with itself. If
+there are no contradictions, return an empty list.

--- a/cognee/infrastructure/llm/prompts/detect_contradictions_user.txt
+++ b/cognee/infrastructure/llm/prompts/detect_contradictions_user.txt
@@ -1,0 +1,4 @@
+Facts:
+{{ facts }}
+
+Identify the pairs of facts that contradict each other.

--- a/cognee/tasks/graph/__init__.py
+++ b/cognee/tasks/graph/__init__.py
@@ -7,3 +7,4 @@ building relationships between entities, and managing graph structures.
 
 from .extract_graph_from_data import extract_graph_from_data
 from .extract_graph_from_code import extract_graph_from_code
+from .detect_contradictions import detect_contradictions

--- a/cognee/tasks/graph/detect_contradictions.py
+++ b/cognee/tasks/graph/detect_contradictions.py
@@ -1,0 +1,260 @@
+"""Contradiction detection task for the knowledge graph (the "brain").
+
+As data accumulates, the graph can end up holding facts that conflict with one another with
+no built-in way to surface those conflicts. This task compares the facts that were just
+ingested during a cognify run — together with the facts already connected to the entities
+they touch — and asks an LLM to flag statements that directly contradict each other (for
+example a fact that negates or is incompatible with a stored one).
+
+Detected contradictions are surfaced in two ways rather than silently coexisting:
+  * a warning is logged for every contradiction, exposing both conflicting facts and the
+    reason they conflict;
+  * a ``contradicts`` edge (carrying the same information as properties) is written into
+    the graph, so the conflict is queryable and visible alongside the data it concerns.
+
+The task is intentionally non-destructive: it never removes or rewrites existing data and
+always returns its input unchanged so it can be appended to a pipeline without affecting
+downstream tasks. Any failure while detecting contradictions is logged and swallowed so it
+can never break ingestion.
+
+Why the "touched neighbourhood" is compared instead of a strict new-vs-existing split:
+entity node ids are deterministic (``Entity:<name>``), so when an entity is re-mentioned by
+new data its id is indistinguishable from the pre-existing one. A conflicting new fact and
+the stored fact it contradicts therefore share a subject that belongs to this ingestion.
+Collecting every fact connected to a newly touched entity guarantees both sides of such a
+contradiction are compared together, while still bounding the work to the region of the
+graph the ingestion actually affected.
+"""
+
+from typing import Dict, List, Optional, Set, Tuple
+
+from pydantic import BaseModel, Field
+
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.llm import LLMGateway
+from cognee.infrastructure.llm.prompts import read_query_prompt, render_prompt
+from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
+from cognee.modules.pipelines.tasks.task import task_summary
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("detect_contradictions")
+
+# Relationship names that describe graph structure rather than semantic facts. Edges of
+# these types are skipped when building the list of facts to compare.
+STRUCTURAL_RELATIONSHIPS = frozenset(
+    {"contains", "is_part_of", "made_from", "exists_in", "contradicts"}
+)
+
+
+class Contradiction(BaseModel):
+    """A single contradiction between two facts in the graph."""
+
+    first_fact_id: str = Field(description="Identifier of the first conflicting fact, e.g. 'F0'.")
+    second_fact_id: str = Field(description="Identifier of the second conflicting fact, e.g. 'F3'.")
+    first_fact: str = Field(description="Text of the first conflicting fact.")
+    second_fact: str = Field(description="Text of the second conflicting fact.")
+    reason: str = Field(description="Why the two facts are incompatible.")
+    confidence: float = Field(
+        ge=0.0, le=1.0, description="Confidence that this is a genuine contradiction."
+    )
+
+
+class ContradictionList(BaseModel):
+    """LLM-structured output: the list of detected contradictions (possibly empty)."""
+
+    contradictions: List[Contradiction] = Field(default_factory=list)
+
+
+def _collect_touched_node_ids(data_chunks: List[DocumentChunk]) -> Set[str]:
+    """Collect the ids of the entity/event nodes produced by the current ingestion."""
+    touched_ids: Set[str] = set()
+    for chunk in data_chunks:
+        contains = getattr(chunk, "contains", None) or []
+        for item in contains:
+            # ``contains`` items are Entity/Event data points or (Edge, Entity) tuples.
+            entity = item[1] if isinstance(item, tuple) else item
+            node_id = getattr(entity, "id", None)
+            if node_id is not None:
+                touched_ids.add(str(node_id))
+    return touched_ids
+
+
+def _node_names(nodes) -> Dict[str, str]:
+    """Map node id -> display name for nodes that carry a non-empty name."""
+    names: Dict[str, str] = {}
+    for node_id, properties in nodes:
+        name = (properties or {}).get("name") or ""
+        if name:
+            names[str(node_id)] = name
+    return names
+
+
+def _build_candidate_facts(
+    edges,
+    node_names: Dict[str, str],
+    touched_node_ids: Set[str],
+    limit: int,
+) -> Tuple[List[str], Dict[str, Tuple[str, str]]]:
+    """Render the facts connected to the touched entities into readable statements.
+
+    Only edges that touch at least one newly ingested entity are considered, and both
+    endpoints must be named (which naturally excludes structural nodes such as chunks and
+    documents).
+
+    Args:
+        edges: ``(source_id, target_id, relationship_name, properties)`` tuples.
+        node_names: Mapping of node id to display name.
+        touched_node_ids: Ids of nodes created or re-mentioned by the current ingestion.
+        limit: Maximum number of facts to emit.
+
+    Returns:
+        A tuple of (rendered fact lines, mapping of fact id -> (source_id, target_id)).
+    """
+    lines: List[str] = []
+    edge_by_id: Dict[str, Tuple[str, str]] = {}
+    index = 0
+    for source_id, target_id, relationship_name, _ in edges:
+        if relationship_name in STRUCTURAL_RELATIONSHIPS:
+            continue
+
+        source_id, target_id = str(source_id), str(target_id)
+        if source_id not in touched_node_ids and target_id not in touched_node_ids:
+            continue
+
+        source_name = node_names.get(source_id)
+        target_name = node_names.get(target_id)
+        if not source_name or not target_name:
+            continue
+
+        fact_id = f"F{index}"
+        readable_relationship = str(relationship_name).replace("_", " ")
+        lines.append(f"[{fact_id}] {source_name} {readable_relationship} {target_name}")
+        edge_by_id[fact_id] = (source_id, target_id)
+        index += 1
+
+        if index >= limit:
+            logger.info(
+                "Contradiction detection reached the fact limit (%s); "
+                "some facts were not compared.",
+                limit,
+            )
+            break
+
+    return lines, edge_by_id
+
+
+def _contradiction_endpoints(
+    first_edge: Tuple[str, str], second_edge: Tuple[str, str]
+) -> Optional[Tuple[str, str]]:
+    """Choose the two nodes to link with a ``contradicts`` edge.
+
+    Prefer connecting the differing subjects; when both facts share the same subject the
+    disagreement is between the objects, so connect those instead. Returns ``None`` when the
+    two facts reference exactly the same pair of nodes (nothing meaningful to link).
+    """
+    first_source, first_target = first_edge
+    second_source, second_target = second_edge
+    if first_source != second_source:
+        return first_source, second_source
+    if first_target != second_target:
+        return first_target, second_target
+    return None
+
+
+@task_summary("Checked {n} chunk(s) for contradictions")
+async def detect_contradictions(
+    data_chunks: List[DocumentChunk],
+    confidence_threshold: float = 0.5,
+    max_facts: int = 500,
+    **kwargs,
+) -> List[DocumentChunk]:
+    """Flag facts touched by the current ingestion that contradict each other.
+
+    Args:
+        data_chunks: The document chunks processed by the current cognify run. Their
+            extracted entities identify which region of the graph to inspect.
+        confidence_threshold: Minimum LLM confidence for a contradiction to be flagged.
+        max_facts: Cap on the number of facts sent to the LLM in a single check.
+
+    Returns:
+        The unchanged ``data_chunks`` list, so the task can be appended to a pipeline.
+    """
+    if not isinstance(data_chunks, list) or not data_chunks:
+        return data_chunks
+
+    try:
+        touched_node_ids = _collect_touched_node_ids(data_chunks)
+        if not touched_node_ids:
+            return data_chunks
+
+        graph_engine = await get_graph_engine()
+        nodes, edges = await graph_engine.get_graph_data()
+        node_names = _node_names(nodes)
+
+        facts, edge_by_id = _build_candidate_facts(
+            edges, node_names, touched_node_ids, limit=max_facts
+        )
+
+        # At least two facts are needed for a contradiction to be possible.
+        if len(facts) < 2:
+            return data_chunks
+
+        user_prompt = render_prompt("detect_contradictions_user.txt", {"facts": "\n".join(facts)})
+        system_prompt = read_query_prompt("detect_contradictions_system.txt")
+
+        result = await LLMGateway.acreate_structured_output(
+            text_input=user_prompt,
+            system_prompt=system_prompt,
+            response_model=ContradictionList,
+        )
+
+        contradiction_edges = []
+        for contradiction in result.contradictions:
+            if contradiction.confidence < confidence_threshold:
+                continue
+
+            logger.warning(
+                "Contradiction detected (confidence %.2f): '%s' contradicts '%s' — %s",
+                contradiction.confidence,
+                contradiction.first_fact,
+                contradiction.second_fact,
+                contradiction.reason,
+            )
+
+            first_edge = edge_by_id.get(contradiction.first_fact_id)
+            second_edge = edge_by_id.get(contradiction.second_fact_id)
+            if first_edge is None or second_edge is None:
+                # The model referenced an id we did not provide; the warning above still
+                # surfaces the contradiction, we just cannot anchor it in the graph.
+                continue
+
+            endpoints = _contradiction_endpoints(first_edge, second_edge)
+            if endpoints is None:
+                continue
+
+            source_id, target_id = endpoints
+            contradiction_edges.append(
+                (
+                    source_id,
+                    target_id,
+                    "contradicts",
+                    {
+                        "relationship_name": "contradicts",
+                        "source_node_id": source_id,
+                        "target_node_id": target_id,
+                        "first_fact": contradiction.first_fact,
+                        "second_fact": contradiction.second_fact,
+                        "reason": contradiction.reason,
+                        "confidence": contradiction.confidence,
+                    },
+                )
+            )
+
+        if contradiction_edges:
+            await graph_engine.add_edges(contradiction_edges)
+            logger.info("Flagged %s contradiction(s) in the graph.", len(contradiction_edges))
+    except Exception as error:
+        # Contradiction detection is auxiliary and must never break ingestion.
+        logger.warning("Contradiction detection skipped due to an error: %s", error)
+
+    return data_chunks

--- a/cognee/tests/unit/tasks/graph/test_detect_contradictions.py
+++ b/cognee/tests/unit/tasks/graph/test_detect_contradictions.py
@@ -1,0 +1,220 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognee.tasks.graph.detect_contradictions import (
+    Contradiction,
+    ContradictionList,
+    _build_candidate_facts,
+    _collect_touched_node_ids,
+    _contradiction_endpoints,
+    _node_names,
+    detect_contradictions,
+)
+
+dc_module = importlib.import_module("cognee.tasks.graph.detect_contradictions")
+
+
+def _entity(node_id):
+    return SimpleNamespace(id=node_id)
+
+
+def _chunk(contains):
+    return SimpleNamespace(contains=contains)
+
+
+# Alice was born in 1985 (stored) but the new data claims 1990.
+NODES = [
+    ("alice", {"name": "Alice", "type": "Person"}),
+    ("1985", {"name": "1985", "type": "Year"}),
+    ("1990", {"name": "1990", "type": "Year"}),
+    ("bob", {"name": "Bob", "type": "Person"}),
+    ("chunk-1", {"type": "DocumentChunk"}),  # unnamed structural node
+]
+
+EDGES = [
+    ("alice", "1985", "born_in", {}),
+    ("alice", "1990", "born_in", {}),
+    ("bob", "1985", "born_in", {}),  # untouched fact (neither endpoint touched)
+    ("chunk-1", "alice", "contains", {}),  # structural edge, must be ignored
+]
+
+
+def _mock_graph_engine():
+    engine = MagicMock()
+    engine.get_graph_data = AsyncMock(return_value=(NODES, EDGES))
+    engine.add_edges = AsyncMock()
+    return engine
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def test_collect_touched_node_ids_handles_entities_and_tuples():
+    chunk = _chunk([_entity("alice"), (MagicMock(), _entity("1990"))])
+    assert _collect_touched_node_ids([chunk]) == {"alice", "1990"}
+
+
+def test_collect_touched_node_ids_ignores_missing_contains():
+    assert _collect_touched_node_ids([SimpleNamespace(contains=None)]) == set()
+
+
+def test_node_names_skips_unnamed_nodes():
+    names = _node_names(NODES)
+    assert names["alice"] == "Alice"
+    assert "chunk-1" not in names
+
+
+def test_build_candidate_facts_filters_to_touched_named_edges():
+    names = _node_names(NODES)
+    lines, edge_by_id = _build_candidate_facts(EDGES, names, {"alice", "1990"}, limit=500)
+
+    # Both Alice facts are kept; the Bob fact (untouched) and the structural edge are dropped.
+    assert len(lines) == 2
+    assert edge_by_id["F0"] == ("alice", "1985")
+    assert edge_by_id["F1"] == ("alice", "1990")
+    assert "Alice born in 1985" in lines[0]
+
+
+def test_build_candidate_facts_respects_limit():
+    names = _node_names(NODES)
+    lines, _ = _build_candidate_facts(EDGES, names, {"alice"}, limit=1)
+    assert len(lines) == 1
+
+
+def test_contradiction_endpoints_prefers_differing_objects_when_subject_shared():
+    assert _contradiction_endpoints(("alice", "1985"), ("alice", "1990")) == ("1985", "1990")
+
+
+def test_contradiction_endpoints_uses_subjects_when_they_differ():
+    assert _contradiction_endpoints(("alice", "x"), ("bob", "x")) == ("alice", "bob")
+
+
+def test_contradiction_endpoints_none_for_identical_edge():
+    assert _contradiction_endpoints(("alice", "1985"), ("alice", "1985")) is None
+
+
+# --------------------------------------------------------------------------- task
+
+
+@pytest.mark.asyncio
+async def test_returns_input_when_no_data_chunks():
+    assert await detect_contradictions([]) == []
+
+
+@pytest.mark.asyncio
+async def test_returns_early_when_nothing_touched():
+    chunks = [SimpleNamespace(contains=[])]
+    with patch.object(dc_module, "get_graph_engine", new_callable=AsyncMock) as mock_engine:
+        result = await detect_contradictions(chunks)
+    assert result is chunks
+    mock_engine.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flags_contradiction_as_graph_edge():
+    chunks = [_chunk([_entity("alice"), _entity("1990")])]
+    engine = _mock_graph_engine()
+
+    llm_result = ContradictionList(
+        contradictions=[
+            Contradiction(
+                first_fact_id="F0",
+                second_fact_id="F1",
+                first_fact="Alice born in 1985",
+                second_fact="Alice born in 1990",
+                reason="A person has a single birth year.",
+                confidence=0.95,
+            )
+        ]
+    )
+
+    with (
+        patch.object(dc_module, "get_graph_engine", new_callable=AsyncMock, return_value=engine),
+        patch.object(
+            dc_module.LLMGateway,
+            "acreate_structured_output",
+            new_callable=AsyncMock,
+            return_value=llm_result,
+        ),
+    ):
+        result = await detect_contradictions(chunks)
+
+    assert result == chunks  # non-destructive pass-through
+    engine.add_edges.assert_awaited_once()
+    added_edges = engine.add_edges.await_args.args[0]
+    assert len(added_edges) == 1
+    source, target, relationship, properties = added_edges[0]
+    # Shared subject (Alice) -> the disagreement is between the objects.
+    assert {source, target} == {"1985", "1990"}
+    assert relationship == "contradicts"
+    assert properties["reason"] == "A person has a single birth year."
+    assert properties["first_fact"] == "Alice born in 1985"
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_contradiction_is_not_flagged():
+    chunks = [_chunk([_entity("alice"), _entity("1990")])]
+    engine = _mock_graph_engine()
+
+    llm_result = ContradictionList(
+        contradictions=[
+            Contradiction(
+                first_fact_id="F0",
+                second_fact_id="F1",
+                first_fact="Alice born in 1985",
+                second_fact="Alice born in 1990",
+                reason="Maybe.",
+                confidence=0.2,
+            )
+        ]
+    )
+
+    with (
+        patch.object(dc_module, "get_graph_engine", new_callable=AsyncMock, return_value=engine),
+        patch.object(
+            dc_module.LLMGateway,
+            "acreate_structured_output",
+            new_callable=AsyncMock,
+            return_value=llm_result,
+        ),
+    ):
+        await detect_contradictions(chunks, confidence_threshold=0.5)
+
+    engine.add_edges.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_contradictions_does_not_write_edges():
+    chunks = [_chunk([_entity("alice"), _entity("1990")])]
+    engine = _mock_graph_engine()
+
+    with (
+        patch.object(dc_module, "get_graph_engine", new_callable=AsyncMock, return_value=engine),
+        patch.object(
+            dc_module.LLMGateway,
+            "acreate_structured_output",
+            new_callable=AsyncMock,
+            return_value=ContradictionList(contradictions=[]),
+        ),
+    ):
+        await detect_contradictions(chunks)
+
+    engine.add_edges.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_errors_are_swallowed_and_input_returned():
+    chunks = [_chunk([_entity("alice"), _entity("1990")])]
+
+    with patch.object(
+        dc_module,
+        "get_graph_engine",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("graph down"),
+    ):
+        result = await detect_contradictions(chunks)
+
+    assert result == chunks


### PR DESCRIPTION
## Summary

Closes #3699.

The brain currently stores knowledge without any consistency check, so facts that conflict
with each other silently coexist in the graph. This PR adds the ability to **detect
contradictions between newly ingested facts and existing ones, and flag them** instead of
storing them silently.

After the knowledge graph is built, a new **opt-in** `detect_contradictions` step:

1. Collects the entities/events touched by the current ingestion.
2. Renders every fact connected to them (`subject relationship object`) with stable ids.
3. Asks the LLM (structured `ContradictionList` output) to identify pairs of facts that
   directly contradict each other, with a reason and a confidence score.
4. **Surfaces** each contradiction in two ways:
   - logs a warning exposing both facts and the reason;
   - writes a `contradicts` edge into the graph carrying `first_fact`, `second_fact`,
     `reason`, and `confidence`, so the conflict is queryable and visible next to the data.

### Acceptance criteria

- ✅ The brain can detect contradictions between new and existing data.
- ✅ Detected contradictions are flagged/surfaced (log + `contradicts` edge) rather than
  stored silently.
- ✅ Both conflicting facts **and** the reason they conflict are exposed.

## Usage

```python
import cognee

await cognee.add("Alice was born in 1985.")
await cognee.cognify()

await cognee.add("Alice was born in 1990.")
await cognee.cognify(detect_contradictions=True)   # opt-in
# -> logs a warning and adds a `contradicts` edge with the reason
```

## Design notes

- **Opt-in and backward compatible.** `cognify(detect_contradictions=False)` by default;
  no change to existing behaviour.
- **Non-destructive & fail-safe.** The task never rewrites/deletes data, returns its input
  unchanged, and swallows any error so contradiction detection can never break ingestion.
- **"Touched neighbourhood" comparison.** Entity ids are deterministic (`Entity:<name>`),
  so a re-mentioned entity's id is identical to the stored one. Comparing every fact
  connected to a newly touched entity guarantees both sides of a contradiction are compared
  together, while bounding the work (with a `max_facts` cap and per-batch execution).
- **Reuses existing infrastructure** only: `Task`, `LLMGateway.acreate_structured_output`,
  `render_prompt` / `read_query_prompt`, `get_graph_engine`. No new dependencies.

## Files changed

| File | Change |
|------|--------|
| `cognee/tasks/graph/detect_contradictions.py` | New task, models, and helpers |
| `cognee/infrastructure/llm/prompts/detect_contradictions_system.txt` | New system prompt |
| `cognee/infrastructure/llm/prompts/detect_contradictions_user.txt` | New user prompt |
| `cognee/tasks/graph/__init__.py` | Export the new task |
| `cognee/api/v1/cognify/cognify.py` | Opt-in `detect_contradictions` param, wired last |
| `cognee/tests/unit/tasks/graph/test_detect_contradictions.py` | 14 unit tests |

## Testing

- 14/14 new unit tests pass: `pytest cognee/tests/unit/tasks/graph/test_detect_contradictions.py`
- No regressions in surrounding graph/cognify unit suites.
- `ruff check` and `ruff format` clean; pre-commit hooks pass.
- Manual end-to-end run confirms the `contradicts` edge and warning are produced.

_Screenshots of unit tests passing and the end-to-end run are attached below._
<img width="1920" height="1080" alt="1" src="https://github.com/user-attachments/assets/aa600a00-6858-4df0-bff1-74883330278e" />


## Future improvements

- Vector-similarity candidate selection instead of the neighbourhood cap for large graphs.
- A dedicated search type / API to list flagged contradictions.
- Optional resolution strategies (keep-latest, mark-uncertain, etc.).

---

I affirm that all code in every commit of this pull request conforms to the terms of the
Topoteretes Developer Certificate of Origin.
