### PR TITLE
Fix deterministic graph deduplication

### DIFF
--- a/cognee/modules/graph/utils/canonicalize.py
+++ b/cognee/modules/graph/utils/canonicalize.py
@@ -1,0 +1,75 @@
+"""Versioned, deterministic identity canonicalization for rule-based dedup.
+
+Approach A (deterministic, LLM-free). This is an *additive* layer: it does NOT
+modify ``DataPoint._normalize_identity_value`` / ``id_for`` (doing so would
+silently re-key every existing node). Instead it produces a richer canonical
+form used to *block* and *merge* duplicate nodes inside
+``deduplicate_nodes_and_edges`` — the surviving node keeps its original UUID5,
+so existing graph references remain valid.
+
+The canonicalizer is versioned so identities can be tagged with the version
+that produced them and migrated non-destructively later.
+"""
+
+import re
+import unicodedata
+
+# Bump when the canonicalization rules change; stamp onto merges so a future
+# migration can tell which nodes were keyed under which rule set.
+CANON_VERSION = 1
+
+# Configurable alias resolution. Keys are already-canonicalized surface forms
+# (post NFKC / casefold / punctuation-strip / whitespace-collapse); values are
+# the canonical form they resolve to. Kept in config-style data, not code
+# branches, so it stays transparent and easy to extend.
+ALIAS_MAP: dict[str, str] = {
+    "nlp": "natural language processing",
+    "n l p": "natural language processing",
+    "natural language processing": "natural language processing",
+    "ibm": "international business machines",
+    "international business machines": "international business machines",
+    "usa": "united states",
+    "u s a": "united states",
+    "united states of america": "united states",
+    "united states": "united states",
+}
+
+_PUNCT = re.compile(r"[^\w\s]", re.UNICODE)  # hyphens, dots, etc. -> space
+_WHITESPACE = re.compile(r"\s+")
+
+
+def canonicalize(value: object, version: int = CANON_VERSION) -> str:
+    """Return the deterministic canonical form of an identity value.
+
+    Rules (all deterministic, no LLM):
+      1. Unicode NFKC normalization (folds look-alikes / compatibility chars).
+      2. Case folding.
+      3. Punctuation (incl. hyphens) -> spaces.
+      4. Whitespace collapsing + trim.
+      5. Configurable alias resolution (abbreviations / known synonyms).
+    """
+    if not isinstance(value, str):
+        return str(value)
+
+    s = unicodedata.normalize("NFKC", value)
+    s = s.casefold()
+    s = _PUNCT.sub(" ", s)
+    s = _WHITESPACE.sub(" ", s).strip()
+    return ALIAS_MAP.get(s, s)
+
+
+def canonical_block_key(node: object) -> tuple:
+    """Deterministic blocking key for a graph node.
+
+    ``(ClassName, canonical(identity values))`` when the node declares
+    ``identity_fields``; otherwise ``("__by_id__", str(id))`` so nodes without a
+    stable identity fall back to the legacy id-equality behavior (never merged
+    across ids). Two node types can never share a block.
+    """
+    metadata = getattr(node, "metadata", None) or {}
+    identity_fields = metadata.get("identity_fields")
+    if not identity_fields:
+        return ("__by_id__", str(getattr(node, "id", id(node))))
+
+    values = [canonicalize(getattr(node, f, None)) for f in identity_fields]
+    return (type(node).__name__, "|".join(values))

--- a/cognee/modules/graph/utils/deduplicate_nodes_and_edges.py
+++ b/cognee/modules/graph/utils/deduplicate_nodes_and_edges.py
@@ -1,20 +1,110 @@
+"""Deterministic, rule-based node/edge deduplication with merge (Approach A).
+
+Previously this kept only the first node seen for a given id and dropped the
+rest, so (a) duplicates that differ only by spelling survived as separate nodes
+and (b) conflicting property values were discarded by insertion order.
+
+This version blocks candidates by a versioned canonical key
+(:func:`canonical_block_key`), merges each block into one surviving node using
+explicit per-field policies applied in a deterministic order, rewrites edges
+onto the surviving id, and records provenance (``merged_from`` + canonical key)
+on the survivor. The survivor keeps its original UUID5 so existing graph
+references stay valid.
+"""
+
 from cognee.infrastructure.engine import DataPoint
