### PR TITLE
Fix inconsistent retry limit check in deadlock_retry

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/deadlock_retry.py
@@ -17,9 +17,6 @@ def deadlock_retry(max_retries=10):
 
     Args:
         max_retries: Maximum number of retry attempts.
-        initial_backoff: Initial backoff time in seconds.
-        backoff_factor: Multiplier for exponential backoff.
-        jitter: Jitter factor to avoid the thundering herd problem.
 
     Returns:
         The decorated async function.
@@ -54,7 +51,7 @@ def deadlock_retry(max_retries=10):
                     else:
                         raise  # Re-raise the original error
                 except DatabaseUnavailable:
-                    if attempt >= max_retries:
+                    if attempt > max_retries:
                         raise  # Re-raise the original error
 
                     await wait()


### PR DESCRIPTION
Fixes #3757

## Description
This PR fixes the inconsistent retry limit check in the `deadlock_retry` decorator.

The retry condition for `DatabaseUnavailable` has been changed from `attempt >= max_retries` to `attempt > max_retries` so it matches the retry behavior used for `Neo4jError`.

I also removed outdated parameter descriptions from the docstring that were no longer present in the function signature.

## Acceptance Criteria
- Retry limit check for `DatabaseUnavailable` now matches the behavior used for `Neo4jError`.
- The docstring accurately reflects the function signature.
- Unit tests pass successfully.

## Type of Change
☑ Bug fix (non-breaking change that fixes an issue)

## Screenshots
<img width="1413" height="550" alt="neo4j_deadlock_test py - cognee - Visual Studio Code 03-07-2026 11_13_19 PM" src="https://github.com/user-attachments/assets/35090919-0b05-4c97-9007-674d17583c8d" />

## Pre-submission Checklist
☑ I have tested my changes thoroughly before submitting this PR
☑ This PR contains minimal changes necessary to address the issue/feature
☑ My code follows the project's coding standards and style guidelines
☑ All new and existing tests pass
☑ I have searched existing PRs to ensure this change hasn't been submitted already
☑ I have linked any relevant issues in the description
☑ My commits have clear and descriptive messages
