### PR TITLE
fix(ingestion): validate outbound URLs to prevent SSRF

### DIFF
--- a/cognee/tasks/ingestion/save_data_item_to_storage.py
+++ b/cognee/tasks/ingestion/save_data_item_to_storage.py
@@ -9,6 +9,7 @@ from cognee.shared.logging_utils import get_logger
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from cognee.tasks.web_scraper.utils import fetch_page_content
+from cognee.tasks.web_scraper.ssrf_protection import validate_outbound_url
 from cognee.tasks.ingestion.data_item import DataItem
 
 
@@ -59,6 +60,9 @@ async def save_data_item_to_storage(data_item: Union[BinaryIO, str, Any]) -> str
         if parsed_url.scheme == "s3":
             return data_item
         elif parsed_url.scheme == "http" or parsed_url.scheme == "https":
+            # Guard against SSRF: reject disabled outbound HTTP, non-http(s) schemes,
+            # and hosts that resolve to internal/reserved addresses before fetching.
+            await validate_outbound_url(data_item)
             urls_to_page_contents = await fetch_page_content(data_item)
             return await save_data_to_file(urls_to_page_contents[data_item], file_extension="html")
         # data is local file path

--- a/cognee/tasks/web_scraper/default_url_crawler.py
+++ b/cognee/tasks/web_scraper/default_url_crawler.py
@@ -9,6 +9,7 @@ import os
 
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.web_scraper.types import UrlsToHtmls
+from cognee.tasks.web_scraper.ssrf_protection import validate_outbound_url
 
 logger = get_logger()
 
@@ -88,7 +89,11 @@ class DefaultUrlCrawler:
     async def _ensure_client(self):
         """Initialize the HTTP client if not already created."""
         if self._client is None:
-            self._client = httpx.AsyncClient(timeout=self.timeout, headers=self.headers)
+            # follow_redirects stays disabled so a public URL cannot redirect the
+            # server to an internal address, bypassing the SSRF host validation.
+            self._client = httpx.AsyncClient(
+                timeout=self.timeout, headers=self.headers, follow_redirects=False
+            )
 
     async def close(self):
         """Close the HTTP client."""
@@ -406,6 +411,11 @@ class DefaultUrlCrawler:
             async with self._sem:
                 try:
                     logger.info(f"Processing URL: {url}")
+
+                    # SSRF guard: validate the target before any outbound request
+                    # (including the robots.txt fetch) so internal/reserved hosts
+                    # are never contacted.
+                    await validate_outbound_url(url)
 
                     # Check robots.txt
                     allowed = await self._is_url_allowed(url)

