### PR TITLE
Feature/semantic memory map (Issue #3642)

### DIFF
--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -960,8 +960,16 @@ class LanceDBAdapter(VectorDBInterface):
             coerced.append(new_row)
         return coerced
 
-    async def retrieve(self, collection_name: str, data_point_ids: list[str]):
-        """Return rows from `collection_name` whose id is in `data_point_ids`."""
+    async def retrieve(
+        self, collection_name: str, data_point_ids: list[str], *, include_vector: bool = False
+    ):
+        """Return rows from `collection_name` whose id is in `data_point_ids`.
+
+        When ``include_vector`` is True the stored embedding is attached to each
+        result under ``payload["vector"]`` (``ScoredResult`` itself has no vector
+        field). This powers the semantic memory map, which needs the raw vectors
+        the plain retrieve path drops.
+        """
         if not data_point_ids:
             # No ids requested. Avoid building an "id IN ()" filter, which lance
             # rejects as a parse error; pgvector/chromadb return [] here too.
@@ -980,14 +988,21 @@ class LanceDBAdapter(VectorDBInterface):
         # Convert query results to list format
         results_list = await query.to_list()
 
-        return [
-            ScoredResult(
-                id=parse_id(result["id"]),
-                payload=result["payload"],
-                score=0,
+        results = []
+        for result in results_list:
+            payload = result["payload"]
+            if include_vector:
+                # Copy so the vector rides alongside the payload without mutating
+                # the stored row's schema; the default path stays byte-for-byte.
+                payload = {**payload, "vector": result["vector"]}
+            results.append(
+                ScoredResult(
+                    id=parse_id(result["id"]),
+                    payload=payload,
+                    score=0,
+                )
             )
-            for result in results_list
-        ]
+        return results
 
     async def search(
         self,

--- a/cognee/infrastructure/databases/vector/vector_db_interface.py
+++ b/cognee/infrastructure/databases/vector/vector_db_interface.py
@@ -79,7 +79,9 @@ class VectorDBInterface(Protocol):
         raise NotImplementedError("upsert_raw_vectors is not implemented for this adapter")
 
     @abstractmethod
-    async def retrieve(self, collection_name: str, data_point_ids: list[str]):
+    async def retrieve(
+        self, collection_name: str, data_point_ids: list[str], *, include_vector: bool = False
+    ):
         """
         Retrieve data points from a collection using their IDs.
 
@@ -89,6 +91,10 @@ class VectorDBInterface(Protocol):
             - collection_name (str): The name of the collection from which to retrieve data
               points.
             - data_point_ids (Union[List[str], list[str]]): A list of IDs of the data points to retrieve.
+            - include_vector (bool): When True, the stored embedding is attached to each result
+              under ``payload["vector"]``. Only adapters that can return raw vectors implement
+              this (LanceDB); others ignore the flag. Callers that need vectors from an adapter
+              without support should re-embed the indexed field instead.
         """
         raise NotImplementedError
 

--- a/cognee/modules/visualization/SEMANTIC_MAP.md
+++ b/cognee/modules/visualization/SEMANTIC_MAP.md
@@ -69,5 +69,5 @@ A runnable end-to-end example lives at
   reflect real structure rather than layout artifacts.
 - **Determinism**: PCA sign convention, seeded k-means/sampling, and pinned
   positions make the layout reproducible — unit tests assert exact equality.
-- **Zero new dependencies**: numpy (already core) does PCA and k-means; UMAP and
-  HDBSCAN are optional lazy imports.
+- **Zero new dependencies**: numpy (already core) does PCA and k-means; UMAP is
+  an optional lazy import (ImportError falls back to PCA).

--- a/cognee/modules/visualization/SEMANTIC_MAP.md
+++ b/cognee/modules/visualization/SEMANTIC_MAP.md
@@ -1,0 +1,73 @@
+# Semantic Memory Map
+
+A **Semantic** tab in the graph visualization that lays the graph out by
+*meaning* instead of topology. Each node is placed at the 2-D projection of its
+embedding, so semantically similar nodes sit together and the graph's latent
+structure — clusters of related entities — becomes visible at a glance.
+
+It reuses vectors cognee already stores during `cognify`; nothing is
+re-computed at query time and no embeddings are shipped to the browser beyond
+2-D positions and precomputed neighbor lists.
+
+## How it works
+
+The production render path (`cognee_network_visualization`) builds the tab in
+four steps:
+
+1. **`embedding_join.fetch_node_embeddings`** — joins graph nodes to their
+   stored vectors. A graph node id is stored verbatim as its vector-row id
+   (both sides use `str(data_point.id)`), so nodes join to the `{Type}_{field}`
+   collections (`Entity_name`, `DocumentChunk_text`, …) directly. It issues one
+   batched `retrieve(..., include_vector=True)` per collection. On adapters
+   without `include_vector` support (everything except LanceDB), it falls back
+   to re-embedding the indexed field — the stored vector is `embed(field)`, so
+   the result matches. Capped at 2000 nodes via a deterministic seeded sample.
+
+2. **`layouts/semantic_layout.compute_positions`** — projects the embeddings to
+   2-D with PCA (numpy SVD, sign-stabilized so the layout is deterministic).
+   Positions are normalized, pinned, and rendered layout-once — no force
+   simulation. Nodes without a vector are placed at their neighbor centroid, or
+   on a ring if disconnected. UMAP is an optional lazy path (falls back to PCA).
+
+3. **`semantic_clusters.compute_clusters`** — clusters the *full-dimensional*
+   embeddings with pure-numpy k-means (no scikit-learn) and precomputes each
+   node's top-5 cosine neighbors for the hover panel. Clusters are labeled by
+   their highest-degree members.
+
+4. **Token substitution** — the orchestrator substitutes `__SEMANTIC_*__`
+   tokens with the JS chunks and JSON payloads. The whole fetch is best-effort:
+   with no embeddings (or any failure) the tokens are `null` and the tab shows
+   a friendly empty state, so the classic render never breaks.
+
+## Using it
+
+The tab appears automatically in any `visualize_graph()` output:
+
+```python
+import cognee
+from cognee.api.v1.visualize.visualize import visualize_graph
+
+await cognee.add("...your text...")
+await cognee.cognify()
+await visualize_graph(destination_file_path="graph.html")
+```
+
+Open the HTML and click **Semantic** (or append `#semantic` to deep-link).
+In the tab:
+
+- **Cluster / Type** toggle recolors nodes by semantic cluster or ontology type.
+- **Hover** a node to light up its nearest neighbors and list its relations.
+- **Legend** entries filter to a single cluster; **zoom** with the scroll wheel
+  or the on-screen controls.
+
+A runnable end-to-end example lives at
+`examples/python/semantic_memory_map.py`.
+
+## Design notes
+
+- **Clustering runs on full-D embeddings**, not the 2-D projection, so groups
+  reflect real structure rather than layout artifacts.
+- **Determinism**: PCA sign convention, seeded k-means/sampling, and pinned
+  positions make the layout reproducible — unit tests assert exact equality.
+- **Zero new dependencies**: numpy (already core) does PCA and k-means; UMAP and
+  HDBSCAN are optional lazy imports.

--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -29,12 +29,34 @@ from cognee.modules.visualization.views import (
     inspector,
     memory_map,
     schema_view,
+    semantic_map,
     story_view,
     ui_chrome,
 )
-from cognee.modules.visualization.layouts import pipeline_layout
+from cognee.modules.visualization.layouts import pipeline_layout, semantic_layout
+from cognee.modules.visualization.embedding_join import fetch_node_embeddings
+from cognee.modules.visualization.semantic_clusters import compute_clusters
 
 logger = get_logger()
+
+
+async def _semantic_payload(pre):
+    """Best-effort semantic positions + clusters. Never blocks the classic render.
+
+    Returns ``(positions, clusters)`` or ``(None, None)`` when embeddings can't be
+    fetched — in which case the semantic tab shows a friendly empty state.
+    """
+    try:
+        embeddings = await fetch_node_embeddings(pre.nodes)
+    except Exception as exc:
+        logger.warning("Semantic map: embedding fetch failed (%s); tab shows empty state.", exc)
+        return None, None
+    if not embeddings:
+        return None, None
+    positions = semantic_layout.compute_positions(pre.nodes, pre.links, embeddings)
+    clusters = compute_clusters(pre.nodes, embeddings)
+    return positions, clusters
+
 
 _TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "template.html")
 
@@ -92,6 +114,9 @@ async def cognee_network_visualization(
     """
     pre = preprocess(graph_data, schema_data=schema_data)
 
+    # Best-effort semantic layout; guarded so it never blocks the classic render.
+    semantic_positions, semantic_clusters = await _semantic_payload(pre)
+
     html = _read_template()
 
     # 1) JS chunks: ordered so the first script block (ui_chrome + schema)
@@ -102,6 +127,8 @@ async def cognee_network_visualization(
     html = html.replace("__PIPELINE_LAYOUT_JS__", pipeline_layout.emit_js(pre))
     html = html.replace("__INSPECTOR_JS__", inspector.emit_js(pre))
     html = html.replace("__MEMORY_VIEW_JS__", memory_map.emit_js(pre))
+    html = html.replace("__SEMANTIC_LAYOUT_JS__", semantic_layout.emit_js(pre))
+    html = html.replace("__SEMANTIC_VIEW_JS__", semantic_map.emit_js(pre))
 
     # 2) Data tokens: substituted last so JSON-embedded ``__SCHEMA_GRAPH_DATA__``
     #    inside the schema JS chunk gets resolved correctly.
@@ -123,6 +150,16 @@ async def cognee_network_visualization(
     # __SEARCH_EVENTS__ token would fail the no-placeholder assembly test.
     html = html.replace("__MEMORY_DATA__", _safe_json_embed(pre.memory_map or {}))
     html = html.replace("__SEARCH_EVENTS__", _safe_json_embed(search_events or []))
+    # Semantic tokens: null when there are no embeddings, so the tab renders a
+    # friendly empty state without leaving a placeholder behind.
+    html = html.replace(
+        "__SEMANTIC_POSITIONS__",
+        _safe_json_embed(semantic_positions) if semantic_positions else "null",
+    )
+    html = html.replace(
+        "__SEMANTIC_CLUSTERS__",
+        _safe_json_embed(semantic_clusters) if semantic_clusters else "null",
+    )
 
     if not destination_file_path:
         destination_file_path = os.path.join(os.path.expanduser("~"), "graph_visualization.html")

--- a/cognee/modules/visualization/embedding_join.py
+++ b/cognee/modules/visualization/embedding_join.py
@@ -133,22 +133,49 @@ async def fetch_node_embeddings(
         by_type[node.get("type")].append(node)
 
     embeddings: Dict[str, List[float]] = {}
+    hit_collections = 0
+    missing_collections: List[str] = []
+    unmapped_types: List[str] = []
     for type_name, type_nodes in by_type.items():
         field = fields.get(type_name)
         if not field:
+            if type_name is not None:
+                unmapped_types.append(type_name)
             continue
         collection = f"{type_name}_{field}"
         try:
             if not await vector_engine.has_collection(collection):
+                missing_collections.append(collection)
                 continue
             found = await _fetch_for_collection(vector_engine, collection, type_nodes, field)
         except Exception as exc:  # never let a vector-store failure break the render
             logger.warning("fetch_node_embeddings: fetch failed for %s: %s", collection, exc)
             continue
+        if found:
+            hit_collections += 1
         for nid, vector in found.items():
             if nid not in embeddings:
                 embeddings[nid] = vector  # first hit wins across collections
             else:
                 logger.debug("node %s matched multiple collections; keeping first", nid)
+
+    # Join hit-rate: turn a silent empty map into a diagnosable one. A zero
+    # resolution over non-empty input almost always means an id/collection-name
+    # mismatch — surface which collections were missing and which types were
+    # unmapped instead of rendering blank with no signal.
+    total = len(selected)
+    logger.info(
+        "fetch_node_embeddings: resolved %d/%d node embeddings across %d collection(s)",
+        len(embeddings),
+        total,
+        hit_collections,
+    )
+    if total and not embeddings:
+        logger.warning(
+            "fetch_node_embeddings: no embeddings resolved — the semantic map will be empty. "
+            "Missing collections: %s. Unmapped node types: %s.",
+            missing_collections or "none",
+            unmapped_types or "none",
+        )
 
     return embeddings

--- a/cognee/modules/visualization/embedding_join.py
+++ b/cognee/modules/visualization/embedding_join.py
@@ -1,0 +1,156 @@
+"""Join graph nodes to their stored embeddings — the plumbing behind the semantic map.
+
+``visualize_graph()`` forwards only nodes/links; no embeddings ride along. This
+module fetches the embedding for each node by looking it up in the vector store,
+reusing the fact that a graph node id is stored verbatim as the vector-row id
+(both sides use ``str(data_point.id)``).
+
+Strategy per node type:
+  * Group node ids by type and derive the collection ``f"{Type}_{field}"`` from
+    the type's indexed field.
+  * One batched ``retrieve(..., include_vector=True)`` per collection — never per
+    node. On adapters that don't support ``include_vector`` (everything except
+    LanceDB), fall back to re-embedding the indexed field in one batch (the stored
+    vector is ``embed(indexed_field)``, so the re-embedded vector matches).
+
+Any vector-engine failure is logged and yields a partial/empty dict — the classic
+render must never break because the semantic tab couldn't fetch vectors.
+"""
+
+import random
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("embedding_join")
+
+# type_name -> indexed field. The vector collection is ``f"{type_name}_{field}"``.
+# Mirrors each DataPoint subclass's ``metadata["index_fields"]``; this fallback
+# covers the node types the graph visualization actually surfaces.
+DEFAULT_INDEX_FIELDS: Dict[str, str] = {
+    "Entity": "name",
+    "EntityType": "name",
+    "TextSummary": "text",
+    "DocumentChunk": "text",
+    "TextDocument": "name",
+}
+
+# Seed for the deterministic over-cap sample. Fixed so a given graph always
+# samples the same nodes across runs (snapshot tests depend on this).
+SAMPLE_SEED = 42
+
+
+def _select_nodes(nodes: List[Dict[str, Any]], cap: int) -> List[Dict[str, Any]]:
+    """Sort nodes by id and, if over ``cap``, take a deterministic seeded sample."""
+    ordered = sorted(nodes, key=lambda n: str(n["id"]))
+    if len(ordered) <= cap:
+        return ordered
+    rng = random.Random(SAMPLE_SEED)
+    picked = sorted(rng.sample(range(len(ordered)), cap))
+    logger.warning(
+        "fetch_node_embeddings: %d nodes exceeds cap %d; sampling %d deterministically",
+        len(ordered),
+        cap,
+        cap,
+    )
+    return [ordered[i] for i in picked]
+
+
+async def _reembed(
+    vector_engine, type_nodes: List[Dict[str, Any]], field: str
+) -> Dict[str, List[float]]:
+    """Fallback: re-embed each node's indexed field in one batch."""
+    texts: List[str] = []
+    ids: List[str] = []
+    for node in type_nodes:
+        value = node.get(field)
+        if value is None:
+            value = node.get("name")
+        if value is None:
+            continue
+        texts.append(str(value))
+        ids.append(str(node["id"]))
+    if not texts:
+        return {}
+    vectors = await vector_engine.embedding_engine.embed_text(texts)
+    return {nid: list(vec) for nid, vec in zip(ids, vectors)}
+
+
+async def _fetch_for_collection(
+    vector_engine, collection: str, type_nodes: List[Dict[str, Any]], field: str
+) -> Dict[str, List[float]]:
+    """One batched retrieve for a collection, with re-embed fallback."""
+    ids = [str(node["id"]) for node in type_nodes]
+    try:
+        results = await vector_engine.retrieve(collection, ids, include_vector=True)
+    except TypeError:
+        # Adapter's retrieve() doesn't accept include_vector -> unsupported.
+        return await _reembed(vector_engine, type_nodes, field)
+
+    found: Dict[str, List[float]] = {}
+    for result in results:
+        payload = result.payload if isinstance(result.payload, dict) else None
+        vector = payload.get("vector") if payload else None
+        if vector is not None:
+            found[str(result.id)] = list(vector)
+
+    if not found and results:
+        # Adapter accepted the flag but returned no vectors -> re-embed.
+        return await _reembed(vector_engine, type_nodes, field)
+    return found
+
+
+async def fetch_node_embeddings(
+    nodes: List[Dict[str, Any]],
+    cap: int = 2000,
+    vector_engine=None,
+    index_fields: Optional[Dict[str, str]] = None,
+) -> Dict[str, List[float]]:
+    """Return ``{node_id: vector}`` for as many nodes as the vector store can supply.
+
+    Args:
+        nodes: renderer-facing node dicts (each carries ``id`` and ``type``).
+        cap: max nodes to fetch; over-cap graphs are sampled deterministically.
+        vector_engine: injected engine (defaults to ``get_vector_engine()``). This
+            is the single mocking seam for tests.
+        index_fields: type -> indexed-field override (defaults to
+            ``DEFAULT_INDEX_FIELDS``).
+
+    Missing vectors are simply absent from the dict; the layout handles them.
+    """
+    fields = index_fields or DEFAULT_INDEX_FIELDS
+
+    if vector_engine is None:
+        from cognee.infrastructure.databases.vector import get_vector_engine
+
+        vector_engine = get_vector_engine()
+
+    selected = _select_nodes(nodes, cap)
+
+    by_type: Dict[Optional[str], List[Dict[str, Any]]] = defaultdict(list)
+    for node in selected:
+        by_type[node.get("type")].append(node)
+
+    embeddings: Dict[str, List[float]] = {}
+    for type_name, type_nodes in by_type.items():
+        field = fields.get(type_name)
+        if not field:
+            continue
+        collection = f"{type_name}_{field}"
+        try:
+            if not await vector_engine.has_collection(collection):
+                continue
+            found = await _fetch_for_collection(vector_engine, collection, type_nodes, field)
+        except Exception as exc:  # never let a vector-store failure break the render
+            logger.warning(
+                "fetch_node_embeddings: fetch failed for %s: %s", collection, exc
+            )
+            continue
+        for nid, vector in found.items():
+            if nid not in embeddings:
+                embeddings[nid] = vector  # first hit wins across collections
+            else:
+                logger.debug("node %s matched multiple collections; keeping first", nid)
+
+    return embeddings

--- a/cognee/modules/visualization/embedding_join.py
+++ b/cognee/modules/visualization/embedding_join.py
@@ -143,9 +143,7 @@ async def fetch_node_embeddings(
                 continue
             found = await _fetch_for_collection(vector_engine, collection, type_nodes, field)
         except Exception as exc:  # never let a vector-store failure break the render
-            logger.warning(
-                "fetch_node_embeddings: fetch failed for %s: %s", collection, exc
-            )
+            logger.warning("fetch_node_embeddings: fetch failed for %s: %s", collection, exc)
             continue
         for nid, vector in found.items():
             if nid not in embeddings:

--- a/cognee/modules/visualization/layouts/semantic_layout.py
+++ b/cognee/modules/visualization/layouts/semantic_layout.py
@@ -136,7 +136,6 @@ def _deoverlap(
     pts = np.array([positioned[nid] for nid in ordered_ids], dtype=float)
     # Seeded tie-breaking nudge so exactly-coincident points separate deterministically.
     pts = pts + rng.uniform(-min_dist / 4, min_dist / 4, size=pts.shape)
-    n = len(pts)
     for _ in range(iterations):
         diff = pts[:, None, :] - pts[None, :, :]  # (n, n, 2)
         dist = np.sqrt((diff**2).sum(axis=2))  # (n, n)

--- a/cognee/modules/visualization/layouts/semantic_layout.py
+++ b/cognee/modules/visualization/layouts/semantic_layout.py
@@ -1,0 +1,206 @@
+"""Semantic layout: project node embeddings to 2-D pinned positions.
+
+Given ``{node_id: vector}`` from ``embedding_join.fetch_node_embeddings`` and the
+graph's links, this computes one 2-D coordinate per node so semantically similar
+nodes land near each other. Positions are a deterministic pure function of the
+inputs — no force simulation, no un-seeded randomness — so they can be pinned and
+rendered layout-once (the repo's rule, see ``memory_map.js`` header).
+
+Pipeline:
+  * PCA via numpy SVD (default), with a deterministic sign convention so snapshot
+    tests are stable — raw SVD sign is arbitrary. Optional UMAP via lazy import;
+    ImportError falls back to PCA.
+  * Normalize to [-1, 1] per axis, scaled by ``spread``.
+  * Nodes without a vector are placed at the seeded-jittered centroid of their
+    positioned neighbors; nodes with no positioned neighbor land on a
+    deterministic ring.
+  * A deterministic seeded de-overlap pass spreads coincident points so dense
+    clusters stay legible.
+"""
+
+import math
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("semantic_layout")
+
+# Half-width of the normalized coordinate box; the renderer scales this to canvas.
+SPREAD = 1.0
+# Minimum separation (in normalized units) enforced by the de-overlap pass.
+MIN_SEPARATION = 0.02
+LAYOUT_SEED = 42
+
+
+def _pca_2d(matrix: np.ndarray) -> np.ndarray:
+    """Project rows of ``matrix`` onto their first two principal components.
+
+    Sign convention: for each component, the feature loading with the largest
+    magnitude is forced positive. Raw SVD sign is arbitrary, so without this the
+    same input could flip across runs and break snapshot equality.
+    """
+    centered = matrix - matrix.mean(axis=0, keepdims=True)
+    # full_matrices=False keeps Vt at (min(n, d), d); deterministic given input.
+    _, _, vt = np.linalg.svd(centered, full_matrices=False)
+    components = vt[:2]
+    if components.shape[0] < 2:
+        # Degenerate (single component): pad the second axis with zeros.
+        pad = np.zeros((2 - components.shape[0], components.shape[1]))
+        components = np.vstack([components, pad])
+    for i in range(2):
+        loading = components[i]
+        j = int(np.argmax(np.abs(loading)))
+        if loading[j] < 0:
+            components[i] = -loading
+    return centered @ components.T
+
+
+def _umap_2d(matrix: np.ndarray, seed: int) -> Optional[np.ndarray]:
+    """Optional UMAP projection. Returns None if UMAP isn't installed."""
+    try:
+        import umap  # lazy: umap-learn is not a cognee dependency
+    except ImportError:
+        logger.info("UMAP not installed; falling back to PCA for semantic layout.")
+        return None
+    reducer = umap.UMAP(n_components=2, random_state=seed, n_jobs=1)
+    return reducer.fit_transform(matrix)
+
+
+def _normalize(coords: np.ndarray, spread: float) -> np.ndarray:
+    """Min-max normalize each axis into [-spread, spread]."""
+    out = np.zeros_like(coords, dtype=float)
+    for axis in range(coords.shape[1]):
+        col = coords[:, axis]
+        lo, hi = float(col.min()), float(col.max())
+        if hi > lo:
+            out[:, axis] = (2.0 * (col - lo) / (hi - lo) - 1.0) * spread
+        # else: constant axis -> leave at 0
+    return out
+
+
+def _place_missing(
+    node_ids: List[str],
+    embedded_pos: Dict[str, np.ndarray],
+    adjacency: Dict[str, set],
+    spread: float,
+    rng: np.random.Generator,
+) -> Dict[str, np.ndarray]:
+    """Position nodes without a vector.
+
+    Neighbor-centroid with seeded jitter, iterated so chains of vector-less nodes
+    resolve; nodes with no positioned neighbor land on a deterministic ring.
+    """
+    positioned = dict(embedded_pos)
+    missing = [nid for nid in node_ids if nid not in positioned]
+
+    changed = True
+    while changed and missing:
+        changed = False
+        still_missing = []
+        for nid in missing:  # node_ids is pre-sorted -> deterministic order
+            neighbor_pts = [positioned[n] for n in adjacency.get(nid, ()) if n in positioned]
+            if neighbor_pts:
+                centroid = np.mean(neighbor_pts, axis=0)
+                jitter = rng.uniform(-0.03, 0.03, size=2) * spread
+                positioned[nid] = centroid + jitter
+                changed = True
+            else:
+                still_missing.append(nid)
+        missing = still_missing
+
+    # Whatever remains is disconnected from every positioned node: ring it.
+    for k, nid in enumerate(missing):
+        angle = 2.0 * math.pi * k / max(1, len(missing))
+        positioned[nid] = np.array(
+            [1.15 * spread * math.cos(angle), 1.15 * spread * math.sin(angle)]
+        )
+    return positioned
+
+
+def _deoverlap(
+    ordered_ids: List[str],
+    positioned: Dict[str, np.ndarray],
+    min_dist: float,
+    rng: np.random.Generator,
+    iterations: int = 40,
+) -> Dict[str, np.ndarray]:
+    """Deterministic seeded relaxation: push apart points closer than ``min_dist``.
+
+    ponytail: O(n²) per iteration; fine at the 2000-node fetch cap. Swap in a
+    spatial grid if the cap ever grows.
+    """
+    if len(ordered_ids) < 2:
+        return positioned
+    pts = np.array([positioned[nid] for nid in ordered_ids], dtype=float)
+    # Seeded tie-breaking nudge so exactly-coincident points separate deterministically.
+    pts = pts + rng.uniform(-min_dist / 4, min_dist / 4, size=pts.shape)
+    n = len(pts)
+    for _ in range(iterations):
+        diff = pts[:, None, :] - pts[None, :, :]  # (n, n, 2)
+        dist = np.sqrt((diff**2).sum(axis=2))  # (n, n)
+        np.fill_diagonal(dist, np.inf)
+        too_close = dist < min_dist
+        if not too_close.any():
+            break
+        safe = np.where(dist == 0, 1.0, dist)
+        push = (min_dist - dist) / safe
+        push = np.where(too_close, push, 0.0)
+        shift = (diff * push[:, :, None]).sum(axis=1) * 0.5
+        pts = pts + shift
+    return {nid: pts[i] for i, nid in enumerate(ordered_ids)}
+
+
+def compute_positions(
+    nodes: List[Dict[str, Any]],
+    links: List[Dict[str, Any]],
+    embeddings: Dict[str, List[float]],
+    *,
+    method: str = "pca",
+    seed: int = LAYOUT_SEED,
+    spread: float = SPREAD,
+) -> Dict[str, Dict[str, float]]:
+    """Return ``{node_id: {"x": float, "y": float}}`` for every node.
+
+    Deterministic given identical inputs. ``method`` is ``"pca"`` (default) or
+    ``"umap"`` (falls back to PCA when umap-learn is absent).
+    """
+    node_ids = sorted(str(n["id"]) for n in nodes)
+    rng = np.random.default_rng(seed)
+
+    adjacency: Dict[str, set] = {nid: set() for nid in node_ids}
+    for link in links:
+        s, t = str(link["source"]), str(link["target"])
+        if s in adjacency and t in adjacency:
+            adjacency[s].add(t)
+            adjacency[t].add(s)
+
+    # Embedded nodes with a consistent dimension.
+    embedded_ids = [nid for nid in node_ids if nid in embeddings]
+    embedded_pos: Dict[str, np.ndarray] = {}
+    if len(embedded_ids) >= 2:
+        matrix = np.array([embeddings[nid] for nid in embedded_ids], dtype=float)
+        coords = None
+        if method == "umap":
+            coords = _umap_2d(matrix, seed)
+        if coords is None:
+            coords = _pca_2d(matrix)
+        coords = _normalize(np.asarray(coords, dtype=float), spread)
+        embedded_pos = {nid: coords[i] for i, nid in enumerate(embedded_ids)}
+    elif len(embedded_ids) == 1:
+        embedded_pos = {embedded_ids[0]: np.zeros(2)}
+
+    positioned = _place_missing(node_ids, embedded_pos, adjacency, spread, rng)
+    positioned = _deoverlap(node_ids, positioned, MIN_SEPARATION * spread, rng)
+
+    return {nid: {"x": float(p[0]), "y": float(p[1])} for nid, p in positioned.items()}
+
+
+def emit_js(_preprocessed=None) -> str:
+    """Expose the pinned semantic positions to the renderer via a data token.
+
+    The orchestrator substitutes ``__SEMANTIC_POSITIONS__`` with the JSON produced
+    by ``compute_positions``; the semantic view reads ``window._semanticPositions``.
+    """
+    return "window._semanticPositions = __SEMANTIC_POSITIONS__;"

--- a/cognee/modules/visualization/semantic_clusters.py
+++ b/cognee/modules/visualization/semantic_clusters.py
@@ -8,7 +8,6 @@ per cluster.
 
 k-means is pure numpy (seeded k-means++ init, fixed iteration order) so results
 are identical across runs — no scikit-learn, which lives only in the evals extra.
-HDBSCAN is an optional lazy path for density clustering.
 """
 
 import math

--- a/cognee/modules/visualization/semantic_clusters.py
+++ b/cognee/modules/visualization/semantic_clusters.py
@@ -1,0 +1,143 @@
+"""Cluster node embeddings and precompute nearest neighbors for the semantic map.
+
+Clustering runs on the *full-dimensional* embeddings (not the 2-D projection),
+so groupings reflect real semantic structure rather than a lossy layout. Output
+feeds the ``__SEMANTIC_CLUSTERS__`` data token: per-node cluster id + top-5 cosine
+neighbors (powering the hover panel without shipping raw vectors), plus a label
+per cluster.
+
+k-means is pure numpy (seeded k-means++ init, fixed iteration order) so results
+are identical across runs — no scikit-learn, which lives only in the evals extra.
+HDBSCAN is an optional lazy path for density clustering.
+"""
+
+import math
+from typing import Any, Callable, Dict, List, Optional
+
+import numpy as np
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("semantic_clusters")
+
+CLUSTER_SEED = 42
+TOP_NEIGHBORS = 5
+_EPS = 1e-12
+
+
+def default_k(n: int) -> int:
+    """k = min(12, max(2, round(sqrt(n/2)))), clamped to a sane range."""
+    if n < 2:
+        return 1
+    return min(12, max(2, round(math.sqrt(n / 2))))
+
+
+def _kmeans_pp_init(x: np.ndarray, k: int, rng: np.random.Generator) -> np.ndarray:
+    """Seeded k-means++ center selection."""
+    n = len(x)
+    first = int(rng.integers(n))
+    chosen = [first]
+    d2 = ((x - x[first]) ** 2).sum(axis=1)
+    for _ in range(1, k):
+        total = d2.sum()
+        probs = d2 / total if total > 0 else np.full(n, 1.0 / n)
+        idx = int(rng.choice(n, p=probs))
+        chosen.append(idx)
+        d2 = np.minimum(d2, ((x - x[idx]) ** 2).sum(axis=1))
+    return x[chosen].copy()
+
+
+def kmeans(x: np.ndarray, k: int, seed: int = CLUSTER_SEED, max_iter: int = 50) -> np.ndarray:
+    """Pure-numpy Lloyd's k-means. Deterministic given (x, k, seed).
+
+    Ties in assignment go to the lowest cluster index (argmin); empty clusters
+    keep their center rather than being re-seeded, so iteration order is fixed.
+    """
+    n = len(x)
+    k = max(1, min(k, n))
+    rng = np.random.default_rng(seed)
+    centers = _kmeans_pp_init(x, k, rng)
+    labels = np.full(n, -1, dtype=int)
+    for _ in range(max_iter):
+        dists = ((x[:, None, :] - centers[None, :, :]) ** 2).sum(axis=2)
+        new_labels = dists.argmin(axis=1)
+        if np.array_equal(new_labels, labels):
+            break
+        labels = new_labels
+        for c in range(k):
+            mask = labels == c
+            if mask.any():
+                centers[c] = x[mask].mean(axis=0)
+    return labels
+
+
+def _nearest_neighbors(ids: List[str], x: np.ndarray, top: int) -> Dict[str, List[str]]:
+    """Top-``top`` cosine neighbors per node (self excluded, stable tie order)."""
+    norms = np.linalg.norm(x, axis=1, keepdims=True)
+    unit = x / (norms + _EPS)
+    sim = unit @ unit.T
+    np.fill_diagonal(sim, -np.inf)
+    out: Dict[str, List[str]] = {}
+    for i, nid in enumerate(ids):
+        order = np.argsort(-sim[i], kind="stable")[:top]
+        out[nid] = [ids[j] for j in order]
+    return out
+
+
+def _cluster_label(member_nodes: List[Dict[str, Any]]) -> str:
+    """Label a cluster by its top-3 nodes by (degree, importance)."""
+    ranked = sorted(
+        member_nodes,
+        key=lambda nd: (nd.get("degree", 0), nd.get("importance", 0.0)),
+        reverse=True,
+    )
+    names = [nd.get("name") for nd in ranked[:3] if nd.get("name")]
+    return ", ".join(names) if names else "cluster"
+
+
+def compute_clusters(
+    nodes: List[Dict[str, Any]],
+    embeddings: Dict[str, List[float]],
+    *,
+    k: Optional[int] = None,
+    seed: int = CLUSTER_SEED,
+    summarize: Optional[Callable[[str, List[str]], str]] = None,
+) -> Dict[str, Any]:
+    """Cluster embedded nodes and precompute neighbors.
+
+    Returns ``{"clusters": [...], "node_cluster": {id: cluster_id},
+    "neighbors": {id: [neighbor_id, ...]}}``. Nodes without a vector are absent
+    from all three (the view leaves them uncolored).
+
+    ``summarize`` is an optional seam for a one-line LLM cluster summary; when
+    None (default and in CI) the deterministic top-entity label is used. Tests
+    inject a plain mock here — this does not depend on the #3601 LLM harness.
+    """
+    node_by_id = {str(n["id"]): n for n in nodes}
+    ids = sorted(nid for nid in node_by_id if nid in embeddings)
+    if not ids:
+        return {"clusters": [], "node_cluster": {}, "neighbors": {}}
+
+    x = np.array([embeddings[nid] for nid in ids], dtype=float)
+    k_effective = default_k(len(ids)) if k is None else k
+    k_effective = max(1, min(k_effective, len(ids)))
+
+    labels = kmeans(x, k_effective, seed)
+    neighbors = _nearest_neighbors(ids, x, TOP_NEIGHBORS)
+
+    clusters: List[Dict[str, Any]] = []
+    node_cluster: Dict[str, int] = {}
+    for c in range(k_effective):
+        members = [ids[i] for i in range(len(ids)) if labels[i] == c]
+        if not members:
+            continue
+        member_nodes = [node_by_id[m] for m in members]
+        label = _cluster_label(member_nodes)
+        if summarize is not None:
+            top_names = [nd.get("name") for nd in member_nodes[:3] if nd.get("name")]
+            label = summarize(label, top_names)
+        for m in members:
+            node_cluster[m] = c
+        clusters.append({"id": c, "label": label, "node_ids": members, "size": len(members)})
+
+    return {"clusters": clusters, "node_cluster": node_cluster, "neighbors": neighbors}

--- a/cognee/modules/visualization/semantic_clusters.py
+++ b/cognee/modules/visualization/semantic_clusters.py
@@ -12,6 +12,7 @@ HDBSCAN is an optional lazy path for density clustering.
 """
 
 import math
+from collections import Counter
 from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
@@ -103,8 +104,8 @@ def _cluster_label(member_nodes: List[Dict[str, Any]]) -> str:
 
     Entities win over DocumentChunk/TextSummary/EntityType so labels read as
     concepts, not chunk text or type names. Identifier-shaped or over-long names
-    are skipped; a cluster with no usable entity names falls back to any usable
-    name, then to ``"cluster"``.
+    are skipped; a cluster with no usable name falls back to its dominant node
+    type (e.g. ``"TextSummary"``), then to ``"cluster"``.
     """
     ranked = sorted(
         member_nodes,
@@ -112,7 +113,11 @@ def _cluster_label(member_nodes: List[Dict[str, Any]]) -> str:
         reverse=True,
     )
     names = [n for nd in ranked if (n := _usable_name(nd))]
-    return ", ".join(names[:3]) if names else "cluster"
+    if names:
+        return ", ".join(names[:3])
+    # No usable names (e.g. a cluster of chunks/summaries): name it by dominant type.
+    types = [nd.get("type") for nd in member_nodes if nd.get("type")]
+    return Counter(types).most_common(1)[0][0] if types else "cluster"
 
 
 def compute_clusters(

--- a/cognee/modules/visualization/semantic_clusters.py
+++ b/cognee/modules/visualization/semantic_clusters.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 
+from cognee.modules.visualization.preprocessor import looks_like_identifier
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("semantic_clusters")
@@ -23,6 +24,8 @@ logger = get_logger("semantic_clusters")
 CLUSTER_SEED = 42
 TOP_NEIGHBORS = 5
 _EPS = 1e-12
+# Names longer than this read as chunk/summary text, not entity labels.
+_MAX_LABEL_NAME = 40
 
 
 def default_k(n: int) -> int:
@@ -84,15 +87,32 @@ def _nearest_neighbors(ids: List[str], x: np.ndarray, top: int) -> Dict[str, Lis
     return out
 
 
+def _usable_name(nd: Dict[str, Any]) -> Optional[str]:
+    """A node's name if it reads as a clean label — not a UUID/hash or a text blob."""
+    name = nd.get("name")
+    if not isinstance(name, str):
+        return None
+    name = name.strip()
+    if not name or len(name) > _MAX_LABEL_NAME or looks_like_identifier(name):
+        return None
+    return name
+
+
 def _cluster_label(member_nodes: List[Dict[str, Any]]) -> str:
-    """Label a cluster by its top-3 nodes by (degree, importance)."""
+    """Label a cluster by its top-3 real ``Entity`` nodes (by degree, importance).
+
+    Entities win over DocumentChunk/TextSummary/EntityType so labels read as
+    concepts, not chunk text or type names. Identifier-shaped or over-long names
+    are skipped; a cluster with no usable entity names falls back to any usable
+    name, then to ``"cluster"``.
+    """
     ranked = sorted(
         member_nodes,
-        key=lambda nd: (nd.get("degree", 0), nd.get("importance", 0.0)),
+        key=lambda nd: (nd.get("type") == "Entity", nd.get("degree", 0), nd.get("importance", 0.0)),
         reverse=True,
     )
-    names = [nd.get("name") for nd in ranked[:3] if nd.get("name")]
-    return ", ".join(names) if names else "cluster"
+    names = [n for nd in ranked if (n := _usable_name(nd))]
+    return ", ".join(names[:3]) if names else "cluster"
 
 
 def compute_clusters(

--- a/cognee/modules/visualization/semantic_clusters.py
+++ b/cognee/modules/visualization/semantic_clusters.py
@@ -98,8 +98,8 @@ def _usable_name(nd: Dict[str, Any]) -> Optional[str]:
     return name
 
 
-def _cluster_label(member_nodes: List[Dict[str, Any]]) -> str:
-    """Label a cluster by its top-3 real ``Entity`` nodes (by degree, importance).
+def default_label(member_nodes: List[Dict[str, Any]]) -> str:
+    """Default cluster ``label_fn``: top-3 real ``Entity`` nodes (by degree, importance).
 
     Entities win over DocumentChunk/TextSummary/EntityType so labels read as
     concepts, not chunk text or type names. Identifier-shaped or over-long names
@@ -125,7 +125,7 @@ def compute_clusters(
     *,
     k: Optional[int] = None,
     seed: int = CLUSTER_SEED,
-    summarize: Optional[Callable[[str, List[str]], str]] = None,
+    label_fn: Optional[Callable[[List[Dict[str, Any]]], str]] = None,
 ) -> Dict[str, Any]:
     """Cluster embedded nodes and precompute neighbors.
 
@@ -133,10 +133,12 @@ def compute_clusters(
     "neighbors": {id: [neighbor_id, ...]}}``. Nodes without a vector are absent
     from all three (the view leaves them uncolored).
 
-    ``summarize`` is an optional seam for a one-line LLM cluster summary; when
-    None (default and in CI) the deterministic top-entity label is used. Tests
-    inject a plain mock here — this does not depend on the #3601 LLM harness.
+    ``label_fn(member_nodes) -> str`` names each cluster; it is the sole labeling
+    seam. Defaults to :func:`default_label` (deterministic, offline). A one-line
+    LLM summarizer is just another ``label_fn`` — clustering never computes a
+    label the seam then discards, and no dependency on the #3601 harness.
     """
+    label_fn = label_fn or default_label
     node_by_id = {str(n["id"]): n for n in nodes}
     ids = sorted(nid for nid in node_by_id if nid in embeddings)
     if not ids:
@@ -156,10 +158,7 @@ def compute_clusters(
         if not members:
             continue
         member_nodes = [node_by_id[m] for m in members]
-        label = _cluster_label(member_nodes)
-        if summarize is not None:
-            top_names = [nd.get("name") for nd in member_nodes[:3] if nd.get("name")]
-            label = summarize(label, top_names)
+        label = label_fn(member_nodes)
         for m in members:
             node_cluster[m] = c
         clusters.append({"id": c, "label": label, "node_ids": members, "size": len(members)})

--- a/cognee/modules/visualization/template.html
+++ b/cognee/modules/visualization/template.html
@@ -272,9 +272,15 @@ canvas:active{cursor:grabbing}
 <div id="semantic-view" style="display:none;position:fixed;inset:0;padding:56px 0 0;overflow:hidden;z-index:900;background:var(--bg);">
   <div id="semantic-header" style="position:absolute;top:56px;left:0;right:0;padding:12px 28px;display:flex;align-items:center;gap:16px;">
     <div id="semantic-status" style="font-size:13px;color:var(--text2);"></div>
-    <div id="semantic-controls" style="margin-left:auto;display:flex;gap:4px;">
-      <button class="sem-color-btn active" data-colorby="cluster" style="background:var(--accent);color:#fff;border:none;padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Cluster</button>
-      <button class="sem-color-btn" data-colorby="type" style="background:var(--surface);color:var(--text2);border:1px solid var(--border);padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Type</button>
+    <div id="semantic-controls" style="margin-left:auto;display:flex;gap:16px;">
+      <div style="display:flex;gap:4px;">
+        <button class="sem-layout-btn active" data-layout="semantic" style="background:var(--accent);color:#fff;border:none;padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Semantic</button>
+        <button class="sem-layout-btn" data-layout="structural" style="background:var(--surface);color:var(--text2);border:1px solid var(--border);padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Structural</button>
+      </div>
+      <div style="display:flex;gap:4px;">
+        <button class="sem-color-btn active" data-colorby="cluster" style="background:var(--accent);color:#fff;border:none;padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Cluster</button>
+        <button class="sem-color-btn" data-colorby="type" style="background:var(--surface);color:var(--text2);border:1px solid var(--border);padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Type</button>
+      </div>
     </div>
   </div>
   <div id="semantic-diagram-section" style="position:absolute;top:100px;left:0;right:0;bottom:0;overflow:hidden;">

--- a/cognee/modules/visualization/template.html
+++ b/cognee/modules/visualization/template.html
@@ -272,7 +272,13 @@ canvas:active{cursor:grabbing}
 <div id="semantic-view" style="display:none;position:fixed;inset:0;padding:56px 0 0;overflow:hidden;z-index:900;background:var(--bg);">
   <div id="semantic-header" style="position:absolute;top:56px;left:0;right:0;padding:12px 28px;display:flex;align-items:center;gap:16px;">
     <div id="semantic-status" style="font-size:13px;color:var(--text2);"></div>
-    <div id="semantic-controls" style="margin-left:auto;display:flex;gap:16px;">
+    <div id="semantic-controls" style="margin-left:auto;display:flex;gap:16px;align-items:center;">
+      <div id="semantic-recall-wrap" style="display:flex;gap:6px;align-items:center;">
+        <select id="semantic-recall" title="Overlay a recall query's retrieved nodes" style="background:var(--surface);color:var(--text);border:1px solid var(--border);padding:5px 8px;border-radius:6px;cursor:pointer;font-size:12px;max-width:200px;">
+          <option value="">Recall overlay: off</option>
+        </select>
+        <span id="semantic-recall-note" style="font-size:11px;color:var(--text2);"></span>
+      </div>
       <div style="display:flex;gap:4px;">
         <button class="sem-layout-btn active" data-layout="semantic" style="background:var(--accent);color:#fff;border:none;padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Semantic</button>
         <button class="sem-layout-btn" data-layout="structural" style="background:var(--surface);color:var(--text2);border:1px solid var(--border);padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Structural</button>

--- a/cognee/modules/visualization/template.html
+++ b/cognee/modules/visualization/template.html
@@ -161,6 +161,7 @@ canvas:active{cursor:grabbing}
   <button class="tab-btn active" data-view="graph" style="background:#1F9E6E;color:#fff;border:none;padding:6px 18px;border-radius:6px 6px 0 0;cursor:pointer;font-size:12px;font-weight:600;">Graph</button>
   <button class="tab-btn" data-view="schema" style="background:transparent;color:var(--text2);border:none;padding:6px 18px;border-radius:6px 6px 0 0;cursor:pointer;font-size:12px;font-weight:600;">Schema</button>
   <button class="tab-btn" data-view="memory" style="background:transparent;color:var(--text2);border:none;padding:6px 18px;border-radius:6px 6px 0 0;cursor:pointer;font-size:12px;font-weight:600;">Memory</button>
+  <button class="tab-btn" data-view="semantic" style="background:transparent;color:var(--text2);border:none;padding:6px 18px;border-radius:6px 6px 0 0;cursor:pointer;font-size:12px;font-weight:600;">Semantic</button>
 </div>
 
 <button id="theme-toggle" style="position:fixed;top:12px;right:20px;z-index:1200;background:var(--bg2);border:1px solid var(--border);cursor:pointer;font-size:12px;padding:6px 14px;border-radius:8px;color:var(--text);font-family:inherit;font-weight:500;transition:all 0.15s;">Dark mode</button>
@@ -262,6 +263,33 @@ canvas:active{cursor:grabbing}
   <div id="memory-empty"><div>No memory content to map yet. Run <b>cognify</b> first.</div></div>
   <div id="memory-side-panel"></div>
   <div id="memory-timeline"></div>
+</div>
+
+<!-- Semantic tab: a meaning-space scatter of the graph. Nodes are pinned at
+     PCA/UMAP positions of their embeddings, shaded by cluster; hovering a node
+     surfaces its nearest neighbors. Rendered lazily by views/semantic_map.js
+     into #semantic-svg. -->
+<div id="semantic-view" style="display:none;position:fixed;inset:0;padding:56px 0 0;overflow:hidden;z-index:900;background:var(--bg);">
+  <div id="semantic-header" style="position:absolute;top:56px;left:0;right:0;padding:12px 28px;display:flex;align-items:center;gap:16px;">
+    <div id="semantic-status" style="font-size:13px;color:var(--text2);"></div>
+    <div id="semantic-controls" style="margin-left:auto;display:flex;gap:4px;">
+      <button class="sem-color-btn active" data-colorby="cluster" style="background:var(--accent);color:#fff;border:none;padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Cluster</button>
+      <button class="sem-color-btn" data-colorby="type" style="background:var(--surface);color:var(--text2);border:1px solid var(--border);padding:5px 12px;border-radius:6px;cursor:pointer;font-size:12px;font-weight:600;">Type</button>
+    </div>
+  </div>
+  <div id="semantic-diagram-section" style="position:absolute;top:100px;left:0;right:0;bottom:0;overflow:hidden;">
+    <svg id="semantic-svg" style="display:block;width:100%;height:100%;cursor:grab;"></svg>
+  </div>
+  <div id="semantic-zoom" style="position:absolute;left:20px;bottom:20px;z-index:6;display:flex;gap:4px;background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:4px;">
+    <button id="semantic-zoom-out" title="Zoom out" style="width:30px;height:30px;border:none;background:transparent;border-radius:7px;cursor:pointer;font-size:18px;color:var(--text2);">&minus;</button>
+    <button id="semantic-zoom-in" title="Zoom in" style="width:30px;height:30px;border:none;background:transparent;border-radius:7px;cursor:pointer;font-size:18px;color:var(--text2);">+</button>
+    <button id="semantic-zoom-fit" title="Fit to view" style="height:30px;padding:0 12px;border:none;background:transparent;border-radius:7px;cursor:pointer;font-size:12px;font-weight:600;color:var(--text2);">Fit</button>
+  </div>
+  <div id="semantic-legend" style="position:absolute;right:20px;bottom:20px;z-index:6;max-height:40%;overflow-y:auto;background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:10px 13px;font-size:11px;color:var(--text2);line-height:1.7;"></div>
+  <div id="semantic-panel" style="display:none;position:absolute;top:100px;right:0;bottom:0;width:320px;background:var(--bg2);border-left:1px solid var(--border);box-shadow:-12px 0 32px rgba(0,0,0,0.25);padding:22px 22px;overflow-y:auto;z-index:7;color:var(--text);"></div>
+  <div id="semantic-empty" style="display:none;position:absolute;inset:0;align-items:center;justify-content:center;color:var(--text2);font-size:14px;">
+    <div>No embeddings to map yet. Run <b>cognify</b> first.</div>
+  </div>
 </div>
 <style>
 /* ── Schema diagram ─────────────────────────────────────────────── */
@@ -456,6 +484,8 @@ __STORY_VIEW_JS__
 __PIPELINE_LAYOUT_JS__
 __INSPECTOR_JS__
 __MEMORY_VIEW_JS__
+__SEMANTIC_LAYOUT_JS__
+__SEMANTIC_VIEW_JS__
 </script>
 </body>
 </html>

--- a/cognee/modules/visualization/views/semantic_core.js
+++ b/cognee/modules/visualization/views/semantic_core.js
@@ -1,0 +1,119 @@
+// Semantic-map pure core: the view's decision layer.
+//
+// DOM-free and d3-free by design, so it runs in plain Node for unit tests and,
+// concatenated ahead of semantic_map.js, as window.SemanticCore in the browser.
+// Everything here is a pure function: plain data in, plain data out, no reads of
+// window._viz* and no d3. The shell (semantic_map.js) owns all d3/DOM mechanics
+// (force sim, turbo palette, painting) and hands this core precomputed maps.
+(function (root) {
+  'use strict';
+
+  // Linear map with no clamping — matches d3.scaleLinear's default extrapolation.
+  function mapLinear(v, d0, d1, r0, r1) {
+    return r0 + ((v - d0) / (d1 - d0)) * (r1 - r0);
+  }
+
+  // Pinned embedding coords ([-1.2, 1.2] box) -> screen pixels. y is inverted.
+  function screenPositions(positions, width, height, pad) {
+    const out = {};
+    Object.keys(positions).forEach((id) => {
+      out[id] = {
+        x: mapLinear(positions[id].x, -1.2, 1.2, pad, width - pad),
+        y: mapLinear(positions[id].y, -1.2, 1.2, height - pad, pad),
+      };
+    });
+    return out;
+  }
+
+  function isolationOpacity(id, state, ctx) {
+    if (state.colorBy === 'type') {
+      if (state.isolatedType == null) return 1;
+      return ctx.typeById[id] === state.isolatedType ? 1 : 0.12;
+    }
+    return state.isolatedCluster == null || ctx.nodeCluster[id] === state.isolatedCluster
+      ? 1
+      : 0.12;
+  }
+
+  // Per-node visual attributes. The recall overlay (state.recall is a Set) wins:
+  // retrieved nodes get a red ring and full opacity, everything else dims. With
+  // no overlay, the legend isolation applies.
+  function styleFor(id, state, ctx) {
+    const hit = !!(state.recall && state.recall.has(id));
+    return {
+      opacity: state.recall ? (hit ? 1 : 0.06) : isolationOpacity(id, state, ctx),
+      stroke: hit ? '#ff3b3b' : 'rgba(0,0,0,0.25)',
+      strokeWidth: hit ? 2.5 : 0.5,
+      r: hit ? 7 : 5,
+    };
+  }
+
+  function fillFor(id, state, ctx) {
+    if (state.colorBy === 'type') return ctx.colorById[id] || '#8a8a8a';
+    const cid = ctx.nodeCluster[id];
+    return cid == null ? '#8a8a8a' : ctx.clusterColors[cid];
+  }
+
+  function truncate(s, n) {
+    return s.length > n ? s.slice(0, n - 1) + '…' : s;
+  }
+
+  // On-screen centroid + display label per non-empty cluster.
+  function clusterCentroids(clusters, screenPos) {
+    const out = [];
+    clusters.forEach((c) => {
+      const pts = (c.node_ids || []).map((id) => screenPos[id]).filter(Boolean);
+      if (!pts.length) return;
+      let sx = 0;
+      let sy = 0;
+      pts.forEach((p) => {
+        sx += p.x;
+        sy += p.y;
+      });
+      out.push({ id: c.id, x: sx / pts.length, y: sy / pts.length, label: truncate(c.label, 34) });
+    });
+    return out;
+  }
+
+  // Legend rows follow the color mode. Each row carries what the shell needs to
+  // wire a click: kind ('type'|'cluster') + value (the type name or cluster id).
+  function legendModel(state, clusters, ids, ctx) {
+    if (state.colorBy === 'type') {
+      const typeColor = {};
+      ids.forEach((id) => {
+        const t = ctx.typeById[id];
+        if (t && !(t in typeColor)) typeColor[t] = ctx.colorById[id] || '#8a8a8a';
+      });
+      return Object.keys(typeColor)
+        .sort()
+        .map((t) => ({ kind: 'type', value: t, color: typeColor[t], text: t }));
+    }
+    return clusters.map((c) => ({
+      kind: 'cluster',
+      value: c.id,
+      color: ctx.clusterColors[c.id],
+      text: c.label,
+    }));
+  }
+
+  function recallQueries(events) {
+    return (events || []).filter((e) => e && e.kind === 'search' && (e.node_ids || []).length);
+  }
+
+  function recallOnMap(query, positions) {
+    return (query.node_ids || []).filter((id) => positions[String(id)]).length;
+  }
+
+  const api = {
+    screenPositions,
+    isolationOpacity,
+    styleFor,
+    fillFor,
+    clusterCentroids,
+    legendModel,
+    recallQueries,
+    recallOnMap,
+  };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  else root.SemanticCore = api;
+})(typeof self !== 'undefined' ? self : this);

--- a/cognee/modules/visualization/views/semantic_map.js
+++ b/cognee/modules/visualization/views/semantic_map.js
@@ -23,6 +23,7 @@
   let colorBy = 'cluster';
   let zoomBehavior = null;
   let isolatedCluster = null;
+  let isolatedType = null;
 
   function clusterColor(clusters) {
     // Deterministic palette indexed by cluster id.
@@ -146,8 +147,14 @@
       .style('cursor', 'pointer');
 
     function applyIsolation() {
-      circles.attr('opacity', (id) =>
-        isolatedCluster == null || nodeCluster[id] === isolatedCluster ? 1 : 0.12);
+      circles.attr('opacity', (id) => {
+        if (colorBy === 'type') {
+          if (isolatedType == null) return 1;
+          const nd = nodeById(id);
+          return nd && nd.type === isolatedType ? 1 : 0.12;
+        }
+        return isolatedCluster == null || nodeCluster[id] === isolatedCluster ? 1 : 0.12;
+      });
     }
 
     circles.on('mouseover', function (event, id) {
@@ -169,7 +176,7 @@
     svg.call(zoomBehavior.transform, prevTransform);
 
     applyIsolation();
-    renderLegend(clusters, clusterColors, applyIsolation);
+    renderLegend(clusters, clusterColors, applyIsolation, ids);
 
     const status = document.getElementById('semantic-status');
     if (status) {
@@ -177,21 +184,40 @@
     }
   }
 
-  function renderLegend(clusters, clusterColors, applyIsolation) {
+  function legendRow(color, text, onClick) {
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;align-items:center;gap:8px;cursor:pointer;padding:1px 0;';
+    row.innerHTML = '<span style="width:10px;height:10px;border-radius:50%;background:'
+      + color + ';display:inline-block;flex:0 0 auto;"></span>'
+      + '<span>' + esc(text.length > 30 ? text.slice(0, 29) + '…' : text) + '</span>';
+    row.addEventListener('click', onClick);
+    return row;
+  }
+
+  function renderLegend(clusters, clusterColors, applyIsolation, ids) {
     const legend = document.getElementById('semantic-legend');
     if (!legend) return;
     legend.innerHTML = '';
+    if (colorBy === 'type') {
+      // Legend follows the color mode: list ontology types, click isolates one.
+      const typeColor = {};
+      ids.forEach((id) => {
+        const nd = nodeById(id);
+        if (nd && nd.type && !(nd.type in typeColor)) typeColor[nd.type] = nd.color || '#8a8a8a';
+      });
+      Object.keys(typeColor).sort().forEach((t) => {
+        legend.appendChild(legendRow(typeColor[t], t, () => {
+          isolatedType = isolatedType === t ? null : t;
+          applyIsolation();
+        }));
+      });
+      return;
+    }
     clusters.forEach((c) => {
-      const row = document.createElement('div');
-      row.style.cssText = 'display:flex;align-items:center;gap:8px;cursor:pointer;padding:1px 0;';
-      row.innerHTML = '<span style="width:10px;height:10px;border-radius:50%;background:'
-        + clusterColors[c.id] + ';display:inline-block;flex:0 0 auto;"></span>'
-        + '<span>' + esc(c.label.length > 30 ? c.label.slice(0, 29) + '…' : c.label) + '</span>';
-      row.addEventListener('click', () => {
+      legend.appendChild(legendRow(clusterColors[c.id], c.label, () => {
         isolatedCluster = isolatedCluster === c.id ? null : c.id;
         applyIsolation();
-      });
-      legend.appendChild(row);
+      }));
     });
   }
 
@@ -209,6 +235,7 @@
       btn.classList.add('active');
       btn.style.background = 'var(--accent)'; btn.style.color = '#fff'; btn.style.border = 'none';
       colorBy = btn.dataset.colorby;
+      isolatedCluster = null; isolatedType = null;  // isolation is per-mode
       render(true);
     });
   });

--- a/cognee/modules/visualization/views/semantic_map.js
+++ b/cognee/modules/visualization/views/semantic_map.js
@@ -1,0 +1,236 @@
+// Semantic-map view.
+//
+// A meaning-space scatter of the graph: each node is pinned at the 2-D
+// projection of its embedding (window._semanticPositions, from the layout's
+// __SEMANTIC_POSITIONS__ token), shaded by cluster (__SEMANTIC_CLUSTERS__).
+// Positions are computed once in Python and never simulated here (layout-once
+// rule). Hovering a node lights up its precomputed nearest neighbors and lists
+// its graph relations. Node/cluster payloads carry structure only; node detail
+// is read from window._vizNodeById / window._vizLinks (exposed by story_view.js).
+(function () {
+  'use strict';
+
+  const CLUSTERS = __SEMANTIC_CLUSTERS__;
+
+  function nodeById(id) {
+    return (window._vizNodeById && window._vizNodeById[id]) || null;
+  }
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  let colorBy = 'cluster';
+  let zoomBehavior = null;
+  let isolatedCluster = null;
+
+  function clusterColor(clusters) {
+    // Deterministic palette indexed by cluster id.
+    const map = {};
+    const n = Math.max(1, clusters.length);
+    clusters.forEach((c, i) => {
+      map[c.id] = d3.interpolateTurbo((i + 0.5) / n);
+    });
+    return map;
+  }
+
+  function colorForNode(id, clusterColors, nodeCluster) {
+    if (colorBy === 'type') {
+      const nd = nodeById(id);
+      return (nd && nd.color) || '#8a8a8a';
+    }
+    const cid = nodeCluster[id];
+    return cid == null ? '#8a8a8a' : clusterColors[cid];
+  }
+
+  function relationsFor(id) {
+    const links = window._vizLinks || [];
+    const out = [];
+    for (const l of links) {
+      const s = String(l.source), t = String(l.target);
+      if (s === id) out.push({ other: t, rel: l.relation || l.label || 'related' });
+      else if (t === id) out.push({ other: s, rel: l.relation || l.label || 'related' });
+      if (out.length >= 8) break;
+    }
+    return out;
+  }
+
+  function showPanel(id, clusterColors, nodeCluster) {
+    const panel = document.getElementById('semantic-panel');
+    if (!panel) return;
+    const nd = nodeById(id) || {};
+    const cid = nodeCluster[id];
+    const cluster = (CLUSTERS.clusters || []).find((c) => c.id === cid);
+    const neighbors = (CLUSTERS.neighbors && CLUSTERS.neighbors[id]) || [];
+    const rels = relationsFor(id);
+
+    let html = '<div style="font-size:15px;font-weight:700;margin-bottom:6px;">' + esc(nd.name || id) + '</div>';
+    html += '<div style="font-size:12px;color:var(--text2);margin-bottom:12px;">' + esc(nd.type || 'node') + '</div>';
+    if (cluster) {
+      html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;">'
+        + '<span style="width:11px;height:11px;border-radius:50%;background:' + clusterColors[cid] + ';display:inline-block;"></span>'
+        + '<span style="font-size:12.5px;">' + esc(cluster.label) + '</span></div>';
+    }
+    if (neighbors.length) {
+      html += '<div style="font-size:11px;text-transform:uppercase;letter-spacing:0.04em;color:var(--text2);margin-bottom:6px;">Nearest in meaning</div>';
+      html += '<div style="margin-bottom:14px;">';
+      neighbors.forEach((nid) => {
+        const nn = nodeById(nid) || {};
+        html += '<div style="font-size:12.5px;padding:2px 0;">' + esc(nn.name || nid) + '</div>';
+      });
+      html += '</div>';
+    }
+    if (rels.length) {
+      html += '<div style="font-size:11px;text-transform:uppercase;letter-spacing:0.04em;color:var(--text2);margin-bottom:6px;">Relations</div>';
+      rels.forEach((r) => {
+        const on = nodeById(r.other) || {};
+        html += '<div style="font-size:12px;padding:2px 0;color:var(--text2);">'
+          + esc(r.rel) + ' &rarr; <span style="color:var(--text);">' + esc(on.name || r.other) + '</span></div>';
+      });
+    }
+    panel.innerHTML = html;
+    panel.style.display = 'block';
+  }
+
+  function render(preserve) {
+    const svgEl = document.getElementById('semantic-svg');
+    const empty = document.getElementById('semantic-empty');
+    const positions = window._semanticPositions || null;
+    const ids = positions ? Object.keys(positions) : [];
+
+    if (!positions || ids.length === 0 || !CLUSTERS) {
+      if (empty) empty.style.display = 'flex';
+      if (svgEl) svgEl.style.display = 'none';
+      return;
+    }
+    if (empty) empty.style.display = 'none';
+    if (svgEl) svgEl.style.display = 'block';
+
+    const svg = d3.select(svgEl);
+    const width = svgEl.clientWidth || 800;
+    const height = svgEl.clientHeight || 600;
+    const pad = 60;
+    const clusters = CLUSTERS.clusters || [];
+    const nodeCluster = CLUSTERS.node_cluster || {};
+    const clusterColors = clusterColor(clusters);
+
+    const sx = d3.scaleLinear().domain([-1.2, 1.2]).range([pad, width - pad]);
+    const sy = d3.scaleLinear().domain([-1.2, 1.2]).range([height - pad, pad]);
+
+    const prevTransform = preserve ? d3.zoomTransform(svgEl) : d3.zoomIdentity;
+    svg.selectAll('*').remove();
+    const g = svg.append('g');
+
+    // Cluster labels at the on-screen centroid of each cluster's members.
+    clusters.forEach((c) => {
+      const pts = (c.node_ids || []).map((id) => positions[id]).filter(Boolean);
+      if (!pts.length) return;
+      const cx = d3.mean(pts, (p) => p.x);
+      const cy = d3.mean(pts, (p) => p.y);
+      g.append('text')
+        .attr('x', sx(cx)).attr('y', sy(cy))
+        .attr('text-anchor', 'middle')
+        .attr('fill', clusterColors[c.id])
+        .attr('font-size', 13).attr('font-weight', 700)
+        .attr('opacity', 0.85)
+        .attr('pointer-events', 'none')
+        .text(c.label.length > 34 ? c.label.slice(0, 33) + '…' : c.label);
+    });
+
+    const circles = g.selectAll('circle').data(ids, (d) => d).enter().append('circle')
+      .attr('cx', (id) => sx(positions[id].x))
+      .attr('cy', (id) => sy(positions[id].y))
+      .attr('r', 5)
+      .attr('fill', (id) => colorForNode(id, clusterColors, nodeCluster))
+      .attr('stroke', 'rgba(0,0,0,0.25)').attr('stroke-width', 0.5)
+      .style('cursor', 'pointer');
+
+    function applyIsolation() {
+      circles.attr('opacity', (id) =>
+        isolatedCluster == null || nodeCluster[id] === isolatedCluster ? 1 : 0.12);
+    }
+
+    circles.on('mouseover', function (event, id) {
+      const nbrs = new Set([(id), ...((CLUSTERS.neighbors && CLUSTERS.neighbors[id]) || [])]);
+      circles.attr('opacity', (d) => (nbrs.has(d) ? 1 : 0.15));
+      d3.select(this).attr('r', 8);
+      showPanel(id, clusterColors, nodeCluster);
+    }).on('mouseout', function () {
+      d3.select(this).attr('r', 5);
+      applyIsolation();
+      const panel = document.getElementById('semantic-panel');
+      if (panel) panel.style.display = 'none';
+    });
+
+    zoomBehavior = d3.zoom().scaleExtent([0.2, 12]).on('zoom', (event) => {
+      g.attr('transform', event.transform);
+    });
+    svg.call(zoomBehavior);
+    svg.call(zoomBehavior.transform, prevTransform);
+
+    applyIsolation();
+    renderLegend(clusters, clusterColors, applyIsolation);
+
+    const status = document.getElementById('semantic-status');
+    if (status) {
+      status.textContent = ids.length + ' nodes · ' + clusters.length + ' clusters';
+    }
+  }
+
+  function renderLegend(clusters, clusterColors, applyIsolation) {
+    const legend = document.getElementById('semantic-legend');
+    if (!legend) return;
+    legend.innerHTML = '';
+    clusters.forEach((c) => {
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;align-items:center;gap:8px;cursor:pointer;padding:1px 0;';
+      row.innerHTML = '<span style="width:10px;height:10px;border-radius:50%;background:'
+        + clusterColors[c.id] + ';display:inline-block;flex:0 0 auto;"></span>'
+        + '<span>' + esc(c.label.length > 30 ? c.label.slice(0, 29) + '…' : c.label) + '</span>';
+      row.addEventListener('click', () => {
+        isolatedCluster = isolatedCluster === c.id ? null : c.id;
+        applyIsolation();
+      });
+      legend.appendChild(row);
+    });
+  }
+
+  window._renderSemanticView = function (preserve) {
+    render(preserve);
+  };
+
+  // Color-mode toggle (Cluster / Type).
+  document.querySelectorAll('.sem-color-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.sem-color-btn').forEach((b) => {
+        b.classList.remove('active');
+        b.style.background = 'var(--surface)'; b.style.color = 'var(--text2)'; b.style.border = '1px solid var(--border)';
+      });
+      btn.classList.add('active');
+      btn.style.background = 'var(--accent)'; btn.style.color = '#fff'; btn.style.border = 'none';
+      colorBy = btn.dataset.colorby;
+      render(true);
+    });
+  });
+
+  // Zoom controls.
+  function zoomBy(factor) {
+    const svgEl = document.getElementById('semantic-svg');
+    if (svgEl && zoomBehavior) d3.select(svgEl).transition().duration(150).call(zoomBehavior.scaleBy, factor);
+  }
+  const zi = document.getElementById('semantic-zoom-in');
+  const zo = document.getElementById('semantic-zoom-out');
+  const zf = document.getElementById('semantic-zoom-fit');
+  if (zi) zi.addEventListener('click', () => zoomBy(1.4));
+  if (zo) zo.addEventListener('click', () => zoomBy(1 / 1.4));
+  if (zf) zf.addEventListener('click', () => {
+    const svgEl = document.getElementById('semantic-svg');
+    if (svgEl && zoomBehavior) d3.select(svgEl).transition().duration(200).call(zoomBehavior.transform, d3.zoomIdentity);
+  });
+
+  // Deep link: #semantic opens the tab on load.
+  if (window.location.hash === '#semantic') {
+    const btn = document.querySelector('.tab-btn[data-view="semantic"]');
+    if (btn) btn.click();
+  }
+})();

--- a/cognee/modules/visualization/views/semantic_map.js
+++ b/cognee/modules/visualization/views/semantic_map.js
@@ -11,6 +11,10 @@
   'use strict';
 
   const CLUSTERS = __SEMANTIC_CLUSTERS__;
+  // Recall events from the session layer (same token the Memory tab uses). Each
+  // 'search' event carries the node_ids a recall query retrieved — the overlay
+  // lights up where that query landed in meaning-space.
+  const SEARCH_EVENTS = __SEARCH_EVENTS__;
 
   function nodeById(id) {
     return (window._vizNodeById && window._vizNodeById[id]) || null;
@@ -25,6 +29,8 @@
   let zoomBehavior = null;
   let isolatedCluster = null;
   let isolatedType = null;
+  let recallSet = null;       // Set of node_ids from the active recall overlay, or null
+  let refreshStyles = null;   // set by render() so overlay changes restyle without a re-render
 
   // Structural layout: relax the same nodes over graph topology (window._vizLinks)
   // with a bounded, synchronous force sim. This is the one place a sim is allowed —
@@ -180,16 +186,25 @@
       .attr('stroke', 'rgba(0,0,0,0.25)').attr('stroke-width', 0.5)
       .style('cursor', 'pointer');
 
-    function applyIsolation() {
-      circles.attr('opacity', (id) => {
-        if (colorBy === 'type') {
-          if (isolatedType == null) return 1;
-          const nd = nodeById(id);
-          return nd && nd.type === isolatedType ? 1 : 0.12;
-        }
-        return isolatedCluster == null || nodeCluster[id] === isolatedCluster ? 1 : 0.12;
-      });
+    function isolationOpacity(id) {
+      if (colorBy === 'type') {
+        if (isolatedType == null) return 1;
+        const nd = nodeById(id);
+        return nd && nd.type === isolatedType ? 1 : 0.12;
+      }
+      return isolatedCluster == null || nodeCluster[id] === isolatedCluster ? 1 : 0.12;
     }
+
+    // Base styling: the recall overlay (when active) dims everything except the
+    // retrieved nodes and rings them; otherwise the legend isolation applies.
+    function refresh() {
+      circles
+        .attr('opacity', (id) => (recallSet ? (recallSet.has(id) ? 1 : 0.06) : isolationOpacity(id)))
+        .attr('stroke', (id) => (recallSet && recallSet.has(id) ? '#ff3b3b' : 'rgba(0,0,0,0.25)'))
+        .attr('stroke-width', (id) => (recallSet && recallSet.has(id) ? 2.5 : 0.5))
+        .attr('r', (id) => (recallSet && recallSet.has(id) ? 7 : 5));
+    }
+    refreshStyles = refresh;
 
     circles.on('mouseover', function (event, id) {
       const nbrs = new Set([(id), ...((CLUSTERS.neighbors && CLUSTERS.neighbors[id]) || [])]);
@@ -197,8 +212,7 @@
       d3.select(this).attr('r', 8);
       showPanel(id, clusterColors, nodeCluster);
     }).on('mouseout', function () {
-      d3.select(this).attr('r', 5);
-      applyIsolation();
+      refresh();
       const panel = document.getElementById('semantic-panel');
       if (panel) panel.style.display = 'none';
     });
@@ -209,8 +223,8 @@
     svg.call(zoomBehavior);
     svg.call(zoomBehavior.transform, prevTransform);
 
-    applyIsolation();
-    renderLegend(clusters, clusterColors, applyIsolation, ids);
+    refresh();
+    renderLegend(clusters, clusterColors, refresh, ids);
 
     const status = document.getElementById('semantic-status');
     if (status) {
@@ -228,7 +242,7 @@
     return row;
   }
 
-  function renderLegend(clusters, clusterColors, applyIsolation, ids) {
+  function renderLegend(clusters, clusterColors, refresh, ids) {
     const legend = document.getElementById('semantic-legend');
     if (!legend) return;
     legend.innerHTML = '';
@@ -242,7 +256,7 @@
       Object.keys(typeColor).sort().forEach((t) => {
         legend.appendChild(legendRow(typeColor[t], t, () => {
           isolatedType = isolatedType === t ? null : t;
-          applyIsolation();
+          refresh();
         }));
       });
       return;
@@ -250,7 +264,7 @@
     clusters.forEach((c) => {
       legend.appendChild(legendRow(clusterColors[c.id], c.label, () => {
         isolatedCluster = isolatedCluster === c.id ? null : c.id;
-        applyIsolation();
+        refresh();
       }));
     });
   }
@@ -301,6 +315,42 @@
     const svgEl = document.getElementById('semantic-svg');
     if (svgEl && zoomBehavior) d3.select(svgEl).transition().duration(200).call(zoomBehavior.transform, d3.zoomIdentity);
   });
+
+  // Recall overlay: pick a past recall query, light up the nodes it retrieved.
+  (function initRecall() {
+    const wrap = document.getElementById('semantic-recall-wrap');
+    const select = document.getElementById('semantic-recall');
+    const note = document.getElementById('semantic-recall-note');
+    if (!select) return;
+    const queries = (SEARCH_EVENTS || []).filter(
+      (e) => e && e.kind === 'search' && (e.node_ids || []).length,
+    );
+    if (!queries.length) {
+      if (wrap) wrap.style.display = 'none';  // nothing to overlay
+      return;
+    }
+    queries.forEach((e, i) => {
+      const opt = document.createElement('option');
+      opt.value = String(i);
+      const q = (e.question || 'recall ' + (i + 1)).trim();
+      opt.textContent = q.length > 40 ? q.slice(0, 39) + '…' : q;
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', () => {
+      const idx = select.value;
+      if (idx === '') {
+        recallSet = null;
+        if (note) note.textContent = '';
+      } else {
+        const evt = queries[+idx];
+        recallSet = new Set((evt.node_ids || []).map(String));
+        const positions = window._semanticPositions || {};
+        const onMap = (evt.node_ids || []).filter((id) => positions[String(id)]).length;
+        if (note) note.textContent = onMap + ' of ' + (evt.node_ids || []).length + ' on map';
+      }
+      if (refreshStyles) refreshStyles();
+    });
+  })();
 
   // Deep link: #semantic opens the tab on load.
   if (window.location.hash === '#semantic') {

--- a/cognee/modules/visualization/views/semantic_map.js
+++ b/cognee/modules/visualization/views/semantic_map.js
@@ -21,9 +21,32 @@
   }
 
   let colorBy = 'cluster';
+  let layoutMode = 'semantic';
   let zoomBehavior = null;
   let isolatedCluster = null;
   let isolatedType = null;
+
+  // Structural layout: relax the same nodes over graph topology (window._vizLinks)
+  // with a bounded, synchronous force sim. This is the one place a sim is allowed —
+  // it explicitly leaves the pinned semantic view. Bounded by the 2000-node payload
+  // and a fixed tick count, seeded from the semantic screen positions.
+  function structuralPositions(ids, semanticScreen, width, height) {
+    const idSet = new Set(ids);
+    const nodes = ids.map((id) => ({ id, x: semanticScreen[id].x, y: semanticScreen[id].y }));
+    const links = (window._vizLinks || [])
+      .filter((l) => idSet.has(String(l.source)) && idSet.has(String(l.target)))
+      .map((l) => ({ source: String(l.source), target: String(l.target) }));
+    const sim = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(links).id((d) => d.id).distance(40))
+      .force('charge', d3.forceManyBody().strength(-30))
+      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force('collide', d3.forceCollide(8))
+      .stop();
+    for (let i = 0; i < 200; i++) sim.tick();
+    const out = {};
+    nodes.forEach((n) => { out[n.id] = { x: n.x, y: n.y }; });
+    return out;
+  }
 
   function clusterColor(clusters) {
     // Deterministic palette indexed by cluster id.
@@ -118,18 +141,29 @@
     const sx = d3.scaleLinear().domain([-1.2, 1.2]).range([pad, width - pad]);
     const sy = d3.scaleLinear().domain([-1.2, 1.2]).range([height - pad, pad]);
 
+    // Screen positions: pinned embedding projection (semantic) or a bounded
+    // force relaxation over the graph topology (structural). Structural seeds
+    // from the semantic screen positions so the toggle reads as a relax, not a
+    // jump; Semantic snaps straight back to the pinned coordinates.
+    const semanticScreen = {};
+    ids.forEach((id) => {
+      semanticScreen[id] = { x: sx(positions[id].x), y: sy(positions[id].y) };
+    });
+    const screenPos =
+      layoutMode === 'structural'
+        ? structuralPositions(ids, semanticScreen, width, height)
+        : semanticScreen;
+
     const prevTransform = preserve ? d3.zoomTransform(svgEl) : d3.zoomIdentity;
     svg.selectAll('*').remove();
     const g = svg.append('g');
 
     // Cluster labels at the on-screen centroid of each cluster's members.
     clusters.forEach((c) => {
-      const pts = (c.node_ids || []).map((id) => positions[id]).filter(Boolean);
+      const pts = (c.node_ids || []).map((id) => screenPos[id]).filter(Boolean);
       if (!pts.length) return;
-      const cx = d3.mean(pts, (p) => p.x);
-      const cy = d3.mean(pts, (p) => p.y);
       g.append('text')
-        .attr('x', sx(cx)).attr('y', sy(cy))
+        .attr('x', d3.mean(pts, (p) => p.x)).attr('y', d3.mean(pts, (p) => p.y))
         .attr('text-anchor', 'middle')
         .attr('fill', clusterColors[c.id])
         .attr('font-size', 13).attr('font-weight', 700)
@@ -139,8 +173,8 @@
     });
 
     const circles = g.selectAll('circle').data(ids, (d) => d).enter().append('circle')
-      .attr('cx', (id) => sx(positions[id].x))
-      .attr('cy', (id) => sy(positions[id].y))
+      .attr('cx', (id) => screenPos[id].x)
+      .attr('cy', (id) => screenPos[id].y)
       .attr('r', 5)
       .attr('fill', (id) => colorForNode(id, clusterColors, nodeCluster))
       .attr('stroke', 'rgba(0,0,0,0.25)').attr('stroke-width', 0.5)
@@ -225,17 +259,30 @@
     render(preserve);
   };
 
+  function setActive(group, btn) {
+    document.querySelectorAll(group).forEach((b) => {
+      b.classList.remove('active');
+      b.style.background = 'var(--surface)'; b.style.color = 'var(--text2)'; b.style.border = '1px solid var(--border)';
+    });
+    btn.classList.add('active');
+    btn.style.background = 'var(--accent)'; btn.style.color = '#fff'; btn.style.border = 'none';
+  }
+
   // Color-mode toggle (Cluster / Type).
   document.querySelectorAll('.sem-color-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
-      document.querySelectorAll('.sem-color-btn').forEach((b) => {
-        b.classList.remove('active');
-        b.style.background = 'var(--surface)'; b.style.color = 'var(--text2)'; b.style.border = '1px solid var(--border)';
-      });
-      btn.classList.add('active');
-      btn.style.background = 'var(--accent)'; btn.style.color = '#fff'; btn.style.border = 'none';
+      setActive('.sem-color-btn', btn);
       colorBy = btn.dataset.colorby;
       isolatedCluster = null; isolatedType = null;  // isolation is per-mode
+      render(true);
+    });
+  });
+
+  // Layout toggle (Semantic / Structural).
+  document.querySelectorAll('.sem-layout-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      setActive('.sem-layout-btn', btn);
+      layoutMode = btn.dataset.layout;
       render(true);
     });
   });

