### PR TITLE
fix: handle small truncate limits

### DIFF
--- a/cognee/modules/agent_memory/sanitization.py
+++ b/cognee/modules/agent_memory/sanitization.py
@@ -11,6 +11,10 @@ def truncate_text(value: str, limit: int) -> str:
     """Bound stored trace strings so unusually large params/returns do not create oversized trace payloads."""
     if len(value) <= limit:
         return value
+    if limit <= 0:
+        return ""
+    if limit < 3:
+        return value[:limit]
     return value[: limit - 3] + "..."
 
 

--- a/cognee/tests/unit/modules/agent_memory/test_agent_memory.py
+++ b/cognee/tests/unit/modules/agent_memory/test_agent_memory.py
@@ -18,6 +18,7 @@ from cognee.modules.agent_memory.runtime import (
     retrieve_memory_context,
     set_current_agent_memory_context,
 )
+from cognee.modules.agent_memory.sanitization import truncate_text
 
 
 def _make_user():
@@ -256,6 +257,22 @@ async def test_agent_memory_with_session_memory_resolves_user_but_not_dataset_sc
     resolve_user.assert_awaited_once()
     resolve_scope.assert_not_awaited()
     retrieve_memory.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("limit", "expected"),
+    [
+        (0, ""),
+        (1, "a"),
+        (2, "ab"),
+        (3, "..."),
+    ],
+)
+def test_truncate_text_keeps_small_limits_within_bounds(limit, expected):
+    value = "abcdef"
+
+    assert truncate_text(value, limit) == expected
+    assert len(truncate_text(value, limit)) <= limit
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Adds a guard for truncate_text when limit is less than 3 so the helper never produces output longer than the requested limit.

## Acceptance Criteria
- Text truncation handles small limits correctly.
- Added a regression test covering small limits.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
All unit tests passed successfully.

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue or feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

fixes #3734
