### PR TITLE
fix: auto-recover DATASET_PROCESSING_ERRORED state before cognify re-run

### DIFF
--- a/cognee/modules/pipelines/operations/pipeline.py
+++ b/cognee/modules/pipelines/operations/pipeline.py
@@ -25,6 +25,9 @@ from cognee.modules.pipelines.layers.check_pipeline_run_qualification import (
 from cognee.modules.pipelines.models.PipelineRunInfo import (
     PipelineRunStarted,
 )
+from cognee.modules.pipelines.models import PipelineRunStatus
+from cognee.modules.pipelines.operations.get_pipeline_status import get_pipeline_status
+from cognee.modules.pipelines.methods import reset_pipeline_run_status
 from typing import Any
 
 logger = get_logger("cognee.pipeline")
@@ -86,6 +89,29 @@ async def run_pipeline_per_dataset(
 ):
     if not data:
         data = await get_dataset_data(dataset_id=dataset.id)
+
+    # Auto-recover datasets stuck in DATASET_PROCESSING_ERRORED state.
+    #
+    # When a previous cognify run fails (e.g. due to a transient DB error or
+    # network issue), the pipeline_runs table retains a row with status
+    # DATASET_PROCESSING_ERRORED. A subsequent cognify call on the same dataset
+    # then raises RetryError[ProgrammingError] inside run_tasks because the
+    # relational DB still holds stale state from the failed run.
+    #
+    # Calling reset_pipeline_run_status inserts a fresh DATASET_PROCESSING_INITIATED
+    # row which clears the stale state and allows run_tasks to proceed normally.
+    #
+    # See: https://github.com/topoteretes/cognee/issues/3853
+    task_status = await get_pipeline_status([dataset.id], pipeline_name)
+    if task_status.get(str(dataset.id)) == PipelineRunStatus.DATASET_PROCESSING_ERRORED:
+        logger.warning(
+            "Dataset %s has a previous errored run for pipeline '%s'. "
+            "Auto-resetting status to allow re-run. "
+            "(See https://github.com/topoteretes/cognee/issues/3853)",
+            dataset.id,
+            pipeline_name,
+        )
+        await reset_pipeline_run_status(user.id, dataset.id, pipeline_name)
 
     process_pipeline_status = await check_pipeline_run_qualification(dataset, data, pipeline_name)
     if process_pipeline_status:


### PR DESCRIPTION
## Problem

When a `cognify` run fails (transient DB error, network issue, etc.), the `pipeline_runs` table retains a row with `status = DATASET_PROCESSING_ERRORED`. A subsequent `POST /api/v1/cognify` call on the **same dataset** then raises:

```
RetryError[<Future state=finished raised ProgrammingError>]
```

This is returned as HTTP 500 and the dataset is permanently stuck — every re-run on that dataset name fails with the same error. The only workaround is to use a completely different dataset name.

Fixes: #3853
Related: #3526

## Root Cause

`run_pipeline_per_dataset` in `pipeline.py` calls `check_pipeline_run_qualification` and then `run_tasks` directly. When the dataset status is `DATASET_PROCESSING_ERRORED`, `check_pipeline_run_qualification` returns `None` (the ERRORED case falls through without being handled), and `run_tasks` is invoked against a dataset whose stale state in the relational DB causes a `ProgrammingError` inside the async DB session.

## Fix

Add a status check for `DATASET_PROCESSING_ERRORED` in `run_pipeline_per_dataset` **before** `run_tasks` is called. When detected, call the existing `reset_pipeline_run_status()` helper (already used by `reset_dataset_pipeline_run_status` layer), which inserts a fresh `DATASET_PROCESSING_INITIATED` row and clears the stale state.

```python
task_status = await get_pipeline_status([dataset.id], pipeline_name)
if task_status.get(str(dataset.id)) == PipelineRunStatus.DATASET_PROCESSING_ERRORED:
    logger.warning(
        "Dataset %s has a previous errored run for pipeline '%s'. "
        "Auto-resetting status to allow re-run. (GitHub Issue #3853)",
        dataset.id,
        pipeline_name,
    )
    await reset_pipeline_run_status(user.id, dataset.id, pipeline_name)
```

## Why This Approach

- Uses **existing recovery infrastructure** — `reset_pipeline_run_status` and `get_pipeline_status` are already part of the codebase
- **Minimal surface area** — two new imports, one guard block added to one function
- **No behaviour change for healthy datasets** — the check adds one DB read (`get_pipeline_status`)
- **Idempotent** — safe to call multiple times; each call inserts a fresh INITIATED row that overrides the ERRORED status

## How to Reproduce (before fix)

1. Call `POST /api/v1/add_text` for a dataset
2. Call `POST /api/v1/cognify` and let it fail (or interrupt it)
3. Call `POST /api/v1/cognify` again on the same dataset → HTTP 500 `RetryError[ProgrammingError]`

After this fix, step 3 succeeds by auto-resetting the ERRORED state first.
