### PR TITLE
feat(versioning): run-ledger time-travel, rollback, and reversible forget (#3650)

### DIFF
--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -84,6 +84,17 @@ from cognee.modules.observability.trace_context import (
 # Agent memory
 from cognee.modules.agent_memory import agent_memory
 
+# Dataset versioning (issue #3650, Approach 1: run-ledger time-travel)
+from .api.v1.version import (
+    graph_as_of,
+    list_snapshots,
+    rollback,
+    search_as_of,
+    snapshot,
+    undo,
+)
+
 # Relational DB models
 from cognee.modules.session_lifecycle.models import SessionModelUsage, SessionRecord
 import cognee.modules.migrations.models  # noqa: F401  (registers global_database_version)
+import cognee.modules.versioning.models  # noqa: F401  (registers dataset_snapshots, version_ops)

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -20,6 +20,7 @@ async def forget(
     dataset_id: Optional[UUID] = None,
     everything: bool = False,
     memory_only: bool = False,
+    reversible: bool = False,
     user: Any = None,
 ) -> dict:
     """Remove data from the knowledge graph.
@@ -57,6 +58,14 @@ async def forget(
             (graph nodes/edges and vector embeddings) and reset pipeline status.
             Raw files and data records are preserved so the dataset can
             be re-cognified with different settings.
+        reversible: If True (requires ``memory_only=True``), commit a
+            write-ahead inverse to the version ledger before deleting, so the
+            forget can be undone exactly (graph rows, provenance, and vector
+            embeddings) with ``cognee.undo(operation_id)`` within the retention
+            window (``VERSION_RETENTION_DAYS``, default 30 days). Requires a
+            graph-provenance backend (default Ladybug + LanceDB stack); other
+            backends raise ``UnsupportedProvenanceCapability`` before any data
+            is deleted. The returned dict gains an ``operation_id`` key.
         user: User context. Resolved to default user when None.
 
     Returns:
@@ -69,6 +78,13 @@ async def forget(
 
     if dataset and dataset_id:
         raise ValueError("Provide either dataset or dataset_id, not both.")
+
+    if reversible and not memory_only:
+        raise ValueError(
+            "reversible=True requires memory_only=True: only graph/vector memory can be "
+            "restored exactly. Raw files and data records removed by a full forget are "
+            "not covered by the version ledger."
+        )
 
     if everything:
         target = "everything"
@@ -104,6 +120,11 @@ async def forget(
 
         client = get_remote_client()
         if client is not None:
+            if reversible:
+                raise ValueError(
+                    "reversible=True is not supported through the remote client; "
+                    "run reversible forget against a local deployment."
+                )
             result = await client.forget(
                 data_id=data_id,
                 dataset=dataset,
@@ -147,8 +168,10 @@ async def forget(
         async with set_database_global_context_variables(dataset_ref, user.id):
             if memory_only:
                 if data_id is not None:
-                    return await _forget_data_memory(data_id, dataset_ref, user)
-                return await _forget_dataset_memory(dataset_ref, user)
+                    return await _forget_data_memory(
+                        data_id, dataset_ref, user, reversible=reversible
+                    )
+                return await _forget_dataset_memory(dataset_ref, user, reversible=reversible)
 
             if data_id is not None:
                 return await _forget_data_item(data_id, dataset_ref, user)
@@ -232,7 +255,9 @@ async def _forget_data_item(data_id: UUID, dataset_ref: Union[str, UUID], user: 
     return {"data_id": str(data_id), "dataset_id": str(dataset_id), "status": "success"}
 
 
-async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> dict:
+async def _forget_dataset_memory(
+    dataset_ref: Union[str, UUID], user: Any, reversible: bool = False
+) -> dict:
     """Delete only memory (graph + vector) for a dataset, preserving raw files.
 
     This allows re-cognifying the dataset with different settings
@@ -244,6 +269,10 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
     - Pipeline status: reset (so cognify re-processes all data)
     - Relational DB (dataset, data records): preserved
     - Raw files: preserved
+
+    With ``reversible=True`` the exact inverse is committed to the version
+    ledger *before* deletion (write-ahead); ``cognee.undo(operation_id)``
+    restores it within the retention window.
     """
     from sqlalchemy import select
     from sqlalchemy.orm import attributes as orm_attributes
@@ -259,6 +288,14 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
     )
 
     dataset_id = await _resolve_dataset_id(dataset_ref, user)
+
+    # 0. Reversible mode: commit the write-ahead inverse before any deletion.
+    #    Unsupported backends raise here, before data is touched.
+    operation_id = None
+    if reversible:
+        from cognee.modules.versioning import capture_forget_inverse
+
+        operation_id = await capture_forget_inverse(dataset_id)
 
     # 1. Delete graph nodes/edges and vector embeddings
     await delete_dataset_nodes_and_edges(dataset_id, user.id)
@@ -298,14 +335,22 @@ async def _forget_dataset_memory(dataset_ref: Union[str, UUID], user: Any) -> di
         user.id,
         len(data_records),
     )
-    return {
+    result = {
         "dataset_id": str(dataset_id),
         "data_records_reset": len(data_records),
         "status": "success",
     }
+    if operation_id is not None:
+        from cognee.modules.versioning import mark_forget_applied
+
+        await mark_forget_applied(operation_id)
+        result["operation_id"] = str(operation_id)
+    return result
 
 
-async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user: Any) -> dict:
+async def _forget_data_memory(
+    data_id: UUID, dataset_ref: Union[str, UUID], user: Any, reversible: bool = False
+) -> dict:
     """Delete only memory (graph + vector) for a single data item, preserving the raw file.
 
     This allows re-cognifying a specific file with different settings
@@ -317,6 +362,10 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
     - Pipeline status (for this data item): reset for cognify only
     - Relational DB (data record): preserved
     - Raw file: preserved
+
+    With ``reversible=True`` the exact inverse is committed to the version
+    ledger *before* deletion (write-ahead); ``cognee.undo(operation_id)``
+    restores it within the retention window.
     """
     from sqlalchemy import select
     from sqlalchemy.orm import attributes as orm_attributes
@@ -328,6 +377,14 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
     )
 
     dataset_id = await _resolve_dataset_id(dataset_ref, user)
+
+    # 0. Reversible mode: commit the write-ahead inverse before any deletion.
+    #    Unsupported backends raise here, before data is touched.
+    operation_id = None
+    if reversible:
+        from cognee.modules.versioning import capture_forget_inverse
+
+        operation_id = await capture_forget_inverse(dataset_id, data_id)
 
     # 1. Delete graph nodes/edges and vector embeddings for this data item
     await delete_data_nodes_and_edges(dataset_id, data_id, user.id)
@@ -360,11 +417,17 @@ async def _forget_data_memory(data_id: UUID, dataset_ref: Union[str, UUID], user
         dataset_id,
         user.id,
     )
-    return {
+    result = {
         "data_id": str(data_id),
         "dataset_id": str(dataset_id),
         "status": "success",
     }
+    if operation_id is not None:
+        from cognee.modules.versioning import mark_forget_applied
+
+        await mark_forget_applied(operation_id)
+        result["operation_id"] = str(operation_id)
+    return result
 
 
 async def _resolve_dataset_id(dataset_ref: Union[str, UUID], user: Any) -> UUID:

--- a/cognee/api/v1/version/__init__.py
+++ b/cognee/api/v1/version/__init__.py
@@ -1,0 +1,8 @@
+from .version import (
+    graph_as_of,
+    list_snapshots,
+    rollback,
+    search_as_of,
+    snapshot,
+    undo,
+)

--- a/cognee/api/v1/version/version.py
+++ b/cognee/api/v1/version/version.py
@@ -1,0 +1,190 @@
+"""Public dataset-versioning API (issue #3650, Approach 1: run-ledger time-travel).
+
+Additive surface over the COG-5522 provenance substrate:
+
+    await cognee.snapshot("before-import", dataset="my_dataset")
+    nodes, edges = await cognee.graph_as_of("before-import", dataset="my_dataset")
+    hits = await cognee.search_as_of("query", "before-import", dataset="my_dataset")
+    result = await cognee.rollback("before-import", dataset="my_dataset")
+    await cognee.undo(result["operation_id"], dataset="my_dataset")
+
+Reversible forget is exposed on ``cognee.forget(..., memory_only=True,
+reversible=True)``, which returns the ledger ``operation_id`` consumed by
+``cognee.undo``. Nothing here changes existing behavior when unused.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple, Union
+from uuid import UUID
+
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.modules import versioning
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("version")
+
+
+async def _resolve_user(user: Any):
+    if user is not None:
+        return user
+    from cognee.modules.users.methods import get_default_user
+
+    return await get_default_user()
+
+
+async def _resolve_dataset(
+    dataset: Optional[str], dataset_id: Optional[UUID], user: Any, permission: str
+):
+    """Resolve a dataset name or UUID to an authorized Dataset object."""
+    if dataset and dataset_id:
+        raise ValueError("Provide either dataset or dataset_id, not both.")
+    if not dataset and not dataset_id:
+        raise ValueError("Provide dataset or dataset_id.")
+
+    if dataset_id is not None:
+        from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
+
+        resolved = await get_authorized_dataset(user, dataset_id, permission)
+        if not resolved:
+            raise ValueError(f"Dataset {dataset_id} not found or not accessible.")
+        return resolved
+
+    from cognee.modules.data.methods import get_authorized_dataset_by_name
+
+    return await get_authorized_dataset_by_name(dataset, user, permission)
+
+
+async def snapshot(
+    name: str,
+    *,
+    dataset: Optional[str] = None,
+    dataset_id: Optional[UUID] = None,
+    user: Any = None,
+) -> Dict[str, Any]:
+    """Label the dataset's current position in the run ledger. Copies nothing."""
+    user = await _resolve_user(user)
+    resolved = await _resolve_dataset(dataset, dataset_id, user, "write")
+
+    created = await versioning.create_snapshot(resolved.id, name)
+    return {
+        "id": str(created.id),
+        "name": created.name,
+        "dataset_id": str(created.dataset_id),
+        "as_of_time": created.as_of_time.isoformat(),
+        "latest_pipeline_run_id": (
+            str(created.latest_pipeline_run_id) if created.latest_pipeline_run_id else None
+        ),
+    }
+
+
+async def list_snapshots(
+    *,
+    dataset: Optional[str] = None,
+    dataset_id: Optional[UUID] = None,
+    user: Any = None,
+) -> List[Dict[str, Any]]:
+    user = await _resolve_user(user)
+    resolved = await _resolve_dataset(dataset, dataset_id, user, "read")
+
+    return [
+        {
+            "id": str(item.id),
+            "name": item.name,
+            "dataset_id": str(item.dataset_id),
+            "as_of_time": item.as_of_time.isoformat(),
+            "latest_pipeline_run_id": (
+                str(item.latest_pipeline_run_id) if item.latest_pipeline_run_id else None
+            ),
+        }
+        for item in await versioning.list_snapshots(resolved.id)
+    ]
+
+
+async def graph_as_of(
+    as_of: Union[str, datetime],
+    *,
+    dataset: Optional[str] = None,
+    dataset_id: Optional[UUID] = None,
+    user: Any = None,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """The dataset's visible subgraph at ``as_of`` (snapshot name or datetime).
+
+    Forward-faithful read: artifacts destroyed by an un-undone forget or
+    rollback executed *after* ``as_of`` are gone from the live store and are
+    not resurrected by this filter (see modules/versioning/methods/as_of_read).
+    """
+    from cognee.infrastructure.databases.graph import get_graph_engine
+
+    user = await _resolve_user(user)
+    resolved = await _resolve_dataset(dataset, dataset_id, user, "read")
+
+    async with set_database_global_context_variables(resolved.id, resolved.owner_id):
+        graph_engine = await get_graph_engine()
+        return await versioning.get_graph_as_of(graph_engine, resolved.id, as_of)
+
+
+async def search_as_of(
+    query_text: str,
+    as_of: Union[str, datetime],
+    *,
+    dataset: Optional[str] = None,
+    dataset_id: Optional[UUID] = None,
+    top_k: int = 15,
+    user: Any = None,
+) -> List[Any]:
+    """Chunk search over the dataset as it existed at ``as_of``."""
+    from cognee.infrastructure.databases.graph import get_graph_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine
+
+    user = await _resolve_user(user)
+    resolved = await _resolve_dataset(dataset, dataset_id, user, "read")
+
+    async with set_database_global_context_variables(resolved.id, resolved.owner_id):
+        graph_engine = await get_graph_engine()
+        vector_engine = get_vector_engine()
+        return await versioning.search_chunks_as_of(
+            graph_engine, vector_engine, resolved.id, query_text, as_of, top_k=top_k
+        )
+
+
+async def rollback(
+    to: Union[str, datetime],
+    *,
+    dataset: Optional[str] = None,
+    dataset_id: Optional[UUID] = None,
+    user: Any = None,
+) -> Dict[str, Any]:
+    """Reverse every run completed after ``to`` (snapshot name or datetime).
+
+    Uses the existing run rollback primitive, newest run first, and records
+    the whole rollback as one undoable ledger operation; the returned
+    ``operation_id`` feeds ``cognee.undo``.
+    """
+    user = await _resolve_user(user)
+    resolved = await _resolve_dataset(dataset, dataset_id, user, "delete")
+
+    async with set_database_global_context_variables(resolved.id, resolved.owner_id):
+        return await versioning.rollback_dataset_to(resolved, to, user)
+
+
+async def undo(
+    operation_id: Union[str, UUID],
+    *,
+    dataset: Optional[str] = None,
+    dataset_id: Optional[UUID] = None,
+    user: Any = None,
+) -> Dict[str, Any]:
+    """Undo a ledgered forget or rollback within the retention window."""
+    user = await _resolve_user(user)
+
+    op_id = operation_id if isinstance(operation_id, UUID) else UUID(str(operation_id))
+
+    if dataset is None and dataset_id is None:
+        # The ledger row knows its dataset; authorize against that.
+        op = await versioning.get_version_op(op_id)
+        dataset_id = op.dataset_id
+
+    resolved = await _resolve_dataset(dataset, dataset_id, user, "delete")
+
+    async with set_database_global_context_variables(resolved.id, resolved.owner_id):
+        return await versioning.undo_version_op(op_id)

--- a/cognee/api/v1/version/version.py
+++ b/cognee/api/v1/version/version.py
@@ -132,7 +132,12 @@ async def search_as_of(
     top_k: int = 15,
     user: Any = None,
 ) -> List[Any]:
-    """Chunk search over the dataset as it existed at ``as_of``."""
+    """Chunk search over the dataset as it existed at ``as_of``.
+
+    Returns scored hits (``id`` + ``score``) with ``payload=None`` by design:
+    the visibility over-fetch runs with ``include_payload=False`` for speed.
+    Callers needing chunk text should re-fetch payloads by the returned ids.
+    """
     from cognee.infrastructure.databases.graph import get_graph_engine
     from cognee.infrastructure.databases.vector import get_vector_engine
 

--- a/cognee/infrastructure/databases/graph/graph_db_interface.py
+++ b/cognee/infrastructure/databases/graph/graph_db_interface.py
@@ -402,6 +402,33 @@ class GraphDBInterface(ABC):
         """
         raise UnsupportedProvenanceCapability()
 
+    async def find_all_node_source_run_refs(self) -> dict[str, list[str]]:
+        """
+        Map every provenanced node id to its source_run_refs in one scan.
+
+        Powers "as of T" visibility reads: an artifact is visible at T when one
+        of its run refs belongs to a run completed at or before T.
+
+        Returns:
+        --------
+
+            - dict[str, list[str]]: source_run_refs keyed by node id; nodes
+              without run refs are omitted.
+        """
+        raise UnsupportedProvenanceCapability()
+
+    async def find_all_edge_source_run_refs(self) -> dict[EdgeIdentity, list[str]]:
+        """
+        Map every provenanced edge to its source_run_refs in one scan.
+
+        Returns:
+        --------
+
+            - dict[EdgeIdentity, list[str]]: source_run_refs keyed by edge
+              identity; edges without run refs are omitted.
+        """
+        raise UnsupportedProvenanceCapability()
+
     async def set_graph_metadata(
         self,
         metadata: dict[str, str],

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -1614,6 +1614,39 @@ class LadybugAdapter(GraphDBInterface):
                 result[edge] = contributed
         return result
 
+    async def find_all_node_source_run_refs(self) -> dict[str, list[str]]:
+        rows = await self.query(
+            """
+            MATCH (n:Node)
+            WHERE n.source_run_refs IS NOT NULL
+            RETURN n.id, n.source_run_refs
+            """,
+            {},
+        )
+        result: dict[str, list[str]] = {}
+        for row in rows:
+            run_refs = _decode_refs(row[1])
+            if run_refs:
+                result[row[0]] = run_refs
+        return result
+
+    async def find_all_edge_source_run_refs(self) -> dict[EdgeIdentity, list[str]]:
+        rows = await self.query(
+            """
+            MATCH (a:Node)-[r:EDGE]->(b:Node)
+            WHERE r.source_run_refs IS NOT NULL
+            RETURN a.id, b.id, r.relationship_name, r.source_run_refs
+            """,
+            {},
+        )
+        result: dict[EdgeIdentity, list[str]] = {}
+        for row in rows:
+            run_refs = _decode_refs(row[3])
+            if run_refs:
+                edge = EdgeIdentity(source_id=row[0], target_id=row[1], relationship_name=row[2])
+                result[edge] = run_refs
+        return result
+
     async def get_edges_created_since(
         self,
         since: Optional[datetime],

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -602,6 +602,114 @@ class LanceDBAdapter(VectorDBInterface):
                 .execute(self._records_for_write(raw_points))
             )
 
+    async def get_raw_rows(self, collection_name: str, data_point_ids: list[str]) -> list[dict]:
+        """Raw (id, vector, payload) rows for the versioning inverse ledger.
+
+        Unlike ``retrieve``, the stored embedding is returned so a later
+        restore is exact (no re-embedding). Missing collections yield [].
+        """
+        if not data_point_ids:
+            return []
+        try:
+            collection = await self.get_collection(collection_name)
+        except CollectionNotFoundError:
+            return []
+
+        escaped_ids = [str(point_id).replace("'", "''") for point_id in data_point_ids]
+        if len(escaped_ids) == 1:
+            where_clause = f"id = '{escaped_ids[0]}'"
+        else:
+            id_list = ", ".join(f"'{point_id}'" for point_id in escaped_ids)
+            where_clause = f"id IN ({id_list})"
+
+        results = await collection.query().where(where_clause).to_list()
+
+        rows = []
+        for result in results:
+            vector = result.get("vector")
+            rows.append(
+                {
+                    "id": result["id"],
+                    "vector": [float(value) for value in vector] if vector is not None else None,
+                    "payload": result.get("payload"),
+                }
+            )
+        return rows
+
+    @staticmethod
+    def _coerce_value_to_arrow_type(value, arrow_type):
+        """Re-typing for JSON round-tripped rows: ISO strings back to timestamps.
+
+        Captured rows pass through a JSON ledger column, which stringifies
+        datetimes inside payload structs; arrow will not coerce a string into
+        a timestamp field, so walk the schema and parse them back.
+        """
+        import pyarrow as pa
+        from datetime import datetime
+
+        if value is None:
+            return None
+        if pa.types.is_timestamp(arrow_type) and isinstance(value, str):
+            return datetime.fromisoformat(value)
+        if pa.types.is_struct(arrow_type) and isinstance(value, dict):
+            return {
+                field.name: LanceDBAdapter._coerce_value_to_arrow_type(
+                    value.get(field.name), field.type
+                )
+                for field in arrow_type
+            }
+        if (
+            pa.types.is_list(arrow_type)
+            or pa.types.is_large_list(arrow_type)
+            or pa.types.is_fixed_size_list(arrow_type)
+        ) and isinstance(value, list):
+            return [
+                LanceDBAdapter._coerce_value_to_arrow_type(item, arrow_type.value_type)
+                for item in value
+            ]
+        return value
+
+    async def restore_raw_rows(self, collection_name: str, rows: list[dict]) -> None:
+        """Upsert rows captured with ``get_raw_rows`` without re-embedding.
+
+        Requires the collection to still exist (deletes remove rows, never
+        tables); restoring into a dropped collection cannot recover the typed
+        schema and raises instead of guessing.
+        """
+        if not rows:
+            return
+        if not await self.has_collection(collection_name):
+            raise CollectionNotFoundError(
+                f"Cannot restore raw vector rows: collection '{collection_name}' no longer exists."
+            )
+
+        import pyarrow as pa
+
+        collection = await self.get_collection(collection_name)
+        if hasattr(collection, "schema"):
+            schema = await collection.schema()
+        else:
+            # Subprocess-proxy tables don't expose schema(); derive it from an
+            # arrow snapshot instead.
+            schema = (await collection.to_arrow()).schema
+
+        coerced_rows = [
+            {
+                field.name: self._coerce_value_to_arrow_type(row.get(field.name), field.type)
+                for field in schema
+            }
+            for row in rows
+        ]
+        table = pa.Table.from_pylist(coerced_rows, schema=schema)
+
+        async with self.VECTOR_DB_LOCK:
+            await (
+                collection.merge_insert("id")
+                .when_matched_update_all()
+                .when_not_matched_insert_all()
+                .execute(table)
+            )
+
     async def _migrate_collection_schema(
         self,
         collection_name: str,

--- a/cognee/infrastructure/databases/vector/vector_db_interface.py
+++ b/cognee/infrastructure/databases/vector/vector_db_interface.py
@@ -78,6 +78,32 @@ class VectorDBInterface(Protocol):
         """
         raise NotImplementedError("upsert_raw_vectors is not implemented for this adapter")
 
+    async def get_raw_rows(self, collection_name: str, data_point_ids: list[str]) -> list[dict]:
+        """
+        Return raw rows (id, vector, payload) for exact capture-and-restore.
+
+        Used by the versioning inverse ledger: unlike ``retrieve``, the stored
+        embedding is included so a later restore does not re-embed. A missing
+        collection returns an empty list. Adapters that cannot expose raw rows
+        raise UnsupportedProvenanceCapability so reversible operations fail
+        closed instead of silently losing vectors.
+        """
+        from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
+
+        raise UnsupportedProvenanceCapability()
+
+    async def restore_raw_rows(self, collection_name: str, rows: list[dict]) -> None:
+        """
+        Upsert rows previously captured with ``get_raw_rows`` (idempotent).
+
+        The rows carry the original embeddings and payloads; restoring must not
+        invoke the embedding engine. Adapters that cannot restore raw rows
+        raise UnsupportedProvenanceCapability.
+        """
+        from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
+
+        raise UnsupportedProvenanceCapability()
+
     @abstractmethod
     async def retrieve(self, collection_name: str, data_point_ids: list[str]):
         """

--- a/cognee/modules/versioning/__init__.py
+++ b/cognee/modules/versioning/__init__.py
@@ -1,0 +1,28 @@
+"""Dataset versioning built on the COG-5522 run ledger (issue #3650, Approach 1).
+
+The ordered sequence of completed pipeline runs *is* the version history:
+
+- **snapshot** — a named label at a ledger cut (no data copied),
+- **as-of reads** — filter the live store to runs completed by T
+  (forward-faithful; see ``methods/as_of_read.py`` for the boundary),
+- **rollback** — reverse post-T runs with the existing rollback primitive,
+  captured as an undoable ledger op,
+- **reversible forget / undo** — a write-ahead ledgered inverse restores the
+  exact graph rows, provenance, and vector embeddings within the retention
+  window (``VERSION_RETENTION_DAYS``, default 30).
+"""
+
+from .methods import (
+    capture_forget_inverse,
+    create_snapshot,
+    get_graph_as_of,
+    get_version_op,
+    get_visible_artifacts_as_of,
+    list_snapshots,
+    mark_forget_applied,
+    resolve_as_of_time,
+    rollback_dataset_to,
+    search_chunks_as_of,
+    undo_version_op,
+)
+from .models import DatasetSnapshot, VersionOp, VersionOpStatus

--- a/cognee/modules/versioning/methods/__init__.py
+++ b/cognee/modules/versioning/methods/__init__.py
@@ -1,0 +1,26 @@
+from .as_of_read import (
+    get_graph_as_of,
+    get_visible_artifacts_as_of,
+    search_chunks_as_of,
+)
+from .inverse import capture_source_ref_removal_inverse, restore_inverse_step
+from .ledger import (
+    append_op_step,
+    assert_within_retention,
+    create_version_op,
+    get_version_op,
+    set_op_status,
+)
+from .operations import (
+    capture_forget_inverse,
+    mark_forget_applied,
+    rollback_dataset_to,
+    undo_version_op,
+)
+from .snapshots import create_snapshot, list_snapshots
+from .timeline import (
+    get_allowed_run_ids,
+    get_latest_completed_run_id,
+    get_run_ids_after,
+    resolve_as_of_time,
+)

--- a/cognee/modules/versioning/methods/as_of_read.py
+++ b/cognee/modules/versioning/methods/as_of_read.py
@@ -130,6 +130,10 @@ async def search_chunks_as_of(
     Chunk vectors are keyed by their graph node id (the provenance the delete
     path relies on), so the graph-derived visible set is the exact filter for
     the vector hits: post-filter, then truncate to ``top_k``.
+
+    Hits carry ``id`` + ``score`` with ``payload=None`` by design: the
+    over-fetch runs with ``include_payload=False`` so visibility filtering
+    stays cheap. Callers needing chunk text re-fetch payloads by the ids.
     """
     visible_nodes, _visible_edges = await get_visible_artifacts_as_of(
         graph_engine, dataset_id, as_of

--- a/cognee/modules/versioning/methods/as_of_read.py
+++ b/cognee/modules/versioning/methods/as_of_read.py
@@ -1,0 +1,145 @@
+"""Time-travel reads: filter the live store down to the runs completed by T.
+
+**Semantics — forward-faithful filter, not full reconstruction.** An "as of T"
+read returns the artifacts whose provenance shows they were attached by a run
+completed at or before T *and that still exist in the live store*. Nothing is
+copied or mutated. The boundary this implies: a destructive operation executed
+*after* T (a forget, a rollback) shadows earlier state — the artifact is gone
+from the live store, so an as-of-T read cannot return it. Reversible
+operations recover the full view: undo the forget (or the rollback) and the
+as-of read is exact again. Reconstructing past state *through* an un-undone
+destructive op is exactly the replay cost Approach 1 trades away (see issue
+#3650); it is documented and tested, not silently approximated.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from uuid import UUID
+
+from cognee.infrastructure.databases.provenance import EdgeIdentity
+from cognee.infrastructure.databases.provenance.source_refs import (
+    get_dataset_id_from_source_ref_key,
+    get_pipeline_run_id_from_source_run_ref,
+    get_source_ref_key_from_source_run_ref,
+)
+from cognee.modules.versioning.methods.timeline import (
+    get_allowed_run_ids,
+    resolve_as_of_time,
+)
+
+
+def _is_visible(
+    source_run_refs: List[str], allowed_run_ids: Set[str], dataset_id: Optional[str]
+) -> bool:
+    """An artifact existed at T when some run completed by T attached it.
+
+    Model A records a run ref only for the run that *first* attached each key,
+    so "any run ref within the allowed set" is exactly "first attached at or
+    before T". When ``dataset_id`` is given, only refs owned by that dataset
+    count.
+    """
+    for run_ref in source_run_refs:
+        if str(get_pipeline_run_id_from_source_run_ref(run_ref)) not in allowed_run_ids:
+            continue
+        if dataset_id is not None:
+            key = get_source_ref_key_from_source_run_ref(run_ref)
+            if str(get_dataset_id_from_source_ref_key(key)) != dataset_id:
+                continue
+        return True
+    return False
+
+
+async def get_visible_artifacts_as_of(
+    graph_engine,
+    dataset_id: UUID,
+    as_of: Union[str, datetime],
+) -> Tuple[Set[str], Set[EdgeIdentity]]:
+    """Node ids and edge identities visible at ``as_of`` for the dataset."""
+    as_of_time = await resolve_as_of_time(dataset_id, as_of)
+    allowed = await get_allowed_run_ids(dataset_id, as_of_time)
+    if not allowed:
+        return set(), set()
+
+    dataset_id_str = str(dataset_id)
+
+    node_run_refs = await graph_engine.find_all_node_source_run_refs()
+    visible_nodes = {
+        node_id
+        for node_id, run_refs in node_run_refs.items()
+        if _is_visible(run_refs, allowed, dataset_id_str)
+    }
+
+    edge_run_refs = await graph_engine.find_all_edge_source_run_refs()
+    visible_edges = {
+        edge
+        for edge, run_refs in edge_run_refs.items()
+        if _is_visible(run_refs, allowed, dataset_id_str)
+        # Guard: an edge is only renderable when both endpoints are visible.
+        and edge.source_id in visible_nodes
+        and edge.target_id in visible_nodes
+    }
+
+    return visible_nodes, visible_edges
+
+
+async def get_graph_as_of(
+    graph_engine,
+    dataset_id: UUID,
+    as_of: Union[str, datetime],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Materialize the visible subgraph at ``as_of`` as plain node/edge dicts."""
+    visible_nodes, visible_edges = await get_visible_artifacts_as_of(
+        graph_engine, dataset_id, as_of
+    )
+
+    node_data = await graph_engine.get_node_delete_data(sorted(visible_nodes))
+    nodes = [
+        {
+            "id": data.node_id,
+            "type": data.node_type,
+            "properties": data.node_properties,
+        }
+        for data in node_data.values()
+    ]
+
+    edge_data = await graph_engine.get_edge_delete_data(sorted(visible_edges, key=str))
+    edges = [
+        {
+            "source_id": edge.source_id,
+            "target_id": edge.target_id,
+            "relationship_name": edge.relationship_name,
+            "properties": data.edge_properties,
+        }
+        for edge, data in edge_data.items()
+    ]
+
+    return nodes, edges
+
+
+async def search_chunks_as_of(
+    graph_engine,
+    vector_engine,
+    dataset_id: UUID,
+    query_text: str,
+    as_of: Union[str, datetime],
+    top_k: int = 15,
+    collection_name: str = "DocumentChunk_text",
+) -> List[Any]:
+    """Chunk vector search restricted to the artifacts visible at ``as_of``.
+
+    Chunk vectors are keyed by their graph node id (the provenance the delete
+    path relies on), so the graph-derived visible set is the exact filter for
+    the vector hits: post-filter, then truncate to ``top_k``.
+    """
+    visible_nodes, _visible_edges = await get_visible_artifacts_as_of(
+        graph_engine, dataset_id, as_of
+    )
+    if not visible_nodes:
+        return []
+
+    # Over-fetch (unbounded) then post-filter: hits removed by the visibility
+    # filter must not shrink the result below top_k when older ones qualify.
+    hits = await vector_engine.search(collection_name, query_text=query_text, limit=None)
+
+    visible_hits = [hit for hit in hits if str(hit.id) in visible_nodes]
+    return visible_hits[:top_k]

--- a/cognee/modules/versioning/methods/inverse.py
+++ b/cognee/modules/versioning/methods/inverse.py
@@ -1,0 +1,320 @@
+"""Ledgered-inverse capture and restore for destructive graph/vector operations.
+
+Approach 1 (run-ledger time-travel) keeps ``forget`` and ``rollback`` reversible
+without copying the graph: before a destructive source-ref removal runs, this
+module captures the *exact inverse* — the graph rows (properties + all four
+provenance columns) and the raw vector rows (id + embedding + payload) the
+operation will destroy — into a JSON payload stored in the ``version_ops``
+write-ahead ledger. Undo replays that payload.
+
+Design constraints this encodes:
+
+- **No cross-store atomicity.** Graph, vector, and relational stores cannot
+  share a transaction. The guarantee is write-ahead order (inverse committed
+  to the relational ledger *before* the destructive op) plus an idempotent
+  restore: every restore primitive is a MERGE upsert or a set-merge attach, so
+  a crash mid-restore is fixed by replaying.
+- **Model A provenance.** A ``source_run_ref`` exists only for the run that
+  *first* attached a key to an artifact, so each key maps to at most one run.
+  Restore re-attaches keys grouped by their original owning run, which
+  reproduces the provenance columns exactly (including ``source_run_ids`` and
+  ``source_dataset_ids``, which the adapters re-derive).
+- **Restore timestamps are not original.** Graph-storage ``created_at`` /
+  ``updated_at`` columns reflect restore time; artifact identity, properties,
+  provenance, and vectors are exact.
+
+Known limitation (documented, not silent): ``belongs_to_set`` tags stripped
+from *surviving* artifacts by the planner's orphaned-NodeSet cleanup are not
+re-added on undo. The NodeSet node itself and everything it owned are restored.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from cognee.infrastructure.databases.provenance import EdgeIdentity
+from cognee.infrastructure.databases.provenance.source_refs import (
+    get_pipeline_run_id_from_source_run_ref,
+    get_source_ref_key_from_source_run_ref,
+)
+from cognee.modules.engine.utils import generate_node_id
+from cognee.modules.graph.models.EdgeType import EdgeType
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("versioning.inverse")
+
+INVERSE_PAYLOAD_VERSION = 1
+
+
+class _RestoredArtifact:
+    """Property bag whose ``vars()`` is the captured flat node payload.
+
+    ``add_nodes`` accepts any object: it reads ``model_dump()`` when present,
+    else ``vars()``. The captured ``node_properties`` is exactly the flat
+    payload the adapter reconstructs on read (core columns merged over the
+    JSON blob), so round-tripping it through ``vars()`` recreates the node
+    byte-equal up to JSON key order.
+    """
+
+    def __init__(self, properties: Dict[str, Any]):
+        self.__dict__.update(properties)
+
+
+def _edge_key(source_id: str, target_id: str, relationship_name: str) -> EdgeIdentity:
+    return EdgeIdentity(
+        source_id=source_id, target_id=target_id, relationship_name=relationship_name
+    )
+
+
+def _is_unowned(current_refs: List[str], removed_refs: List[str]) -> bool:
+    """Mirror of the delete planner's ownership rule (kept in lockstep)."""
+    return len(set(current_refs) - set(removed_refs)) == 0
+
+
+def _group_keys_by_owning_run(
+    source_ref_keys: List[str], source_run_refs: List[str]
+) -> Dict[Optional[str], List[str]]:
+    """Group ref keys by the run that first attached them (None = no run ref)."""
+    run_by_key: Dict[str, str] = {}
+    for run_ref in source_run_refs:
+        key = get_source_ref_key_from_source_run_ref(run_ref)
+        run_by_key[key] = str(get_pipeline_run_id_from_source_run_ref(run_ref))
+
+    groups: Dict[Optional[str], List[str]] = {}
+    for key in source_ref_keys:
+        groups.setdefault(run_by_key.get(key), []).append(key)
+    return groups
+
+
+async def _capture_vector_rows(
+    vector_engine, collection: str, ids: List[str], vector_rows: Dict[str, List[dict]]
+) -> None:
+    if not ids:
+        return
+    rows = await vector_engine.get_raw_rows(collection, ids)
+    if rows:
+        vector_rows.setdefault(collection, []).extend(rows)
+
+
+async def capture_source_ref_removal_inverse(
+    graph_engine,
+    vector_engine,
+    *,
+    refs_by_node: Dict[str, List[str]],
+    refs_by_edge: Dict[EdgeIdentity, List[str]],
+) -> Dict[str, Any]:
+    """Capture the exact inverse of one planned source-ref removal.
+
+    ``refs_by_node`` / ``refs_by_edge`` are the same inputs the delete planner
+    receives (artifact -> refs about to be removed), so the capture partitions
+    artifacts into deleted-vs-detached with the identical ownership rule and
+    snapshots everything the planner will destroy: full graph rows and
+    provenance for unowned artifacts, the removed refs (with their original
+    run refs) for surviving ones, and the raw vector rows for every vector
+    point the planner deletes (node index fields, Triplet_text, and the
+    EdgeType rows its orphan cleanup may prune).
+    """
+    node_data = await graph_engine.get_node_delete_data(list(refs_by_node.keys()))
+    edge_data = await graph_engine.get_edge_delete_data(list(refs_by_edge.keys()))
+
+    nodes_deleted: List[dict] = []
+    nodes_detached: List[dict] = []
+    edges_deleted: List[dict] = []
+    edges_detached: List[dict] = []
+    vector_rows: Dict[str, List[dict]] = {}
+
+    unowned_node_ids: List[str] = []
+    for node_id, data in node_data.items():
+        removed = refs_by_node.get(node_id, [])
+        if _is_unowned(data.source_ref_keys, removed):
+            unowned_node_ids.append(node_id)
+            nodes_deleted.append(
+                {
+                    "node_id": data.node_id,
+                    "node_type": data.node_type,
+                    "indexed_fields": list(data.indexed_fields),
+                    "node_properties": dict(data.node_properties),
+                    "source_ref_keys": list(data.source_ref_keys),
+                    "source_run_refs": list(data.source_run_refs),
+                }
+            )
+        else:
+            removed_set = set(removed)
+            nodes_detached.append(
+                {
+                    "node_id": data.node_id,
+                    "removed_ref_keys": list(removed),
+                    "removed_run_refs": [
+                        run_ref
+                        for run_ref in data.source_run_refs
+                        if get_source_ref_key_from_source_run_ref(run_ref) in removed_set
+                    ],
+                }
+            )
+
+    unowned_edges: List[EdgeIdentity] = []
+    for edge, data in edge_data.items():
+        removed = refs_by_edge.get(edge, [])
+        if _is_unowned(data.source_ref_keys, removed):
+            unowned_edges.append(edge)
+            edges_deleted.append(
+                {
+                    "source_id": edge.source_id,
+                    "target_id": edge.target_id,
+                    "relationship_name": edge.relationship_name,
+                    "edge_properties": dict(data.edge_properties),
+                    "source_ref_keys": list(data.source_ref_keys),
+                    "source_run_refs": list(data.source_run_refs),
+                }
+            )
+        else:
+            removed_set = set(removed)
+            edges_detached.append(
+                {
+                    "source_id": edge.source_id,
+                    "target_id": edge.target_id,
+                    "relationship_name": edge.relationship_name,
+                    "removed_ref_keys": list(removed),
+                    "removed_run_refs": [
+                        run_ref
+                        for run_ref in data.source_run_refs
+                        if get_source_ref_key_from_source_run_ref(run_ref) in removed_set
+                    ],
+                }
+            )
+
+    # Vector rows the planner will delete: per-node index-field collections.
+    node_collections: Dict[str, List[str]] = {}
+    for node_id in unowned_node_ids:
+        data = node_data[node_id]
+        for field in data.indexed_fields:
+            node_collections.setdefault(f"{data.node_type}_{field}", []).append(node_id)
+    for collection, ids in node_collections.items():
+        await _capture_vector_rows(vector_engine, collection, ids, vector_rows)
+
+    # Per-edge triplet vectors + the EdgeType artifacts the orphan cleanup may
+    # prune. EdgeType restore is a MERGE keyed by relationship text, so
+    # capturing the superset (all texts touched, orphaned or not) stays exact.
+    edge_type_nodes: List[dict] = []
+    if unowned_edges:
+        triplet_ids = [
+            str(generate_node_id(edge.source_id + edge.relationship_name + edge.target_id))
+            for edge in unowned_edges
+        ]
+        await _capture_vector_rows(vector_engine, "Triplet_text", triplet_ids, vector_rows)
+
+        edge_texts = {
+            edge_data[edge].edge_text for edge in unowned_edges if edge_data[edge].edge_text
+        }
+        edge_type_ids = [str(EdgeType.id_for(text)) for text in sorted(edge_texts)]
+        if edge_type_ids:
+            edge_type_data = await graph_engine.get_node_delete_data(edge_type_ids)
+            for node_id, data in edge_type_data.items():
+                edge_type_nodes.append(
+                    {
+                        "node_id": data.node_id,
+                        "node_type": data.node_type,
+                        "node_properties": dict(data.node_properties),
+                    }
+                )
+            await _capture_vector_rows(
+                vector_engine, "EdgeType_relationship_name", edge_type_ids, vector_rows
+            )
+
+    return {
+        "nodes_deleted": nodes_deleted,
+        "nodes_detached": nodes_detached,
+        "edges_deleted": edges_deleted,
+        "edges_detached": edges_detached,
+        "edge_type_nodes": edge_type_nodes,
+        "vector_rows": vector_rows,
+    }
+
+
+async def _attach_grouped_node_refs(graph_engine, groups: Dict[tuple, List[str]]) -> None:
+    for (run_id, keys), node_ids in groups.items():
+        await graph_engine.attach_node_source_refs(node_ids, list(keys), run_id)
+
+
+async def _attach_grouped_edge_refs(graph_engine, groups: Dict[tuple, List[EdgeIdentity]]) -> None:
+    for (run_id, keys), edges in groups.items():
+        await graph_engine.attach_edge_source_refs(edges, list(keys), run_id)
+
+
+async def restore_inverse_step(graph_engine, vector_engine, step: Dict[str, Any]) -> None:
+    """Replay one captured inverse step. Idempotent: safe to re-run after a crash.
+
+    Order matters only where restores depend on each other: nodes before edges
+    (edge MERGE matches endpoints), artifacts before provenance attach.
+    """
+    nodes_deleted = step.get("nodes_deleted", [])
+    edges_deleted = step.get("edges_deleted", [])
+
+    # 1. Recreate deleted nodes (MERGE by id) and the EdgeType nodes the
+    #    orphan cleanup may have pruned.
+    restored_nodes = [_RestoredArtifact(dict(node["node_properties"])) for node in nodes_deleted]
+    restored_nodes.extend(
+        _RestoredArtifact(dict(node["node_properties"])) for node in step.get("edge_type_nodes", [])
+    )
+    if restored_nodes:
+        await graph_engine.add_nodes(restored_nodes)
+
+    # 2. Recreate deleted edges (MERGE by endpoints + relationship_name).
+    if edges_deleted:
+        await graph_engine.add_edges(
+            [
+                (
+                    edge["source_id"],
+                    edge["target_id"],
+                    edge["relationship_name"],
+                    dict(edge["edge_properties"]),
+                )
+                for edge in edges_deleted
+            ]
+        )
+
+    # 3. Re-attach provenance, grouped by the original owning run. Recreated
+    #    artifacts start with empty provenance, so every key is "newly
+    #    attached" and Model A records exactly the original run refs.
+    node_groups: Dict[tuple, List[str]] = {}
+    for node in nodes_deleted:
+        for run_id, keys in _group_keys_by_owning_run(
+            node["source_ref_keys"], node["source_run_refs"]
+        ).items():
+            node_groups.setdefault((run_id, tuple(keys)), []).append(node["node_id"])
+    for node in step.get("nodes_detached", []):
+        for run_id, keys in _group_keys_by_owning_run(
+            node["removed_ref_keys"], node["removed_run_refs"]
+        ).items():
+            node_groups.setdefault((run_id, tuple(keys)), []).append(node["node_id"])
+    await _attach_grouped_node_refs(graph_engine, node_groups)
+
+    edge_groups: Dict[tuple, List[EdgeIdentity]] = {}
+    for edge in edges_deleted:
+        for run_id, keys in _group_keys_by_owning_run(
+            edge["source_ref_keys"], edge["source_run_refs"]
+        ).items():
+            edge_groups.setdefault((run_id, tuple(keys)), []).append(
+                _edge_key(edge["source_id"], edge["target_id"], edge["relationship_name"])
+            )
+    for edge in step.get("edges_detached", []):
+        for run_id, keys in _group_keys_by_owning_run(
+            edge["removed_ref_keys"], edge["removed_run_refs"]
+        ).items():
+            edge_groups.setdefault((run_id, tuple(keys)), []).append(
+                _edge_key(edge["source_id"], edge["target_id"], edge["relationship_name"])
+            )
+    await _attach_grouped_edge_refs(graph_engine, edge_groups)
+
+    # 4. Restore the exact vector rows (id + embedding + payload). No
+    #    re-embedding: restored vectors are the captured ones.
+    for collection, rows in step.get("vector_rows", {}).items():
+        await vector_engine.restore_raw_rows(collection, rows)
+
+    logger.info(
+        "Restored inverse step: %d nodes, %d edges, %d detached nodes, %d detached edges, "
+        "%d vector collections.",
+        len(nodes_deleted),
+        len(edges_deleted),
+        len(step.get("nodes_detached", [])),
+        len(step.get("edges_detached", [])),
+        len(step.get("vector_rows", {})),
+    )

--- a/cognee/modules/versioning/methods/inverse.py
+++ b/cognee/modules/versioning/methods/inverse.py
@@ -35,6 +35,10 @@ from cognee.infrastructure.databases.provenance.source_refs import (
     get_pipeline_run_id_from_source_run_ref,
     get_source_ref_key_from_source_run_ref,
 )
+
+# The capture MUST partition deleted-vs-detached with the delete planner's own
+# ownership rule — a mirrored copy could drift and make undo silently lossy.
+from cognee.infrastructure.databases.unified.provenance_delete_planner import _is_unowned
 from cognee.modules.engine.utils import generate_node_id
 from cognee.modules.graph.models.EdgeType import EdgeType
 from cognee.shared.logging_utils import get_logger
@@ -62,11 +66,6 @@ def _edge_key(source_id: str, target_id: str, relationship_name: str) -> EdgeIde
     return EdgeIdentity(
         source_id=source_id, target_id=target_id, relationship_name=relationship_name
     )
-
-
-def _is_unowned(current_refs: List[str], removed_refs: List[str]) -> bool:
-    """Mirror of the delete planner's ownership rule (kept in lockstep)."""
-    return len(set(current_refs) - set(removed_refs)) == 0
 
 
 def _group_keys_by_owning_run(

--- a/cognee/modules/versioning/methods/ledger.py
+++ b/cognee/modules/versioning/methods/ledger.py
@@ -1,0 +1,123 @@
+"""CRUD for the version-op write-ahead ledger.
+
+The write-ahead rule: the inverse payload is committed here *before* the
+destructive graph/vector operation executes. A crash between the two leaves a
+``CAPTURED`` row whose payload can be replayed (restore is idempotent) or
+inspected — never a destroyed artifact without its inverse.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import attributes as orm_attributes
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.storage.utils import JSONEncoder
+from cognee.modules.versioning.methods.inverse import INVERSE_PAYLOAD_VERSION
+from cognee.modules.versioning.methods.timeline import ensure_utc
+from cognee.modules.versioning.models import VersionOp, VersionOpStatus
+
+DEFAULT_RETENTION_DAYS = 30
+
+
+def get_retention_days() -> int:
+    return int(os.environ.get("VERSION_RETENTION_DAYS", DEFAULT_RETENTION_DAYS))
+
+
+def sanitize_payload(payload: Any) -> Any:
+    """Normalize a payload to JSON-native types (datetimes -> ISO strings).
+
+    Vector-row payloads read back from storage can contain datetime objects;
+    the relational JSON column serializer requires JSON-native values.
+    """
+    return json.loads(json.dumps(payload, cls=JSONEncoder))
+
+
+async def create_version_op(
+    dataset_id: UUID,
+    op_type: str,
+    *,
+    steps: Optional[List[Dict[str, Any]]] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> UUID:
+    """Commit a new ledger row (status CAPTURED) and return its id."""
+    now = datetime.now(timezone.utc)
+    payload: Dict[str, Any] = {
+        "version": INVERSE_PAYLOAD_VERSION,
+        "steps": sanitize_payload(steps or []),
+    }
+    if extra:
+        payload.update(sanitize_payload(extra))
+
+    op = VersionOp(
+        dataset_id=dataset_id,
+        op_type=op_type,
+        status=VersionOpStatus.CAPTURED,
+        payload=payload,
+        created_at=now,
+        expires_at=now + timedelta(days=get_retention_days()),
+    )
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        session.add(op)
+        await session.commit()
+        return op.id
+
+
+async def append_op_step(op_id: UUID, step: Dict[str, Any]) -> None:
+    """Append one captured inverse step to an op and commit before it executes."""
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        op = (
+            (await session.execute(select(VersionOp).where(VersionOp.id == op_id)))
+            .scalars()
+            .first()
+        )
+        if op is None:
+            raise ValueError(f"Version op {op_id} not found.")
+        op.payload["steps"].append(sanitize_payload(step))
+        orm_attributes.flag_modified(op, "payload")
+        await session.commit()
+
+
+async def set_op_status(op_id: UUID, status: str) -> None:
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        op = (
+            (await session.execute(select(VersionOp).where(VersionOp.id == op_id)))
+            .scalars()
+            .first()
+        )
+        if op is None:
+            raise ValueError(f"Version op {op_id} not found.")
+        op.status = status
+        await session.commit()
+
+
+async def get_version_op(op_id: UUID) -> VersionOp:
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        op = (
+            (await session.execute(select(VersionOp).where(VersionOp.id == op_id)))
+            .scalars()
+            .first()
+        )
+    if op is None:
+        raise ValueError(f"Version op {op_id} not found.")
+    return op
+
+
+def assert_within_retention(op: VersionOp) -> None:
+    """Raise when the op's retention window has lapsed (payload may be pruned)."""
+    if op.expires_at is None:
+        return
+    if datetime.now(timezone.utc) > ensure_utc(op.expires_at):
+        raise ValueError(
+            f"Version op {op.id} is outside the retention window "
+            f"(expired {op.expires_at}); it can no longer be undone."
+        )

--- a/cognee/modules/versioning/methods/operations.py
+++ b/cognee/modules/versioning/methods/operations.py
@@ -1,0 +1,279 @@
+"""Reversible destructive operations: forget capture, rollback-to-T, and undo.
+
+Every destructive operation follows the same write-ahead discipline:
+
+1. compute exactly what the existing delete path will remove (same inputs the
+   planner receives — never a forked delete),
+2. commit the inverse to the ``version_ops`` ledger,
+3. run the *existing* destructive primitive
+   (``UnifiedStoreEngine.delete_by_* `` / ``rollback_by_pipeline_run_id`` via
+   their established callers),
+4. mark the op APPLIED.
+
+Undo replays the committed inverse steps in reverse application order. All
+restore primitives are idempotent, so a crash anywhere in 2-4 or during undo
+is recovered by replaying.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import attributes as orm_attributes
+
+from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
+from cognee.infrastructure.databases.provenance import make_source_ref_key
+from cognee.infrastructure.databases.provenance.markers import stores_provenance_in_graph
+from cognee.infrastructure.databases.provenance.source_refs import (
+    get_data_id_from_source_ref_key,
+)
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.databases.unified import get_unified_engine
+from cognee.modules.data.models import Data
+from cognee.modules.versioning.methods.inverse import (
+    capture_source_ref_removal_inverse,
+    restore_inverse_step,
+)
+from cognee.modules.versioning.methods.ledger import (
+    append_op_step,
+    assert_within_retention,
+    create_version_op,
+    get_version_op,
+    set_op_status,
+)
+from cognee.modules.versioning.methods.timeline import (
+    get_run_ids_after,
+    resolve_as_of_time,
+)
+from cognee.modules.versioning.models import VersionOpStatus
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("versioning.operations")
+
+
+async def _get_provenance_engines():
+    """The unified engine's graph/vector pair, or raise when unsupported.
+
+    Reversibility requires graph-provenance mode: the inverse is captured from
+    (and restored into) the provenance columns the delete path maintains.
+    Backends without that capability fail closed with a typed error instead of
+    silently losing data.
+    """
+    unified = await get_unified_engine()
+    if not unified.supports_graph_provenance_delete():
+        raise UnsupportedProvenanceCapability()
+    if not await stores_provenance_in_graph(unified.graph):
+        raise UnsupportedProvenanceCapability()
+    return unified.graph, unified.vector
+
+
+def _data_ids_from_refs(
+    refs_by_node: Dict[str, List[str]], refs_by_edge: Dict[Any, List[str]]
+) -> set:
+    data_ids = set()
+    for refs in list(refs_by_node.values()) + list(refs_by_edge.values()):
+        for key in refs:
+            data_ids.add(get_data_id_from_source_ref_key(key))
+    return data_ids
+
+
+async def _snapshot_pipeline_status(data_ids: set, dataset_id: UUID) -> Dict[str, Dict[str, Any]]:
+    """Capture each data item's per-dataset pipeline status before it is reset."""
+    if not data_ids:
+        return {}
+
+    dataset_id_str = str(dataset_id)
+    snapshot: Dict[str, Dict[str, Any]] = {}
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        data_records = (
+            (await session.execute(select(Data).where(Data.id.in_(list(data_ids))))).scalars().all()
+        )
+        for record in data_records:
+            statuses = {}
+            for pipeline_name, per_dataset in (record.pipeline_status or {}).items():
+                if dataset_id_str in per_dataset:
+                    statuses[pipeline_name] = per_dataset[dataset_id_str]
+            if statuses:
+                snapshot[str(record.id)] = statuses
+
+    return snapshot
+
+
+async def _restore_pipeline_status(snapshot: Dict[str, Dict[str, Any]], dataset_id: UUID) -> None:
+    if not snapshot:
+        return
+
+    dataset_id_str = str(dataset_id)
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        data_records = (
+            (
+                await session.execute(
+                    select(Data).where(Data.id.in_([UUID(key) for key in snapshot.keys()]))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for record in data_records:
+            statuses = snapshot.get(str(record.id), {})
+            if not statuses:
+                continue
+            pipeline_status = record.pipeline_status or {}
+            for pipeline_name, value in statuses.items():
+                pipeline_status.setdefault(pipeline_name, {})[dataset_id_str] = value
+            record.pipeline_status = pipeline_status
+            orm_attributes.flag_modified(record, "pipeline_status")
+        await session.commit()
+
+
+async def capture_forget_inverse(dataset_id: UUID, data_id: Optional[UUID] = None) -> UUID:
+    """Commit the inverse of an imminent memory-forget; returns the op id.
+
+    Must be called *before* the forget executes. Mirrors the exact discovery
+    the unified delete path performs (``find_*_by_source_ref`` for a data
+    item, ``find_*_source_refs_by_dataset`` for a whole dataset), so the
+    captured inverse covers precisely what the delete will remove.
+    """
+    graph, vector = await _get_provenance_engines()
+
+    if data_id is not None:
+        source_ref_key = make_source_ref_key(dataset_id, data_id)
+        node_ids = await graph.find_nodes_by_source_ref(source_ref_key)
+        edges = await graph.find_edges_by_source_ref(source_ref_key)
+        refs_by_node = {node_id: [source_ref_key] for node_id in node_ids}
+        refs_by_edge = {edge: [source_ref_key] for edge in edges}
+    else:
+        refs_by_node = await graph.find_node_source_refs_by_dataset(str(dataset_id))
+        refs_by_edge = await graph.find_edge_source_refs_by_dataset(str(dataset_id))
+
+    step = await capture_source_ref_removal_inverse(
+        graph, vector, refs_by_node=refs_by_node, refs_by_edge=refs_by_edge
+    )
+    step["pipeline_status"] = await _snapshot_pipeline_status(
+        _data_ids_from_refs(refs_by_node, refs_by_edge), dataset_id
+    )
+
+    op_id = await create_version_op(
+        dataset_id,
+        "forget",
+        steps=[step],
+        extra={
+            "target": "data_item_memory" if data_id is not None else "dataset_memory",
+            "data_id": str(data_id) if data_id is not None else None,
+        },
+    )
+
+    logger.info(
+        "Captured forget inverse op=%s (dataset=%s, data_id=%s): %d nodes, %d edges.",
+        op_id,
+        dataset_id,
+        data_id,
+        len(refs_by_node),
+        len(refs_by_edge),
+    )
+    return op_id
+
+
+async def mark_forget_applied(op_id: UUID) -> None:
+    await set_op_status(op_id, VersionOpStatus.APPLIED)
+
+
+async def rollback_dataset_to(
+    dataset: Any, as_of: Union[str, datetime], user: Any = None
+) -> Dict[str, Any]:
+    """Reverse every run completed after ``as_of``, newest first, reversibly.
+
+    Each run is undone with the existing rollback primitive
+    (``cognify_rollback_handler`` -> ``rollback_by_pipeline_run_id``); this
+    orchestration adds only the write-ahead inverse capture so the rollback is
+    itself an undoable ledger entry. Note the Approach-1 boundary: rollback
+    reverses *run contributions*; a forget executed after T is a separate
+    ledger op and is undone via its own op id, not by rollback.
+    """
+    # Imported here: modules.cognify pulls the graph engine stack at import
+    # time, which must not become an import-time dependency of versioning.
+    from cognee.modules.cognify.rollback import cognify_rollback_handler
+
+    dataset_id = dataset.id
+
+    as_of_time = await resolve_as_of_time(dataset_id, as_of)
+    run_ids = await get_run_ids_after(dataset_id, as_of_time)
+
+    if not run_ids:
+        return {"operation_id": None, "rolled_back_runs": [], "status": "noop"}
+
+    graph, vector = await _get_provenance_engines()
+
+    op_id = await create_version_op(
+        dataset_id,
+        "rollback",
+        extra={"as_of_time": as_of_time.isoformat(), "candidate_run_ids": run_ids},
+    )
+
+    rolled_back_runs: List[str] = []
+    for run_id in run_ids:  # newest first
+        refs_by_node = await graph.find_node_source_refs_by_pipeline_run(run_id)
+        refs_by_edge = await graph.find_edge_source_refs_by_pipeline_run(run_id)
+
+        if not refs_by_node and not refs_by_edge:
+            # Runs that attached no graph artifacts (e.g. add-pipeline runs, or
+            # runs whose ownership was later superseded) have nothing to
+            # reverse; skip them rather than record empty ledger steps.
+            continue
+
+        step = await capture_source_ref_removal_inverse(
+            graph, vector, refs_by_node=refs_by_node, refs_by_edge=refs_by_edge
+        )
+        step["run_id"] = run_id
+        step["pipeline_status"] = await _snapshot_pipeline_status(
+            _data_ids_from_refs(refs_by_node, refs_by_edge), dataset_id
+        )
+
+        # Write-ahead: the step is committed before its destructive execution.
+        await append_op_step(op_id, step)
+
+        await cognify_rollback_handler(UUID(run_id), dataset, user)
+        rolled_back_runs.append(run_id)
+
+    await set_op_status(op_id, VersionOpStatus.APPLIED)
+
+    logger.info(
+        "Rolled back dataset %s to %s (%d of %d candidate runs) as op=%s.",
+        dataset_id,
+        as_of_time.isoformat(),
+        len(rolled_back_runs),
+        len(run_ids),
+        op_id,
+    )
+    return {
+        "operation_id": str(op_id),
+        "rolled_back_runs": rolled_back_runs,
+        "status": "success",
+    }
+
+
+async def undo_version_op(op_id: UUID) -> Dict[str, Any]:
+    """Replay a ledgered op's inverse (newest step first) and mark it UNDONE."""
+    op = await get_version_op(op_id)
+
+    if op.status == VersionOpStatus.UNDONE:
+        raise ValueError(f"Version op {op_id} has already been undone.")
+    assert_within_retention(op)
+
+    graph, vector = await _get_provenance_engines()
+
+    steps = op.payload.get("steps", [])
+    # Reverse application order: the last-applied step is restored first.
+    for step in reversed(steps):
+        await restore_inverse_step(graph, vector, step)
+        await _restore_pipeline_status(step.get("pipeline_status", {}), op.dataset_id)
+
+    await set_op_status(op_id, VersionOpStatus.UNDONE)
+
+    logger.info("Undid version op %s (%s, %d steps).", op_id, op.op_type, len(steps))
+    return {"operation_id": str(op_id), "op_type": op.op_type, "status": "undone"}

--- a/cognee/modules/versioning/methods/snapshots.py
+++ b/cognee/modules/versioning/methods/snapshots.py
@@ -1,0 +1,68 @@
+"""Named snapshots: labels pointing at a cut in the run ledger. Zero copies."""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.versioning.methods.timeline import get_latest_completed_run_id
+from cognee.modules.versioning.models import DatasetSnapshot
+
+
+async def create_snapshot(
+    dataset_id: UUID, name: str, as_of_time: Optional[datetime] = None
+) -> DatasetSnapshot:
+    """Label the dataset's current (or given) ledger position with ``name``."""
+    if not name or not name.strip():
+        raise ValueError("Snapshot name must be a non-empty string.")
+
+    cut = as_of_time or datetime.now(timezone.utc)
+    latest_run_id = await get_latest_completed_run_id(dataset_id, cut)
+
+    snapshot = DatasetSnapshot(
+        name=name.strip(),
+        dataset_id=dataset_id,
+        as_of_time=cut,
+        latest_pipeline_run_id=latest_run_id,
+    )
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        existing = (
+            (
+                await session.execute(
+                    select(DatasetSnapshot).where(
+                        DatasetSnapshot.dataset_id == dataset_id,
+                        DatasetSnapshot.name == snapshot.name,
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if existing is not None:
+            raise ValueError(f"Snapshot '{snapshot.name}' already exists for dataset {dataset_id}.")
+        session.add(snapshot)
+        await session.commit()
+        # Detach a plain copy so callers can read attributes post-session.
+        session.expunge(snapshot)
+
+    return snapshot
+
+
+async def list_snapshots(dataset_id: UUID) -> List[DatasetSnapshot]:
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        return list(
+            (
+                await session.execute(
+                    select(DatasetSnapshot)
+                    .where(DatasetSnapshot.dataset_id == dataset_id)
+                    .order_by(DatasetSnapshot.created_at.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )

--- a/cognee/modules/versioning/methods/timeline.py
+++ b/cognee/modules/versioning/methods/timeline.py
@@ -1,0 +1,111 @@
+"""Resolve "as of T" against the pipeline-run ledger.
+
+The version timeline of a dataset is its ordered sequence of *completed*
+pipeline runs. One logical run writes several ``PipelineRun`` status rows
+(INITIATED/STARTED/COMPLETED) sharing a ``pipeline_run_id``, so the ledger
+unit here is the ``pipeline_run_id`` deduplicated over rows with
+``DATASET_PROCESSING_COMPLETED`` status.
+"""
+
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple, Union
+from uuid import UUID
+
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
+from cognee.modules.versioning.models import DatasetSnapshot
+
+
+def ensure_utc(value: datetime) -> datetime:
+    """Coerce a naive datetime (SQLite round-trips lose tzinfo) to UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+async def resolve_as_of_time(dataset_id: UUID, as_of: Union[str, datetime]) -> datetime:
+    """Resolve an ``as_of`` argument (snapshot name or datetime) to a UTC datetime."""
+    if isinstance(as_of, datetime):
+        return ensure_utc(as_of)
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        snapshot = (
+            (
+                await session.execute(
+                    select(DatasetSnapshot).where(
+                        DatasetSnapshot.dataset_id == dataset_id,
+                        DatasetSnapshot.name == as_of,
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+
+    if snapshot is None:
+        raise ValueError(f"No snapshot named '{as_of}' exists for dataset {dataset_id}.")
+
+    return ensure_utc(snapshot.as_of_time)
+
+
+async def _completed_runs(dataset_id: UUID) -> List[Tuple[UUID, datetime]]:
+    """(pipeline_run_id, completed_at) for the dataset, deduped, oldest first."""
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        rows = (
+            await session.execute(
+                select(PipelineRun.pipeline_run_id, PipelineRun.created_at)
+                .where(
+                    PipelineRun.dataset_id == dataset_id,
+                    PipelineRun.status == PipelineRunStatus.DATASET_PROCESSING_COMPLETED,
+                )
+                .order_by(PipelineRun.created_at.asc())
+            )
+        ).all()
+
+    seen: dict[UUID, datetime] = {}
+    for run_id, completed_at in rows:
+        # A run id normally completes once; keep the first completion time.
+        if run_id not in seen:
+            seen[run_id] = ensure_utc(completed_at)
+    return list(seen.items())
+
+
+async def get_allowed_run_ids(dataset_id: UUID, as_of_time: datetime) -> set:
+    """Run ids completed at or before ``as_of_time`` — the visible history at T."""
+    as_of_time = ensure_utc(as_of_time)
+    return {
+        str(run_id)
+        for run_id, completed_at in await _completed_runs(dataset_id)
+        if completed_at <= as_of_time
+    }
+
+
+async def get_run_ids_after(dataset_id: UUID, as_of_time: datetime) -> List[str]:
+    """Run ids completed after ``as_of_time``, newest first (rollback order)."""
+    as_of_time = ensure_utc(as_of_time)
+    later = [
+        (run_id, completed_at)
+        for run_id, completed_at in await _completed_runs(dataset_id)
+        if completed_at > as_of_time
+    ]
+    later.sort(key=lambda item: item[1], reverse=True)
+    return [str(run_id) for run_id, _completed_at in later]
+
+
+async def get_latest_completed_run_id(
+    dataset_id: UUID, as_of_time: Optional[datetime] = None
+) -> Optional[UUID]:
+    """Newest completed run id at ``as_of_time`` (now when omitted)."""
+    cutoff = ensure_utc(as_of_time) if as_of_time else datetime.now(timezone.utc)
+    candidates = [
+        (run_id, completed_at)
+        for run_id, completed_at in await _completed_runs(dataset_id)
+        if completed_at <= cutoff
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[1])[0]

--- a/cognee/modules/versioning/models/DatasetSnapshot.py
+++ b/cognee/modules/versioning/models/DatasetSnapshot.py
@@ -1,0 +1,29 @@
+from uuid import uuid4
+from datetime import datetime, timezone
+
+from sqlalchemy import UUID, Column, DateTime, String, UniqueConstraint
+
+from cognee.infrastructure.databases.relational import Base
+
+
+class DatasetSnapshot(Base):
+    """A named cursor into a dataset's pipeline-run ledger.
+
+    A snapshot copies no data: it records the wall-clock cut (``as_of_time``)
+    and, for convenience, the newest completed ``pipeline_run_id`` at that cut.
+    Time-travel reads resolve a snapshot name to its ``as_of_time`` and filter
+    artifacts by the runs completed up to that moment.
+    """
+
+    __tablename__ = "dataset_snapshots"
+    __table_args__ = (UniqueConstraint("dataset_id", "name", name="uq_dataset_snapshot_name"),)
+
+    id = Column(UUID, primary_key=True, default=uuid4)
+
+    name = Column(String, nullable=False)
+    dataset_id = Column(UUID, index=True, nullable=False)
+
+    as_of_time = Column(DateTime(timezone=True), nullable=False)
+    latest_pipeline_run_id = Column(UUID, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))

--- a/cognee/modules/versioning/models/VersionOp.py
+++ b/cognee/modules/versioning/models/VersionOp.py
@@ -1,0 +1,46 @@
+from uuid import uuid4
+from datetime import datetime, timezone
+
+from sqlalchemy import JSON, UUID, Column, DateTime, String
+
+from cognee.infrastructure.databases.relational import Base
+
+
+class VersionOpStatus:
+    """Lifecycle of a destructive versioning operation.
+
+    The inverse payload is committed (``CAPTURED``) *before* the destructive
+    graph/vector mutation runs. Graph, vector, and relational stores cannot
+    share one ACID transaction, so this write-ahead order plus an idempotent
+    restore is the recovery guarantee: a crash mid-operation leaves a
+    ``CAPTURED`` row whose inverse can be replayed safely.
+    """
+
+    CAPTURED = "captured"
+    APPLIED = "applied"
+    UNDONE = "undone"
+
+
+class VersionOp(Base):
+    """Write-ahead undo ledger for destructive versioning operations.
+
+    Each row records one reversible operation (a ``forget`` or a ``rollback``)
+    with the exact inverse needed to restore the destroyed graph artifacts,
+    their provenance columns, and their vector rows. Rows past ``expires_at``
+    (the retention window) may be pruned, after which the operation is
+    permanently irreversible.
+    """
+
+    __tablename__ = "version_ops"
+
+    id = Column(UUID, primary_key=True, default=uuid4)
+
+    dataset_id = Column(UUID, index=True, nullable=False)
+    op_type = Column(String, nullable=False)  # "forget" | "rollback"
+    status = Column(String, nullable=False, default=VersionOpStatus.CAPTURED)
+
+    # Versioned inverse payload; see modules/versioning/methods/inverse.py.
+    payload = Column(JSON, nullable=False, default=dict)
+
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    expires_at = Column(DateTime(timezone=True), nullable=True)

--- a/cognee/modules/versioning/models/__init__.py
+++ b/cognee/modules/versioning/models/__init__.py
@@ -1,0 +1,2 @@
+from .DatasetSnapshot import DatasetSnapshot
+from .VersionOp import VersionOp, VersionOpStatus

--- a/cognee/tests/integration/modules/versioning/test_versioning_default_stack.py
+++ b/cognee/tests/integration/modules/versioning/test_versioning_default_stack.py
@@ -1,0 +1,758 @@
+"""Dataset versioning proof on the REAL default stack (issue #3650, Approach 1).
+
+Runs the run-ledger time-travel surface — snapshot, as-of reads, rollback,
+reversible forget + undo — against real Ladybug (graph), real LanceDB (vector,
+deterministic hash embeddings), and real SQLite (relational ledger). No LLM
+and no network: graph state is seeded through the same ``add_data_points``
+provenance-stamping write path cognify uses, with explicit ``PipelineRun``
+ledger rows so run completion times are deterministic.
+
+What the fidelity assertions pin down:
+
+- as-of T returns *exactly* the artifact and vector-id sets of the runs
+  completed by T (chunk/entity vector ids are graph node ids, so the
+  graph-derived visible set is asserted against the vector hits directly);
+- rollback to T and undo are exact round-trips, including the shared-ownership
+  case (an artifact co-owned by two runs must survive the partial rollback and
+  come back with both provenance attachments after undo);
+- reversible forget restores byte-equal embeddings (no re-embedding) and the
+  full provenance columns;
+- the as-of boundary is *documented behavior*: a destructive op after T
+  shadows earlier state until it is undone (forward-faithful filter, not
+  reconstruction through un-undone deletes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import pathlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+import cognee
+from cognee.context_global_variables import (
+    graph_db_config,
+    set_database_global_context_variables,
+    vector_db_config,
+)
+from cognee.infrastructure.databases.exceptions import UnsupportedProvenanceCapability
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.data.methods import create_authorized_dataset
+from cognee.modules.engine.operations.setup import setup as engine_setup
+from cognee.modules.pipelines.models import PipelineContext, PipelineRun, PipelineRunStatus
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.versioning import (
+    VersionOp,
+    VersionOpStatus,
+    create_snapshot,
+    get_graph_as_of,
+    get_visible_artifacts_as_of,
+    rollback_dataset_to,
+    search_chunks_as_of,
+    undo_version_op,
+)
+from cognee.tasks.storage.add_data_points import add_data_points
+
+try:
+    import ladybug  # noqa: F401
+    import lancedb  # noqa: F401
+
+    HAS_DEFAULT_STACK = True
+except ModuleNotFoundError:
+    HAS_DEFAULT_STACK = False
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(not HAS_DEFAULT_STACK, reason="default stack not installed"),
+]
+
+
+class Person(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"]}
+
+
+def _hash_vector(text: str, size: int = 8) -> list[float]:
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    return [byte / 255.0 for byte in digest[:size]]
+
+
+@pytest_asyncio.fixture
+async def versioning_env(request, tmp_path, monkeypatch):
+    """Clean per-test default stack under tmp_path with deterministic embeddings."""
+    monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    monkeypatch.setenv("GRAPH_DATASET_DATABASE_HANDLER", "ladybug")
+    monkeypatch.setenv("VECTOR_DATASET_DATABASE_HANDLER", "lancedb")
+
+    root = pathlib.Path(tmp_path) / request.node.name
+
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+
+    graph_db_config.set(None)
+    vector_db_config.set(None)
+    cognee.config.set_graph_db_config(
+        {
+            "graph_database_provider": "ladybug",
+            "graph_dataset_database_handler": "ladybug",
+        }
+    )
+    cognee.config.set_vector_db_config(
+        {
+            "vector_db_provider": "lancedb",
+            "vector_dataset_database_handler": "lancedb",
+        }
+    )
+    cognee.config.set_relational_db_config({"db_provider": "sqlite"})
+    cognee.config.system_root_directory(str(root / "system"))
+    cognee.config.data_root_directory(str(root / "data"))
+    cognee.config.set_vector_db_url(str(root / "system" / "databases" / "cognee.lancedb"))
+
+    # Deterministic offline embeddings: same text -> same vector, no network.
+    from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+        LiteLLMEmbeddingEngine,
+    )
+
+    async def _fake_embed_text(self, texts):
+        return [_hash_vector(text) for text in texts]
+
+    monkeypatch.setattr(LiteLLMEmbeddingEngine, "embed_text", _fake_embed_text)
+    monkeypatch.setattr(LiteLLMEmbeddingEngine, "get_vector_size", lambda self: 8)
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await engine_setup()
+
+    yield
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+async def _log_completed_run(dataset_id: UUID, pipeline_run_id: UUID, completed_at: datetime):
+    """Write the COMPLETED ledger row with a controlled completion time."""
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        # One logical run writes several status rows sharing pipeline_run_id;
+        # timeline resolution must dedupe on COMPLETED rows only.
+        session.add(
+            PipelineRun(
+                pipeline_run_id=pipeline_run_id,
+                pipeline_name="cognify_pipeline",
+                pipeline_id=uuid4(),
+                status=PipelineRunStatus.DATASET_PROCESSING_STARTED,
+                dataset_id=dataset_id,
+                run_info={},
+                created_at=completed_at - timedelta(seconds=1),
+            )
+        )
+        session.add(
+            PipelineRun(
+                pipeline_run_id=pipeline_run_id,
+                pipeline_name="cognify_pipeline",
+                pipeline_id=uuid4(),
+                status=PipelineRunStatus.DATASET_PROCESSING_COMPLETED,
+                dataset_id=dataset_id,
+                run_info={},
+                created_at=completed_at,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_run(dataset, user, data_id, pipeline_run_id, nodes, edges=None):
+    """Write nodes/edges through the provenance-stamping cognify write path."""
+    async with set_database_global_context_variables(dataset.id, dataset.owner_id):
+        await add_data_points(
+            nodes,
+            custom_edges=edges or [],
+            ctx=PipelineContext(
+                user=user,
+                dataset=dataset,
+                data_item=SimpleNamespace(id=data_id),
+                pipeline_name="cognify_pipeline",
+                pipeline_run_id=pipeline_run_id,
+            ),
+        )
+
+
+async def _all_graph_node_ids(graph) -> set[str]:
+    rows = await graph.query("MATCH (n:Node) RETURN n.id", {})
+    return {row[0] for row in rows}
+
+
+async def _all_graph_edges(graph) -> set[tuple]:
+    rows = await graph.query(
+        "MATCH (a:Node)-[r:EDGE]->(b:Node) RETURN a.id, b.id, r.relationship_name", {}
+    )
+    return {(row[0], row[1], row[2]) for row in rows}
+
+
+def _normalized_node_state(node_data: dict) -> dict:
+    """Comparable snapshot: properties + provenance with order-insensitive refs."""
+    return {
+        node_id: {
+            "type": data.node_type,
+            "properties": data.node_properties,
+            "source_ref_keys": sorted(data.source_ref_keys),
+            "source_dataset_ids": sorted(data.source_dataset_ids),
+            "source_run_ids": sorted(data.source_run_ids),
+            "source_run_refs": sorted(data.source_run_refs),
+        }
+        for node_id, data in node_data.items()
+    }
+
+
+async def _full_state(graph, vector, collections: list[str]):
+    """Graph rows + provenance + raw vector rows (embeddings included)."""
+    node_ids = sorted(await _all_graph_node_ids(graph))
+    node_state = _normalized_node_state(await graph.get_node_delete_data(node_ids))
+
+    edge_state = {}
+    edges = await _all_graph_edges(graph)
+    from cognee.infrastructure.databases.provenance import EdgeIdentity
+
+    edge_data = await graph.get_edge_delete_data(
+        [EdgeIdentity(source_id=s, target_id=t, relationship_name=r) for s, t, r in edges]
+    )
+    for edge, data in edge_data.items():
+        edge_state[(edge.source_id, edge.target_id, edge.relationship_name)] = {
+            "properties": data.edge_properties,
+            "source_ref_keys": sorted(data.source_ref_keys),
+            "source_run_refs": sorted(data.source_run_refs),
+        }
+
+    vector_state = {}
+    for collection in collections:
+        rows = await vector.get_raw_rows(collection, node_ids)
+        vector_state[collection] = {
+            row["id"]: (tuple(row["vector"]), tuple(sorted((row["payload"] or {}).keys())))
+            for row in rows
+        }
+
+    return node_state, edge_state, vector_state
+
+
+@pytest_asyncio.fixture
+async def two_run_dataset(versioning_env):
+    """Shared fixture: dataset with two completed runs and a snapshot between.
+
+    R1 (t1): Alice, Bob + knows-edge for data item 1.
+    snapshot "v1" at t_mid.
+    R2 (t2): Carol for data item 2, plus a second ownership ref on Bob
+             (shared artifact across runs — the partial-rollback case).
+    """
+    user = await get_default_user()
+    dataset = await create_authorized_dataset("versioning_fixture_dataset", user)
+
+    add1 = await cognee.add("Alice knows Bob.", dataset_name=dataset.name, user=user)
+    add2 = await cognee.add("Carol appears later.", dataset_name=dataset.name, user=user)
+    data_id_1 = add1.data_ingestion_info[0]["data_id"]
+    data_id_2 = add2.data_ingestion_info[0]["data_id"]
+
+    base = datetime.now(timezone.utc)
+    t1, t_mid, t2 = (
+        base - timedelta(minutes=10),
+        base - timedelta(minutes=5),
+        base - timedelta(minutes=1),
+    )
+
+    run1, run2 = uuid4(), uuid4()
+
+    alice, bob, carol = Person(name="Alice"), Person(name="Bob"), Person(name="Carol")
+
+    await _seed_run(
+        dataset,
+        user,
+        data_id_1,
+        run1,
+        [alice, bob],
+        edges=[(str(alice.id), str(bob.id), "knows", {"edge_text": "knows"})],
+    )
+    await _log_completed_run(dataset.id, run1, t1)
+
+    snapshot = await create_snapshot(dataset.id, "v1", as_of_time=t_mid)
+
+    # R2: new node Carol (data 2) + re-own Bob under data 2 (shared artifact).
+    await _seed_run(dataset, user, data_id_2, run2, [carol, Person(id=bob.id, name="Bob")])
+    await _log_completed_run(dataset.id, run2, t2)
+
+    return SimpleNamespace(
+        user=user,
+        dataset=dataset,
+        data_id_1=UUID(str(data_id_1)),
+        data_id_2=UUID(str(data_id_2)),
+        run1=run1,
+        run2=run2,
+        t1=t1,
+        t_mid=t_mid,
+        t2=t2,
+        snapshot=snapshot,
+        alice=alice,
+        bob=bob,
+        carol=carol,
+    )
+
+
+async def test_as_of_returns_exactly_r1_state(two_run_dataset):
+    """as-of the snapshot shows exactly R1's nodes/edges; live view shows R2 too."""
+    fx = two_run_dataset
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+
+        nodes, edges = await get_graph_as_of(graph, fx.dataset.id, "v1")
+        as_of_node_ids = {node["id"] for node in nodes}
+        as_of_edges = {
+            (edge["source_id"], edge["target_id"], edge["relationship_name"]) for edge in edges
+        }
+
+        assert as_of_node_ids == {str(fx.alice.id), str(fx.bob.id)}
+        assert as_of_edges == {(str(fx.alice.id), str(fx.bob.id), "knows")}
+
+        live_node_ids = await _all_graph_node_ids(graph)
+        assert str(fx.carol.id) in live_node_ids  # live view has R2
+
+        # Datetime as-of works identically to the snapshot name.
+        nodes_by_time, _ = await get_graph_as_of(graph, fx.dataset.id, fx.t_mid)
+        assert {node["id"] for node in nodes_by_time} == as_of_node_ids
+
+        # After t2, everything is visible.
+        nodes_now, _ = await get_graph_as_of(graph, fx.dataset.id, datetime.now(timezone.utc))
+        assert {node["id"] for node in nodes_now} == {
+            str(fx.alice.id),
+            str(fx.bob.id),
+            str(fx.carol.id),
+        }
+
+
+async def test_as_of_vector_search_filters_to_exact_id_set(two_run_dataset):
+    """The vector post-filter returns exactly the visible vector-id set at T.
+
+    Vector ids in per-type collections are graph node ids — assert the as-of
+    hits equal R1's id set, not merely a subset (over- and under-return both
+    fail).
+    """
+    fx = two_run_dataset
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        hits = await search_chunks_as_of(
+            graph,
+            vector,
+            fx.dataset.id,
+            "person",
+            "v1",
+            top_k=10,
+            collection_name="Person_name",
+        )
+        assert {str(hit.id) for hit in hits} == {str(fx.alice.id), str(fx.bob.id)}
+
+        live_hits = await vector.search("Person_name", query_text="person", limit=None)
+        assert str(fx.carol.id) in {str(hit.id) for hit in live_hits}
+
+
+async def test_reversible_forget_then_undo_restores_exactly(two_run_dataset):
+    """forget(reversible) -> undo restores graph rows, provenance, and embeddings."""
+    fx = two_run_dataset
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        before = await _full_state(graph, vector, ["Person_name"])
+
+    result = await cognee.forget(
+        data_id=fx.data_id_1,
+        dataset_id=fx.dataset.id,
+        memory_only=True,
+        reversible=True,
+        user=fx.user,
+    )
+    assert result["status"] == "success"
+    operation_id = result["operation_id"]
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        # Alice (owned only by data 1) is gone from graph AND vector store;
+        # Bob (shared with data 2) survives with data 1's ref detached.
+        remaining_ids = await _all_graph_node_ids(graph)
+        assert str(fx.alice.id) not in remaining_ids
+        assert str(fx.bob.id) in remaining_ids
+        assert await vector.get_raw_rows("Person_name", [str(fx.alice.id)]) == []
+
+        bob_data = await graph.get_node_delete_data([str(fx.bob.id)])
+        assert len(bob_data[str(fx.bob.id)].source_ref_keys) == 1
+
+    await cognee.undo(operation_id, dataset_id=fx.dataset.id, user=fx.user)
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        after = await _full_state(graph, vector, ["Person_name"])
+
+    assert after == before  # exact restore: properties, provenance, embeddings
+
+
+async def test_forget_after_t_shadows_as_of_until_undone(two_run_dataset):
+    """Documented as-of boundary: a destructive op after T hides pre-T state.
+
+    as-of is a forward-faithful filter over the live store, not reconstruction
+    through un-undone deletes: forgetting data 1 (ingested in R1, i.e. before
+    the snapshot cut) makes as_of("v1") stop returning Alice. Undoing the
+    forget makes the same read exact again.
+    """
+    fx = two_run_dataset
+
+    result = await cognee.forget(
+        data_id=fx.data_id_1,
+        dataset_id=fx.dataset.id,
+        memory_only=True,
+        reversible=True,
+        user=fx.user,
+    )
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        visible_nodes, _ = await get_visible_artifacts_as_of(graph, fx.dataset.id, "v1")
+        # The boundary: Alice existed at T but a post-T forget shadows her.
+        assert str(fx.alice.id) not in visible_nodes
+
+    await cognee.undo(result["operation_id"], dataset_id=fx.dataset.id, user=fx.user)
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        visible_nodes, _ = await get_visible_artifacts_as_of(graph, fx.dataset.id, "v1")
+        assert visible_nodes == {str(fx.alice.id), str(fx.bob.id)}
+
+
+async def test_rollback_to_snapshot_and_undo_with_shared_ownership(two_run_dataset):
+    """rollback reverses post-T runs newest-first; undo restores them exactly.
+
+    Shared-ownership pin: Bob is owned by data 1 (attached in R1) and data 2
+    (attached in R2). Rolling back to v1 removes R2's contribution — Carol is
+    deleted, Bob *survives* with only R1's ref. Undo restores Carol and Bob's
+    second ownership attachment.
+    """
+    fx = two_run_dataset
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        before = await _full_state(graph, vector, ["Person_name"])
+
+    result = await cognee.rollback("v1", dataset_id=fx.dataset.id, user=fx.user)
+    assert result["status"] == "success"
+    assert result["rolled_back_runs"] == [str(fx.run2)]
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        remaining_ids = await _all_graph_node_ids(graph)
+        assert str(fx.carol.id) not in remaining_ids  # R2-only artifact removed
+        assert str(fx.bob.id) in remaining_ids  # co-owned artifact survives
+
+        bob_data = await graph.get_node_delete_data([str(fx.bob.id)])
+        assert len(bob_data[str(fx.bob.id)].source_ref_keys) == 1  # R2's ref detached
+        assert await vector.get_raw_rows("Person_name", [str(fx.carol.id)]) == []
+
+        # The rolled-back state matches the as-of view of the same cut.
+        visible_nodes, _ = await get_visible_artifacts_as_of(graph, fx.dataset.id, "v1")
+        assert visible_nodes == {str(fx.alice.id), str(fx.bob.id)}
+        assert visible_nodes <= remaining_ids
+
+    await cognee.undo(result["operation_id"], dataset_id=fx.dataset.id, user=fx.user)
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        after = await _full_state(graph, vector, ["Person_name"])
+
+    assert after == before
+
+
+async def test_rollback_noop_when_nothing_after_t(two_run_dataset):
+    fx = two_run_dataset
+
+    result = await cognee.rollback(
+        datetime.now(timezone.utc), dataset_id=fx.dataset.id, user=fx.user
+    )
+    assert result == {"operation_id": None, "rolled_back_runs": [], "status": "noop"}
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        assert {str(fx.alice.id), str(fx.bob.id), str(fx.carol.id)} <= (
+            await _all_graph_node_ids(graph)
+        )
+
+
+async def test_reversible_forget_fails_closed_on_unsupported_backend(two_run_dataset, monkeypatch):
+    """Backends without graph provenance raise before any data is touched."""
+    fx = two_run_dataset
+
+    from cognee.modules.versioning.methods import operations as operations_module
+
+    async def _not_in_graph(_graph_engine):
+        return False
+
+    monkeypatch.setattr(operations_module, "stores_provenance_in_graph", _not_in_graph)
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        before = await _all_graph_node_ids(graph)
+
+    with pytest.raises(UnsupportedProvenanceCapability):
+        await cognee.forget(
+            data_id=fx.data_id_1,
+            dataset_id=fx.dataset.id,
+            memory_only=True,
+            reversible=True,
+            user=fx.user,
+        )
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        assert await _all_graph_node_ids(graph) == before  # nothing was deleted
+
+
+async def test_undo_refuses_outside_retention_window(two_run_dataset):
+    fx = two_run_dataset
+
+    result = await cognee.forget(
+        data_id=fx.data_id_1,
+        dataset_id=fx.dataset.id,
+        memory_only=True,
+        reversible=True,
+        user=fx.user,
+    )
+    op_id = UUID(result["operation_id"])
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        op = (await session.execute(select(VersionOp).where(VersionOp.id == op_id))).scalars().one()
+        op.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+        await session.commit()
+
+    with pytest.raises(ValueError, match="retention window"):
+        await cognee.undo(op_id, dataset_id=fx.dataset.id, user=fx.user)
+
+
+async def test_undo_twice_refuses_and_ledger_tracks_status(two_run_dataset):
+    fx = two_run_dataset
+
+    result = await cognee.forget(
+        data_id=fx.data_id_1,
+        dataset_id=fx.dataset.id,
+        memory_only=True,
+        reversible=True,
+        user=fx.user,
+    )
+    op_id = UUID(result["operation_id"])
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        op = (await session.execute(select(VersionOp).where(VersionOp.id == op_id))).scalars().one()
+        assert op.status == VersionOpStatus.APPLIED
+
+    await cognee.undo(op_id, dataset_id=fx.dataset.id, user=fx.user)
+
+    async with db_engine.get_async_session() as session:
+        op = (await session.execute(select(VersionOp).where(VersionOp.id == op_id))).scalars().one()
+        assert op.status == VersionOpStatus.UNDONE
+
+    with pytest.raises(ValueError, match="already been undone"):
+        await cognee.undo(op_id, dataset_id=fx.dataset.id, user=fx.user)
+
+
+async def test_undo_is_idempotent_after_partial_restore(two_run_dataset):
+    """Crash-recovery contract: replaying a restore converges to the same state.
+
+    Restore primitives are MERGE upserts / set-merge attaches, so re-running
+    the inverse over an already-restored store must not duplicate artifacts or
+    provenance attachments.
+    """
+    fx = two_run_dataset
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        before = await _full_state(graph, vector, ["Person_name"])
+
+    result = await cognee.forget(
+        data_id=fx.data_id_1,
+        dataset_id=fx.dataset.id,
+        memory_only=True,
+        reversible=True,
+        user=fx.user,
+    )
+    op_id = UUID(result["operation_id"])
+
+    from cognee.modules.versioning import get_version_op
+    from cognee.modules.versioning.methods.inverse import restore_inverse_step
+
+    op = await get_version_op(op_id)
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        # Simulate a crash mid-undo: the first replay happens, then the whole
+        # undo runs again from the top.
+        await restore_inverse_step(graph, vector, op.payload["steps"][0])
+
+    await undo_version_op(op_id)
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+
+        after = await _full_state(graph, vector, ["Person_name"])
+
+    assert after == before
+
+
+async def test_concurrent_writer_during_reversible_forget(two_run_dataset):
+    """A concurrent cognify-style writer must not corrupt forget/undo.
+
+    Reversible forget of data 1 races a writer adding artifacts for data 2.
+    Neither operation may fail (no 'database is locked' regressions), the
+    forgotten artifacts must be restorable, and the concurrent write must
+    survive both the forget and the undo untouched.
+    """
+    fx = two_run_dataset
+
+    concurrent_nodes = [Person(name=f"Concurrent-{i}") for i in range(5)]
+    run3 = uuid4()
+
+    async def _concurrent_writes():
+        for node in concurrent_nodes:
+            await _seed_run(fx.dataset, fx.user, fx.data_id_2, run3, [node])
+
+    async def _reversible_forget():
+        return await cognee.forget(
+            data_id=fx.data_id_1,
+            dataset_id=fx.dataset.id,
+            memory_only=True,
+            reversible=True,
+            user=fx.user,
+        )
+
+    result, _ = await asyncio.gather(_reversible_forget(), _concurrent_writes())
+    assert result["status"] == "success"
+
+    await cognee.undo(result["operation_id"], dataset_id=fx.dataset.id, user=fx.user)
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+
+        node_ids = await _all_graph_node_ids(graph)
+        # Forgotten-and-undone artifacts are back.
+        assert str(fx.alice.id) in node_ids
+        # Concurrent writes survived forget + undo.
+        assert {str(node.id) for node in concurrent_nodes} <= node_ids
+
+
+async def test_snapshot_names_are_unique_per_dataset(two_run_dataset):
+    fx = two_run_dataset
+
+    with pytest.raises(ValueError, match="already exists"):
+        await create_snapshot(fx.dataset.id, "v1")
+
+    listed = await cognee.list_snapshots(dataset_id=fx.dataset.id, user=fx.user)
+    assert [item["name"] for item in listed] == ["v1"]
+
+
+async def test_as_of_before_first_run_is_empty(two_run_dataset):
+    fx = two_run_dataset
+
+    async with set_database_global_context_variables(fx.dataset.id, fx.dataset.owner_id):
+        graph = await get_graph_engine()
+        nodes, edges = await get_graph_as_of(graph, fx.dataset.id, fx.t1 - timedelta(minutes=5))
+    assert nodes == []
+    assert edges == []
+
+
+async def test_rollback_multiple_runs_newest_first_full_round_trip(versioning_env):
+    """Three runs, rollback to before R2 (drops R2+R3 newest-first), then undo.
+
+    The R2 artifact is also co-owned by R3 (attach of a second data item's
+    ref), so the newest-first order matters: R3's rollback detaches, R2's
+    rollback deletes. Undo restores in reverse application order.
+    """
+    user = await get_default_user()
+    dataset = await create_authorized_dataset("versioning_multirun_dataset", user)
+
+    add1 = await cognee.add("first", dataset_name=dataset.name, user=user)
+    add2 = await cognee.add("second", dataset_name=dataset.name, user=user)
+    add3 = await cognee.add("third", dataset_name=dataset.name, user=user)
+    data_ids = [UUID(str(entry.data_ingestion_info[0]["data_id"])) for entry in (add1, add2, add3)]
+
+    base = datetime.now(timezone.utc)
+    times = [base - timedelta(minutes=m) for m in (9, 6, 3)]
+    runs = [uuid4(), uuid4(), uuid4()]
+
+    n1, n2, n3 = Person(name="One"), Person(name="Two"), Person(name="Three")
+
+    await _seed_run(dataset, user, data_ids[0], runs[0], [n1])
+    await _log_completed_run(dataset.id, runs[0], times[0])
+
+    await _seed_run(dataset, user, data_ids[1], runs[1], [n2])
+    await _log_completed_run(dataset.id, runs[1], times[1])
+
+    # R3: own node three AND co-own node two (shared across R2/R3).
+    await _seed_run(dataset, user, data_ids[2], runs[2], [n3, Person(id=n2.id, name="Two")])
+    await _log_completed_run(dataset.id, runs[2], times[2])
+
+    async with set_database_global_context_variables(dataset.id, dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        before = await _full_state(graph, vector, ["Person_name"])
+
+    cut = times[0] + timedelta(minutes=1)  # after R1, before R2
+    result = await cognee.rollback(cut, dataset_id=dataset.id, user=user)
+    assert result["rolled_back_runs"] == [str(runs[2]), str(runs[1])]  # newest first
+
+    async with set_database_global_context_variables(dataset.id, dataset.owner_id):
+        graph = await get_graph_engine()
+        node_ids = await _all_graph_node_ids(graph)
+        assert str(n1.id) in node_ids
+        assert str(n2.id) not in node_ids
+        assert str(n3.id) not in node_ids
+
+    await cognee.undo(result["operation_id"], dataset_id=dataset.id, user=user)
+
+    async with set_database_global_context_variables(dataset.id, dataset.owner_id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        after = await _full_state(graph, vector, ["Person_name"])
+
+    assert after == before

--- a/cognee/tests/integration/modules/versioning/test_versioning_e2e_mocked_llm.py
+++ b/cognee/tests/integration/modules/versioning/test_versioning_e2e_mocked_llm.py
@@ -239,5 +239,10 @@ async def test_snapshot_mutate_time_travel_rollback_and_undo_forget(e2e_env):
     async with set_database_global_context_variables(dataset_id, user.id):
         graph = await get_graph_engine()
         vector = get_vector_engine()
+        # DO NOT REMOVE / weaken: full-state equality is the capture<->delete
+        # invariant. Reversible forget is correct only if capture
+        # (find_{node,edge}_source_refs_by_dataset) discovers exactly what
+        # delete (delete_dataset_nodes_and_edges) removes. If the delete path
+        # ever changes, this equality is what catches silent undo loss.
         assert await _all_node_ids(graph) == live_node_ids
         assert await _chunk_ids(vector) == live_chunk_ids

--- a/cognee/tests/integration/modules/versioning/test_versioning_e2e_mocked_llm.py
+++ b/cognee/tests/integration/modules/versioning/test_versioning_e2e_mocked_llm.py
@@ -1,0 +1,243 @@
+"""End-to-end versioning proof through the REAL cognify pipeline (issue #3650).
+
+The shared-fixture scenario the hackathon ticket asks for, deterministic in CI
+via a mocked LLM (canned structured outputs) and hash-based embeddings — no
+API keys, no network:
+
+    add(doc1) -> cognify (run R1) -> snapshot "v1"
+    add(doc2) -> cognify (run R2)
+    - as-of "v1" returns exactly R1's artifacts (including the DocumentChunk
+      vector-id set — the chunks/RAG surface);
+    - rollback to "v1" restores R1's live state exactly; undo restores R2;
+    - reversible forget of doc2's memory + undo restores exactly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.context_global_variables import (
+    graph_db_config,
+    set_database_global_context_variables,
+    vector_db_config,
+)
+from cognee.infrastructure.databases.graph import get_graph_engine
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.llm import LLMGateway
+from cognee.modules.engine.operations.setup import setup as engine_setup
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.versioning import get_visible_artifacts_as_of, search_chunks_as_of
+
+try:
+    import ladybug  # noqa: F401
+    import lancedb  # noqa: F401
+
+    HAS_DEFAULT_STACK = True
+except ModuleNotFoundError:
+    HAS_DEFAULT_STACK = False
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(not HAS_DEFAULT_STACK, reason="default stack not installed"),
+]
+
+
+def _hash_vector(text: str, size: int = 8) -> list[float]:
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    return [byte / 255.0 for byte in digest[:size]]
+
+
+async def _mock_structured_output(text_input: str, _system_prompt: str, response_model, **_kwargs):
+    """Canned, deterministic structured outputs keyed on the input text."""
+    from cognee.shared.data_models import Edge as KGEdge
+    from cognee.shared.data_models import KnowledgeGraph, Node as KGNode, SummarizedContent
+
+    if response_model is SummarizedContent:
+        return SummarizedContent(summary="Deterministic summary", description="Mocked")
+
+    if response_model is KnowledgeGraph:
+        if "Alice" in text_input:
+            return KnowledgeGraph(
+                nodes=[
+                    KGNode(id="Alice", name="Alice", type="Person", description="Person A"),
+                    KGNode(id="Bob", name="Bob", type="Person", description="Person B"),
+                ],
+                edges=[
+                    KGEdge(source_node_id="Alice", target_node_id="Bob", relationship_name="knows")
+                ],
+            )
+        return KnowledgeGraph(
+            nodes=[
+                KGNode(id="Carol", name="Carol", type="Person", description="Person C"),
+            ],
+            edges=[],
+        )
+
+    if response_model is str:
+        return "mocked"
+
+    # Generic fallback: minimal valid instance for any other model.
+    try:
+        return response_model()
+    except Exception:
+        return response_model.model_construct()
+
+
+@pytest_asyncio.fixture
+async def e2e_env(request, tmp_path, monkeypatch):
+    monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    monkeypatch.setenv("GRAPH_DATASET_DATABASE_HANDLER", "ladybug")
+    monkeypatch.setenv("VECTOR_DATASET_DATABASE_HANDLER", "lancedb")
+
+    root = pathlib.Path(tmp_path) / request.node.name
+
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+
+    graph_db_config.set(None)
+    vector_db_config.set(None)
+    cognee.config.set_graph_db_config(
+        {"graph_database_provider": "ladybug", "graph_dataset_database_handler": "ladybug"}
+    )
+    cognee.config.set_vector_db_config(
+        {"vector_db_provider": "lancedb", "vector_dataset_database_handler": "lancedb"}
+    )
+    cognee.config.set_relational_db_config({"db_provider": "sqlite"})
+    cognee.config.system_root_directory(str(root / "system"))
+    cognee.config.data_root_directory(str(root / "data"))
+    cognee.config.set_vector_db_url(str(root / "system" / "databases" / "cognee.lancedb"))
+
+    from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+        LiteLLMEmbeddingEngine,
+    )
+
+    async def _fake_embed_text(self, texts):
+        return [_hash_vector(text) for text in texts]
+
+    monkeypatch.setattr(LiteLLMEmbeddingEngine, "embed_text", _fake_embed_text)
+    monkeypatch.setattr(LiteLLMEmbeddingEngine, "get_vector_size", lambda self: 8)
+    monkeypatch.setattr(LLMGateway, "acreate_structured_output", _mock_structured_output)
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await engine_setup()
+
+    yield
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+async def _all_node_ids(graph) -> set[str]:
+    rows = await graph.query("MATCH (n:Node) RETURN n.id", {})
+    return {row[0] for row in rows}
+
+
+async def _chunk_ids(vector) -> set[str]:
+    hits = await vector.search("DocumentChunk_text", query_text="anything", limit=None)
+    return {str(hit.id) for hit in hits}
+
+
+async def test_snapshot_mutate_time_travel_rollback_and_undo_forget(e2e_env):
+    user = await get_default_user()
+    dataset_name = "versioning_e2e_dataset"
+
+    # --- R1: first document through the real pipeline (mocked LLM). ---------
+    await cognee.add("Alice knows Bob since 2020.", dataset_name=dataset_name, user=user)
+    cognify_1 = await cognee.cognify(datasets=[dataset_name], user=user)
+    (dataset_id,) = cognify_1.keys()
+    assert cognify_1[dataset_id].status == "PipelineRunCompleted"
+
+    async with set_database_global_context_variables(dataset_id, user.id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        r1_node_ids = await _all_node_ids(graph)
+        r1_chunk_ids = await _chunk_ids(vector)
+    assert r1_chunk_ids, "cognify should have produced document chunks"
+
+    # --- snapshot, then R2: second document. ---------------------------------
+    await cognee.snapshot("v1", dataset_id=dataset_id, user=user)
+
+    add_2 = await cognee.add("Carol appears later.", dataset_name=dataset_name, user=user)
+    data_id_2 = add_2.data_ingestion_info[0]["data_id"]
+    cognify_2 = await cognee.cognify(datasets=[dataset_name], user=user)
+    assert cognify_2[dataset_id].status == "PipelineRunCompleted"
+
+    async with set_database_global_context_variables(dataset_id, user.id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        live_node_ids = await _all_node_ids(graph)
+        live_chunk_ids = await _chunk_ids(vector)
+
+        assert r1_node_ids < live_node_ids  # R2 added artifacts
+        assert r1_chunk_ids < live_chunk_ids
+
+        # --- time-travel: as-of "v1" is exactly the R1 state. ----------------
+        visible_nodes, _ = await get_visible_artifacts_as_of(graph, dataset_id, "v1")
+        assert visible_nodes == r1_node_ids
+
+        # The chunks surface (user-facing RAG reads) filters to the exact
+        # R1 chunk-vector id set — not merely a subset.
+        as_of_hits = await search_chunks_as_of(
+            graph, vector, dataset_id, "anything", "v1", top_k=50
+        )
+        assert {str(hit.id) for hit in as_of_hits} == r1_chunk_ids
+
+    # --- rollback to "v1", then undo the rollback. ---------------------------
+    rollback_result = await cognee.rollback("v1", dataset_id=dataset_id, user=user)
+    assert rollback_result["status"] == "success"
+    assert rollback_result["rolled_back_runs"], "R2 should have been reversed"
+
+    async with set_database_global_context_variables(dataset_id, user.id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        assert await _all_node_ids(graph) == r1_node_ids
+        assert await _chunk_ids(vector) == r1_chunk_ids
+
+    await cognee.undo(rollback_result["operation_id"], dataset_id=dataset_id, user=user)
+
+    async with set_database_global_context_variables(dataset_id, user.id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        assert await _all_node_ids(graph) == live_node_ids
+        assert await _chunk_ids(vector) == live_chunk_ids
+
+    # --- reversible forget of doc2's memory, then undo. ----------------------
+    forget_result = await cognee.forget(
+        data_id=data_id_2,
+        dataset_id=dataset_id,
+        memory_only=True,
+        reversible=True,
+        user=user,
+    )
+    assert forget_result["status"] == "success"
+
+    async with set_database_global_context_variables(dataset_id, user.id):
+        graph = await get_graph_engine()
+        node_ids_after_forget = await _all_node_ids(graph)
+        assert node_ids_after_forget < live_node_ids  # something was forgotten
+        assert r1_node_ids <= node_ids_after_forget  # R1's memory untouched
+
+    await cognee.undo(forget_result["operation_id"], dataset_id=dataset_id, user=user)
+
+    async with set_database_global_context_variables(dataset_id, user.id):
+        graph = await get_graph_engine()
+        vector = get_vector_engine()
+        assert await _all_node_ids(graph) == live_node_ids
+        assert await _chunk_ids(vector) == live_chunk_ids

--- a/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
+++ b/cognee/tests/unit/api/v1/forget/test_forget_memory_only.py
@@ -336,7 +336,7 @@ async def test_forget_routes_to_dataset_memory(monkeypatch):
         result = await forget_module.forget(dataset="my-dataset", memory_only=True)
 
     assert result["status"] == "success"
-    mock_forget_dataset_memory.assert_awaited_once_with("my-dataset", USER)
+    mock_forget_dataset_memory.assert_awaited_once_with("my-dataset", USER, reversible=False)
 
 
 @pytest.mark.asyncio
@@ -365,7 +365,9 @@ async def test_forget_routes_to_data_memory(monkeypatch):
         )
 
     assert result["status"] == "success"
-    mock_forget_data_memory.assert_awaited_once_with(DATA_ID_A, "my-dataset", USER)
+    mock_forget_data_memory.assert_awaited_once_with(
+        DATA_ID_A, "my-dataset", USER, reversible=False
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/modules/versioning/test_inverse_logic.py
+++ b/cognee/tests/unit/modules/versioning/test_inverse_logic.py
@@ -1,0 +1,63 @@
+"""Pure-logic tests for the versioning inverse: ownership partitioning, Model-A
+run grouping, and as-of visibility — no databases involved."""
+
+from uuid import uuid4
+
+from cognee.infrastructure.databases.provenance import make_source_ref_key
+from cognee.infrastructure.databases.provenance.source_refs import make_source_run_ref
+from cognee.modules.versioning.methods.as_of_read import _is_visible
+from cognee.modules.versioning.methods.inverse import (
+    _group_keys_by_owning_run,
+    _is_unowned,
+)
+
+
+def test_is_unowned_mirrors_planner_rule():
+    key_a, key_b = "source_ref:v1:d:1", "source_ref:v1:d:2"
+    assert _is_unowned([key_a], [key_a])
+    assert not _is_unowned([key_a, key_b], [key_a])
+    assert _is_unowned([key_a, key_b], [key_a, key_b])
+    assert _is_unowned([], [])
+
+
+def test_group_keys_by_owning_run_model_a():
+    """Each key maps to at most one run ref (the first attacher); keys without
+    a run ref group under None (non-rollbackable-by-run attachments)."""
+    dataset_id, run_a, run_b = uuid4(), uuid4(), uuid4()
+    key_1 = make_source_ref_key(dataset_id, uuid4())
+    key_2 = make_source_ref_key(dataset_id, uuid4())
+    key_3 = make_source_ref_key(dataset_id, uuid4())
+
+    run_refs = [
+        make_source_run_ref(run_a, key_1),
+        make_source_run_ref(run_b, key_2),
+    ]
+
+    groups = _group_keys_by_owning_run([key_1, key_2, key_3], run_refs)
+
+    assert groups == {
+        str(run_a): [key_1],
+        str(run_b): [key_2],
+        None: [key_3],
+    }
+
+
+def test_is_visible_requires_allowed_run_and_matching_dataset():
+    dataset_id, other_dataset = uuid4(), uuid4()
+    run_old, run_new = uuid4(), uuid4()
+
+    own_ref = make_source_run_ref(run_old, make_source_ref_key(dataset_id, uuid4()))
+    new_ref = make_source_run_ref(run_new, make_source_ref_key(dataset_id, uuid4()))
+    foreign_ref = make_source_run_ref(run_old, make_source_ref_key(other_dataset, uuid4()))
+
+    allowed = {str(run_old)}
+
+    assert _is_visible([own_ref], allowed, str(dataset_id))
+    # Attached only by a run after T -> not visible.
+    assert not _is_visible([new_ref], allowed, str(dataset_id))
+    # Attached at T but for another dataset -> not visible for this dataset.
+    assert not _is_visible([foreign_ref], allowed, str(dataset_id))
+    # Mixed: any qualifying ref makes it visible.
+    assert _is_visible([new_ref, own_ref], allowed, str(dataset_id))
+    # No dataset scoping: the foreign ref counts.
+    assert _is_visible([foreign_ref], allowed, None)

--- a/cognee/tests/unit/modules/versioning/test_inverse_logic.py
+++ b/cognee/tests/unit/modules/versioning/test_inverse_logic.py
@@ -12,7 +12,15 @@ from cognee.modules.versioning.methods.inverse import (
 )
 
 
-def test_is_unowned_mirrors_planner_rule():
+def test_is_unowned_is_the_planner_rule():
+    """The capture partitions with the planner's own function (imported, not
+    mirrored), so this pins the shared rule both paths use."""
+    from cognee.infrastructure.databases.unified.provenance_delete_planner import (
+        _is_unowned as planner_is_unowned,
+    )
+
+    assert _is_unowned is planner_is_unowned
+
     key_a, key_b = "source_ref:v1:d:1", "source_ref:v1:d:2"
     assert _is_unowned([key_a], [key_a])
     assert not _is_unowned([key_a, key_b], [key_a])

--- a/examples/python/versioning_as_of_benchmark.py
+++ b/examples/python/versioning_as_of_benchmark.py
@@ -1,0 +1,104 @@
+"""Benchmark: "as of T" filtered read vs live read (issue #3650, Approach 1).
+
+Approach 1 stores no copies — a version is a filter over run provenance. The
+trade-off to prove is the cost of that filter: an as-of read scans the
+artifacts' ``source_run_refs`` (one graph pass) and intersects them with the
+allowed run-id set, instead of reading the live graph directly.
+
+This script seeds N completed runs x M nodes each into a real Ladybug graph
+(offline: no LLM, no embeddings, no relational DB — the allowed-run set is
+computed in memory; in production it is one indexed query over
+``pipeline_runs``) and reports, per history depth:
+
+- live read:   full graph node scan (the baseline every reader pays),
+- as-of read:  provenance scan + run-set filter (the versioning surcharge).
+
+Run:  python examples/python/versioning_as_of_benchmark.py
+"""
+
+import asyncio
+import statistics
+import tempfile
+import time
+from uuid import uuid4
+
+from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
+from cognee.infrastructure.databases.provenance import make_source_ref_key
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.versioning.methods.as_of_read import _is_visible
+
+RUN_COUNTS = [5, 10, 25, 50]
+NODES_PER_RUN = 40
+REPEATS = 5
+
+
+class BenchNode(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"]}
+
+
+async def _seed(graph, dataset_id, run_count: int):
+    run_ids = []
+    for run_index in range(run_count):
+        run_id = uuid4()
+        run_ids.append(str(run_id))
+        source_ref_key = make_source_ref_key(dataset_id, uuid4())
+        nodes = [BenchNode(name=f"run{run_index}-node{i}") for i in range(NODES_PER_RUN)]
+        await graph.add_nodes(nodes, source_ref_key=source_ref_key, pipeline_run_id=str(run_id))
+    return run_ids
+
+
+async def _time(coro_factory, repeats: int = REPEATS) -> float:
+    samples = []
+    for _ in range(repeats):
+        started = time.perf_counter()
+        await coro_factory()
+        samples.append(time.perf_counter() - started)
+    return statistics.median(samples)
+
+
+async def bench(run_count: int) -> tuple[float, float, int]:
+    dataset_id = uuid4()
+    with tempfile.TemporaryDirectory() as tmp:
+        graph = LadybugAdapter(f"{tmp}/graph")
+        try:
+            run_ids = await _seed(graph, dataset_id, run_count)
+            # "as of T" = first half of the history is visible.
+            allowed = set(run_ids[: max(1, run_count // 2)])
+            dataset_id_str = str(dataset_id)
+
+            async def live_read():
+                await graph.query("MATCH (n:Node) RETURN n.id, n.name, n.type", {})
+
+            async def as_of_read():
+                refs_by_node = await graph.find_all_node_source_run_refs()
+                return {
+                    node_id
+                    for node_id, run_refs in refs_by_node.items()
+                    if _is_visible(run_refs, allowed, dataset_id_str)
+                }
+
+            live = await _time(live_read)
+            as_of = await _time(as_of_read)
+            visible = len(await as_of_read())
+            return live, as_of, visible
+        finally:
+            await graph.close()
+
+
+async def main():
+    total_nodes = {n: n * NODES_PER_RUN for n in RUN_COUNTS}
+    print(
+        f"{'runs':>5} {'nodes':>7} {'live read':>12} {'as-of read':>12} {'overhead':>9} {'visible':>8}"
+    )
+    for run_count in RUN_COUNTS:
+        live, as_of, visible = await bench(run_count)
+        overhead = as_of / live if live else float("inf")
+        print(
+            f"{run_count:>5} {total_nodes[run_count]:>7} "
+            f"{live * 1000:>10.1f}ms {as_of * 1000:>10.1f}ms {overhead:>8.2f}x {visible:>8}"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/versioning_as_of_benchmark.py
+++ b/examples/python/versioning_as_of_benchmark.py
@@ -17,12 +17,18 @@ Run:  python examples/python/versioning_as_of_benchmark.py
 """
 
 import asyncio
+import os
 import statistics
 import tempfile
 import time
 from uuid import uuid4
 
-from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
+# Keep the benchmark truly offline: importing cognee pulls in litellm, whose
+# import-time model-cost-map fetch would otherwise hit the network (and fail
+# in air-gapped environments). Must be set before the first cognee import.
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter  # noqa: E402
 from cognee.infrastructure.databases.provenance import make_source_ref_key
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.versioning.methods.as_of_read import _is_visible


### PR DESCRIPTION
## Description

Implements #3650 (Approach 1: run-ledger time-travel). Instead of copying the graph to version it, I treat the ordered sequence of completed pipeline runs as the version history - a "version" is just a filter over the `source_run_ref` provenance from COG-5522, so no data is duplicated. Reversibility is a write-ahead undo ledger (`version_ops`): before any destructive op runs, the exact inverse (graph rows + all provenance columns + raw vector rows) is committed to the relational DB, so undo restores byte-for-byte and never re-embeds.

**Stacked PR - base is `feat/cog-5522-all-parts` (#3433), not `dev`.** This builds directly on the provenance substrate from that branch (`attach/find_*_source_refs`, `rollback_by_pipeline_run_id`, `stores_provenance_in_graph`); those primitives don't exist on `dev`/`main` yet, so it can't merge there until #3433 lands. Reviewing against the base
shows only the ~2.8k added lines, not the substrate. Same pattern as #3432 on #3279.

New public API (all additive - existing behavior is unchanged when unused):
- `cognee.snapshot(name, ...)` / `list_snapshots` - named cursors into the run ledger, zero copies.
- `cognee.graph_as_of(as_of, ...)` / `search_as_of(query, as_of, ...)` - reads filtered to runs completed by T. `as_of` accepts a snapshot name or a datetime.
- `cognee.rollback(to, ...)` - reverses post-T runs newest-first via the existing `rollback_by_pipeline_run_id` (no forked delete path), recorded as one undoable ledger op.
- `cognee.forget(..., memory_only=True, reversible=True)` + `cognee.undo(operation_id)`
 exact undo-forget within `VERSION_RETENTION_DAYS` (default 30).

Contract additions default-raise `UnsupportedProvenanceCapability`, so backends without graph-native provenance fail closed *before* touching data rather than losing it silently: `GraphDBInterface.find_all_{node,edge}_source_run_refs` (Ladybug impl) and `VectorDBInterface.get_raw_rows / restore_raw_rows` (LanceDB impl).

A few intentional behaviors worth calling out:
- `as_of` is a forward-faithful filter, not full reconstruction: a destructive  op *after* T shadows earlier state until it's undone. Documented in `as_of_read.py` and covered by a boundary test.
- No cross-store atomicity is claimed - the guarantee is write-ahead order plus idempotent (MERGE-upsert) restore, so a crash mid-op is fixed by replay.
- `search_as_of` returns hits as `id` + `score` with `payload=None` (the visibility over-fetch skips payloads for speed); re-fetch text by id if needed.

## Acceptance Criteria

- [x] `snapshot` → mutate → `graph_as_of`/`search_as_of` returns exactly the node/edge and chunk vector-id sets of the runs completed by T (set equality, not subset), including an e2e through real `add` → `cognify`.
- [x] `rollback` to T restores exactly and is itself undoable; shared-ownership pinned (an artifact co-owned by two runs survives a partial rollback and both provenance attachments return on undo).
- [x] `forget` → `undo` restores full state (properties, provenance, byte-equal embeddings - no re-embedding); retention expiry refuses undo; partial-restore replay is idempotent.
- [x] Concurrent writer during reversible forget + undo — no locking failures.
- [x] Perf (`examples/python/versioning_as_of_benchmark.py`, real Ladybug): an as-of read costs ~2.0–2.7× a live scan, <10 ms at 2,000 nodes / 50 runs.
- [x] 18 new tests (unit + default-stack integration + mocked-LLM e2e, all offline/deterministic, no keys), the 92 existing provenance/forget/rollback tests stay green, and 2 existing forget unit tests were updated for the new `reversible` kwarg.

Reproduce: `uv run pytest cognee/tests/unit/modules/versioning cognee/tests/integration/modules/versioning`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots

<img width="1767" height="222" alt="Screenshot 2026-07-03 045148" src="https://github.com/user-attachments/assets/d14ac81d-31eb-4516-ac7b-008d79ed5605" />
<img width="1793" height="297" alt="Screenshot 2026-07-03 051431" src="https://github.com/user-attachments/assets/dc7f2411-c02f-4735-b89a-b533e79fe430" />


## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.