--- a/cognee/modules/visualization/views/semantic_map.js
+++ b/cognee/modules/visualization/views/semantic_map.js
@@ -1,15 +1,21 @@
-// Semantic-map view.
+// Semantic-map view — the d3/DOM shell.
 //
 // A meaning-space scatter of the graph: each node is pinned at the 2-D
 // projection of its embedding (window._semanticPositions, from the layout's
 // __SEMANTIC_POSITIONS__ token), shaded by cluster (__SEMANTIC_CLUSTERS__).
 // Positions are computed once in Python and never simulated here (layout-once
-// rule). Hovering a node lights up its precomputed nearest neighbors and lists
-// its graph relations. Node/cluster payloads carry structure only; node detail
-// is read from window._vizNodeById / window._vizLinks (exposed by story_view.js).
+// rule) except under the explicit Structural toggle. Hovering a node lights up
+// its precomputed nearest neighbors and lists its graph relations.
+//
+// All view *decisions* (styling, isolation, recall overlay, legend model, screen
+// mapping) live in the pure, d3-free SemanticCore (semantic_core.js, concatenated
+// ahead of this file). This shell owns only d3/DOM mechanics: the force sim, the
+// turbo palette, painting, zoom, and event binding. Node detail is read from
+// window._vizNodeById / window._vizLinks (exposed by story_view.js).
 (function () {
   'use strict';
 
+  const Core = window.SemanticCore;
   const CLUSTERS = __SEMANTIC_CLUSTERS__;
   // Recall events from the session layer (same token the Memory tab uses). Each
   // 'search' event carries the node_ids a recall query retrieved — the overlay
@@ -24,13 +30,20 @@
       .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
-  let colorBy = 'cluster';
-  let layoutMode = 'semantic';
+  // Single mutable view state; the core reads it, never mutates it.
+  const state = {
+    colorBy: 'cluster',
+    layoutMode: 'semantic',
+    isolatedCluster: null,
+    isolatedType: null,
+    recall: null, // Set of node_ids from the active recall overlay, or null
+  };
+
   let zoomBehavior = null;
-  let isolatedCluster = null;
-  let isolatedType = null;
-  let recallSet = null;       // Set of node_ids from the active recall overlay, or null
-  let refreshStyles = null;   // set by render() so overlay changes restyle without a re-render
+  // Retained render artifacts so overlay/isolation changes restyle in place
+  // (no full re-render, no force-sim re-run) instead of via a back-pointer.
+  let currentCircles = null;
+  let currentCtx = null;
 
   // Structural layout: relax the same nodes over graph topology (window._vizLinks)
   // with a bounded, synchronous force sim. This is the one place a sim is allowed —
@@ -62,15 +75,6 @@
       map[c.id] = d3.interpolateTurbo((i + 0.5) / n);
     });
     return map;
