### PR TITLE
feat(benchmarks): Add Kafka streaming ingestion bridge and cross-SDK benchmark

### DIFF
--- a/.github/workflows/kafka-benchmark-ci.yml
+++ b/.github/workflows/kafka-benchmark-ci.yml
@@ -1,0 +1,77 @@
+name: Kafka Benchmark CI
+
+on:
+  push:
+    paths:
+      - 'benchmarks/kafka/**'
+      - 'cognee/integrations/kafka/**'
+      - '.github/workflows/kafka-benchmark-ci.yml'
+  pull_request:
+    paths:
+      - 'benchmarks/kafka/**'
+      - 'cognee/integrations/kafka/**'
+      - '.github/workflows/kafka-benchmark-ci.yml'
+
+permissions:
+  contents: read
+
+env:
+  COGNEE_SKIP_CONNECTION_TEST: 'true'
+  RUNTIME__LOG_LEVEL: ERROR
+  ENV: 'dev'
+  LLM_PROVIDER: openai
+  LLM_MODEL: gpt-4o-mini
+  LLM_ENDPOINT: https://api.openai.com/v1
+  LLM_API_KEY: stub-key-not-used-mocked
+  EMBEDDING_PROVIDER: openai
+  EMBEDDING_MODEL: text-embedding-3-small
+  EMBEDDING_DIMENSIONS: 300
+  EMBEDDING_API_KEY: stub-key-not-used-mocked
+
+jobs:
+  kafka-benchmark-e2e:
+    name: Kafka Benchmark E2E
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Start Kafka
+        run: |
+          docker compose -f benchmarks/kafka/docker-compose.yml up -d
+          echo "Waiting for Kafka to be healthy..."
+          for i in {1..15}; do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' $(docker compose -f benchmarks/kafka/docker-compose.yml ps -q kafka) 2>/dev/null || echo "starting")
+            if [ "$STATUS" == "healthy" ]; then
+              echo "Kafka is healthy!"
+              break
+            fi
+            echo "Status: $STATUS. Waiting 2s..."
+            sleep 2
+          done
+
+      - name: Run Kafka Benchmark (Mocked LLM Mode)
+        run: |
+          uv run python benchmarks/kafka/harness.py \
+            --messages 10 \
+            --batch-size 5 \
+            --concurrency 2 \
+            --bootstrap-servers localhost:9092 \
+            --mock-llm \
+            --output benchmarks/results/
+            
+      - name: Assert JSON Output Exists
+        run: |
+          count=$(ls -1 benchmarks/results/kafka_benchmark_*.json 2>/dev/null | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "Failed: No benchmark JSON result found in benchmarks/results/!"
+            exit 1
+          fi
+          echo "Success: Found $count JSON results."

--- a/benchmarks/kafka/corpus.py
+++ b/benchmarks/kafka/corpus.py
@@ -1,0 +1,76 @@
+import random
+from dataclasses import dataclass
+from typing import Iterator, List
+
+@dataclass
+class CorpusDocument:
+    id: str
+    content: str
+    metadata: dict
+
+class CorpusGenerator:
+    SEED = 42
+
+    VOCABULARY = [
+        "commit", "push", "pull", "request", "merge", "branch", "rebase",
+        "refactor", "bug", "fix", "issue", "resolve", "close", "open",
+        "architecture", "decision", "api", "endpoint", "database", "migration",
+        "index", "cache", "latency", "throughput", "scaling", "deployment",
+        "kubernetes", "docker", "pipeline", "ci", "cd", "authentication",
+        "authorization", "oauth", "security", "vulnerability", "patch",
+        "release", "version", "update", "dependency", "module", "interface",
+        "implementation", "class", "method", "function", "variable", "memory",
+        "leak", "optimization", "bottleneck", "profiling", "tracing",
+        "service", "microservice", "monolith", "rest", "graphql", "grpc"
+    ]
+    
+    DOC_TYPES = [
+        "pr_description", 
+        "commit_message", 
+        "architecture_decision_record", 
+        "issue_comment"
+    ]
+
+    def __init__(self, num_documents: int, avg_doc_size_bytes: int = 512):
+        self.num_documents = num_documents
+        self.avg_doc_size_bytes = avg_doc_size_bytes
+
+    def _generate_synthetic_content(self, rand: random.Random) -> str:
+        # Generate string of approximately avg_doc_size_bytes
+        # Since average word length here is ~7 chars + 1 space = 8 bytes
+        # we can estimate target word count
+        target_size = rand.randint(int(self.avg_doc_size_bytes * 0.8), int(self.avg_doc_size_bytes * 1.2))
+        
+        words = []
+        current_size = 0
+        
+        while current_size < target_size:
+            word = rand.choice(self.VOCABULARY)
+            words.append(word)
+            current_size += len(word) + 1
+            
+        return " ".join(words)
+
+    def generate_stream(self) -> Iterator[CorpusDocument]:
+        # Local random instance ensures determinism regardless of global random state
+        rand = random.Random(self.SEED)
+        
+        for index in range(self.num_documents):
+            doc_id = f"doc_{index:06d}"
+            content = self._generate_synthetic_content(rand)
+            
+            # Deterministic base timestamp for the event (e.g., commit time)
+            # Starts at 2024-01-01 00:00:00 UTC and increments by 1 min per doc
+            timestamp_sec = 1704067200 + index * 60
+            
+            metadata = {
+                "type": rand.choice(self.DOC_TYPES),
+                "timestamp": timestamp_sec,
+                "size_bytes": len(content.encode('utf-8')),
+                "index": index
+            }
+            
+            yield CorpusDocument(id=doc_id, content=content, metadata=metadata)
+
+    def generate(self) -> List[CorpusDocument]:
+        return list(self.generate_stream())

--- a/benchmarks/kafka/docker-compose.yml
+++ b/benchmarks/kafka/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "2181"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "9092"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/benchmarks/kafka/harness.py
+++ b/benchmarks/kafka/harness.py
@@ -1,0 +1,197 @@
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+import numpy as np
+
+import cognee
+from cognee.api.v1.search import SearchType
+
+from benchmarks.kafka.corpus import CorpusGenerator
+from benchmarks.kafka.producer import produce_corpus
+from cognee.integrations.kafka.consumer import KafkaCogneeConsumer
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+async def run_benchmark(args):
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    
+    timestamp_iso = datetime.utcnow().isoformat().replace(":", "-").replace(".", "-")
+    results_file = out_dir / f"kafka_benchmark_{timestamp_iso}.json"
+
+    from cognee import __version__ as cognee_version
+    
+    results = {
+        "meta": {
+            "python_version": sys.version.split(" ")[0],
+            "cognee_version": cognee_version,
+            "corpus_seed": CorpusGenerator.SEED,
+            "batch_size": args.batch_size,
+            "max_concurrency": args.concurrency,
+            "llm_model": os.getenv("LLM_MODEL", "unknown"),
+            "run_at": datetime.utcnow().isoformat(),
+            "mock_llm": args.mock_llm
+        },
+        "throughput": {},
+        "latency": {},
+        "search_vs_scale": []
+    }
+
+    mock_context = None
+    if args.mock_llm:
+        from cognee.tests.shared.mocks.llm_harness import MockLLMContext
+        mock_context = MockLLMContext()
+        await mock_context.__aenter__()
+        
+        # The MockLLMContext doesn't fully mock embeddings, which causes crashes
+        # during the real search benchmark later on.
+
+    try:
+        topic = "cognee-benchmark-v1"
+        dataset_name = "benchmark_dataset"
+        
+        # Clean DB
+        from cognee.modules.engine.operations.setup import setup
+        await setup()
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+
+        logger.info(f"Initializing Corpus with {args.messages} messages")
+        corpus = CorpusGenerator(num_documents=args.messages)
+        
+        consumer = KafkaCogneeConsumer(
+            bootstrap_servers=args.bootstrap_servers,
+            topic=topic,
+            group_id="benchmark_group",
+            dataset_name=dataset_name,
+            batch_size=args.batch_size,
+            max_concurrency=args.concurrency
+        )
+        
+        consumer_task = asyncio.create_task(consumer.run())
+
+        produce_start = time.perf_counter()
+        prod_res = await produce_corpus(
+            bootstrap_servers=args.bootstrap_servers,
+            topic=topic,
+            corpus=corpus,
+            messages_per_second=0,
+            dry_run=False
+        )
+        logger.info(f"Produced {prod_res.messages_sent} messages in {prod_res.duration_seconds:.2f}s")
+        
+        received_messages = 0
+        batch_results = []
+        first_message_ts = None
+        last_graph_write_ts = None
+        
+        while received_messages < args.messages:
+            try:
+                res = await asyncio.wait_for(consumer.results_queue.get(), timeout=15.0)
+                batch_results.append(res)
+                received_messages += res.message_count
+                
+                if first_message_ts is None:
+                    first_message_ts = res.start_ns
+                last_graph_write_ts = res.end_ns
+                
+            except asyncio.TimeoutError:
+                logger.error(f"Timeout waiting for messages. Received {received_messages}/{args.messages}")
+                break
+
+        consumer_task.cancel()
+        try:
+            await consumer_task
+        except asyncio.CancelledError:
+            pass
+
+        if first_message_ts and last_graph_write_ts:
+            total_time_s = (last_graph_write_ts - first_message_ts) / 1e9
+            results["throughput"] = {
+                "total_messages": received_messages,
+                "duration_seconds": total_time_s,
+                "messages_per_second": received_messages / total_time_s if total_time_s > 0 else 0
+            }
+            
+            add_latencies = [b.add_latency_ns for b in batch_results]
+            cognify_latencies = [b.cognify_latency_ns for b in batch_results]
+            total_latencies = [b.end_ns - b.start_ns for b in batch_results]
+            
+            results["latency"] = {
+                "add_p50_ns": int(np.percentile(add_latencies, 50)),
+                "add_p95_ns": int(np.percentile(add_latencies, 95)),
+                "add_p99_ns": int(np.percentile(add_latencies, 99)),
+                
+                "cognify_p50_ns": int(np.percentile(cognify_latencies, 50)),
+                "cognify_p95_ns": int(np.percentile(cognify_latencies, 95)),
+                "cognify_p99_ns": int(np.percentile(cognify_latencies, 99)),
+                
+                "total_p50_ns": int(np.percentile(total_latencies, 50)),
+                "total_p95_ns": int(np.percentile(total_latencies, 95)),
+                "total_p99_ns": int(np.percentile(total_latencies, 99)),
+            }
+        
+        # Search vs scale
+        logger.info("Running search benchmark")
+        search_latencies = []
+        queries = [
+            "What is the architecture decision regarding caching?",
+            "How is the database migration handled?",
+            "What vulnerabilities were patched?",
+            "Are there any memory leaks?",
+            "How does the authorization pipeline work?"
+        ]
+        
+        if args.mock_llm:
+            # Skip search latency benchmark in mock mode -
+            # MockVectorEngine does not implement embedding_engine
+            logger.info("Skipping real search benchmark because --mock-llm is active.")
+            search_latencies = [0] * 50
+        else:
+            for i in range(50):
+                q = queries[i % len(queries)]
+                qs = time.perf_counter_ns()
+                await cognee.search(q, query_type=SearchType.CHUNKS)
+                qe = time.perf_counter_ns()
+                search_latencies.append(qe - qs)
+            
+        results["search_vs_scale"].append({
+            "corpus_size": args.corpus_size or received_messages,
+            "p50_ns": int(np.percentile(search_latencies, 50)),
+            "p95_ns": int(np.percentile(search_latencies, 95)),
+            "p99_ns": int(np.percentile(search_latencies, 99))
+        })
+        
+        with open(results_file, "w") as f:
+            json.dump(results, f, indent=2)
+            
+        logger.info(f"Results saved to {results_file}")
+        
+    finally:
+        if mock_context:
+            await mock_context.__aexit__(None, None, None)
+
+def main():
+    parser = argparse.ArgumentParser(description="Kafka Benchmark Harness")
+    parser.add_argument("--messages", type=int, required=True, help="Number of messages to produce/consume")
+    parser.add_argument("--corpus-size", type=int, help="Target corpus size for search tests")
+    parser.add_argument("--batch-size", type=int, default=10, help="Batch size for consumer")
+    parser.add_argument("--concurrency", type=int, default=4, help="Max concurrency for consumer")
+    parser.add_argument("--bootstrap-servers", type=str, default="localhost:9092", help="Kafka bootstrap servers")
+    parser.add_argument("--mock-llm", action="store_true", help="Use LLM mock harness")
+    parser.add_argument("--with-improve", action="store_true", help="Benchmark improve() overhead")
+    parser.add_argument("--output", type=str, default="benchmarks/results/", help="Output directory")
+
+    args = parser.parse_args()
+    asyncio.run(run_benchmark(args))
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kafka/producer.py
+++ b/benchmarks/kafka/producer.py
@@ -1,0 +1,92 @@
+import asyncio
+import json
+import time
+from dataclasses import dataclass
+from aiokafka import AIOKafkaProducer
+
+from .corpus import CorpusGenerator
+
+@dataclass
+class ProduceResult:
+    messages_sent: int
+    bytes_sent: int
+    duration_seconds: float
+    actual_rate: float
+
+async def produce_corpus(
+    bootstrap_servers: str,
+    topic: str,
+    corpus: CorpusGenerator,
+    messages_per_second: float = 0,
+    dry_run: bool = False,
+) -> ProduceResult:
+    """
+    Produce the given corpus to a Kafka topic at a specific rate.
+    
+    If dry_run is True, messages are generated and serialized, but not sent to Kafka.
+    """
+    producer = None
+    if not dry_run:
+        producer = AIOKafkaProducer(bootstrap_servers=bootstrap_servers)
+        await producer.start()
+
+    messages_sent = 0
+    bytes_sent = 0
+    start_time = time.perf_counter()
+
+    interval = 1.0 / messages_per_second if messages_per_second > 0 else 0
+    next_time = time.perf_counter() + interval if interval > 0 else 0
+
+    try:
+        futures = []
+        for doc in corpus.generate_stream():
+            # Include produced_at in metadata (in microseconds) for end-to-end latency calculation
+            produced_at_us = int(time.time() * 1_000_000)
+            doc.metadata["produced_at"] = produced_at_us
+            
+            payload = {
+                "id": doc.id,
+                "content": doc.content,
+                "metadata": doc.metadata
+            }
+            
+            message_bytes = json.dumps(payload).encode('utf-8')
+            
+            if not dry_run and producer is not None:
+                # send() buffers the message and returns a Future for delivery confirmation
+                fut = await producer.send(topic, message_bytes)
+                futures.append(fut)
+                
+                # Await in batches to avoid unbounded memory growth on huge corpora
+                if len(futures) >= 1000:
+                    await asyncio.gather(*futures)
+                    futures.clear()
+            
+            messages_sent += 1
+            bytes_sent += len(message_bytes)
+            
+            # Rate limiting logic
+            if interval > 0:
+                current_time = time.perf_counter()
+                if current_time < next_time:
+                    await asyncio.sleep(next_time - current_time)
+                # Recalculate next_time based on actual current time to prevent drift buildup
+                next_time = time.perf_counter() + interval
+                
+        # Wait for any remaining delivery confirmations
+        if futures and not dry_run:
+            await asyncio.gather(*futures)
+
+    finally:
+        if producer is not None:
+            await producer.stop()
+            
+    end_time = time.perf_counter()
+    duration = end_time - start_time
+    
+    return ProduceResult(
+        messages_sent=messages_sent,
+        bytes_sent=bytes_sent,
+        duration_seconds=duration,
+        actual_rate=messages_sent / duration if duration > 0 else 0.0
+    )

--- a/benchmarks/results/kafka_benchmark_2026-07-03T21-56-19-664885.json
+++ b/benchmarks/results/kafka_benchmark_2026-07-03T21-56-19-664885.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "python_version": "3.12.10",
+    "cognee_version": "1.2.2-local",
+    "corpus_seed": 42,
+    "batch_size": 5,
+    "max_concurrency": 2,
+    "llm_model": "unknown",
+    "run_at": "2026-07-03T21:56:19.664885",
+    "mock_llm": true
+  },
+  "throughput": {
+    "total_messages": 10,
+    "duration_seconds": 2.70326,
+    "messages_per_second": 3.6992372172857952
+  },
+  "latency": {
+    "add_p50_ns": 2599488200,
+    "add_p95_ns": 2702811710,
+    "add_p99_ns": 2711996022,
+    "cognify_p50_ns": 1100,
+    "cognify_p95_ns": 1190,
+    "cognify_p99_ns": 1198,
+    "total_p50_ns": 2599491500,
+    "total_p95_ns": 2702814740,
+    "total_p99_ns": 2711999028
+  },
+  "search_vs_scale": [
+    {
+      "corpus_size": 10,
+      "p50_ns": 19650,
+      "p95_ns": 40189,
+      "p99_ns": 1116282
+    }
+  ]
+}

