### PR TITLE
feat(retrieval): include source document path in recall citations

### DIFF
--- a/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
+++ b/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
@@ -41,6 +41,7 @@ class IndexSchema(DataPoint):
     # compatible with every indexed DataPoint type.
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    document_path: Optional[str] = None
     chunk_index: Optional[int] = None
     source_chunk_id: Optional[str] = None
     importance_weight: Optional[float] = 0.5
@@ -478,6 +479,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                     # fall back to None instead of raising.
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
+                    document_path=getattr(data_point, "document_path", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
                     source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),
@@ -557,6 +559,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                     text=getattr(dp, field_name),
                     document_id=getattr(dp, "document_id", None),
                     document_name=getattr(dp, "document_name", None),
+                    document_path=getattr(dp, "document_path", None),
                     chunk_index=getattr(dp, "chunk_index", None),
                     source_chunk_id=getattr(dp, "source_chunk_id", None),
                     importance_weight=getattr(dp, "importance_weight", None),

--- a/cognee/infrastructure/databases/hybrid/postgres/adapter.py
+++ b/cognee/infrastructure/databases/hybrid/postgres/adapter.py
@@ -338,6 +338,7 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
                     # Reference scalars for search "Evidence"; None for non-chunks.
                     document_id=getattr(dp, "document_id", None),
                     document_name=getattr(dp, "document_name", None),
+                    document_path=getattr(dp, "document_path", None),
                     chunk_index=getattr(dp, "chunk_index", None),
                     source_chunk_id=getattr(dp, "source_chunk_id", None),
                     importance_weight=getattr(dp, "importance_weight", None),

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -71,6 +71,7 @@ class IndexSchema(DataPoint):
     # compatible with every indexed DataPoint type.
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    document_path: Optional[str] = None
     chunk_index: Optional[int] = None
     source_chunk_id: Optional[str] = None
     importance_weight: Optional[float] = 0.5
