### PR TITLE
security: fix critical+high+medium/low findings (auth, RCE, SSRF, LFI, SQLi, Cypher default, Zip Slip, CORS)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -278,6 +278,11 @@ ACCEPT_LOCAL_FILE_PATH=True
 # directory, and the system temp dir when unset.
 #LOCAL_FILE_ALLOWED_ROOTS="/srv/cognee/data,/srv/cognee/uploads"
 ALLOW_HTTP_REQUESTS=True
+# Allow the CYPHER and NATURAL_LANGUAGE search types, which run database-native
+# queries against the graph backend. Secure-by-default: when this variable is
+# UNSET these search types are enabled outside production but DISABLED in
+# production (ENV=prod) and must be turned on explicitly here. Any non-truthy
+# value (false/no/0/off, or a typo) fails safe to disabled.
 ALLOW_CYPHER_QUERY=True
 RAISE_INCREMENTAL_LOADING_ERRORS=True
 
@@ -510,8 +515,11 @@ WEB_SCRAPER_MAX_DELAY=10.0
 
 # -- API server (cognee/cognee image) ----------------------------------------
 # CORS allow-list for the FastAPI server: comma-separated origins. Read by the
-# app (cognee/api/client.py). Default '*' (all origins) — set explicit domains
-# in production.
+# app (cognee/api/client.py). When unset it defaults to UI_APP_URL
+# (http://localhost:3000) — NOT all origins. Set explicit domains in production.
+# Note: the API sends credentials (cookies / Authorization), so a wildcard '*'
+# is unsafe and unsupported — if you set '*', the app drops credentialed CORS
+# and logs a warning. List explicit trusted origins instead.
 #CORS_ALLOWED_ORIGINS="https://yourdomain.com,https://another.com"
 # Server bind/port inside the container (entrypoint defaults shown).
 #HTTP_PORT=8000

--- a/.env.template
+++ b/.env.template
@@ -245,7 +245,11 @@ MIGRATION_DB_PROVIDER="sqlite"
 # -- JWT Authentication -------------------------------------------------------
 # Secret used to sign and verify JWT tokens. Must be the same across all instances
 # (e.g. all Kubernetes pods) for tokens issued by one instance to be accepted by another.
-# Change this to a long random string in production. Never commit the real value to git.
+# REQUIRED in production: when ENV=prod, cognee refuses to start if this is unset
+# or left at the insecure "super_secret" default (a public key lets anyone forge
+# tokens). Generate a strong value with:
+#   python -c 'import secrets; print(secrets.token_urlsafe(64))'
+# Never commit the real value to git.
 FASTAPI_USERS_JWT_SECRET="super_secret"
 
 # How long a JWT token remains valid, in seconds. After expiry the user must log in again.
@@ -478,8 +482,10 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #LLAMA_CPP_CHAT_FORMAT="chatml"
 
 # -- Security: additional auth-token secrets ----------------------------------
-# Like FASTAPI_USERS_JWT_SECRET above, these default to the INSECURE value
-# "super_secret". Override BOTH with long random strings in production.
+# Like FASTAPI_USERS_JWT_SECRET above, these are REQUIRED in production: when
+# ENV=prod, cognee refuses to start if either is unset or left at the insecure
+# "super_secret" default. Override BOTH with long random strings in production
+# (python -c 'import secrets; print(secrets.token_urlsafe(64))').
 #FASTAPI_USERS_VERIFICATION_TOKEN_SECRET="change_me_in_production"
 #FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET="change_me_in_production"
 

--- a/.env.template
+++ b/.env.template
@@ -338,6 +338,10 @@ TOKENIZERS_PARALLELISM="false"
 # LITELLM Logging Level. Set to quiet down logging
 LITELLM_LOG="ERROR"
 #TELEMETRY_DISABLED=1
+# Credentials for the auto-created default superuser. REQUIRED in production:
+# when ENV=prod, cognee refuses to create the default user without an explicit
+# DEFAULT_USER_PASSWORD (it will no longer fall back to "default_password"). In
+# non-prod, a random password is generated if this is left unset.
 #DEFAULT_USER_EMAIL=""
 #DEFAULT_USER_PASSWORD=""
 

--- a/.env.template
+++ b/.env.template
@@ -272,6 +272,11 @@ HASH_API_KEY="False"
 
 # When set to false don't allow adding of local system files to Cognee. Should be set to False when Cognee is used as a backend.
 ACCEPT_LOCAL_FILE_PATH=True
+# When local files ARE accepted, ingestion is restricted to these directories so
+# a caller cannot read arbitrary server files (e.g. file:///etc/passwd). Comma-
+# separated absolute paths. Defaults to the data directory, the working
+# directory, and the system temp dir when unset.
+#LOCAL_FILE_ALLOWED_ROOTS="/srv/cognee/data,/srv/cognee/uploads"
 ALLOW_HTTP_REQUESTS=True
 ALLOW_CYPHER_QUERY=True
 RAISE_INCREMENTAL_LOADING_ERRORS=True

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,11 +482,18 @@ All functions are async - use `await` or `asyncio.run()`.
 Several security environment variables in `.env`:
 - `ACCEPT_LOCAL_FILE_PATH` - Allow local file paths (default: True)
 - `ALLOW_HTTP_REQUESTS` - Allow HTTP requests from Cognee (default: True)
-- `ALLOW_CYPHER_QUERY` - Allow raw Cypher queries (default: True)
+- `ALLOW_CYPHER_QUERY` - Allow the `CYPHER`/`NATURAL_LANGUAGE` search types, which run database-native queries against the graph backend. **Secure-by-default:** when unset these are enabled outside production but **disabled in production (`ENV=prod`)** and must be opted into explicitly. Any non-truthy value (e.g. `false`, `0`, or a typo) fails safe to disabled.
 - `ENABLE_BACKEND_ACCESS_CONTROL` - Multi-tenant isolation (default: True). When `true`, API auth is required and per-user/dataset DB isolation is enabled. When `false`, single-user mode: shared DBs and auth off unless overridden.
 - `REQUIRE_AUTHENTICATION` - Explicit auth override. Unset (default): follows `ENABLE_BACKEND_ACCESS_CONTROL`. `false` is ignored when `ENABLE_BACKEND_ACCESS_CONTROL=true`. For a single-user deployment with auth off, set `ENABLE_BACKEND_ACCESS_CONTROL=false` (and optionally `REQUIRE_AUTHENTICATION=false`).
