### PR TITLE
Fix: Standardize deadlock_retry limits and docstring (Resolves #3757)

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
@@ -10,16 +10,14 @@ logger = get_logger("deadlock_retry")
 
 def deadlock_retry(max_retries=10):
     """
-    Decorator that automatically retries an asynchronous function when rate limit errors occur.
+    Decorator that automatically retries an asynchronous function when Neo4j deadlocks, 
+    transient errors, or database unavailability occur.
 
     This decorator implements an exponential backoff strategy with jitter
-    to handle rate limit errors efficiently.
+    to handle these errors efficiently.
 
     Args:
-        max_retries: Maximum number of retry attempts.
-        initial_backoff: Initial backoff time in seconds.
-        backoff_factor: Multiplier for exponential backoff.
-        jitter: Jitter factor to avoid the thundering herd problem.
+        max_retries: Maximum number of retry attempts (default is 10).
 
     Returns:
         The decorated async function.
@@ -44,6 +42,11 @@ def deadlock_retry(max_retries=10):
                 try:
                     attempt += 1
                     return await func(self, *args, **kwargs)
+                except DatabaseUnavailable:
+                    if attempt > max_retries:
+                        raise  # Re-raise the original error
+
+                    await wait()
                 except Neo4jError as error:
                     if attempt > max_retries:
                         raise  # Re-raise the original error
@@ -53,11 +56,6 @@ def deadlock_retry(max_retries=10):
                         await wait()
                     else:
                         raise  # Re-raise the original error
-                except DatabaseUnavailable:
-                    if attempt >= max_retries:
-                        raise  # Re-raise the original error
-
-                    await wait()
 
         return wrapper
 

--- a/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
@@ -1,7 +1,7 @@
 import pytest
 import asyncio
-from unittest.mock import MagicMock
-from neo4j.exceptions import Neo4jError
+from unittest.mock import MagicMock, AsyncMock
+from neo4j.exceptions import Neo4jError, DatabaseUnavailable
 from cognee.infrastructure.databases.graph.neo4j_driver.deadlock_retry import deadlock_retry
 
 
@@ -45,11 +45,57 @@ async def test_deadlock_retry_exhaustive():
     assert result, "Function should have succeded on second time"
 
 
+@pytest.mark.asyncio
+async def test_database_unavailable_retry_succeeds():
+    """DatabaseUnavailable should retry and succeed within max_retries."""
+    mock_function = AsyncMock(side_effect=[DatabaseUnavailable(), True])
+
+    wrapped_function = deadlock_retry(max_retries=2)(mock_function)
+
+    result = await wrapped_function(self=None)
+    assert result, "Function should have succeeded after one DatabaseUnavailable retry"
+
+
+@pytest.mark.asyncio
+async def test_database_unavailable_exhausts_retries():
+    """DatabaseUnavailable should re-raise once max_retries is exhausted."""
+    mock_function = AsyncMock(
+        side_effect=[DatabaseUnavailable(), DatabaseUnavailable()]
+    )
+
+    wrapped_function = deadlock_retry(max_retries=1)(mock_function)
+
+    with pytest.raises(DatabaseUnavailable):
+        await wrapped_function(self=None)
+
+
+@pytest.mark.asyncio
+async def test_database_unavailable_retries_match_neo4j_error():
+    """DatabaseUnavailable and Neo4jError should both allow exactly max_retries attempts.
+
+    This test directly validates the fix from issue #3757: the DatabaseUnavailable
+    handler previously used >= max_retries (re-raising one attempt too early),
+    while Neo4jError used > max_retries. Both now use > max_retries.
+    """
+    # With max_retries=2, we should be able to fail twice and succeed on the 3rd attempt.
+    mock_function = AsyncMock(
+        side_effect=[DatabaseUnavailable(), DatabaseUnavailable(), True]
+    )
+
+    wrapped_function = deadlock_retry(max_retries=2)(mock_function)
+
+    result = await wrapped_function(self=None)
+    assert result, "Function should have succeeded on the last allowed retry attempt"
+
+
 if __name__ == "__main__":
 
     async def main():
         await test_deadlock_retry()
         await test_deadlock_retry_errored()
         await test_deadlock_retry_exhaustive()
+        await test_database_unavailable_retry_succeeds()
+        await test_database_unavailable_exhausts_retries()
+        await test_database_unavailable_retries_match_neo4j_error()
 
     asyncio.run(main())


### PR DESCRIPTION
This PR standardizes the loop condition and updates the docstring in the deadlock_retry decorator to ensure DatabaseUnavailable and Neo4jError both retry the exact max_retries amount before failing, resolving #3757.