### PR TITLE
fix: re-export llmconfig from api config

### DIFF
--- a/cognee/api/v1/config/__init__.py
+++ b/cognee/api/v1/config/__init__.py
@@ -1,1 +1,5 @@
+from cognee.infrastructure.llm.config import LLMConfig
+
 from .config import config
+
+__all__ = ["LLMConfig", "config"]

--- a/cognee/tests/unit/api/v1/config/test_llmconfig_export.py
+++ b/cognee/tests/unit/api/v1/config/test_llmconfig_export.py
@@ -1,0 +1,6 @@
+from cognee.api.v1.config import LLMConfig
+from cognee.infrastructure.llm.config import LLMConfig as InfrastructureLLMConfig
+
+
+def test_llmconfig_is_reexported_from_public_api_package():
+    assert LLMConfig is InfrastructureLLMConfig


### PR DESCRIPTION
## Description
Re-exports LLMConfig from the public config package so the public export path works as expected.

## Acceptance Criteria
- LLMConfig is importable from the public config package.
- Added a regression test asserting the public export is the same class as the infrastructure LLMConfig.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots
All unit tests passed successfully.

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue or feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

fixes #3774
