### PR TITLE
[#3609] Slack bot powered by cognee memory (with cited answers)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -588,3 +588,21 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #EMBEDDING_API_VERSION=""
 #EMBEDDING_DIMENSIONS=3072
 #EMBEDDING_MAX_COMPLETION_TOKENS=8191
+
+########## Slack bot example (examples/slack_cognee_bot, issue #3609) ##########
+# Only needed to run the Slack bot example. Requires the "slack" extra:
+#   uv pip install -e ".[slack]"
+# Create a Slack app in Socket Mode; see examples/slack_cognee_bot/README.md.
+# Bot token (xoxb-...) — used for chat.postMessage / chat.getPermalink.
+#SLACK_BOT_TOKEN="xoxb-..."
+# App-level token (xapp-...) — the Socket Mode connection token.
+#SLACK_APP_TOKEN="xapp-..."
+# Optional: workspace id fallback used to build the conversation session id.
+#COGNEE_SLACK_DEFAULT_TEAM_ID=""
+# Optional: comma-separated channel ids to ingest from at startup
+# (channels can also be toggled live with /cognee-optin and /cognee-optout).
+#COGNEE_SLACK_OPTED_IN_CHANNELS=""
+# Optional: number of buffered messages that triggers a cognify (default 10).
+#COGNEE_SLACK_COGNIFY_BATCH=10
+# Optional: seconds before a pending channel is flushed on a timer (default: off).
+#COGNEE_SLACK_FLUSH_INTERVAL_SECONDS=

--- a/examples/slack_cognee_bot/README.md
+++ b/examples/slack_cognee_bot/README.md
@@ -1,0 +1,128 @@
+# Slack bot powered by cognee memory
+
+A [Slack Bolt](https://slack.dev/bolt-python/) app that quietly turns a channel's
+conversation into [cognee](https://www.cognee.ai/) memory, so your team can ask
+**"@cognee what did we decide about X?"** and get an answer **with links back to
+the source messages**.
+
+> Example app for [issue #3609](https://github.com/topoteretes/cognee/issues/3609).
+> It lives in `examples/` and is not part of the cognee core install.
+
+## What it does
+
+- **Silently ingests** messages from channels you opt in — each message becomes a
+  cognee data item, tagged to that channel.
+- **Answers questions** from the channel's memory via an **@mention** or the
+  **`/recall`** slash command, replying with a Block Kit message that lists the
+  **source messages as clickable permalinks** (citations).
+- **Forgets on request** — **`/cognee-forget`** deletes the whole channel's memory.
+- **Opt-in / opt-out** per channel with **`/cognee-optin`** and **`/cognee-optout`**;
+  the bot only ingests channels you've opted in.
+
+## Prerequisites
+
+- A working cognee install and an LLM key (`LLM_API_KEY`) — see the repo's main
+  README / `.env.template`. cognee's local defaults (SQLite + LanceDB + Ladybug)
+  are enough; no extra services required.
+- Python 3.10–3.14.
+- The **`slack`** extra (adds `slack-bolt`):
+
+  ```bash
+  uv pip install -e ".[slack]"
+  ```
+
+- A Slack app in **Socket Mode** (no public URL needed):
+  1. Create an app at <https://api.slack.com/apps> → **From scratch**.
+  2. **Socket Mode** → enable it → create an **App-Level Token** with the
+     `connections:write` scope (this is your `SLACK_APP_TOKEN`, `xapp-...`).
+  3. **OAuth & Permissions** → add **Bot Token Scopes**:
+     `app_mentions:read`, `channels:history`, `chat:write`, `commands`.
+     Install the app to your workspace → copy the **Bot User OAuth Token**
+     (`SLACK_BOT_TOKEN`, `xoxb-...`).
+  4. **Event Subscriptions** → subscribe to bot events: `app_mention`,
+     `message.channels`.
+  5. **Slash Commands** → create: `/recall`, `/cognee-optin`, `/cognee-optout`,
+     `/cognee-forget`.
+
+## Run it (5 minutes)
+
+```bash
+# 1. Install cognee with the slack extra
+uv pip install -e ".[slack]"
+
+# 2. Configure env: copy the template and fill in your keys/tokens
+cp .env.template .env
+# set at least: LLM_API_KEY, SLACK_BOT_TOKEN, SLACK_APP_TOKEN
+# (see the "Slack bot example" section at the bottom of .env.template)
+
+# 3. Load the env vars into your shell
+set -a && source .env && set +a
+# (or run with: uv run --env-file .env python -m src)
+
+# 4. Start the bot
+cd examples/slack_cognee_bot
+python -m src
+```
+
+Then, in Slack:
+
+1. **Invite** the bot to a channel (`/invite @your-bot`).
+2. Run **`/cognee-optin`** — the bot posts a one-time disclosure and starts
+   remembering new messages.
+3. Chat normally for a bit.
+4. Ask **`@your-bot what did we decide about the launch?`** or
+   **`/recall who owns billing?`** — you'll get an answer with source links.
+5. Done? **`/cognee-optout`** stops ingestion; **`/cognee-forget`** deletes the
+   channel's memory entirely.
+
+## Configuration
+
+All settings are environment variables (see `.env.template`). Only the tokens are
+required; the rest have sensible defaults.
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `SLACK_BOT_TOKEN` | Bot token (`xoxb-…`) for Web API calls | — (required) |
+| `SLACK_APP_TOKEN` | App-level token (`xapp-…`) for Socket Mode | — (required) |
+| `COGNEE_SLACK_DEFAULT_TEAM_ID` | Workspace id fallback for the session id | `""` |
+| `COGNEE_SLACK_OPTED_IN_CHANNELS` | Comma-separated channels to ingest at startup | `""` |
+| `COGNEE_SLACK_COGNIFY_BATCH` | Messages buffered before a cognify runs | `10` |
+| `COGNEE_SLACK_FLUSH_INTERVAL_SECONDS` | Timer flush (seconds); unset = size-only | off |
+
+## How it works
+
+Each channel maps to its own cognee dataset (`slack_<channel_id>`). Ingested
+messages are buffered and turned into a knowledge graph in batches
+(`cognify`). Answers run a graph-completion search for the prose plus a chunk
+search for the sources; each source chunk carries a `document_id` we set at
+ingest time, which we join back to the original message's permalink via a small
+local index — that's how citations are produced.
+
+The bot talks to cognee through a thin local **chat-memory adapter**
+(`ingest` / `flush` / `answer` / `forget`). This implements the shared adapter
+pattern from [issue #3608](https://github.com/topoteretes/cognee/issues/3608)
+locally; when that shared core lands, only the adapter implementation is swapped
+— the Slack layer is unchanged.
+
+## Limitations (read me)
+
+- **Answers reflect the last flush, not every message instantly.** Ingestion is
+  batched/triggered — a channel is cognified when it hits
+  `COGNEE_SLACK_COGNIFY_BATCH` messages, on the optional timer, or right before a
+  question. A message sent seconds before you ask may not be in the answer yet.
+- **Forget is channel-level only.** `/cognee-forget` deletes the whole channel
+  dataset. cognee has no per-user delete today, so a per-user "forget me" is
+  **not** supported — it's a follow-up.
+- **Scope is per channel.** Memory and answers are isolated to the channel you're
+  in; the bot doesn't reason across channels.
+- **#3608 is local.** The chat-memory adapter is implemented in this example
+  until the shared #3608 core is merged.
+
+## Development
+
+Run the example's test suite (no Slack tokens, no cognee keys, no network — the
+Slack SDK and cognee calls are mocked):
+
+```bash
+uv run pytest examples/slack_cognee_bot/tests/ -v
+```

--- a/examples/slack_cognee_bot/src/__init__.py
+++ b/examples/slack_cognee_bot/src/__init__.py
@@ -1,0 +1,5 @@
+"""Slack + cognee memory bot (issue #3609) — example application package.
+
+This package is an example integration and is intentionally kept out of the
+cognee core install. See the sibling ``README.md`` for setup.
+"""

--- a/examples/slack_cognee_bot/src/__main__.py
+++ b/examples/slack_cognee_bot/src/__main__.py
@@ -1,0 +1,45 @@
+"""Entry point: run the Slack + cognee memory bot over Socket Mode (issue #3609).
+
+Usage (from the example directory, with the "slack" extra installed and the env
+vars from the repo ``.env.template`` exported)::
+
+    cd examples/slack_cognee_bot
+    python -m src
+
+This module is pure wiring — it composes the pieces built in earlier commits
+(citation index → cognee-backed adapter → ingestion buffer → Bolt app) and
+starts Socket Mode. slack_bolt is imported lazily by ``build_app`` /
+``start_socket_mode``; running without the extra raises a clear install message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from src.citation_index import CitationIndex
+from src.cognee_memory import CogneeChatMemory
+from src.config import load_ingestion_settings, load_slack_settings
+from src.ingestion_buffer import IngestionBuffer
+from src.slack_app import build_app, start_socket_mode
+
+
+async def _run() -> None:
+    slack_settings = load_slack_settings()
+    ingestion_settings = load_ingestion_settings()
+
+    memory = CogneeChatMemory(CitationIndex())
+    buffer = IngestionBuffer(memory, settings=ingestion_settings)
+    # The live opt-in set: seeded from config, then mutated by the
+    # /cognee-optin and /cognee-optout commands.
+    opted_in = set(slack_settings.opted_in_channels)
+
+    app = build_app(buffer, slack_settings, opted_in)
+    await start_socket_mode(app, slack_settings)
+
+
+def main() -> None:
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/slack_cognee_bot/src/citation_index.py
+++ b/examples/slack_cognee_bot/src/citation_index.py
@@ -1,0 +1,128 @@
+"""Adapter-owned side index for Slack message citations (issue #3609).
+
+Why this exists — the metadata round-trip, honestly:
+
+Recon proved that arbitrary per-message metadata (channel / ts / permalink) does
+**not** survive into what ``search(SearchType.CHUNKS)`` returns. The chunk
+``metadata`` dict and the source Document's ``external_metadata`` are both
+stripped from the vector payload
+(``LanceDBAdapter._build_data_point_schema`` excludes ``metadata`` and nested
+models). The *only* field that survives and that we can control is
+``document_id`` — because we assign a deterministic ``DataItem.data_id`` at
+ingest, and cognee reuses it as the ``Data`` id → ``Document`` id →
+``DocumentChunk.document_id``.
+
+So citations are produced by a **join**, not by smuggled metadata: this index
+maps ``document_id`` → the human-readable ``{channel, ts, permalink, author,
+snippet}``. ``ingest`` writes a row; ``answer`` reads ``document_id`` off each
+returned chunk and looks the row up here.
+
+Backed by the standard-library ``sqlite3`` (no new dependency), matching
+cognee's SQLite-by-default convention.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from dataclasses import dataclass
+
+SNIPPET_MAX_CHARS = 200
+
+
+@dataclass(frozen=True)
+class CitationRecord:
+    """A stored citation row, joined back by ``document_id``."""
+
+    document_id: str
+    channel_id: str
+    ts: str
+    permalink: str
+    author: str
+    snippet: str
+
+
+class CitationIndex:
+    """Persistent ``document_id`` → citation map backing cited answers.
+
+    A single shared connection is reused across calls so an in-memory database
+    (``":memory:"``, used by tests) keeps its state for the object's lifetime.
+    Access is guarded by a lock since the async adapter may touch it from more
+    than one task.
+    """
+
+    def __init__(self, db_path: str = "slack_citations.db"):
+        # check_same_thread=False so the index is usable regardless of which
+        # worker thread an async callback happens to run on.
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._lock = threading.Lock()
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS citations (
+                    document_id TEXT PRIMARY KEY,
+                    channel_id  TEXT NOT NULL,
+                    ts          TEXT NOT NULL,
+                    permalink   TEXT NOT NULL,
+                    author      TEXT NOT NULL,
+                    snippet     TEXT NOT NULL
+                )
+                """
+            )
+            self._conn.commit()
+
+    def put(
+        self,
+        document_id: str,
+        *,
+        channel_id: str,
+        ts: str,
+        permalink: str,
+        author: str,
+        snippet: str,
+    ) -> None:
+        """Upsert the citation row for a message (keyed by its ``document_id``)."""
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO citations
+                    (document_id, channel_id, ts, permalink, author, snippet)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(document_id) DO UPDATE SET
+                    channel_id = excluded.channel_id,
+                    ts         = excluded.ts,
+                    permalink  = excluded.permalink,
+                    author     = excluded.author,
+                    snippet    = excluded.snippet
+                """,
+                (document_id, channel_id, ts, permalink, author, snippet[:SNIPPET_MAX_CHARS]),
+            )
+            self._conn.commit()
+
+    def get(self, document_id: str) -> CitationRecord | None:
+        """Look up the citation row for a chunk's ``document_id`` (or ``None``)."""
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT document_id, channel_id, ts, permalink, author, snippet
+                FROM citations WHERE document_id = ?
+                """,
+                (document_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return CitationRecord(*row)
+
+    def delete_channel(self, channel_id: str) -> int:
+        """Delete every citation row for a channel (used by ``forget``). Returns row count."""
+        with self._lock:
+            cur = self._conn.execute("DELETE FROM citations WHERE channel_id = ?", (channel_id,))
+            self._conn.commit()
+            return cur.rowcount
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()

--- a/examples/slack_cognee_bot/src/citations.py
+++ b/examples/slack_cognee_bot/src/citations.py
@@ -1,0 +1,123 @@
+"""Slack Block Kit renderer for cited answers (issue #3609, #3604).
+
+Turns an :class:`Answer` (answer text + ordered ``Citation`` list from the
+Commit-2 adapter) into Slack Block Kit blocks: a ``section`` block with the
+answer, followed by a ``context`` block listing each source as a clickable
+``<permalink|#channel · author · time>`` link (Slack mrkdwn link syntax).
+
+Block Kit reference — blocks used:
+* ``section`` with a ``mrkdwn`` text object (the answer);
+* ``context`` with ``mrkdwn`` elements (the Sources list / no-sources note).
+
+Dedupe: the adapter already collapses multiple chunks of one message to a single
+Citation (keyed by ``document_id`` in ``cognee_memory._build_citations``). This
+renderer additionally does a *defensive, display-level* dedupe keyed on
+``(channel_id, ts)`` — idempotent when the input is already unique, and it never
+merges the empty-``ts`` fallback citations. Citation order (relevance order from
+the adapter) is preserved.
+
+Graceful degradation (the #3604 "actionable, never broken output" bar):
+* missing/blank permalink → plain-text source entry, never a broken ``<|>`` link;
+* zero citations → the answer plus a subtle "no sources" note, not an empty block;
+* blank answer text → a calm fallback message, never an empty reply.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.memory_adapter import Answer, Citation
+
+# Slack section text objects are capped at 3000 chars; keep a safe margin.
+_MAX_SECTION_CHARS = 2900
+# Cap the number of rendered source links; note the remainder as "+N more".
+DEFAULT_MAX_SOURCES = 5
+
+_ANSWER_FALLBACK = "I couldn't find anything about that in this channel's memory yet."
+_NO_SOURCES_NOTE = "_No sources found for this answer._"
+
+
+def notification_text(answer: Answer) -> str:
+    """Plain fallback text for the Slack notification / accessibility layer."""
+    return answer.text.strip() if answer.text and answer.text.strip() else _ANSWER_FALLBACK
+
+
+def _format_time(ts: str) -> str:
+    """Render a Slack ts ("1700000000.000100") as a short UTC time, robustly."""
+    try:
+        seconds = int(float(ts))
+        return datetime.fromtimestamp(seconds, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    except (ValueError, TypeError, OverflowError, OSError):
+        return ts or ""
+
+
+def _source_label(cite: Citation) -> str:
+    parts = [f"#{cite.channel_id}"] if cite.channel_id else []
+    if cite.author:
+        parts.append(cite.author)
+    if cite.ts:
+        parts.append(_format_time(cite.ts))
+    return " · ".join(parts)
+
+
+def _format_source(cite: Citation) -> str:
+    """One Sources bullet — a link when possible, else safe plain text."""
+    label = _source_label(cite)
+    if cite.ok and cite.permalink:
+        return f"• <{cite.permalink}|{label or 'message'}>"
+    # No usable link: never emit "<|...>". Prefer the descriptive label, then
+    # fall back to the message snippet.
+    if label:
+        return f"• {label}"
+    return f"• {cite.snippet or 'source'}"
+
+
+def _dedupe_for_display(citations: list[Citation]) -> list[Citation]:
+    """Drop repeat (channel_id, ts) citations, preserving order.
+
+    Defensive only — the adapter already dedupes by document_id. Citations with
+    an empty ``ts`` (the missing-metadata fallback) are never merged.
+    """
+    seen: set[tuple[str, str]] = set()
+    result: list[Citation] = []
+    for cite in citations:
+        key = (cite.channel_id, cite.ts)
+        if cite.ts and key in seen:
+            continue
+        if cite.ts:
+            seen.add(key)
+        result.append(cite)
+    return result
+
+
+def _answer_section_text(answer: Answer) -> str:
+    text = answer.text.strip() if answer.text else ""
+    if not text:
+        return _ANSWER_FALLBACK
+    if len(text) > _MAX_SECTION_CHARS:
+        return text[: _MAX_SECTION_CHARS - 1].rstrip() + "…"
+    return text
+
+
+def render_answer(answer: Answer, *, max_sources: int = DEFAULT_MAX_SOURCES) -> list[dict]:
+    """Render an :class:`Answer` to Slack Block Kit blocks."""
+    blocks: list[dict] = [
+        {"type": "section", "text": {"type": "mrkdwn", "text": _answer_section_text(answer)}}
+    ]
+
+    citations = _dedupe_for_display(answer.citations)
+    if not citations:
+        blocks.append(
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": _NO_SOURCES_NOTE}]}
+        )
+        return blocks
+
+    shown = citations[:max_sources]
+    bullets = [_format_source(cite) for cite in shown]
+    text = "*Sources:*\n" + "\n".join(bullets)
+    extra = len(citations) - len(shown)
+    if extra > 0:
+        text += f"\n_+{extra} more_"
+
+    blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": text}]})
+    return blocks

--- a/examples/slack_cognee_bot/src/cognee_memory.py
+++ b/examples/slack_cognee_bot/src/cognee_memory.py
@@ -1,0 +1,219 @@
+"""cognee-backed implementation of the thin ``ChatMemory`` adapter (issue #3609).
+
+This is the concrete backend behind the Slack bot's ingest / flush / answer /
+forget contract. It calls cognee's real public memory API. When the #3608
+chat-memory core lands, this module is the single thing that gets swapped — the
+Slack handlers keep talking to :class:`ChatMemory`.
+
+Real cognee signatures used (verified against the source, cited inline):
+
+* ``cognee.add(data, dataset_name="main_dataset", ..., node_set=None, ...)``
+      cognee/api/v1/add/add.py:25-48 — accepts ``DataItem`` / ``list[DataItem]``.
+* ``DataItem(data, label=None, external_metadata=None, data_id=None)``
+      cognee/tasks/ingestion/data_item.py:6-11 — the supplied ``data_id`` is
+      honored (ingest_data.py:100-101) and becomes the Data/Document/chunk id.
+* ``cognee.cognify(datasets=None, ...)`` — cognee/api/v1/cognify/cognify.py:43-44
+      accepts ``str | list[str] | list[UUID]`` dataset name(s).
+* ``cognee.search(query_text, query_type=SearchType.GRAPH_COMPLETION, ...,
+      datasets=None, node_name=None, ...)`` — cognee/api/v1/search/search.py:31-58.
+* ``cognee.forget(*, data_id=None, dataset=None, dataset_id=None,
+      everything=False, memory_only=False, user=None)`` —
+      cognee/api/v1/forget/forget.py:16-24. Dataset-level delete = ``dataset=<name>``
+      (forget.py:192-210).
+
+IMPORTANT SIGNATURE MISMATCH vs. the scope-lock shorthand ``delete(dataset_name=...)``:
+``cognee.delete`` is **deprecated since 0.3.9** and is item-level
+(``delete(data_id, dataset_id, mode, user)`` — cognee/api/v1/delete/__init__.py:10-39).
+There is no ``delete(dataset_name=...)``. The correct, non-deprecated dataset-level
+delete is ``cognee.forget(dataset=<name>)``, which is what ``forget`` uses below.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cognee
+
+# DataItem is not exported at the cognee top level; import it from its module.
+from cognee.tasks.ingestion.data_item import DataItem
+
+from src.citation_index import CitationIndex
+from src.memory_adapter import (
+    Answer,
+    ChatMemory,
+    Citation,
+    ConversationRef,
+    message_data_id,
+)
+
+# Chunk-payload keys returned by search(SearchType.CHUNKS) — a flat list of
+# DocumentChunk payload dicts. ``document_id`` is the citation join key.
+_CHUNK_DOCUMENT_ID_KEY = "document_id"
+_CHUNK_TEXT_KEY = "text"
+
+DEFAULT_TOP_K = 10
+
+
+def _first_text(results: Any) -> str:
+    """Extract the natural-language answer string from a ``search`` return.
+
+    ``search`` returns ``list[SearchResult]``. Its exact shape varies:
+
+    * non-access-control (single-user) mode: a flat list — e.g. ``["answer"]``
+      for GRAPH_COMPLETION (search.py:423-433);
+    * access-control mode: ``[{"search_result": <result>, "dataset_id": ...}]``
+      (search.py:391-409).
+
+    We walk either shape and return the first non-empty string found.
+    """
+    if isinstance(results, str):
+        return results
+    if isinstance(results, dict):
+        return _first_text(results.get("search_result"))
+    if isinstance(results, (list, tuple)):
+        for item in results:
+            text = _first_text(item)
+            if text:
+                return text
+    return ""
+
+
+def _normalize_chunk_payloads(results: Any) -> list[dict]:
+    """Flatten a ``search(SearchType.CHUNKS)`` return into a list of payload dicts.
+
+    Handles both the flat ``[chunk_dict, ...]`` (single-user) shape and the
+    access-control ``[{"search_result": [chunk_dict, ...]}, ...]`` wrapper.
+    """
+    payloads: list[dict] = []
+    if results is None:
+        return payloads
+    if isinstance(results, dict):
+        # Access-control wrapper: unwrap the inner search_result.
+        if "search_result" in results:
+            return _normalize_chunk_payloads(results["search_result"])
+        return [results]
+    if isinstance(results, (list, tuple)):
+        for item in results:
+            if isinstance(item, dict) and "search_result" in item:
+                payloads.extend(_normalize_chunk_payloads(item["search_result"]))
+            elif isinstance(item, dict):
+                payloads.append(item)
+            elif isinstance(item, (list, tuple)):
+                payloads.extend(_normalize_chunk_payloads(item))
+    return payloads
+
+
+def _build_citations(chunk_payloads: list[dict], index: CitationIndex) -> list[Citation]:
+    """Map chunk payloads → deduplicated ``Citation`` objects via the side index.
+
+    * Dedupe by ``document_id`` so multiple chunks of one message collapse to a
+      single citation (equivalently: one citation per source message ts).
+    * When the index has no row (or a blank permalink) for a chunk, fall back to
+      a plain-text citation (``ok=False``) built from the chunk text — never a
+      broken link, never a crash.
+    """
+    citations: list[Citation] = []
+    seen: set[str] = set()
+    for payload in chunk_payloads:
+        document_id = payload.get(_CHUNK_DOCUMENT_ID_KEY)
+        if not document_id or document_id in seen:
+            continue
+        seen.add(document_id)
+
+        record = index.get(str(document_id))
+        if record is not None and record.permalink:
+            citations.append(
+                Citation(
+                    channel_id=record.channel_id,
+                    ts=record.ts,
+                    permalink=record.permalink,
+                    author=record.author,
+                    snippet=record.snippet,
+                    ok=True,
+                )
+            )
+        else:
+            # Missing row or stale/blank permalink → graceful text fallback.
+            snippet = (record.snippet if record else payload.get(_CHUNK_TEXT_KEY, "")) or ""
+            citations.append(
+                Citation(
+                    channel_id=record.channel_id if record else "",
+                    ts=record.ts if record else "",
+                    permalink="",
+                    author=record.author if record else "",
+                    snippet=snippet,
+                    ok=False,
+                )
+            )
+    return citations
+
+
+class CogneeChatMemory(ChatMemory):
+    """``ChatMemory`` backed by cognee's real add / cognify / search / forget API."""
+
+    def __init__(self, index: CitationIndex, *, top_k: int = DEFAULT_TOP_K):
+        self._index = index
+        self._top_k = top_k
+
+    async def ingest(
+        self,
+        ref: ConversationRef,
+        *,
+        ts: str,
+        text: str,
+        permalink: str,
+        author: str,
+    ) -> None:
+        """Add one message to the channel dataset with a controllable citation id.
+
+        Does NOT cognify — that is deferred to :meth:`flush` (batch trigger).
+        """
+        data_id = message_data_id(ref.channel_id, ts)
+        # DataItem.data_id → Data.id → Document.id → DocumentChunk.document_id,
+        # which is what a CHUNKS search returns and how we cite the message.
+        await cognee.add(
+            DataItem(data=text, data_id=data_id),
+            dataset_name=ref.dataset_name,
+            node_set=ref.node_set,
+        )
+        self._index.put(
+            str(data_id),
+            channel_id=ref.channel_id,
+            ts=ts,
+            permalink=permalink,
+            author=author,
+            snippet=text,
+        )
+
+    async def flush(self, ref: ConversationRef) -> None:
+        """Build the knowledge graph for the channel dataset (batch cognify)."""
+        await cognee.cognify(datasets=[ref.dataset_name])
+
+    async def answer(self, ref: ConversationRef, *, query: str) -> Answer:
+        """Answer ``query`` from the channel's memory, with source citations.
+
+        Two searches: GRAPH_COMPLETION for the prose answer, CHUNKS (filtered to
+        this channel's node set) for the citable source messages.
+        """
+        prose_results = await cognee.search(
+            query,
+            query_type=cognee.SearchType.GRAPH_COMPLETION,
+            datasets=[ref.dataset_name],
+            top_k=self._top_k,
+        )
+        chunk_results = await cognee.search(
+            query,
+            query_type=cognee.SearchType.CHUNKS,
+            datasets=[ref.dataset_name],
+            node_name=ref.node_set,
+            top_k=self._top_k,
+        )
+
+        answer_text = _first_text(prose_results)
+        citations = _build_citations(_normalize_chunk_payloads(chunk_results), self._index)
+        return Answer(text=answer_text, citations=citations)
+
+    async def forget(self, ref: ConversationRef) -> None:
+        """Delete all memory for the channel (dataset-level forget) + its citations."""
+        await cognee.forget(dataset=ref.dataset_name)
+        self._index.delete_channel(ref.channel_id)

--- a/examples/slack_cognee_bot/src/config.py
+++ b/examples/slack_cognee_bot/src/config.py
@@ -1,0 +1,47 @@
+"""Configuration for the Slack + cognee bot (issue #3609).
+
+Commit 3 scope: only the ingestion/trigger thresholds live here. Slack transport
+settings (bot/app tokens, opted-in channels) are added in commit 4 when the Bolt
+layer lands — this module is intentionally extended incrementally.
+
+Thresholds are environment-driven so the batch/timer behaviour can be tuned
+without code changes, following cognee's env-var configuration convention.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# Default number of buffered messages that triggers a cognify for a channel.
+DEFAULT_COGNIFY_BATCH_SIZE = 10
+
+
+@dataclass(frozen=True)
+class IngestionSettings:
+    """Batch/timer thresholds for the ingestion buffer.
+
+    Attributes
+    ----------
+    cognify_batch_size:
+        Flush (cognify) a channel once this many messages have been buffered.
+    flush_interval_seconds:
+        Optional time-based trigger. ``None`` disables the timer (size-only).
+    """
+
+    cognify_batch_size: int = DEFAULT_COGNIFY_BATCH_SIZE
+    flush_interval_seconds: float | None = None
+
+
+def load_ingestion_settings() -> IngestionSettings:
+    """Build :class:`IngestionSettings` from the environment.
+
+    * ``COGNEE_SLACK_COGNIFY_BATCH`` — int, batch size (default 10).
+    * ``COGNEE_SLACK_FLUSH_INTERVAL_SECONDS`` — float, timer (default: disabled).
+    """
+    batch = os.getenv("COGNEE_SLACK_COGNIFY_BATCH")
+    interval = os.getenv("COGNEE_SLACK_FLUSH_INTERVAL_SECONDS")
+    return IngestionSettings(
+        cognify_batch_size=int(batch) if batch else DEFAULT_COGNIFY_BATCH_SIZE,
+        flush_interval_seconds=float(interval) if interval else None,
+    )

--- a/examples/slack_cognee_bot/src/config.py
+++ b/examples/slack_cognee_bot/src/config.py
@@ -45,3 +45,45 @@ def load_ingestion_settings() -> IngestionSettings:
         cognify_batch_size=int(batch) if batch else DEFAULT_COGNIFY_BATCH_SIZE,
         flush_interval_seconds=float(interval) if interval else None,
     )
+
+
+@dataclass(frozen=True)
+class SlackSettings:
+    """Slack transport configuration (Socket Mode).
+
+    Attributes
+    ----------
+    bot_token:
+        ``SLACK_BOT_TOKEN`` (xoxb-...) — used for Web API calls (postMessage,
+        getPermalink).
+    app_token:
+        ``SLACK_APP_TOKEN`` (xapp-...) — the Socket Mode connection token.
+    default_team_id:
+        Fallback workspace id used to build the conversation session id when an
+        event payload doesn't carry ``team``.
+    opted_in_channels:
+        Channels the bot is allowed to ingest from (comma-separated env value).
+        The opt-out command in commit 6 mutates the live set derived from this.
+    """
+
+    bot_token: str
+    app_token: str
+    default_team_id: str = ""
+    opted_in_channels: frozenset[str] = frozenset()
+
+
+def load_slack_settings() -> SlackSettings:
+    """Build :class:`SlackSettings` from the environment.
+
+    * ``SLACK_BOT_TOKEN`` / ``SLACK_APP_TOKEN`` — required to actually run.
+    * ``COGNEE_SLACK_DEFAULT_TEAM_ID`` — optional workspace id fallback.
+    * ``COGNEE_SLACK_OPTED_IN_CHANNELS`` — optional comma-separated channel ids.
+    """
+    channels = os.getenv("COGNEE_SLACK_OPTED_IN_CHANNELS", "")
+    opted_in = frozenset(c.strip() for c in channels.split(",") if c.strip())
+    return SlackSettings(
+        bot_token=os.getenv("SLACK_BOT_TOKEN", ""),
+        app_token=os.getenv("SLACK_APP_TOKEN", ""),
+        default_team_id=os.getenv("COGNEE_SLACK_DEFAULT_TEAM_ID", ""),
+        opted_in_channels=opted_in,
+    )

--- a/examples/slack_cognee_bot/src/ingestion_buffer.py
+++ b/examples/slack_cognee_bot/src/ingestion_buffer.py
@@ -116,3 +116,10 @@ class IngestionBuffer:
         """Flush pending messages for the channel, then answer the query."""
         await self.flush(ref)
         return await self._memory.answer(ref, query=query)
+
+    async def forget(self, ref: ConversationRef) -> None:
+        """Drop the channel's buffered state and delete its memory via the adapter."""
+        async with self._lock:
+            self._pending.pop(ref.channel_id, None)
+            self._opened_at.pop(ref.channel_id, None)
+        await self._memory.forget(ref)

--- a/examples/slack_cognee_bot/src/ingestion_buffer.py
+++ b/examples/slack_cognee_bot/src/ingestion_buffer.py
@@ -1,0 +1,118 @@
+"""Per-channel ingestion buffer + cognify trigger for the Slack bot (issue #3609).
+
+This sits on top of the Commit-2 :class:`ChatMemory` adapter and decides *when*
+to turn buffered messages into a knowledge graph. It does not call cognee
+directly — it orchestrates the adapter's ``ingest`` / ``flush`` / ``answer``.
+
+Trigger policy (exactly the triggers the Phase 3 plan specified):
+
+1. **Size threshold** — flush (cognify) a channel once ``cognify_batch_size``
+   messages have accumulated for it. This is the primary trigger.
+2. **Time interval** — optionally flush a channel once ``flush_interval_seconds``
+   has elapsed since its batch started accumulating. Disabled by default
+   (``None``). Implemented as a passive elapsed-time check evaluated on activity
+   with an injectable clock, so it is deterministic and needs no free-running
+   background task for an example app.
+3. **On-demand before answer** — :meth:`answer` flushes any pending messages for
+   the channel first, so a question always reflects everything said so far.
+
+The per-channel pending counter is only a *trigger heuristic*. cognee's
+``cognify`` reprocesses the whole (incrementally-loaded) dataset, so even if a
+flush is skipped or fails, a later flush still picks up any un-cognified
+messages — nothing is permanently missed.
+
+Accumulation is guarded by an ``asyncio.Lock``; the slow adapter awaits
+(``ingest`` / ``flush``) happen outside the lock so they never serialize.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+
+from src.config import IngestionSettings, load_ingestion_settings
+from src.memory_adapter import Answer, ChatMemory, ConversationRef
+
+
+class IngestionBuffer:
+    """Buffers ingested messages per channel and triggers cognify per the policy."""
+
+    def __init__(
+        self,
+        memory: ChatMemory,
+        *,
+        settings: IngestionSettings | None = None,
+        time_fn: Callable[[], float] = time.monotonic,
+    ):
+        settings = settings or load_ingestion_settings()
+        self._memory = memory
+        self._batch_size = max(1, settings.cognify_batch_size)
+        self._flush_interval = settings.flush_interval_seconds
+        self._time_fn = time_fn
+
+        self._lock = asyncio.Lock()
+        # channel_id -> count of messages ingested but not yet cognified.
+        self._pending: dict[str, int] = {}
+        # channel_id -> monotonic time the current batch started accumulating.
+        self._opened_at: dict[str, float] = {}
+
+    def pending_count(self, channel_id: str) -> int:
+        """Number of buffered-but-not-yet-cognified messages for a channel."""
+        return self._pending.get(channel_id, 0)
+
+    async def add_message(
+        self,
+        ref: ConversationRef,
+        *,
+        ts: str,
+        text: str,
+        permalink: str,
+        author: str,
+    ) -> None:
+        """Ingest a message into its channel and flush if a trigger fires."""
+        # Ingest (the slow cognee.add) happens outside the lock.
+        await self._memory.ingest(ref, ts=ts, text=text, permalink=permalink, author=author)
+
+        async with self._lock:
+            channel_id = ref.channel_id
+            if self._pending.get(channel_id, 0) == 0:
+                self._opened_at[channel_id] = self._time_fn()
+            self._pending[channel_id] = self._pending.get(channel_id, 0) + 1
+            should_flush = self._should_flush_locked(channel_id)
+
+        if should_flush:
+            await self.flush(ref)
+
+    def _should_flush_locked(self, channel_id: str) -> bool:
+        """Decide whether ``channel_id`` should flush. Caller must hold the lock."""
+        count = self._pending.get(channel_id, 0)
+        if count == 0:
+            return False
+        if count >= self._batch_size:
+            return True
+        if self._flush_interval is not None:
+            opened_at = self._opened_at.get(channel_id)
+            if opened_at is not None and self._time_fn() - opened_at >= self._flush_interval:
+                return True
+        return False
+
+    async def flush(self, ref: ConversationRef) -> None:
+        """Cognify the channel's dataset if it has pending messages; else no-op.
+
+        Empty-buffer flush never calls the adapter (clean no-op). The counter is
+        reset under the lock before the (idempotent) cognify runs.
+        """
+        channel_id = ref.channel_id
+        async with self._lock:
+            if self._pending.get(channel_id, 0) == 0:
+                return
+            self._pending[channel_id] = 0
+            self._opened_at.pop(channel_id, None)
+
+        await self._memory.flush(ref)
+
+    async def answer(self, ref: ConversationRef, *, query: str) -> Answer:
+        """Flush pending messages for the channel, then answer the query."""
+        await self.flush(ref)
+        return await self._memory.answer(ref, query=query)

--- a/examples/slack_cognee_bot/src/memory_adapter.py
+++ b/examples/slack_cognee_bot/src/memory_adapter.py
@@ -1,0 +1,148 @@
+"""Thin chat-memory adapter interface for the Slack + cognee bot (issue #3609).
+
+This module implements the **#3608 "shared chat-memory adapter" pattern locally**.
+Issue #3608 (a reusable ingest / answer / forget core for chat bots) is still in
+its design phase and is not merged, so we cannot import it. Instead we define a
+thin, framework-agnostic ``ChatMemory`` interface plus the value types it works
+with, and build the Slack bot against that interface. When the real #3608 core
+lands, only the concrete implementation (commit 2, ``cognee_memory.py``) is
+swapped out — the Slack handlers keep talking to this interface unchanged.
+
+Deliberately kept dependency-free: this module imports only the standard library.
+It does **not** import Slack (``slack_bolt``) or cognee — those belong to the
+concrete implementation and the transport layer, not the contract.
+
+Session / dataset mapping (see the Phase 2 design contract):
+
+* **Memory boundary = one dataset per channel** (``slack_<channel_id>``). This is
+  the granularity at which cognee can actually forget (dataset-level delete), so
+  it is the boundary that makes the ``forget`` story work.
+* **Node-set tag = ``[channel_id]``** so chunk retrieval can be filtered to a
+  single channel within a dataset.
+* **session_id = ``<team>:<channel>[:<thread>]``** — a deterministic, per-thread
+  identifier used only as optional conversational Q&A context, never as the
+  store of ingested messages.
+* **Per-message identity = ``uuid5(namespace, "<channel>:<ts>")``** — a stable,
+  controllable id assigned at ingest so a retrieved chunk's ``document_id`` can
+  be joined back to the original Slack message (the citation key).
+"""
+
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from uuid import UUID
+
+# Stable namespace for deriving per-message data ids. Fixed forever so the same
+# (channel, ts) always maps to the same cognee data/document id across runs.
+SLACK_UUID_NAMESPACE: UUID = uuid.uuid5(uuid.NAMESPACE_URL, "https://cognee.ai/slack-bot/3609")
+
+
+def message_data_id(channel_id: str, ts: str) -> UUID:
+    """Deterministic cognee data id for a single Slack message.
+
+    The value is passed as ``DataItem.data_id`` at ingest (commit 2). cognee then
+    reuses it as the ``Data`` record id, the ``Document`` id, and ultimately each
+    ``DocumentChunk.document_id`` returned by a ``CHUNKS`` search — which is how a
+    retrieved chunk is mapped back to its source message for citations.
+
+    Parameters
+    ----------
+    channel_id:
+        Slack channel id the message was posted in.
+    ts:
+        Slack message timestamp (its unique id within the channel).
+    """
+    return uuid.uuid5(SLACK_UUID_NAMESPACE, f"{channel_id}:{ts}")
+
+
+@dataclass(frozen=True)
+class ConversationRef:
+    """Identity of a Slack conversation, and its mapping into cognee.
+
+    Frozen (hashable) so it can be used as a dict/queue key by later commits.
+    """
+
+    team_id: str
+    channel_id: str
+    thread_ts: str | None = None
+
+    @property
+    def dataset_name(self) -> str:
+        """cognee dataset that stores this channel's memory (the forget boundary)."""
+        return f"slack_{self.channel_id}"
+
+    @property
+    def node_set(self) -> list[str]:
+        """Node-set tag applied at ingest, used to filter chunk retrieval by channel."""
+        return [self.channel_id]
+
+    @property
+    def session_id(self) -> str:
+        """Deterministic per-thread session id (optional Q&A-context scope only)."""
+        base = f"{self.team_id}:{self.channel_id}"
+        return f"{base}:{self.thread_ts}" if self.thread_ts else base
+
+
+@dataclass(frozen=True)
+class Citation:
+    """A single source message backing an answer.
+
+    ``ok`` is ``False`` when the permalink is stale/missing; renderers must then
+    fall back to plain text (``snippet``/``author``) instead of emitting a link.
+    """
+
+    channel_id: str
+    ts: str
+    permalink: str
+    author: str
+    snippet: str
+    ok: bool = True
+
+
+@dataclass(frozen=True)
+class Answer:
+    """A natural-language answer plus its deduplicated source citations."""
+
+    text: str
+    citations: list[Citation] = field(default_factory=list)
+
+
+class ChatMemory(ABC):
+    """The thin ingest / flush / answer / forget contract (#3608 pattern, local).
+
+    Implementations wrap cognee's public memory API. The Slack transport layer
+    depends only on this abstract type, so the concrete backend can be replaced
+    (e.g. by the real #3608 core) without touching the handlers.
+    """
+
+    @abstractmethod
+    async def ingest(
+        self,
+        ref: ConversationRef,
+        *,
+        ts: str,
+        text: str,
+        permalink: str,
+        author: str,
+    ) -> None:
+        """Buffer a single Slack message into the channel's memory.
+
+        Implementations assign a deterministic per-message id (see
+        :func:`message_data_id`) and record the ``permalink``/``author`` so the
+        message can later be cited. Ingestion does not build the graph — that is
+        deferred to :meth:`flush` (batch/triggered cognify).
+        """
+
+    @abstractmethod
+    async def flush(self, ref: ConversationRef) -> None:
+        """Make buffered messages for ``ref``'s channel searchable (trigger cognify)."""
+
+    @abstractmethod
+    async def answer(self, ref: ConversationRef, *, query: str) -> Answer:
+        """Answer ``query`` from the channel's memory, with source citations."""
+
+    @abstractmethod
+    async def forget(self, ref: ConversationRef) -> None:
+        """Delete all memory for ``ref``'s channel (dataset-level forget)."""

--- a/examples/slack_cognee_bot/src/slack_app.py
+++ b/examples/slack_cognee_bot/src/slack_app.py
@@ -18,9 +18,9 @@ message). The event-handling *logic* lives in plain async functions
 :func:`handle_recall_command`) that take a mockable Slack client/say — no
 slack_bolt needed to import or unit-test them.
 
-Out of scope here (later commits): rich Block Kit citation rendering (commit 5 —
-see the seam in :func:`format_reply`); the ``/forget`` command and opt-in/opt-out
-management (commit 6). This commit wires ingestion, @mention, and /recall only.
+Out of scope here (later commits): the ``/forget`` command and opt-in/opt-out
+management (commit 6). This commit wires ingestion, @mention, and /recall; the
+reply is rendered by the Block Kit citation renderer (:mod:`src.citations`).
 """
 
 from __future__ import annotations
@@ -28,15 +28,14 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from src.citations import notification_text, render_answer
 from src.config import SlackSettings
 from src.ingestion_buffer import IngestionBuffer
-from src.memory_adapter import Answer, ConversationRef
+from src.memory_adapter import ConversationRef
 
 # Matches a leading Slack user mention token like "<@U12345>" so we can strip
 # the "@cognee" prefix off an app_mention to get the bare question.
 _MENTION_TOKEN = re.compile(r"<@[A-Z0-9]+>")
-
-_NO_ANSWER_TEXT = "I couldn't find anything about that in this channel's memory yet."
 
 
 def _load_bolt():
@@ -125,26 +124,6 @@ async def handle_message_event(
     return True
 
 
-def format_reply(answer: Answer) -> str:
-    """Render an :class:`Answer` to a Slack message string.
-
-    NOTE (commit 5 seam): this is the minimal plain/mrkdwn renderer. Commit 5
-    replaces it with the rich Block Kit citations renderer (deduped Sources
-    context block, stale-permalink fallback). The answer handlers already carry
-    ``answer.citations``, so the swap is renderer-only.
-    """
-    lines = [answer.text or _NO_ANSWER_TEXT]
-    if answer.citations:
-        lines.append("")
-        lines.append("Sources:")
-        for cite in answer.citations:
-            if cite.ok and cite.permalink:
-                lines.append(f"• <{cite.permalink}|{cite.author or 'message'}>")
-            else:
-                lines.append(f"• {cite.snippet or 'source'}")
-    return "\n".join(lines)
-
-
 async def _answer_and_reply(
     ref: ConversationRef,
     question: str,
@@ -152,7 +131,9 @@ async def _answer_and_reply(
     say: Any,
 ) -> None:
     answer = await buffer.answer(ref, query=question)
-    await say(format_reply(answer))
+    # Rich Block Kit citations reply; text= is the notification/accessibility
+    # fallback Slack shows when blocks can't be rendered.
+    await say(blocks=render_answer(answer), text=notification_text(answer))
 
 
 async def handle_app_mention(

--- a/examples/slack_cognee_bot/src/slack_app.py
+++ b/examples/slack_cognee_bot/src/slack_app.py
@@ -1,0 +1,234 @@
+"""Slack Bolt app + event handlers for the cognee memory bot (issue #3609).
+
+Wires Slack (Socket Mode) onto the Commit-3 :class:`IngestionBuffer`:
+
+* ``message`` events in opted-in channels are silently ingested (with each
+  message's permalink resolved via ``chat.getPermalink``);
+* ``app_mention`` ("@cognee …") and the ``/recall`` slash command answer from
+  memory, flushing pending messages first.
+
+slack_bolt import isolation
+---------------------------
+``slack_bolt`` is an **example-only** dependency and is NOT part of the cognee
+core install. So this module must import cleanly when slack_bolt is absent — the
+import is therefore deferred into :func:`build_app` / :func:`start_socket_mode`
+(guarded by :func:`_load_bolt`, which raises a clear "install the slack extra"
+message). The event-handling *logic* lives in plain async functions
+(:func:`handle_message_event`, :func:`handle_app_mention`,
+:func:`handle_recall_command`) that take a mockable Slack client/say — no
+slack_bolt needed to import or unit-test them.
+
+Out of scope here (later commits): rich Block Kit citation rendering (commit 5 —
+see the seam in :func:`format_reply`); the ``/forget`` command and opt-in/opt-out
+management (commit 6). This commit wires ingestion, @mention, and /recall only.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from src.config import SlackSettings
+from src.ingestion_buffer import IngestionBuffer
+from src.memory_adapter import Answer, ConversationRef
+
+# Matches a leading Slack user mention token like "<@U12345>" so we can strip
+# the "@cognee" prefix off an app_mention to get the bare question.
+_MENTION_TOKEN = re.compile(r"<@[A-Z0-9]+>")
+
+_NO_ANSWER_TEXT = "I couldn't find anything about that in this channel's memory yet."
+
+
+def _load_bolt():
+    """Import slack_bolt lazily, with an actionable error if it's missing."""
+    try:
+        from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
+        from slack_bolt.async_app import AsyncApp
+    except ImportError as error:  # pragma: no cover - trivial re-raise
+        raise ImportError(
+            "slack_bolt is required to run the Slack bot. Install the example's "
+            "dependencies with `pip install -e examples/slack_cognee_bot` "
+            "(or `pip install slack-bolt`)."
+        ) from error
+    return AsyncApp, AsyncSocketModeHandler
+
+
+# --------------------------------------------------------------------------- #
+# Pure handler logic (slack_bolt-agnostic, unit-testable with mocks)          #
+# --------------------------------------------------------------------------- #
+
+
+def should_ingest(event: dict, opted_in: set[str], bot_user_id: str | None) -> bool:
+    """Decide whether a ``message`` event should be ingested.
+
+    Skips: message subtypes (edits ``message_changed``, deletions, joins, and
+    ``bot_message``), any bot-authored message, the bot's own messages, empty
+    text, and channels the bot hasn't been opted into.
+    """
+    if event.get("subtype"):
+        return False
+    if event.get("bot_id"):
+        return False
+    if bot_user_id and event.get("user") == bot_user_id:
+        return False
+    if not (event.get("text") or "").strip():
+        return False
+    if event.get("channel") not in opted_in:
+        return False
+    return True
+
+
+def _conversation_ref(event: dict, default_team_id: str) -> ConversationRef:
+    return ConversationRef(
+        team_id=event.get("team") or default_team_id,
+        channel_id=event["channel"],
+        thread_ts=event.get("thread_ts"),
+    )
+
+
+async def _resolve_permalink(client: Any, channel: str, ts: str) -> str:
+    """Resolve a message permalink, degrading to "" if Slack can't provide one.
+
+    A blank permalink is handled downstream (the citation renderer falls back to
+    plain text), so a getPermalink failure must never drop the message.
+    """
+    try:
+        response = await client.chat_getPermalink(channel=channel, message_ts=ts)
+        return response.get("permalink", "") or ""
+    except Exception:  # noqa: BLE001 - external SDK call; never fail ingestion
+        return ""
+
+
+async def handle_message_event(
+    event: dict,
+    client: Any,
+    buffer: IngestionBuffer,
+    *,
+    opted_in: set[str],
+    bot_user_id: str | None = None,
+    default_team_id: str = "",
+) -> bool:
+    """Ingest a channel message (permalink resolved). Returns True if ingested."""
+    if not should_ingest(event, opted_in, bot_user_id):
+        return False
+
+    channel = event["channel"]
+    ts = event["ts"]
+    permalink = await _resolve_permalink(client, channel, ts)
+    await buffer.add_message(
+        _conversation_ref(event, default_team_id),
+        ts=ts,
+        text=event.get("text", ""),
+        permalink=permalink,
+        author=event.get("user", ""),
+    )
+    return True
+
+
+def format_reply(answer: Answer) -> str:
+    """Render an :class:`Answer` to a Slack message string.
+
+    NOTE (commit 5 seam): this is the minimal plain/mrkdwn renderer. Commit 5
+    replaces it with the rich Block Kit citations renderer (deduped Sources
+    context block, stale-permalink fallback). The answer handlers already carry
+    ``answer.citations``, so the swap is renderer-only.
+    """
+    lines = [answer.text or _NO_ANSWER_TEXT]
+    if answer.citations:
+        lines.append("")
+        lines.append("Sources:")
+        for cite in answer.citations:
+            if cite.ok and cite.permalink:
+                lines.append(f"• <{cite.permalink}|{cite.author or 'message'}>")
+            else:
+                lines.append(f"• {cite.snippet or 'source'}")
+    return "\n".join(lines)
+
+
+async def _answer_and_reply(
+    ref: ConversationRef,
+    question: str,
+    buffer: IngestionBuffer,
+    say: Any,
+) -> None:
+    answer = await buffer.answer(ref, query=question)
+    await say(format_reply(answer))
+
+
+async def handle_app_mention(
+    event: dict,
+    say: Any,
+    buffer: IngestionBuffer,
+    *,
+    default_team_id: str = "",
+) -> None:
+    """Answer an "@cognee …" mention from the channel's memory."""
+    question = _MENTION_TOKEN.sub("", event.get("text", "")).strip()
+    await _answer_and_reply(_conversation_ref(event, default_team_id), question, buffer, say)
+
+
+async def handle_recall_command(
+    command: dict,
+    ack: Any,
+    say: Any,
+    buffer: IngestionBuffer,
+    *,
+    default_team_id: str = "",
+) -> None:
+    """Answer a ``/recall <question>`` slash command."""
+    await ack()
+    question = (command.get("text") or "").strip()
+    ref = ConversationRef(
+        team_id=command.get("team_id") or default_team_id,
+        channel_id=command["channel_id"],
+    )
+    await _answer_and_reply(ref, question, buffer, say)
+
+
+# --------------------------------------------------------------------------- #
+# Bolt wiring (imports slack_bolt lazily)                                      #
+# --------------------------------------------------------------------------- #
+
+
+def build_app(
+    buffer: IngestionBuffer,
+    settings: SlackSettings,
+    opted_in: set[str],
+    *,
+    bot_user_id: str | None = None,
+):
+    """Construct the Bolt ``AsyncApp`` and register the handlers.
+
+    ``opted_in`` is a live set (commit 6's opt-out command mutates it).
+    """
+    AsyncApp, _ = _load_bolt()
+    app = AsyncApp(token=settings.bot_token)
+    default_team_id = settings.default_team_id
+
+    @app.event("message")
+    async def _on_message(event, client):
+        await handle_message_event(
+            event,
+            client,
+            buffer,
+            opted_in=opted_in,
+            bot_user_id=bot_user_id,
+            default_team_id=default_team_id,
+        )
+
+    @app.event("app_mention")
+    async def _on_app_mention(event, say):
+        await handle_app_mention(event, say, buffer, default_team_id=default_team_id)
+
+    @app.command("/recall")
+    async def _on_recall(ack, command, say):
+        await handle_recall_command(command, ack, say, buffer, default_team_id=default_team_id)
+
+    return app
+
+
+async def start_socket_mode(app, settings: SlackSettings) -> None:
+    """Start the app over Socket Mode (no public URL needed)."""
+    _, AsyncSocketModeHandler = _load_bolt()
+    handler = AsyncSocketModeHandler(app, settings.app_token)
+    await handler.start_async()

--- a/examples/slack_cognee_bot/src/slack_app.py
+++ b/examples/slack_cognee_bot/src/slack_app.py
@@ -167,6 +167,77 @@ async def handle_recall_command(
 
 
 # --------------------------------------------------------------------------- #
+# forget + opt-in / opt-out commands                                          #
+# --------------------------------------------------------------------------- #
+
+# Deletion is dataset-level (whole channel). cognee has no per-user delete
+# (recon: forget() deletes by dataset / data_id / everything — there is no
+# per-author scope), so a per-user "forget me" is intentionally NOT offered and
+# is left as a follow-up. Do not imply per-user deletion in these replies.
+_FORGET_REPLY = (
+    ":wastebasket: Deleted this channel's memory — the entire `{dataset}` dataset "
+    "(messages, graph, and citations).\n"
+    "_Note: cognee forgets at the channel level. Removing just one person's messages "
+    "(\"forget me\") isn't supported yet — that's a follow-up._"
+)
+_OPTIN_DISCLOSURE = (
+    ":wave: I'll now remember messages in this channel — I ingest them into cognee "
+    "memory so anyone here can ask *@cognee …* or */recall …* and get cited answers.\n"
+    "Run */cognee-optout* to stop, or */cognee-forget* to erase what I've stored."
+)
+_OPTIN_ALREADY = "This channel is already opted in — I'm already remembering it."
+_OPTOUT_REPLY = (
+    ":mute: Opted out — I'll stop ingesting new messages in this channel.\n"
+    "_Existing memory is kept. Run */cognee-forget* to delete it too._"
+)
+
+
+async def handle_forget_command(
+    command: dict,
+    ack: Any,
+    say: Any,
+    buffer: IngestionBuffer,
+    *,
+    default_team_id: str = "",
+) -> None:
+    """Delete the current channel's memory (dataset-level forget)."""
+    await ack()
+    channel_id = command["channel_id"]
+    ref = ConversationRef(
+        team_id=command.get("team_id") or default_team_id,
+        channel_id=channel_id,
+    )
+    await buffer.forget(ref)
+    await say(_FORGET_REPLY.format(dataset=ref.dataset_name))
+
+
+async def handle_optin_command(
+    command: dict,
+    ack: Any,
+    say: Any,
+    opted_in: set[str],
+) -> None:
+    """Opt a channel in to ingestion; post the disclosure on first opt-in."""
+    await ack()
+    channel_id = command["channel_id"]
+    first_time = channel_id not in opted_in
+    opted_in.add(channel_id)
+    await say(_OPTIN_DISCLOSURE if first_time else _OPTIN_ALREADY)
+
+
+async def handle_optout_command(
+    command: dict,
+    ack: Any,
+    say: Any,
+    opted_in: set[str],
+) -> None:
+    """Opt a channel out of ingestion (stops future ingest; keeps existing data)."""
+    await ack()
+    opted_in.discard(command["channel_id"])
+    await say(_OPTOUT_REPLY)
+
+
+# --------------------------------------------------------------------------- #
 # Bolt wiring (imports slack_bolt lazily)                                      #
 # --------------------------------------------------------------------------- #
 
@@ -204,6 +275,20 @@ def build_app(
     @app.command("/recall")
     async def _on_recall(ack, command, say):
         await handle_recall_command(command, ack, say, buffer, default_team_id=default_team_id)
+
+    # forget + opt-in/opt-out all close over the SAME `opted_in` set the message
+    # handler reads — a single source of truth, no divergent store.
+    @app.command("/cognee-forget")
+    async def _on_forget(ack, command, say):
+        await handle_forget_command(command, ack, say, buffer, default_team_id=default_team_id)
+
+    @app.command("/cognee-optin")
+    async def _on_optin(ack, command, say):
+        await handle_optin_command(command, ack, say, opted_in)
+
+    @app.command("/cognee-optout")
+    async def _on_optout(ack, command, say):
+        await handle_optout_command(command, ack, say, opted_in)
 
     return app
 

--- a/examples/slack_cognee_bot/tests/conftest.py
+++ b/examples/slack_cognee_bot/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Test bootstrap for the Slack + cognee bot example.
+
+Puts the example app root on ``sys.path`` so tests can ``import src.<module>``
+without installing the package, mirroring ``cognee-mcp/tests`` conventions.
+"""
+
+import sys
+from pathlib import Path
+
+APP_ROOT = Path(__file__).resolve().parents[1]  # examples/slack_cognee_bot/
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))

--- a/examples/slack_cognee_bot/tests/test_citations.py
+++ b/examples/slack_cognee_bot/tests/test_citations.py
@@ -1,0 +1,134 @@
+"""Unit tests for the Block Kit citation renderer (issue #3609, commit 5).
+
+Pure rendering — no cognee, no Slack, no keys.
+"""
+
+from src.citations import (
+    DEFAULT_MAX_SOURCES,
+    _NO_SOURCES_NOTE,
+    notification_text,
+    render_answer,
+)
+from src.memory_adapter import Answer, Citation
+
+
+def _cite(ts="1700000000.000100", *, permalink="https://slack.example/x", ok=True, **kw):
+    base = dict(channel_id="C1", ts=ts, permalink=permalink, author="alice", snippet="snip", ok=ok)
+    base.update(kw)
+    return Citation(**base)
+
+
+def _blocks_text(blocks):
+    """Flatten all mrkdwn text in a Block Kit block list for assertions."""
+    out = []
+    for block in blocks:
+        if "text" in block and isinstance(block["text"], dict):
+            out.append(block["text"]["text"])
+        for element in block.get("elements", []):
+            out.append(element.get("text", ""))
+    return "\n".join(out)
+
+
+def test_section_block_carries_answer_text():
+    blocks = render_answer(Answer(text="We shipped Friday.", citations=[]))
+    assert blocks[0]["type"] == "section"
+    assert blocks[0]["text"]["type"] == "mrkdwn"
+    assert blocks[0]["text"]["text"] == "We shipped Friday."
+
+
+def test_two_citations_render_two_ordered_permalink_sources():
+    answer = Answer(
+        text="Answer.",
+        citations=[
+            _cite(ts="1700000000.000100", permalink="https://slack.example/a", author="alice"),
+            _cite(ts="1700000100.000100", permalink="https://slack.example/b", author="bob"),
+        ],
+    )
+    blocks = render_answer(answer)
+    text = _blocks_text(blocks)
+
+    assert "https://slack.example/a" in text
+    assert "https://slack.example/b" in text
+    # Order preserved (relevance order from the adapter).
+    assert text.index("https://slack.example/a") < text.index("https://slack.example/b")
+    # Rendered as mrkdwn links.
+    assert "<https://slack.example/a|" in text
+    assert "#C1" in text and "alice" in text
+
+
+def test_same_ts_citations_dedupe_to_one_source():
+    answer = Answer(
+        text="Answer.",
+        citations=[
+            _cite(ts="1700000000.000100", permalink="https://slack.example/a"),
+            _cite(ts="1700000000.000100", permalink="https://slack.example/a"),
+        ],
+    )
+    blocks = render_answer(answer)
+    text = _blocks_text(blocks)
+    assert text.count("https://slack.example/a") == 1
+
+
+def test_missing_permalink_renders_plain_text_no_broken_link():
+    answer = Answer(
+        text="Answer.",
+        citations=[_cite(permalink="", ok=False, author="alice")],
+    )
+    blocks = render_answer(answer)
+    text = _blocks_text(blocks)
+
+    assert "<|" not in text  # never a broken link
+    assert "alice" in text  # descriptive label still shown
+    assert "#C1" in text
+
+
+def test_missing_permalink_and_empty_label_falls_back_to_snippet():
+    # The adapter's missing-index-row fallback: blank channel/ts/author.
+    answer = Answer(
+        text="Answer.",
+        citations=[
+            Citation(channel_id="", ts="", permalink="", author="", snippet="orphan text", ok=False)
+        ],
+    )
+    text = _blocks_text(render_answer(answer))
+    assert "orphan text" in text
+    assert "<|" not in text
+
+
+def test_zero_citations_render_no_sources_note():
+    blocks = render_answer(Answer(text="Answer with no sources.", citations=[]))
+    text = _blocks_text(blocks)
+    assert "Answer with no sources." in text
+    assert _NO_SOURCES_NOTE in text
+    # No empty Sources block — the second block is the note, not a blank list.
+    assert "*Sources:*" not in text
+
+
+def test_blank_answer_uses_calm_fallback():
+    blocks = render_answer(Answer(text="   ", citations=[]))
+    section = blocks[0]["text"]["text"]
+    assert section  # non-empty
+    assert "couldn't find" in section.lower()
+
+
+def test_source_cap_notes_plus_n_more():
+    citations = [
+        _cite(ts=f"170000000{i}.000100", permalink=f"https://slack.example/{i}")
+        for i in range(DEFAULT_MAX_SOURCES + 3)
+    ]
+    blocks = render_answer(Answer(text="A.", citations=citations))
+    text = _blocks_text(blocks)
+    # Only DEFAULT_MAX_SOURCES links shown, with a "+3 more" note.
+    assert text.count("https://slack.example/") == DEFAULT_MAX_SOURCES
+    assert "+3 more" in text
+
+
+def test_notification_text_falls_back_when_blank():
+    assert notification_text(Answer(text="hi", citations=[])) == "hi"
+    assert "couldn't find" in notification_text(Answer(text="", citations=[])).lower()
+
+
+def test_block_kit_structure_is_section_then_context():
+    blocks = render_answer(Answer(text="A.", citations=[_cite()]))
+    assert [b["type"] for b in blocks] == ["section", "context"]
+    assert blocks[1]["elements"][0]["type"] == "mrkdwn"

--- a/examples/slack_cognee_bot/tests/test_cognee_memory.py
+++ b/examples/slack_cognee_bot/tests/test_cognee_memory.py
@@ -1,0 +1,336 @@
+"""Unit tests for the cognee-backed adapter (issue #3609, commit 2).
+
+Every cognee call (add / cognify / search / forget) is mocked — real cognify is
+expensive and needs API keys, so it is never run here. No Slack, no keys.
+
+The critical test is the citation round-trip: it mocks ``cognee.search`` to
+return chunk payloads shaped EXACTLY like cognee's real ``search(CHUNKS)`` output
+(a flat ``list[dict]`` of DocumentChunk payloads carrying ``document_id``) and
+asserts the resulting ``Answer`` citations carry the correct channel/ts/permalink
+joined back from that ``document_id``.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import cognee
+import pytest
+
+from src.citation_index import CitationIndex
+from src.cognee_memory import (
+    CogneeChatMemory,
+    _first_text,
+    _normalize_chunk_payloads,
+)
+from src.memory_adapter import Answer, ConversationRef, message_data_id
+
+REF = ConversationRef(team_id="T1", channel_id="C42")
+
+
+@pytest.fixture
+def index():
+    idx = CitationIndex(":memory:")
+    yield idx
+    idx.close()
+
+
+@pytest.fixture
+def memory(index):
+    return CogneeChatMemory(index, top_k=5)
+
+
+def _real_chunk_payload(document_id: str, text: str, chunk_index: int = 0) -> dict:
+    """A dict shaped like a real search(SearchType.CHUNKS) result item.
+
+    Keys mirror the DocumentChunk vector payload kept by LanceDB
+    (``_build_data_point_schema`` keeps scalar fields + id + belongs_to_set,
+    drops ``metadata`` and nested models). ``document_id`` is the join key.
+    """
+    return {
+        "id": f"chunk-{document_id}-{chunk_index}",
+        "text": text,
+        "chunk_size": len(text),
+        "chunk_index": chunk_index,
+        "cut_type": "sentence_end",
+        "document_id": document_id,
+        "document_name": "slack_message.txt",
+        "belongs_to_set": ["C42"],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# ingest                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_ingest_adds_with_deterministic_id_and_records_citation(memory, index, monkeypatch):
+    add_mock = AsyncMock()
+    monkeypatch.setattr(cognee, "add", add_mock)
+
+    asyncio.run(
+        memory.ingest(
+            REF,
+            ts="1700000000.000100",
+            text="We decided to ship on Friday.",
+            permalink="https://slack.example/archives/C42/p1700000000000100",
+            author="alice",
+        )
+    )
+
+    add_mock.assert_awaited_once()
+    args, kwargs = add_mock.await_args
+    data_item = args[0]
+    expected_id = message_data_id("C42", "1700000000.000100")
+    assert data_item.data == "We decided to ship on Friday."
+    assert data_item.data_id == expected_id
+    assert kwargs["dataset_name"] == "slack_C42"
+    assert kwargs["node_set"] == ["C42"]
+
+    record = index.get(str(expected_id))
+    assert record is not None
+    assert record.channel_id == "C42"
+    assert record.ts == "1700000000.000100"
+    assert record.permalink == "https://slack.example/archives/C42/p1700000000000100"
+    assert record.author == "alice"
+    assert record.snippet == "We decided to ship on Friday."
+
+
+def test_ingest_does_not_cognify(memory, monkeypatch):
+    add_mock = AsyncMock()
+    cognify_mock = AsyncMock()
+    monkeypatch.setattr(cognee, "add", add_mock)
+    monkeypatch.setattr(cognee, "cognify", cognify_mock)
+
+    asyncio.run(memory.ingest(REF, ts="1.0", text="hi", permalink="https://x", author="bob"))
+
+    cognify_mock.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# flush                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_flush_triggers_cognify_for_channel_dataset(memory, monkeypatch):
+    cognify_mock = AsyncMock()
+    monkeypatch.setattr(cognee, "cognify", cognify_mock)
+
+    asyncio.run(memory.flush(REF))
+
+    cognify_mock.assert_awaited_once()
+    _, kwargs = cognify_mock.await_args
+    assert kwargs["datasets"] == ["slack_C42"]
+
+
+# --------------------------------------------------------------------------- #
+# answer — the critical citation round-trip                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _patch_search(monkeypatch, *, prose, chunks):
+    def fake_search(query_text, *, query_type, **kwargs):
+        if query_type == cognee.SearchType.GRAPH_COMPLETION:
+            return prose
+        if query_type == cognee.SearchType.CHUNKS:
+            return chunks
+        raise AssertionError(f"unexpected query_type {query_type}")
+
+    search_mock = AsyncMock(side_effect=fake_search)
+    monkeypatch.setattr(cognee, "search", search_mock)
+    return search_mock
+
+
+def test_answer_round_trip_maps_chunks_to_citations(memory, index, monkeypatch):
+    # Ingest a real message so the side index holds its citation row.
+    add_mock = AsyncMock()
+    monkeypatch.setattr(cognee, "add", add_mock)
+    ts = "1700000000.000100"
+    permalink = "https://slack.example/archives/C42/p1700000000000100"
+    asyncio.run(
+        memory.ingest(
+            REF, ts=ts, text="We decided to ship on Friday.", permalink=permalink, author="alice"
+        )
+    )
+    document_id = str(message_data_id("C42", ts))
+
+    # Mock search: prose from GRAPH_COMPLETION, real-shaped chunk from CHUNKS.
+    search_mock = _patch_search(
+        monkeypatch,
+        prose=["The team decided to ship on Friday."],
+        chunks=[_real_chunk_payload(document_id, "We decided to ship on Friday.")],
+    )
+
+    answer = asyncio.run(memory.answer(REF, query="what did we decide?"))
+
+    assert isinstance(answer, Answer)
+    assert answer.text == "The team decided to ship on Friday."
+    assert len(answer.citations) == 1
+    cite = answer.citations[0]
+    assert cite.ok is True
+    assert cite.permalink == permalink
+    assert cite.channel_id == "C42"
+    assert cite.ts == ts
+    assert cite.author == "alice"
+
+    # Confirm the two searches used the right types / scope.
+    assert search_mock.await_count == 2
+    query_types = {call.kwargs["query_type"] for call in search_mock.await_args_list}
+    assert query_types == {cognee.SearchType.GRAPH_COMPLETION, cognee.SearchType.CHUNKS}
+    chunks_call = next(
+        c for c in search_mock.await_args_list if c.kwargs["query_type"] == cognee.SearchType.CHUNKS
+    )
+    assert chunks_call.kwargs["datasets"] == ["slack_C42"]
+    assert chunks_call.kwargs["node_name"] == ["C42"]
+
+
+def test_answer_dedupes_multiple_chunks_from_one_message(memory, index, monkeypatch):
+    ts = "1700000000.000100"
+    document_id = str(message_data_id("C42", ts))
+    index.put(
+        document_id,
+        channel_id="C42",
+        ts=ts,
+        permalink="https://slack.example/x",
+        author="alice",
+        snippet="msg",
+    )
+
+    _patch_search(
+        monkeypatch,
+        prose=["answer"],
+        chunks=[
+            _real_chunk_payload(document_id, "chunk one", chunk_index=0),
+            _real_chunk_payload(document_id, "chunk two", chunk_index=1),
+        ],
+    )
+
+    answer = asyncio.run(memory.answer(REF, query="q"))
+
+    assert len(answer.citations) == 1
+    assert answer.citations[0].permalink == "https://slack.example/x"
+
+
+def test_answer_missing_permalink_falls_back_gracefully(memory, monkeypatch):
+    # No index row for this document_id → must not crash, must degrade to text.
+    unknown_document_id = str(message_data_id("C42", "9999.0001"))
+    _patch_search(
+        monkeypatch,
+        prose=["here is what I found"],
+        chunks=[_real_chunk_payload(unknown_document_id, "orphan chunk text")],
+    )
+
+    answer = asyncio.run(memory.answer(REF, query="q"))
+
+    assert answer.text == "here is what I found"
+    assert len(answer.citations) == 1
+    cite = answer.citations[0]
+    assert cite.ok is False
+    assert cite.permalink == ""
+    assert cite.snippet == "orphan chunk text"
+
+
+def test_answer_blank_permalink_in_index_falls_back(memory, index, monkeypatch):
+    ts = "1700000000.000100"
+    document_id = str(message_data_id("C42", ts))
+    index.put(
+        document_id,
+        channel_id="C42",
+        ts=ts,
+        permalink="",  # stale/blank permalink
+        author="alice",
+        snippet="stored snippet",
+    )
+    _patch_search(
+        monkeypatch,
+        prose=["a"],
+        chunks=[_real_chunk_payload(document_id, "chunk text")],
+    )
+
+    answer = asyncio.run(memory.answer(REF, query="q"))
+
+    cite = answer.citations[0]
+    assert cite.ok is False
+    assert cite.permalink == ""
+    assert cite.snippet == "stored snippet"
+
+
+def test_answer_handles_access_control_wrapper_shape(memory, index, monkeypatch):
+    # Prove _first_text / _normalize handle the ENABLE_BACKEND_ACCESS_CONTROL shape:
+    # search returns [{"dataset_id":..., "search_result": <result>}].
+    ts = "1700000000.000100"
+    document_id = str(message_data_id("C42", ts))
+    index.put(
+        document_id,
+        channel_id="C42",
+        ts=ts,
+        permalink="https://slack.example/x",
+        author="alice",
+        snippet="msg",
+    )
+    _patch_search(
+        monkeypatch,
+        prose=[
+            {"dataset_id": "d1", "dataset_name": "slack_C42", "search_result": "wrapped answer"}
+        ],
+        chunks=[
+            {
+                "dataset_id": "d1",
+                "dataset_name": "slack_C42",
+                "search_result": [_real_chunk_payload(document_id, "chunk text")],
+            }
+        ],
+    )
+
+    answer = asyncio.run(memory.answer(REF, query="q"))
+
+    assert answer.text == "wrapped answer"
+    assert len(answer.citations) == 1
+    assert answer.citations[0].permalink == "https://slack.example/x"
+
+
+# --------------------------------------------------------------------------- #
+# forget                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_forget_deletes_channel_dataset_and_citations(memory, index, monkeypatch):
+    document_id = str(message_data_id("C42", "1.0"))
+    index.put(
+        document_id,
+        channel_id="C42",
+        ts="1.0",
+        permalink="https://slack.example/x",
+        author="alice",
+        snippet="msg",
+    )
+    forget_mock = AsyncMock()
+    monkeypatch.setattr(cognee, "forget", forget_mock)
+
+    asyncio.run(memory.forget(REF))
+
+    forget_mock.assert_awaited_once()
+    _, kwargs = forget_mock.await_args
+    assert kwargs["dataset"] == "slack_C42"
+    assert index.get(document_id) is None
+
+
+# --------------------------------------------------------------------------- #
+# shape helpers (direct)                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_normalize_chunk_payloads_flat_and_wrapped():
+    flat = [{"document_id": "a"}, {"document_id": "b"}]
+    assert _normalize_chunk_payloads(flat) == flat
+
+    wrapped = [{"dataset_id": "d1", "search_result": [{"document_id": "a"}]}]
+    assert _normalize_chunk_payloads(wrapped) == [{"document_id": "a"}]
+
+    assert _normalize_chunk_payloads(None) == []
+
+
+def test_first_text_variants():
+    assert _first_text(["hello"]) == "hello"
+    assert _first_text("hello") == "hello"
+    assert _first_text([{"search_result": "wrapped"}]) == "wrapped"
+    assert _first_text([]) == ""

--- a/examples/slack_cognee_bot/tests/test_ingestion_buffer.py
+++ b/examples/slack_cognee_bot/tests/test_ingestion_buffer.py
@@ -1,0 +1,253 @@
+"""Unit tests for the per-channel ingestion buffer (issue #3609, commit 3).
+
+The adapter (ingest / flush / answer) is mocked — no cognee, no keys. These
+tests exercise only the buffering + trigger policy.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.config import IngestionSettings
+from src.ingestion_buffer import IngestionBuffer
+from src.memory_adapter import Answer, ConversationRef
+
+REF_A = ConversationRef(team_id="T1", channel_id="A")
+REF_B = ConversationRef(team_id="T1", channel_id="B")
+
+
+def _fake_memory():
+    memory = AsyncMock()
+    memory.answer.return_value = Answer(text="answer", citations=[])
+    return memory
+
+
+def _add(buffer, ref, n, start=0):
+    async def _run():
+        for i in range(start, start + n):
+            await buffer.add_message(
+                ref, ts=f"{i}.0", text=f"msg {i}", permalink=f"https://x/{i}", author="alice"
+            )
+
+    asyncio.run(_run())
+
+
+# --------------------------------------------------------------------------- #
+# accumulation                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_messages_accumulate_without_flushing_below_threshold():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=5))
+
+    _add(buffer, REF_A, 3)
+
+    assert memory.ingest.await_count == 3
+    assert buffer.pending_count("A") == 3
+    memory.flush.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# size-threshold trigger                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_size_threshold_fires_flush_at_exact_count():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=3))
+
+    # First two must not flush.
+    _add(buffer, REF_A, 2)
+    memory.flush.assert_not_awaited()
+    assert buffer.pending_count("A") == 2
+
+    # Third hits the threshold -> exactly one flush, counter resets.
+    _add(buffer, REF_A, 1, start=2)
+    memory.flush.assert_awaited_once()
+    assert memory.flush.await_args.args[0] is REF_A
+    assert buffer.pending_count("A") == 0
+
+
+def test_second_batch_triggers_a_second_flush():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=2))
+
+    _add(buffer, REF_A, 4)  # two full batches
+
+    assert memory.ingest.await_count == 4
+    assert memory.flush.await_count == 2
+    assert buffer.pending_count("A") == 0
+
+
+# --------------------------------------------------------------------------- #
+# on-demand flush before answer                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_answer_flushes_pending_first():
+    memory = _fake_memory()
+    call_order = []
+    memory.flush.side_effect = lambda ref: call_order.append(("flush", ref.channel_id))
+
+    async def _answer_side_effect(ref, *, query):
+        call_order.append(("answer", ref.channel_id))
+        return Answer(text="answer", citations=[])
+
+    memory.answer.side_effect = _answer_side_effect
+
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=100))
+    _add(buffer, REF_A, 2)  # pending, below threshold
+    assert buffer.pending_count("A") == 2
+
+    result = asyncio.run(buffer.answer(REF_A, query="what did we decide?"))
+
+    assert isinstance(result, Answer)
+    # flush happened before answer, and pending was cleared.
+    assert call_order == [("flush", "A"), ("answer", "A")]
+    assert buffer.pending_count("A") == 0
+
+
+def test_answer_with_no_pending_is_still_answered_without_flush():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=5))
+
+    result = asyncio.run(buffer.answer(REF_A, query="q"))
+
+    assert isinstance(result, Answer)
+    memory.flush.assert_not_awaited()  # empty buffer -> no cognify
+    memory.answer.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# per-channel isolation                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_buffers_are_isolated_per_channel():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=3))
+
+    _add(buffer, REF_A, 2)  # A: 2 pending
+    _add(buffer, REF_B, 1)  # B: 1 pending
+
+    assert buffer.pending_count("A") == 2
+    assert buffer.pending_count("B") == 1
+    memory.flush.assert_not_awaited()
+
+    # Filling A to threshold flushes A only; B untouched.
+    _add(buffer, REF_A, 1, start=2)
+    assert memory.flush.await_count == 1
+    assert memory.flush.await_args.args[0] is REF_A
+    assert buffer.pending_count("A") == 0
+    assert buffer.pending_count("B") == 1
+
+
+def test_flush_one_channel_does_not_touch_another():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=100))
+
+    _add(buffer, REF_A, 2)
+    _add(buffer, REF_B, 2)
+
+    asyncio.run(buffer.flush(REF_A))
+
+    assert memory.flush.await_count == 1
+    assert buffer.pending_count("A") == 0
+    assert buffer.pending_count("B") == 2  # B still pending
+
+
+# --------------------------------------------------------------------------- #
+# empty-buffer flush is a clean no-op                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_buffer_flush_is_noop():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=5))
+
+    asyncio.run(buffer.flush(REF_A))
+
+    memory.flush.assert_not_awaited()
+    assert buffer.pending_count("A") == 0
+
+
+def test_flush_is_noop_again_immediately_after_flushing():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=2))
+
+    _add(buffer, REF_A, 2)  # triggers one flush, resets to 0
+    assert memory.flush.await_count == 1
+
+    asyncio.run(buffer.flush(REF_A))  # nothing pending now
+    assert memory.flush.await_count == 1  # unchanged
+
+
+# --------------------------------------------------------------------------- #
+# time-interval trigger (injectable clock)                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_time_interval_trigger_fires_after_elapsed():
+    memory = _fake_memory()
+    clock = {"t": 100.0}
+    buffer = IngestionBuffer(
+        memory,
+        settings=IngestionSettings(cognify_batch_size=100, flush_interval_seconds=30.0),
+        time_fn=lambda: clock["t"],
+    )
+
+    # First message opens the batch at t=100; below size threshold, no flush.
+    _add(buffer, REF_A, 1)
+    memory.flush.assert_not_awaited()
+    assert buffer.pending_count("A") == 1
+
+    # Advance past the interval; the next message's check trips the timer.
+    clock["t"] = 131.0
+    _add(buffer, REF_A, 1, start=1)
+
+    memory.flush.assert_awaited_once()
+    assert buffer.pending_count("A") == 0
+
+
+def test_time_interval_does_not_fire_before_elapsed():
+    memory = _fake_memory()
+    clock = {"t": 100.0}
+    buffer = IngestionBuffer(
+        memory,
+        settings=IngestionSettings(cognify_batch_size=100, flush_interval_seconds=30.0),
+        time_fn=lambda: clock["t"],
+    )
+
+    _add(buffer, REF_A, 1)
+    clock["t"] = 110.0  # only 10s elapsed
+    _add(buffer, REF_A, 1, start=1)
+
+    memory.flush.assert_not_awaited()
+    assert buffer.pending_count("A") == 2
+
+
+# --------------------------------------------------------------------------- #
+# config                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_load_ingestion_settings_reads_env(monkeypatch):
+    from src.config import load_ingestion_settings
+
+    monkeypatch.setenv("COGNEE_SLACK_COGNIFY_BATCH", "7")
+    monkeypatch.setenv("COGNEE_SLACK_FLUSH_INTERVAL_SECONDS", "45.5")
+    settings = load_ingestion_settings()
+    assert settings.cognify_batch_size == 7
+    assert settings.flush_interval_seconds == 45.5
+
+
+def test_load_ingestion_settings_defaults(monkeypatch):
+    from src.config import DEFAULT_COGNIFY_BATCH_SIZE, load_ingestion_settings
+
+    monkeypatch.delenv("COGNEE_SLACK_COGNIFY_BATCH", raising=False)
+    monkeypatch.delenv("COGNEE_SLACK_FLUSH_INTERVAL_SECONDS", raising=False)
+    settings = load_ingestion_settings()
+    assert settings.cognify_batch_size == DEFAULT_COGNIFY_BATCH_SIZE
+    assert settings.flush_interval_seconds is None

--- a/examples/slack_cognee_bot/tests/test_ingestion_buffer.py
+++ b/examples/slack_cognee_bot/tests/test_ingestion_buffer.py
@@ -173,6 +173,22 @@ def test_empty_buffer_flush_is_noop():
     assert buffer.pending_count("A") == 0
 
 
+def test_forget_clears_pending_and_delegates_to_adapter():
+    memory = _fake_memory()
+    buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=100))
+
+    _add(buffer, REF_A, 2)  # A has pending
+    _add(buffer, REF_B, 1)
+    assert buffer.pending_count("A") == 2
+
+    asyncio.run(buffer.forget(REF_A))
+
+    memory.forget.assert_awaited_once()
+    assert memory.forget.await_args.args[0] is REF_A
+    assert buffer.pending_count("A") == 0  # A's buffered state dropped
+    assert buffer.pending_count("B") == 1  # B untouched
+
+
 def test_flush_is_noop_again_immediately_after_flushing():
     memory = _fake_memory()
     buffer = IngestionBuffer(memory, settings=IngestionSettings(cognify_batch_size=2))

--- a/examples/slack_cognee_bot/tests/test_memory_adapter_contract.py
+++ b/examples/slack_cognee_bot/tests/test_memory_adapter_contract.py
@@ -1,0 +1,184 @@
+"""Unit tests for the thin chat-memory adapter interface (issue #3609, commit 1).
+
+Covers only the framework-agnostic contract: the session/dataset mapping helper,
+the value types, and abstractness of the interface. No cognee, no Slack, no keys.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from src.memory_adapter import (
+    SLACK_UUID_NAMESPACE,
+    Answer,
+    ChatMemory,
+    Citation,
+    ConversationRef,
+    message_data_id,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Session / dataset mapping helper                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_dataset_name_is_channel_scoped():
+    ref = ConversationRef(team_id="T1", channel_id="C42", thread_ts="1700000000.1")
+    assert ref.dataset_name == "slack_C42"
+
+
+def test_node_set_tags_the_channel():
+    ref = ConversationRef(team_id="T1", channel_id="C42")
+    assert ref.node_set == ["C42"]
+
+
+def test_session_id_includes_team_channel_thread():
+    ref = ConversationRef(team_id="T1", channel_id="C42", thread_ts="1700000000.1")
+    assert ref.session_id == "T1:C42:1700000000.1"
+
+
+def test_session_id_falls_back_to_channel_without_thread():
+    ref = ConversationRef(team_id="T1", channel_id="C42")
+    assert ref.session_id == "T1:C42"
+
+
+def test_mapping_is_deterministic():
+    a = ConversationRef(team_id="T1", channel_id="C42", thread_ts="99.1")
+    b = ConversationRef(team_id="T1", channel_id="C42", thread_ts="99.1")
+    assert a == b
+    assert a.dataset_name == b.dataset_name
+    assert a.session_id == b.session_id
+    # Frozen dataclass is hashable (usable as a dict/queue key by later commits).
+    assert hash(a) == hash(b)
+
+
+def test_message_data_id_is_deterministic_and_channel_ts_scoped():
+    first = message_data_id("C42", "1700000000.000100")
+    second = message_data_id("C42", "1700000000.000100")
+    assert isinstance(first, uuid.UUID)
+    assert first == second
+    # Matches the documented uuid5(namespace, "channel:ts") derivation exactly.
+    assert first == uuid.uuid5(SLACK_UUID_NAMESPACE, "C42:1700000000.000100")
+
+
+def test_message_data_id_differs_per_message():
+    a = message_data_id("C42", "1700000000.000100")
+    b = message_data_id("C42", "1700000000.000200")
+    c = message_data_id("C99", "1700000000.000100")
+    assert a != b
+    assert a != c
+
+
+# --------------------------------------------------------------------------- #
+# Value types                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_citation_holds_source_fields_and_defaults_ok_true():
+    cite = Citation(
+        channel_id="C42",
+        ts="1700000000.000100",
+        permalink="https://slack.example/archives/C42/p1700000000000100",
+        author="alice",
+        snippet="we decided to ship on Friday",
+    )
+    assert cite.channel_id == "C42"
+    assert cite.ts == "1700000000.000100"
+    assert cite.permalink.startswith("https://")
+    assert cite.author == "alice"
+    assert cite.snippet == "we decided to ship on Friday"
+    assert cite.ok is True
+
+
+def test_citation_can_mark_stale_permalink():
+    cite = Citation(
+        channel_id="C42",
+        ts="1700000000.000100",
+        permalink="",
+        author="alice",
+        snippet="fallback text",
+        ok=False,
+    )
+    assert cite.ok is False
+
+
+def test_answer_holds_text_and_citations():
+    cite = Citation(
+        channel_id="C42",
+        ts="1.0",
+        permalink="https://slack.example/x",
+        author="bob",
+        snippet="s",
+    )
+    answer = Answer(text="We shipped on Friday.", citations=[cite])
+    assert answer.text == "We shipped on Friday."
+    assert answer.citations == [cite]
+
+
+def test_answer_defaults_to_no_citations():
+    answer = Answer(text="I don't know yet.")
+    assert answer.citations == []
+
+
+# --------------------------------------------------------------------------- #
+# Interface contract                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_chatmemory_is_abstract_and_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        ChatMemory()  # type: ignore[abstract]
+
+
+def test_chatmemory_declares_the_expected_abstract_methods():
+    assert ChatMemory.__abstractmethods__ == frozenset({"ingest", "flush", "answer", "forget"})
+
+
+def test_incomplete_subclass_cannot_be_instantiated():
+    class Partial(ChatMemory):
+        async def ingest(self, ref, *, ts, text, permalink, author):  # noqa: D401
+            return None
+
+        # flush / answer / forget intentionally missing.
+
+    with pytest.raises(TypeError):
+        Partial()  # type: ignore[abstract]
+
+
+def test_complete_subclass_satisfies_the_contract():
+    class Fake(ChatMemory):
+        def __init__(self):
+            self.calls = []
+
+        async def ingest(self, ref, *, ts, text, permalink, author):
+            self.calls.append(("ingest", ref, ts, text, permalink, author))
+
+        async def flush(self, ref):
+            self.calls.append(("flush", ref))
+
+        async def answer(self, ref, *, query):
+            self.calls.append(("answer", ref, query))
+            return Answer(text=f"echo:{query}")
+
+        async def forget(self, ref):
+            self.calls.append(("forget", ref))
+
+    fake = Fake()
+    ref = ConversationRef(team_id="T1", channel_id="C42")
+
+    async def _exercise():
+        await fake.ingest(
+            ref, ts="1.0", text="hi", permalink="https://slack.example/x", author="alice"
+        )
+        await fake.flush(ref)
+        result = await fake.answer(ref, query="what did we decide?")
+        await fake.forget(ref)
+        return result
+
+    answer = asyncio.run(_exercise())
+
+    assert isinstance(answer, Answer)
+    assert answer.text == "echo:what did we decide?"
+    assert [c[0] for c in fake.calls] == ["ingest", "flush", "answer", "forget"]

--- a/examples/slack_cognee_bot/tests/test_slack_commands.py
+++ b/examples/slack_cognee_bot/tests/test_slack_commands.py
@@ -1,0 +1,146 @@
+"""Unit tests for the forget + opt-in/opt-out commands (issue #3609, commit 6).
+
+Bolt (ack/say) and the buffer/adapter are mocked — no cognee, no keys, no
+sockets. These tests also verify the opt-in set is a single source of truth
+shared with the Commit-4 message handler.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from src.slack_app import (
+    handle_forget_command,
+    handle_message_event,
+    handle_optin_command,
+    handle_optout_command,
+    should_ingest,
+)
+
+
+def _cmd(channel_id="C1", team_id="T1"):
+    return {"channel_id": channel_id, "team_id": team_id, "text": ""}
+
+
+# --------------------------------------------------------------------------- #
+# /cognee-forget                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_forget_command_deletes_channel_dataset_and_confirms():
+    buffer = AsyncMock()
+    ack = AsyncMock()
+    say = AsyncMock()
+
+    asyncio.run(handle_forget_command(_cmd("C1", "T1"), ack, say, buffer, default_team_id="T0"))
+
+    ack.assert_awaited_once()
+    buffer.forget.assert_awaited_once()
+    ref = buffer.forget.await_args.args[0]
+    assert ref.channel_id == "C1"
+    assert ref.dataset_name == "slack_C1"
+
+    say.assert_awaited_once()
+    reply = say.await_args.args[0]
+    assert "slack_C1" in reply  # names the deleted dataset
+
+
+def test_forget_reply_surfaces_channel_level_limitation_honestly():
+    buffer = AsyncMock()
+    say = AsyncMock()
+    asyncio.run(handle_forget_command(_cmd("C1"), AsyncMock(), say, buffer))
+
+    reply = say.await_args.args[0].lower()
+    assert "channel level" in reply
+    assert "forget me" in reply  # explicitly states per-user forget is unsupported
+
+
+# --------------------------------------------------------------------------- #
+# /cognee-optin                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_optin_adds_channel_and_posts_disclosure_first_time():
+    opted_in: set[str] = set()
+    say = AsyncMock()
+    ack = AsyncMock()
+
+    asyncio.run(handle_optin_command(_cmd("C1"), ack, say, opted_in))
+
+    ack.assert_awaited_once()
+    assert "C1" in opted_in
+    reply = say.await_args.args[0]
+    assert "remember" in reply.lower()  # disclosure describes what is recorded
+    assert "optout" in reply.lower()  # tells the user how to stop
+
+
+def test_optin_second_time_does_not_repeat_disclosure():
+    opted_in = {"C1"}
+    say = AsyncMock()
+
+    asyncio.run(handle_optin_command(_cmd("C1"), AsyncMock(), say, opted_in))
+
+    assert "C1" in opted_in
+    assert "already" in say.await_args.args[0].lower()
+
+
+# --------------------------------------------------------------------------- #
+# /cognee-optout                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_optout_removes_channel_and_confirms():
+    opted_in = {"C1", "C2"}
+    ack = AsyncMock()
+    say = AsyncMock()
+
+    asyncio.run(handle_optout_command(_cmd("C1"), ack, say, opted_in))
+
+    ack.assert_awaited_once()
+    assert "C1" not in opted_in
+    assert "C2" in opted_in  # other channels untouched
+    assert "forget" in say.await_args.args[0].lower()  # points at /cognee-forget
+
+
+def test_optout_of_unknown_channel_is_safe():
+    opted_in: set[str] = set()
+    # discard() never raises on a missing key.
+    asyncio.run(handle_optout_command(_cmd("C_missing"), AsyncMock(), AsyncMock(), opted_in))
+    assert opted_in == set()
+
+
+# --------------------------------------------------------------------------- #
+# single source of truth: commands + message handler share one opt-in set     #
+# --------------------------------------------------------------------------- #
+
+
+def test_optin_optout_drive_the_same_set_the_message_handler_reads():
+    opted_in: set[str] = set()
+    buffer = AsyncMock()
+    client = AsyncMock()
+    client.chat_getPermalink.return_value = {"permalink": "https://slack.example/x"}
+    event = {"channel": "C1", "ts": "1.0", "text": "hello", "user": "U_alice"}
+
+    # Before opt-in: message is skipped.
+    ingested = asyncio.run(handle_message_event(event, client, buffer, opted_in=opted_in))
+    assert ingested is False
+    buffer.add_message.assert_not_awaited()
+
+    # Opt in via the command -> mutates the same set.
+    asyncio.run(handle_optin_command(_cmd("C1"), AsyncMock(), AsyncMock(), opted_in))
+    ingested = asyncio.run(handle_message_event(event, client, buffer, opted_in=opted_in))
+    assert ingested is True
+    buffer.add_message.assert_awaited_once()
+
+    # Opt out -> the message handler now skips again.
+    asyncio.run(handle_optout_command(_cmd("C1"), AsyncMock(), AsyncMock(), opted_in))
+    ingested = asyncio.run(handle_message_event(event, client, buffer, opted_in=opted_in))
+    assert ingested is False
+    assert buffer.add_message.await_count == 1  # unchanged since opt-out
+
+
+def test_should_ingest_reflects_live_optin_set():
+    opted_in: set[str] = set()
+    event = {"channel": "C1", "text": "x", "user": "U"}
+    assert should_ingest(event, opted_in, None) is False
+    opted_in.add("C1")
+    assert should_ingest(event, opted_in, None) is True

--- a/examples/slack_cognee_bot/tests/test_slack_handlers.py
+++ b/examples/slack_cognee_bot/tests/test_slack_handlers.py
@@ -17,9 +17,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.memory_adapter import Answer, Citation
+from src.memory_adapter import Answer
 from src.slack_app import (
-    format_reply,
     handle_app_mention,
     handle_message_event,
     handle_recall_command,
@@ -174,7 +173,9 @@ def test_app_mention_answers_extracted_question_and_replies():
     assert call.args[0].channel_id == "C1"
     assert call.kwargs["query"] == "what did we decide about the launch?"
     say.assert_awaited_once()
-    assert "We shipped Friday." in say.await_args.args[0]
+    # Reply is Block Kit blocks + a plain notification fallback.
+    assert isinstance(say.await_args.kwargs["blocks"], list)
+    assert "We shipped Friday." in say.await_args.kwargs["text"]
 
 
 # --------------------------------------------------------------------------- #
@@ -199,51 +200,25 @@ def test_recall_command_acks_answers_and_replies():
 
 
 # --------------------------------------------------------------------------- #
-# reply rendering (minimal; commit 5 replaces with Block Kit)                 #
+# reply wiring — the handler posts Block Kit blocks via render_answer          #
 # --------------------------------------------------------------------------- #
 
 
-def test_format_reply_includes_answer_and_ok_citation_link():
-    answer = Answer(
-        text="We shipped Friday.",
-        citations=[
-            Citation(
-                channel_id="C1",
-                ts="1.0",
-                permalink="https://slack.example/x",
-                author="alice",
-                snippet="ship friday",
-                ok=True,
-            )
-        ],
-    )
-    reply = format_reply(answer)
-    assert "We shipped Friday." in reply
-    assert "<https://slack.example/x|alice>" in reply
+def test_answer_reply_is_rendered_via_render_answer(monkeypatch):
+    # Prove the commit-5 renderer is wired into the handler's reply path.
+    import src.slack_app as slack_app
 
+    sentinel_blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": "SENTINEL"}}]
+    monkeypatch.setattr(slack_app, "render_answer", lambda answer: sentinel_blocks)
 
-def test_format_reply_falls_back_for_stale_citation():
-    answer = Answer(
-        text="Answer.",
-        citations=[
-            Citation(
-                channel_id="C1",
-                ts="1.0",
-                permalink="",
-                author="",
-                snippet="fallback text",
-                ok=False,
-            )
-        ],
-    )
-    reply = format_reply(answer)
-    assert "fallback text" in reply
-    assert "<|" not in reply  # no broken link
+    buffer = _fake_buffer()
+    say = AsyncMock()
+    event = {"channel": "C1", "team": "T1", "ts": "5.0", "text": "<@U0BOT123> q?"}
 
+    asyncio.run(slack_app.handle_app_mention(event, say, buffer, default_team_id="T0"))
 
-def test_format_reply_handles_empty_answer():
-    reply = format_reply(Answer(text="", citations=[]))
-    assert reply  # non-empty placeholder, no crash
+    say.assert_awaited_once()
+    assert say.await_args.kwargs["blocks"] is sentinel_blocks
 
 
 # --------------------------------------------------------------------------- #
@@ -261,6 +236,7 @@ def test_non_slack_modules_import_without_slack_bolt():
         "src.cognee_memory",
         "src.ingestion_buffer",
         "src.config",
+        "src.citations",
         "src.slack_app",  # imports without slack_bolt because the import is deferred
     ):
         assert importlib.import_module(mod) is not None

--- a/examples/slack_cognee_bot/tests/test_slack_handlers.py
+++ b/examples/slack_cognee_bot/tests/test_slack_handlers.py
@@ -238,6 +238,7 @@ def test_non_slack_modules_import_without_slack_bolt():
         "src.config",
         "src.citations",
         "src.slack_app",  # imports without slack_bolt because the import is deferred
+        "src.__main__",  # entry point also imports without slack_bolt
     ):
         assert importlib.import_module(mod) is not None
 

--- a/examples/slack_cognee_bot/tests/test_slack_handlers.py
+++ b/examples/slack_cognee_bot/tests/test_slack_handlers.py
@@ -1,0 +1,281 @@
+"""Unit tests for the Slack Bolt handlers (issue #3609, commit 4).
+
+Two mock layers, no real cognee and no real Slack:
+
+* Slack SDK — ``client.chat_getPermalink``, ``say``, ``ack`` are AsyncMocks and
+  events/commands are plain dicts. This mirrors cognee's precedent for mocking
+  external async SDK clients (``httpx.AsyncClient.post`` patched in
+  cognee/tests/integration/infrastructure/session/test_tapes_cache_adapter.py;
+  ``aiohttp.ClientSession.post`` in cognee/tests/test_telemetry.py).
+* Buffer/adapter — an AsyncMock, so no cognee is touched.
+
+No sockets are opened; slack_bolt is not imported by these tests.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.memory_adapter import Answer, Citation
+from src.slack_app import (
+    format_reply,
+    handle_app_mention,
+    handle_message_event,
+    handle_recall_command,
+    should_ingest,
+)
+
+
+def _permalink_client(permalink="https://slack.example/archives/C1/p1"):
+    client = AsyncMock()
+    client.chat_getPermalink.return_value = {"ok": True, "permalink": permalink}
+    return client
+
+
+def _fake_buffer():
+    buffer = AsyncMock()
+    buffer.answer.return_value = Answer(text="We shipped Friday.", citations=[])
+    return buffer
+
+
+# --------------------------------------------------------------------------- #
+# message ingestion                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_normal_message_is_ingested_with_metadata():
+    buffer = _fake_buffer()
+    client = _permalink_client("https://slack.example/archives/C1/p1700000000000100")
+    event = {
+        "type": "message",
+        "channel": "C1",
+        "ts": "1700000000.000100",
+        "user": "U_alice",
+        "team": "T1",
+        "text": "we decided to ship on Friday",
+    }
+
+    ingested = asyncio.run(
+        handle_message_event(
+            event, client, buffer, opted_in={"C1"}, bot_user_id="U_bot", default_team_id="T0"
+        )
+    )
+
+    assert ingested is True
+    client.chat_getPermalink.assert_awaited_once_with(channel="C1", message_ts="1700000000.000100")
+    buffer.add_message.assert_awaited_once()
+    call = buffer.add_message.await_args
+    ref = call.args[0]
+    assert ref.channel_id == "C1"
+    assert ref.team_id == "T1"
+    assert call.kwargs["ts"] == "1700000000.000100"
+    assert call.kwargs["text"] == "we decided to ship on Friday"
+    assert call.kwargs["permalink"] == "https://slack.example/archives/C1/p1700000000000100"
+    assert call.kwargs["author"] == "U_alice"
+
+
+def test_bot_message_is_skipped():
+    buffer = _fake_buffer()
+    client = _permalink_client()
+    event = {"channel": "C1", "ts": "1.0", "text": "beep", "bot_id": "B999"}
+
+    ingested = asyncio.run(handle_message_event(event, client, buffer, opted_in={"C1"}))
+
+    assert ingested is False
+    buffer.add_message.assert_not_awaited()
+    client.chat_getPermalink.assert_not_awaited()
+
+
+def test_edited_message_is_skipped():
+    buffer = _fake_buffer()
+    client = _permalink_client()
+    event = {"channel": "C1", "ts": "1.0", "text": "edited", "subtype": "message_changed"}
+
+    ingested = asyncio.run(handle_message_event(event, client, buffer, opted_in={"C1"}))
+
+    assert ingested is False
+    buffer.add_message.assert_not_awaited()
+
+
+def test_own_message_is_skipped():
+    buffer = _fake_buffer()
+    client = _permalink_client()
+    event = {"channel": "C1", "ts": "1.0", "text": "hi", "user": "U_bot"}
+
+    ingested = asyncio.run(
+        handle_message_event(event, client, buffer, opted_in={"C1"}, bot_user_id="U_bot")
+    )
+
+    assert ingested is False
+    buffer.add_message.assert_not_awaited()
+
+
+def test_message_from_non_opted_in_channel_is_skipped():
+    buffer = _fake_buffer()
+    client = _permalink_client()
+    event = {"channel": "C_other", "ts": "1.0", "text": "secret", "user": "U_alice"}
+
+    ingested = asyncio.run(handle_message_event(event, client, buffer, opted_in={"C1"}))
+
+    assert ingested is False
+    buffer.add_message.assert_not_awaited()
+
+
+def test_empty_text_message_is_skipped():
+    buffer = _fake_buffer()
+    client = _permalink_client()
+    event = {"channel": "C1", "ts": "1.0", "text": "   ", "user": "U_alice"}
+
+    ingested = asyncio.run(handle_message_event(event, client, buffer, opted_in={"C1"}))
+
+    assert ingested is False
+
+
+def test_ingestion_survives_permalink_failure():
+    buffer = _fake_buffer()
+    client = AsyncMock()
+    client.chat_getPermalink.side_effect = RuntimeError("slack down")
+    event = {"channel": "C1", "ts": "1.0", "text": "still ingest me", "user": "U_alice"}
+
+    ingested = asyncio.run(handle_message_event(event, client, buffer, opted_in={"C1"}))
+
+    assert ingested is True
+    assert buffer.add_message.await_args.kwargs["permalink"] == ""
+
+
+def test_should_ingest_predicate_direct():
+    assert should_ingest({"channel": "C1", "text": "x", "user": "U"}, {"C1"}, "U_bot") is True
+    assert (
+        should_ingest({"channel": "C1", "text": "x", "subtype": "bot_message"}, {"C1"}, None)
+        is False
+    )
+
+
+# --------------------------------------------------------------------------- #
+# @mention answer                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_app_mention_answers_extracted_question_and_replies():
+    buffer = _fake_buffer()
+    say = AsyncMock()
+    event = {
+        "channel": "C1",
+        "team": "T1",
+        "ts": "5.0",
+        "text": "<@U0BOT123> what did we decide about the launch?",
+    }
+
+    asyncio.run(handle_app_mention(event, say, buffer, default_team_id="T0"))
+
+    buffer.answer.assert_awaited_once()
+    call = buffer.answer.await_args
+    assert call.args[0].channel_id == "C1"
+    assert call.kwargs["query"] == "what did we decide about the launch?"
+    say.assert_awaited_once()
+    assert "We shipped Friday." in say.await_args.args[0]
+
+
+# --------------------------------------------------------------------------- #
+# /recall slash command                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_recall_command_acks_answers_and_replies():
+    buffer = _fake_buffer()
+    say = AsyncMock()
+    ack = AsyncMock()
+    command = {"channel_id": "C1", "team_id": "T1", "text": "who owns billing?"}
+
+    asyncio.run(handle_recall_command(command, ack, say, buffer, default_team_id="T0"))
+
+    ack.assert_awaited_once()
+    buffer.answer.assert_awaited_once()
+    call = buffer.answer.await_args
+    assert call.args[0].channel_id == "C1"
+    assert call.kwargs["query"] == "who owns billing?"
+    say.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# reply rendering (minimal; commit 5 replaces with Block Kit)                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_format_reply_includes_answer_and_ok_citation_link():
+    answer = Answer(
+        text="We shipped Friday.",
+        citations=[
+            Citation(
+                channel_id="C1",
+                ts="1.0",
+                permalink="https://slack.example/x",
+                author="alice",
+                snippet="ship friday",
+                ok=True,
+            )
+        ],
+    )
+    reply = format_reply(answer)
+    assert "We shipped Friday." in reply
+    assert "<https://slack.example/x|alice>" in reply
+
+
+def test_format_reply_falls_back_for_stale_citation():
+    answer = Answer(
+        text="Answer.",
+        citations=[
+            Citation(
+                channel_id="C1",
+                ts="1.0",
+                permalink="",
+                author="",
+                snippet="fallback text",
+                ok=False,
+            )
+        ],
+    )
+    reply = format_reply(answer)
+    assert "fallback text" in reply
+    assert "<|" not in reply  # no broken link
+
+
+def test_format_reply_handles_empty_answer():
+    reply = format_reply(Answer(text="", citations=[]))
+    assert reply  # non-empty placeholder, no crash
+
+
+# --------------------------------------------------------------------------- #
+# slack_bolt import isolation                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_non_slack_modules_import_without_slack_bolt():
+    # These import cleanly even though slack_bolt is not installed.
+    import importlib
+
+    for mod in (
+        "src.memory_adapter",
+        "src.citation_index",
+        "src.cognee_memory",
+        "src.ingestion_buffer",
+        "src.config",
+        "src.slack_app",  # imports without slack_bolt because the import is deferred
+    ):
+        assert importlib.import_module(mod) is not None
+
+
+def test_build_app_raises_clear_error_when_slack_bolt_missing():
+    # slack_bolt is not installed in the test env, so build_app must fail loudly
+    # with an actionable message rather than at import time.
+    import importlib.util
+
+    if importlib.util.find_spec("slack_bolt") is not None:
+        pytest.skip("slack_bolt is installed; import-isolation error path not exercised")
+
+    from src.config import SlackSettings
+    from src.slack_app import build_app
+
+    with pytest.raises(ImportError, match="slack_bolt"):
+        build_app(AsyncMock(), SlackSettings(bot_token="x", app_token="y"), set())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ azure = ["azure-identity>=1.15.0,<2"]
 deepeval = ["deepeval>=3.0.1,<4"]
 posthog = ["posthog>=3.5.0,<4"]
 groq = ["groq>=0.8.0,<1.0.0"]
+slack = ["slack-bolt>=1.18,<2"]
 llama-cpp = ["llama-cpp-python[server]>=0.3.0,<1.0.0"]
 docs = [
     "lxml>=4.9.3,<5 ; python_version < '3.13'",


### PR DESCRIPTION
## Description

This adds a Slack bot (Bolt, Socket Mode) that ingests messages from invited channels into cognee and answers questions like `@cognee what did we decide about X?` or `/recall …` — replying with clickable citations back to the source Slack messages. It's a self-contained example under `examples/slack_cognee_bot/`.

I want to be upfront about the design decisions, because a few of them differ from the literal ticket once you hit cognee's real behavior:

**Ingestion is batch/triggered, not per-message.** I found that `remember()` writes to the session cache but doesn't make content searchable — you need `cognify()` for that, and running `cognify()` on every single message would be very expensive. So the bot buffers messages per channel and triggers `cognify()` on a size threshold, an optional timer, or on-demand right before a question is answered. This keeps cost sane and means answers reflect the last flush rather than the very latest message. I think that's the honest, correct mapping onto cognee's primitives.

**Citations are done via a document-id join, not by metadata riding through search.** This is the important one: cognee strips chunk metadata during search, so `channel/ts/permalink` do NOT survive inside the search payload. What I do instead is control each message's `document_id` (via `DataItem.data_id = uuid5(channel:ts)`), store the permalink in a small adapter-owned SQLite `CitationIndex` keyed by that id, and join it back after `search()` returns. So the citation-to-source-message requirement is delivered — the join key survives, and the permalink is looked up locally. I built the index specifically because I confirmed the raw metadata wouldn't survive.

**Built on the #3608 adapter pattern locally.** #3608 (the shared chat-memory adapter) isn't merged yet, so I defined a thin `ChatMemory` interface (`ingest`/`flush`/`answer`/`forget`) and built the bot on that. When #3608 lands, the Slack layer swaps to the shared core with minimal change — it only depends on the interface.

**forget is dataset-level.** `/cognee-forget` deletes the whole channel's memory (cognee has no per-user delete), and the reply says so plainly. `/cognee-optin` / `/cognee-optout` share one opt-in store with the message handler, so opt-out actually stops ingestion.

I split this into 7 small commits (adapter interface → cognee-backed impl → ingestion buffer → Slack handlers → citation rendering → forget/opt-out → packaging + docs) so each layer is reviewable on its own.

Closes #3609

## Acceptance Criteria

- **Bolt app ingests invited-channel messages** — message handler → buffer → `cognee.add(...)`, gated on opt-in, skipping bot messages, edits, own messages, and empty text. ✅
- **@mention + /recall answer with citations to source messages** — answer flow runs `search()`, maps results back to permalinks via the `document_id` join, and renders a Block Kit reply with a clickable Sources block. ✅ (mechanism described above)
- **forget + opt-out** — dataset-level `/cognee-forget`; opt-out reliably stops ingestion via the shared opt-in set. ✅
- **Built on the #3608 adapter pattern** — implemented locally as a swappable interface. ✅
- **Tested with mocked LLM + mocked Slack, deterministic, no real keys** — 71 tests; cognee (`add/cognify/search/forget`) and Slack (`chat.getPermalink`, `say`, `ack`, events) are all mocked; no sockets, no keys. ✅ (see Screenshots)
- **5-minute onboarding guide** — README with Socket Mode setup, tokens, install, run, and an honest limitations section. ✅

**Honest scope / limitations (deliberate):**
- Answers reflect the last `cognify()` flush, not every message instantly (batch design, documented).
- Citation delivery is a `document_id` join + local index, not raw metadata surviving `search()`.
- `forget` is channel/dataset-level; per-user "forget me" isn't supported by cognee (noted as follow-up).
- Not built (out of scope, noted as follow-ups): catch-me-up / thread summarization, Telegram/Discord adapters.
- The `__main__` entry point is import-tested but not execution-tested (~15 lines of pure wiring); the full cite chain is proven across three focused tests rather than one end-to-end test.

**Files outside `examples/`:** two additive root changes only — `pyproject.toml` (adds an optional `slack` extra) and `.env.template` (documents the bot's env vars). No cognee core logic touched. `uv.lock` is intentionally not committed (the optional extra doesn't affect core resolution, and regenerating it locally introduced unrelated Python-marker churn — happy to add a clean lock entry if you'd prefer).

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Screenshots

<img width="1595" height="855" alt="image" src="https://github.com/user-attachments/assets/59ab442d-c09f-4998-aab7-dbd86c079d4e" />

<img width="1597" height="927" alt="image" src="https://github.com/user-attachments/assets/2f623e14-6cc3-47df-86b8-91c0c66ba877" />

<img width="1566" height="282" alt="image" src="https://github.com/user-attachments/assets/7a33314c-0f26-4b7a-b72d-5c3dea2047c3" />

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.