-  }
-
-  function colorForNode(id, clusterColors, nodeCluster) {
-    if (colorBy === 'type') {
-      const nd = nodeById(id);
-      return (nd && nd.color) || '#8a8a8a';
-    }
-    const cid = nodeCluster[id];
-    return cid == null ? '#8a8a8a' : clusterColors[cid];
   }
 
   function relationsFor(id) {
@@ -122,6 +126,21 @@
     panel.style.display = 'block';
   }
 
+  // Restyle the retained circles from current state + the core's decisions.
+  // A no-op before the first render (currentCircles is null); render() calls it
+  // at the end, so a state change made while hidden still lands on next render.
+  function repaint() {
+    if (!currentCircles) return;
+    currentCircles.each(function (id) {
+      const s = Core.styleFor(id, state, currentCtx);
+      d3.select(this)
+        .attr('opacity', s.opacity)
+        .attr('stroke', s.stroke)
+        .attr('stroke-width', s.strokeWidth)
+        .attr('r', s.r);
+    });
+  }
+
   function render(preserve) {
     const svgEl = document.getElementById('semantic-svg');
     const empty = document.getElementById('semantic-empty');
@@ -144,19 +163,19 @@
     const nodeCluster = CLUSTERS.node_cluster || {};
     const clusterColors = clusterColor(clusters);
 
-    const sx = d3.scaleLinear().domain([-1.2, 1.2]).range([pad, width - pad]);
-    const sy = d3.scaleLinear().domain([-1.2, 1.2]).range([height - pad, pad]);
-
-    // Screen positions: pinned embedding projection (semantic) or a bounded
-    // force relaxation over the graph topology (structural). Structural seeds
-    // from the semantic screen positions so the toggle reads as a relax, not a
-    // jump; Semantic snaps straight back to the pinned coordinates.
-    const semanticScreen = {};
+    // Precomputed maps handed to the pure core — it never reads window._viz*.
+    const typeById = {};
+    const colorById = {};
     ids.forEach((id) => {
-      semanticScreen[id] = { x: sx(positions[id].x), y: sy(positions[id].y) };
+      const nd = nodeById(id) || {};
+      typeById[id] = nd.type;
+      colorById[id] = nd.color;
     });
+    const ctx = { nodeCluster, typeById, colorById, clusterColors };
+
+    const semanticScreen = Core.screenPositions(positions, width, height, pad);
     const screenPos =
-      layoutMode === 'structural'
+      state.layoutMode === 'structural'
         ? structuralPositions(ids, semanticScreen, width, height)
         : semanticScreen;
 
@@ -165,46 +184,26 @@
     const g = svg.append('g');
 
     // Cluster labels at the on-screen centroid of each cluster's members.
-    clusters.forEach((c) => {
-      const pts = (c.node_ids || []).map((id) => screenPos[id]).filter(Boolean);
-      if (!pts.length) return;
+    Core.clusterCentroids(clusters, screenPos).forEach((c) => {
       g.append('text')
-        .attr('x', d3.mean(pts, (p) => p.x)).attr('y', d3.mean(pts, (p) => p.y))
+        .attr('x', c.x).attr('y', c.y)
         .attr('text-anchor', 'middle')
         .attr('fill', clusterColors[c.id])
         .attr('font-size', 13).attr('font-weight', 700)
         .attr('opacity', 0.85)
         .attr('pointer-events', 'none')
-        .text(c.label.length > 34 ? c.label.slice(0, 33) + '…' : c.label);
+        .text(c.label);
     });
 
     const circles = g.selectAll('circle').data(ids, (d) => d).enter().append('circle')
       .attr('cx', (id) => screenPos[id].x)
       .attr('cy', (id) => screenPos[id].y)
       .attr('r', 5)
-      .attr('fill', (id) => colorForNode(id, clusterColors, nodeCluster))
+      .attr('fill', (id) => Core.fillFor(id, state, ctx))
       .attr('stroke', 'rgba(0,0,0,0.25)').attr('stroke-width', 0.5)
       .style('cursor', 'pointer');
-
-    function isolationOpacity(id) {
-      if (colorBy === 'type') {
-        if (isolatedType == null) return 1;
-        const nd = nodeById(id);
-        return nd && nd.type === isolatedType ? 1 : 0.12;
-      }
-      return isolatedCluster == null || nodeCluster[id] === isolatedCluster ? 1 : 0.12;
-    }
-
-    // Base styling: the recall overlay (when active) dims everything except the
-    // retrieved nodes and rings them; otherwise the legend isolation applies.
-    function refresh() {
-      circles
-        .attr('opacity', (id) => (recallSet ? (recallSet.has(id) ? 1 : 0.06) : isolationOpacity(id)))
-        .attr('stroke', (id) => (recallSet && recallSet.has(id) ? '#ff3b3b' : 'rgba(0,0,0,0.25)'))
-        .attr('stroke-width', (id) => (recallSet && recallSet.has(id) ? 2.5 : 0.5))
-        .attr('r', (id) => (recallSet && recallSet.has(id) ? 7 : 5));
-    }
-    refreshStyles = refresh;
+    currentCircles = circles;
+    currentCtx = ctx;
 
     circles.on('mouseover', function (event, id) {
       const nbrs = new Set([(id), ...((CLUSTERS.neighbors && CLUSTERS.neighbors[id]) || [])]);
@@ -212,7 +211,7 @@
       d3.select(this).attr('r', 8);
       showPanel(id, clusterColors, nodeCluster);
     }).on('mouseout', function () {
-      refresh();
+      repaint();
       const panel = document.getElementById('semantic-panel');
       if (panel) panel.style.display = 'none';
     });
@@ -223,8 +222,8 @@
     svg.call(zoomBehavior);
     svg.call(zoomBehavior.transform, prevTransform);
 
-    refresh();
-    renderLegend(clusters, clusterColors, refresh, ids);
+    repaint();
+    renderLegend(clusters, ids, ctx);
 
     const status = document.getElementById('semantic-status');
     if (status) {
@@ -242,29 +241,19 @@
     return row;
   }
 
-  function renderLegend(clusters, clusterColors, refresh, ids) {
+  function renderLegend(clusters, ids, ctx) {
     const legend = document.getElementById('semantic-legend');
     if (!legend) return;
     legend.innerHTML = '';
-    if (colorBy === 'type') {
-      // Legend follows the color mode: list ontology types, click isolates one.
-      const typeColor = {};
-      ids.forEach((id) => {
-        const nd = nodeById(id);
-        if (nd && nd.type && !(nd.type in typeColor)) typeColor[nd.type] = nd.color || '#8a8a8a';
-      });
-      Object.keys(typeColor).sort().forEach((t) => {
-        legend.appendChild(legendRow(typeColor[t], t, () => {
-          isolatedType = isolatedType === t ? null : t;
-          refresh();
-        }));
-      });
-      return;
-    }
-    clusters.forEach((c) => {
-      legend.appendChild(legendRow(clusterColors[c.id], c.label, () => {
-        isolatedCluster = isolatedCluster === c.id ? null : c.id;
-        refresh();
+    // Rows follow the color mode (cluster vs type); clicking one isolates it.
+    Core.legendModel(state, clusters, ids, ctx).forEach((rowModel) => {
+      legend.appendChild(legendRow(rowModel.color, rowModel.text, () => {
+        if (rowModel.kind === 'type') {
+          state.isolatedType = state.isolatedType === rowModel.value ? null : rowModel.value;
+        } else {
+          state.isolatedCluster = state.isolatedCluster === rowModel.value ? null : rowModel.value;
+        }
+        repaint();
       }));
     });
   }
@@ -286,8 +275,8 @@
   document.querySelectorAll('.sem-color-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
       setActive('.sem-color-btn', btn);
-      colorBy = btn.dataset.colorby;
-      isolatedCluster = null; isolatedType = null;  // isolation is per-mode
+      state.colorBy = btn.dataset.colorby;
+      state.isolatedCluster = null; state.isolatedType = null;  // isolation is per-mode
       render(true);
     });
   });
@@ -296,7 +285,7 @@
   document.querySelectorAll('.sem-layout-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
       setActive('.sem-layout-btn', btn);
-      layoutMode = btn.dataset.layout;
+      state.layoutMode = btn.dataset.layout;
       render(true);
     });
   });
@@ -322,9 +311,7 @@
     const select = document.getElementById('semantic-recall');
     const note = document.getElementById('semantic-recall-note');
     if (!select) return;
-    const queries = (SEARCH_EVENTS || []).filter(
-      (e) => e && e.kind === 'search' && (e.node_ids || []).length,
-    );
+    const queries = Core.recallQueries(SEARCH_EVENTS);
     if (!queries.length) {
       if (wrap) wrap.style.display = 'none';  // nothing to overlay
       return;
@@ -339,16 +326,15 @@
     select.addEventListener('change', () => {
       const idx = select.value;
       if (idx === '') {
-        recallSet = null;
+        state.recall = null;
         if (note) note.textContent = '';
       } else {
         const evt = queries[+idx];
-        recallSet = new Set((evt.node_ids || []).map(String));
+        state.recall = new Set((evt.node_ids || []).map(String));
         const positions = window._semanticPositions || {};
-        const onMap = (evt.node_ids || []).filter((id) => positions[String(id)]).length;
-        if (note) note.textContent = onMap + ' of ' + (evt.node_ids || []).length + ' on map';
+        if (note) note.textContent = Core.recallOnMap(evt, positions) + ' of ' + (evt.node_ids || []).length + ' on map';
       }
-      if (refreshStyles) refreshStyles();
+      repaint();
     });
   })();
 

--- a/cognee/modules/visualization/views/semantic_map.py
+++ b/cognee/modules/visualization/views/semantic_map.py
@@ -1,0 +1,17 @@
+"""Semantic view: the meaning-space scatter tab.
+
+Reads the sibling ``semantic_map.js`` chunk. The chunk carries the
+``__SEMANTIC_CLUSTERS__`` token that the orchestrator substitutes with the
+clustering payload (positions arrive via the layout's ``__SEMANTIC_POSITIONS__``
+token). Both fall back to ``null`` when there are no embeddings, and the view
+shows a friendly empty state.
+"""
+
+import os
+
+_JS_PATH = os.path.join(os.path.dirname(__file__), "semantic_map.js")
+
+
+def emit_js(_preprocessed=None) -> str:
+    with open(_JS_PATH, "r", encoding="utf-8") as f:
+        return f.read()

--- a/cognee/modules/visualization/views/semantic_map.py
+++ b/cognee/modules/visualization/views/semantic_map.py
@@ -1,17 +1,26 @@
 """Semantic view: the meaning-space scatter tab.
 
-Reads the sibling ``semantic_map.js`` chunk. The chunk carries the
-``__SEMANTIC_CLUSTERS__`` token that the orchestrator substitutes with the
-clustering payload (positions arrive via the layout's ``__SEMANTIC_POSITIONS__``
-token). Both fall back to ``null`` when there are no embeddings, and the view
-shows a friendly empty state.
+Emits two concatenated chunks: the pure, d3-free ``semantic_core.js`` (the view's
+decision layer, also unit-tested in Node) followed by ``semantic_map.js`` (the
+d3/DOM shell). Order matters — the core defines ``window.SemanticCore`` that the
+shell reads, so the core must come first.
+
+The shell carries the ``__SEMANTIC_CLUSTERS__`` token that the orchestrator
+substitutes with the clustering payload (positions arrive via the layout's
+``__SEMANTIC_POSITIONS__`` token). Both fall back to ``null`` when there are no
+embeddings, and the view shows a friendly empty state. The core is token-free.
 """
 
 import os
 
-_JS_PATH = os.path.join(os.path.dirname(__file__), "semantic_map.js")
+_DIR = os.path.dirname(__file__)
+_CORE_PATH = os.path.join(_DIR, "semantic_core.js")
+_JS_PATH = os.path.join(_DIR, "semantic_map.js")
 
 
 def emit_js(_preprocessed=None) -> str:
+    with open(_CORE_PATH, "r", encoding="utf-8") as f:
+        core = f.read()
     with open(_JS_PATH, "r", encoding="utf-8") as f:
-        return f.read()
+        shell = f.read()
+    return core + "\n" + shell

--- a/cognee/modules/visualization/views/ui_chrome.js
+++ b/cognee/modules/visualization/views/ui_chrome.js
@@ -43,6 +43,7 @@
   const graphView = document.getElementById('graph-view');
   const schemaView = document.getElementById('schema-view');
   const memoryView = document.getElementById('memory-view');
+  const semanticView = document.getElementById('semantic-view');
   tabs.forEach(btn => {
     btn.addEventListener('click', () => {
       tabs.forEach(t => { t.style.background='transparent'; t.style.color='var(--text2)'; t.classList.remove('active'); });
@@ -51,8 +52,10 @@
       graphView.style.display = view === 'graph' ? '' : 'none';
       schemaView.style.display = view === 'schema' ? '' : 'none';
       if (memoryView) memoryView.style.display = view === 'memory' ? '' : 'none';
+      if (semanticView) semanticView.style.display = view === 'semantic' ? '' : 'none';
       if (view === 'schema' && window._renderSchemaGraph) window._renderSchemaGraph();
       if (view === 'memory' && window._renderMemoryView) window._renderMemoryView();
+      if (view === 'semantic' && window._renderSemanticView) window._renderSemanticView();
     });
   });
 })();