--- a/cognee/tasks/web_scraper/ssrf_protection.py
+++ b/cognee/tasks/web_scraper/ssrf_protection.py
@@ -1,0 +1,139 @@
+"""Server-Side Request Forgery (SSRF) protection for outbound URL fetching.
+
+Cognee fetches user-supplied ``http(s)`` URLs server-side during ingestion
+(``add()`` -> ``save_data_item_to_storage``) and web scraping. Without
+validation, a caller can point Cognee at internal-only addresses -- loopback,
+private ranges, link-local, or cloud metadata endpoints such as
+``169.254.169.254`` -- and exfiltrate the response through the knowledge graph.
+This is a classic SSRF (CWE-918).
+
+This module centralises the outbound-URL policy so every fetch path shares the
+same guard:
+
+* ``ALLOW_HTTP_REQUESTS`` (default ``true``) gates outbound HTTP(S) fetching.
+  Setting it to ``false`` disables remote URL ingestion entirely. Previously
+  this variable was documented but never enforced.
+* Only the ``http`` and ``https`` schemes are permitted.
+* The hostname is resolved and *every* resolved address is checked. A request
+  is rejected if any address is loopback, private, link-local, reserved,
+  multicast or unspecified. Checking the resolved IPs (rather than the literal
+  string) also blocks IP-literal bypasses (``http://0x7f.1``, ``http://[::1]``)
+  and hostnames that resolve to internal addresses.
+"""
+
+import asyncio
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+from fastapi import status
+
+from cognee.exceptions import CogneeValidationError
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+_FALSEY = frozenset({"false", "0", "no", "off"})
+
+
+class SSRFProtectionError(CogneeValidationError):
+    """Raised when an outbound URL is disallowed or targets an internal address."""
+
+    def __init__(
+        self,
+        message: str = "The requested URL is not allowed.",
+        name: str = "SSRFProtectionError",
+        status_code=status.HTTP_403_FORBIDDEN,
+    ):
+        super().__init__(message, name, status_code)
+
+
+def is_http_requests_allowed() -> bool:
+    """Return whether outbound HTTP(S) fetching is enabled via ``ALLOW_HTTP_REQUESTS``."""
+    return os.getenv("ALLOW_HTTP_REQUESTS", "true").strip().lower() not in _FALSEY
+
+
+def _is_blocked_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Return True if ``ip`` is not a routable, public address."""
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+        # IPv6 site-local (deprecated) and IPv4-mapped IPv6 that decodes to a blocked v4.
+        or getattr(ip, "is_site_local", False)
+    )
+
+
+async def _resolve_host_ips(host: str) -> list:
+    """Resolve ``host`` to all of its IP addresses without blocking the event loop."""
+    loop = asyncio.get_event_loop()
+    infos = await loop.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+
+    ips = []
+    for info in infos:
+        address = info[4][0]
+        # Strip any IPv6 zone/scope id (e.g. "fe80::1%eth0").
+        address = address.split("%", 1)[0]
+        try:
+            ips.append(ipaddress.ip_address(address))
+        except ValueError:
+            continue
+    return ips
+
+
+async def validate_outbound_url(url: str) -> None:
+    """Validate a user-supplied URL before Cognee fetches it server-side.
+
+    Raises:
+        SSRFProtectionError: if outbound HTTP is disabled, the scheme is not
+            ``http``/``https``, the URL has no host, the host cannot be
+            resolved, or the host resolves to an internal / reserved address.
+    """
+    if not is_http_requests_allowed():
+        raise SSRFProtectionError(
+            "Outbound HTTP requests are disabled (ALLOW_HTTP_REQUESTS=false)."
+        )
+
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise SSRFProtectionError(
+            f"URL scheme '{scheme or '(none)'}' is not allowed; only http/https are permitted."
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise SSRFProtectionError("URL does not contain a valid host.")
+
+    # If the host is an IP literal, validate it directly. This covers cases like
+    # http://169.254.169.254 and http://[::1] without a DNS lookup.
+    try:
+        literal_ip = ipaddress.ip_address(host)
+    except ValueError:
+        literal_ip = None
+
+    if literal_ip is not None:
+        if _is_blocked_ip(literal_ip):
+            raise SSRFProtectionError(
+                f"URL host '{host}' points to a non-public address and is blocked."
+            )
+        return
+
+    try:
+        resolved_ips = await _resolve_host_ips(host)
+    except socket.gaierror as error:
+        raise SSRFProtectionError(f"Could not resolve URL host '{host}'.") from error
+
+    if not resolved_ips:
+        raise SSRFProtectionError(f"Could not resolve URL host '{host}'.")
+
+    for ip in resolved_ips:
+        if _is_blocked_ip(ip):
+            raise SSRFProtectionError(
+                f"URL host '{host}' resolves to a non-public address ({ip}) and is blocked."
+            )

--- a/cognee/tests/unit/tasks/web_scraper/test_ssrf_protection.py
+++ b/cognee/tests/unit/tasks/web_scraper/test_ssrf_protection.py
@@ -1,0 +1,131 @@
+"""Unit tests for the SSRF protection guard used by outbound URL fetching."""
+
+import ipaddress
+
+import pytest
+
+from cognee.tasks.web_scraper import ssrf_protection as ssrf
+from cognee.tasks.web_scraper.ssrf_protection import (
+    SSRFProtectionError,
+    is_http_requests_allowed,
+    validate_outbound_url,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/",
+        "http://127.0.0.1:6379/",
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata (IMDS)
+        "http://10.0.0.5/admin",
+        "http://192.168.1.1/",
+        "http://172.16.0.1/",
+        "http://0.0.0.0/",
+        "http://[::1]/",  # IPv6 loopback
+    ],
+)
+async def test_blocks_internal_ip_literals(url, monkeypatch):
+    monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+    with pytest.raises(SSRFProtectionError):
+        await validate_outbound_url(url)
+
+
+@pytest.mark.asyncio
+async def test_allows_public_ip_literal(monkeypatch):
+    monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+    # A public IP literal needs no DNS lookup and must be permitted.
+    await validate_outbound_url("http://8.8.8.8/")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "ftp://example.com/resource",
+        "gopher://example.com/",
+        "//example.com/no-scheme",
+    ],
+)
+async def test_blocks_disallowed_schemes(url, monkeypatch):
+    monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+    with pytest.raises(SSRFProtectionError):
+        await validate_outbound_url(url)
+
+
+@pytest.mark.asyncio
+async def test_blocks_url_without_host(monkeypatch):
+    monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+    with pytest.raises(SSRFProtectionError):
+        await validate_outbound_url("http:///path-only")
+
+
+@pytest.mark.asyncio
+async def test_disabled_outbound_http_blocks_even_public(monkeypatch):
+    monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "false")
+    with pytest.raises(SSRFProtectionError, match="disabled"):
+        await validate_outbound_url("http://8.8.8.8/")
+
+
+@pytest.mark.asyncio
+async def test_hostname_resolving_to_internal_is_blocked(monkeypatch):
+    """A public-looking hostname that resolves to an internal IP must be blocked
+    (defends against DNS rebinding / internal DNS names)."""
+    monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+
+    async def fake_resolve(host):
+        return [ipaddress.ip_address("127.0.0.1")]
+
+    monkeypatch.setattr(ssrf, "_resolve_host_ips", fake_resolve)
+
+    with pytest.raises(SSRFProtectionError, match="non-public"):
+        await validate_outbound_url("http://evil.example.com/")
+
+
+@pytest.mark.asyncio
+async def test_hostname_resolving_to_public_is_allowed(monkeypatch):
+    monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+
+    async def fake_resolve(host):
+        return [ipaddress.ip_address("93.184.216.34")]  # example.com
+
+    monkeypatch.setattr(ssrf, "_resolve_host_ips", fake_resolve)
+
+    await validate_outbound_url("http://example.com/page")
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_host_is_blocked(monkeypatch):
+    monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+
+    async def fake_resolve(host):
+        return []
+
+    monkeypatch.setattr(ssrf, "_resolve_host_ips", fake_resolve)
+
+    with pytest.raises(SSRFProtectionError, match="resolve"):
+        await validate_outbound_url("http://nonexistent.invalid/")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, True),  # unset -> default enabled
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+    ],
+)
+def test_is_http_requests_allowed_parsing(value, expected, monkeypatch):
+    if value is None:
+        monkeypatch.delenv("ALLOW_HTTP_REQUESTS", raising=False)
+    else:
+        monkeypatch.setenv("ALLOW_HTTP_REQUESTS", value)
+    assert is_http_requests_allowed() is expected


### PR DESCRIPTION
## Description

This fixes the SSRF I reported in #3814.

`add()` fetches any http/https URL you give it on the server side, and nothing checks where the URL points. So a caller can make cognee request `http://169.254.169.254/...` (cloud metadata) or an internal service like `http://127.0.0.1:6379/`, and since the fetched body ends up in the graph, it comes back out through search. The `ALLOW_HTTP_REQUESTS` flag that the docs mention as the control for this isn't read anywhere in the code, so it doesn't currently protect anything.

The fetch path is `save_data_item_to_storage()` -> `fetch_page_content()` -> `DefaultUrlCrawler._fetch_httpx()`.

What I changed:

- Added `cognee/tasks/web_scraper/ssrf_protection.py` with a `validate_outbound_url()` helper. It honors `ALLOW_HTTP_REQUESTS` (default true, so public URLs behave as before), only allows http/https, resolves the host, and rejects the request if any resolved IP is loopback/private/link-local/reserved/multicast/unspecified. Resolving first means it catches both IP literals like `169.254.169.254` and hostnames that resolve to internal IPs.
- Called it in `save_data_item_to_storage()` before fetching, so a blocked URL returns a 403 instead of quietly hitting an internal address.
- Called it in `DefaultUrlCrawler` too (before the robots.txt fetch) as a second layer, and set the httpx client to `follow_redirects=False` so a public URL can't redirect the server onto an internal one.

I tried to keep it small - no existing function signatures changed and normal public-URL ingestion still works the same.

Fixes #3814

## Acceptance Criteria

- Internal/reserved targets (127.0.0.1, 169.254.169.254, 10/8, 172.16/12, 192.168/16, 0.0.0.0, ::1) are rejected at ingestion.
- Public URLs still get fetched and ingested as before.
- Non-http(s) schemes and URLs without a host are rejected.
- `ALLOW_HTTP_REQUESTS=false` disables outbound fetching.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

`pytest cognee/tests/unit/tasks/web_scraper/test_ssrf_protection.py` - 27 passed.

Quick check through the real ingestion entry point:

```
BLOCKED http://169.254.169.254/latest/meta-data/ -> SSRFProtectionError
BLOCKED http://127.0.0.1:6379/                    -> SSRFProtectionError
BLOCKED http://10.0.0.1/                          -> SSRFProtectionError
```

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