+from cognee.modules.graph.utils.canonicalize import CANON_VERSION, canonical_block_key
 
 
-def deduplicate_nodes_and_edges(nodes: list[DataPoint], edges: list[dict]):
-    added_entities = {}
-    final_nodes = []
-    final_edges = []
+def _merge_field(existing, incoming):
+    """Merge one field value deterministically.
 
+    - list/tuple/set -> ``union`` (order-preserving, no information lost)
+    - scalars -> ``non_null_wins`` (keep survivor's value unless it is empty)
+    """
+    if isinstance(existing, (list, tuple, set)):
+        merged = list(existing)
+        seen = {repr(item) for item in merged}
+        for item in incoming or []:
+            key = repr(item)
+            if key not in seen:
+                seen.add(key)
+                merged.append(item)
+        return merged if isinstance(existing, list) else type(existing)(merged)
+
+    # non_null_wins: survivor's non-empty value is authoritative.
+    if existing in (None, "", [], {}):
+        return incoming
+    return existing
+
+
+def _merge_group(members: list[DataPoint]) -> DataPoint:
+    """Merge a block of duplicate nodes into one surviving node.
+
+    Members are sorted by ``str(id)`` for reproducibility (never asynchronous
+    arrival order); the first is the survivor. Remaining members are folded in
+    field-by-field and recorded as provenance.
+    """
+    ordered = sorted(members, key=lambda n: str(n.id))
+    survivor = ordered[0].model_copy(deep=True)
+
+    if len(ordered) == 1:
+        return survivor
+
+    merged_from: list[str] = []
+    for other in ordered[1:]:
+        other_id = str(other.id)
+        if other_id != str(survivor.id) and other_id not in merged_from:
+            merged_from.append(other_id)
+        for field_name in type(survivor).model_fields:
+            if field_name in ("id", "metadata"):
+                continue
+            merged_value = _merge_field(
+                getattr(survivor, field_name, None),
+                getattr(other, field_name, None),
+            )
+            setattr(survivor, field_name, merged_value)
+
+    # Provenance / auditability: what merged in, and under which rule version.
+    if merged_from and isinstance(getattr(survivor, "metadata", None), dict):
+        provenance = dict(survivor.metadata)
+        provenance["merged_from"] = merged_from
+        provenance["canonical_version"] = CANON_VERSION
+        survivor.metadata = provenance
+
+    return survivor
+
+
+def deduplicate_nodes_and_edges(nodes: list[DataPoint], edges: list):
+    # Block nodes by canonical key, preserving first-seen order for determinism.
+    groups: dict[tuple, list[DataPoint]] = {}
+    order: list[tuple] = []
     for node in nodes:
-        if str(node.id) not in added_entities:
-            final_nodes.append(node)
-            added_entities[str(node.id)] = True
+        key = canonical_block_key(node)
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(node)
 
+    final_nodes: list[DataPoint] = []
+    id_remap: dict[str, object] = {}
+    for key in order:
+        survivor = _merge_group(groups[key])
+        final_nodes.append(survivor)
+        for member in groups[key]:
+            if str(member.id) != str(survivor.id):
+                id_remap[str(member.id)] = survivor.id
+
+    # Rewrite edges onto surviving ids, then dedup by (source, rel, target).
+    final_edges = []
+    seen_edges = set()
     for edge in edges:
-        edge_key = str(edge[0]) + str(edge[2]) + str(edge[1])
-        if edge_key not in added_entities:
-            final_edges.append(edge)
-            added_entities[edge_key] = True
+        source = id_remap.get(str(edge[0]), edge[0])
+        target = id_remap.get(str(edge[1]), edge[1])
+        remapped = (source, target) + tuple(edge[2:])
+        edge_key = str(source) + str(edge[2]) + str(target)
+        if edge_key not in seen_edges:
+            seen_edges.add(edge_key)
+            final_edges.append(remapped)
 
     return final_nodes, final_edges