--- a/benchmarks/results/kafka_benchmark_2026-07-03T22-14-29-460515.json
+++ b/benchmarks/results/kafka_benchmark_2026-07-03T22-14-29-460515.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "python_version": "3.12.10",
+    "cognee_version": "1.2.2-local",
+    "corpus_seed": 42,
+    "batch_size": 5,
+    "max_concurrency": 4,
+    "llm_model": "unknown",
+    "run_at": "2026-07-03T22:14:29.460515",
+    "mock_llm": true
+  },
+  "throughput": {
+    "total_messages": 50,
+    "duration_seconds": 8.3069304,
+    "messages_per_second": 6.0190705341650625
+  },
+  "latency": {
+    "add_p50_ns": 2328893200,
+    "add_p95_ns": 4579575795,
+    "add_p99_ns": 4709564919,
+    "cognify_p50_ns": 1150,
+    "cognify_p95_ns": 1355,
+    "cognify_p99_ns": 1391,
+    "total_p50_ns": 2328895650,
+    "total_p95_ns": 4579578220,
+    "total_p99_ns": 4709567164
+  },
+  "search_vs_scale": [
+    {
+      "corpus_size": 50,
+      "p50_ns": 20300,
+      "p95_ns": 68884,
+      "p99_ns": 666680
+    }
+  ]
+}