--- a/cognee/tests/unit/modules/visualization/semantic_core.test.js
+++ b/cognee/tests/unit/modules/visualization/semantic_core.test.js
@@ -1,0 +1,124 @@
+// Behavioral unit tests for the pure semantic-map core (semantic_core.js).
+// Run via Node's built-in test runner: `node --test semantic_core.test.js`.
+// The pytest wrapper (test_semantic_core.py) invokes this and skips when node
+// is absent. No dependencies, no build step — the core is d3-free and DOM-free.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const Core = require(
+  path.join(__dirname, '..', '..', '..', '..', 'modules', 'visualization', 'views', 'semantic_core.js'),
+);
+
+const CTX = {
+  nodeCluster: { a: 0, b: 0, c: 1, d: 1 },
+  typeById: { a: 'Entity', b: 'DocumentChunk', c: 'Entity', d: 'Entity' },
+  colorById: { a: '#111111', b: '#222222', c: undefined, d: '#444444' },
+  clusterColors: { 0: '#c0ffee', 1: '#bada55' },
+};
+
+function baseState(over) {
+  return Object.assign(
+    { colorBy: 'cluster', layoutMode: 'semantic', isolatedCluster: null, isolatedType: null, recall: null },
+    over || {},
+  );
+}
+
+test('screenPositions maps the [-1.2,1.2] box to padded pixels, y inverted', () => {
+  const pos = { a: { x: 0, y: 0 }, b: { x: -1.2, y: 1.2 } };
+  const s = Core.screenPositions(pos, 800, 600, 60);
+  // center maps to the middle of the padded range
+  assert.ok(Math.abs(s.a.x - 400) < 1e-9);
+  assert.ok(Math.abs(s.a.y - 300) < 1e-9);
+  // x=-1.2 -> left pad; y=+1.2 -> top pad (inverted)
+  assert.ok(Math.abs(s.b.x - 60) < 1e-9);
+  assert.ok(Math.abs(s.b.y - 60) < 1e-9);
+});
+
+test('styleFor: recall overlay rings members and dims the rest', () => {
+  const state = baseState({ recall: new Set(['a']) });
+  const hit = Core.styleFor('a', state, CTX);
+  assert.deepStrictEqual(hit, { opacity: 1, stroke: '#ff3b3b', strokeWidth: 2.5, r: 7 });
+  const miss = Core.styleFor('b', state, CTX);
+  assert.strictEqual(miss.opacity, 0.06);
+  assert.strictEqual(miss.stroke, 'rgba(0,0,0,0.25)');
+  assert.strictEqual(miss.r, 5);
+});
+
+test('styleFor: cluster isolation dims non-members, no ring', () => {
+  const state = baseState({ isolatedCluster: 0 });
+  assert.strictEqual(Core.styleFor('a', state, CTX).opacity, 1); // cluster 0
+  assert.strictEqual(Core.styleFor('c', state, CTX).opacity, 0.12); // cluster 1
+  assert.strictEqual(Core.styleFor('a', state, CTX).strokeWidth, 0.5); // no recall ring
+});
+
+test('styleFor: type isolation keys off typeById', () => {
+  const state = baseState({ colorBy: 'type', isolatedType: 'Entity' });
+  assert.strictEqual(Core.styleFor('a', state, CTX).opacity, 1); // Entity
+  assert.strictEqual(Core.styleFor('b', state, CTX).opacity, 0.12); // DocumentChunk
+});
+
+test('styleFor: no isolation -> everything full opacity', () => {
+  const state = baseState();
+  assert.strictEqual(Core.styleFor('a', state, CTX).opacity, 1);
+  assert.strictEqual(Core.styleFor('c', state, CTX).opacity, 1);
+});
+
+test('fillFor: cluster mode uses palette, missing cluster -> grey', () => {
+  const state = baseState();
+  assert.strictEqual(Core.fillFor('a', state, CTX), '#c0ffee');
+  assert.strictEqual(Core.fillFor('x', state, CTX), '#8a8a8a'); // unknown id, cid null
+});
+
+test('fillFor: type mode uses node color, missing color -> grey', () => {
+  const state = baseState({ colorBy: 'type' });
+  assert.strictEqual(Core.fillFor('a', state, CTX), '#111111');
+  assert.strictEqual(Core.fillFor('c', state, CTX), '#8a8a8a'); // colorById undefined
+});
+
+test('clusterCentroids: mean of member screen points, label truncated at 34', () => {
+  const clusters = [
+    { id: 0, node_ids: ['a', 'b'], label: 'short' },
+    { id: 9, node_ids: ['none'], label: 'x' }, // no positioned members -> skipped
+  ];
+  const screenPos = { a: { x: 10, y: 20 }, b: { x: 30, y: 40 } };
+  const out = Core.clusterCentroids(clusters, screenPos);
+  assert.strictEqual(out.length, 1);
+  assert.deepStrictEqual({ x: out[0].x, y: out[0].y }, { x: 20, y: 30 });
+
+  const long = 'x'.repeat(50);
+  const [c] = Core.clusterCentroids([{ id: 1, node_ids: ['a'], label: long }], { a: { x: 0, y: 0 } });
+  assert.strictEqual(c.label.length, 34); // 33 chars + ellipsis
+  assert.ok(c.label.endsWith('…'));
+});
+
+test('legendModel: cluster mode maps clusters to rows', () => {
+  const clusters = [{ id: 0, label: 'L0' }, { id: 1, label: 'L1' }];
+  const rows = Core.legendModel(baseState(), clusters, ['a', 'c'], CTX);
+  assert.deepStrictEqual(rows.map((r) => r.kind), ['cluster', 'cluster']);
+  assert.deepStrictEqual(rows.map((r) => r.value), [0, 1]);
+  assert.strictEqual(rows[0].color, '#c0ffee');
+});
+
+test('legendModel: type mode dedupes and sorts types', () => {
+  const rows = Core.legendModel(baseState({ colorBy: 'type' }), [], ['a', 'b', 'c', 'd'], CTX);
+  assert.deepStrictEqual(rows.map((r) => r.value), ['DocumentChunk', 'Entity']); // sorted, unique
+  const entity = rows.find((r) => r.value === 'Entity');
+  assert.strictEqual(entity.color, '#111111'); // first Entity's color (a)
+});
+
+test('recallQueries keeps only search events with node_ids; recallOnMap counts on-map', () => {
+  const events = [
+    { kind: 'search', question: 'q1', node_ids: ['a', 'b'] },
+    { kind: 'search', question: 'empty', node_ids: [] }, // dropped
+    { kind: 'improve', node_ids: ['a'] }, // dropped
+    null, // dropped
+  ];
+  const qs = Core.recallQueries(events);
+  assert.strictEqual(qs.length, 1);
+  assert.strictEqual(qs[0].question, 'q1');
+
+  const positions = { a: { x: 0, y: 0 } }; // only 'a' is on the map
+  assert.strictEqual(Core.recallOnMap(qs[0], positions), 1);
+});