--- a/cognee/tests/unit/modules/graph/test_deterministic_dedup.py
+++ b/cognee/tests/unit/modules/graph/test_deterministic_dedup.py
@@ -1,0 +1,109 @@
+"""Deterministic rule-based dedup + merge (Approach A). No LLM, no graph I/O."""
+
+from cognee.modules.engine.models.Entity import Entity
+from cognee.modules.engine.models.EntityType import EntityType
+from cognee.modules.graph.utils.canonicalize import canonicalize, canonical_block_key
+from cognee.modules.graph.utils.deduplicate_nodes_and_edges import (
+    deduplicate_nodes_and_edges,
+)
+
+
+def _entity(name, description="d"):
+    et = EntityType(name="Concept", description="c")
+    return Entity(name=name, is_a=et, description=description)
+
+
+class TestCanonicalization:
+    def test_case_and_whitespace(self):
+        assert canonicalize("  Hello   World  ") == "hello world"
+
+    def test_unicode_nfkc_lookalike(self):
+        # U+0139 (Ĺ) NFKC-folds; compatibility forms collapse deterministically.
+        assert canonicalize("ﬁle") == "file"  # U+FB01 ligature -> "fi"
+
+    def test_punctuation_and_hyphen(self):
+        assert canonicalize("Natural-Language, Processing.") == "natural language processing"
+
+    def test_alias_resolution(self):
+        assert canonicalize("NLP") == "natural language processing"
+        assert canonicalize("IBM") == canonicalize("International Business Machines")
+
+
+class TestBlockingKey:
+    def test_variants_share_block(self):
+        assert canonical_block_key(_entity("NLP")) == canonical_block_key(
+            _entity("Natural Language Processing")
+        )
+
+    def test_distinct_entities_separate_blocks(self):
+        assert canonical_block_key(_entity("Python")) != canonical_block_key(_entity("Java"))
+
+    def test_same_name_different_type_separate(self):
+        et = EntityType(name="Concept", description="c")
+        assert canonical_block_key(et) != canonical_block_key(_entity("Concept"))
+
+
+class TestMerge:
+    def test_variants_merge_to_one(self):
+        variants = [
+            "NLP",
+            "nlp",
+            "Natural Language Processing",
+            "Natural-Language Processing",
+        ]
+        nodes, _ = deduplicate_nodes_and_edges([_entity(v) for v in variants], [])
+        assert len(nodes) == 1
+
+    def test_distinct_entities_stay_separate(self):
+        nodes, _ = deduplicate_nodes_and_edges([_entity("Python"), _entity("Java")], [])
+        assert len(nodes) == 2
+
+    def test_provenance_recorded(self):
+        nodes, _ = deduplicate_nodes_and_edges(
+            [_entity("NLP"), _entity("Natural Language Processing")], []
+        )
+        assert nodes[0].metadata.get("merged_from")
+        assert nodes[0].metadata.get("canonical_version") == 1
+
+    def test_non_null_wins(self):
+        # An empty field on the survivor is filled from a peer (non_null_wins).
+        a = _entity("NLP", description="")
+        b = _entity("nlp", description="filled in")
+        nodes, _ = deduplicate_nodes_and_edges([a, b], [])
+        assert nodes[0].description == "filled in"
+
+    def test_list_field_union(self):
+        a = _entity("NLP")
+        a.relations = [("uses", "x")]
+        b = _entity("nlp")
+        b.relations = [("uses", "y")]
+        nodes, _ = deduplicate_nodes_and_edges([a, b], [])
+        assert ("uses", "x") in nodes[0].relations
+        assert ("uses", "y") in nodes[0].relations
+
+    def test_deterministic_survivor_id(self):
+        variants = ["NLP", "nlp", "Natural Language Processing"]
+        run1, _ = deduplicate_nodes_and_edges([_entity(v) for v in variants], [])
+        run2, _ = deduplicate_nodes_and_edges([_entity(v) for v in reversed(variants)], [])
+        assert run1[0].id == run2[0].id  # order-independent
+
+    def test_idempotent(self):
+        variants = ["NLP", "Natural Language Processing"]
+        once, _ = deduplicate_nodes_and_edges([_entity(v) for v in variants], [])
+        twice, _ = deduplicate_nodes_and_edges(once, [])
+        assert len(twice) == 1
+        assert twice[0].id == once[0].id
+
+
+class TestEdgeRemap:
+    def test_edges_rewired_to_survivor(self):
+        a, b = _entity("NLP"), _entity("Natural Language Processing")
+        other = _entity("Linguistics")
+        # edge from the soon-to-be-merged-away node onto `other`
+        edges = [(b.id, other.id, "related_to", {})]
+        nodes, out_edges = deduplicate_nodes_and_edges([a, b, other], edges)
+        surviving_ids = {str(n.id) for n in nodes}
+        # every edge endpoint must reference a surviving node
+        for e in out_edges:
+            assert str(e[0]) in surviving_ids
+            assert str(e[1]) in surviving_ids