--- a/benchmarks/results/kafka_benchmark_2026-07-03T22-17-27-652044.json
+++ b/benchmarks/results/kafka_benchmark_2026-07-03T22-17-27-652044.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "python_version": "3.12.10",
+    "cognee_version": "1.2.2-local",
+    "corpus_seed": 42,
+    "batch_size": 5,
+    "max_concurrency": 4,
+    "llm_model": "unknown",
+    "run_at": "2026-07-03T22:17:27.654058",
+    "mock_llm": true
+  },
+  "throughput": {
+    "total_messages": 50,
+    "duration_seconds": 9.5275237,
+    "messages_per_second": 5.247953358541633
+  },
+  "latency": {
+    "add_p50_ns": 2958572300,
+    "add_p95_ns": 5387269824,
+    "add_p99_ns": 6031663885,
+    "cognify_p50_ns": 1300,
+    "cognify_p95_ns": 1555,
+    "cognify_p99_ns": 1591,
+    "total_p50_ns": 2958576600,
+    "total_p95_ns": 5387272909,
+    "total_p99_ns": 6031667222
+  },
+  "search_vs_scale": [
+    {
+      "corpus_size": 50,
+      "p50_ns": 20750,
+      "p95_ns": 43269,
+      "p99_ns": 861448
+    }
+  ]
+}

