### PR TITLE
Created a small regression test to lock in the dependency fix.

### DIFF
--- a/cognee/tests/unit/test_pyproject_dependencies.py
+++ b/cognee/tests/unit/test_pyproject_dependencies.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+
+def test_pylance_is_dev_optional_dependency_only():
+    pyproject_path = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    pyproject_text = pyproject_path.read_text(encoding="utf-8")
+
+    assert "pylance>=0.22.0,<=0.36.0" in pyproject_text
+
+    current_section = None
+    in_dependencies = False
+    in_dev = False
+    runtime_dependencies = []
+    dev_dependencies = []
+
+    for line in pyproject_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if stripped.startswith("[") and stripped.endswith("]"):
+            current_section = stripped
+            in_dependencies = False
+            in_dev = False
+            continue
+
+        if current_section == "[project]":
+            if stripped.startswith("dependencies") and stripped.endswith("["):
+                in_dependencies = True
+                continue
+            if in_dependencies:
+                if stripped.startswith("]"):
+                    in_dependencies = False
+                else:
+                    runtime_dependencies.append(stripped)
+
+        elif current_section == "[project.optional-dependencies]":
+            if stripped.startswith("dev") and stripped.endswith("["):
+                in_dev = True
+                continue
+            if in_dev:
+                if stripped.startswith("]"):
+                    in_dev = False
+                else:
+                    dev_dependencies.append(stripped)
+
+    assert any("pylance>=0.22.0,<=0.36.0" in dep for dep in dev_dependencies), (
+        "Expected pylance to be declared in [project.optional-dependencies].dev"
+    )
+    assert not any("pylance>=0.22.0,<=0.36.0" in dep for dep in runtime_dependencies), (
+        "Expected pylance to be removed from the [project].dependencies runtime list"
+    )


### PR DESCRIPTION
fixes #3832

Description
Added a focused regression test that validates [pyproject.toml] dependency metadata. The new test ensures pylance is not included in runtime dependencies and is declared only under [project.optional-dependencies].dev.

Acceptance Criteria
[pyproject.toml] is checked for the pylance>=0.22.0,<=0.36.0 dependency.
The test verifies pylance does not appear in [project].dependencies.
The test verifies pylance appears under [project.optional-dependencies].dev.

Type of Change
 Bug fix (non-breaking change that fixes an issue)
 
Screenshots
N/A

Pre-submission Checklist

 I have tested my changes thoroughly before submitting this PR
 This PR contains minimal changes necessary to address the issue
 My code follows the project's coding standards and style guidelines
 I have added tests that prove my fix is effective or that my feature works
 I have added necessary documentation (if applicable)
 All new and existing tests pass
 I have searched existing PRs to ensure this change hasn't been submitted already
 I have linked any relevant issues in the description
 My commits have clear and descriptive messages
 
 DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

