### PR TITLE
feat(bots): embeddable web chat widget powered by cognee memory (#3612)

### DIFF
--- a/cognee/tests/unit/bots/test_web_widget_bot.py
+++ b/cognee/tests/unit/bots/test_web_widget_bot.py
@@ -1,0 +1,163 @@
+"""Deterministic, mocked tests for the web-widget chat-memory adapter.
+
+These run in CI with no real LLM keys: every cognee memory call
+(``remember`` / ``recall`` / ``forget`` / session manager) is monkeypatched
+so the test asserts the adapter's *behavior* — session scoping, background
+ingestion, opt-out, citations, and per-conversation forget — without
+touching a provider. This mirrors the mocked-LLM harness in issue #3601.
+
+Run just this file::
+
+    uv run pytest cognee/tests/unit/bots/test_web_widget_bot.py -v
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the web-widget example importable (it ships its own thin adapter).
+WIDGET_DIR = Path(__file__).resolve().parents[4] / "examples" / "bots" / "web_widget"
+sys.path.insert(0, str(WIDGET_DIR))
+
+import adapter as adapter_mod  # noqa: E402
+from adapter import ChatMemoryAdapter  # noqa: E402
+from citations import extract_citations  # noqa: E402
+
+
+class _FakeUser:
+    id = "test-user"
+
+
+class _FakeSessionManager:
+    def __init__(self):
+        self.deleted = []
+
+    async def delete_session(self, *, user_id, session_id):
+        self.deleted.append((user_id, session_id))
+        return True
+
+
+@pytest.fixture
+def cognee_calls(monkeypatch):
+    """Record every cognee memory call the adapter makes."""
+    calls = {"remember": [], "recall": [], "forget": []}
+
+    async def fake_remember(data, **kwargs):
+        calls["remember"].append({"data": data, **kwargs})
+        return {"status": "completed"}
+
+    async def fake_recall(**kwargs):
+        calls["recall"].append(kwargs)
+        # Canned graph answer with an explicit citation to a docs chunk.
+        return [
+            {
+                "source": "graph",
+                "text": "Cognee stores memory as a knowledge graph.",
+                "score": 0.91,
+                "dataset_name": "web:demo:docs",
+                "metadata": {
+                    "references": [
+                        {
+                            "snippet": "Cognee turns raw data into a knowledge graph.",
+                            "data_id": "doc-1",
+                            "score": 0.91,
+                        }
+                    ]
+                },
+            }
+        ]
+
+    async def fake_forget(**kwargs):
+        calls["forget"].append(kwargs)
+        return {"removed": 1}
+
+    monkeypatch.setattr(adapter_mod.cognee, "remember", fake_remember)
+    monkeypatch.setattr(adapter_mod.cognee, "recall", fake_recall)
+    monkeypatch.setattr(adapter_mod.cognee, "forget", fake_forget)
+
+    session_manager = _FakeSessionManager()
+    monkeypatch.setattr(adapter_mod, "get_session_manager", lambda: session_manager)
+
+    async def fake_default_user():
+        return _FakeUser()
+
+    monkeypatch.setattr(adapter_mod, "get_default_user", fake_default_user)
+
+    return calls, session_manager
+
+
+def test_session_id_convention():
+    adapter = ChatMemoryAdapter()
+    conv = adapter.conversation(site_id="acme", visitor_id="v1", conversation_id="c1")
+    assert conv.session_id == "web:acme:v1:c1"
+    assert adapter.docs_dataset("acme") == "web:acme:docs"
+
+
+def test_answer_returns_text_and_citations(cognee_calls):
+    calls, _ = cognee_calls
+    adapter = ChatMemoryAdapter(top_k=5)
+    conv = adapter.conversation(site_id="demo", visitor_id="v1", conversation_id="c1")
+
+    answer = asyncio.run(adapter.answer(conversation=conv, query="What is cognee?"))
+
+    assert answer.text == "Cognee stores memory as a knowledge graph."
+    assert answer.session_id == "web:demo:v1:c1"
+    assert len(answer.citations) == 1
+    assert answer.citations[0].reference == "doc-1"
+
+    # recall must be session-scoped, docs-scoped, and ask for references.
+    recall_kwargs = calls["recall"][0]
+    assert recall_kwargs["session_id"] == "web:demo:v1:c1"
+    assert recall_kwargs["datasets"] == ["web:demo:docs"]
+    assert recall_kwargs["include_references"] is True
+    assert recall_kwargs["top_k"] == 5
+
+
+def test_ingest_opt_in_uses_background_session(cognee_calls):
+    calls, _ = cognee_calls
+    adapter = ChatMemoryAdapter()
+    conv = adapter.conversation(site_id="demo", visitor_id="v1", conversation_id="c1")
+
+    stored = asyncio.run(adapter.ingest(conversation=conv, message="hello", role="user"))
+
+    assert stored is True
+    remember_kwargs = calls["remember"][0]
+    assert remember_kwargs["session_id"] == "web:demo:v1:c1"
+    assert remember_kwargs["run_in_background"] is True
+    assert remember_kwargs["self_improvement"] is False
+    assert remember_kwargs["data"] == "user: hello"
+
+
+def test_ingest_opt_out_skips_remember(cognee_calls):
+    calls, _ = cognee_calls
+    adapter = ChatMemoryAdapter()
+    conv = adapter.conversation(site_id="demo", visitor_id="v1", conversation_id="c1")
+
+    stored = asyncio.run(
+        adapter.ingest(conversation=conv, message="secret", role="user", opt_in=False)
+    )
+
+    assert stored is False
+    assert calls["remember"] == []
+
+
+def test_forget_clears_only_this_conversation(cognee_calls):
+    _, session_manager = cognee_calls
+    adapter = ChatMemoryAdapter()
+    conv = adapter.conversation(site_id="demo", visitor_id="v1", conversation_id="c1")
+
+    cleared = asyncio.run(adapter.forget(conversation=conv))
+
+    assert cleared is True
+    assert session_manager.deleted == [("test-user", "web:demo:v1:c1")]
+
+
+def test_extract_citations_fallback_when_no_references():
+    # No explicit references -> cite the entry text so replies stay attributable.
+    results = [{"source": "session", "answer": "You told me your name is Ada."}]
+    citations = extract_citations(results)
+    assert len(citations) == 1
+    assert citations[0].source == "session"
+    assert "Ada" in citations[0].snippet

--- a/cognee/tests/unit/bots/test_web_widget_bot.py
+++ b/cognee/tests/unit/bots/test_web_widget_bot.py
@@ -106,6 +106,8 @@ def test_answer_returns_text_and_citations(cognee_calls):
     assert answer.session_id == "web:demo:v1:c1"
     assert len(answer.citations) == 1
     assert answer.citations[0].reference == "doc-1"
+    # HTTP / widget contract uses "answer", not "text".
+    assert answer.as_dict()["answer"] == answer.text
 
     # recall must be session-scoped, docs-scoped, and ask for references.
     recall_kwargs = calls["recall"][0]

--- a/examples/bots/web_widget/README.md
+++ b/examples/bots/web_widget/README.md
@@ -1,0 +1,86 @@
+# Web chat widget powered by cognee memory
+
+An embeddable chat widget — one `<script>` tag — that answers questions from
+your docs/site with **cited** sources, remembers each visitor's conversation
+in isolation, and lets anyone **forget** their chat or opt out entirely.
+
+It's built on a thin, framework-agnostic [`ChatMemoryAdapter`](adapter.py)
+(`ingest` / `answer` / `forget`) so the same core can back a WhatsApp or MS
+Teams bot later without touching the transport. This is the web transport for
+issue [#3612](https://github.com/topoteretes/cognee/issues/3612), and is
+shaped to fold onto the shared adapter core ([#3608]) when that lands.
+
+## How memory is scoped
+
+Each browser conversation maps to a stable cognee `session_id`:
+
+```
+web:{site_id}:{visitor_id}:{conversation_id}
+```
+
+- **Default boundary: per visitor-conversation.** Turns are stored in cognee's
+  *session cache* (scoped by `session_id`), so one visitor's chat never leaks
+  into another's.
+- **"Ask our docs" mode:** your docs are seeded once into a shared, read-only
+  dataset `web:{site_id}:docs`. Every conversation can `recall` from it; none
+  can write to it. Clean split between shared knowledge and personal memory.
+- **Citations:** answers come back via `recall(..., include_references=True)`
+  and the widget renders each source inline.
+- **Forget / opt-out:** the `/forget` command (and the widget's *Forget me*
+  link) clears just that conversation; unticking *Remember this chat* stops
+  any ingestion.
+
+## Run your own in 5 minutes
+
+```bash
+# 1. Install cognee (from the repo root)
+uv pip install -e .
+
+# 2. Point cognee at an LLM (OpenAI shown; any supported provider works)
+cp .env.template .env
+# edit .env -> LLM_API_KEY="sk-..."
+
+# 3. Start the widget backend (seeds a small demo docs corpus on boot)
+uv run python examples/bots/web_widget/server.py
+
+# 4. Open the "ask our docs" demo
+open http://localhost:8000
+```
+
+Ask *“What is cognee?”*, then type `/forget` to wipe the conversation.
+
+### Embed on your own site
+
+```html
+<script src="http://localhost:8000/widget.js"
+        data-site-id="acme"
+        data-api="http://localhost:8000"></script>
+```
+
+### Seed your real docs
+
+```python
+from adapter import ChatMemoryAdapter
+
+adapter = ChatMemoryAdapter()
+await adapter.ingest_docs(site_id="acme", documents=["...your docs text..."])
+```
+
+## HTTP API
+
+| Method | Path          | Body                                                        | Returns                          |
+| ------ | ------------- | ----------------------------------------------------------- | -------------------------------- |
+| POST   | `/api/chat`   | `{message, conversation_id, visitor_id, site_id, opt_in}`   | `{answer, citations, session_id}`|
+| POST   | `/api/forget` | `{conversation_id, visitor_id, site_id}`                    | `{cleared, session_id}`          |
+| GET    | `/`           | —                                                           | demo "ask our docs" page         |
+| GET    | `/widget.js`  | —                                                           | the embeddable snippet           |
+
+## Tests (deterministic, no API keys)
+
+Memory calls are mocked, so tests run fast in CI with no real LLM:
+
+```bash
+uv run pytest cognee/tests/unit/bots/test_web_widget_bot.py -v
+```
+
+[#3608]: https://github.com/topoteretes/cognee/issues/3608

--- a/examples/bots/web_widget/README.md
+++ b/examples/bots/web_widget/README.md
@@ -57,6 +57,18 @@ Ask *“What is cognee?”*, then type `/forget` to wipe the conversation.
         data-api="http://localhost:8000"></script>
 ```
 
+Cross-origin embeds need CORS. By default the server allows any origin
+(`WIDGET_ALLOWED_ORIGINS=*`), which is fine for the local demo. For
+production, set an explicit comma-separated list:
+
+```bash
+export WIDGET_ALLOWED_ORIGINS="https://docs.example.com,https://www.example.com"
+```
+
+When origins are restricted (not `*`), the server also enables credentialed
+requests. Wildcard + credentials is invalid per the CORS spec, so credentials
+are off when the default `*` is used.
+
 ### Seed your real docs
 
 ```python

--- a/examples/bots/web_widget/adapter.py
+++ b/examples/bots/web_widget/adapter.py
@@ -1,0 +1,174 @@
+"""Framework-agnostic chat-memory adapter for cognee-powered bots.
+
+Every transport (web chat widget, WhatsApp, MS Teams, ...) plugs into this
+thin layer so each bot stays small and they all share one memory model.
+The adapter maps a platform conversation to a stable cognee ``session_id``
+and delegates storage/retrieval to cognee's memory API
+(``remember`` / ``recall`` / ``forget``).
+
+This ships inside the web-widget example so it is copy-pastable today; it is
+deliberately shaped to fold onto the shared chat-memory adapter core
+(issue #3608) once that lands, without changing the transport code.
+
+Session convention::
+
+    web:{site_id}:{visitor_id}:{conversation_id}
+
+Memory boundary (default): **per visitor-conversation**. Conversation turns
+are stored in cognee's *session cache* (scoped by ``session_id``), so one
+visitor's chat never leaks into another's. An optional shared, read-only
+*docs* dataset (``{namespace}:{site_id}:docs``) powers the "ask our docs"
+mode: every conversation can recall from it, but no conversation writes to
+it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, List, Optional, Sequence
+
+import cognee
+from cognee.infrastructure.session.get_session_manager import get_session_manager
+from cognee.modules.users.methods import get_default_user
+
+from citations import Citation, extract_citations
+
+
+@dataclasses.dataclass(frozen=True)
+class Conversation:
+    """A platform conversation, resolved to a cognee session."""
+
+    site_id: str
+    visitor_id: str
+    conversation_id: str
+    namespace: str = "web"
+
+    @property
+    def session_id(self) -> str:
+        return f"{self.namespace}:{self.site_id}:{self.visitor_id}:{self.conversation_id}"
+
+
+@dataclasses.dataclass
+class Answer:
+    """A recalled answer plus the sources that back it."""
+
+    text: str
+    citations: List[Citation]
+    session_id: str
+
+    def as_dict(self) -> dict:
+        return {
+            "text": self.text,
+            "citations": [c.as_dict() for c in self.citations],
+            "session_id": self.session_id,
+        }
+
+
+def _first_answer_text(results: Sequence[Any]) -> str:
+    """Pick the best renderable answer string across heterogeneous results."""
+    for entry in results or []:
+        data = entry if isinstance(entry, dict) else _model_dump(entry)
+        for key in ("answer", "text", "content"):
+            value = data.get(key)
+            if value and str(value).strip():
+                return str(value).strip()
+    return "I don't have anything in memory for that yet."
+
+
+def _model_dump(entry: Any) -> dict:
+    for attr in ("model_dump", "dict"):
+        fn = getattr(entry, attr, None)
+        if callable(fn):
+            try:
+                return fn()
+            except Exception:  # noqa: BLE001
+                pass
+    return {k: v for k, v in vars(entry).items() if not k.startswith("_")}
+
+
+class ChatMemoryAdapter:
+    """Thin ingest / answer / forget layer over cognee memory."""
+
+    def __init__(self, *, namespace: str = "web", top_k: int = 8) -> None:
+        self.namespace = namespace
+        self.top_k = top_k
+
+    # -- session helpers ---------------------------------------------------
+
+    def conversation(self, *, site_id: str, visitor_id: str, conversation_id: str) -> Conversation:
+        return Conversation(
+            site_id=site_id,
+            visitor_id=visitor_id,
+            conversation_id=conversation_id,
+            namespace=self.namespace,
+        )
+
+    def docs_dataset(self, site_id: str) -> str:
+        return f"{self.namespace}:{site_id}:docs"
+
+    # -- ingestion (background remember) -----------------------------------
+
+    async def ingest(
+        self,
+        *,
+        conversation: Conversation,
+        message: str,
+        role: str = "user",
+        opt_in: bool = True,
+    ) -> bool:
+        """Remember one conversation turn. No-op when the visitor opted out.
+
+        Runs as a background ``remember`` so replies are never blocked on the
+        write, and keeps the turn in the session cache
+        (``self_improvement=False``) so it stays private to this conversation.
+        """
+        if not opt_in or not message.strip():
+            return False
+        await cognee.remember(
+            f"{role}: {message}",
+            session_id=conversation.session_id,
+            run_in_background=True,
+            self_improvement=False,
+        )
+        return True
+
+    async def ingest_docs(self, *, site_id: str, documents: Sequence[str]) -> None:
+        """Seed the shared, read-only "ask our docs" corpus for a site."""
+        docs = [d for d in documents if d and d.strip()]
+        if not docs:
+            return
+        await cognee.remember(list(docs), dataset_name=self.docs_dataset(site_id))
+
+    # -- retrieval (synchronous recall + citations) ------------------------
+
+    async def answer(
+        self, *, conversation: Conversation, query: str, use_docs: bool = True
+    ) -> Answer:
+        """Recall an answer scoped to this conversation (+ docs in docs mode)."""
+        datasets = [self.docs_dataset(conversation.site_id)] if use_docs else None
+        results = await cognee.recall(
+            query_text=query,
+            session_id=conversation.session_id,
+            datasets=datasets,
+            top_k=self.top_k,
+            include_references=True,
+        )
+        return Answer(
+            text=_first_answer_text(results),
+            citations=extract_citations(results),
+            session_id=conversation.session_id,
+        )
+
+    # -- forget / opt-out --------------------------------------------------
+
+    async def forget(self, *, conversation: Conversation) -> bool:
+        """Forget everything remembered for a single conversation."""
+        session_manager = get_session_manager()
+        user = await get_default_user()
+        return await session_manager.delete_session(
+            user_id=str(user.id), session_id=conversation.session_id
+        )
+
+    async def forget_docs(self, *, site_id: str) -> dict:
+        """Drop the shared docs corpus for a site (account-level forget)."""
+        return await cognee.forget(dataset=self.docs_dataset(site_id))

--- a/examples/bots/web_widget/adapter.py
+++ b/examples/bots/web_widget/adapter.py
@@ -25,7 +25,7 @@ it.
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, List, Optional, Sequence
+from typing import Any, List, Sequence
 
 import cognee
 from cognee.infrastructure.session.get_session_manager import get_session_manager
@@ -57,8 +57,9 @@ class Answer:
     session_id: str
 
     def as_dict(self) -> dict:
+        # Key name matches the HTTP API / widget contract ({answer, citations, ...}).
         return {
-            "text": self.text,
+            "answer": self.text,
             "citations": [c.as_dict() for c in self.citations],
             "session_id": self.session_id,
         }

--- a/examples/bots/web_widget/citations.py
+++ b/examples/bots/web_widget/citations.py
@@ -1,0 +1,116 @@
+"""Citation extraction for cognee-powered bots.
+
+``cognee.recall(..., include_references=True)`` returns a list of result
+entries (session QA hits, graph completions, graph context, ...). Agents
+and end users both need to *attribute* an answer to its sources, so this
+module normalizes those heterogeneous entries into a flat list of
+``Citation`` objects the transport layer can render inline.
+
+The extractor is intentionally defensive: results may arrive as Pydantic
+models (``RecallResponse``) or plain dicts, and references may live under
+``metadata``/``raw`` depending on the retriever. When no explicit
+reference is present we fall back to a snippet of the entry text so a
+reply is never uncited.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Iterable, List, Optional
+
+# Score in cognee is a raw backend distance where *lower is better*. At the
+# surface we want the intuitive direction (higher = more relevant), matching
+# the ranking work in issue #3604.
+_MAX_SNIPPET = 240
+
+
+@dataclasses.dataclass
+class Citation:
+    """One attributable source behind an answer."""
+
+    source: str  # "session" | "graph" | "graph_context" | "docs" | ...
+    snippet: str
+    score: Optional[float] = None
+    dataset: Optional[str] = None
+    reference: Optional[str] = None  # data_id / chunk_id / url when available
+
+    def as_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+def _to_dict(entry: Any) -> dict:
+    """Normalize a Pydantic model or dict result entry into a plain dict."""
+    if isinstance(entry, dict):
+        return entry
+    for attr in ("model_dump", "dict"):
+        fn = getattr(entry, attr, None)
+        if callable(fn):
+            try:
+                return fn()
+            except Exception:  # noqa: BLE001 - best-effort normalization
+                pass
+    return {k: v for k, v in vars(entry).items() if not k.startswith("_")}
+
+
+def _snippet(text: Optional[str]) -> str:
+    if not text:
+        return ""
+    text = " ".join(str(text).split())
+    return text if len(text) <= _MAX_SNIPPET else text[: _MAX_SNIPPET - 1] + "…"
+
+
+def _reference_id(ref: dict) -> Optional[str]:
+    for key in ("url", "reference", "chunk_id", "data_id", "id"):
+        value = ref.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _references_from(entry: dict) -> List[dict]:
+    """Pull an explicit references list from wherever the retriever put it."""
+    for container in (entry, entry.get("metadata") or {}, entry.get("raw") or {}):
+        refs = container.get("references") if isinstance(container, dict) else None
+        if isinstance(refs, list) and refs:
+            return [r for r in refs if isinstance(r, dict)]
+    return []
+
+
+def extract_citations(results: Iterable[Any]) -> List[Citation]:
+    """Turn ``recall`` results into a flat, de-duplicated citation list."""
+    citations: List[Citation] = []
+    seen: set = set()
+
+    for entry in results or []:
+        data = _to_dict(entry)
+        source = str(data.get("source") or "graph")
+        dataset = data.get("dataset_name") or data.get("dataset")
+        score = data.get("score")
+
+        explicit = _references_from(data)
+        if explicit:
+            for ref in explicit:
+                snippet = _snippet(ref.get("snippet") or ref.get("text"))
+                key = (snippet, _reference_id(ref))
+                if not snippet or key in seen:
+                    continue
+                seen.add(key)
+                citations.append(
+                    Citation(
+                        source=source,
+                        snippet=snippet,
+                        score=ref.get("score", score),
+                        dataset=ref.get("dataset") or dataset,
+                        reference=_reference_id(ref),
+                    )
+                )
+            continue
+
+        # Fallback: cite the entry itself so a reply is never uncited.
+        snippet = _snippet(data.get("text") or data.get("answer") or data.get("content"))
+        key = (snippet, None)
+        if snippet and key not in seen:
+            seen.add(key)
+            citations.append(Citation(source=source, snippet=snippet, score=score, dataset=dataset))
+
+    return citations

--- a/examples/bots/web_widget/citations.py
+++ b/examples/bots/web_widget/citations.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Iterable, List, Optional
 
-# Score in cognee is a raw backend distance where *lower is better*. At the
-# surface we want the intuitive direction (higher = more relevant), matching
-# the ranking work in issue #3604.
+# Score is passed through as returned by the backend (often a distance where
+# lower is better). No inversion is applied here; ranking polish is tracked
+# in issue #3604.
 _MAX_SNIPPET = 240
 
 

--- a/examples/bots/web_widget/server.py
+++ b/examples/bots/web_widget/server.py
@@ -1,0 +1,153 @@
+"""Embeddable web chat widget powered by cognee memory.
+
+Run a tiny FastAPI backend that any site can talk to via a single
+``<script>`` tag. It doubles as an "ask our docs" assistant: seed a docs
+corpus once and every visitor conversation can recall from it, with
+inline **citations** to the source material.
+
+The HTTP layer is intentionally thin — all memory behavior lives in
+``ChatMemoryAdapter`` (``adapter.py``), which any other transport
+(WhatsApp, Teams) can reuse unchanged.
+
+Run it::
+
+    uv run python examples/bots/web_widget/server.py
+
+Then open http://localhost:8000 for the "ask our docs" demo page, or embed
+the widget on your own site::
+
+    <script src="http://localhost:8000/widget.js"
+            data-site-id="acme" data-api="http://localhost:8000"></script>
+
+Endpoints:
+    POST /api/chat    -> {answer, citations, session_id}
+    POST /api/forget  -> clear one conversation's memory
+    GET  /            -> demo "ask our docs" page
+    GET  /widget.js   -> the embeddable snippet
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+# Make the example importable whether run as a script or a module.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
+
+from adapter import ChatMemoryAdapter
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+# A couple of "docs" so the demo returns something without external setup.
+# Replace these with your real docs/site content.
+DEMO_DOCS: List[str] = [
+    "Cognee is an open-source AI memory platform. It turns raw data into a "
+    "knowledge graph that AI agents can recall from, replacing plain RAG "
+    "with an Extract-Cognify-Load pipeline.",
+    "You store data with remember(), build the graph, then query it with "
+    "recall(). Each conversation is isolated by a session_id, so one user's "
+    "chat never leaks into another's.",
+    "Use forget() to delete memory for a conversation or dataset. Visitors "
+    "can opt out of being remembered at any time.",
+]
+
+DEMO_SITE_ID = os.getenv("WIDGET_SITE_ID", "demo")
+
+adapter = ChatMemoryAdapter(namespace="web", top_k=8)
+app = FastAPI(title="cognee web chat widget")
+
+
+class ChatRequest(BaseModel):
+    message: str
+    conversation_id: str
+    visitor_id: str = "anonymous"
+    site_id: str = DEMO_SITE_ID
+    opt_in: bool = True
+    use_docs: bool = True
+
+
+class ForgetRequest(BaseModel):
+    conversation_id: str
+    visitor_id: str = "anonymous"
+    site_id: str = DEMO_SITE_ID
+
+
+@app.on_event("startup")
+async def _seed_docs() -> None:
+    """Seed the demo "ask our docs" corpus once, best-effort."""
+    if os.getenv("WIDGET_SKIP_SEED") == "1":
+        return
+    try:
+        await adapter.ingest_docs(site_id=DEMO_SITE_ID, documents=DEMO_DOCS)
+    except Exception as error:  # noqa: BLE001 - demo should still boot
+        print(f"[web_widget] docs seeding skipped: {error}")
+
+
+@app.post("/api/chat")
+async def chat(req: ChatRequest) -> JSONResponse:
+    conversation = adapter.conversation(
+        site_id=req.site_id,
+        visitor_id=req.visitor_id,
+        conversation_id=req.conversation_id,
+    )
+
+    # A "/forget" message is a first-class command, not something to remember.
+    if req.message.strip().lower() in ("/forget", "forget me"):
+        await adapter.forget(conversation=conversation)
+        return JSONResponse(
+            {
+                "answer": "Done — I've forgotten this conversation.",
+                "citations": [],
+                "session_id": conversation.session_id,
+            }
+        )
+
+    # Remember the user turn in the background (skipped if opted out).
+    await adapter.ingest(
+        conversation=conversation, message=req.message, role="user", opt_in=req.opt_in
+    )
+
+    answer = await adapter.answer(
+        conversation=conversation, query=req.message, use_docs=req.use_docs
+    )
+
+    # Remember the assistant turn too so follow-ups have context.
+    await adapter.ingest(
+        conversation=conversation, message=answer.text, role="assistant", opt_in=req.opt_in
+    )
+
+    return JSONResponse(answer.as_dict())
+
+
+@app.post("/api/forget")
+async def forget(req: ForgetRequest) -> JSONResponse:
+    conversation = adapter.conversation(
+        site_id=req.site_id,
+        visitor_id=req.visitor_id,
+        conversation_id=req.conversation_id,
+    )
+    cleared = await adapter.forget(conversation=conversation)
+    return JSONResponse({"cleared": bool(cleared), "session_id": conversation.session_id})
+
+
+@app.get("/")
+async def demo_page() -> FileResponse:
+    return FileResponse(STATIC_DIR / "demo.html")
+
+
+@app.get("/widget.js")
+async def widget_js() -> FileResponse:
+    return FileResponse(STATIC_DIR / "widget.js", media_type="application/javascript")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/examples/bots/web_widget/server.py
+++ b/examples/bots/web_widget/server.py
@@ -30,13 +30,15 @@ from __future__ import annotations
 
 import os
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 # Make the example importable whether run as a script or a module.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
@@ -59,8 +61,39 @@ DEMO_DOCS: List[str] = [
 
 DEMO_SITE_ID = os.getenv("WIDGET_SITE_ID", "demo")
 
+# Comma-separated origins allowed to call the API. Default "*" is fine for the
+# local demo; production embeds should list explicit origins
+# (e.g. WIDGET_ALLOWED_ORIGINS=https://docs.example.com,https://www.example.com).
+_ALLOWED_ORIGINS = [
+    origin.strip()
+    for origin in os.getenv("WIDGET_ALLOWED_ORIGINS", "*").split(",")
+    if origin.strip()
+]
+# Browsers reject Access-Control-Allow-Origin: * together with credentials.
+_ALLOW_CREDENTIALS = _ALLOWED_ORIGINS != ["*"]
+
 adapter = ChatMemoryAdapter(namespace="web", top_k=8)
-app = FastAPI(title="cognee web chat widget")
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Seed the demo "ask our docs" corpus once, best-effort."""
+    if os.getenv("WIDGET_SKIP_SEED") != "1":
+        try:
+            await adapter.ingest_docs(site_id=DEMO_SITE_ID, documents=DEMO_DOCS)
+        except Exception as error:  # noqa: BLE001 - demo should still boot
+            print(f"[web_widget] docs seeding skipped: {error}")
+    yield
+
+
+app = FastAPI(title="cognee web chat widget", lifespan=lifespan)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_ALLOWED_ORIGINS,
+    allow_credentials=_ALLOW_CREDENTIALS,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+)
 
 
 class ChatRequest(BaseModel):
@@ -76,17 +109,6 @@ class ForgetRequest(BaseModel):
     conversation_id: str
     visitor_id: str = "anonymous"
     site_id: str = DEMO_SITE_ID
-
-
-@app.on_event("startup")
-async def _seed_docs() -> None:
-    """Seed the demo "ask our docs" corpus once, best-effort."""
-    if os.getenv("WIDGET_SKIP_SEED") == "1":
-        return
-    try:
-        await adapter.ingest_docs(site_id=DEMO_SITE_ID, documents=DEMO_DOCS)
-    except Exception as error:  # noqa: BLE001 - demo should still boot
-        print(f"[web_widget] docs seeding skipped: {error}")
 
 
 @app.post("/api/chat")

--- a/examples/bots/web_widget/static/demo.html
+++ b/examples/bots/web_widget/static/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>cognee web widget — ask our docs</title>
+    <style>
+      body {
+        font: 16px/1.6 system-ui, sans-serif;
+        margin: 0;
+        color: #111827;
+        background: #f3f4f6;
+      }
+      .wrap {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 64px 24px;
+      }
+      code {
+        background: #111827;
+        color: #f9fafb;
+        padding: 2px 6px;
+        border-radius: 4px;
+      }
+      pre {
+        background: #111827;
+        color: #f9fafb;
+        padding: 16px;
+        border-radius: 10px;
+        overflow-x: auto;
+      }
+      h1 {
+        margin-bottom: 4px;
+      }
+      .muted {
+        color: #6b7280;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Ask our docs</h1>
+      <p class="muted">
+        This page embeds the cognee chat widget. Click the bubble in the
+        bottom-right and ask about cognee — answers come back with citations to
+        the source docs, and everything is scoped to your conversation.
+      </p>
+
+      <h3>Embed it on your own site</h3>
+      <p>One tag, no build step:</p>
+      <pre>&lt;script src="http://localhost:8000/widget.js"
+        data-site-id="acme"
+        data-api="http://localhost:8000"&gt;&lt;/script&gt;</pre>
+
+      <p class="muted">
+        Try: <em>“What is cognee?”</em>, <em>“How is memory kept private?”</em>,
+        or type <code>/forget</code> to wipe this conversation.
+      </p>
+    </div>
+
+    <!-- The widget under test embeds itself: -->
+    <script src="/widget.js" data-site-id="demo" data-api=""></script>
+  </body>
+</html>

--- a/examples/bots/web_widget/static/widget.js
+++ b/examples/bots/web_widget/static/widget.js
@@ -1,0 +1,155 @@
+/*
+ * cognee web chat widget — embeddable snippet.
+ *
+ * Drop one tag on any page:
+ *   <script src="https://your-host/widget.js"
+ *           data-site-id="acme" data-api="https://your-host"></script>
+ *
+ * It renders a floating chat bubble, talks to the cognee-backed backend,
+ * shows inline citations, and supports a /forget command + opt-out. No
+ * build step, no framework.
+ */
+(function () {
+  var script = document.currentScript;
+  var API = (script && script.getAttribute("data-api")) || window.location.origin;
+  var SITE_ID = (script && script.getAttribute("data-site-id")) || "demo";
+
+  // Stable per-browser ids so a returning visitor keeps their conversation.
+  function id(key, prefix) {
+    var v = localStorage.getItem(key);
+    if (!v) {
+      v = prefix + "-" + Math.random().toString(36).slice(2, 10);
+      localStorage.setItem(key, v);
+    }
+    return v;
+  }
+  var visitorId = id("cognee_visitor_id", "visitor");
+  var conversationId = id("cognee_conversation_id", "conv");
+  var optIn = localStorage.getItem("cognee_opt_in") !== "0";
+
+  var css =
+    ".cognee-w{position:fixed;bottom:20px;right:20px;width:360px;max-width:92vw;font:14px/1.5 system-ui,sans-serif;z-index:2147483000}" +
+    ".cognee-box{display:none;flex-direction:column;background:#fff;border:1px solid #e5e7eb;border-radius:12px;box-shadow:0 12px 32px rgba(0,0,0,.18);overflow:hidden}" +
+    ".cognee-box.open{display:flex}" +
+    ".cognee-head{background:#111827;color:#fff;padding:10px 14px;display:flex;justify-content:space-between;align-items:center}" +
+    ".cognee-head b{font-weight:600}" +
+    ".cognee-log{padding:12px;height:340px;overflow-y:auto;background:#f9fafb}" +
+    ".cognee-msg{margin:6px 0;padding:8px 10px;border-radius:10px;max-width:85%;white-space:pre-wrap;word-wrap:break-word}" +
+    ".cognee-user{background:#2563eb;color:#fff;margin-left:auto}" +
+    ".cognee-bot{background:#fff;border:1px solid #e5e7eb}" +
+    ".cognee-cites{margin:4px 0 10px;font-size:12px;color:#6b7280}" +
+    ".cognee-cite{border-left:3px solid #d1d5db;padding:2px 8px;margin:3px 0}" +
+    ".cognee-in{display:flex;border-top:1px solid #e5e7eb}" +
+    ".cognee-in input{flex:1;border:0;padding:11px;outline:none}" +
+    ".cognee-in button{border:0;background:#2563eb;color:#fff;padding:0 16px;cursor:pointer}" +
+    ".cognee-bar{padding:6px 12px;font-size:12px;color:#6b7280;display:flex;justify-content:space-between;background:#fff;border-top:1px solid #f3f4f6}" +
+    ".cognee-bar a{color:#2563eb;cursor:pointer;text-decoration:none}" +
+    ".cognee-launch{border:0;background:#111827;color:#fff;border-radius:24px;padding:12px 18px;cursor:pointer;box-shadow:0 8px 24px rgba(0,0,0,.2)}";
+  var style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+
+  var root = document.createElement("div");
+  root.className = "cognee-w";
+  root.innerHTML =
+    '<div class="cognee-box" id="cognee-box">' +
+    '  <div class="cognee-head"><b>Ask our docs</b>' +
+    '    <span style="cursor:pointer" id="cognee-close">×</span></div>' +
+    '  <div class="cognee-log" id="cognee-log"></div>' +
+    '  <div class="cognee-bar">' +
+    '    <label><input type="checkbox" id="cognee-optin"> Remember this chat</label>' +
+    '    <a id="cognee-forget">Forget me</a></div>' +
+    '  <div class="cognee-in">' +
+    '    <input id="cognee-input" placeholder="Ask a question…" autocomplete="off"/>' +
+    '    <button id="cognee-send">Send</button></div>' +
+    "</div>" +
+    '<button class="cognee-launch" id="cognee-launch">💬 Chat</button>';
+  document.body.appendChild(root);
+
+  var box = root.querySelector("#cognee-box");
+  var log = root.querySelector("#cognee-log");
+  var input = root.querySelector("#cognee-input");
+  var optinBox = root.querySelector("#cognee-optin");
+  optinBox.checked = optIn;
+
+  function open(v) {
+    box.classList.toggle("open", v);
+  }
+  root.querySelector("#cognee-launch").onclick = function () {
+    open(true);
+    input.focus();
+  };
+  root.querySelector("#cognee-close").onclick = function () {
+    open(false);
+  };
+  optinBox.onchange = function () {
+    optIn = optinBox.checked;
+    localStorage.setItem("cognee_opt_in", optIn ? "1" : "0");
+  };
+
+  function el(cls, text) {
+    var d = document.createElement("div");
+    d.className = cls;
+    d.textContent = text;
+    return d;
+  }
+  function addMsg(role, text) {
+    log.appendChild(el("cognee-msg cognee-" + role, text));
+    log.scrollTop = log.scrollHeight;
+  }
+  function addCitations(cites) {
+    if (!cites || !cites.length) return;
+    var wrap = document.createElement("div");
+    wrap.className = "cognee-cites";
+    wrap.appendChild(el("", "Sources:"));
+    cites.slice(0, 4).forEach(function (c) {
+      var line = c.snippet + (c.dataset ? "  (" + c.dataset + ")" : "");
+      wrap.appendChild(el("cognee-cite", line));
+    });
+    log.appendChild(wrap);
+    log.scrollTop = log.scrollHeight;
+  }
+
+  async function send() {
+    var text = input.value.trim();
+    if (!text) return;
+    input.value = "";
+    addMsg("user", text);
+    try {
+      var res = await fetch(API + "/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: text,
+          conversation_id: conversationId,
+          visitor_id: visitorId,
+          site_id: SITE_ID,
+          opt_in: optIn,
+        }),
+      });
+      var data = await res.json();
+      addMsg("bot", data.answer || "…");
+      addCitations(data.citations);
+    } catch (e) {
+      addMsg("bot", "Sorry — I couldn't reach memory right now.");
+    }
+  }
+  root.querySelector("#cognee-send").onclick = send;
+  input.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") send();
+  });
+
+  root.querySelector("#cognee-forget").onclick = async function () {
+    await fetch(API + "/api/forget", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversation_id: conversationId,
+        visitor_id: visitorId,
+        site_id: SITE_ID,
+      }),
+    });
+    log.innerHTML = "";
+    addMsg("bot", "Done — I've forgotten this conversation.");
+  };
+})();


### PR DESCRIPTION
## Description

Closes #3612 (web-widget transport).

This adds an embeddable web chat widget backed by cognee memory, plus the thin chat-memory adapter it runs on. My reasoning for the main decisions:

**Why the web widget (of the three transports):** it's the only one with no app-review gate (WhatsApp/Teams both need one), and the same build doubles as the "ask our docs" assistant, so one PR delivers both a bot and an embeddable docs-search demo.

**Session scoping:** each browser conversation maps to `web:{site_id}:{visitor_id}:{conversation_id}`. The default memory boundary is per visitor-conversation — turns go into cognee's session cache via `remember(session_id=..., run_in_background=True, self_improvement=False)`, so one visitor's chat can't leak into another's and replies are never blocked on the write. Docs mode is a separate shared read-only dataset (`web:{site_id}:docs`) that every conversation recalls from but none writes to.

**Citations:** answers come from `recall(session_id=..., datasets=[docs], include_references=True)`. A small normalizer (`citations.py`) flattens the heterogeneous result entries (session/graph/graph_context, Pydantic or dict) into a citation list the widget renders inline; when a result has no explicit references it falls back to the entry snippet, so replies are never uncited.

**Forget/opt-out:** `/forget` (and the widget's "Forget me" link) clears just that conversation via `SessionManager.delete_session` — I went through the session manager because `cognee.forget()` has no per-session target. The "Remember this chat" checkbox is a hard opt-out: when off, ingest is a no-op.

**One deviation from my proposal comment:** I had suggested the TypeScript client, but the shared adapter core (#3608) doesn't exist in the repo yet and neither does any TS example infra. So the backend is Python (testable with the repo's pytest setup) and the embed is a dependency-free vanilla-JS snippet — zero build step, and all memory logic stays server-side. The adapter is shaped to fold onto #3608 once it lands, without touching the transport code.


## Acceptance Criteria

From #3612:
- [x] One transport implemented end to end (web widget) on a thin adapter
- [x] Conversation → session mapping (`web:{site_id}:{visitor_id}:{conversation_id}`)
- [x] Cited answers (`include_references=True` + inline rendering in the widget)
- [x] `forget` command + opt-out (per-conversation delete; opt-out skips ingestion)
- [x] Embeddable snippet + "ask our docs" mode (shared read-only docs dataset)
- [x] Mocked tests, deterministic, no real API keys — 6 tests covering session
      convention, docs/session-scoped recall with citations, background ingest,
      opt-out, per-conversation forget, and citation fallback
- [x] Copy-paste "run your own in 5 minutes" README

Proof: all 6 tests pass locally in ~0.02s with no LLM keys
(`uv run pytest cognee/tests/unit/bots/ -v`) — screenshot below. `ruff check`,
`ruff format`, and `pre-commit run` all pass on the new files.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="1139" height="451" alt="Screendrop_2026-07-03-00-44-01" src="https://github.com/user-attachments/assets/0253c336-53ac-4871-9f58-90f954d1015e" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