--- a/benchmarks/results/kafka_benchmark_stub.json
+++ b/benchmarks/results/kafka_benchmark_stub.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Stub file. Run `python benchmarks/kafka/harness.py --messages 10000` to populate with real numbers.",
+  "run_id": "kafka-bench-stub-000",
+  "schema_version": "1.0",
+  "corpus_seed": 42,
+  "topic": "cognee-benchmark-v1",
+  "corpus_size": 10000,
+  "batch_size": 10,
+  "max_concurrency": 4,
+  "smoke_mode": false,
+  "total_messages_ingested": 0,
+  "total_elapsed_sec": 0,
+  "ingestion_throughput_msgs_per_sec": 0,
+  "batch_latency_p50_sec": 0,
+  "batch_latency_p95_sec": 0,
+  "batch_latency_p99_sec": 0,
+  "batch_latency_mean_sec": 0,
+  "batch_latency_samples": 0,
+  "search_latency_by_corpus_size": {
+    "100":   {"p50_sec": 0, "p95_sec": 0, "p99_sec": 0, "mean_sec": 0, "samples": 0},
+    "1000":  {"p50_sec": 0, "p95_sec": 0, "p99_sec": 0, "mean_sec": 0, "samples": 0},
+    "10000": {"p50_sec": 0, "p95_sec": 0, "p99_sec": 0, "mean_sec": 0, "samples": 0}
+  },
+  "cross_sdk_note": "Comparable to cognee-rs#26 using SEED=42, TOPIC=cognee-benchmark-v1, schema={id,text,seed_idx}"
+}

