### PR TITLE
feat(llm): simplify LLM configuration — provider inference, quote-strip, rate-limit move, Ollama cross-config, instructor-mode table (part of #3382)

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -81,6 +81,12 @@ class EmbeddingConfig(BaseSettings):
     embedding_max_completion_tokens: Optional[int] = 8191
     embedding_batch_size: Optional[int] = None
     huggingface_tokenizer: Optional[str] = None
+    # Rate-limiting for embedding requests. Lives here (not in LLMConfig) so the
+    # knobs sit with the embedding settings they govern.
+    embedding_rate_limit_enabled: bool = False
+    embedding_rate_limit_requests: int = 60
+    embedding_rate_limit_interval: int = 60  # seconds (default: 60 requests per minute)
+    embedding_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
     def model_post_init(self, __context) -> None:
@@ -124,6 +130,10 @@ class EmbeddingConfig(BaseSettings):
             "embedding_api_version": self.embedding_api_version,
             "embedding_max_completion_tokens": self.embedding_max_completion_tokens,
             "huggingface_tokenizer": self.huggingface_tokenizer,
+            "embedding_rate_limit_enabled": self.embedding_rate_limit_enabled,
+            "embedding_rate_limit_requests": self.embedding_rate_limit_requests,
+            "embedding_rate_limit_interval": self.embedding_rate_limit_interval,
+            "embedding_rate_limit_tokens": self.embedding_rate_limit_tokens,
         }
 
 

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -12,6 +12,26 @@ except ImportError:
     ClientRegistry = None
 
 
+# Provider identifiers cognee can dispatch to. Kept in sync with the
+# ``LLMProvider`` enum in
+# ``.structured_output_framework.litellm_instructor.llm.get_llm_client``; a unit
+# test asserts the two stay aligned. Defined here rather than imported to avoid a
+# circular import, since that module imports from this one.
+KNOWN_LLM_PROVIDERS = frozenset(
+    {
+        "openai",
+        "ollama",
+        "anthropic",
+        "custom",
+        "gemini",
+        "mistral",
+        "azure",
+        "bedrock",
+        "llama_cpp",
+    }
+)
+
+
 class LLMConfig(BaseSettings):
     """
     Configuration settings for the LLM (Large Language Model) provider and related options.
@@ -30,9 +50,6 @@ class LLMConfig(BaseSettings):
     - llm_rate_limit_enabled
     - llm_rate_limit_requests
     - llm_rate_limit_interval
-    - embedding_rate_limit_enabled
-    - embedding_rate_limit_requests
-    - embedding_rate_limit_interval
 
     Public methods include:
     - ensure_env_vars_for_ollama
@@ -65,10 +82,6 @@ class LLMConfig(BaseSettings):
     llm_rate_limit_requests: int = 60
     llm_rate_limit_interval: int = 60  # in seconds (default is 60 requests per minute)
     llm_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
-    embedding_rate_limit_enabled: bool = False
-    embedding_rate_limit_requests: int = 60
-    embedding_rate_limit_interval: int = 60  # in seconds (default is 60 requests per minute)
-    embedding_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
 
     llama_cpp_model_path: str | None = None
     llama_cpp_n_ctx: int = 2048
@@ -90,37 +103,58 @@ class LLMConfig(BaseSettings):
     @model_validator(mode="after")
     def strip_quotes_from_strings(self) -> "LLMConfig":
         """
