### PR TITLE
[#3629] Entity canonicalization via LLM judge (Approach C)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -429,6 +429,22 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # -- Triplet embedding (extra triplet-level vectors during cognify) -----------
 #TRIPLET_EMBEDDING=false
 
+# -- Entity canonicalization (opt-in LLM-judge dedup during cognify) ----------
+# When on, cognify asks an LLM to judge near-duplicate entities and merges the
+# duplicates (reconciling their descriptions) before storage. Default off — when
+# off the cognify pipeline is unchanged.
+#ENTITY_CANONICALIZATION=false
+# Cosine-similarity threshold for blocking: only entity pairs at or above this
+# similarity are sent to the LLM judge.
+#CANONICALIZATION_SIMILARITY_THRESHOLD=0.8
+# Minimum LLM-judge confidence required to actually merge a pair.
+#CANONICALIZATION_CONFIDENCE_THRESHOLD=0.85
+# Cap on candidate pairs judged per batch (highest-similarity first; the rest
+# are logged and skipped).
+#CANONICALIZATION_MAX_PAIRS=200
+# Number of candidate pairs sent per LLM judge call.
+#CANONICALIZATION_JUDGE_BATCH_SIZE=8
+
 # -- Session cache (Redis backend + session/usage tuning) ---------------------
 # Used when CACHE_BACKEND=redis; also the host/port for a remote cache.
 #CACHE_HOST="localhost"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -538,6 +538,14 @@ await cognee.cognify(datasets=["my_project"])
 ### DataPoints
 Atomic knowledge units that form the foundation of graph structures. All graph nodes extend the `DataPoint` base class with versioning and metadata support.
 
+### Entity Canonicalization
+Opt-in LLM-judge deduplication that runs during `cognify()` (default **off**). After entity extraction and before storage, near-duplicate entities are blocked by embedding cosine similarity, an LLM judges whether each candidate pair is the same real-world entity, and confident matches are merged: the losing entity is renamed onto the winner's canonical identity (so the existing UUID5 dedup collapses them), its description is reconciled, and its edges are preserved.
+
+- **Enable**: set `ENTITY_CANONICALIZATION=true`. When off, the cognify pipeline is unchanged.
+- **Tuning** (env): `CANONICALIZATION_SIMILARITY_THRESHOLD` (default 0.8, blocking), `CANONICALIZATION_CONFIDENCE_THRESHOLD` (default 0.85, minimum merge confidence), `CANONICALIZATION_MAX_PAIRS` (default 200), `CANONICALIZATION_JUDGE_BATCH_SIZE` (default 8).
+- **Audit**: each merge emits a structured `entity_canonicalization_merge` log record and is stamped on the surviving entity (`merged_aliases`, `merge_confidence`).
+- **Scope / limitations**: blocking is within the current cognify batch only (no cross-batch or cross-run dedup); only the entity `description` is reconciled; the temporal cognify path is not covered.
+
 ### Permissions System
 Multi-tenant architecture with users, roles, and Access Control Lists (ACLs):
 - Read, write, delete, and share permissions per dataset

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -27,6 +27,7 @@ from cognee.tasks.documents import (
     extract_chunks_from_documents,
 )
 from cognee.tasks.graph.extract_graph_and_summarize import extract_graph_and_summarize
+from cognee.tasks.graph import canonicalize_entities
 from cognee.tasks.storage import add_data_points
 from cognee.tasks.ingestion.extract_dlt_fk_edges import extract_dlt_fk_edges
 from cognee.modules.pipelines.layers.pipeline_execution_mode import get_pipeline_executor
@@ -316,6 +317,7 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
 
     cognify_config = get_cognify_config()
     embed_triplets = cognify_config.triplet_embedding
+    canonicalize = cognify_config.entity_canonicalization
 
     if chunks_per_batch is None:
         chunks_per_batch = (
@@ -340,6 +342,14 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
             custom_prompt=custom_prompt,
             task_config={"batch_size": chunks_per_batch},
             **kwargs,
+        ),
+        # COGNIFY (opt-in): LLM-judge canonicalization of duplicate entities.
+        # Default OFF — when the flag is off this spread is empty and the task
+        # list is identical to the pre-canonicalization pipeline.
+        *(
+            [Task(canonicalize_entities, task_config={"batch_size": chunks_per_batch})]
+            if canonicalize
+            else []
         ),
         # LOAD: persist nodes, edges, and embeddings to graph/vector DBs
         Task(

--- a/cognee/infrastructure/llm/prompts/canonicalize_entities.txt
+++ b/cognee/infrastructure/llm/prompts/canonicalize_entities.txt
@@ -1,0 +1,14 @@
+You are an entity-resolution judge for knowledge graph construction.
+
+You are given candidate pairs of entities extracted from text. For each pair, decide whether the two entities refer to the SAME real-world entity.
+
+Judge each pair independently and return exactly one judgment per pair, keyed by its pair_index.
+
+For each pair provide:
+- is_same_entity: true only if the two entities are clearly the same real-world entity; false otherwise.
+- canonical_name: the single preferred surface form to use for the merged entity.
+- reconciled_description: a merged description that combines the information from both descriptions WITHOUT inventing any facts that are not present in at least one of them.
+- confidence: your confidence that the verdict is correct, as a number from 0.0 to 1.0.
+- rationale: one short sentence explaining the verdict.
+
+Be conservative: when you are unsure, set is_same_entity to false with a low confidence. Only merge entities that are genuinely the same; different entities that merely share a similar name or type must NOT be merged.

--- a/cognee/modules/cognify/config.py
+++ b/cognee/modules/cognify/config.py
@@ -10,6 +10,13 @@ class CognifyConfig(BaseSettings):
     summarization_model: object = SummarizedContent
     triplet_embedding: bool = False
     chunks_per_batch: Optional[int] = None
+    # Opt-in LLM-judge entity canonicalization (issue #3629). Default OFF so the
+    # standard cognify pipeline is unchanged. Tunables gate blocking and the judge.
+    entity_canonicalization: bool = False
+    canonicalization_similarity_threshold: float = 0.8
+    canonicalization_confidence_threshold: float = 0.85
+    canonicalization_max_pairs: int = 200
+    canonicalization_judge_batch_size: int = 8
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
     def to_dict(self) -> dict:
@@ -18,6 +25,11 @@ class CognifyConfig(BaseSettings):
             "summarization_model": self.summarization_model,
             "triplet_embedding": self.triplet_embedding,
             "chunks_per_batch": self.chunks_per_batch,
+            "entity_canonicalization": self.entity_canonicalization,
+            "canonicalization_similarity_threshold": self.canonicalization_similarity_threshold,
+            "canonicalization_confidence_threshold": self.canonicalization_confidence_threshold,
+            "canonicalization_max_pairs": self.canonicalization_max_pairs,
+            "canonicalization_judge_batch_size": self.canonicalization_judge_batch_size,
         }
 
 

--- a/cognee/modules/engine/models/Entity.py
+++ b/cognee/modules/engine/models/Entity.py
@@ -14,6 +14,13 @@ class Entity(DataPoint):
     truth_alignment: Optional[list[float]] = None
     truth_subspace_signature: Optional[str] = None
     truth_epoch: Optional[int] = None
+    # Optional entity-canonicalization audit metadata (issue #3629); stamped on the
+    # surviving entity when a duplicate is merged into it. Like the truth-alignment
+    # fields above, these are never embedded and never part of id/dedup, so they do
+    # not affect the vector index or the UUID5 identity — they simply ride along in
+    # the serialized node attributes.
+    merged_aliases: Optional[list[str]] = None
+    merge_confidence: Optional[float] = None
     # identity_fields makes the id deterministic and namespaced by class
     # (``Entity:<name>``) when constructed without an explicit id — the same
     # value ``Entity.id_for(name)`` produces. Prevents the random-uuid4 footgun.

--- a/cognee/tasks/graph/__init__.py
+++ b/cognee/tasks/graph/__init__.py
@@ -7,3 +7,4 @@ building relationships between entities, and managing graph structures.
 
 from .extract_graph_from_data import extract_graph_from_data
 from .extract_graph_from_code import extract_graph_from_code
+from .canonicalize_entities import canonicalize_entities

--- a/cognee/tasks/graph/canonicalize_entities.py
+++ b/cognee/tasks/graph/canonicalize_entities.py
@@ -37,6 +37,7 @@ import numpy as np
 from cognee.infrastructure.databases.vector import get_vector_engine
 from cognee.infrastructure.engine.models.Edge import Edge
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
+from cognee.infrastructure.llm.prompts import render_prompt
 from cognee.modules.cognify.config import get_cognify_config
 from cognee.modules.engine.models import Entity
 from cognee.modules.pipelines.tasks.task import task_summary
@@ -45,23 +46,6 @@ from cognee.tasks.graph.models import CanonicalizationJudgment
 from cognee.tasks.summarization.models import TextSummary
 
 logger = get_logger("canonicalize_entities")
-
-# Inline system prompt for the judge. A later commit moves this to a dedicated
-# prompt file loaded via ``render_prompt("canonicalize_entities.txt", {})``,
-# matching the extraction convention.
-_JUDGE_SYSTEM_PROMPT = (
-    "You are an entity-resolution judge. You are given candidate pairs of entities "
-    "extracted from text. For each pair decide whether the two entities refer to the "
-    "SAME real-world entity.\n\n"
-    "For each pair return, keyed by its pair_index:\n"
-    "- is_same_entity: true only if they are clearly the same real-world entity.\n"
-    "- canonical_name: the single preferred surface form for the merged entity.\n"
-    "- reconciled_description: a merged description that combines both descriptions "
-    "WITHOUT inventing facts not present in either.\n"
-    "- confidence: your confidence in [0.0, 1.0].\n"
-    "- rationale: one short sentence explaining the verdict.\n\n"
-    "Be conservative: when unsure, set is_same_entity to false with low confidence."
-)
 
 
 def _safe_setattr(obj, name: str, value) -> None:
@@ -199,10 +183,12 @@ async def _judge_pairs(
     indexed = list(enumerate(pairs))
     batches = [indexed[i : i + batch_size] for i in range(0, len(indexed), batch_size)]
 
+    system_prompt = render_prompt("canonicalize_entities.txt", {})
+
     async def judge_batch(batch):
         result = await LLMGateway.acreate_structured_output(
             text_input=_render_pairs(batch),
-            system_prompt=_JUDGE_SYSTEM_PROMPT,
+            system_prompt=system_prompt,
             response_model=CanonicalizationJudgment,
         )
         return result.judgments

--- a/cognee/tasks/graph/canonicalize_entities.py
+++ b/cognee/tasks/graph/canonicalize_entities.py
@@ -1,9 +1,12 @@
 """LLM-judge entity canonicalization task (issue #3629).
 
-Commit 2 scope: entity gathering + blocking (candidate generation) only. The
-judge, union-find, mirror-loser-onto-winner merge primitive, and audit are added
-in a later commit; ``canonicalize_entities`` is a gather-only stub for now and is
-not yet wired into the cognify pipeline.
+Pipeline seam: runs after ``extract_graph_and_summarize`` and before
+``add_data_points``. It gathers the entities produced by extraction, blocks them
+into genuine near-duplicate candidate pairs (embedding cosine), asks an LLM judge
+whether each pair is the same real-world entity, and — for confident matches —
+merges duplicates by renaming the loser onto the winner's canonical identity so
+the existing UUID5 dedup in ``deduplicate_nodes_and_edges`` collapses them at
+storage.
 
 Design notes (grounded in the extraction path):
 - After ``extract_graph_and_summarize`` the objects flowing toward storage are
@@ -11,10 +14,21 @@ Design notes (grounded in the extraction path):
   ``TextSummary.made_from.contains`` as ``(Edge, Entity)`` tuples (or bare
   ``Entity``), never as top-level items.
 - Blocking embeds entity names transiently (no vector-index write) and keeps only
-  pairs whose cosine similarity clears a threshold, so the LLM judge added later
-  only ever sees genuine near-duplicates.
+  pairs whose cosine similarity clears a threshold, so the LLM judge only ever
+  sees genuine near-duplicates.
+- The merge is a rename+mirror primitive (see ``_mirror_loser_onto_winner``): no
+  active edge-reassignment or graph rewriting. Edges follow automatically because
+  they are stored as live object references and their endpoint ids are read at
+  ``get_graph_from_model`` time.
+
+Ordering note: ``merged_aliases`` / ``merge_confidence`` are stamped on the
+surviving entity through ``_safe_setattr`` so this task works before those
+optional fields are added to the ``Entity`` model (a later commit). Until then
+they live on the instance (readable, not serialized); the structured audit log
+carries the full, authoritative merge record regardless.
 """
 
+import asyncio
 from types import SimpleNamespace
 from typing import List, Optional, Tuple
 
@@ -22,13 +36,47 @@ import numpy as np
 
 from cognee.infrastructure.databases.vector import get_vector_engine
 from cognee.infrastructure.engine.models.Edge import Edge
+from cognee.infrastructure.llm.LLMGateway import LLMGateway
 from cognee.modules.cognify.config import get_cognify_config
 from cognee.modules.engine.models import Entity
 from cognee.modules.pipelines.tasks.task import task_summary
 from cognee.shared.logging_utils import get_logger
+from cognee.tasks.graph.models import CanonicalizationJudgment
 from cognee.tasks.summarization.models import TextSummary
 
 logger = get_logger("canonicalize_entities")
+
+# Inline system prompt for the judge. A later commit moves this to a dedicated
+# prompt file loaded via ``render_prompt("canonicalize_entities.txt", {})``,
+# matching the extraction convention.
+_JUDGE_SYSTEM_PROMPT = (
+    "You are an entity-resolution judge. You are given candidate pairs of entities "
+    "extracted from text. For each pair decide whether the two entities refer to the "
+    "SAME real-world entity.\n\n"
+    "For each pair return, keyed by its pair_index:\n"
+    "- is_same_entity: true only if they are clearly the same real-world entity.\n"
+    "- canonical_name: the single preferred surface form for the merged entity.\n"
+    "- reconciled_description: a merged description that combines both descriptions "
+    "WITHOUT inventing facts not present in either.\n"
+    "- confidence: your confidence in [0.0, 1.0].\n"
+    "- rationale: one short sentence explaining the verdict.\n\n"
+    "Be conservative: when unsure, set is_same_entity to false with low confidence."
+)
+
+
+def _safe_setattr(obj, name: str, value) -> None:
+    """Set ``obj.name = value``, falling back to ``object.__setattr__``.
+
+    Pydantic v2 rejects assignment to a name that is not a declared model field.
+    ``merged_aliases`` / ``merge_confidence`` are added to ``Entity`` in a later
+    commit; until then this keeps the value readable on the instance without
+    raising. Once the fields exist the normal setattr path is taken and the value
+    serializes into ``node.attributes``.
+    """
+    try:
+        setattr(obj, name, value)
+    except (ValueError, AttributeError):
+        object.__setattr__(obj, name, value)
 
 
 def _gather_entities(summaries: List) -> List[Entity]:
@@ -126,24 +174,225 @@ async def _block_candidate_pairs(entities: List[Entity], cfg) -> List[Tuple[Enti
     return [(a, b) for _similarity, a, b in scored_pairs]
 
 
+def _render_pairs(indexed_pairs: List[Tuple[int, Tuple[Entity, Entity]]]) -> str:
+    """Render a batch of (pair_index, (a, b)) into judge-readable text."""
+    blocks = []
+    for pair_index, (a, b) in indexed_pairs:
+        blocks.append(
+            f"Pair {pair_index}:\n"
+            f"  Entity A: name={a.name!r} description={a.description!r}\n"
+            f"  Entity B: name={b.name!r} description={b.description!r}"
+        )
+    return "\n\n".join(blocks)
+
+
+async def _judge_pairs(
+    pairs: List[Tuple[Entity, Entity]], cfg
+) -> List[Tuple[object, Entity, Entity]]:
+    """Ask the LLM judge to rule on each candidate pair, batched and concurrent.
+
+    Returns a list of ``(PairJudgment, entity_a, entity_b)`` with each judgment
+    mapped back to its pair via ``PairJudgment.pair_index`` (out-of-range indices
+    are dropped defensively).
+    """
+    batch_size = max(1, cfg.canonicalization_judge_batch_size)
+    indexed = list(enumerate(pairs))
+    batches = [indexed[i : i + batch_size] for i in range(0, len(indexed), batch_size)]
+
+    async def judge_batch(batch):
+        result = await LLMGateway.acreate_structured_output(
+            text_input=_render_pairs(batch),
+            system_prompt=_JUDGE_SYSTEM_PROMPT,
+            response_model=CanonicalizationJudgment,
+        )
+        return result.judgments
+
+    batch_results = await asyncio.gather(*[judge_batch(batch) for batch in batches])
+
+    mapped = []
+    for judgments in batch_results:
+        for judgment in judgments:
+            if 0 <= judgment.pair_index < len(pairs):
+                a, b = pairs[judgment.pair_index]
+                mapped.append((judgment, a, b))
+    return mapped
+
+
+def _select_winner(members: List[Entity], canonical_name: str) -> Entity:
+    """Deterministically pick the surviving entity for a merge component.
+
+    A member whose normalized name equals the normalized canonical name wins
+    (ties broken by smallest ``str(id)``); otherwise the member with the smallest
+    normalized name wins. Order-independent.
+    """
+    target = Entity._normalize_identity_value(canonical_name)
+    exact = [m for m in members if Entity._normalize_identity_value(m.name) == target]
+    if exact:
+        return min(exact, key=lambda m: str(m.id))
+    return min(members, key=lambda m: Entity._normalize_identity_value(m.name))
+
+
+def _mirror_loser_onto_winner(
+    winner: Entity, loser: Entity, canonical_name: str, reconciled_description: str
+) -> None:
+    """The §0 merge primitive: make loser and winner one canonical entity.
+
+    Sets the winner's canonical identity + reconciled description, unions the two
+    entities' outbound relations onto the winner, then mirrors that state onto the
+    loser so BOTH objects end up sharing the same id AND carrying the unioned
+    relations. This is what makes the downstream machinery collapse them:
+
+    - Sharing ``id = Entity.id_for(canonical_name)`` lets ``deduplicate_nodes_and_edges``
+      (which keys on ``str(node.id)``) drop the duplicate node. Renaming ``name``
+      alone would NOT work — ``Entity.id`` is derived once at construction.
+    - Carrying the same unioned relations on both objects means whichever object
+      ``get_graph_from_model`` traverses first emits every edge; the other is
+      skipped (already-visited id) without dropping any edge. Mutating ``id`` alone
+      would strip the loser's outbound edges.
+    """
+    canonical_id = Entity.id_for(canonical_name)
+
+    winner.name = canonical_name
+    winner.id = canonical_id
+    winner.description = reconciled_description
+    winner.relations = _dedup_relations(list(winner.relations) + list(loser.relations))
+
+    loser.id = canonical_id
+    loser.name = canonical_name
+    loser.description = reconciled_description
+    loser.relations = winner.relations
+
+
+def _stamp_and_audit(winner: Entity, loser: Entity, judgment, ctx) -> None:
+    """Stamp merge provenance on the survivor and emit one structured audit log.
+
+    Captures the loser's original name/description BEFORE the mirror mutates them.
+    """
+    loser_name = loser.name
+    loser_description = loser.description
+
+    aliases = list(getattr(winner, "merged_aliases", None) or [])
+    if loser_name not in aliases:
+        aliases.append(loser_name)
+    _safe_setattr(winner, "merged_aliases", aliases)
+    _safe_setattr(winner, "merge_confidence", judgment.confidence)
+    winner.source_task = "canonicalize_entities"
+
+    logger.info(
+        "entity_canonicalization_merge",
+        extra={
+            "canonical_id": str(Entity.id_for(judgment.canonical_name)),
+            "canonical_name": judgment.canonical_name,
+            "merged_id": str(loser.id),
+            "merged_name": loser_name,
+            "confidence": judgment.confidence,
+            "rationale": judgment.rationale,
+            "property_diff": {"description": [loser_description, judgment.reconciled_description]},
+            "pipeline_run_id": str(getattr(ctx, "pipeline_run_id", None)),
+            "dataset_id": str(getattr(getattr(ctx, "dataset", None), "id", None)),
+        },
+    )
+
+
+def _apply_merges(
+    entities: List[Entity], judgments: List[Tuple[object, Entity, Entity]], cfg, ctx
+) -> None:
+    """Collapse confirmed duplicate entities using union-find + the merge primitive.
+
+    Only judgments with ``is_same_entity`` and confidence at or above
+    ``cfg.canonicalization_confidence_threshold`` are accepted. Accepted pairs are
+    unioned into components (handles transitive chains A~B, B~C); each component
+    uses its highest-confidence judgment (tie-break: smallest normalized
+    canonical_name) to pick the canonical name/description, selects a deterministic
+    winner, mirrors every loser onto it, and stamps the audit.
+    """
+    parent = {str(e.id): str(e.id) for e in entities}
+
+    def find(node):
+        while parent[node] != node:
+            parent[node] = parent[parent[node]]
+            node = parent[node]
+        return node
+
+    def union(a, b):
+        root_a, root_b = find(a), find(b)
+        if root_a != root_b:
+            parent[root_b] = root_a
+
+    accepted = []
+    for judgment, a, b in judgments:
+        if not judgment.is_same_entity:
+            continue
+        if judgment.confidence < cfg.canonicalization_confidence_threshold:
+            continue
+        id_a, id_b = str(a.id), str(b.id)
+        if id_a not in parent or id_b not in parent:
+            continue
+        union(id_a, id_b)
+        accepted.append((judgment, a, b))
+
+    if not accepted:
+        return
+
+    # Per-component canonical decision: highest confidence wins; tie-break on the
+    # smallest normalized canonical_name for determinism.
+    def _is_better(candidate, current) -> bool:
+        if candidate.confidence != current.confidence:
+            return candidate.confidence > current.confidence
+        return Entity._normalize_identity_value(
+            candidate.canonical_name
+        ) < Entity._normalize_identity_value(current.canonical_name)
+
+    best = {}
+    for judgment, a, _b in accepted:
+        root = find(str(a.id))
+        current = best.get(root)
+        if current is None or _is_better(judgment, current):
+            best[root] = judgment
+
+    members_by_root = {}
+    for entity in entities:
+        members_by_root.setdefault(find(str(entity.id)), []).append(entity)
+
+    for root, judgment in best.items():
+        members = members_by_root.get(root, [])
+        if len(members) < 2:
+            continue
+        winner = _select_winner(members, judgment.canonical_name)
+        for loser in members:
+            if loser is winner:
+                continue
+            _stamp_and_audit(winner, loser, judgment, ctx)
+            _mirror_loser_onto_winner(
+                winner, loser, judgment.canonical_name, judgment.reconciled_description
+            )
+        winner.update_version()
+
+
 @task_summary("Canonicalized entities in {n} summary(ies)")
 async def canonicalize_entities(
     summaries: List, ctx: Optional[SimpleNamespace] = None, **kwargs
 ) -> List:
     """Reconcile duplicate entities across a batch of TextSummary objects.
 
-    Commit 2 stub: gathers candidate entities and returns the summaries unchanged.
-    Blocking (``_block_candidate_pairs``) and the relation-dedup helper
-    (``_dedup_relations``) are implemented and unit-tested but not yet driven from
-    here — that happens once the LLM judge + merge primitive land.
+    Gathers candidate entities, blocks them into near-duplicate pairs, judges each
+    pair with an LLM, and merges confident duplicates in place (rename+mirror).
+    Returns the same ``summaries`` list; entities are mutated in place so
+    ``add_data_points`` stores the reconciled graph. Not yet wired into the cognify
+    pipeline (that is gated behind the ``entity_canonicalization`` config flag in a
+    later commit).
     """
     entities = _gather_entities(summaries)
     if len(entities) < 2:
         return summaries
 
-    # commit 4: judge + merge — block candidate pairs (_block_candidate_pairs),
-    # judge them via LLMGateway, collapse transitive chains with union-find, apply
-    # the mirror-loser-onto-winner primitive (with _dedup_relations), and emit the
-    # structured merge audit. Until then this task is a no-op pass-through and is
-    # not wired into the cognify pipeline.
+    cfg = get_cognify_config()
+    pairs = await _block_candidate_pairs(entities, cfg)
+    if not pairs:
+        return summaries
+
+    judgments = await _judge_pairs(pairs, cfg)
+    if judgments:
+        _apply_merges(entities, judgments, cfg, ctx)
+
     return summaries

--- a/cognee/tasks/graph/canonicalize_entities.py
+++ b/cognee/tasks/graph/canonicalize_entities.py
@@ -1,0 +1,149 @@
+"""LLM-judge entity canonicalization task (issue #3629).
+
+Commit 2 scope: entity gathering + blocking (candidate generation) only. The
+judge, union-find, mirror-loser-onto-winner merge primitive, and audit are added
+in a later commit; ``canonicalize_entities`` is a gather-only stub for now and is
+not yet wired into the cognify pipeline.
+
+Design notes (grounded in the extraction path):
+- After ``extract_graph_and_summarize`` the objects flowing toward storage are
+  ``TextSummary`` instances; entities live nested under
+  ``TextSummary.made_from.contains`` as ``(Edge, Entity)`` tuples (or bare
+  ``Entity``), never as top-level items.
+- Blocking embeds entity names transiently (no vector-index write) and keeps only
+  pairs whose cosine similarity clears a threshold, so the LLM judge added later
+  only ever sees genuine near-duplicates.
+"""
+
+from types import SimpleNamespace
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.engine.models.Edge import Edge
+from cognee.modules.cognify.config import get_cognify_config
+from cognee.modules.engine.models import Entity
+from cognee.modules.pipelines.tasks.task import task_summary
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.summarization.models import TextSummary
+
+logger = get_logger("canonicalize_entities")
+
+
+def _gather_entities(summaries: List) -> List[Entity]:
+    """Collect the unique ``Entity`` objects reachable from a list of TextSummary.
+
+    Walks ``TextSummary.made_from.contains``, handling both the ``(Edge, Entity)``
+    tuple shape produced by extraction and bare ``Entity`` items. ``Event`` items,
+    ``(Edge, non-Entity)`` tuples, and non-TextSummary rows (e.g. raw DLT rows that
+    ``summarize_text`` passes through) are skipped. Dedup is by ``str(id)`` and
+    order-stable (first occurrence wins).
+    """
+    seen = {}
+    for summary in summaries:
+        if not isinstance(summary, TextSummary):
+            # Non-TextSummary rows (e.g. DLT rows appended by summarize_text) carry
+            # no made_from.contains entity graph to canonicalize.
+            continue
+
+        chunk = getattr(summary, "made_from", None)
+        for item in getattr(chunk, "contains", None) or []:
+            if isinstance(item, tuple) and len(item) == 2 and isinstance(item[1], Entity):
+                entity = item[1]
+            elif isinstance(item, Entity):
+                entity = item
+            else:
+                # Event, or (Edge, non-Entity) — not a canonicalization candidate.
+                continue
+
+            seen.setdefault(str(entity.id), entity)
+
+    return list(seen.values())
+
+
+def _dedup_relations(relations: List) -> List:
+    """Deduplicate outbound relation tuples by (relationship_type, target id).
+
+    Relations are ``(Edge, target)`` tuples (see expand_with_nodes_and_edges); the
+    first occurrence of a given (relationship_type, target-id) pair is kept. Items
+    that are not well-formed relation tuples are passed through unchanged.
+    """
+    seen = set()
+    result = []
+    for relation in relations:
+        if isinstance(relation, tuple) and len(relation) == 2:
+            edge, target = relation
+            relationship_type = getattr(edge, "relationship_type", None)
+            key = (relationship_type, str(getattr(target, "id", target)))
+            if key in seen:
+                continue
+            seen.add(key)
+        result.append(relation)
+    return result
+
+
+async def _block_candidate_pairs(entities: List[Entity], cfg) -> List[Tuple[Entity, Entity]]:
+    """Produce candidate near-duplicate entity pairs via embedding cosine similarity.
+
+    Entity names are embedded transiently (no vector-index write). Pairs whose
+    cosine similarity is at or above ``cfg.canonicalization_similarity_threshold``
+    are returned, highest-similarity first, capped at
+    ``cfg.canonicalization_max_pairs`` (the drop is logged — never silently
+    truncated). Identical-id pairs are skipped (already merged by construction).
+    """
+    names = [entity.name for entity in entities]
+
+    vector_engine = get_vector_engine()
+    vectors = await vector_engine.embedding_engine.embed_text(names)
+
+    matrix = np.asarray(vectors, dtype=float)
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    # Guard zero-norm rows so they yield 0 similarity instead of NaN.
+    norms[norms == 0] = 1.0
+    unit = matrix / norms
+    similarities = unit @ unit.T
+
+    scored_pairs = []
+    for i in range(len(entities)):
+        for k in range(i + 1, len(entities)):
+            if str(entities[i].id) == str(entities[k].id):
+                continue
+            similarity = float(similarities[i][k])
+            if similarity >= cfg.canonicalization_similarity_threshold:
+                scored_pairs.append((similarity, entities[i], entities[k]))
+
+    scored_pairs.sort(key=lambda scored: scored[0], reverse=True)
+
+    max_pairs = cfg.canonicalization_max_pairs
+    if len(scored_pairs) > max_pairs:
+        logger.info(
+            "canonicalization blocking capping candidate pairs",
+            extra={"found": len(scored_pairs), "kept": max_pairs},
+        )
+        scored_pairs = scored_pairs[:max_pairs]
+
+    return [(a, b) for _similarity, a, b in scored_pairs]
+
+
+@task_summary("Canonicalized entities in {n} summary(ies)")
+async def canonicalize_entities(
+    summaries: List, ctx: Optional[SimpleNamespace] = None, **kwargs
+) -> List:
+    """Reconcile duplicate entities across a batch of TextSummary objects.
+
+    Commit 2 stub: gathers candidate entities and returns the summaries unchanged.
+    Blocking (``_block_candidate_pairs``) and the relation-dedup helper
+    (``_dedup_relations``) are implemented and unit-tested but not yet driven from
+    here — that happens once the LLM judge + merge primitive land.
+    """
+    entities = _gather_entities(summaries)
+    if len(entities) < 2:
+        return summaries
+
+    # commit 4: judge + merge — block candidate pairs (_block_candidate_pairs),
+    # judge them via LLMGateway, collapse transitive chains with union-find, apply
+    # the mirror-loser-onto-winner primitive (with _dedup_relations), and emit the
+    # structured merge audit. Until then this task is a no-op pass-through and is
+    # not wired into the cognify pipeline.
+    return summaries

--- a/cognee/tasks/graph/models.py
+++ b/cognee/tasks/graph/models.py
@@ -87,3 +87,37 @@ class GraphOntology(BaseModel):
 
     nodes: list[OntologyNode]
     edges: list[OntologyEdge]
+
+
+class PairJudgment(BaseModel):
+    """
+    The LLM judge's verdict for a single candidate entity pair (issue #3629).
+
+    Instance variables:
+
+    - pair_index: Index of the candidate pair this judgment answers, so a batched
+      response can be mapped back to the entities that were submitted.
+    - is_same_entity: Whether the two candidate entities refer to the same real-world entity.
+    - canonical_name: The preferred canonical surface form for the merged entity.
+    - reconciled_description: The merged description written onto the surviving entity.
+    - confidence: The judge's confidence in [0.0, 1.0].
+    - rationale: A short justification for the verdict.
+
+    Note: per-property reconciliation (property_overrides) is intentionally out of
+    scope for this iteration; only ``description`` is reconciled today.
+    """
+
+    pair_index: int
+    is_same_entity: bool
+    canonical_name: str
+    reconciled_description: str
+    confidence: float
+    rationale: str
+
+
+class CanonicalizationJudgment(BaseModel):
+    """
+    Batched judge response: one PairJudgment per submitted candidate pair.
+    """
+
+    judgments: list[PairJudgment]

--- a/cognee/tests/unit/infrastructure/engine/test_entity_merge_fields.py
+++ b/cognee/tests/unit/infrastructure/engine/test_entity_merge_fields.py
@@ -1,0 +1,56 @@
+"""Tests for the entity-canonicalization audit fields on the Entity model
+(issue #3629): merged_aliases and merge_confidence. They must default to None,
+serialize into node attributes when set, and never affect the UUID5 identity or
+the embedding index_fields."""
+
+from fastapi.encoders import jsonable_encoder
+
+from cognee.modules.engine.models import Entity
+
+
+class TestEntityMergeFields:
+    def test_defaults_are_none(self):
+        entity = Entity(name="Alice", description="an engineer")
+        assert entity.merged_aliases is None
+        assert entity.merge_confidence is None
+
+    def test_setting_fields_does_not_change_identity(self):
+        # The id is derived from the identity_fields (name) only; stamping the
+        # merge audit fields must not alter it.
+        baseline_id = Entity(name="Alice", description="an engineer").id
+
+        entity = Entity(name="Alice", description="an engineer")
+        entity.merged_aliases = ["Alicia", "Alyce"]
+        entity.merge_confidence = 0.93
+
+        assert entity.id == baseline_id
+        assert entity.id == Entity.id_for("Alice")
+
+    def test_fields_excluded_from_index_and_identity(self):
+        entity = Entity(name="Alice", description="an engineer")
+        assert entity.metadata["index_fields"] == ["name"]
+        assert entity.metadata["identity_fields"] == ["name"]
+        assert "merged_aliases" not in entity.metadata["index_fields"]
+        assert "merge_confidence" not in entity.metadata["index_fields"]
+        assert "merged_aliases" not in entity.metadata["identity_fields"]
+        assert "merge_confidence" not in entity.metadata["identity_fields"]
+
+    def test_fields_serialize_into_node_attributes(self):
+        # add_data_points persists nodes via jsonable_encoder(node); the audit
+        # fields must ride along in that serialization when set.
+        entity = Entity(name="Alice", description="an engineer")
+        entity.merged_aliases = ["Alicia"]
+        entity.merge_confidence = 0.87
+
+        encoded = jsonable_encoder(entity)
+        assert encoded["merged_aliases"] == ["Alicia"]
+        assert encoded["merge_confidence"] == 0.87
+
+    def test_normal_setattr_path_now_used(self):
+        # Regression guard for commit 3's _safe_setattr: since these are now real
+        # declared fields, plain setattr must succeed (no ValueError to catch).
+        entity = Entity(name="Alice", description="an engineer")
+        entity.merged_aliases = ["Alicia"]  # would raise before the fields existed
+        entity.merge_confidence = 0.5
+        assert entity.merged_aliases == ["Alicia"]
+        assert entity.merge_confidence == 0.5

--- a/cognee/tests/unit/modules/cognify/test_canonicalization_config_and_models.py
+++ b/cognee/tests/unit/modules/cognify/test_canonicalization_config_and_models.py
@@ -1,0 +1,94 @@
+"""Coherence tests for the canonicalization config flag/tunables and judge models
+(issue #3629, commit 1). No task logic, wiring, or Entity changes are exercised here."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from cognee.modules.cognify.config import CognifyConfig
+from cognee.tasks.graph.models import CanonicalizationJudgment, PairJudgment
+
+
+class TestCanonicalizationConfig:
+    """CognifyConfig gains the #3629 flag + 4 tunables, default OFF."""
+
+    def test_canonicalization_defaults(self):
+        """Flag defaults False and each tunable has the planned default."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = CognifyConfig()
+            assert config.entity_canonicalization is False
+            assert config.canonicalization_similarity_threshold == 0.8
+            assert config.canonicalization_confidence_threshold == 0.85
+            assert config.canonicalization_max_pairs == 200
+            assert config.canonicalization_judge_batch_size == 8
+
+    def test_to_dict_includes_canonicalization_keys(self):
+        """to_dict() surfaces all five new keys with their values."""
+        with patch.dict(os.environ, {}, clear=True):
+            config_dict = CognifyConfig().to_dict()
+            assert config_dict["entity_canonicalization"] is False
+            assert config_dict["canonicalization_similarity_threshold"] == 0.8
+            assert config_dict["canonicalization_confidence_threshold"] == 0.85
+            assert config_dict["canonicalization_max_pairs"] == 200
+            assert config_dict["canonicalization_judge_batch_size"] == 8
+
+    def test_flag_is_env_overridable(self):
+        """ENTITY_CANONICALIZATION env var flips the flag on (opt-in path)."""
+        with patch.dict(os.environ, {"ENTITY_CANONICALIZATION": "true"}, clear=True):
+            assert CognifyConfig().entity_canonicalization is True
+
+
+class TestJudgeModels:
+    """The batched judge response validates well-formed payloads and rejects bad ones."""
+
+    def test_canonicalization_judgment_validates_canned_payload(self):
+        payload = {
+            "judgments": [
+                {
+                    "pair_index": 0,
+                    "is_same_entity": True,
+                    "canonical_name": "Alice",
+                    "reconciled_description": "A software engineer at Acme.",
+                    "confidence": 0.95,
+                    "rationale": "Same person, name variant.",
+                }
+            ]
+        }
+        result = CanonicalizationJudgment.model_validate(payload)
+        assert len(result.judgments) == 1
+        judgment = result.judgments[0]
+        assert isinstance(judgment, PairJudgment)
+        assert judgment.pair_index == 0
+        assert judgment.is_same_entity is True
+        assert judgment.canonical_name == "Alice"
+        assert judgment.confidence == 0.95
+
+    def test_pair_judgment_rejects_missing_field(self):
+        """A judgment missing a required field fails validation."""
+        with pytest.raises(ValidationError):
+            PairJudgment.model_validate(
+                {
+                    "pair_index": 0,
+                    "is_same_entity": True,
+                    "canonical_name": "Alice",
+                    # reconciled_description missing
+                    "confidence": 0.9,
+                    "rationale": "x",
+                }
+            )
+
+    def test_pair_judgment_rejects_wrong_type(self):
+        """A non-numeric confidence fails validation."""
+        with pytest.raises(ValidationError):
+            PairJudgment.model_validate(
+                {
+                    "pair_index": 0,
+                    "is_same_entity": True,
+                    "canonical_name": "Alice",
+                    "reconciled_description": "desc",
+                    "confidence": "not-a-float",
+                    "rationale": "x",
+                }
+            )

--- a/cognee/tests/unit/modules/cognify/test_get_default_tasks_splice.py
+++ b/cognee/tests/unit/modules/cognify/test_get_default_tasks_splice.py
@@ -1,0 +1,66 @@
+"""Regression tests for the opt-in canonicalization splice in get_default_tasks
+(issue #3629, commit 5). The flag-OFF case is the critical invariant: the task
+list must be element-for-element identical to the pre-canonicalization pipeline.
+No real API keys are required (get_cognify_config is patched; config + chunk_size
+are passed so no ontology/LLM setup runs)."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from cognee.api.v1.cognify.cognify import get_default_tasks
+from cognee.modules.cognify.config import CognifyConfig
+
+# `from cognee.api.v1.cognify import cognify` would resolve to the re-exported
+# cognify FUNCTION; grab the actual module object for patching get_cognify_config.
+cognify_module = sys.modules["cognee.api.v1.cognify.cognify"]
+
+# The canonical pre-canonicalization task order.
+_BASE_SEQUENCE = [
+    "classify_documents",
+    "extract_chunks_from_documents",
+    "extract_graph_and_summarize",
+    "add_data_points",
+    "extract_dlt_fk_edges",
+]
+
+
+async def _task_name_sequence(flag_value):
+    """Build the default task list with the flag set, returning executable names."""
+    config = CognifyConfig(entity_canonicalization=flag_value)
+    with patch.object(cognify_module, "get_cognify_config", return_value=config):
+        tasks = await get_default_tasks(
+            # Pass a non-None config so the ontology-env branch is skipped, and an
+            # explicit chunk_size so get_max_chunk_tokens() is never called.
+            config={"ontology_config": {"ontology_resolver": None}},
+            chunk_size=1024,
+        )
+    return [task.executable.__name__ for task in tasks]
+
+
+@pytest.mark.asyncio
+async def test_flag_off_task_list_is_byte_identical():
+    """(f-OFF) With the flag off, the task list matches today's pipeline exactly."""
+    sequence = await _task_name_sequence(False)
+    assert sequence == _BASE_SEQUENCE
+    assert "canonicalize_entities" not in sequence
+
+
+@pytest.mark.asyncio
+async def test_flag_on_inserts_canonicalize_between_summarize_and_store():
+    """(f-ON) With the flag on, canonicalize_entities is spliced at index 3."""
+    sequence = await _task_name_sequence(True)
+    assert sequence == [
+        "classify_documents",
+        "extract_chunks_from_documents",
+        "extract_graph_and_summarize",
+        "canonicalize_entities",
+        "add_data_points",
+        "extract_dlt_fk_edges",
+    ]
+    # It sits strictly between extraction/summarization and storage.
+    assert (
+        sequence.index("canonicalize_entities") == sequence.index("extract_graph_and_summarize") + 1
+    )
+    assert sequence.index("canonicalize_entities") == sequence.index("add_data_points") - 1

--- a/cognee/tests/unit/tasks/graph/test_canonicalize_entities.py
+++ b/cognee/tests/unit/tasks/graph/test_canonicalize_entities.py
@@ -1,0 +1,205 @@
+"""Unit tests for the gather + blocking helpers of the canonicalization task
+(issue #3629, commit 2). The judge/merge/audit logic is not implemented yet, so
+only ``_gather_entities``, ``_block_candidate_pairs``, and ``_dedup_relations``
+are exercised here. All external calls (the embedding engine) are mocked; no real
+API keys are required."""
+
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import patch
+
+from cognee.infrastructure.engine.models.Edge import Edge
+from cognee.modules.cognify.config import CognifyConfig
+from cognee.modules.engine.models import Entity, EntityType
+from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
+from cognee.modules.data.processing.document_types.Document import Document
+from cognee.tasks.summarization.models import TextSummary
+from cognee.tasks.temporal_graph.models import Event
+from cognee.tasks.graph.canonicalize_entities import (
+    _gather_entities,
+    _block_candidate_pairs,
+    _dedup_relations,
+)
+
+ce = sys.modules["cognee.tasks.graph.canonicalize_entities"]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+class _FakeEmbedder:
+    """Deterministic per-text embedder.
+
+    MockEmbeddingEngine returns a *constant* vector for every input, which would
+    make cosine blocking meaningless (everything looks identical). This fake maps
+    each name to a fixed vector so near-duplicates (Alice/Alicia/Alyce) are highly
+    similar and unrelated names (Acme) are orthogonal.
+    """
+
+    _VECTORS = {
+        "alice": [1.0, 0.0, 0.0],
+        "alicia": [0.98, 0.03, 0.0],
+        "alyce": [0.97, 0.05, 0.0],
+        "acme": [0.0, 1.0, 0.0],
+    }
+
+    async def embed_text(self, texts):
+        return [self._VECTORS.get(text.lower(), [0.0, 0.0, 1.0]) for text in texts]
+
+
+def _patch_vector_engine():
+    """Patch get_vector_engine in the task module to use the deterministic fake."""
+    return patch.object(
+        ce,
+        "get_vector_engine",
+        return_value=SimpleNamespace(embedding_engine=_FakeEmbedder()),
+    )
+
+
+def _entity(name, description="desc"):
+    return Entity(name=name, description=description)
+
+
+def _make_summary(contains):
+    """Build a real TextSummary whose made_from chunk holds the given contains list.
+
+    contains is assigned post-construction so mixed/edge-case items don't trip
+    pydantic validation (DataPoint does not validate on assignment)."""
+    document = Document(
+        name="Doc",
+        raw_data_location="memory",
+        external_metadata=None,
+        mime_type="text/plain",
+    )
+    chunk = DocumentChunk(
+        text="chunk text",
+        chunk_size=10,
+        chunk_index=0,
+        cut_type="paragraph",
+        is_part_of=document,
+    )
+    chunk.contains = contains
+    return TextSummary(text="summary", made_from=chunk)
+
+
+# ---------------------------------------------------------------------------
+# _gather_entities
+# ---------------------------------------------------------------------------
+def test_gather_entities_handles_tuple_bare_and_skips_others():
+    alice = _entity("Alice")
+    bob = _entity("Bob")
+    person_type = EntityType(name="Person", description="A person type")
+
+    summary = _make_summary(
+        [
+            (Edge(relationship_type="contains"), alice),  # (Edge, Entity) -> kept
+            bob,  # bare Entity -> kept
+            Event(name="Some meeting"),  # Event -> skipped
+            (Edge(relationship_type="contains"), person_type),  # (Edge, non-Entity) -> skipped
+            object(),  # bare non-Entity -> skipped
+        ]
+    )
+
+    result = _gather_entities([summary])
+    names = {e.name for e in result}
+    assert names == {"Alice", "Bob"}
+
+
+def test_gather_entities_skips_non_textsummary_rows():
+    alice = _entity("Alice")
+    summary = _make_summary([(Edge(relationship_type="contains"), alice)])
+
+    # A raw (non-TextSummary) row — e.g. a DLT row passed through by summarize_text.
+    dlt_row = object()
+
+    result = _gather_entities([summary, dlt_row])
+    assert [e.name for e in result] == ["Alice"]
+
+
+def test_gather_entities_dedups_by_id_first_wins():
+    # Two Entity objects with the same name resolve to the same id (identity_fields
+    # = ["name"]); the first occurrence must win.
+    first = _entity("Alice", description="first")
+    second = _entity("Alice", description="second")
+    assert str(first.id) == str(second.id)
+
+    summary = _make_summary([first, second])
+    result = _gather_entities([summary])
+    assert len(result) == 1
+    assert result[0].description == "first"
+
+
+def test_gather_entities_empty_and_missing_contains():
+    empty_summary = _make_summary([])
+    none_summary = _make_summary(None)
+    assert _gather_entities([empty_summary, none_summary]) == []
+
+
+# ---------------------------------------------------------------------------
+# _block_candidate_pairs
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_block_candidate_pairs_returns_only_near_dupes():
+    alice = _entity("Alice")
+    alicia = _entity("Alicia")
+    acme = _entity("Acme")
+    cfg = CognifyConfig()  # similarity threshold 0.8
+
+    with _patch_vector_engine():
+        pairs = await _block_candidate_pairs([alice, alicia, acme], cfg)
+
+    assert len(pairs) == 1
+    pair_names = {pairs[0][0].name, pairs[0][1].name}
+    assert pair_names == {"Alice", "Alicia"}
+    # Acme is orthogonal to the Alice cluster and must not appear in any pair.
+    assert all("Acme" not in {a.name, b.name} for a, b in pairs)
+
+
+@pytest.mark.asyncio
+async def test_block_candidate_pairs_caps_and_logs(caplog):
+    # Three mutually near-identical entities -> 3 candidate pairs; cap to 1.
+    entities = [_entity("Alice"), _entity("Alicia"), _entity("Alyce")]
+    cfg = CognifyConfig(canonicalization_max_pairs=1)
+
+    with _patch_vector_engine():
+        with caplog.at_level(logging.INFO):
+            pairs = await _block_candidate_pairs(entities, cfg)
+
+    assert len(pairs) == 1
+    assert any("capping candidate pairs" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_block_candidate_pairs_no_pairs_below_threshold():
+    # Two orthogonal entities -> no pair clears the threshold.
+    acme = _entity("Acme")
+    other = _entity("Zeta")  # maps to default [0,0,1], orthogonal to Acme's [0,1,0]
+    cfg = CognifyConfig()
+
+    with _patch_vector_engine():
+        pairs = await _block_candidate_pairs([acme, other], cfg)
+
+    assert pairs == []
+
+
+# ---------------------------------------------------------------------------
+# _dedup_relations
+# ---------------------------------------------------------------------------
+def test_dedup_relations_keeps_first_by_type_and_target():
+    target_a = _entity("Alice")
+    target_b = _entity("Bob")
+
+    relations = [
+        (Edge(relationship_type="knows"), target_a),
+        (Edge(relationship_type="knows"), target_a),  # duplicate -> dropped
+        (Edge(relationship_type="likes"), target_a),  # diff type -> kept
+        (Edge(relationship_type="knows"), target_b),  # diff target -> kept
+    ]
+
+    result = _dedup_relations(relations)
+    assert len(result) == 3
+    keys = {(edge.relationship_type, target.name) for edge, target in result}
+    assert keys == {("knows", "Alice"), ("likes", "Alice"), ("knows", "Bob")}

--- a/cognee/tests/unit/tasks/graph/test_canonicalize_entities.py
+++ b/cognee/tests/unit/tasks/graph/test_canonicalize_entities.py
@@ -1,27 +1,36 @@
-"""Unit tests for the gather + blocking helpers of the canonicalization task
-(issue #3629, commit 2). The judge/merge/audit logic is not implemented yet, so
-only ``_gather_entities``, ``_block_candidate_pairs``, and ``_dedup_relations``
-are exercised here. All external calls (the embedding engine) are mocked; no real
-API keys are required."""
+"""Unit tests for the canonicalization task (issue #3629): entity gathering,
+blocking, and the LLM-judge + rename/mirror merge gate. All external calls (the
+embedding engine and the LLM) are mocked; no real API keys are required. The
+merge tests drive the REAL get_graph_from_model + deduplicate_nodes_and_edges to
+prove edges survive a merge (the trap-2 guarantee)."""
 
 import logging
 import sys
 from types import SimpleNamespace
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from cognee.infrastructure.engine.models.Edge import Edge
 from cognee.modules.cognify.config import CognifyConfig
 from cognee.modules.engine.models import Entity, EntityType
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.modules.data.processing.document_types.Document import Document
+from cognee.modules.graph.utils.get_graph_from_model import get_graph_from_model
+from cognee.modules.graph.utils.deduplicate_nodes_and_edges import (
+    deduplicate_nodes_and_edges,
+)
 from cognee.tasks.summarization.models import TextSummary
 from cognee.tasks.temporal_graph.models import Event
+from cognee.tasks.graph.models import CanonicalizationJudgment, PairJudgment
 from cognee.tasks.graph.canonicalize_entities import (
     _gather_entities,
     _block_candidate_pairs,
     _dedup_relations,
+    _select_winner,
+    _mirror_loser_onto_winner,
+    _apply_merges,
+    canonicalize_entities,
 )
 
 ce = sys.modules["cognee.tasks.graph.canonicalize_entities"]
@@ -203,3 +212,242 @@ def test_dedup_relations_keeps_first_by_type_and_target():
     assert len(result) == 3
     keys = {(edge.relationship_type, target.name) for edge, target in result}
     assert keys == {("knows", "Alice"), ("likes", "Alice"), ("knows", "Bob")}
+
+
+# ---------------------------------------------------------------------------
+# Merge-gate helpers
+# ---------------------------------------------------------------------------
+def _entity_with_relation(name, rel_type, target, description="desc"):
+    entity = _entity(name, description)
+    entity.relations = [(Edge(relationship_type=rel_type), target)]
+    return entity
+
+
+def _judgment(pair_index, is_same, canonical, reconciled, confidence, rationale="because"):
+    return PairJudgment(
+        pair_index=pair_index,
+        is_same_entity=is_same,
+        canonical_name=canonical,
+        reconciled_description=reconciled,
+        confidence=confidence,
+        rationale=rationale,
+    )
+
+
+def _patch_llm(judgments):
+    """Patch the LLM judge seam to return a canned CanonicalizationJudgment."""
+    mock = AsyncMock(return_value=CanonicalizationJudgment(judgments=judgments))
+    return patch.object(ce.LLMGateway, "acreate_structured_output", mock)
+
+
+async def _flatten(summaries):
+    """Run the REAL get_graph_from_model + deduplicate_nodes_and_edges over a
+    summary list, exactly as add_data_points does (shared visited dicts)."""
+    added_nodes, added_edges, visited = {}, {}, {}
+    all_nodes, all_edges = [], []
+    for summary in summaries:
+        nodes, edges = await get_graph_from_model(
+            summary,
+            added_nodes=added_nodes,
+            added_edges=added_edges,
+            visited_properties=visited,
+        )
+        all_nodes.extend(nodes)
+        all_edges.extend(edges)
+    return deduplicate_nodes_and_edges(all_nodes, all_edges)
+
+
+# ---------------------------------------------------------------------------
+# (b) THE CRITICAL CASE: merge collapses to one node AND edges survive
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_merge_collapses_and_both_edges_survive():
+    acme = _entity("Acme", "a company")
+    globex = _entity("Globex", "another company")
+    # Two near-dup entities, EACH with a DISTINCT outbound relation.
+    alice = _entity_with_relation("Alice", "works_at", acme, "engineer")
+    alicia = _entity_with_relation("Alicia", "founded", globex, "software engineer")
+
+    summary = _make_summary(
+        [
+            (Edge(relationship_type="contains"), alice),
+            (Edge(relationship_type="contains"), alicia),
+        ]
+    )
+
+    judgments = [_judgment(0, True, "Alice", "Engineer who founded Globex.", 0.95)]
+
+    with _patch_vector_engine(), _patch_llm(judgments):
+        await canonicalize_entities([summary])
+
+    nodes, edges = await _flatten([summary])
+
+    canonical_id = str(Entity.id_for("Alice"))
+    survivors = [n for n in nodes if str(n.id) == canonical_id]
+    assert len(survivors) == 1  # trap-1: dedup collapsed the duplicate
+    assert survivors[0].description == "Engineer who founded Globex."
+
+    # trap-2: BOTH the winner's and the loser's outbound edges survive the merge.
+    targets_from_canonical = {str(e[1]) for e in edges if str(e[0]) == canonical_id}
+    assert str(acme.id) in targets_from_canonical
+    assert str(globex.id) in targets_from_canonical
+
+
+# ---------------------------------------------------------------------------
+# (c) no-merge -> both entities survive unchanged
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_no_merge_keeps_both_entities():
+    alice = _entity("Alice", "engineer")
+    alicia = _entity("Alicia", "sw engineer")
+    original_alice_id, original_alicia_id = str(alice.id), str(alicia.id)
+
+    summary = _make_summary(
+        [
+            (Edge(relationship_type="contains"), alice),
+            (Edge(relationship_type="contains"), alicia),
+        ]
+    )
+
+    judgments = [_judgment(0, False, "Alice", "unused", 0.99)]
+
+    with _patch_vector_engine(), _patch_llm(judgments):
+        await canonicalize_entities([summary])
+
+    assert str(alice.id) == original_alice_id
+    assert str(alicia.id) == original_alicia_id
+    assert alice.id != alicia.id
+    assert not getattr(alice, "merged_aliases", None)
+
+
+# ---------------------------------------------------------------------------
+# (d) confidence gate
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "confidence, should_merge",
+    [(0.70, False), (0.90, True)],  # default threshold is 0.85
+)
+async def test_confidence_gate(confidence, should_merge):
+    alice = _entity("Alice", "engineer")
+    alicia = _entity("Alicia", "sw engineer")
+
+    summary = _make_summary(
+        [
+            (Edge(relationship_type="contains"), alice),
+            (Edge(relationship_type="contains"), alicia),
+        ]
+    )
+
+    judgments = [_judgment(0, True, "Alice", "merged", confidence)]
+
+    with _patch_vector_engine(), _patch_llm(judgments):
+        await canonicalize_entities([summary])
+
+    if should_merge:
+        assert str(alicia.id) == str(Entity.id_for("Alice"))
+        assert str(alice.id) == str(alicia.id)
+    else:
+        assert str(alice.id) != str(alicia.id)
+
+
+# ---------------------------------------------------------------------------
+# (e) audit / provenance stamped on survivor + exactly one structured log
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_merge_stamps_audit_metadata_and_logs(caplog):
+    alice = _entity("Alice", "engineer")
+    alicia = _entity("Alicia", "sw engineer")
+
+    summary = _make_summary(
+        [
+            (Edge(relationship_type="contains"), alice),
+            (Edge(relationship_type="contains"), alicia),
+        ]
+    )
+
+    judgments = [_judgment(0, True, "Alice", "merged desc", 0.93)]
+    ctx = SimpleNamespace(pipeline_run_id="run-1", dataset=SimpleNamespace(id="ds-1"))
+
+    with _patch_vector_engine(), _patch_llm(judgments):
+        with caplog.at_level(logging.INFO):
+            await canonicalize_entities([summary], ctx=ctx)
+
+    # alice is the winner (canonical "Alice" matches its normalized name).
+    assert getattr(alice, "merge_confidence", None) == 0.93
+    assert "Alicia" in (getattr(alice, "merged_aliases", None) or [])
+    assert alice.source_task == "canonicalize_entities"
+    assert alice.version == 2  # bumped once from the default version 1
+
+    merge_logs = [r for r in caplog.records if "entity_canonicalization_merge" in r.getMessage()]
+    assert len(merge_logs) == 1
+
+
+# ---------------------------------------------------------------------------
+# union-find: transitive chain A~B, B~C collapses to one id
+# ---------------------------------------------------------------------------
+def test_apply_merges_union_find_transitive_chain():
+    alpha = _entity("Alpha", "one")
+    beta = _entity("Beta", "two")
+    gamma = _entity("Gamma", "three")
+
+    judgments = [
+        (_judgment(0, True, "Alpha", "merged", 0.95), alpha, beta),
+        (_judgment(1, True, "Alpha", "merged", 0.95), beta, gamma),
+    ]
+
+    _apply_merges([alpha, beta, gamma], judgments, CognifyConfig(), ctx=None)
+
+    canonical_id = str(Entity.id_for("Alpha"))
+    assert str(alpha.id) == canonical_id
+    assert str(beta.id) == canonical_id
+    assert str(gamma.id) == canonical_id
+
+
+# ---------------------------------------------------------------------------
+# _mirror_loser_onto_winner primitive
+# ---------------------------------------------------------------------------
+def test_mirror_shares_id_and_unions_relations():
+    acme = _entity("Acme")
+    globex = _entity("Globex")
+    winner = _entity_with_relation("Alice", "works_at", acme)
+    loser = _entity_with_relation("Alicia", "founded", globex)
+
+    _mirror_loser_onto_winner(winner, loser, "Alice", "merged")
+
+    canonical_id = str(Entity.id_for("Alice"))
+    assert str(winner.id) == canonical_id
+    assert str(loser.id) == canonical_id  # both share the canonical id
+    assert winner.description == loser.description == "merged"
+    # union of both entities' outbound relations, carried by BOTH objects
+    winner_targets = {t.name for _e, t in winner.relations}
+    loser_targets = {t.name for _e, t in loser.relations}
+    assert winner_targets == {"Acme", "Globex"}
+    assert loser_targets == {"Acme", "Globex"}
+
+
+# ---------------------------------------------------------------------------
+# _select_winner determinism (order-independent)
+# ---------------------------------------------------------------------------
+def test_select_winner_exact_match_is_order_independent():
+    alice = _entity("Alice")
+    alicia = _entity("Alicia")
+    members = [alice, alicia]
+
+    forward = _select_winner(members, "Alice")
+    backward = _select_winner(list(reversed(members)), "Alice")
+    assert forward is alice
+    assert backward is alice
+
+
+def test_select_winner_falls_back_to_min_normalized_name():
+    zeta = _entity("Zeta")
+    alpha = _entity("Alpha")
+    mid = _entity("Mid")
+    members = [zeta, alpha, mid]
+
+    # canonical matches none -> smallest normalized name ("alpha") wins.
+    forward = _select_winner(members, "Brand New Name")
+    backward = _select_winner(list(reversed(members)), "Brand New Name")
+    assert forward is alpha
+    assert backward is alpha


### PR DESCRIPTION
Closes #3629

## Description

This implements Approach C for #3629 — LLM-judge entity canonicalization. Today cognee's dedup only merges entities whose normalized names produce an identical UUID5, so "OpenAI" and "OpenAI Inc." stay as two separate nodes. This adds an opt-in step that uses an LLM to judge whether near-duplicate entities are actually the same, and merges them while reconciling their descriptions.

My approach, and the reasoning behind the key decisions:

- **I extended the existing dedup path instead of forking a parallel one**, as the issue requires. The trick: rather than writing my own node-removal code, the merge renames the losing entity onto the winner's canonical id (`Entity.id_for(canonical_name)`) so the *existing* `deduplicate_nodes_and_edges` collapses them at storage.

The existing dedup already handles node/edge collapsing correctly, so reusing it meant less new code to get wrong — a parallel merge path would just risk diverging from logic that already works.

- **The two traps I had to solve for the rename to actually work:** (1) setting `.name` alone is a no-op because an Entity's id is baked once at construction — so I set `.id` explicitly. (2) once two objects share an id, the graph traversal skips the second one, which would silently drop the loser's edges — so I union both entities' relations onto both objects before storage. There's a test that runs the real `get_graph_from_model` + `deduplicate_nodes_and_edges` and asserts the loser's edge survives.

- **Cost is gated by blocking:** only entity pairs above a cosine-similarity threshold are sent to the LLM, capped and batched, with a clean early-return (zero LLM calls) when there are no candidates.

- **It's opt-in, default off** (`ENTITY_CANONICALIZATION=false`). When off, the cognify task list is byte-for-byte identical to today — there's a regression test asserting exactly that.

- **I split it into 7 small commits** (config → blocking → judge+merge → Entity fields → wiring → prompt → docs) so each piece — especially the merge primitive — is reviewable on its own.

## Acceptance Criteria

- **Extends existing dedup, no parallel pipeline** — the rename/mirror primitive rides the existing UUID5 `deduplicate_nodes_and_edges`; the task is spliced into `get_default_tasks`, not forked. ✅
- **Provenance preserved on merge** — the survivor carries `merged_aliases` + `merge_confidence`, and each merge emits a structured `entity_canonicalization_merge` log with canonical/merged ids, confidence, rationale, and the description diff. ✅
- **Deterministic tests, mocked LLM, no real keys** — 30 unit tests; the LLM and embedder are both mocked. ✅ (see Screenshots)
- **LLM judges same/different + reconciles + confidence + rationale; blocking gates cost** — Approach C core, via a structured `CanonicalizationJudgment` response model. ✅

**Honest scope notes (deliberate limits, follow-ups noted):**
- **Reconciliation is description-only.** `description` is the one reconcilable non-identity text field on `Entity` today; general per-property reconciliation is a noted follow-up.
- **Merges are auditable but not yet programmatically reversible.** The audit trail (log + survivor metadata) records what merged into what; a full un-merge would need a dedicated audit table (scoped out to keep this PR migration-free).
- **Blocking is within the current cognify batch** (no cross-run dedup), and the **temporal cognify path is not wired** — both noted follow-ups.
- Coverage is unit-level (task internals + splice wiring, all mocked); no end-to-end run with the flag on.

**Note on CI:** some pre-existing failures in `test_expand_with_nodes_and_edges.py` / `test_extract_graph_from_data.py` (`Node` requiring a `label` field) exist on `dev` independently of this PR — none of these 7 commits touch those files.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Code refactoring

## Screenshots

<img width="1818" height="781" alt="image" src="https://github.com/user-attachments/assets/87d779d0-a0b4-4b6d-9040-c402379d2649" />

<img width="1830" height="251" alt="image" src="https://github.com/user-attachments/assets/5ab6053b-479b-4315-bdba-5e8428861b07" />


## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.