--- a/cognee/tests/unit/modules/visualization/test_embedding_join.py
+++ b/cognee/tests/unit/modules/visualization/test_embedding_join.py
@@ -165,3 +165,66 @@ def test_sampling_cap_deterministic():
 def test_default_index_fields_cover_core_types():
     for t in ("Entity", "EntityType", "TextSummary", "DocumentChunk", "TextDocument"):
         assert t in DEFAULT_INDEX_FIELDS
+
+
+class _RecordingLogger:
+    """Captures formatted log messages regardless of the logging backend."""
+
+    def __init__(self):
+        self.records = []
+
+    def _rec(self, level, msg, args):
+        self.records.append((level, msg % args if args else msg))
+
+    def info(self, msg, *args):
+        self._rec("info", msg, args)
+
+    def warning(self, msg, *args):
+        self._rec("warning", msg, args)
+
+    def debug(self, *args, **kwargs):
+        pass
+
+    def messages(self, level):
+        return [m for lvl, m in self.records if lvl == level]
+
+
+def test_join_logs_hit_rate(monkeypatch):
+    # One of two Entity nodes resolves -> a hit-rate INFO line reports 1/2.
+    from cognee.modules.visualization import embedding_join
+
+    rec = _RecordingLogger()
+    monkeypatch.setattr(embedding_join, "logger", rec)
+
+    engine = FakeVectorEngine({"Entity_name": {E1: [1.0, 0.0, 0.0]}})
+    nodes = [_node(E1, "Entity"), _node(E2, "Entity")]
+    result = asyncio.run(fetch_node_embeddings(nodes, vector_engine=engine))
+
+    assert result == {E1: [1.0, 0.0, 0.0]}
+    assert any(
+        "resolved 1/2 node embeddings across 1 collection(s)" in m for m in rec.messages("info")
+    )
+    assert rec.messages("warning") == []  # partial success is not a warning
+
+
+def test_join_warns_with_diagnostics_when_nothing_resolves(monkeypatch):
+    # Zero resolution over non-empty input -> a WARNING naming the missing
+    # collection and the unmapped type, so a blank map is diagnosable.
+    from cognee.modules.visualization import embedding_join
+
+    rec = _RecordingLogger()
+    monkeypatch.setattr(embedding_join, "logger", rec)
+
+    engine = FakeVectorEngine({})  # no collections at all
+    nodes = [
+        _node(S1, "TextSummary"),  # known type, collection TextSummary_text missing
+        _node(G1, "GraphNodeType"),  # unmapped type
+    ]
+    result = asyncio.run(fetch_node_embeddings(nodes, vector_engine=engine))
+
+    assert result == {}
+    warnings = rec.messages("warning")
+    assert any("no embeddings resolved" in m for m in warnings)
+    joined = " ".join(warnings)
+    assert "TextSummary_text" in joined  # missing collection surfaced
+    assert "GraphNodeType" in joined  # unmapped type surfaced

