### PR TITLE
fix: align neo4j retry limits

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
@@ -10,7 +10,7 @@ logger = get_logger("deadlock_retry")
 
 def deadlock_retry(max_retries=10):
     """
-    Decorator that automatically retries an asynchronous function when rate limit errors occur.
+    Decorator that automatically retries an asynchronous function on transient Neo4j errors.
 
     This decorator implements an exponential backoff strategy with jitter
     to handle rate limit errors efficiently.
@@ -54,7 +54,7 @@ def deadlock_retry(max_retries=10):
                     else:
                         raise  # Re-raise the original error
                 except DatabaseUnavailable:
-                    if attempt >= max_retries:
+                    if attempt > max_retries:
                         raise  # Re-raise the original error
 
                     await wait()

--- a/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
@@ -10,16 +10,10 @@ logger = get_logger("deadlock_retry")
 
 def deadlock_retry(max_retries=10):
     """
-    Decorator that automatically retries an asynchronous function on transient Neo4j errors.
-
-    This decorator implements an exponential backoff strategy with jitter
-    to handle rate limit errors efficiently.
+    Decorator that automatically retries an asynchronous function on transient Neo4j errors or database unavailability.
 
     Args:
         max_retries: Maximum number of retry attempts.
-        initial_backoff: Initial backoff time in seconds.
-        backoff_factor: Multiplier for exponential backoff.
-        jitter: Jitter factor to avoid the thundering herd problem.
 
     Returns:
         The decorated async function.
@@ -35,8 +29,8 @@ def deadlock_retry(max_retries=10):
             async def wait():
                 backoff_time = calculate_backoff(attempt)
                 logger.warning(
-                    f"Neo4j rate limit hit, retrying in {backoff_time:.2f}s "
-                    f"Attempt {attempt}/{max_retries}"
+                    f"Neo4j transient error or database unavailable, retrying in {backoff_time:.2f}s "
+                    f"Attempt {attempt} of {max_retries}"
                 )
                 await asyncio.sleep(backoff_time)
 

--- a/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
@@ -1,7 +1,28 @@
 import pytest
 import asyncio
-from unittest.mock import MagicMock
-from neo4j.exceptions import Neo4jError
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+try:
+    from neo4j.exceptions import DatabaseUnavailable, Neo4jError
+except ModuleNotFoundError:
+    class Neo4jError(Exception):
+        pass
+
+
+    class DatabaseUnavailable(Exception):
+        pass
+
+
+    neo4j_module = types.ModuleType("neo4j")
+    exceptions_module = types.ModuleType("neo4j.exceptions")
+    exceptions_module.DatabaseUnavailable = DatabaseUnavailable
+    exceptions_module.Neo4jError = Neo4jError
+    neo4j_module.exceptions = exceptions_module
+    sys.modules.setdefault("neo4j", neo4j_module)
+    sys.modules["neo4j.exceptions"] = exceptions_module
+
 from cognee.infrastructure.databases.graph.neo4j_driver.deadlock_retry import deadlock_retry
 
 
@@ -43,6 +64,23 @@ async def test_deadlock_retry_exhaustive():
 
     result = await wrapped_function(self=None)
     assert result, "Function should have succeded on second time"
+
+
+@pytest.mark.asyncio
+async def test_deadlock_retry_allows_database_unavailable_retry(monkeypatch):
+    mock_return = asyncio.Future()
+    mock_return.set_result(True)
+    mock_function = MagicMock(side_effect=[DatabaseUnavailable("temporary outage"), mock_return])
+
+    wrapped_function = deadlock_retry(max_retries=1)(mock_function)
+
+    monkeypatch.setattr(
+        "cognee.infrastructure.databases.graph.neo4j_driver.deadlock_retry.asyncio.sleep",
+        AsyncMock(),
+    )
+
+    result = await wrapped_function(self=None)
+    assert result, "Function should succeed after one DatabaseUnavailable retry"
 
 
 if __name__ == "__main__":

--- a/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
@@ -15,13 +15,16 @@ except ModuleNotFoundError:
         pass
 
 
-    neo4j_module = types.ModuleType("neo4j")
-    exceptions_module = types.ModuleType("neo4j.exceptions")
-    exceptions_module.DatabaseUnavailable = DatabaseUnavailable
-    exceptions_module.Neo4jError = Neo4jError
-    neo4j_module.exceptions = exceptions_module
-    sys.modules.setdefault("neo4j", neo4j_module)
-    sys.modules["neo4j.exceptions"] = exceptions_module
+@pytest.fixture(autouse=True)
+def stub_neo4j_modules(monkeypatch):
+    if "neo4j" not in sys.modules:
+        neo4j_module = types.ModuleType("neo4j")
+        exceptions_module = types.ModuleType("neo4j.exceptions")
+        exceptions_module.DatabaseUnavailable = DatabaseUnavailable
+        exceptions_module.Neo4jError = Neo4jError
+        neo4j_module.exceptions = exceptions_module
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_module)
+        monkeypatch.setitem(sys.modules, "neo4j.exceptions", exceptions_module)
 
 from cognee.infrastructure.databases.graph.neo4j_driver.deadlock_retry import deadlock_retry
 


### PR DESCRIPTION
## Description
Normalizes the retry limit check so DatabaseUnavailable follows the same max_retries behavior as deadlock and transient Neo4j errors.

## Acceptance Criteria
- DatabaseUnavailable checks follow maximum retry limits consistently.
- Added a regression test for the retry path.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
All unit tests passed successfully.

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue or feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

fixes #3757
