### PR TITLE
fix: restore database exception init

### DIFF
--- a/cognee/infrastructure/databases/exceptions/exceptions.py
+++ b/cognee/infrastructure/databases/exceptions/exceptions.py
@@ -43,10 +43,7 @@ class EntityNotFoundError(CogneeValidationError):
         name: str = "EntityNotFoundError",
         status_code=status.HTTP_404_NOT_FOUND,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
-        # super().__init__(message, name, status_code) :TODO: This is not an error anymore with the dynamic exception handling therefore we shouldn't log error
+        super().__init__(message, name, status_code)
 
 
 class EntityAlreadyExistsError(CogneeValidationError):
@@ -81,9 +78,7 @@ class NodesetFilterNotSupportedError(CogneeConfigurationError):
         name: str = "NodeSetFilterNotSupportedError",
         status_code=status.HTTP_404_NOT_FOUND,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
+        super().__init__(message, name, status_code)
 
 
 class EmbeddingException(CogneeConfigurationError):

--- a/cognee/tests/unit/infrastructure/databases/exceptions/test_exceptions.py
+++ b/cognee/tests/unit/infrastructure/databases/exceptions/test_exceptions.py
@@ -1,0 +1,22 @@
+from cognee.infrastructure.databases.exceptions.exceptions import (
+    EntityNotFoundError,
+    NodesetFilterNotSupportedError,
+)
+
+
+def test_entity_not_found_error_initializes_base_exception_state():
+    error = EntityNotFoundError()
+
+    assert error.message == "The requested entity does not exist."
+    assert error.name == "EntityNotFoundError"
+    assert error.status_code == 404
+    assert error.args == (error.message, error.name)
+
+
+def test_nodeset_filter_not_supported_error_initializes_base_exception_state():
+    error = NodesetFilterNotSupportedError()
+
+    assert error.message == "The nodeset filter is not supported in the current graph database."
+    assert error.name == "NodeSetFilterNotSupportedError"
+    assert error.status_code == 404
+    assert error.args == (error.message, error.name)


### PR DESCRIPTION
## Description
Restores the shared exception initialization for EntityNotFoundError and NodesetFilterNotSupportedError so they populate the base exception args.

## Acceptance Criteria
- Inherited exception arguments are properly populated.
- Added a regression test verifying the inherited args tuple.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
All unit tests passed successfully.

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue or feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

fixes #3749