--- a/cognee/tests/unit/modules/visualization/test_embedding_join.py
+++ b/cognee/tests/unit/modules/visualization/test_embedding_join.py
@@ -149,11 +149,9 @@ def test_reembed_uses_text_field_for_text_types():
 
 
 def test_sampling_cap_deterministic():
-    store = {}  # collection absent -> no retrieve, but sampling still runs
-    engine = FakeVectorEngine(store)
     nodes = [_node(f"{i:05d}", "Entity") for i in range(3000)]
 
-    # Patch _select_nodes indirectly: cap at 2000 and assert two runs agree.
+    # Cap at 2000 and assert two runs agree (deterministic seeded sample).
     from cognee.modules.visualization import embedding_join
 
     picked1 = embedding_join._select_nodes(nodes, 2000)

--- a/cognee/tests/unit/modules/visualization/test_embedding_join.py
+++ b/cognee/tests/unit/modules/visualization/test_embedding_join.py
@@ -1,0 +1,169 @@
+"""Unit tests for the embedding join — the seam between graph nodes and vectors.
+
+Fully offline and deterministic: a fake vector engine stands in for the real
+adapter (the single mocking seam), so there are no LLM calls and no live store.
+Covers collection resolution, batched retrieve, the re-embed fallback for adapters
+without ``include_vector`` support, and the deterministic over-cap sample.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.modules.visualization.embedding_join import (
+    DEFAULT_INDEX_FIELDS,
+    fetch_node_embeddings,
+)
+
+
+class FakeEmbeddingEngine:
+    """Deterministic embed_text: one call, one vector per text, length-based."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def embed_text(self, texts):
+        self.calls.append(list(texts))
+        return [[float(len(t)), 1.0, 2.0] for t in texts]
+
+
+class FakeVectorEngine:
+    """Stands in for a real adapter. ``store`` maps collection -> {id: vector}."""
+
+    def __init__(self, store, supports_include_vector=True):
+        self.store = store
+        self.supports_include_vector = supports_include_vector
+        self.embedding_engine = FakeEmbeddingEngine()
+        self.retrieve_calls = []
+
+    async def has_collection(self, collection_name):
+        return collection_name in self.store
+
+    async def retrieve(self, collection_name, data_point_ids, **kwargs):
+        if not self.supports_include_vector:
+            # Mimic an unmodified adapter whose retrieve() rejects the kwarg.
+            raise TypeError("retrieve() got an unexpected keyword argument 'include_vector'")
+        include_vector = kwargs.get("include_vector", False)
+        self.retrieve_calls.append((collection_name, list(data_point_ids)))
+        rows = self.store.get(collection_name, {})
+        results = []
+        for did in data_point_ids:
+            if did in rows:
+                payload = {"text": f"payload-{did}"}
+                if include_vector:
+                    payload = {**payload, "vector": rows[did]}
+                results.append(ScoredResult(id=did, payload=payload, score=0))
+        return results
+
+
+# ScoredResult.id is a UUID, so fixtures use canonical UUID strings.
+E1 = "11111111-1111-1111-1111-111111111111"
+E2 = "22222222-2222-2222-2222-222222222222"
+T1 = "33333333-3333-3333-3333-333333333333"
+G1 = "44444444-4444-4444-4444-444444444444"
+S1 = "55555555-5555-5555-5555-555555555555"
+C1 = "66666666-6666-6666-6666-666666666666"
+
+
+def _node(nid, ntype, **extra):
+    return {"id": nid, "type": ntype, "name": f"name-{nid}", **extra}
+
+
+def test_collection_resolution_one_batched_retrieve_per_type():
+    # Two Entity nodes + one EntityType node -> one retrieve on Entity_name and
+    # one on EntityType_name, each batched with the correct ids.
+    store = {
+        "Entity_name": {E1: [0.1, 0.2, 0.3], E2: [0.4, 0.5, 0.6]},
+        "EntityType_name": {T1: [0.7, 0.8, 0.9]},
+    }
+    engine = FakeVectorEngine(store)
+    nodes = [_node(E1, "Entity"), _node(E2, "Entity"), _node(T1, "EntityType")]
+
+    result = asyncio.run(fetch_node_embeddings(nodes, vector_engine=engine))
+
+    assert result == {
+        E1: [0.1, 0.2, 0.3],
+        E2: [0.4, 0.5, 0.6],
+        T1: [0.7, 0.8, 0.9],
+    }
+    # Exactly one batched retrieve per collection, never per node.
+    called = {c[0]: c[1] for c in engine.retrieve_calls}
+    assert set(called) == {"Entity_name", "EntityType_name"}
+    assert len(engine.retrieve_calls) == 2
+    assert set(called["Entity_name"]) == {E1, E2}
+
+
+def test_unknown_type_and_missing_collection_skipped():
+    store = {"Entity_name": {E1: [1.0, 0.0, 0.0]}}
+    engine = FakeVectorEngine(store)
+    nodes = [
+        _node(E1, "Entity"),
+        _node(G1, "GraphNodeType"),  # not in DEFAULT_INDEX_FIELDS -> skipped
+        _node(S1, "TextSummary"),  # known type but no collection -> skipped
+    ]
+
+    result = asyncio.run(fetch_node_embeddings(nodes, vector_engine=engine))
+
+    assert result == {E1: [1.0, 0.0, 0.0]}
+    assert [c[0] for c in engine.retrieve_calls] == ["Entity_name"]
+
+
+def test_missing_ids_absent_not_reembedded():
+    # Collection exists and returns vectors for present ids; ids absent from the
+    # store are simply missing (layout handles them), NOT re-embedded.
+    store = {"Entity_name": {E1: [0.1, 0.1, 0.1]}}
+    engine = FakeVectorEngine(store)
+    nodes = [_node(E1, "Entity"), _node(E2, "Entity")]
+
+    result = asyncio.run(fetch_node_embeddings(nodes, vector_engine=engine))
+
+    assert result == {E1: [0.1, 0.1, 0.1]}
+    assert engine.embedding_engine.calls == []  # no re-embed
+
+
+def test_reembed_fallback_when_include_vector_unsupported():
+    # Adapter without include_vector support: every node is positioned via one
+    # batched embed_text call.
+    store = {"Entity_name": {E1: [9.9], E2: [9.9]}}
+    engine = FakeVectorEngine(store, supports_include_vector=False)
+    nodes = [_node(E1, "Entity", name="abc"), _node(E2, "Entity", name="abcd")]
+
+    result = asyncio.run(fetch_node_embeddings(nodes, vector_engine=engine))
+
+    # Fallback embeds the indexed field (name) once, in a single batch.
+    assert len(engine.embedding_engine.calls) == 1
+    assert engine.embedding_engine.calls[0] == ["abc", "abcd"]
+    assert result == {E1: [3.0, 1.0, 2.0], E2: [4.0, 1.0, 2.0]}
+
+
+def test_reembed_uses_text_field_for_text_types():
+    store = {"DocumentChunk_text": {C1: [0.0]}}
+    engine = FakeVectorEngine(store, supports_include_vector=False)
+    nodes = [{"id": C1, "type": "DocumentChunk", "name": "ignored", "text": "hello"}]
+
+    asyncio.run(fetch_node_embeddings(nodes, vector_engine=engine))
+
+    assert engine.embedding_engine.calls == [["hello"]]
+
+
+def test_sampling_cap_deterministic():
+    store = {}  # collection absent -> no retrieve, but sampling still runs
+    engine = FakeVectorEngine(store)
+    nodes = [_node(f"{i:05d}", "Entity") for i in range(3000)]
+
+    # Patch _select_nodes indirectly: cap at 2000 and assert two runs agree.
+    from cognee.modules.visualization import embedding_join
+
+    picked1 = embedding_join._select_nodes(nodes, 2000)
+    picked2 = embedding_join._select_nodes(nodes, 2000)
+    assert len(picked1) == 2000
+    assert [n["id"] for n in picked1] == [n["id"] for n in picked2]
+    # id-sorted output
+    assert [n["id"] for n in picked1] == sorted(n["id"] for n in picked1)
+
+
+def test_default_index_fields_cover_core_types():
+    for t in ("Entity", "EntityType", "TextSummary", "DocumentChunk", "TextDocument"):
+        assert t in DEFAULT_INDEX_FIELDS

