### PR TITLE
Fix: Add missing super().__init__ to database exceptions (Resolves #3749)

### DIFF
--- a/cognee/infrastructure/databases/exceptions/exceptions.py
+++ b/cognee/infrastructure/databases/exceptions/exceptions.py
@@ -43,10 +43,7 @@ class EntityNotFoundError(CogneeValidationError):
         name: str = "EntityNotFoundError",
         status_code=status.HTTP_404_NOT_FOUND,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
-        # super().__init__(message, name, status_code) :TODO: This is not an error anymore with the dynamic exception handling therefore we shouldn't log error
+        super().__init__(message, name, status_code)
 
 
 class EntityAlreadyExistsError(CogneeValidationError):
@@ -81,9 +78,7 @@ class NodesetFilterNotSupportedError(CogneeConfigurationError):
         name: str = "NodeSetFilterNotSupportedError",
         status_code=status.HTTP_404_NOT_FOUND,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
+        super().__init__(message, name, status_code)
 
 
 class EmbeddingException(CogneeConfigurationError):


### PR DESCRIPTION
This PR adds the missing \super().__init__(message, name, status_code)\ calls to \EntityNotFoundError\ and \NodesetFilterNotSupportedError\ in \exceptions.py\ to properly initialize the base exception classes and ensure correct logging and error tracking. Resolves #3749.