### PR DESCRIPTION
## Summary

This PR implements **Approach A** by extending the existing graph deduplication pipeline with deterministic, rule-based entity merging. Instead of discarding duplicate nodes, the deduplication process now merges equivalent entities while preserving information and provenance.

The implementation is deterministic, requires no LLMs or embeddings, and keeps the existing UUID generation strategy unchanged for backward compatibility.

## Changes

### Canonicalization

Introduced `cognee/modules/graph/utils/canonicalize.py` to provide a versioned canonicalization layer.

* Unicode normalization (NFKC)
* Case folding
* Punctuation and hyphen normalization
* Whitespace normalization
* Configurable alias mapping for abbreviations and synonyms
* Versioned canonicalization (`CANON_VERSION`) for future compatibility

This layer is additive and does **not** modify the existing identity generation (`id_for` or `DataPoint._normalize_identity_value`), ensuring existing UUIDs remain stable.

### Deterministic Deduplication

Updated `cognee/modules/graph/utils/deduplicate_nodes_and_edges.py` to merge duplicate nodes instead of keeping only the first occurrence.

Key improvements include:

* Candidate grouping using canonical block keys
* Deterministic processing order independent of insertion or async execution
* Explicit merge policies

  * Union for list fields
  * Non-null wins for scalar fields
* Edge rewiring to the surviving node
* Edge deduplication after merge
* Provenance metadata including:

  * `merged_from`
  * `canonical_version`

### Tests

Added comprehensive unit tests in:

`cognee/tests/unit/modules/graph/test_deterministic_dedup.py`

The test suite covers:

* Canonicalization behavior
* Alias resolution
* Merge policies
* Provenance tracking
* Edge rewiring
* Order independence
* Idempotency
* Negative cases (entities that should not merge)

## Scope

This PR performs deterministic merging **within a single ingestion run**, which matches the current deduplication contract.

Cross-run deduplication against already persisted graph data is intentionally left out of scope and can be implemented later using the canonical-key infrastructure introduced in this PR.

## Results

* Duplicate entities are merged instead of silently discarded.
* Existing UUID generation remains unchanged.
* Information is preserved during merges.
* Provenance is retained for merged entities.
* The deduplication process produces deterministic output regardless of processing order.

## Validation

* Added comprehensive deterministic unit tests.
* Existing graph behavior remains compatible.
* All tests pass locally.
* Ruff formatting and linting pass successfully.

## Type of Change

* ✅ Bug fix
* ✅ New feature

## Checklist

* [x] Tested locally
* [x] Added unit tests
* [x] Existing tests continue to pass
* [x] Code follows project style guidelines
* [x] Minimal implementation required for the proposed approach
* [x] Linked relevant issue (to be added)

## DCO

I affirm that all code in every commit of this pull request conforms to the Topoteretes Developer Certificate of Origin.
<img width="1447" height="871" alt="Screenshot 2026-07-04 121636 png" src="https://github.com/user-attachments/assets/344fc7b6-7941-4a13-b6fd-c99d06d935da" />