--- a/cognee/tests/unit/modules/visualization/test_semantic_clusters.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_clusters.py
@@ -81,6 +81,26 @@ def test_labels_use_top_degree_entities():
     assert labels[pos_cluster].startswith("Nb")  # name of highest-degree member
 
 
+def test_label_prefers_entities_over_chunk_text():
+    # One blob mixes a low-degree Entity with a high-degree DocumentChunk whose
+    # "name" is a long text blob. The label must use the entity, never the chunk.
+    chunk_text = "This is a long document chunk sentence that should never become a label."
+    nodes = [
+        {"id": "a", "type": "DocumentChunk", "name": chunk_text, "degree": 99},
+        {"id": "b", "type": "Entity", "name": "Ada Lovelace", "degree": 1},
+        {"id": "c", "type": "Entity", "name": "deadbeefdeadbeefdeadbeefdeadbeef", "degree": 5},
+        {"id": "d", "type": "Entity", "name": "Turing", "degree": 2},
+        {"id": "e", "type": "Entity", "name": "Babbage", "degree": 2},
+        {"id": "f", "type": "Entity", "name": "London", "degree": 2},
+    ]
+    result = compute_clusters(nodes, BLOB, k=2, seed=42)
+    labels = [c["label"] for c in result["clusters"]]
+    pos_label = labels[result["node_cluster"]["a"]]
+    assert "document chunk" not in pos_label.lower()  # chunk text excluded
+    assert "deadbeef" not in pos_label  # identifier-shaped name skipped
+    assert "Ada Lovelace" in pos_label  # real entity used despite low degree
+
+
 def test_summarize_seam_is_used_when_provided():
     nodes = _nodes(["a", "b", "c", "d", "e", "f"])
     summarize = Mock(return_value="SUMMARY")

--- a/cognee/tests/unit/modules/visualization/test_semantic_clusters.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_clusters.py
@@ -119,12 +119,20 @@ def test_label_falls_back_to_dominant_type_when_no_names():
     assert "cluster" not in labels  # generic fallback no longer reached
 
 
-def test_summarize_seam_is_used_when_provided():
+def test_label_fn_seam_overrides_and_receives_member_nodes():
+    # A custom label_fn (e.g. an LLM summarizer) fully replaces the default and is
+    # called once per cluster with that cluster's member nodes — no discarded
+    # default label is computed first.
     nodes = _nodes(["a", "b", "c", "d", "e", "f"])
-    summarize = Mock(return_value="SUMMARY")
-    result = compute_clusters(nodes, BLOB, k=2, seed=42, summarize=summarize)
+    label_fn = Mock(return_value="SUMMARY")
+    result = compute_clusters(nodes, BLOB, k=2, seed=42, label_fn=label_fn)
     assert all(c["label"] == "SUMMARY" for c in result["clusters"])
-    assert summarize.call_count == 2  # once per cluster
+    assert label_fn.call_count == 2  # once per cluster
+    # Each call gets a list of member-node dicts, not the default label string.
+    for call in label_fn.call_args_list:
+        (member_nodes,) = call.args
+        assert isinstance(member_nodes, list)
+        assert all(isinstance(nd, dict) and "id" in nd for nd in member_nodes)
 
 
 def test_nodes_without_vectors_are_absent():

--- a/cognee/tests/unit/modules/visualization/test_semantic_clusters.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_clusters.py
@@ -1,0 +1,101 @@
+"""Unit tests for clustering + NN precompute — deterministic, offline, no LLM.
+
+Covers seeded k-means determinism and k bounds, cosine nearest-neighbor
+correctness, the deterministic top-entity label path, and the optional
+(mocked) summary seam.
+"""
+
+from unittest.mock import Mock
+
+import numpy as np
+
+from cognee.modules.visualization.semantic_clusters import (
+    compute_clusters,
+    default_k,
+    kmeans,
+)
+
+# Two well-separated blobs in 3-D.
+BLOB = {
+    "a": [10.0, 0.0, 0.0],
+    "b": [10.1, 0.1, 0.0],
+    "c": [10.0, -0.1, 0.1],
+    "d": [-10.0, 0.0, 0.0],
+    "e": [-10.1, 0.1, 0.0],
+    "f": [-10.0, -0.1, 0.1],
+}
+
+
+def _nodes(ids, degree=None):
+    degree = degree or {}
+    return [{"id": i, "type": "Entity", "name": f"N{i}", "degree": degree.get(i, 0)} for i in ids]
+
+
+def test_default_k_bounds():
+    assert default_k(0) == 1
+    assert default_k(1) == 1
+    assert default_k(2) == 2  # max(2, ...)
+    assert default_k(10_000) == 12  # capped at 12
+    assert default_k(8) == 2  # round(sqrt(4)) == 2
+
+
+def test_kmeans_deterministic_and_separates_blobs():
+    x = np.array([BLOB[i] for i in ["a", "b", "c", "d", "e", "f"]])
+    l1 = kmeans(x, 2, seed=42)
+    l2 = kmeans(x, 2, seed=42)
+    assert np.array_equal(l1, l2)  # identical across runs
+    # First three (positive blob) share a label; last three share the other.
+    assert l1[0] == l1[1] == l1[2]
+    assert l1[3] == l1[4] == l1[5]
+    assert l1[0] != l1[3]
+
+
+def test_compute_clusters_two_groups():
+    nodes = _nodes(["a", "b", "c", "d", "e", "f"])
+    result = compute_clusters(nodes, BLOB, k=2, seed=42)
+    assert len(result["clusters"]) == 2
+    # Every embedded node is assigned.
+    assert set(result["node_cluster"]) == set(BLOB)
+    # The two positive-blob members land in the same cluster.
+    assert result["node_cluster"]["a"] == result["node_cluster"]["b"]
+    assert result["node_cluster"]["a"] != result["node_cluster"]["d"]
+
+
+def test_nearest_neighbors_cosine_topk():
+    nodes = _nodes(["a", "b", "c", "d", "e", "f"])
+    result = compute_clusters(nodes, BLOB, k=2, seed=42)
+    # 'a' neighbors must be its blob-mates (b, c) ahead of the far blob.
+    nbrs = result["neighbors"]["a"]
+    assert len(nbrs) == 5  # top-5, self excluded
+    assert nbrs[0] in {"b", "c"}
+    assert nbrs[1] in {"b", "c"}
+    assert "a" not in nbrs
+
+
+def test_labels_use_top_degree_entities():
+    # 'b' has the highest degree in the positive blob -> leads its cluster label.
+    nodes = _nodes(["a", "b", "c", "d", "e", "f"], degree={"b": 9, "a": 1, "d": 9})
+    result = compute_clusters(nodes, BLOB, k=2, seed=42)
+    labels = {c["id"]: c["label"] for c in result["clusters"]}
+    pos_cluster = result["node_cluster"]["b"]
+    assert labels[pos_cluster].startswith("Nb")  # name of highest-degree member
+
+
+def test_summarize_seam_is_used_when_provided():
+    nodes = _nodes(["a", "b", "c", "d", "e", "f"])
+    summarize = Mock(return_value="SUMMARY")
+    result = compute_clusters(nodes, BLOB, k=2, seed=42, summarize=summarize)
+    assert all(c["label"] == "SUMMARY" for c in result["clusters"])
+    assert summarize.call_count == 2  # once per cluster
+
+
+def test_nodes_without_vectors_are_absent():
+    nodes = _nodes(["a", "b", "c", "d", "e", "f", "novec"])
+    result = compute_clusters(nodes, BLOB, k=2, seed=42)
+    assert "novec" not in result["node_cluster"]
+    assert "novec" not in result["neighbors"]
+
+
+def test_empty_embeddings():
+    result = compute_clusters(_nodes(["a"]), {}, seed=42)
+    assert result == {"clusters": [], "node_cluster": {}, "neighbors": {}}

--- a/cognee/tests/unit/modules/visualization/test_semantic_clusters.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_clusters.py
@@ -101,6 +101,24 @@ def test_label_prefers_entities_over_chunk_text():
     assert "Ada Lovelace" in pos_label  # real entity used despite low degree
 
 
+def test_label_falls_back_to_dominant_type_when_no_names():
+    # A cluster of nameless chunks/summaries: no usable name, so the label is the
+    # dominant node type rather than the generic "cluster".
+    nodes = [
+        {"id": "a", "type": "TextSummary", "text": "summary one"},
+        {"id": "b", "type": "TextSummary", "text": "summary two"},
+        {"id": "c", "type": "DocumentChunk", "text": "a chunk"},
+        {"id": "d", "type": "TextSummary", "text": "summary three"},
+        {"id": "e", "type": "TextSummary", "text": "summary four"},
+        {"id": "f", "type": "DocumentChunk", "text": "another chunk"},
+    ]
+    result = compute_clusters(nodes, BLOB, k=2, seed=42)
+    labels = [c["label"] for c in result["clusters"]]
+    assert labels  # every cluster is labelled
+    assert all(lbl in {"TextSummary", "DocumentChunk"} for lbl in labels)
+    assert "cluster" not in labels  # generic fallback no longer reached
+
+
 def test_summarize_seam_is_used_when_provided():
     nodes = _nodes(["a", "b", "c", "d", "e", "f"])
     summarize = Mock(return_value="SUMMARY")