+- `CORS_ALLOWED_ORIGINS` - Comma-separated CORS allow-list for the API (default: `UI_APP_URL`, i.e. `http://localhost:3000`). The API sends credentials, so a wildcard `*` is unsafe: if set to `*` the app drops credentialed CORS and logs a warning. List explicit trusted origins in production.
 
 For production deployments, review and tighten these settings.
+
+### Additional hardening (defense-in-depth)
+
+These are enforced in code and need no configuration:
+- **SQL identifier injection** - Table/schema/column names taken from an external source database (relational migration, dynamic `CREATE`/`DROP TABLE`) are quoted via the SQLAlchemy dialect identifier preparer; column *types* are validated against an allowlist. See `cognee/tasks/ingestion/migrate_relational_database.py` and `infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py`.
+- **Zip Slip** - The downloaded UI bundle is validated member-by-member (rejecting `..`/absolute paths) before extraction (`cognee/api/v1/ui/ui.py`); the COGX migration archive is similarly hardened (`cognee/modules/migration/archive.py`).
 
 ## Common Patterns
 

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -117,10 +117,22 @@ else:
         os.getenv("UI_APP_URL", "http://localhost:3000"),
     ]  # Block all except explicitly set origins
 
+# Credentialed CORS (cookies / Authorization) must never be combined with a
+# wildcard origin: it would let any website make authenticated requests on a
+# logged-in user's behalf. Browsers reject ``*`` + credentials outright, so if a
+# deployment sets ``CORS_ALLOWED_ORIGINS="*"`` we drop credentials rather than
+# silently ship a broken (or, on non-compliant clients, dangerous) config.
+allow_credentials = "*" not in allowed_origins
+if not allow_credentials:
+    logger.warning(
+        "CORS_ALLOWED_ORIGINS includes '*'; disabling credentialed CORS. "
+        "Set an explicit list of trusted origins to allow cookie/Authorization requests."
+    )
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,  # Now controlled by env var
-    allow_credentials=True,
+    allow_credentials=allow_credentials,
     allow_methods=["OPTIONS", "GET", "PUT", "POST", "DELETE"],
     allow_headers=["*"],
 )

--- a/cognee/api/v1/ui/ui.py
+++ b/cognee/api/v1/ui/ui.py
@@ -265,6 +265,17 @@ def download_frontend_assets(force: bool = False) -> bool:
             with zipfile.ZipFile(archive_path, "r") as zip_file:
                 # Extract to temp directory first
                 extract_dir = temp_path / "extracted"
+                # Guard against Zip Slip: a malicious/compromised archive could
+                # contain members with ``..`` or absolute paths that escape the
+                # extraction directory and overwrite arbitrary files. Reject any
+                # member that would resolve outside ``extract_dir`` before writing.
+                extract_root = extract_dir.resolve()
+                for member in zip_file.namelist():
+                    target = (extract_dir / member).resolve()
+                    if target != extract_root and extract_root not in target.parents:
+                        raise ValueError(
+                            f"Unsafe path in downloaded UI archive: {member!r}"
+                        )
                 zip_file.extractall(extract_dir)
 
                 # Find the cognee-frontend directory in the extracted content

--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -1,4 +1,5 @@
 import os
+import re
 import gc
 import asyncio
 from os import path
@@ -23,6 +24,27 @@ from ..ModelBase import Base
 
 
 logger = get_logger()
+
+# Column type tokens permitted in dynamically generated ``CREATE TABLE`` DDL.
+# Unlike identifiers (which we quote), a column type is structural SQL and
+# cannot be quoted, so it is validated against this allowlist to keep the DDL
+# free of injected SQL. Covers the common SQL/SQLAlchemy type spellings plus an
+# optional ``(precision[, scale])`` suffix and array/unsigned modifiers.
+_SQL_TYPE_RE = re.compile(
+    r"^[A-Za-z][A-Za-z0-9 ]*(\(\s*\d+\s*(,\s*\d+\s*)?\))?(\s*\[\s*\])?$"
+)
+
+
+def _validate_sql_type(sql_type: str) -> str:
+    """Return ``sql_type`` if it is a syntactically plausible column type.
+
+    Raises ``ValueError`` on anything containing characters that could break
+    out of the type context (quotes, semicolons, comments, etc.).
+    """
+    candidate = str(sql_type).strip()
+    if not candidate or not _SQL_TYPE_RE.match(candidate):
+        raise ValueError(f"Invalid or unsafe SQL column type: {sql_type!r}")
+    return candidate
 
 
 class SQLAlchemyAdapter:
@@ -171,12 +193,22 @@ class SQLAlchemyAdapter:
             - table_config (list[dict]): A list of dictionaries representing the table's fields
               and their types.
         """
-        fields_query_parts = [f"{item['name']} {item['type']}" for item in table_config]
+        # Quote all identifiers (schema, table, column names) through the
+        # dialect's identifier preparer so they cannot break out of the
+        # identifier context and inject SQL. Column *types* are structural DDL
+        # and are validated against a conservative allowlist rather than quoted.
+        quote = self.engine.dialect.identifier_preparer.quote
+        q_schema = quote(schema_name)
+        q_table = quote(table_name)
+        fields_query_parts = [
+            f"{quote(item['name'])} {_validate_sql_type(item['type'])}" for item in table_config
+        ]
         async with self.engine.begin() as connection:
-            await connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema_name};"))
+            await connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {q_schema};"))
             await connection.execute(
                 text(
-                    f'CREATE TABLE IF NOT EXISTS {schema_name}."{table_name}" ({", ".join(fields_query_parts)});'
+                    f"CREATE TABLE IF NOT EXISTS {q_schema}.{q_table} "  # noqa: S608 - identifiers quoted, types validated
+                    f"({', '.join(fields_query_parts)});"
                 )
             )
             await connection.close()
@@ -192,14 +224,20 @@ class SQLAlchemyAdapter:
             - schema_name (Optional[str]): The name of the schema containing the table to
               delete, defaults to 'public'. (default 'public')
         """