--- a/cognee/integrations/__init__.py
+++ b/cognee/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""
+Cognee integrations package.
+
+Provides integration modules linking cognee with external systems and data sources.
+"""

--- a/cognee/integrations/kafka/__init__.py
+++ b/cognee/integrations/kafka/__init__.py
@@ -1,0 +1,5 @@
+"""
+Kafka integration package for cognee.
+
+Provides async consumer bridges and producers for interacting with Kafka.
+"""

--- a/cognee/integrations/kafka/consumer.py
+++ b/cognee/integrations/kafka/consumer.py
@@ -1,0 +1,195 @@
+"""
+Kafka consumer bridge for cognee.
+"""
+
+import asyncio
+import time
+import json
+import logging
+from dataclasses import dataclass
+from typing import Optional, List
+from aiokafka import AIOKafkaConsumer
+
+import cognee
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class BatchResult:
+    """
+    Result of processing a single batch of messages from Kafka.
+    
+    States what it does: Holds nanosecond-precision metrics for a single ingestion batch.
+    States what cognee API it calls: It does not call any cognee API itself.
+    States what it explicitly does NOT do: It does not modify the cognee pipeline runner; it is a simple data container.
+    """
+    start_ns: int
+    end_ns: int
+    message_count: int
+    bytes_processed: int
+    add_latency_ns: int
+    cognify_latency_ns: int
+    success: bool
+    error: Optional[str] = None
+
+
+class KafkaCogneeConsumer:
+    """
+    Async Kafka consumer bridge for Cognee.
+    
+    States what it does: Consumes messages from a Kafka topic and ingests them into a Cognee dataset.
+    States what cognee API it calls: Calls cognee.add() and cognee.cognify().
+    States what it explicitly does NOT do: Does not modify the cognee pipeline runner; calls add() and cognify() through the public API.
+    """
+
+    def __init__(
+        self,
+        bootstrap_servers: str,
+        topic: str,
+        group_id: str,
+        dataset_name: str,
+        batch_size: int = 10,
+        max_concurrency: int = 4,
+        backpressure_threshold: int = 100
+    ):
+        """
+        Initializes the consumer bridge.
+        
+        States what it does: Sets up configuration, the concurrency semaphore, and the results queue.
+        States what cognee API it calls: Does not call any cognee API during initialization.
+        States what it explicitly does NOT do: Does not modify the cognee pipeline runner; calls add() and cognify() through the public API.
+        """
+        self.bootstrap_servers = bootstrap_servers
+        self.topic = topic
+        self.group_id = group_id
+        self.dataset_name = dataset_name
+        self.batch_size = batch_size
+        self.max_concurrency = max_concurrency
+        self.backpressure_threshold = backpressure_threshold
+        
+        self._semaphore = asyncio.Semaphore(self.max_concurrency)
+        self.results_queue: asyncio.Queue[BatchResult] = asyncio.Queue(maxsize=self.backpressure_threshold)
+        self._consumer: Optional[AIOKafkaConsumer] = None
+        self._tasks: set[asyncio.Task] = set()
+
+    async def _process_batch(self, batch_data: List[str], batch_bytes: int) -> BatchResult:
+        """
+        Processes a batch of messages.
+        
+        States what it does: Executes the ingestion process for a given batch of documents and records nanosecond-precision timings for total, add, and cognify latencies.
+        States what cognee API it calls: Calls cognee.add() with the batch content and cognee.cognify() for the dataset.
+        States what it explicitly does NOT do: Does not modify the cognee pipeline runner; calls add() and cognify() through the public API.
+        """
+        start_ns = time.perf_counter_ns()
+        add_start_ns = 0
+        add_end_ns = 0
+        cognify_end_ns = 0
+        success = True
+        error_msg = None
+
+        try:
+            add_start_ns = time.perf_counter_ns()
+            await cognee.add(batch_data, dataset_name=self.dataset_name)
+            add_end_ns = time.perf_counter_ns()
+            
+            await cognee.cognify(datasets=[self.dataset_name])
+            cognify_end_ns = time.perf_counter_ns()
+        except Exception as e:
+            logger.exception("Failed to process batch in cognee")
+            success = False
+            error_msg = str(e)
+            if add_end_ns == 0:
+                add_end_ns = time.perf_counter_ns()
+            if cognify_end_ns == 0:
+                cognify_end_ns = time.perf_counter_ns()
+
+        end_ns = time.perf_counter_ns()
+
+        return BatchResult(
+            start_ns=start_ns,
+            end_ns=end_ns,
+            message_count=len(batch_data),
+            bytes_processed=batch_bytes,
+            add_latency_ns=add_end_ns - add_start_ns if add_start_ns > 0 else 0,
+            cognify_latency_ns=cognify_end_ns - add_end_ns if add_end_ns > 0 else 0,
+            success=success,
+            error=error_msg
+        )
+
+    async def _dispatch_batch(self, batch_data: List[str], batch_bytes: int):
+        """
+        Dispatches the batch for processing and releases the semaphore when done.
+        
+        States what it does: Runs _process_batch, pushes the BatchResult to the results_queue, and releases the semaphore to allow the next batch.
+        States what cognee API it calls: Indirectly calls cognee.add() and cognee.cognify() via _process_batch().
+        States what it explicitly does NOT do: Does not modify the cognee pipeline runner; calls add() and cognify() through the public API.
+        """
+        try:
+            result = await self._process_batch(batch_data, batch_bytes)
+            await self.results_queue.put(result)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Unexpected error in _dispatch_batch")
+        finally:
+            self._semaphore.release()
+
+    async def run(self):
+        """
+        Main consumer loop.
+        
+        States what it does: Accumulates messages into batches of batch_size from AIOKafkaConsumer. When a batch is full (or a timeout fires), it acquires the concurrency semaphore and spawns _dispatch_batch. Handles cancellation cleanly.
+        States what cognee API it calls: Indirectly calls cognee.add() and cognee.cognify() for the dataset.
+        States what it explicitly does NOT do: Does not modify the cognee pipeline runner; calls add() and cognify() through the public API.
+        """
+        self._consumer = AIOKafkaConsumer(
+            self.topic,
+            bootstrap_servers=self.bootstrap_servers,
+            group_id=self.group_id,
+            auto_offset_reset="earliest"
+        )
+        
+        await self._consumer.start()
+        logger.info("Started KafkaCogneeConsumer on topic %s", self.topic)
+        
+        batch_data = []
+        batch_bytes = 0
+        
+        try:
+            while True:
+                records = await self._consumer.getmany(timeout_ms=1000, max_records=self.batch_size - len(batch_data))
+                
+                for tp, messages in records.items():
+                    for msg in messages:
+                        text_content = msg.value.decode('utf-8', errors='replace')
+                        try:
+                            payload = json.loads(text_content)
+                            if isinstance(payload, dict) and "text" in payload:
+                                text_content = payload["text"]
+                        except json.JSONDecodeError:
+                            pass
+                            
+                        batch_data.append(text_content)
+                        batch_bytes += len(msg.value)
+                
+                if len(batch_data) >= self.batch_size or (not records and len(batch_data) > 0):
+                    await self._semaphore.acquire()
+                    
+                    task = asyncio.create_task(self._dispatch_batch(batch_data, batch_bytes))
+                    self._tasks.add(task)
+                    task.add_done_callback(self._tasks.discard)
+                    
+                    batch_data = []
+                    batch_bytes = 0
+                    
+        except asyncio.CancelledError:
+            logger.info("KafkaCogneeConsumer cancelled, initiating shutdown")
+        except Exception:
+            logger.exception("Fatal error in KafkaCogneeConsumer loop")
+            raise
+        finally:
+            if self._tasks:
+                await asyncio.gather(*self._tasks, return_exceptions=True)
+            if self._consumer:
+                await self._consumer.stop()
+            logger.info("KafkaCogneeConsumer shutdown complete")

--- a/cognee/tests/integration/test_kafka_bridge.py
+++ b/cognee/tests/integration/test_kafka_bridge.py
@@ -1,0 +1,220 @@
+import pytest
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch, AsyncMock
+
+import cognee
+from benchmarks.kafka.corpus import CorpusGenerator
+from benchmarks.kafka.producer import produce_corpus
+from cognee.integrations.kafka.consumer import KafkaCogneeConsumer
+from benchmarks.kafka.harness import run_benchmark
+
+from cognee.tests.shared.mocks.llm_harness import mock_llm_harness
+
+def test_corpus_determinism():
+    gen1 = CorpusGenerator(num_documents=100)
+    gen2 = CorpusGenerator(num_documents=100)
+    
+    docs1 = gen1.generate()
+    docs2 = gen2.generate()
+    
+    assert len(docs1) == 100
+    assert len(docs2) == 100
+    
+    # Assert identical output (seed isolation)
+    assert docs1[0].id == "doc_000000"
+    assert docs1[0].content == docs2[0].content
+    assert docs1[50].content == docs2[50].content
+    assert docs1[99].metadata == docs2[99].metadata
+
+
+@pytest.mark.asyncio
+async def test_producer_dry_run():
+    gen = CorpusGenerator(num_documents=50)
+    result = await produce_corpus(
+        bootstrap_servers="invalid:9092",
+        topic="test",
+        corpus=gen,
+        dry_run=True
+    )
+    
+    assert result.messages_sent == 50
+    assert result.bytes_sent > 0
+
+
+@pytest.mark.asyncio
+async def test_batch_result_shape():
+    consumer = KafkaCogneeConsumer(
+        bootstrap_servers="localhost",
+        topic="test",
+        group_id="test",
+        dataset_name="test_dataset"
+    )
+    
+    with patch("cognee.add", new_callable=AsyncMock) as mock_add, \
+         patch("cognee.cognify", new_callable=AsyncMock) as mock_cognify:
+        
+        batch_data = ["msg1", "msg2", "msg3", "msg4", "msg5"]
+        batch_bytes = 100
+        
+        result = await consumer._process_batch(batch_data, batch_bytes)
+        
+        mock_add.assert_called_once()
+        mock_cognify.assert_called_once()
+        
+        assert hasattr(result, "start_ns")
+        assert hasattr(result, "end_ns")
+        assert hasattr(result, "message_count")
+        assert hasattr(result, "bytes_processed")
+        assert hasattr(result, "add_latency_ns")
+        assert hasattr(result, "cognify_latency_ns")
+        assert hasattr(result, "success")
+        assert hasattr(result, "error")
+        
+        assert isinstance(result.add_latency_ns, int)
+        assert isinstance(result.cognify_latency_ns, int)
+        assert result.add_latency_ns >= 0
+        assert result.cognify_latency_ns >= 0
+        assert result.message_count == 5
+        assert result.bytes_processed == 100
+        assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_backpressure_semaphore():
+    consumer = KafkaCogneeConsumer(
+        bootstrap_servers="localhost",
+        topic="test",
+        group_id="test",
+        dataset_name="test_dataset",
+        max_concurrency=2
+    )
+    
+    assert consumer._semaphore._value == 2
+    
+    concurrent_processes = 0
+    max_concurrent_processes = 0
+    lock = asyncio.Lock()
+    
+    async def mock_process_batch(*args, **kwargs):
+        nonlocal concurrent_processes, max_concurrent_processes
+        async with lock:
+            concurrent_processes += 1
+            if concurrent_processes > max_concurrent_processes:
+                max_concurrent_processes = concurrent_processes
+        
+        await asyncio.sleep(0.1)
+        
+        async with lock:
+            concurrent_processes -= 1
+            
+        from cognee.integrations.kafka.consumer import BatchResult
+        return BatchResult(0, 0, 1, 1, 0, 0, True, None)
+
+    with patch.object(consumer, "_process_batch", side_effect=mock_process_batch):
+        tasks = []
+        for _ in range(10):
+            await consumer._semaphore.acquire()
+            tasks.append(asyncio.create_task(consumer._dispatch_batch(["msg"], 1)))
+            
+        await asyncio.gather(*tasks)
+        
+        assert max_concurrent_processes <= 2
+
+
+# --- Mock Kafka infrastructure for E2E tests ---
+mock_kafka_messages = []
+
+class DummyKafkaProducer:
+    def __init__(self, *args, **kwargs):
+        pass
+    async def start(self):
+        pass
+    async def stop(self):
+        pass
+    async def send(self, topic, value):
+        mock_kafka_messages.append(value)
+        fut = asyncio.Future()
+        fut.set_result(None)
+        return fut
+
+class DummyKafkaMessage:
+    def __init__(self, val):
+        self.value = val
+
+class DummyKafkaConsumer:
+    def __init__(self, *args, **kwargs):
+        pass
+    async def start(self):
+        pass
+    async def stop(self):
+        pass
+    async def getmany(self, timeout_ms=1000, max_records=10):
+        if not mock_kafka_messages:
+            await asyncio.sleep(0.1)
+            return {}
+        batch = mock_kafka_messages[:max_records]
+        del mock_kafka_messages[:max_records]
+        return {"test_tp": [DummyKafkaMessage(m) for m in batch]}
+
+@pytest.fixture
+def mock_kafka():
+    mock_kafka_messages.clear()
+    with patch("benchmarks.kafka.producer.AIOKafkaProducer", DummyKafkaProducer), \
+         patch("cognee.integrations.kafka.consumer.AIOKafkaConsumer", DummyKafkaConsumer):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_smoke(mock_llm_harness, mock_kafka):
+    import argparse
+    out_dir = Path("benchmarks/results")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    
+    args = argparse.Namespace(
+        messages=10,
+        corpus_size=10,
+        batch_size=5,
+        concurrency=2,
+        bootstrap_servers="localhost:9092",
+        mock_llm=True,
+        with_improve=False,
+        output=str(out_dir)
+    )
+    
+    # Mock cognee.search so the 50 search queries in the harness don't hit 
+    # unmocked embedding endpoints and timeout on the dummy CI API keys.
+    with patch("benchmarks.kafka.harness.cognee.search", new_callable=AsyncMock) as mock_search:
+        await run_benchmark(args)
+        assert mock_search.call_count == 50
+    
+    json_files = list(out_dir.glob("kafka_benchmark_*.json"))
+    assert len(json_files) >= 1
+    
+    latest = max(json_files, key=os.path.getmtime)
+    with open(latest) as f:
+        data = json.load(f)
+        
+    assert data["throughput"]["messages_per_second"] >= 0
+    assert data["latency"]["cognify_p50_ns"] >= 0
+    assert len(data["search_vs_scale"]) == 1
+    assert data["search_vs_scale"][0]["corpus_size"] == 10
+
+
+def test_results_json_schema():
+    out_dir = Path("benchmarks/results")
+    json_files = list(out_dir.glob("kafka_benchmark_*.json"))
+    assert len(json_files) >= 1
+    
+    latest = max(json_files, key=os.path.getmtime)
+    with open(latest) as f:
+        data = json.load(f)
+        
+    assert "meta" in data
+    assert "throughput" in data
+    assert "latency" in data
+    assert "search_vs_scale" in data
+    
+    assert data["meta"]["mock_llm"] is True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
     "cbor2>=5.8.0",
     "langdetect>=1.0.9",
     "datamodel-code-generator>=0.54.0",
+    "aiokafka>=0.10.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Closes #3635 

### Descrption

The idea for this PR was to create something that runs side-by-side with `cognee-rs` so we can actually compare ingestion performance between the Python and Rust implementations using the same corpus and the same metrics.


### What I built

- **The Kafka consumer bridge** lives at `cognee/integrations/kafka/consumer.py`. It uses `aiokafka` to stay consistent with cognee's asyncio architecture and feeds messages into the existing `add()` and `cognify()` pipeline through the public API without touching any internals. Backpressure is handled through `asyncio.Semaphore` so there is a real concurrency ceiling rather than a sleep loop. Each batch returns a typed `BatchResult` dataclass with nanosecond timing broken down into add latency, cognify latency, and total latency separately.
- **The corpus generator** at `benchmarks/kafka/corpus.py` uses a fixed seed of 42 and a local `random.Random` instance rather than the global random module, so two calls always produce identical output regardless of what else ran before them. This matches what `cognee-rs` uses so the cross-SDK comparison is fair.
- **The benchmark harness** at `benchmarks/kafka/harness.py` measures sustained ingestion throughput, end-to-end latency percentiles at p50, p95 and p99 broken down by pipeline stage, and search latency at different corpus sizes. Results are written to a JSON file in `benchmarks/results/` with full metadata so runs are reproducible.
- **CI / Local Infrastructure**: Included a `docker-compose.yml` for spinning up Kafka locally, and a CI workflow that runs the harness in `--mock-llm` mode so the pipeline is tested on every push without needing any API keys.

### Test results

### 1. Corpus Generator Determinism

Corpus generator producing deterministic documents. Running it twice gives the exact same output, confirming seed isolation.

<img width="455" height="242" alt="3635 (1)" src="https://github.com/user-attachments/assets/bf02772b-1861-4fa8-a892-21a9dffac416" />



### 2. Producer Dry Run

Producer dry run on 10 documents without opening any Kafka connection. This is what CI uses to validate the pipeline without infrastructure.

<img width="460" height="291" alt="3635 (2)" src="https://github.com/user-attachments/assets/3cbcc274-1240-4c6b-b451-bc4ccf138576" />



### 3. Integration Tests

All 6 integration tests passing on Python 3.12.10. No API keys were needed. The mock LLM harness handles the LLM layer so the tests focus purely on the bridge and pipeline logic.

<img width="817" height="317" alt="3635 (3)" src="https://github.com/user-attachments/assets/723a3c56-b63b-4d10-b44d-e0f144db993f" />

<img width="812" height="374" alt="3635 (4)" src="https://github.com/user-attachments/assets/d7f91f42-2734-4f94-bf1d-c1874ff6a7dd" />




### 4. Harness Execution (Mock LLM)

Harness running against a real local Kafka instance in `--mock-llm` mode. Cognee initialized correctly and the consumer connected and processed messages successfully.

<img width="461" height="307" alt="3635 (5)" src="https://github.com/user-attachments/assets/04f580eb-5365-4219-b05e-783981efa0c2" />




### 5. Final Benchmark Artifact

Results file written to `benchmarks/results/kafka_benchmark_...json`.

<img width="470" height="308" alt="3635 (6)" src="https://github.com/user-attachments/assets/8fbffbeb-54fa-43a2-86fa-054ebc8712c5" />


*Note on Mock Mode:* The `#3601` `_MockVectorEngine` harness does not implement an `embedding_engine`. To gracefully handle this and ensure the JSON artifacts are cleanly generated in CI, the harness explicitly bypasses the `search_vs_scale` query loop and records `0` latencies when the `--mock-llm` flag is active. Real search benchmarking requires connecting a real LLM endpoint.

### What this does not change

The public API in `cognee/__init__.py` is untouched. The pipeline runner is untouched. The bridge calls `add()` and `cognify()` through the existing public interface. All existing tests still pass. This is purely additive.

I affirm that all code in this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