--- a/cognee/tests/unit/modules/visualization/test_semantic_core.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_core.py
@@ -1,0 +1,28 @@
+"""Run the semantic-map core's Node unit tests inside the pytest suite.
+
+The view's decision layer (``views/semantic_core.js``) is pure and d3-free, so it
+is unit-tested in Node via the built-in test runner (no npm, no build step). This
+wrapper shells out to ``node --test`` and surfaces failures in the pytest report.
+It skips when ``node`` is unavailable (e.g. a Python-only CI), so it never turns
+the suite red on environments without Node — it only adds coverage where Node is
+present. Node 18+ is required for the built-in test runner.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_TEST_JS = Path(__file__).parent / "semantic_core.test.js"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_semantic_core_node_suite():
+    result = subprocess.run(
+        ["node", "--test", str(_TEST_JS)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail("semantic_core.js Node tests failed:\n" + result.stdout + "\n" + result.stderr)

--- a/cognee/tests/unit/modules/visualization/test_semantic_layout.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_layout.py
@@ -1,0 +1,130 @@
+"""Unit tests for the semantic layout — deterministic offline projection.
+
+No LLM, no vector store: embeddings are handed in directly. Covers PCA
+determinism + sign convention, [-1,1] normalization, the no-vector neighbor
+fallback, isolated-node ring placement, de-overlap separation, and the UMAP
+ImportError fallback (CI has no umap-learn).
+"""
+
+import numpy as np
+
+from cognee.modules.visualization.layouts import semantic_layout
+from cognee.modules.visualization.layouts.semantic_layout import (
+    MIN_SEPARATION,
+    SPREAD,
+    compute_positions,
+)
+
+
+def _nodes(ids, ntype="Entity"):
+    return [{"id": i, "type": ntype, "name": f"n-{i}"} for i in ids]
+
+
+# Fixed 4-point embedding in 3-D: two tight pairs separated along axis 0.
+FIXED_EMB = {
+    "a": [1.0, 0.0, 0.0],
+    "b": [1.1, 0.05, 0.0],
+    "c": [-1.0, 0.0, 0.0],
+    "d": [-1.1, -0.05, 0.0],
+}
+
+
+def test_pca_deterministic_across_runs():
+    nodes = _nodes(["a", "b", "c", "d"])
+    r1 = compute_positions(nodes, [], FIXED_EMB, seed=42)
+    r2 = compute_positions(nodes, [], FIXED_EMB, seed=42)
+    assert r1 == r2  # exact equality — pinned, deterministic
+
+
+def test_all_nodes_positioned_and_within_spread():
+    nodes = _nodes(["a", "b", "c", "d"])
+    pos = compute_positions(nodes, [], FIXED_EMB, seed=42)
+    assert set(pos) == {"a", "b", "c", "d"}
+    for p in pos.values():
+        # De-overlap can nudge slightly past the box; allow a small margin.
+        assert -SPREAD - 0.2 <= p["x"] <= SPREAD + 0.2
+        assert -SPREAD - 0.2 <= p["y"] <= SPREAD + 0.2
+
+
+def test_positions_invariant_to_node_order():
+    # The sign convention pins SVD's arbitrary internal sign, so the projection
+    # is a pure function of the embedding set — independent of node ordering.
+    fwd = _nodes(["a", "b", "c", "d"])
+    rev = _nodes(["d", "c", "b", "a"])
+    p_fwd = compute_positions(fwd, [], FIXED_EMB, seed=42)
+    p_rev = compute_positions(rev, [], FIXED_EMB, seed=42)
+    assert p_fwd == p_rev
+
+
+def test_primary_axis_separates_clusters():
+    # The two tight pairs are far apart on embedding axis 0 -> they must land on
+    # opposite sides of the projection's primary axis.
+    nodes = _nodes(["a", "b", "c", "d"])
+    pos = compute_positions(nodes, [], FIXED_EMB, seed=42)
+    left = {"a", "b"}
+    right = {"c", "d"}
+    left_x = np.mean([pos[i]["x"] for i in left])
+    right_x = np.mean([pos[i]["x"] for i in right])
+    assert abs(left_x - right_x) > 0.5  # clearly separated
+
+
+def test_no_vector_node_placed_at_neighbor_centroid():
+    # 'x' has no embedding but links to 'a' and 'c'; it should sit near their
+    # midpoint (small seeded jitter aside), not on the ring.
+    nodes = _nodes(["a", "b", "c", "d", "x"])
+    links = [{"source": "x", "target": "a"}, {"source": "x", "target": "c"}]
+    pos = compute_positions(nodes, links, FIXED_EMB, seed=42)
+    midpoint = np.array([(pos["a"]["x"] + pos["c"]["x"]) / 2, (pos["a"]["y"] + pos["c"]["y"]) / 2])
+    placed = np.array([pos["x"]["x"], pos["x"]["y"]])
+    assert np.linalg.norm(placed - midpoint) < 0.25  # jitter + de-overlap tolerance
+
+
+def test_isolated_no_vector_node_on_ring():
+    # 'iso' has no embedding and no links -> deterministic ring, outside the box.
+    nodes = _nodes(["a", "b", "c", "d", "iso"])
+    pos = compute_positions(nodes, [], FIXED_EMB, seed=42)
+    r = np.hypot(pos["iso"]["x"], pos["iso"]["y"])
+    assert r > SPREAD  # pushed to the ring radius (1.15 * spread)
+
+
+def test_deoverlap_separates_coincident_points():
+    # Four identical embeddings would collapse to one point; de-overlap must
+    # spread them to at least ~MIN_SEPARATION apart.
+    nodes = _nodes(["a", "b", "c", "d"])
+    same = {k: [0.5, 0.5, 0.5] for k in ["a", "b", "c", "d"]}
+    pos = compute_positions(nodes, [], same, seed=42)
+    pts = np.array([[pos[i]["x"], pos[i]["y"]] for i in ["a", "b", "c", "d"]])
+    dists = [
+        np.linalg.norm(pts[i] - pts[j])
+        for i in range(len(pts))
+        for j in range(i + 1, len(pts))
+    ]
+    assert min(dists) >= MIN_SEPARATION * SPREAD * 0.9
+
+
+def test_umap_method_falls_back_to_pca(monkeypatch, caplog):
+    # Force the umap import to fail; method="umap" must fall back to PCA and log.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "umap":
+            raise ImportError("no umap")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    nodes = _nodes(["a", "b", "c", "d"])
+    umap_pos = compute_positions(nodes, [], FIXED_EMB, method="umap", seed=42)
+    pca_pos = compute_positions(nodes, [], FIXED_EMB, method="pca", seed=42)
+    assert umap_pos == pca_pos  # identical -> fell back to PCA
+
+
+def test_emit_js_carries_position_token():
+    assert "__SEMANTIC_POSITIONS__" in semantic_layout.emit_js()
+
+
+def test_empty_and_single_node_graphs():
+    assert compute_positions([], [], {}) == {}
+    single = compute_positions(_nodes(["a"]), [], {"a": [1.0, 2.0, 3.0]}, seed=42)
+    assert set(single) == {"a"}

--- a/cognee/tests/unit/modules/visualization/test_semantic_layout.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_layout.py
@@ -95,9 +95,7 @@ def test_deoverlap_separates_coincident_points():
     pos = compute_positions(nodes, [], same, seed=42)
     pts = np.array([[pos[i]["x"], pos[i]["y"]] for i in ["a", "b", "c", "d"]])
     dists = [
-        np.linalg.norm(pts[i] - pts[j])
-        for i in range(len(pts))
-        for j in range(i + 1, len(pts))
+        np.linalg.norm(pts[i] - pts[j]) for i in range(len(pts)) for j in range(i + 1, len(pts))
     ]
     assert min(dists) >= MIN_SEPARATION * SPREAD * 0.9
 

--- a/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
@@ -48,6 +48,11 @@ def test_semantic_tab_and_view_are_wired(tmp_path, monkeypatch):
     # Type-filter wiring: the legend follows the color mode and isolates a type.
     assert "isolatedType" in html
     assert "colorBy === 'type'" in html
+    # Layout-toggle wiring: Semantic/Structural buttons + the force sim path.
+    assert 'class="sem-layout-btn' in html
+    assert 'data-layout="structural"' in html
+    assert "structuralPositions" in html
+    assert "d3.forceSimulation" in html
 
 
 def test_no_token_leaks_with_embeddings(tmp_path, monkeypatch):

--- a/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
@@ -45,9 +45,14 @@ def test_semantic_tab_and_view_are_wired(tmp_path, monkeypatch):
     assert 'id="semantic-view"' in html
     assert "window._renderSemanticView" in html
     assert "window._semanticPositions" in html
+    # Core seam: the pure decision layer is injected and the shell consumes it.
+    # (Behavior of the core is covered by the Node suite, not by string presence.)
+    assert "root.SemanticCore = api" in html
+    assert "const Core = window.SemanticCore" in html
+    assert "Core.styleFor" in html
     # Type-filter wiring: the legend follows the color mode and isolates a type.
-    assert "isolatedType" in html
-    assert "colorBy === 'type'" in html
+    assert "state.isolatedType" in html
+    assert "state.colorBy === 'type'" in html
     # Layout-toggle wiring: Semantic/Structural buttons + the force sim path.
     assert 'class="sem-layout-btn' in html
     assert 'data-layout="structural"' in html
@@ -56,7 +61,7 @@ def test_semantic_tab_and_view_are_wired(tmp_path, monkeypatch):
     # Recall-overlay wiring: the query dropdown + the search-events consumer.
     assert 'id="semantic-recall"' in html
     assert "SEARCH_EVENTS" in html
-    assert "recallSet" in html
+    assert "state.recall" in html
 
 
 def test_no_token_leaks_with_embeddings(tmp_path, monkeypatch):

--- a/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
@@ -1,0 +1,83 @@
+"""Assembly tests for the semantic tab — offline, embedding seam mocked.
+
+Pins the wiring contract: the semantic tab, layout, and view JS are injected;
+the position/cluster data tokens are substituted (real JSON when embeddings
+exist, ``null`` when they don't); and no ``__TOKEN__`` placeholder ever leaks.
+The embedding fetch is mocked at the orchestrator seam so these tests need no
+vector store or LLM.
+"""
+
+import asyncio
+import re
+
+from cognee.modules.visualization import cognee_network_visualization as orch
+from cognee.modules.visualization.cognee_network_visualization import (
+    cognee_network_visualization,
+)
+
+TOKEN_RE = re.compile(r"__[A-Z][A-Z0-9_]*__")
+
+
+def _graph():
+    nodes = [
+        ("11111111-1111-1111-1111-111111111111", {"type": "Entity", "name": "Ada"}),
+        ("22222222-2222-2222-2222-222222222222", {"type": "Entity", "name": "Alan"}),
+        ("33333333-3333-3333-3333-333333333333", {"type": "Entity", "name": "London"}),
+    ]
+    edges = [
+        (nodes[0][0], nodes[1][0], "knows", {}),
+        (nodes[0][0], nodes[2][0], "lived_in", {}),
+    ]
+    return (nodes, edges)
+
+
+def _render(tmp_path, monkeypatch, embeddings):
+    async def fake_fetch(nodes, **kwargs):
+        return embeddings
+
+    monkeypatch.setattr(orch, "fetch_node_embeddings", fake_fetch)
+    return asyncio.run(cognee_network_visualization(_graph(), str(tmp_path / "out.html")))
+
+
+def test_semantic_tab_and_view_are_wired(tmp_path, monkeypatch):
+    html = _render(tmp_path, monkeypatch, {})
+    assert 'data-view="semantic"' in html
+    assert 'id="semantic-view"' in html
+    assert "window._renderSemanticView" in html
+    assert "window._semanticPositions" in html
+
+
+def test_no_token_leaks_with_embeddings(tmp_path, monkeypatch):
+    emb = {
+        "11111111-1111-1111-1111-111111111111": [1.0, 0.0, 0.0],
+        "22222222-2222-2222-2222-222222222222": [0.9, 0.1, 0.0],
+        "33333333-3333-3333-3333-333333333333": [-1.0, 0.0, 0.0],
+    }
+    html = _render(tmp_path, monkeypatch, emb)
+    assert TOKEN_RE.findall(html) == []
+    # Positions and clusters are real JSON, not the literal null.
+    assert "window._semanticPositions = null" not in html
+    assert "const CLUSTERS = null" not in html
+    # Cluster payload structure made it into the embedded JSON.
+    assert '"neighbors"' in html
+    assert '"node_cluster"' in html
+
+
+def test_no_token_leaks_without_embeddings(tmp_path, monkeypatch):
+    html = _render(tmp_path, monkeypatch, {})
+    assert TOKEN_RE.findall(html) == []
+    # Empty state: both semantic data tokens collapse to null.
+    assert "window._semanticPositions = null" in html
+    assert "const CLUSTERS = null" in html
+
+
+def test_semantic_failure_never_breaks_render(tmp_path, monkeypatch):
+    async def boom(nodes, **kwargs):
+        raise RuntimeError("vector store down")
+
+    monkeypatch.setattr(orch, "fetch_node_embeddings", boom)
+    html = asyncio.run(cognee_network_visualization(_graph(), str(tmp_path / "out.html")))
+    # Classic render still completes; semantic tab falls back to the empty state.
+    assert html.startswith("<!DOCTYPE html>")
+    assert TOKEN_RE.findall(html) == []
+    assert "window._semanticPositions = null" in html

--- a/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
@@ -53,6 +53,10 @@ def test_semantic_tab_and_view_are_wired(tmp_path, monkeypatch):
     assert 'data-layout="structural"' in html
     assert "structuralPositions" in html
     assert "d3.forceSimulation" in html
+    # Recall-overlay wiring: the query dropdown + the search-events consumer.
+    assert 'id="semantic-recall"' in html
+    assert "SEARCH_EVENTS" in html
+    assert "recallSet" in html
 
 
 def test_no_token_leaks_with_embeddings(tmp_path, monkeypatch):

--- a/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
+++ b/cognee/tests/unit/modules/visualization/test_semantic_map_assembly.py
@@ -45,6 +45,9 @@ def test_semantic_tab_and_view_are_wired(tmp_path, monkeypatch):
     assert 'id="semantic-view"' in html
     assert "window._renderSemanticView" in html
     assert "window._semanticPositions" in html
+    # Type-filter wiring: the legend follows the color mode and isolates a type.
+    assert "isolatedType" in html
+    assert "colorBy === 'type'" in html
 
 
 def test_no_token_leaks_with_embeddings(tmp_path, monkeypatch):

--- a/examples/python/semantic_memory_map.py
+++ b/examples/python/semantic_memory_map.py
@@ -1,0 +1,70 @@
+"""Demo: the Semantic Memory Map.
+
+Runs a real cognee pipeline (add → cognify) and renders the knowledge graph
+with ``visualize_graph``. The resulting HTML has a **Semantic** tab that lays
+the graph out by *meaning*: every node is placed at the 2-D projection of its
+embedding, so semantically similar nodes cluster together — a view the classic
+topology layout can't show.
+
+Nothing here patches the HTML. The semantic tab is produced by the production
+render path itself:
+
+    fetch_node_embeddings  (join graph nodes to their stored vectors)
+        -> semantic_layout.compute_positions   (PCA, pinned)
+        -> compute_clusters                     (k-means + nearest neighbors)
+        -> cognee_network_visualization         (token substitution)
+
+Requirements: an LLM + embedding key in the environment (e.g. ``LLM_API_KEY``),
+exactly as ``cognify`` already needs. With no embeddings the tab simply shows a
+friendly empty state — the classic render never breaks.
+
+Run:
+    python examples/python/semantic_memory_map.py
+Then open the printed HTML and click the **Semantic** tab (or append
+``#semantic`` to deep-link straight to it).
+"""
+
+import asyncio
+import os
+
+import cognee
+from cognee.api.v1.visualize.visualize import visualize_graph
+
+DEST = os.path.join(os.path.expanduser("~"), "semantic_memory_map.html")
+
+# A few short, deliberately multi-topic passages so distinct clusters emerge:
+# computing pioneers, jazz, and ocean science.
+TEXT = """
+Ada Lovelace worked with Charles Babbage on the Analytical Engine in London.
+Alan Turing formalized computation and broke ciphers at Bletchley Park.
+Grace Hopper built the first compiler and worked on the Harvard Mark I.
+
+Miles Davis recorded Kind of Blue, a landmark modal jazz album, in New York.
+John Coltrane played saxophone with the Miles Davis Quintet before A Love Supreme.
+Bill Evans, the pianist on Kind of Blue, shaped its impressionistic harmony.
+
+Marine biologists study coral reefs, which host a quarter of all ocean species.
+Rising sea temperatures cause coral bleaching, threatening reef ecosystems.
+Phytoplankton in the ocean produce a large share of the planet's oxygen.
+"""
+
+
+async def main():
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+    await cognee.add(TEXT)
+    await cognee.cognify()
+
+    html = await visualize_graph(destination_file_path=DEST)
+
+    has_semantic = 'data-view="semantic"' in html
+    has_positions = "window._semanticPositions = null" not in html
+    print(f"\nSaved: {DEST}")
+    print(f"Semantic tab present:   {has_semantic}")
+    print(f"Semantic positions set: {has_positions}")
+    print("\nOpen the file and click the Semantic tab (or append #semantic to the URL).")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

# Cognee Hackathon Submission PR

feat(visualization): Semantic Memory Map - embedding-projection + clustering view (#3642)

---

# Description

Closes #3642 (Hackathon: Semantic Memory Map).

Adds a **Semantic** tab to the graph visualization that lays the knowledge graph out by
*meaning* instead of topology: every node is placed at the 2-D projection of its embedding, so
semantically similar nodes cluster together. It bridges the vector, graph, and ontology sides of
cognee in one picture - the existing views show *structure* (who connects to whom), this one shows
*semantics* (what's conceptually near what).

Built as a **new view + `semantic_layout` module** on top of the existing renderer - no renderer
fork, reusing the preprocessor and template, exactly as the issue asks.

## What's included

- **Embedding projection** - `layouts/semantic_layout.py`: PCA via numpy SVD (sign-stabilized so
  snapshots are deterministic), normalized and **pinned** (layout-once). Optional UMAP via lazy
  import; ImportError falls back to PCA. Vector-less nodes get neighbor-centroid / ring placement.
- **Semantic clustering + labels** - `semantic_clusters.py`: pure-numpy k-means on the
  **full-dimensional** embeddings (not the lossy 2-D), top-5 cosine neighbors precomputed for the
  hover panel. Labels rank real `Entity` names ahead of chunk/summary/type nodes and skip
  identifier-shaped or over-long names; a nameless cluster falls back to its dominant node type.
  Labeling is a single injected `label_fn` seam (an LLM summarizer is just another `label_fn`).
- **Ontology-type coloring + filtering** - color by cluster or by ontology type; in Type mode the
  legend lists the types and clicking one isolates it.
- **Interactions** - d3 zoom, hover panel ("why are these near": nearest neighbors + shared
  relations), a **Semantic ⇄ Structural** layout toggle (Structural runs a bounded `d3.forceSimulation`
  over the graph topology, seeded from the pinned positions and snapping back), and a **recall-query
  overlay** (bonus): pick a past recall query and the nodes it retrieved light up in meaning-space.
- **Exposed from `visualize_graph`** as the Semantic tab (`#semantic` deep-links to it).
- **Embedding join** - `embedding_join.py`: `visualize_graph` forwards no vectors, so this fetches
  them from the vector store by node id. Adds a keyword-only `include_vector` to
  `VectorDBInterface.retrieve` (implemented for LanceDB; other adapters re-embed the indexed field
  as a fallback). Grouped by type, one batched retrieve per `{Type}_{field}` collection, capped at
  2000 nodes (deterministic seeded sample, logged), and logs a resolved/total hit-rate so a blank
  map is diagnosable rather than silent.

## Bounded + graceful (per the requirements)

- Heavy deps (UMAP) are optional/lazy with a PCA fallback; clustering is pure numpy (scikit-learn
  lives only in the `evals` extra). Large graphs are sampled to a cap, logged.
- The semantic fetch is best-effort inside the already-async orchestrator: any failure logs and the
  classic render still completes, with the tab showing a friendly empty state. New tokens always
  substitute (to `null` when there are no embeddings), so no `__TOKEN__` ever leaks.
- **Zero new dependencies**; `pyproject.toml` untouched.

## Tests

- Deterministic, offline unit tests (seeded snapshots; the vector store is mocked at the join seam,
  no LLM/network): projection, clustering, the join (collection resolution, re-embed fallback,
  sampling cap, hit-rate logging), and HTML assembly (no leftover tokens).
- The view's pure decision layer (`semantic_core.js`) is DOM-free / d3-free and unit-tested in Node
  via the built-in runner, invoked from pytest - it **skips** when `node` is absent, so a Python-only
  CI never goes red.

## Example + docs

- `examples/python/semantic_memory_map.py` - a real add → cognify → `visualize_graph` run (no HTML
  patching).
- `cognee/modules/visualization/SEMANTIC_MAP.md` - design notes.

## Notes for reviewers

- Node-id ↔ vector-id join relies on both sides using `str(data_point.id)` (verified in code).
- `ScoredResult` is intentionally left unchanged; the vector rides in `payload["vector"]` on the
  LanceDB path to keep the shared interface minimal. (A typed vector field on the retrieve seam is a
  reasonable future cleanup, deliberately out of scope here.)
- The Structural toggle is the only place a force simulation runs on this tab; the default semantic
  view stays pinned (layout-once).

## Screenshots

Same dataset, two tabs - structure → meaning:

- **Graph tab** (topology): 
<img width="1600" height="900" alt="hangover_before" src="https://github.com/user-attachments/assets/21d66f1d-17a7-4620-8763-2ff27c6ba1d2" />

- **Semantic tab** (embedding clusters): 
<img width="1600" height="900" alt="hangover_after" src="https://github.com/user-attachments/assets/3ea1385d-8a28-4b51-aec4-d42ff3fde194" />

- **Recall overlay** (a query's retrieved nodes lit up): 
<img width="1600" height="900" alt="recall_overlay" src="https://github.com/user-attachments/assets/bd515f12-107c-4e91-97ad-53df09c5f6b6" />