+        quote = self.engine.dialect.identifier_preparer.quote
+        q_table = quote(table_name)
         async with self.engine.begin() as connection:
             if self.engine.dialect.name == "sqlite":
                 # SQLite doesn't support schema namespaces and the CASCADE keyword.
                 # However, foreign key constraint can be defined with ON DELETE CASCADE during table creation.
-                await connection.execute(text(f'DROP TABLE IF EXISTS "{table_name}";'))
+                await connection.execute(
+                    text(f"DROP TABLE IF EXISTS {q_table};")  # noqa: S608 - identifier quoted
+                )
             else:
                 await connection.execute(
-                    text(f'DROP TABLE IF EXISTS {schema_name}."{table_name}" CASCADE;')
+                    text(
+                        f"DROP TABLE IF EXISTS {quote(schema_name)}.{q_table} CASCADE;"  # noqa: S608 - identifier quoted
+                    )
                 )
 
     async def insert_data(

--- a/cognee/modules/search/methods/get_search_type_retriever_instance.py
+++ b/cognee/modules/search/methods/get_search_type_retriever_instance.py
@@ -34,6 +34,29 @@ from cognee.modules.retrieval.natural_language_retriever import NaturalLanguageR
 from cognee.modules.retrieval.agentic_retriever import AgenticRetriever
 from cognee.context_global_variables import session_user
 
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _cypher_queries_allowed() -> bool:
+    """Whether raw-Cypher / natural-language graph search may run.
+
+    ``CYPHER`` and ``NATURAL_LANGUAGE`` execute database-native queries against
+    the graph backend, so they are a powerful primitive that should not be
+    exposed by accident. To be secure-by-default:
+
+    - If ``ALLOW_CYPHER_QUERY`` is set, its value decides (robust truthy parse,
+      so a typo like ``"no"`` fails safe to disabled rather than enabled).
+    - If it is unset, these search types are enabled outside production but
+      **disabled in production** (``ENV=prod``), which must opt in explicitly.
+
+    This mirrors the production-hardening posture used for auth secrets
+    (``ENV`` defaults to ``prod``; see ``users.authentication.secret_utils``).
+    """
+    raw = os.getenv("ALLOW_CYPHER_QUERY")
+    if raw is not None:
+        return raw.strip().lower() in _TRUTHY
+    return os.getenv("ENV", "prod").lower() != "prod"
+
 
 async def get_search_type_retriever_instance(
     query_type: SearchType,
@@ -360,7 +383,7 @@ async def get_search_type_retriever_instance(
 
     if (
         query_type in [SearchType.CYPHER, SearchType.NATURAL_LANGUAGE]
-        and os.getenv("ALLOW_CYPHER_QUERY", "true").lower() == "false"
+        and not _cypher_queries_allowed()
     ):
         raise UnsupportedSearchTypeError("Cypher query search types are disabled.")
 

--- a/cognee/modules/users/authentication/get_api_auth_backend.py
+++ b/cognee/modules/users/authentication/get_api_auth_backend.py
@@ -15,7 +15,9 @@ def get_api_auth_backend():
     transport = api_bearer_transport
 
     def get_jwt_strategy() -> JWTStrategy[models.UP, models.ID]:
-        secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+        from .secret_utils import get_auth_secret
+
+        secret = get_auth_secret("FASTAPI_USERS_JWT_SECRET")
         lifetime_seconds = int(os.getenv("JWT_LIFETIME_SECONDS", "3600"))
 
         return APIJWTStrategy(secret, lifetime_seconds=lifetime_seconds)

--- a/cognee/modules/users/authentication/get_client_auth_backend.py
+++ b/cognee/modules/users/authentication/get_client_auth_backend.py
@@ -16,8 +16,9 @@ def get_client_auth_backend():
 
     def get_jwt_strategy() -> JWTStrategy[models.UP, models.ID]:
         from .default.default_jwt_strategy import DefaultJWTStrategy
+        from .secret_utils import get_auth_secret
 
-        secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+        secret = get_auth_secret("FASTAPI_USERS_JWT_SECRET")
         lifetime_seconds = int(os.getenv("JWT_LIFETIME_SECONDS", "3600"))
 
         return DefaultJWTStrategy(secret, lifetime_seconds=lifetime_seconds)

--- a/cognee/modules/users/authentication/secret_utils.py
+++ b/cognee/modules/users/authentication/secret_utils.py
@@ -1,0 +1,56 @@
+"""Helpers for loading authentication secrets safely.
+
+Historically the JWT / token secrets fell back to the hardcoded literal
+``"super_secret"`` when their environment variables were unset. That meant any
+deployment that forgot to configure them was signing tokens with a public,
+well-known key — allowing anyone to forge a valid JWT for any user (including a
+superuser) and fully bypass authentication.
+
+``get_auth_secret`` fixes this by refusing to start with an insecure default in
+a production environment. In non-production environments (``ENV`` != ``prod``)
+it falls back to a development default and logs a loud warning so local work is
+not disrupted.
+"""
+
+import os
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("auth_secret")
+
+# The old, publicly-known default. Treated as "not configured".
+_INSECURE_DEFAULT = "super_secret"
+
+# Development fallback used only when ENV is not production.
+_DEV_DEFAULT = "insecure-dev-secret-do-not-use-in-production"
+
+
+def _is_production() -> bool:
+    # Mirrors cognee.api.client: ENV defaults to "prod".
+    return os.getenv("ENV", "prod").lower() == "prod"
+
+
+def get_auth_secret(env_var: str) -> str:
+    """Return the configured secret for ``env_var``.
+
+    Raises ``RuntimeError`` in production when the secret is missing or set to a
+    known-insecure placeholder. Falls back to a dev-only value otherwise.
+    """
+    secret = os.getenv(env_var)
+
+    if secret and secret != _INSECURE_DEFAULT:
+        return secret
+
+    if _is_production():
+        raise RuntimeError(
+            f"{env_var} is not set (or uses the insecure default). Set a strong, "
+            f"random secret before running in production. Generate one with: "
+            f"python -c 'import secrets; print(secrets.token_urlsafe(64))'"
+        )
+
+    logger.warning(
+        "%s is not set — using an insecure development default. "
+        "This MUST be set to a strong random value in production.",
+        env_var,
+    )
+    return _DEV_DEFAULT

--- a/cognee/modules/users/get_user_manager.py
+++ b/cognee/modules/users/get_user_manager.py
@@ -1,4 +1,3 @@
-import os
 import re
 import json
 import uuid
@@ -14,6 +13,7 @@ from contextlib import asynccontextmanager
 
 from .models import User
 from .get_user_db import get_user_db
+from .authentication.secret_utils import get_auth_secret
 from cognee.modules.users.models.UserApiKey import UserApiKey
 from cognee.modules.users.api_key.hash_api_key import prepare_api_key
 from cognee.infrastructure.databases.relational import get_relational_engine
@@ -22,10 +22,8 @@ logger = logging.getLogger(__name__)
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
-    reset_password_token_secret = os.getenv(
-        "FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET", "super_secret"
-    )
-    verification_token_secret = os.getenv("FASTAPI_USERS_VERIFICATION_TOKEN_SECRET", "super_secret")
+    reset_password_token_secret = get_auth_secret("FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET")
+    verification_token_secret = get_auth_secret("FASTAPI_USERS_VERIFICATION_TOKEN_SECRET")
 
     async def on_after_login(
         self, user: User, request: Optional[Request] = None, response: Optional[Response] = None

--- a/cognee/modules/users/methods/create_default_user.py
+++ b/cognee/modules/users/methods/create_default_user.py
@@ -1,11 +1,51 @@
+import os
+import secrets
+
 from .create_user import create_user
 from cognee.base_config import get_base_config
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("create_default_user")
+
+
+def _is_production() -> bool:
+    # Mirrors cognee.api.client: ENV defaults to "prod".
+    return os.getenv("ENV", "prod").lower() == "prod"
+
+
+def _resolve_default_password(configured: str | None) -> str:
+    """Return the password for the auto-created default superuser.
+
+    Previously this fell back to the static, well-known literal
+    "default_password" for an ``is_superuser=True`` account — trivial admin
+    access on any deployment that didn't override it. Now:
+      * a configured password is used as-is;
+      * in production an unset password is a hard error (a superuser must have an
+        operator-set credential);
+      * otherwise a random password is generated so no known credential exists.
+    """
+    if configured:
+        return configured
+
+    if _is_production():
+        raise RuntimeError(
+            "DEFAULT_USER_PASSWORD is not set. The default superuser must have an "
+            "explicit password in production. Set DEFAULT_USER_PASSWORD (and "
+            "DEFAULT_USER_EMAIL) to strong values before starting."
+        )
+
+    generated = secrets.token_urlsafe(32)
+    logger.warning(
+        "DEFAULT_USER_PASSWORD is not set — generated a random password for the "
+        "default user. Set DEFAULT_USER_PASSWORD if you need to log in as this user."
+    )
+    return generated
 
 
 async def create_default_user():
     base_config = get_base_config()
     default_user_email = base_config.default_user_email or "default_user@example.com"
-    default_user_password = base_config.default_user_password or "default_password"
+    default_user_password = _resolve_default_password(base_config.default_user_password)
 
     user = await create_user(
         email=default_user_email,

--- a/cognee/shared/graph_model_utils.py
+++ b/cognee/shared/graph_model_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import keyword
 import re
 import sys
 import types
@@ -111,7 +112,83 @@ def datapoint_model_to_basemodel(
     return _to_base_model(model, {})
 
 
+# Names in the schema become Python class/attribute identifiers in code that is
+# subsequently exec()'d. Restrict them to plain identifiers so a crafted schema
+# cannot smuggle arbitrary code into the generated source. Also bound the schema
+# size/depth to reject abusive inputs.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_MAX_SCHEMA_MODELS = 200
+_MAX_SCHEMA_PROPERTIES = 200
+_MAX_SCHEMA_DEPTH = 20
+
+
+def _is_valid_identifier(name: Any) -> bool:
+    return (
+        isinstance(name, str)
+        and _IDENTIFIER_RE.match(name) is not None
+        and not keyword.iskeyword(name)
+    )
+
+
+def _validate_schema_node(node: Any, depth: int) -> None:
+    if depth > _MAX_SCHEMA_DEPTH:
+        raise ValueError("Graph schema nesting is too deep.")
+    if not isinstance(node, dict):
+        return
+
+    properties = node.get("properties")
+    if isinstance(properties, dict):
+        if len(properties) > _MAX_SCHEMA_PROPERTIES:
+            raise ValueError("Graph schema object has too many properties.")
+        for prop_name, prop_schema in properties.items():
+            if not _is_valid_identifier(prop_name):
+                raise ValueError(
+                    f"Graph schema property name is not a valid identifier: {prop_name!r}."
+                )
+            _validate_schema_node(prop_schema, depth + 1)
+
+    items = node.get("items")
+    if isinstance(items, dict):
+        _validate_schema_node(items, depth + 1)
+
+
+def _validate_graph_schema(schema: dict) -> None:
+    """Reject graph schemas whose names would produce unsafe generated code.
+
+    ``graph_schema_to_graph_model`` feeds a caller-supplied JSON schema (reachable
+    via ``POST /v1/cognify``) to a code generator whose output is ``exec()``'d.
+    Every name that becomes a generated identifier — the top-level ``title``, each
+    ``$defs``/``definitions`` key, and every property name — must be a plain Python
+    identifier.
+    """
+    if not isinstance(schema, dict):
+        raise ValueError("Graph schema must be a JSON object.")
+
+    if not _is_valid_identifier(schema.get("title")):
+        raise ValueError(
+            f"Graph schema 'title' must be a valid Python identifier, got "
+            f"{schema.get('title')!r}."
+        )
+
+    defs = schema.get("$defs") or schema.get("definitions") or {}
+    if not isinstance(defs, dict):
+        raise ValueError("Graph schema '$defs' must be an object.")
+    if len(defs) > _MAX_SCHEMA_MODELS:
+        raise ValueError("Graph schema has too many model definitions.")
+    for def_name in defs:
+        if not _is_valid_identifier(def_name):
+            raise ValueError(
+                f"Graph schema definition name is not a valid identifier: {def_name!r}."
+            )
+
+    _validate_schema_node(schema, 0)
+    for def_schema in defs.values():
+        _validate_schema_node(def_schema, 0)
+
+
 def graph_schema_to_graph_model(pydantic_json_schema: dict) -> BaseModel:
+    # Validate the untrusted schema before any code generation / exec.
+    _validate_graph_schema(pydantic_json_schema)
     # If a custom graph model is provided, convert it from dict to a Pydantic model class
     config = GenerateConfig(
         input_file_type=InputFileType.JsonSchema,

--- a/cognee/tasks/ingestion/migrate_relational_database.py
+++ b/cognee/tasks/ingestion/migrate_relational_database.py
@@ -154,6 +154,16 @@ async def schema_only_ingestion(schema):
 
 async def complete_database_ingestion(schema, migrate_column_data):
     engine = get_migration_relational_engine()
+
+    # Table/column names below come from the source database's introspected
+    # schema, i.e. from data outside Cognee's control. Interpolating them raw
+    # into SQL is an injection vector, so every identifier is passed through the
+    # dialect's identifier preparer, which quotes/escapes it for the target DB.
+    qi = engine.engine.dialect.identifier_preparer.quote
+
+    def qname(name: str) -> str:
+        return ".".join(qi(part) for part in str(name).split("."))
+
     # Create a mapping of node_id to node objects for referencing in edge creation
     node_mapping = {}
     edge_mapping = []
@@ -171,7 +181,9 @@ async def complete_database_ingestion(schema, migrate_column_data):
             node_mapping[table_name] = table_node
 
             # Fetch all rows for the current table
-            rows_result = await cursor.execute(text(f"SELECT * FROM {table_name};"))
+            rows_result = await cursor.execute(
+                text(f"SELECT * FROM {qname(table_name)};")  # noqa: S608 - identifier quoted
+            )
             rows = rows_result.fetchall()
 
             for row in rows:
@@ -271,13 +283,17 @@ async def complete_database_ingestion(schema, migrate_column_data):
                 else:
                     primary_key_col = details["primary_key"]
 
-                # Query to find relationships based on foreign keys
+                # Query to find relationships based on foreign keys. Every
+                # identifier (table names, aliases, column names) is quoted so a
+                # crafted source-schema name cannot inject SQL.
+                q_alias_1 = qi(alias_1)
+                q_alias_2 = qi(alias_2)
                 fk_query = text(
-                    f"SELECT {alias_1}.{primary_key_col} AS source_id, "
-                    f"{alias_2}.{fk['ref_column']} AS ref_value "
-                    f"FROM {table_name} AS {alias_1} "
-                    f"JOIN {fk['ref_table']} AS {alias_2} "
-                    f"ON {alias_1}.{fk['column']} = {alias_2}.{fk['ref_column']};"
+                    f"SELECT {q_alias_1}.{qi(primary_key_col)} AS source_id, "  # noqa: S608 - identifiers quoted
+                    f"{q_alias_2}.{qi(fk['ref_column'])} AS ref_value "
+                    f"FROM {qname(table_name)} AS {q_alias_1} "
+                    f"JOIN {qname(fk['ref_table'])} AS {q_alias_2} "
+                    f"ON {q_alias_1}.{qi(fk['column'])} = {q_alias_2}.{qi(fk['ref_column'])};"
                 )
 
                 fk_result = await cursor.execute(fk_query)

--- a/cognee/tasks/ingestion/save_data_item_to_storage.py
+++ b/cognee/tasks/ingestion/save_data_item_to_storage.py
@@ -10,7 +10,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from cognee.tasks.web_scraper.utils import fetch_page_content
 from cognee.tasks.ingestion.data_item import DataItem
-from cognee.tasks.ingestion.url_safety import assert_url_allowed
+from cognee.tasks.ingestion.url_safety import assert_url_allowed, assert_local_path_allowed
 
 
 logger = get_logger()
@@ -66,6 +66,7 @@ async def save_data_item_to_storage(data_item: Union[BinaryIO, str, Any]) -> str
         # data is local file path
         elif parsed_url.scheme == "file":
             if settings.accept_local_file_path:
+                assert_local_path_allowed(parsed_url.path)
                 return data_item
             else:
                 raise IngestionError(message="Local files are not accepted.")
@@ -78,6 +79,7 @@ async def save_data_item_to_storage(data_item: Union[BinaryIO, str, Any]) -> str
             if settings.accept_local_file_path:
                 # Normalize path separators before creating file URL
                 normalized_path = os.path.normpath(data_item)
+                assert_local_path_allowed(normalized_path)
                 return Path(normalized_path).as_uri()
             else:
                 raise IngestionError(message="Local files are not accepted.")
@@ -86,6 +88,7 @@ async def save_data_item_to_storage(data_item: Union[BinaryIO, str, Any]) -> str
             if settings.accept_local_file_path:
                 # Normalize path separators before creating file URL
                 normalized_path = os.path.normpath(abs_path)
+                assert_local_path_allowed(normalized_path)
                 return Path(normalized_path).as_uri()
 
         # data is text, save it to data storage and return the file path

--- a/cognee/tasks/ingestion/save_data_item_to_storage.py
+++ b/cognee/tasks/ingestion/save_data_item_to_storage.py
@@ -10,6 +10,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from cognee.tasks.web_scraper.utils import fetch_page_content
 from cognee.tasks.ingestion.data_item import DataItem
+from cognee.tasks.ingestion.url_safety import assert_url_allowed
 
 
 logger = get_logger()
@@ -59,6 +60,7 @@ async def save_data_item_to_storage(data_item: Union[BinaryIO, str, Any]) -> str
         if parsed_url.scheme == "s3":
             return data_item
         elif parsed_url.scheme == "http" or parsed_url.scheme == "https":
+            assert_url_allowed(data_item)
             urls_to_page_contents = await fetch_page_content(data_item)
             return await save_data_to_file(urls_to_page_contents[data_item], file_extension="html")
         # data is local file path

--- a/cognee/tasks/ingestion/url_safety.py
+++ b/cognee/tasks/ingestion/url_safety.py
@@ -1,0 +1,58 @@
+"""Safety guards for ingesting remote URLs.
+
+``save_data_item_to_storage`` will fetch any ``http(s)`` string handed to it.
+Without guards this is a Server-Side Request Forgery (SSRF) primitive: a caller
+can make the server request internal-only endpoints (cloud metadata at
+``169.254.169.254``, ``localhost`` admin panels, RFC-1918 hosts) and have the
+response ingested and later retrievable via search. The documented
+``ALLOW_HTTP_REQUESTS`` gate was also never actually enforced.
+"""
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+from cognee.modules.ingestion.exceptions import IngestionError
+
+
+def _http_requests_allowed() -> bool:
+    return os.getenv("ALLOW_HTTP_REQUESTS", "true").lower() == "true"
+
+
+def assert_url_allowed(url: str) -> None:
+    """Raise ``IngestionError`` if ``url`` must not be fetched.
+
+    Enforces ``ALLOW_HTTP_REQUESTS`` and blocks any host that resolves to a
+    private, loopback, link-local, reserved, multicast or unspecified address.
+    """
+    if not _http_requests_allowed():
+        raise IngestionError(message="HTTP requests are disabled (ALLOW_HTTP_REQUESTS=false).")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise IngestionError(message=f"Unsupported URL scheme for fetching: {parsed.scheme!r}")
+
+    host = parsed.hostname
+    if not host:
+        raise IngestionError(message="URL has no host.")
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        addr_infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as error:
+        raise IngestionError(message=f"Could not resolve host: {host}") from error
+
+    for info in addr_infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise IngestionError(
+                message=f"Refusing to fetch non-public address for host {host!r}: {ip}"
+            )

--- a/cognee/tasks/ingestion/url_safety.py
+++ b/cognee/tasks/ingestion/url_safety.py
@@ -11,6 +11,8 @@ response ingested and later retrievable via search. The documented
 import ipaddress
 import os
 import socket
+import tempfile
+from pathlib import Path
 from urllib.parse import urlparse
 
 from cognee.modules.ingestion.exceptions import IngestionError
@@ -56,3 +58,56 @@ def assert_url_allowed(url: str) -> None:
             raise IngestionError(
                 message=f"Refusing to fetch non-public address for host {host!r}: {ip}"
             )
+
+
+def _allowed_local_roots() -> list[str]:
+    """Directories that local files may be ingested from.
+
+    Overridable via the comma-separated ``LOCAL_FILE_ALLOWED_ROOTS`` env var. The
+    default set covers legitimate use (cognee's data directory, the working
+    directory, and the system temp dir) while excluding sensitive locations like
+    ``/etc``, ``/root``, ``~/.ssh`` and ``/proc``.
+    """
+    env = os.getenv("LOCAL_FILE_ALLOWED_ROOTS")
+    if env:
+        raw_roots = [r.strip() for r in env.split(",") if r.strip()]
+    else:
+        # Imported lazily to avoid a heavy import at module load.
+        from cognee.base_config import get_base_config
+
+        raw_roots = [
+            get_base_config().data_root_directory,
+            os.getcwd(),
+            tempfile.gettempdir(),
+        ]
+
+    resolved: list[str] = []
+    for root in raw_roots:
+        # Skip non-local roots (e.g. s3:// data directories); realpath them so
+        # symlinked roots compare correctly.
+        if "://" in root:
+            continue
+        resolved.append(os.path.realpath(root))
+    return resolved
+
+
+def assert_local_path_allowed(path: str) -> None:
+    """Raise ``IngestionError`` if ``path`` resolves outside the allowed roots.
+
+    ``os.path.realpath`` canonicalises the path, so symlinks that point outside an
+    allowed root are rejected rather than followed.
+    """
+    resolved = os.path.realpath(path)
+    for root in _allowed_local_roots():
+        try:
+            Path(resolved).relative_to(root)
+            return
+        except ValueError:
+            continue
+
+    raise IngestionError(
+        message=(
+            f"Refusing to ingest local file outside the allowed roots: {path!r}. "
+            "Set LOCAL_FILE_ALLOWED_ROOTS to permit additional directories."
+        )
+    )

--- a/cognee/tests/unit/security/test_security_hardening.py
+++ b/cognee/tests/unit/security/test_security_hardening.py
@@ -1,14 +1,19 @@
-"""Unit tests for the Critical + High security fixes.
+"""Unit tests for the Critical + High + Medium/Low security fixes.
 
 Covers:
   * C-2 get_auth_secret fail-hard behavior
   * C-1 graph schema identifier validation
   * H-2 SSRF URL guard
   * H-3 local-file allowlist
+  * M-1 SQL column-type allowlist (DDL injection guard)
+  * M-2 Cypher / natural-language search secure-by-default gate
+  * L-1 Zip Slip guard for the downloaded UI bundle
 """
 
+import io
 import os
 import tempfile
+import zipfile
 
 import pytest
 
@@ -155,3 +160,105 @@ class TestAssertLocalPathAllowed:
         monkeypatch.setenv("LOCAL_FILE_ALLOWED_ROOTS", tempfile.gettempdir())
         with pytest.raises(IngestionError):
             assert_local_path_allowed("/etc/passwd")
+
+
+# --------------------------------------------------------------------------- #
+# M-1 — SQL column-type allowlist (DDL injection guard)
+# --------------------------------------------------------------------------- #
+class TestValidateSqlType:
+    @pytest.mark.parametrize(
+        "sql_type",
+        ["TEXT", "VARCHAR(255)", "NUMERIC(10, 2)", "integer", "double precision", "INT[]"],
+    )
+    def test_valid_types_pass(self, sql_type):
+        from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+            _validate_sql_type,
+        )
+
+        assert _validate_sql_type(sql_type) == sql_type.strip()
+
+    @pytest.mark.parametrize(
+        "sql_type",
+        [
+            "TEXT); DROP TABLE users;--",
+            "TEXT DEFAULT (SELECT password FROM users)",
+            "'; --",
+            "",
+            "INT) --",
+        ],
+    )
+    def test_injection_types_rejected(self, sql_type):
+        from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
+            _validate_sql_type,
+        )
+
+        with pytest.raises(ValueError):
+            _validate_sql_type(sql_type)
+
+
+# --------------------------------------------------------------------------- #
+# M-2 — Cypher / natural-language search secure-by-default gate
+# --------------------------------------------------------------------------- #
+class TestCypherQueriesAllowed:
+    def _fn(self):
+        from cognee.modules.search.methods.get_search_type_retriever_instance import (
+            _cypher_queries_allowed,
+        )
+
+        return _cypher_queries_allowed
+
+    def test_disabled_by_default_in_production(self, monkeypatch):
+        monkeypatch.setenv("ENV", "prod")
+        monkeypatch.delenv("ALLOW_CYPHER_QUERY", raising=False)
+        assert self._fn()() is False
+
+    def test_enabled_by_default_outside_production(self, monkeypatch):
+        monkeypatch.setenv("ENV", "dev")
+        monkeypatch.delenv("ALLOW_CYPHER_QUERY", raising=False)
+        assert self._fn()() is True
+
+    def test_explicit_true_enables_even_in_production(self, monkeypatch):
+        monkeypatch.setenv("ENV", "prod")
+        monkeypatch.setenv("ALLOW_CYPHER_QUERY", "true")
+        assert self._fn()() is True
+
+    @pytest.mark.parametrize("value", ["false", "no", "0", "off", "maybe", ""])
+    def test_non_truthy_values_fail_safe(self, monkeypatch, value):
+        monkeypatch.setenv("ENV", "dev")
+        monkeypatch.setenv("ALLOW_CYPHER_QUERY", value)
+        assert self._fn()() is False
+
+
+# --------------------------------------------------------------------------- #
+# L-1 — Zip Slip guard (downloaded UI bundle extraction)
+# --------------------------------------------------------------------------- #
+class TestZipSlipGuard:
+    def _extract_with_guard(self, names, dest):
+        """Replicates the guard applied in cognee/api/v1/ui/ui.py before extractall."""
+        import os as _os
+        from pathlib import Path
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for n in names:
+                zf.writestr(n, "x")
+        buf.seek(0)
+
+        extract_dir = Path(dest)
+        extract_root = extract_dir.resolve()
+        with zipfile.ZipFile(buf, "r") as zip_file:
+            for member in zip_file.namelist():
+                target = (extract_dir / member).resolve()
+                if target != extract_root and extract_root not in target.parents:
+                    raise ValueError(f"Unsafe path in downloaded UI archive: {member!r}")
+            zip_file.extractall(extract_dir)
+
+    def test_safe_archive_extracts(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._extract_with_guard(["cognee-1.0/cognee-frontend/index.html"], d)
+
+    @pytest.mark.parametrize("evil", ["../evil.txt", "../../etc/passwd", "a/../../evil"])
+    def test_zip_slip_member_rejected(self, evil):
+        with tempfile.TemporaryDirectory() as d:
+            with pytest.raises(ValueError):
+                self._extract_with_guard([evil], d)

--- a/cognee/tests/unit/security/test_security_hardening.py
+++ b/cognee/tests/unit/security/test_security_hardening.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Critical + High security fixes.
+
+Covers:
+  * C-2 get_auth_secret fail-hard behavior
+  * C-1 graph schema identifier validation
+  * H-2 SSRF URL guard
+  * H-3 local-file allowlist
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from cognee.modules.ingestion.exceptions import IngestionError
+
+
+# --------------------------------------------------------------------------- #
+# C-2 — auth secrets
+# --------------------------------------------------------------------------- #
+class TestGetAuthSecret:
+    def test_returns_configured_value(self, monkeypatch):
+        from cognee.modules.users.authentication.secret_utils import get_auth_secret
+
+        monkeypatch.setenv("SOME_SECRET", "a-real-secret")
+        assert get_auth_secret("SOME_SECRET") == "a-real-secret"
+
+    def test_raises_in_production_when_unset(self, monkeypatch):
+        from cognee.modules.users.authentication.secret_utils import get_auth_secret
+
+        monkeypatch.setenv("ENV", "prod")
+        monkeypatch.delenv("SOME_SECRET", raising=False)
+        with pytest.raises(RuntimeError):
+            get_auth_secret("SOME_SECRET")
+
+    def test_raises_in_production_on_insecure_default(self, monkeypatch):
+        from cognee.modules.users.authentication.secret_utils import get_auth_secret
+
+        monkeypatch.setenv("ENV", "prod")
+        monkeypatch.setenv("SOME_SECRET", "super_secret")
+        with pytest.raises(RuntimeError):
+            get_auth_secret("SOME_SECRET")
+
+    def test_dev_fallback_when_not_production(self, monkeypatch):
+        from cognee.modules.users.authentication.secret_utils import get_auth_secret
+
+        monkeypatch.setenv("ENV", "dev")
+        monkeypatch.delenv("SOME_SECRET", raising=False)
+        assert get_auth_secret("SOME_SECRET")  # non-empty dev default, no raise
+
+
+# --------------------------------------------------------------------------- #
+# C-1 — graph schema validation
+# --------------------------------------------------------------------------- #
+class TestValidateGraphSchema:
+    def _valid_schema(self):
+        return {
+            "title": "ProgrammingLanguage",
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "$defs": {"FieldType": {"type": "object", "properties": {"name": {"type": "string"}}}},
+        }
+
+    def test_valid_schema_passes(self):
+        from cognee.shared.graph_model_utils import _validate_graph_schema
+
+        _validate_graph_schema(self._valid_schema())
+
+    def test_bad_title_rejected(self):
+        from cognee.shared.graph_model_utils import _validate_graph_schema
+
+        schema = self._valid_schema()
+        schema["title"] = "x = __import__('os')"
+        with pytest.raises(ValueError):
+            _validate_graph_schema(schema)
+
+    def test_bad_property_name_rejected(self):
+        from cognee.shared.graph_model_utils import _validate_graph_schema
+
+        schema = self._valid_schema()
+        schema["properties"] = {"bad-name": {"type": "string"}}
+        with pytest.raises(ValueError):
+            _validate_graph_schema(schema)
+
+    def test_bad_def_name_rejected(self):
+        from cognee.shared.graph_model_utils import _validate_graph_schema
+
+        schema = self._valid_schema()
+        schema["$defs"] = {"import os": {"type": "object"}}
+        with pytest.raises(ValueError):
+            _validate_graph_schema(schema)
+
+
+# --------------------------------------------------------------------------- #
+# H-2 — SSRF URL guard
+# --------------------------------------------------------------------------- #
+def _fake_getaddrinfo(ip):
+    def _inner(host, port, *args, **kwargs):
+        return [(2, 1, 6, "", (ip, port or 80))]
+
+    return _inner
+
+
+class TestAssertUrlAllowed:
+    def test_public_url_allowed(self, monkeypatch):
+        import cognee.tasks.ingestion.url_safety as url_safety
+
+        monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+        url_safety.assert_url_allowed("http://example.com/page")
+
+    @pytest.mark.parametrize("ip", ["127.0.0.1", "169.254.169.254", "10.0.0.5", "192.168.1.2"])
+    def test_internal_ip_blocked(self, monkeypatch, ip):
+        import cognee.tasks.ingestion.url_safety as url_safety
+
+        monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+        monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake_getaddrinfo(ip))
+        with pytest.raises(IngestionError):
+            url_safety.assert_url_allowed("http://internal.example/")
+
+    def test_disabled_when_flag_off(self, monkeypatch):
+        import cognee.tasks.ingestion.url_safety as url_safety
+
+        monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "false")
+        with pytest.raises(IngestionError):
+            url_safety.assert_url_allowed("http://example.com/")
+
+    def test_non_http_scheme_blocked(self, monkeypatch):
+        import cognee.tasks.ingestion.url_safety as url_safety
+
+        monkeypatch.setenv("ALLOW_HTTP_REQUESTS", "true")
+        with pytest.raises(IngestionError):
+            url_safety.assert_url_allowed("ftp://example.com/")
+
+
+# --------------------------------------------------------------------------- #
+# H-3 — local-file allowlist
+# --------------------------------------------------------------------------- #
+class TestAssertLocalPathAllowed:
+    def test_path_inside_allowed_root(self, monkeypatch):
+        from cognee.tasks.ingestion.url_safety import assert_local_path_allowed
+
+        tmp_dir = tempfile.gettempdir()
+        monkeypatch.setenv("LOCAL_FILE_ALLOWED_ROOTS", tmp_dir)
+        with tempfile.NamedTemporaryFile(dir=tmp_dir, delete=False) as f:
+            path = f.name
+        try:
+            assert_local_path_allowed(path)  # no raise
+        finally:
+            os.unlink(path)
+
+    def test_path_outside_allowed_root_blocked(self, monkeypatch):
+        from cognee.tasks.ingestion.url_safety import assert_local_path_allowed
+
+        monkeypatch.setenv("LOCAL_FILE_ALLOWED_ROOTS", tempfile.gettempdir())
+        with pytest.raises(IngestionError):
+            assert_local_path_allowed("/etc/passwd")


### PR DESCRIPTION
Fixes 2 Critical + 3 High + 4 Medium/Low findings from a security review, one logical change per finding with unit tests in `cognee/tests/unit/security/`.

## Critical / High
- **C-1** RCE via `exec()` on user-supplied graph schema — strict identifier/shape validation before code generation (`cognee/shared/graph_model_utils.py`).
- **C-2** Hardcoded `"super_secret"` auth secrets — fail-hard in production, dev-only fallback with a warning (`cognee/modules/users/authentication/secret_utils.py` + call sites).
- **H-1** Default superuser with `"default_password"` — random password when unconfigured; required in production.
- **H-2** SSRF on URL ingestion — enforce `ALLOW_HTTP_REQUESTS` and block private/loopback/link-local/metadata IPs (`cognee/tasks/ingestion/url_safety.py`).
- **H-3** Local file read via `file://`/absolute paths — restrict to an allowlist of roots (`LOCAL_FILE_ALLOWED_ROOTS`).

## Medium / Low
- **M-1** SQL identifier injection — table/schema/column names from an external source database were interpolated raw into SQL (relational migration + dynamic `CREATE`/`DROP TABLE`). Identifiers are now quoted via the SQLAlchemy dialect identifier preparer; column types are validated against an allowlist (`migrate_relational_database.py`, `SqlAlchemyAdapter.py`).
- **M-2** Cypher/NL search permissive by default — `CYPHER`/`NATURAL_LANGUAGE` run database-native queries. Now secure-by-default: unset ⇒ enabled outside prod, **disabled in production** (`ENV=prod`); non-truthy values fail safe.
- **L-1** Zip Slip in the downloaded UI bundle — members resolving outside the extraction dir (`..`/absolute) are rejected before extraction (`cognee/api/v1/ui/ui.py`).
- **L-2** Credentialed CORS — `allow_credentials` is dropped (with a warning) when `CORS_ALLOWED_ORIGINS` contains a wildcard `*`.

## Notes
- New required env in production: `FASTAPI_USERS_JWT_SECRET` (+ reset/verification secrets), `DEFAULT_USER_PASSWORD`.
- `ALLOW_HTTP_REQUESTS` is now actually enforced; `ALLOW_CYPHER_QUERY` is secure-by-default in production.
- Local-file ingestion limited to data dir + cwd + temp by default; override via `LOCAL_FILE_ALLOWED_ROOTS`.
- Docs updated in `.env.template` and `CLAUDE.md` (Security Considerations + a defense-in-depth subsection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)