### PR TITLE
fix(improve): forward session_ids and run flags in remote (serve) mode

### DIFF
--- a/cognee/api/v1/improve/improve.py
+++ b/cognee/api/v1/improve/improve.py
@@ -132,7 +132,18 @@ async def improve(
 
         client = get_remote_client()
         if client is not None:
-            return await client.improve(dataset, node_name=node_name, **kwargs)
+            if build_truth_subspace:
+                logger.warning(
+                    "build_truth_subspace is not supported by the remote improve API; ignoring."
+                )
+            return await client.improve(
+                dataset,
+                node_name=node_name,
+                session_ids=session_ids,
+                run_in_background=run_in_background,
+                build_global_context_index=build_global_context_index,
+                **kwargs,
+            )
 
         from cognee.modules.users.methods import get_default_user
 

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -221,6 +221,10 @@ class CloudClient:
             payload["run_in_background"] = True
         if kwargs.get("node_name"):
             payload["node_name"] = kwargs["node_name"]
+        if kwargs.get("session_ids"):
+            payload["session_ids"] = list(kwargs["session_ids"])
+        if kwargs.get("build_global_context_index"):
+            payload["build_global_context_index"] = True
 
         async with session.post(
             f"{self.service_url}/api/v1/improve",

--- a/cognee/tests/unit/api/v1/improve/test_improve_remote_forwarding.py
+++ b/cognee/tests/unit/api/v1/improve/test_improve_remote_forwarding.py
@@ -1,0 +1,122 @@
+"""Remote (serve) mode must forward improve()'s session parameters.
+
+Before the fix, ``improve(session_ids=[...])`` against a remote backend
+silently dropped ``session_ids``, ``run_in_background`` and
+``build_global_context_index``: they are keyword-only parameters, so they
+never reached ``client.improve(dataset, node_name=..., **kwargs)``, and the
+CloudClient did not serialize them either. The call returned 200 but only ran
+the default enrichment stage — no session bridging.
+"""
+
+from importlib import import_module
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.api.v1.serve.cloud_client import CloudClient
+
+
+class DummySpan:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def set_attribute(self, key, value):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_improve_remote_dispatch_forwards_session_params(monkeypatch):
+    import cognee.shared.utils as shared_utils
+
+    improve_module = import_module("cognee.api.v1.improve.improve")
+    serve_state = import_module("cognee.api.v1.serve.state")
+
+    remote_client = AsyncMock()
+    remote_client.improve = AsyncMock(return_value={"status": "completed"})
+
+    monkeypatch.setattr(shared_utils, "send_telemetry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(serve_state, "get_remote_client", lambda: remote_client)
+    monkeypatch.setattr(improve_module, "new_span", lambda _: DummySpan())
+
+    result = await improve_module.improve(
+        dataset="docs",
+        session_ids=["chat_1", "chat_2"],
+        run_in_background=True,
+        build_global_context_index=True,
+        node_name=["entity"],
+    )
+
+    assert result == {"status": "completed"}
+    remote_client.improve.assert_awaited_once()
+    args, kwargs = remote_client.improve.await_args
+    assert args == ("docs",)
+    assert kwargs["session_ids"] == ["chat_1", "chat_2"]
+    assert kwargs["run_in_background"] is True
+    assert kwargs["build_global_context_index"] is True
+    assert kwargs["node_name"] == ["entity"]
+
+
+class _FakeResponse:
+    status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return {"status": "completed"}
+
+    async def text(self):
+        return ""
+
+
+class _FakeSession:
+    def __init__(self):
+        self.last_url = None
+        self.last_json = None
+
+    def post(self, url, json=None, **kwargs):
+        self.last_url = url
+        self.last_json = json
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_cloud_client_improve_serializes_session_params():
+    client = CloudClient(service_url="https://tenant.example.com", api_key="key")
+    fake_session = _FakeSession()
+
+    with patch.object(client, "_get_session", new=AsyncMock(return_value=fake_session)):
+        result = await client.improve(
+            "docs",
+            session_ids=["chat_1"],
+            run_in_background=True,
+            build_global_context_index=True,
+            node_name=["entity"],
+        )
+
+    assert result == {"status": "completed"}
+    assert fake_session.last_url == "https://tenant.example.com/api/v1/improve"
+    assert fake_session.last_json == {
+        "dataset_name": "docs",
+        "run_in_background": True,
+        "node_name": ["entity"],
+        "session_ids": ["chat_1"],
+        "build_global_context_index": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cloud_client_improve_omits_unset_session_params():
+    client = CloudClient(service_url="https://tenant.example.com", api_key="key")
+    fake_session = _FakeSession()
+
+    with patch.object(client, "_get_session", new=AsyncMock(return_value=fake_session)):
+        await client.improve("docs")
+
+    assert fake_session.last_json == {"dataset_name": "docs"}


### PR DESCRIPTION
## Problem

In serve mode, `improve()`'s keyword-only parameters never reach the remote call. `session_ids`, `run_in_background`, and `build_global_context_index` are named keyword-only params, so they are not part of `**kwargs` in the remote dispatch:

```python
client = get_remote_client()
if client is not None:
    return await client.improve(dataset, node_name=node_name, **kwargs)  # session_ids dropped here
```

…and `CloudClient.improve()` did not serialize them into the POST payload either.

Consequence: a remote `improve(session_ids=[...])` returns 200 but only runs the default enrichment stage — **no feedback weights, no session Q&A persistence, no lesson distillation, no graph→session sync-back**. A silent no-op of the entire self-improvement pipeline. (Surfaced by a Cloud user building a self-improving agent; the Cloud leg is topoteretes/cloud-backend#204, which exposes `/api/v1/improve` on the pod — this is the client leg that makes the params actually arrive.)

The server-side `ImprovePayloadDTO` already accepts `session_ids` and `build_global_context_index` — this is purely a client-side forwarding gap.

## Changes

- `improve.py`: remote dispatch explicitly forwards `session_ids`, `run_in_background`, `build_global_context_index`. `build_truth_subspace` has no remote DTO field yet, so it logs a warning in remote mode instead of being silently dropped.
- `cloud_client.py`: `CloudClient.improve()` serializes `session_ids` and `build_global_context_index` into the payload (`run_in_background` was already handled).

## Tests

New `tests/unit/api/v1/improve/test_improve_remote_forwarding.py`:
- remote dispatch forwards all session params to the client
- `CloudClient.improve()` serializes them into the JSON payload
- unset params stay omitted from the payload

3/3 new + 8 surrounding improve unit tests green; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)