@@ -1286,6 +1287,7 @@ class LanceDBAdapter(VectorDBInterface):
                     # fall back to None instead of raising.
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
+                    document_path=getattr(data_point, "document_path", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
                     source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -54,6 +54,7 @@ class IndexSchema(DataPoint):
     # compatible with every indexed DataPoint type.
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    document_path: Optional[str] = None
     chunk_index: Optional[int] = None
     source_chunk_id: Optional[str] = None
     importance_weight: Optional[float] = 0.5
@@ -397,6 +398,7 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
                     # fall back to None instead of raising.
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
+                    document_path=getattr(data_point, "document_path", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
                     source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),

--- a/cognee/modules/chunking/CsvChunker.py
+++ b/cognee/modules/chunking/CsvChunker.py
@@ -13,6 +13,7 @@ class CsvChunker(Chunker):
     async def read(self):
         document_id = str(self.document.id)
         document_name = self.document.name or basename(self.document.raw_data_location)
+        document_path = self.document.raw_data_location
         async for content_text in self.get_text():
             if content_text is None:
                 continue
@@ -29,6 +30,7 @@ class CsvChunker(Chunker):
                         contains=[],
                         document_id=document_id,
                         document_name=document_name,
+                        document_path=document_path,
                         metadata={
                             "index_fields": ["text"],
                         },

--- a/cognee/modules/chunking/LangchainChunker.py
+++ b/cognee/modules/chunking/LangchainChunker.py
@@ -37,6 +37,7 @@ class LangchainChunker(Chunker):
     async def read(self):
         document_id = str(self.document.id)
         document_name = self.document.name or basename(self.document.raw_data_location)
+        document_path = self.document.raw_data_location
         async for content_text in self.get_text():
             for chunk in self.splitter.split_text(content_text):
                 embedding_engine = get_vector_engine().embedding_engine
@@ -53,6 +54,7 @@ class LangchainChunker(Chunker):
                         contains=[],
                         document_id=document_id,
                         document_name=document_name,
+                        document_path=document_path,
                         metadata={
                             "index_fields": ["text"],
                         },

--- a/cognee/modules/chunking/TextChunker.py
+++ b/cognee/modules/chunking/TextChunker.py
@@ -13,6 +13,7 @@ class TextChunker(Chunker):
     async def read(self):
         document_id = str(self.document.id)
         document_name = self.document.name or basename(self.document.raw_data_location)
+        document_path = self.document.raw_data_location
         paragraph_chunks = []
         async for content_text in self.get_text():
             for chunk_data in chunk_by_paragraph(
@@ -36,6 +37,7 @@ class TextChunker(Chunker):
                             importance_weight=self.document.importance_weight,
                             document_id=document_id,
                             document_name=document_name,
+                            document_path=document_path,
                             metadata={
                                 "index_fields": ["text"],
                             },
@@ -58,6 +60,7 @@ class TextChunker(Chunker):
                                 importance_weight=self.document.importance_weight,
                                 document_id=document_id,
                                 document_name=document_name,
+                                document_path=document_path,
                                 metadata={
                                     "index_fields": ["text"],
                                 },
@@ -83,6 +86,7 @@ class TextChunker(Chunker):
                     importance_weight=self.document.importance_weight,
                     document_id=document_id,
                     document_name=document_name,
+                    document_path=document_path,
                     metadata={"index_fields": ["text"]},
                 )
             except Exception as e:

--- a/cognee/modules/chunking/models/DocumentChunk.py
+++ b/cognee/modules/chunking/models/DocumentChunk.py
@@ -25,6 +25,9 @@ class DocumentChunk(DataPoint):
     - contains: A list of entities or events contained within the chunk (default is None).
     - document_id: Flat string id of the source document, for reference rendering.
     - document_name: Display name (basename) of the source document, for reference rendering.
+    - document_path: Full source location of the document (``raw_data_location``), for
+    reference rendering. Lets citations disambiguate identically-named files in different
+    directories; ``None`` for chunks indexed before this field existed.
     - metadata: A dictionary to hold meta information related to the chunk, including index
     fields.
     """
@@ -38,6 +41,7 @@ class DocumentChunk(DataPoint):
     importance_weight: Optional[float] = 0.5
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    document_path: Optional[str] = None
     # Optional truth-alignment fields; never embedded (kept out of index_fields)
     # and not part of id/dedup.
     truth_alignment: Optional[list[float]] = None

--- a/cognee/modules/chunking/text_chunker_with_overlap.py
+++ b/cognee/modules/chunking/text_chunker_with_overlap.py
@@ -20,6 +20,7 @@ class TextChunkerWithOverlap(Chunker):
     ):
         super().__init__(document, get_text, max_chunk_size)
         self.document_name = document.name or basename(document.raw_data_location)
+        self.document_path = document.raw_data_location
         self._accumulated_chunk_data = []
         self._accumulated_size = 0
         self.chunk_overlap_ratio = chunk_overlap_ratio
@@ -80,6 +81,7 @@ class TextChunkerWithOverlap(Chunker):
                 contains=[],
                 document_id=str(self.document.id),
                 document_name=self.document_name,
+                document_path=self.document_path,
                 metadata={"index_fields": ["text"]},
             )
         except Exception as e:

--- a/cognee/modules/data/processing/document_types/DltRowDocument.py
+++ b/cognee/modules/data/processing/document_types/DltRowDocument.py
@@ -37,4 +37,5 @@ class DltRowDocument(Document):
             contains=[],
             document_id=str(self.id),
             document_name=self.name or basename(self.raw_data_location),
+            document_path=self.raw_data_location,
         )

--- a/cognee/modules/recall/methods/normalize_search_payload.py
+++ b/cognee/modules/recall/methods/normalize_search_payload.py
@@ -79,7 +79,9 @@ def _provenance_metadata(raw: dict) -> dict:
     Lets callers map a result back to the data they ingested and inspect the
     cited chunk. ``document_id`` is the ingested Data item's id (cognify sets
     ``Document.id = data.id``), exposed here as ``data_id``; ``id`` is the
-    chunk's own node id. Only keys actually present are included.
+    chunk's own node id. ``document_path`` is the source ``raw_data_location``,
+    letting a client resolve the result to the exact file even when several
+    documents share a basename. Only keys actually present are included.
     """
     metadata: dict[str, Any] = {}
     data_id = raw.get("document_id")
@@ -94,6 +96,9 @@ def _provenance_metadata(raw: dict) -> dict:
     document_name = raw.get("document_name")
     if document_name is not None:
         metadata["document_name"] = str(document_name)
+    document_path = raw.get("document_path")
+    if document_path is not None:
+        metadata["document_path"] = str(document_path)
     return metadata
 
 

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -133,14 +133,21 @@ def _get_payload(obj: Any) -> Optional[dict]:
     return None
 
 
-def _provenance_suffix(data_id: Optional[str], chunk_id: Optional[str]) -> str:
-    """Render a '(data_id: …, chunk_id: …)' annotation for whichever ids exist.
+def _provenance_suffix(path: Optional[str], data_id: Optional[str], chunk_id: Optional[str]) -> str:
+    """Render a '(path: …, data_id: …, chunk_id: …)' annotation for whichever fields exist.
 
-    Lets a reader map the citation back to the ingested data item and the exact
-    cited chunk, instead of only a (possibly auto-generated) document name and a
-    positional chunk number.
+    Lets a reader map the citation back to the source file, the ingested data
+    item, and the exact cited chunk, instead of only a (possibly auto-generated)
+    document name and a positional chunk number.
+
+    ``path`` is the source document location (``raw_data_location``). It
+    disambiguates identically-named files in different directories, which a
+    basename-only ``document name`` cannot. It is omitted when absent so chunks
+    indexed before the field existed render exactly as before.
     """
     parts = []
+    if path:
+        parts.append(f"path: {path}")
     if data_id:
         parts.append(f"data_id: {data_id}")
     if chunk_id:
@@ -175,8 +182,12 @@ def format_chunk_references(
     Reads ``payload["document_name"]``, ``payload["chunk_number"]`` (falling back
     to ``payload["chunk_index"] + 1``), and ``payload["text"]`` from each
     retrieved object. Entries missing usable document name or chunk-number
-    metadata are skipped. Results are deduplicated by chunk id and capped at
-    3-5 bullets.
+    metadata are skipped. When present, ``payload["document_id"]`` and
+    ``payload["document_path"]`` (the source ``raw_data_location``) are appended
+    to the citation so a reader can resolve it to the exact file even when
+    several documents share a basename; both are omitted when absent, so older
+    indexed data renders unchanged. Results are deduplicated by chunk id and
+    capped at 3-5 bullets.
 
     When ``answer`` is provided, candidates that share no significant terms
     with the answer are dropped and the remainder is ranked by term overlap,
@@ -216,8 +227,8 @@ def format_chunk_references(
             # rather than presenting unverifiable retrieval order as provenance.
             return ""
 
-    # (overlap_score, document_name, number, text, data_id, chunk_id) per candidate.
-    candidates: List[Tuple[int, str, int, str, Optional[str], Optional[str]]] = []
+    # (overlap_score, document_name, number, text, path, data_id, chunk_id) per candidate.
+    candidates: List[Tuple[int, str, int, str, Optional[str], Optional[str], Optional[str]]] = []
     seen: set = set()
 
     for obj in iterator:
@@ -239,6 +250,10 @@ def format_chunk_references(
         # Document.id = data.id), i.e. the dataId a caller needs to map a
         # citation back to the document they ingested.
         data_id = _clean_str(payload.get("document_id"))
+        # document_path == the source document's raw_data_location, so a caller
+        # can resolve a citation to the exact file even when several documents
+        # share a basename. None for chunks indexed before the field existed.
+        document_path = _clean_str(payload.get("document_path"))
 
         dedup_key = chunk_id or f"{document_name}#{number}"
         if dedup_key in seen:
@@ -254,7 +269,7 @@ def format_chunk_references(
                 # certainly not a source of the answer.
                 continue
 
-        candidates.append((score, document_name, number, text, data_id, chunk_id))
+        candidates.append((score, document_name, number, text, document_path, data_id, chunk_id))
 
     if not candidates:
         return ""
@@ -266,8 +281,8 @@ def format_chunk_references(
     max_bullets = _clamp_limit(limit)
     bullets = [
         f"- chunk {number} of document {document_name}"
-        f'{_provenance_suffix(data_id, chunk_id)}: "{_snippet(text)}"'
-        for _, document_name, number, text, data_id, chunk_id in candidates[:max_bullets]
+        f'{_provenance_suffix(path, data_id, chunk_id)}: "{_snippet(text)}"'
+        for _, document_name, number, text, path, data_id, chunk_id in candidates[:max_bullets]
     ]
 
     return EVIDENCE_HEADER + "\n" + "\n".join(bullets)

--- a/cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py
@@ -8,7 +8,13 @@ from its payload — which would make chunk Evidence render empty on that backen
 
 import pytest
 
-REFERENCE_FIELDS = ("document_id", "document_name", "chunk_index", "source_chunk_id")
+REFERENCE_FIELDS = (
+    "document_id",
+    "document_name",
+    "document_path",
+    "chunk_index",
+    "source_chunk_id",
+)
 
 
 def _index_schema_classes():
@@ -62,6 +68,7 @@ def test_index_schema_round_trips_reference_fields(name, schema_cls):
         text="some chunk text",
         document_id="22222222-2222-2222-2222-222222222222",
         document_name="annual_report.pdf",
+        document_path="/abs/path/to/annual_report.pdf",
         chunk_index=4,
         source_chunk_id="33333333-3333-3333-3333-333333333333",
         importance_weight=0.8,
@@ -69,6 +76,7 @@ def test_index_schema_round_trips_reference_fields(name, schema_cls):
     dumped = instance.model_dump()
     assert dumped["document_id"] == "22222222-2222-2222-2222-222222222222"
     assert dumped["document_name"] == "annual_report.pdf"
+    assert dumped["document_path"] == "/abs/path/to/annual_report.pdf"
     assert dumped["chunk_index"] == 4
     assert dumped["source_chunk_id"] == "33333333-3333-3333-3333-333333333333"
     assert dumped["importance_weight"] == 0.8

--- a/cognee/tests/unit/modules/chunking/test_chunk_reference_fields.py
+++ b/cognee/tests/unit/modules/chunking/test_chunk_reference_fields.py
@@ -1,10 +1,11 @@
 """Unit tests asserting chunkers populate the reference scalar fields.
 
 The References (Evidence) feature relies on every produced ``DocumentChunk``
-carrying flat ``document_id`` / ``document_name`` scalars (basename only, never
-an absolute path). These tests run the real chunkers over an in-memory text
-generator (no LLM, no network) and assert the fields are set, and that the
-format helper renders the 1-based number from ``chunk_index + 1``.
+carrying flat ``document_id`` / ``document_name`` (basename only) scalars plus
+``document_path`` (the full source location, for disambiguating same-named
+files). These tests run the real chunkers over an in-memory text generator (no
+LLM, no network) and assert the fields are set, and that the format helper
+renders the 1-based number from ``chunk_index + 1``.
 """
 
 from uuid import uuid4
@@ -55,6 +56,9 @@ async def test_chunk_sets_document_id_and_name_from_document_name(chunker_class)
     for chunk in chunks:
         assert chunk.document_id == str(doc_id)
         assert chunk.document_name == "annual_report.pdf"
+        # document_path carries the full source location, unlike the
+        # basename-only document_name, so citations can disambiguate files.
+        assert chunk.document_path == "/abs/path/to/annual_report.pdf"
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/recall/test_normalize_search_payload.py
+++ b/cognee/tests/unit/modules/recall/test_normalize_search_payload.py
@@ -23,6 +23,7 @@ def test_chunk_result_exposes_provenance_metadata():
         "id": "chunk-9",
         "document_id": "data-123",  # == ingested Data item id
         "document_name": "report.pdf",
+        "document_path": "/repo/api/report.pdf",
         "chunk_index": 4,
         "text": "Revenue grew 12 percent.",
     }
@@ -39,8 +40,30 @@ def test_chunk_result_exposes_provenance_metadata():
     assert metadata["chunk_id"] == "chunk-9"
     assert metadata["chunk_index"] == 4
     assert metadata["document_name"] == "report.pdf"
+    # document_path lets a client resolve the result to the exact file.
+    assert metadata["document_path"] == "/repo/api/report.pdf"
     # raw still preserves the full original payload.
     assert items[0].raw["document_id"] == "data-123"
+
+
+def test_chunk_metadata_omits_document_path_when_absent():
+    """Backward compatibility: chunks indexed before document_path existed carry
+    no path key rather than a null one."""
+    chunk = {
+        "id": "chunk-9",
+        "document_id": "data-123",
+        "document_name": "report.pdf",
+        "chunk_index": 4,
+        "text": "Revenue grew 12 percent.",
+    }
+    payload = SearchResultPayload(
+        result_object=[chunk],
+        search_type=SearchType.CHUNKS,
+    )
+
+    items = normalize_search_payload(payload)
+
+    assert "document_path" not in items[0].metadata
 
 
 def test_completion_result_has_no_provenance_metadata():

--- a/cognee/tests/unit/modules/retrieval/test_references_helpers.py
+++ b/cognee/tests/unit/modules/retrieval/test_references_helpers.py
@@ -71,6 +71,50 @@ def test_format_chunk_references_includes_data_id_and_chunk_id():
     )
 
 
+def test_format_chunk_references_includes_document_path():
+    """document_path (the source raw_data_location) is surfaced in the bullet so a
+    reader can resolve the citation to the exact file, not just a basename."""
+    result = format_chunk_references([_payload(document_path="/repo/api/README.md")])
+
+    assert "- chunk 5 of document annual_report.pdf (path: /repo/api/README.md):" in result
+
+
+def test_format_chunk_references_orders_path_before_ids():
+    """When path and ids are all present, path is rendered first, then data_id, chunk_id."""
+    result = format_chunk_references(
+        [_payload(document_path="/repo/api/README.md", document_id="data-123", id="chunk-9")]
+    )
+
+    assert (
+        "- chunk 5 of document annual_report.pdf "
+        "(path: /repo/api/README.md, data_id: data-123, chunk_id: chunk-9):" in result
+    )
+
+
+def test_format_chunk_references_omits_path_when_absent():
+    """Backward compatibility: a payload without document_path renders exactly as
+    before (no empty 'path:' fragment), so pre-existing indexed data is unchanged."""
+    result = format_chunk_references([_payload(document_id="data-123", id="chunk-9")])
+
+    assert (
+        "- chunk 5 of document annual_report.pdf (data_id: data-123, chunk_id: chunk-9):" in result
+    )
+    assert "path:" not in result
+
+
+def test_format_chunk_references_disambiguates_same_basename_by_path():
+    """Two chunks sharing a basename are told apart by their distinct paths."""
+    result = format_chunk_references(
+        [
+            _payload(document_name="README.md", document_path="/repo/api/README.md", id="a"),
+            _payload(document_name="README.md", document_path="/repo/web/README.md", id="b"),
+        ]
+    )
+
+    assert "path: /repo/api/README.md" in result
+    assert "path: /repo/web/README.md" in result
+
+
 def test_format_chunk_references_empty_when_document_name_missing():
     """Old-data case: missing document_name -> entry skipped -> empty string."""
     payload = _payload()


### PR DESCRIPTION
## Description

I ran into this while building a client on top of `recall(..., include_references=True)`. The Evidence block gives you `chunk N of document <name>`, but `<name>` is only the **basename** (`document_name`), so when a repo has several files that share a name — `README.md`, `__init__.py`, `index.ts` — there is no way to tell which one a citation actually points to. That makes it impossible to reliably link a citation back to a source file unless you only ever query files you ingested yourself.

I traced where that name comes from. Chunkers set `document_name = document.name or basename(raw_data_location)`,
and the citation is rendered in `cognee/modules/retrieval/utils/references.py` from the payload stored in the `DocumentChunk_text` vector collection. That collection doesn't store the raw `DocumentChunk` — it stores an `IndexSchema` payload, which already carries a set of "reference scalars" (`document_id`, `document_name`, `chunk_index`, `source_chunk_id`) specifically for the Evidence feature. The full path (`raw_data_location`) exists on the `Document` at chunk-creation time but was simply never propagated onto the chunk or the index payload.

So the fix follows the exact pattern that's already there for `document_name`, one more scalar:

- Added `document_path` to `DocumentChunk` and populated it (from `raw_data_location`) in every chunk
  producer: `TextChunker`, `TextChunkerWithOverlap`, `LangchainChunker`, `CsvChunker`, `DltRowDocument`.
- Added `document_path` to the `IndexSchema` of every vector backend (LanceDB, PGVector, Postgres-hybrid, Neptune) and   carried it at index time the same way the other scalars are (`getattr(dp, "document_path", None)`).
- Rendered it in `references.py`, appended to the provenance suffix as `path: <path>` — but only when the field is actually present, so nothing changes for data indexed before this.
- Surfaced it in the structured result too: `normalize_search_payload` now puts `document_path` in `SearchResultItem.metadata`, so a client can read the path directly instead of parsing the Evidence text.

I deliberately kept the existing Evidence text untouched and made the path purely additive — I didn't want to break anyone already parsing that output, and old chunks that don't have a path should keep rendering exactly as they do today.

## Acceptance Criteria

Requirements from #3844:

- **Path is surfaced in citations, alongside the basename** — done, in both the Evidence text and the structured metadata.
- **Backward compatible / existing Evidence format unchanged** — the `path:` fragment is only emitted when the field is present; chunks without it render byte-for-byte as before. `document_path` is`Optional[str] = None` everywhere and defaults to `None` for non-chunk data points, so nothing raises.
- **Structured references, not just prose** — `document_path` is exposed on `SearchResultItem.metadata`.
- **No dependency / schema-migration / API-signature changes.**

Proof it works:

- Unit tests (mocked, no live LLM) — extended the existing reference-scalar suites:
  - `tests/unit/modules/retrieval/test_references_helpers.py` — path rendered in the bullet; suffix order
    `(path, data_id, chunk_id)`; **omitted when absent** (regression guard); two same-basename chunks
    disambiguated by distinct paths.
  - `tests/unit/infrastructure/databases/test_index_schema_reference_fields.py` — `document_path` present,
    defaults to `None`, round-trips across all installed backends.
  - `tests/unit/modules/chunking/test_chunk_reference_fields.py` — real chunkers set `document_path` to the
    full source location.
  - `tests/unit/modules/recall/test_normalize_search_payload.py` — `document_path` surfaced in metadata;
    omitted when absent.

- Local run (see screenshot):

  ```
  pytest cognee/tests/unit/modules/retrieval/test_references_helpers.py \
         cognee/tests/unit/modules/retrieval/test_include_references_wiring.py \
         cognee/tests/unit/infrastructure/databases/test_index_schema_reference_fields.py \
         cognee/tests/unit/modules/chunking/ \
         cognee/tests/unit/modules/recall/
  # 70 passed

  ruff check .            # All checks passed
  ruff format --check .   # all files formatted
  ```

- End-to-end sanity (real `TextChunker` → real `format_chunk_references`):

  ```
  Evidence:
  - chunk 1 of document README.md (path: /repo/api/README.md, data_id: …): "Revenue grew 12 percent …"
  ```

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots

<img width="1175" height="573" alt="image" src="https://github.com/user-attachments/assets/7dfa7064-f0a2-44f2-86fa-fc3901b42982" />

<img width="1186" height="502" alt="image" src="https://github.com/user-attachments/assets/6c645639-ec23-4b9d-a756-373b470201cc" />

<img width="927" height="203" alt="image" src="https://github.com/user-attachments/assets/cd2ec7fa-ae38-4d4e-b2d4-d2308d5de0fb" />

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

Closes #3844

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