-        Strip surrounding quotes from specific string fields that often come from
+        Strip surrounding quotes from string fields that often arrive from
         environment variables with extra quotes (e.g., via Docker's --env-file).
 
-        Only applies to known config keys where quotes are invalid or cause issues.
+        Applies to every declared string field rather than a hand-maintained
+        allow-list, so newly added string fields are covered automatically.
+        Only a matching pair of surrounding quotes (both ``'`` or both ``"``) is
+        removed; mismatched or internal quotes are left untouched.
         """
-        string_fields_to_strip = [
-            "llm_api_key",
-            "llm_endpoint",
-            "llm_api_version",
-            "baml_llm_api_key",
-            "baml_llm_endpoint",
-            "baml_llm_api_version",
-            "fallback_api_key",
-            "fallback_endpoint",
-            "fallback_model",
-            "llm_provider",
-            "llm_model",
-            "baml_llm_provider",
-            "baml_llm_model",
-            "llama_cpp_model_path",
-            "llama_cpp_chat_format",
-        ]
-
-        cls = self.__class__
-        for field_name in string_fields_to_strip:
-            if field_name not in cls.model_fields:
-                continue
+        for field_name in self.__class__.model_fields:
             value = getattr(self, field_name, None)
             if isinstance(value, str) and len(value) >= 2:
                 if value[0] == value[-1] and value[0] in ("'", '"'):
                     setattr(self, field_name, value[1:-1])
+
+        return self
+
+    @model_validator(mode="after")
+    def infer_provider_from_model(self) -> "LLMConfig":
+        """
+        Infer ``llm_provider`` from the ``llm_model`` prefix when the provider was
+        not set explicitly.
+
+        LiteLLM-style model identifiers embed the provider as a prefix
+        (e.g. ``"anthropic/claude-3-5-sonnet"``). When only ``LLM_MODEL`` is
+        supplied, the provider is derived from that prefix so ``LLM_PROVIDER``
+        becomes optional.
+
+        Inference is intentionally conservative: it only applies when the prefix
+        is a provider cognee actually supports (see ``KNOWN_LLM_PROVIDERS``).
+        A prefixed model whose prefix is *not* a supported provider (e.g.
+        ``"openrouter/..."``, which is configured via ``LLM_PROVIDER="custom"``)
+        raises ``ProviderNotDeducibleError`` rather than silently falling back to
+        a default that would fail downstream, so the user is told to set
+        ``LLM_PROVIDER`` explicitly. An explicitly provided ``llm_provider``
+        (keyword argument or environment variable) always takes precedence, as
+        does a model without a ``"/"`` prefix.
+
+        Runs after ``strip_quotes_from_strings`` so the model prefix is compared
+        without surrounding quotes.
+        """
+        if "llm_provider" in self.model_fields_set:
+            return self
+
+        model = self.llm_model
+        if isinstance(model, str) and "/" in model:
+            prefix = model.split("/", 1)[0].strip().lower()
+            if prefix in KNOWN_LLM_PROVIDERS:
+                self.llm_provider = prefix
+            else:
+                from cognee.infrastructure.llm.exceptions import ProviderNotDeducibleError
+
+                raise ProviderNotDeducibleError(model)
 
         return self
 
@@ -186,9 +220,10 @@ class LLMConfig(BaseSettings):
             val = os.environ.get(var_name)
             return val is not None and val.strip() != ""
 
-        #
-        # 1. Check LLM environment variables
-        #
+        # Check LLM environment variables. Embedding env vars are intentionally
+        # not validated here: that is EmbeddingConfig's responsibility, and
+        # reaching into embedding settings from LLMConfig via raw os.environ was
+        # an improper cross-config dependency.
         llm_env_vars = {
             "LLM_MODEL": is_env_set("LLM_MODEL"),
             "LLM_ENDPOINT": is_env_set("LLM_ENDPOINT"),
@@ -199,23 +234,6 @@ class LLMConfig(BaseSettings):
             raise ValueError(
                 "You have set some but not all of the required environment variables "
                 f"for LLM usage (LLM_MODEL, LLM_ENDPOINT, LLM_API_KEY). Missing: {missing_llm}"
-            )
-
-        #
-        # 2. Check embedding environment variables
-        #
-        embedding_env_vars = {
-            "EMBEDDING_PROVIDER": is_env_set("EMBEDDING_PROVIDER"),
-            "EMBEDDING_MODEL": is_env_set("EMBEDDING_MODEL"),
-            "EMBEDDING_DIMENSIONS": is_env_set("EMBEDDING_DIMENSIONS"),
-        }
-        if any(embedding_env_vars.values()) and not all(embedding_env_vars.values()):
-            missing_embed = [key for key, is_set in embedding_env_vars.items() if not is_set]
-            raise ValueError(
-                "You have set some but not all of the required environment variables "
-                "for embeddings (EMBEDDING_PROVIDER, EMBEDDING_MODEL, "
-                "EMBEDDING_DIMENSIONS). Missing: "
-                f"{missing_embed}"
             )
 
         return self
@@ -245,9 +263,6 @@ class LLMConfig(BaseSettings):
             "rate_limit_enabled": self.llm_rate_limit_enabled,
             "rate_limit_requests": self.llm_rate_limit_requests,
             "rate_limit_interval": self.llm_rate_limit_interval,
-            "embedding_rate_limit_enabled": self.embedding_rate_limit_enabled,
-            "embedding_rate_limit_requests": self.embedding_rate_limit_requests,
-            "embedding_rate_limit_interval": self.embedding_rate_limit_interval,
             "fallback_api_key": self.fallback_api_key,
             "fallback_endpoint": self.fallback_endpoint,
             "fallback_model": self.fallback_model,

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -24,6 +24,22 @@ class UnsupportedLLMProviderError(CogneeValidationError):
         super().__init__(message=message, name="UnsupportedLLMProviderError")
 
 
+class ProviderNotDeducibleError(CogneeValidationError):
+    """
+    Raised when ``llm_provider`` is not set and cannot be inferred from the
+    ``llm_model`` prefix because the prefix is not a provider cognee supports.
+
+    Tells the user to set the provider explicitly, since it could not be inferred.
+    """
+
+    def __init__(self, model: str) -> None:
+        message = (
+            f"Could not infer an LLM provider from LLM_MODEL={model!r}: the prefix "
+            "is not a provider cognee supports. Set LLM_PROVIDER explicitly."
+        )
+        super().__init__(message=message, name="ProviderNotDeducibleError")
+
+
 class MissingSystemPromptPathError(CogneeValidationError):
     def __init__(
         self,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/anthropic/adapter.py
@@ -4,6 +4,9 @@ from typing import Any
 
 import anthropic  # ty:ignore[unresolved-import]
 import instructor
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+    get_instructor_mode,
+)
 import litellm
 from instructor.core.patch import AsyncInstructorChatCompletionCreate
 from pydantic import BaseModel
@@ -36,7 +39,7 @@ class AnthropicAdapter(GenericAPIAdapter):
     and prompt display.
     """
 
-    default_instructor_mode = "anthropic_tools"
+    default_instructor_mode = get_instructor_mode("anthropic")
 
     def __init__(
         self,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
@@ -1,6 +1,9 @@
 from typing import Any
 
 import instructor
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+    get_instructor_mode,
+)
 import litellm
 from instructor.exceptions import InstructorRetryException
 from litellm.exceptions import ContentPolicyViolationError
@@ -38,7 +41,7 @@ class BedrockAdapter(LLMInterface):
     """
 
     name = "Bedrock"
-    default_instructor_mode = "json_schema_mode"
+    default_instructor_mode = get_instructor_mode("bedrock")
 
     MAX_RETRIES = 2
 

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/gemini/adapter.py
@@ -5,6 +5,9 @@ import logging
 from typing import Any
 
 import instructor
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+    get_instructor_mode,
+)
 import litellm
 from instructor.core import InstructorRetryException
 from litellm.exceptions import ContentPolicyViolationError
@@ -47,7 +50,7 @@ class GeminiAdapter(GenericAPIAdapter):
     - transcribe_image(input) -> BaseModel: Inherited from GenericAPIAdapter
     """
 
-    default_instructor_mode = "json_mode"
+    default_instructor_mode = get_instructor_mode("gemini")
 
     def __init__(
         self,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/generic_llm_api/adapter.py
@@ -6,6 +6,9 @@ import mimetypes
 from typing import Any
 
 import instructor
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+    get_instructor_mode,
+)
 import litellm
 from instructor.core import InstructorRetryException
 from litellm.exceptions import ContentPolicyViolationError
@@ -73,7 +76,7 @@ class GenericAPIAdapter(LLMInterface):
     """
 
     MAX_RETRIES = 2
-    default_instructor_mode = "json_mode"
+    default_instructor_mode = get_instructor_mode("generic")
 
     def __init__(
         self,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/instructor_modes.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/instructor_modes.py
@@ -1,0 +1,34 @@
+"""Central table of default Instructor modes per LLM provider.
+
+Single source of truth that replaces the per-adapter ``default_instructor_mode``
+class attributes previously scattered across the individual adapter modules.
+"""
+
+import instructor
+
+# Provider -> default instructor mode. Values match what each adapter used
+# historically. ``llama_cpp`` uses the enum member directly, as it did before.
+# (Azure is intentionally absent: AzureOpenAIAdapter subclasses OpenAIAdapter and
+# therefore inherits the "openai" default.)
+INSTRUCTOR_MODE_TABLE: dict[str, object] = {
+    "openai": "json_schema_mode",
+    "anthropic": "anthropic_tools",
+    "gemini": "json_mode",
+    "bedrock": "json_schema_mode",
+    "ollama": "json_mode",
+    "mistral": "mistral_tools",
+    "generic": "json_mode",
+    "llama_cpp": instructor.Mode.JSON,
+}
+
+# Fallback used when a provider has no explicit entry above.
+DEFAULT_INSTRUCTOR_MODE = "json_mode"
+
+
+def get_instructor_mode(provider: str):
+    """Return the default instructor mode for ``provider``.
+
+    See ``INSTRUCTOR_MODE_TABLE``; unknown providers fall back to
+    ``DEFAULT_INSTRUCTOR_MODE``.
+    """
+    return INSTRUCTOR_MODE_TABLE.get(provider, DEFAULT_INSTRUCTOR_MODE)

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/llama_cpp/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/llama_cpp/adapter.py
@@ -5,6 +5,9 @@ import threading
 from typing import Any, cast
 
 import instructor
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+    get_instructor_mode,
+)
 import litellm
 from instructor.core.patch import InstructorChatCompletionCreate
 from openai import AsyncOpenAI
@@ -64,7 +67,7 @@ class LlamaCppAPIAdapter(LLMInterface):
     model: str | None
     model_path: str | None
     mode_type: str  # "server" or "local"
-    default_instructor_mode = instructor.Mode.JSON
+    default_instructor_mode = get_instructor_mode("llama_cpp")
 
     def __init__(
         self,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mistral/adapter.py
@@ -3,6 +3,9 @@ import logging
 from typing import Any
 
 import instructor
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+    get_instructor_mode,
+)
 import litellm
 from litellm import JSONSchemaValidationError
 from mistralai import Mistral  # ty:ignore[unresolved-import]
@@ -43,7 +46,7 @@ class MistralAdapter(GenericAPIAdapter):
     - show_prompt
     """
 
-    default_instructor_mode = "mistral_tools"
+    default_instructor_mode = get_instructor_mode("mistral")
 
     def __init__(
         self,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/ollama/adapter.py
@@ -4,6 +4,9 @@ import logging
 from typing import Any
 
 import instructor
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+    get_instructor_mode,
+)
 import litellm
 from openai import AsyncOpenAI
 from pydantic import BaseModel
@@ -55,7 +58,7 @@ class OllamaAPIAdapter(LLMInterface):
     - aclient
     """
 
-    default_instructor_mode = "json_mode"
+    default_instructor_mode = get_instructor_mode("ollama")
 
     def __init__(
         self,

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py
@@ -2,6 +2,9 @@ import logging
 from typing import Any
 
 import instructor
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+    get_instructor_mode,
+)
 import litellm
 from instructor.core import InstructorRetryException
 from litellm.exceptions import ContentPolicyViolationError
@@ -59,7 +62,7 @@ class OpenAIAdapter(GenericAPIAdapter):
     - MAX_RETRIES
     """
 
-    default_instructor_mode = "json_schema_mode"
+    default_instructor_mode = get_instructor_mode("openai")
     MAX_RETRIES = 2
 
     """Adapter for OpenAI's GPT-3, GPT=4 API"""

--- a/cognee/shared/rate_limiting.py
+++ b/cognee/shared/rate_limiting.py
@@ -9,9 +9,25 @@ llm_config = get_llm_config()
 llm_rate_limiter = AsyncLimiter(
     llm_config.llm_rate_limit_requests, llm_config.llm_rate_limit_interval
 )
-embedding_rate_limiter = AsyncLimiter(
-    llm_config.embedding_rate_limit_requests, llm_config.embedding_rate_limit_interval
-)
+# The embedding rate-limiter reads its settings from EmbeddingConfig. It is built
+# lazily (on first use) to avoid a circular import at module load time, since the
+# embedding engines import this module.
+_embedding_rate_limiter = None
+
+
+def _get_embedding_rate_limiter():
+    global _embedding_rate_limiter
+    if _embedding_rate_limiter is None:
+        from cognee.infrastructure.databases.vector.embeddings.config import (
+            get_embedding_config,
+        )
+
+        embedding_config = get_embedding_config()
+        _embedding_rate_limiter = AsyncLimiter(
+            embedding_config.embedding_rate_limit_requests,
+            embedding_config.embedding_rate_limit_interval,
+        )
+    return _embedding_rate_limiter
 
 
 def llm_rate_limiter_context_manager():
@@ -24,9 +40,12 @@ def llm_rate_limiter_context_manager():
 
 
 def embedding_rate_limiter_context_manager():
-    global embedding_rate_limiter
-    if llm_config.embedding_rate_limit_enabled:
-        return embedding_rate_limiter
+    from cognee.infrastructure.databases.vector.embeddings.config import (
+        get_embedding_config,
+    )
+
+    if get_embedding_config().embedding_rate_limit_enabled:
+        return _get_embedding_rate_limiter()
     else:
         #  Return a no-op context manager if rate limiting is disabled
         return nullcontext()

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config.py
@@ -44,3 +44,153 @@ def test_strip_quotes_from_strings():
 
     # Strings with internal quotes ("internal\"quotes" → internal"quotes")
     assert config.baml_llm_model == 'internal"quotes'
+
+
+def test_strip_quotes_generalized_to_all_string_fields(monkeypatch):
+    """
+    Quote-stripping applies to every string field, not just a hard-coded allow-list.
+
+    ``transcription_model`` was not part of the original 14-field allow-list, so it
+    exercises the generalized behavior.
+    """
+    for var in ("LLM_PROVIDER", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    config = LLMConfig(transcription_model='"whisper-1"', _env_file=None)
+    assert config.transcription_model == "whisper-1"
+
+
+def test_infer_provider_from_model(monkeypatch):
+    """
+    llm_provider is inferred from the llm_model prefix when it is not set explicitly.
+    """
+    for var in ("LLM_PROVIDER", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    # Only the model is provided -> provider inferred from the litellm-style prefix.
+    config = LLMConfig(llm_model="anthropic/claude-3-5-sonnet-20241022", _env_file=None)
+    assert config.llm_provider == "anthropic"
+
+
+def test_explicit_provider_takes_precedence(monkeypatch):
+    """
+    An explicitly set llm_provider is never overridden by inference.
+    """
+    for var in ("LLM_PROVIDER", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    config = LLMConfig(
+        llm_provider="custom",
+        llm_model="openrouter/google/gemini-2.0-flash-lite",
+        _env_file=None,
+    )
+    assert config.llm_provider == "custom"
+
+
+def test_provider_unchanged_without_prefix(monkeypatch):
+    """
+    A model without a '/' prefix leaves the default provider untouched.
+    """
+    for var in ("LLM_PROVIDER", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    config = LLMConfig(llm_model="gpt-4o", _env_file=None)
+    assert config.llm_provider == "openai"
+
+
+def test_default_config_provider_consistent(monkeypatch):
+    """
+    Defaults remain backward compatible (openai provider, openai/gpt-5-mini model).
+    """
+    for var in ("LLM_PROVIDER", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    config = LLMConfig(_env_file=None)
+    assert config.llm_provider == "openai"
+    assert config.llm_model == "openai/gpt-5-mini"
+
+
+def test_unknown_provider_prefix_raises(monkeypatch):
+    """
+    An unrecognized model prefix raises rather than guessing a bad provider.
+
+    e.g. OpenRouter models use LLM_PROVIDER="custom"; if only the model is set we
+    must not guess provider="openrouter" (which cognee cannot dispatch) nor
+    silently fall back. Per maintainer guidance on the issue, we raise and tell
+    the user to set the provider explicitly.
+    """
+    from cognee.infrastructure.llm.exceptions import ProviderNotDeducibleError
+
+    for var in ("LLM_PROVIDER", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    with pytest.raises(ProviderNotDeducibleError):
+        LLMConfig(llm_model="openrouter/google/gemini-2.0-flash-lite", _env_file=None)
+
+
+def test_ollama_partial_embedding_env_does_not_raise(monkeypatch):
+    """
+    The Ollama validator no longer validates embedding env vars (that belongs to
+    EmbeddingConfig), so partial embedding env no longer blocks LLMConfig.
+    """
+    for var in (
+        "LLM_MODEL",
+        "LLM_ENDPOINT",
+        "LLM_API_KEY",
+        "EMBEDDING_MODEL",
+        "EMBEDDING_DIMENSIONS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "ollama")  # only one embedding var set
+
+    config = LLMConfig(llm_provider="ollama", _env_file=None)
+    assert config.llm_provider == "ollama"
+
+
+def test_ollama_partial_llm_env_still_raises(monkeypatch):
+    """
+    The Ollama validator still enforces that LLM env vars are all-or-nothing.
+    """
+    for var in ("LLM_ENDPOINT", "LLM_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("LLM_MODEL", "ollama/llama3.1:8b")  # only one LLM var set
+
+    with pytest.raises(ValueError):
+        LLMConfig(llm_provider="ollama", _env_file=None)
+
+
+def test_instructor_mode_table_and_adapter_wiring():
+    """
+    Instructor-mode defaults come from one central table, and adapters read from
+    it (single source of truth) instead of hard-coding their own default.
+    """
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
+        get_instructor_mode,
+    )
+
+    # Table values match the historical per-adapter defaults.
+    assert get_instructor_mode("openai") == "json_schema_mode"
+    assert get_instructor_mode("anthropic") == "anthropic_tools"
+    # Unknown providers fall back to the default.
+    assert get_instructor_mode("totally-unknown-provider") == "json_mode"
+
+    # Adapters now derive their default from the table. OpenAIAdapter is used
+    # here because it has no optional third-party dependency to import.
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.openai.adapter import (
+        OpenAIAdapter,
+    )
+
+    assert OpenAIAdapter.default_instructor_mode == get_instructor_mode("openai")
+
+
+def test_known_providers_match_enum():
+    """
+    KNOWN_LLM_PROVIDERS must stay aligned with the LLMProvider dispatch enum so
+    inference never yields a provider the client cannot construct.
+    """
+    from cognee.infrastructure.llm.config import KNOWN_LLM_PROVIDERS
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client import (
+        LLMProvider,
+    )
+
+    assert KNOWN_LLM_PROVIDERS == {provider.value for provider in LLMProvider}

--- a/cognee/tests/unit/infrastructure/test_embedding_rate_limiting_realistic.py
+++ b/cognee/tests/unit/infrastructure/test_embedding_rate_limiting_realistic.py
@@ -3,8 +3,9 @@ import time
 import asyncio
 import logging
 
-from cognee.infrastructure.llm.config import (
-    get_llm_config,
+import cognee.shared.rate_limiting as rate_limiting
+from cognee.infrastructure.databases.vector.embeddings.config import (
+    get_embedding_config,
 )
 from cognee.tests.unit.infrastructure.mock_embedding_engine import MockEmbeddingEngine
 
@@ -29,10 +30,11 @@ async def test_embedding_rate_limiting_realistic():
     os.environ["DISABLE_RETRIES"] = "true"  # Disable automatic retries for testing
 
     # Clear the config and rate limiter caches to ensure our settings are applied
-    get_llm_config.cache_clear()
+    get_embedding_config.cache_clear()
+    rate_limiting._embedding_rate_limiter = None
 
     # Create a fresh config instance and verify settings
-    config = get_llm_config()
+    config = get_embedding_config()
     logger.info(f"Embedding Rate Limiting Enabled: {config.embedding_rate_limit_enabled}")
     logger.info(
         f"Embedding Rate Limit: {config.embedding_rate_limit_requests} requests per {config.embedding_rate_limit_interval} seconds"
@@ -165,7 +167,8 @@ async def test_with_mock_failures():
     os.environ["DISABLE_RETRIES"] = "true"
 
     # Clear caches
-    get_llm_config.cache_clear()
+    get_embedding_config.cache_clear()
+    rate_limiting._embedding_rate_limiter = None
 
     # Create a mock engine configured to fail every 3rd request
     engine = MockEmbeddingEngine()
@@ -189,6 +192,32 @@ async def test_with_mock_failures():
     os.environ.pop("EMBEDDING_RATE_LIMIT_REQUESTS", None)
     os.environ.pop("EMBEDDING_RATE_LIMIT_INTERVAL", None)
     os.environ.pop("DISABLE_RETRIES", None)
+
+
+def test_embedding_rate_limit_fields_on_embedding_config(monkeypatch):
+    """The embedding rate-limit knobs live on EmbeddingConfig and read their env vars."""
+    monkeypatch.setenv("EMBEDDING_RATE_LIMIT_ENABLED", "true")
+    monkeypatch.setenv("EMBEDDING_RATE_LIMIT_REQUESTS", "7")
+    get_embedding_config.cache_clear()
+    try:
+        cfg = get_embedding_config()
+        assert cfg.embedding_rate_limit_enabled is True
+        assert cfg.embedding_rate_limit_requests == 7
+    finally:
+        get_embedding_config.cache_clear()
+
+
+def test_llm_config_no_longer_defines_embedding_rate_limit_fields():
+    """The knobs were moved out of LLMConfig, leaving a single source of truth."""
+    from cognee.infrastructure.llm.config import LLMConfig
+
+    for field in (
+        "embedding_rate_limit_enabled",
+        "embedding_rate_limit_requests",
+        "embedding_rate_limit_interval",
+        "embedding_rate_limit_tokens",
+    ):
+        assert field not in LLMConfig.model_fields
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Addresses **5 of the 6** sub-problems in #3382 ("Simplify LLM configuration"). Each change reduces configuration friction or removes duplication in the LLM/embedding config layer, and is covered by unit tests. The remaining item (#4, BAML config dedup) is intentionally left as a follow-up — see "Out of scope" below.

Partially addresses #3382.

## What changed

| # (from issue) | Change | How |
|---|---|---|
| **1** | `LLM_PROVIDER` is now **optional** — inferred from the `llm_model` prefix | New `infer_provider_from_model` validator in `config.py`, guarded by `KNOWN_LLM_PROVIDERS` (kept in sync with the `LLMProvider` enum). An explicit `LLM_PROVIDER` always wins. Per @dexters1's request, an **unknown/undeducible** prefix raises `ProviderNotDeducibleError` (new, inherits `CogneeValidationError` → `CogneeApiError`) telling the user to set the provider manually. |
| **5** | Generalized quote-stripping | Replaced the hard-coded 14-field allow-list with `strip_quotes_from_strings`, which iterates **all declared string fields**. Added a test asserting `KNOWN_LLM_PROVIDERS` stays in sync with the enum. |
| **3** | Moved `embedding_rate_limit_*` out of `LLMConfig` | The 4 rate-limit fields (+ `to_dict` keys) now live on `EmbeddingConfig`, where they belong. `rate_limiting.py` builds the embedding limiter **lazily** from `get_embedding_config()` to avoid a circular import. |
| **6** | Ollama LLM validator no longer validates **embedding** env vars | Removed the embedding `os.environ` block from `ensure_env_vars_for_ollama`; the LLM env-var check is unchanged. |
| **2** | One central instructor-mode table (was duplicated across 9 adapters) | New `instructor_modes.py` with `INSTRUCTOR_MODE_TABLE` + `get_instructor_mode(provider)`. Each adapter's `default_instructor_mode` now reads from it. (Azure inherits OpenAI's via subclass, so 8 adapters were edited; `llama_cpp` keeps its `instructor.Mode.JSON` value.) |

## Out of scope (follow-up)

- **#4 — BAML config surface dedup.** The `baml_*` fields in `config.py` duplicate the main LLM fields and feed `LLMConfig.model_post_init`'s BAML `ClientRegistry`. The acceptance bar requires "no regressions across BAML", but BAML is an **optional dependency** and needs a live model, so it can't be verified without the `baml` extra + CI. Tracking it as a separate PR to keep this one reviewable and verifiable.

## Testing

**Unit tests — 33 passing** (no API key needed):

```bash
python -m pytest cognee/tests/unit/infrastructure/llm/ \
  cognee/tests/unit/infrastructure/test_embedding_rate_limiting_realistic.py \
  -v --disable-warnings
# 33 passed
```

Coverage includes: provider inference, explicit-provider precedence, unknown-prefix raises `ProviderNotDeducibleError`, no-prefix default, `KNOWN_LLM_PROVIDERS` ↔ enum drift guard, generalized quote-strip, Ollama partial-embedding-no-raise / partial-LLM-still-raises, the instructor-mode table + adapter wiring, embedding rate-limit fields present on `EmbeddingConfig` and removed from `LLMConfig`.

_Unit-test screenshot: to be added._

**Live LLM-path integration** — exercises the changed surface end-to-end against a real model (Gemini). `LLM_PROVIDER` unset → inferred; instructor mode pulled from the new table; live structured-output call via cognee → litellm:

```
[config]     llm_model    = gemini/gemini-flash-latest
[config]     llm_provider = gemini   <- INFERRED (LLM_PROVIDER was unset)
[instructor] mode(gemini)  = json_mode   <- from central INSTRUCTOR_MODE_TABLE
RESULT: {'name': 'Ada Lovelace', 'role': 'lead mathematician', 'company': 'Analytical Engines Inc.'}
LLM_INTEGRATION_OK
```

_Integration screenshot: to be added._

> Full `add → cognify → search` is validated in CI; the default local graph backend (ladybug) wasn't installable on the dev machine, so integration is shown here via the live LLM-config path that this PR actually changes.

## Checklist

- [x] Branched from `dev`; PR targets `dev`
- [x] Every commit is DCO signed-off (`git commit -s`)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] Unit tests passing (33)
- [x] Live LLM-path integration verified

---

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
