### PR TITLE
fix(relational): enable WAL + busy_timeout on SQLite engine to avoid 'database is locked'

### DIFF
--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -9,7 +9,7 @@ from typing import AsyncGenerator, List
 from contextlib import asynccontextmanager
 from sqlalchemy.orm import joinedload
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy import NullPool, text, select, MetaData, Table, delete, inspect, func
+from sqlalchemy import NullPool, text, select, MetaData, Table, delete, inspect, func, event
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
 from cognee.modules.data.models.Data import Data
@@ -78,6 +78,18 @@ class SQLAlchemyAdapter:
                 poolclass=NullPool,
                 connect_args={**{"timeout": 30}, **final_connect_args},
             )
+
+            # Bring the relational SQLite engine to parity with SqlCacheAdapter:
+            # enable WAL journaling and a busy timeout so the concurrent async
+            # writes the ingest pipeline makes (e.g. pipeline_runs during
+            # remember/cognify) wait out writer locks instead of failing with
+            # "sqlite3.OperationalError: database is locked".
+            @event.listens_for(self.engine.sync_engine, "connect")
+            def _set_sqlite_pragmas(dbapi_connection, connection_record):
+                cursor = dbapi_connection.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.execute("PRAGMA busy_timeout=30000")
+                cursor.close()
         else:
             # Transform pool_args from tuple into dict if provided
             # Note: For caching purposes, pool_args is stored as a sorted tuple of key-value pairs in the config


### PR DESCRIPTION
## Summary
The relational SQLite engine (`SqlAlchemyAdapter`) is created with `connect_args={"timeout": 30}` but never enables WAL journaling or a `busy_timeout` PRAGMA. Under the concurrent async writes the ingest pipeline makes to the metadata database (`pipeline_runs` and friends) during `remember(..., temporal_cognify=True)`, the default rollback-journal locking raises `sqlite3.OperationalError: database is locked` and the dataset ends in `DATASET_PROCESSING_ERRORED`.

The newer `SqlCacheAdapter` already tunes SQLite exactly this way (WAL + busy_timeout via a `connect` hook); this PR brings the relational engine to parity.

## Reproduction
cognee 1.2.2, local backend (Kuzu graph + SQLite relational), no Cognee Cloud vars, Python 3.12:

```python
import asyncio, cognee
docs = [...]  # ~40 multi-hundred-char email documents
asyncio.run(cognee.remember(docs, dataset_name="repro", temporal_cognify=True, self_improvement=False))
```

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) database is locked
[SQL: INSERT INTO pipeline_runs (id, created_at, status, pipeline_run_id, pipeline_name, pipeline_id, dataset_id, run_info) VALUES (?, ?, ?, ?, ?, ?, ?, ?)]
```

## Fix
Mirror `SqlCacheAdapter._set_sqlite_pragmas` on the relational SQLite engine: enable `journal_mode=WAL` and `busy_timeout=30000` via a `connect` event hook. No effect on Postgres.

## Testing
- The reproduction above no longer raises `database is locked` after the change.
- WAL is the standard remedy for SQLite writer-lock contention, and the identical hook already ships in `SqlCacheAdapter`.
