### PR TITLE
Turso graph db

### DIFF
--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -229,6 +229,7 @@ class DatabaseContextManager:
             "kuzu_num_threads": get_graph_config().kuzu_num_threads,
             "kuzu_buffer_pool_size": get_graph_config().kuzu_buffer_pool_size,
             "kuzu_max_db_size": get_graph_config().kuzu_max_db_size,
+            "graph_database_sync_interval": get_graph_config().graph_database_sync_interval,
         }
 
         storage_config = {

--- a/cognee/infrastructure/databases/dataset_database_handler/supported_dataset_database_handlers.py
+++ b/cognee/infrastructure/databases/dataset_database_handler/supported_dataset_database_handlers.py
@@ -16,6 +16,9 @@ from cognee.infrastructure.databases.vector.pgvector.PGVectorDatasetDatabaseHand
 from cognee.infrastructure.databases.graph.postgres.PostgresGraphDatasetDatabaseHandler import (
     PostgresGraphDatasetDatabaseHandler,
 )
+from cognee.infrastructure.databases.graph.turso.TursoGraphDatasetDatabaseHandler import (
+    TursoGraphDatasetDatabaseHandler,
+)
 
 supported_dataset_database_handlers = {
     "neo4j_aura_dev": {
@@ -40,4 +43,8 @@ supported_dataset_database_handlers = {
         "handler_provider": "ladybug",
     },
     "kuzu": {"handler_instance": LadybugDatasetDatabaseHandler, "handler_provider": "kuzu"},
+    "turso_graph": {
+        "handler_instance": TursoGraphDatasetDatabaseHandler,
+        "handler_provider": "turso",
+    },
 }

--- a/cognee/infrastructure/databases/graph/config.py
+++ b/cognee/infrastructure/databases/graph/config.py
@@ -58,6 +58,7 @@ class GraphConfig(BaseSettings):
     graph_topology: object = KnowledgeGraph
     graph_dataset_database_handler: str = "ladybug"
     graph_database_subprocess_enabled: bool = True
+    graph_database_sync_interval: float = Field(5.0, env="GRAPH_DATABASE_SYNC_INTERVAL")
 
     # Kuzu tuning. 0 means "use Kuzu's default" (one thread per CPU).
     kuzu_num_threads: int = Field(0, env="KUZU_NUM_THREADS")
@@ -139,6 +140,7 @@ class GraphConfig(BaseSettings):
             "kuzu_num_threads": self.kuzu_num_threads,
             "kuzu_buffer_pool_size": self.kuzu_buffer_pool_size,
             "kuzu_max_db_size": self.kuzu_max_db_size,
+            "graph_database_sync_interval": self.graph_database_sync_interval,
         }
 
     def to_hashable_dict(self) -> dict:
@@ -170,6 +172,7 @@ class GraphConfig(BaseSettings):
             "kuzu_num_threads": self.kuzu_num_threads,
             "kuzu_buffer_pool_size": self.kuzu_buffer_pool_size,
             "kuzu_max_db_size": self.kuzu_max_db_size,
+            "graph_database_sync_interval": self.graph_database_sync_interval,
         }
 
 

--- a/cognee/infrastructure/databases/graph/config.py
+++ b/cognee/infrastructure/databases/graph/config.py
@@ -80,6 +80,8 @@ class GraphConfig(BaseSettings):
             self.graph_dataset_database_handler = "postgres_graph"
         if provider == "neo4j" and graph_dataset_database_handler in ("ladybug", "neo4j"):
             self.graph_dataset_database_handler = "neo4j"
+        if provider == "turso" and graph_dataset_database_handler in ("ladybug", "turso"):
+            self.graph_dataset_database_handler = "turso_graph"
         base_config = get_base_config()
 
         databases_directory_path = os.path.join(base_config.system_root_directory, "databases")

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -458,6 +458,26 @@ def _create_graph_engine(
         return NeptuneAnalyticsAdapter(
             graph_id=graph_identifier,
         )
+    elif graph_database_provider == "turso":
+        if not graph_database_url:
+            raise EnvironmentError("Missing required Turso database URL.")
+
+        auth_token = graph_database_key if graph_database_key else ""
+
+        if auth_token:
+            raise NotImplementedError(
+                "Remote Turso support is not yet implemented. "
+                "Set GRAPH_DATABASE_KEY to an empty string to use local SQLite mode."
+            )
+        else:
+            # Local mode — graph_database_url must be an absolute path.
+            # sqlite+aioturso:/// + /abs/path => sqlite+aioturso:////abs/path (4 slashes = absolute)
+            # pyturso provides Rust-backed async via turso.aio worker thread (same model as aiosqlite).
+            connection_string: str = f"sqlite+aioturso:///{graph_database_url}"
+
+        from .turso.adapter import TursoAdapter
+
+        return TursoAdapter(connection_string=connection_string)
 
     all_providers = list(supported_databases.keys()) + [
         "neo4j",
@@ -468,6 +488,7 @@ def _create_graph_engine(
         "postgres",
         "neptune",
         "neptune_analytics",
+        "turso",
     ]
     raise EnvironmentError(
         f"Unsupported graph database provider: {graph_database_provider}. "

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -131,6 +131,7 @@ def create_graph_engine(
     kuzu_num_threads=0,
     kuzu_buffer_pool_size=DEFAULT_KUZU_BUFFER_POOL_SIZE,
     kuzu_max_db_size=DEFAULT_KUZU_MAX_DB_SIZE,
+    graph_database_sync_interval=5.0,
 ):
     """
     Wrapper function to call create graph engine with caching.
@@ -157,6 +158,7 @@ def create_graph_engine(
     kuzu_num_threads = normalized_optional_params["kuzu_num_threads"]
     kuzu_buffer_pool_size = normalized_optional_params["kuzu_buffer_pool_size"]
     kuzu_max_db_size = normalized_optional_params["kuzu_max_db_size"]
+    graph_database_sync_interval = normalized_optional_params["graph_database_sync_interval"]
 
     # Check USE_UNIFIED_PROVIDER outside the cache so it's always re-read
     unified_provider = os.environ.get("USE_UNIFIED_PROVIDER", "")
@@ -184,6 +186,7 @@ def create_graph_engine(
         kuzu_num_threads,
         kuzu_buffer_pool_size,
         kuzu_max_db_size,
+        graph_database_sync_interval,
     )
 
 
@@ -215,6 +218,7 @@ def evict_graph_engine(**kwargs) -> bool:
         normalized["kuzu_num_threads"],
         normalized["kuzu_buffer_pool_size"],
         normalized["kuzu_max_db_size"],
+        normalized["graph_database_sync_interval"],
     )
 
 
@@ -238,6 +242,7 @@ def is_graph_engine_cached(**kwargs) -> bool:
         normalized["kuzu_num_threads"],
         normalized["kuzu_buffer_pool_size"],
         normalized["kuzu_max_db_size"],
+        normalized["graph_database_sync_interval"],
     )
 
 
@@ -258,6 +263,7 @@ def _create_graph_engine(
     kuzu_num_threads=0,
     kuzu_buffer_pool_size=DEFAULT_KUZU_BUFFER_POOL_SIZE,
     kuzu_max_db_size=DEFAULT_KUZU_MAX_DB_SIZE,
+    graph_database_sync_interval=5.0,
 ):
     """
     Create a graph engine based on the specified provider type.
@@ -459,25 +465,36 @@ def _create_graph_engine(
             graph_id=graph_identifier,
         )
     elif graph_database_provider == "turso":
-        if not graph_database_url:
-            raise EnvironmentError("Missing required Turso database URL.")
-
         auth_token = graph_database_key if graph_database_key else ""
 
+        from .turso.adapter import TursoAdapter
+
         if auth_token:
-            raise NotImplementedError(
-                "Remote Turso support is not yet implemented. "
-                "Set GRAPH_DATABASE_KEY to an empty string to use local SQLite mode."
+            # Remote sync (embedded replica) mode.
+            # graph_database_url = remote libSQL URL (e.g. libsql://<db>.turso.io).
+            # graph_file_path    = local replica file (absolute path).
+            if not graph_database_url:
+                raise EnvironmentError("Missing required Turso remote database URL.")
+            if not graph_file_path:
+                raise EnvironmentError(
+                    "Turso remote sync mode requires a local replica file path "
+                    "(GRAPH_FILE_PATH), to store the embedded replica."
+                )
+            connection_string: str = f"sqlite+aioturso:///{graph_file_path}"
+            return TursoAdapter(
+                connection_string=connection_string,
+                remote_url=graph_database_url,
+                auth_token=auth_token,
+                sync_interval_seconds=graph_database_sync_interval,
             )
         else:
             # Local mode — graph_database_url must be an absolute path.
             # sqlite+aioturso:/// + /abs/path => sqlite+aioturso:////abs/path (4 slashes = absolute)
             # pyturso provides Rust-backed async via turso.aio worker thread (same model as aiosqlite).
+            if not graph_database_url:
+                raise EnvironmentError("Missing required Turso database URL.")
             connection_string: str = f"sqlite+aioturso:///{graph_database_url}"
-
-        from .turso.adapter import TursoAdapter
-
-        return TursoAdapter(connection_string=connection_string)
+            return TursoAdapter(connection_string=connection_string)
 
     all_providers = list(supported_databases.keys()) + [
         "neo4j",

--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -14,10 +14,22 @@ from cognee.modules.users.models import User, DatasetDatabase
 class TursoGraphDatasetDatabaseHandler:
     """Handler for per-dataset Turso/SQLite graph databases.
 
-    Local mode: each dataset gets its own SQLite file under the system databases directory.
-    Remote Turso: set GRAPH_DATABASE_URL to the remote libSQL URL and GRAPH_DATABASE_KEY
-    to the auth token; each dataset then uses a dataset-scoped URL path.
+    Local mode: each dataset gets its own SQLite file under
+    ``<system_root>/databases/<user_id>/<dataset_id>``.
+
+    Remote Turso: set GRAPH_DATABASE_URL to the remote libSQL URL and
+    GRAPH_DATABASE_KEY to the auth token. Each dataset still gets its own local
+    replica file at the same path, kept in sync via ``turso.aio.sync.connect()``,
+    but (v1 limitation) all datasets sync against the same remote database/token —
+    there is no per-dataset remote isolation yet.
     """
+
+    @classmethod
+    def _local_path(cls, user_id: UUID, dataset_id: UUID) -> str:
+        base_config = get_base_config()
+        databases_dir = os.path.join(base_config.system_root_directory, "databases", str(user_id))
+        os.makedirs(databases_dir, exist_ok=True)
+        return os.path.join(databases_dir, str(dataset_id))
 
     @classmethod
     async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
@@ -29,27 +41,35 @@ class TursoGraphDatasetDatabaseHandler:
                 "with the turso graph database provider."
             )
 
-        base_config = get_base_config()
-        databases_dir = os.path.join(base_config.system_root_directory, "databases")
-        os.makedirs(databases_dir, exist_ok=True)
+        local_path = cls._local_path(user.id, dataset_id)
+        remote_url = graph_config.graph_database_url
+        auth_token = graph_config.graph_database_key
 
-        db_file = os.path.join(databases_dir, f"graph_{dataset_id}.db")
-        # sqlite+aiosqlite:/// needs three slashes for absolute path
-        dataset_url = f"/{db_file}" if not db_file.startswith("/") else db_file
+        if auth_token:
+            engine = create_graph_engine(
+                graph_database_provider="turso",
+                graph_file_path=local_path,
+                graph_database_url=remote_url,
+                graph_database_key=auth_token,
+                graph_database_sync_interval=graph_config.graph_database_sync_interval,
+            )
+            dataset_url_field = remote_url
+        else:
+            engine = create_graph_engine(
+                graph_database_provider="turso",
+                graph_file_path="",
+                graph_database_url=local_path,
+                graph_database_key="",
+            )
+            dataset_url_field = local_path
 
-        engine = create_graph_engine(
-            graph_database_provider="turso",
-            graph_file_path="",
-            graph_database_url=dataset_url,
-            graph_database_key="",
-        )
         await engine.initialize()
 
         return {
             "graph_database_provider": "turso",
-            "graph_database_url": dataset_url,
+            "graph_database_url": dataset_url_field,
             "graph_database_name": str(dataset_id),
-            "graph_database_key": "",
+            "graph_database_key": auth_token,
             "graph_dataset_database_handler": "turso_graph",
             "graph_database_connection_info": {},
         }
@@ -58,26 +78,54 @@ class TursoGraphDatasetDatabaseHandler:
     async def resolve_dataset_connection_info(
         cls, dataset_database: DatasetDatabase
     ) -> DatasetDatabase:
-        # No credentials to inject for local SQLite; remote Turso would pull key from config.
         graph_config = get_graph_config()
         if graph_config.graph_database_key:
             dataset_database.graph_database_connection_info["graph_database_key"] = (
                 graph_config.graph_database_key
             )
+            # Backfill remote credentials for datasets created before remote sync
+            # was configured, so they can adopt it without a data migration.
+            if not dataset_database.graph_database_key:
+                dataset_database.graph_database_key = graph_config.graph_database_key
+            if not dataset_database.graph_database_url:
+                dataset_database.graph_database_url = graph_config.graph_database_url
         return dataset_database
 
     @classmethod
     async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
-        dataset_url = dataset_database.graph_database_url
+        dataset_database = await cls.resolve_dataset_connection_info(dataset_database)
 
-        evict_graph_engine(
-            graph_database_provider="turso",
-            graph_file_path="",
-            graph_database_url=dataset_url,
-            graph_database_key="",
+        local_path = cls._local_path(
+            dataset_database.owner_id, UUID(dataset_database.graph_database_name)
         )
+        auth_token = dataset_database.graph_database_key
 
-        # Remove the SQLite file for local mode
-        # For remote Turso, file won't exist locally — that's fine.
-        if dataset_url and dataset_url.startswith("/") and os.path.exists(dataset_url):
-            os.remove(dataset_url)
+        if auth_token:
+            engine_kwargs = dict(
+                graph_database_provider="turso",
+                graph_file_path=local_path,
+                graph_database_url=dataset_database.graph_database_url,
+                graph_database_key=auth_token,
+                graph_database_sync_interval=get_graph_config().graph_database_sync_interval,
+            )
+        else:
+            engine_kwargs = dict(
+                graph_database_provider="turso",
+                graph_file_path="",
+                graph_database_url=local_path,
+                graph_database_key="",
+            )
+
+        # Explicitly empty the graph (and, in remote mode, push that empty state to
+        # the shared remote) before evicting — all datasets share one remote
+        # database in v1, so simply removing the local replica would otherwise
+        # leave this dataset's rows permanently on the remote.
+        engine = create_graph_engine(**engine_kwargs)
+        try:
+            await engine.delete_graph()
+        finally:
+            evict_graph_engine(**engine_kwargs)
+            await engine.close()
+
+        if os.path.exists(local_path):
+            os.remove(local_path)

--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -1,0 +1,83 @@
+import os
+from uuid import UUID
+from typing import Optional
+
+from cognee.base_config import get_base_config
+from cognee.infrastructure.databases.graph.config import get_graph_config
+from cognee.infrastructure.databases.graph.get_graph_engine import (
+    create_graph_engine,
+    evict_graph_engine,
+)
+from cognee.modules.users.models import User, DatasetDatabase
+
+
+class TursoGraphDatasetDatabaseHandler:
+    """Handler for per-dataset Turso/SQLite graph databases.
+
+    Local mode: each dataset gets its own SQLite file under the system databases directory.
+    Remote Turso: set GRAPH_DATABASE_URL to the remote libSQL URL and GRAPH_DATABASE_KEY
+    to the auth token; each dataset then uses a dataset-scoped URL path.
+    """
+
+    @classmethod
+    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        graph_config = get_graph_config()
+
+        if graph_config.graph_database_provider != "turso":
+            raise ValueError(
+                "TursoGraphDatasetDatabaseHandler can only be used "
+                "with the turso graph database provider."
+            )
+
+        base_config = get_base_config()
+        databases_dir = os.path.join(base_config.system_root_directory, "databases")
+        os.makedirs(databases_dir, exist_ok=True)
+
+        db_file = os.path.join(databases_dir, f"graph_{dataset_id}.db")
+        # sqlite+aiosqlite:/// needs three slashes for absolute path
+        dataset_url = f"/{db_file}" if not db_file.startswith("/") else db_file
+
+        engine = create_graph_engine(
+            graph_database_provider="turso",
+            graph_file_path="",
+            graph_database_url=dataset_url,
+            graph_database_key="",
+        )
+        await engine.initialize()
+
+        return {
+            "graph_database_provider": "turso",
+            "graph_database_url": dataset_url,
+            "graph_database_name": str(dataset_id),
+            "graph_database_key": "",
+            "graph_dataset_database_handler": "turso_graph",
+            "graph_database_connection_info": {},
+        }
+
+    @classmethod
+    async def resolve_dataset_connection_info(
+        cls, dataset_database: DatasetDatabase
+    ) -> DatasetDatabase:
+        # No credentials to inject for local SQLite; remote Turso would pull key from config.
+        graph_config = get_graph_config()
+        if graph_config.graph_database_key:
+            dataset_database.graph_database_connection_info["graph_database_key"] = (
+                graph_config.graph_database_key
+            )
+        return dataset_database
+
+    @classmethod
+    async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
+        dataset_url = dataset_database.graph_database_url
+
+        evict_graph_engine(
+            graph_database_provider="turso",
+            graph_file_path="",
+            graph_database_url=dataset_url,
+            graph_database_key="",
+        )
+
+        # Remove the SQLite file for local mode
+        # For remote Turso, file won't exist locally — that's fine.
+        if dataset_url and dataset_url.startswith("/") and os.path.exists(dataset_url):
+            os.remove(dataset_url)

--- a/cognee/infrastructure/databases/graph/turso/__init__.py
+++ b/cognee/infrastructure/databases/graph/turso/__init__.py
@@ -1,0 +1,2 @@
+from .adapter import TursoAdapter
+from .TursoGraphDatasetDatabaseHandler import TursoGraphDatasetDatabaseHandler

--- a/cognee/infrastructure/databases/graph/turso/adapter.py
+++ b/cognee/infrastructure/databases/graph/turso/adapter.py
@@ -1,0 +1,780 @@
+"""Turso/libSQL graph adapter using two tables (graph_node, graph_edge) over SQLAlchemy + aiosqlite."""
+
+import asyncio
+import json
+from uuid import UUID
+from datetime import datetime, timezone
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Dict, Any, List, Union, Optional, Tuple, Type
+
+from sqlalchemy import text, insert
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from cognee.shared.logging_utils import get_logger
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface
+from cognee.modules.storage.utils import JSONEncoder
+
+from .tables import _meta, _node_table, _edge_table
+
+logger = get_logger()
+
+_WRITE_CHUNK_SIZE = 500
+
+
+def _in_params(prefix: str, values: List[str]) -> Tuple[str, Dict[str, str]]:
+    """Build named params for SQLite IN clause (SQLite has no ANY(:list) support)."""
+    params = {f"{prefix}_{i}": v for i, v in enumerate(values)}
+    placeholders = ", ".join(f":{prefix}_{i}" for i in range(len(values)))
+    return placeholders, params
+
+
+class TursoAdapter(GraphDBInterface):
+    """Graph-as-tables adapter backed by Turso/libSQL, accessed via SQLAlchemy async sessions."""
+
+    _ALLOWED_FILTER_ATTRS = {"id", "name", "type"}
+
+    def __init__(self, connection_string: str) -> None:
+        """Create engine and sessionmaker from a Turso connection string."""
+        # pyturso 0.6.1 omits has_stop on AsyncAdapt_turso_dbapi.
+        # SQLAlchemy 2.0.51+ reads this flag in SQLiteDialect_aiosqlite.__init__
+        # to decide whether force-close via stop() is available.
+        # Setting False tells SQLAlchemy to skip force-close and use graceful
+        # close only — correct since turso.aio has no stop() method.
+        try:
+            import turso.sqlalchemy.dialect as _turso_dialect
+            if not hasattr(_turso_dialect.AsyncAdapt_turso_dbapi, "has_stop"):
+                _turso_dialect.AsyncAdapt_turso_dbapi.has_stop = False
+        except ImportError:
+            pass
+
+        self.db_uri = connection_string
+        self.engine = create_async_engine(
+            self.db_uri,
+            json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
+        )
+        self.sessionmaker = async_sessionmaker(bind=self.engine, expire_on_commit=False)
+        self._write_lock = asyncio.Lock()
+
+    async def close(self) -> None:
+        """Dispose connection pool. Called by closing_lru_cache on eviction."""
+        await self.engine.dispose(close=True)
+
+    async def initialize(self) -> None:
+        """Create tables and indexes if they do not exist."""
+        async with self.engine.begin() as conn:
+            # SQLite disables FK enforcement by default; cascade deletes need this
+            await conn.execute(text("PRAGMA foreign_keys = ON"))
+            await conn.run_sync(_meta.create_all, checkfirst=True)
+
+    @asynccontextmanager
+    async def _session(self) -> AsyncIterator[Any]:
+        """Yield an async session from the underlying engine."""
+        async with self.sessionmaker() as session:
+            await session.execute(text("PRAGMA foreign_keys = ON"))
+            yield session
+
+    def _serialize_properties(self, props: Dict[str, Any]) -> str:
+        """Serialize a dict to a JSON string, handling datetimes and UUIDs."""
+        return json.dumps(props, cls=JSONEncoder)
+
+    def _parse_node_row(self, row) -> Dict[str, Any]:
+        """Convert a (id, name, type, properties) row to a merged dict."""
+        data = {"id": row.id, "name": row.name, "type": row.type}
+        if row.properties is not None:
+            props = (
+                row.properties if isinstance(row.properties, dict) else json.loads(row.properties)
+            )
+            data.update(props)
+        return data
+
+    async def query(self, query_str: str, params: Optional[dict] = None) -> List[Any]:
+        """Not supported. Use typed adapter methods or a graph-native backend.
+
+        Raises:
+        -------
+            NotImplementedError
+        """
+        raise NotImplementedError(
+            "The Turso graph backend does not support raw Cypher queries. "
+            "Use a graph-native backend (Neo4j, Ladybug) for raw query support, "
+            "or use the typed adapter methods (add_nodes, get_neighbors, etc.)."
+        )
+
+    async def is_empty(self) -> bool:
+        """Return True if the graph has no nodes."""
+        await self.initialize()
+        async with self._session() as session:
+            result = await session.execute(text("SELECT EXISTS(SELECT 1 FROM graph_node LIMIT 1)"))
+            return not result.scalar()
+
+    async def add_node(
+        self, node: Union[DataPoint, str], properties: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Add a single node. Delegates to add_nodes."""
+        if isinstance(node, str):
+            props = properties or {}
+            props.setdefault("id", node)
+            await self.add_nodes([(node, props)])
+        else:
+            await self.add_nodes([node])
+
+    async def add_nodes(self, nodes: Union[List[Tuple[str, Dict]], List[DataPoint]]) -> None:
+        """Add multiple nodes via batch upsert."""
+        if not nodes:
+            return
+
+        now = datetime.now(timezone.utc)
+        core_keys = {"id", "name", "type"}
+
+        rows = []
+        for node in nodes:
+            if isinstance(node, tuple):
+                props = {**(node[1] or {}), "id": node[0]}
+            elif hasattr(node, "model_dump"):
+                props = node.model_dump()
+            else:
+                props = vars(node)
+
+            extra = {k: v for k, v in props.items() if k not in core_keys}
+            rows.append(
+                {
+                    "id": str(props.get("id", "")),
+                    "name": str(props.get("name", "")),
+                    "type": str(props.get("type", "")),
+                    "properties": self._serialize_properties(extra),
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+
+        # Deduplicate by id (last wins)
+        rows = list({r["id"]: r for r in rows}.values())
+
+        async with self._write_lock:
+            async with self._session() as session:
+                for i in range(0, len(rows), _WRITE_CHUNK_SIZE):
+                    chunk = rows[i : i + _WRITE_CHUNK_SIZE]
+                    for row in chunk:
+                        # prefix_with("OR REPLACE") → INSERT OR REPLACE INTO ...
+                        stmt = insert(_node_table).prefix_with("OR REPLACE").values(row)
+                        await session.execute(stmt)
+                await session.commit()
+
+    async def delete_node(self, node_id: str) -> None:
+        """Delete a single node. Delegates to delete_nodes."""
+        await self.delete_nodes([node_id])
+
+    async def delete_nodes(self, node_ids: List[str]) -> None:
+        """Delete multiple nodes by ID. Cascade-deletes connected edges."""
+        if not node_ids:
+            return
+        placeholders, params = _in_params("did", node_ids)
+        async with self._write_lock:
+            async with self._session() as session:
+                await session.execute(
+                    text(f"DELETE FROM graph_node WHERE id IN ({placeholders})"), params
+                )
+                await session.commit()
+
+    async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a single node by ID."""
+        results = await self.get_nodes([node_id])
+        return results[0] if results else None
+
+    async def get_nodes(self, node_ids: List[str]) -> List[Dict[str, Any]]:
+        """Retrieve multiple nodes by ID."""
+        if not node_ids:
+            return []
+        placeholders, params = _in_params("gid", node_ids)
+        async with self._session() as session:
+            result = await session.execute(
+                text(
+                    f"SELECT id, name, type, properties FROM graph_node WHERE id IN ({placeholders})"
+                ),
+                params,
+            )
+            return [self._parse_node_row(row) for row in result.fetchall()]
+
+    async def add_edge(
+        self,
+        source_id: str,
+        target_id: str,
+        relationship_name: str,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Add a single edge. Delegates to add_edges."""
+        await self.add_edges(
+            [(str(source_id), str(target_id), relationship_name, properties or {})]
+        )
+
+    async def add_edges(
+        self, edges: Union[List[Tuple[str, str, str, Optional[Dict[str, Any]]]], List]
+    ) -> None:
+        """Add multiple edges via batch upsert."""
+        if not edges:
+            return
+
+        now = datetime.now(timezone.utc)
+
+        rows = []
+        for edge in edges:
+            raw_props = edge[3] if len(edge) > 3 and edge[3] else {}
+            rows.append(
+                {
+                    "source_id": str(edge[0]),
+                    "target_id": str(edge[1]),
+                    "relationship_name": edge[2],
+                    "properties": self._serialize_properties(raw_props),
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+
+        # Deduplicate by composite key (last wins)
+        rows = list(
+            {(r["source_id"], r["target_id"], r["relationship_name"]): r for r in rows}.values()
+        )
+
+        async with self._write_lock:
+            async with self._session() as session:
+                for i in range(0, len(rows), _WRITE_CHUNK_SIZE):
+                    chunk = rows[i : i + _WRITE_CHUNK_SIZE]
+                    for row in chunk:
+                        stmt = insert(_edge_table).prefix_with("OR REPLACE").values(row)
+                        await session.execute(stmt)
+                await session.commit()
+
+    async def has_edge(self, source_id: str, target_id: str, relationship_name: str) -> bool:
+        """Check whether a single edge exists."""
+        result = await self.has_edges([(str(source_id), str(target_id), relationship_name)])
+        return len(result) > 0
+
+    async def has_edges(self, edges: List[Tuple[str, str, str]]) -> List[Tuple[str, str, str]]:
+        """Return subset of input edge tuples that exist in the database."""
+        if not edges:
+            return []
+
+        found: List[Tuple[str, str, str]] = []
+        async with self._session() as session:
+            for source_id, target_id, relationship_name in edges:
+                result = await session.execute(
+                    text("""
+                        SELECT source_id, target_id, relationship_name
+                        FROM graph_edge
+                        WHERE source_id = :src
+                          AND target_id = :tgt
+                          AND relationship_name = :rel
+                    """),
+                    {"src": str(source_id), "tgt": str(target_id), "rel": relationship_name},
+                )
+                row = result.fetchone()
+                if row:
+                    found.append((row[0], row[1], row[2]))
+        return found
+
+    async def get_edges(self, node_id: str) -> List[Tuple[Dict[str, Any], str, Dict[str, Any]]]:
+        """Retrieve all edges connected to a node as (source_dict, rel_name, target_dict)."""
+        async with self._session() as session:
+            result = await session.execute(
+                text("""
+                    SELECT
+                        n.id, n.name, n.type, n.properties,
+                        e.relationship_name,
+                        m.id, m.name, m.type, m.properties
+                    FROM graph_edge e
+                    JOIN graph_node n ON n.id = e.source_id
+                    JOIN graph_node m ON m.id = e.target_id
+                    WHERE e.source_id = :nid OR e.target_id = :nid
+                """),
+                {"nid": node_id},
+            )
+            edges = []
+            for row in result.fetchall():
+                src = {"id": row[0], "name": row[1], "type": row[2]}
+                if row[3]:
+                    src.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                tgt = {"id": row[5], "name": row[6], "type": row[7]}
+                if row[8]:
+                    tgt.update(row[8] if isinstance(row[8], dict) else json.loads(row[8]))
+                edges.append((src, row[4], tgt))
+            return edges
+
+    async def get_neighbors(self, node_id: str) -> List[Dict[str, Any]]:
+        """Retrieve all nodes directly connected to a given node."""
+        async with self._session() as session:
+            result = await session.execute(
+                text("""
+                    SELECT DISTINCT m.id, m.name, m.type, m.properties
+                    FROM graph_edge e
+                    JOIN graph_node m ON m.id = CASE
+                        WHEN e.source_id = :nid THEN e.target_id
+                        ELSE e.source_id
+                    END
+                    WHERE e.source_id = :nid OR e.target_id = :nid
+                """),
+                {"nid": node_id},
+            )
+            return [self._parse_node_row(row) for row in result.fetchall()]
+
+    async def get_connections(
+        self, node_id: Union[str, UUID]
+    ) -> List[Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]]:
+        """Retrieve all connections (source, edge, target) for a node."""
+        nid = str(node_id)
+        async with self._session() as session:
+            result = await session.execute(
+                text("""
+                    SELECT
+                        n.id, n.name, n.type, n.properties,
+                        e.relationship_name, e.properties AS edge_props,
+                        m.id, m.name, m.type, m.properties
+                    FROM graph_edge e
+                    JOIN graph_node n ON n.id = e.source_id
+                    JOIN graph_node m ON m.id = e.target_id
+                    WHERE e.source_id = :nid OR e.target_id = :nid
+                """),
+                {"nid": nid},
+            )
+
+            connections = []
+            for row in result.fetchall():
+                src = {"id": row[0], "name": row[1], "type": row[2]}
+                if row[3]:
+                    src.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+
+                edge = {"relationship_name": row[4]}
+                if row[5]:
+                    edge_props = row[5] if isinstance(row[5], dict) else json.loads(row[5])
+                    edge.update(edge_props)
+
+                tgt = {"id": row[6], "name": row[7], "type": row[8]}
+                if row[9]:
+                    tgt.update(row[9] if isinstance(row[9], dict) else json.loads(row[9]))
+
+                connections.append((src, edge, tgt))
+            return connections
+
+    async def get_graph_data(
+        self,
+    ) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[Tuple[str, str, str, Dict[str, Any]]]]:
+        """Retrieve all nodes as (id, props) and edges as (src, tgt, rel, props)."""
+        async with self._session() as session:
+            node_result = await session.execute(
+                text("SELECT id, name, type, properties FROM graph_node")
+            )
+            nodes = []
+            for row in node_result.fetchall():
+                data = {"name": row[1], "type": row[2]}
+                if row[3]:
+                    data.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                nodes.append((row[0], data))
+
+            if not nodes:
+                return [], []
+
+            edge_result = await session.execute(
+                text("SELECT source_id, target_id, relationship_name, properties FROM graph_edge")
+            )
+            edges = []
+            for row in edge_result.fetchall():
+                props = {}
+                if row[3]:
+                    props = row[3] if isinstance(row[3], dict) else json.loads(row[3])
+                edges.append((row[0], row[1], row[2], props))
+
+            return nodes, edges
+
+    async def get_id_filtered_graph_data(
+        self, target_ids: List[str]
+    ) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[Tuple[str, str, str, Dict[str, Any]]]]:
+        """Retrieve subgraph for edges touching target_ids, plus their endpoint nodes."""
+        if not target_ids:
+            return [], []
+        ids = [str(i) for i in target_ids]
+        placeholders, params = _in_params("tid", ids)
+
+        async with self._session() as session:
+            edge_result = await session.execute(
+                text(f"""
+                    SELECT source_id, target_id, relationship_name, properties
+                    FROM graph_edge
+                    WHERE source_id IN ({placeholders}) OR target_id IN ({placeholders})
+                """),
+                params,
+            )
+            edges = []
+            endpoint_ids: set = set()
+            for row in edge_result.fetchall():
+                props = {}
+                if row[3]:
+                    props = row[3] if isinstance(row[3], dict) else json.loads(row[3])
+                endpoint_ids.update((row[0], row[1]))
+                edges.append((row[0], row[1], row[2], props))
+
+            if not endpoint_ids:
+                return [], []
+
+            ep_ph, ep_params = _in_params("ep", list(endpoint_ids))
+            node_result = await session.execute(
+                text(
+                    f"SELECT id, name, type, properties FROM graph_node WHERE id IN ({ep_ph})"
+                ),
+                ep_params,
+            )
+            nodes = []
+            for row in node_result.fetchall():
+                data = {"name": row[1], "type": row[2]}
+                if row[3]:
+                    data.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                nodes.append((row[0], data))
+
+            return nodes, edges
+
+    async def get_filtered_graph_data(
+        self, attribute_filters: List[Dict[str, List[Union[str, int]]]]
+    ) -> Tuple[List[Tuple[str, Dict]], List[Tuple[str, str, str, Dict]]]:
+        """Retrieve nodes matching attribute filters, plus edges between them."""
+        if not attribute_filters:
+            return await self.get_graph_data()
+
+        where_parts = []
+        params: Dict[str, Any] = {}
+        for i, filter_dict in enumerate(attribute_filters):
+            for attr, filter_values in filter_dict.items():
+                if attr not in self._ALLOWED_FILTER_ATTRS:
+                    raise ValueError(f"Invalid filter attribute: {attr!r}")
+                ph, fp = _in_params(f"filt_{i}_{attr}", [str(v) for v in filter_values])
+                where_parts.append(f"n.{attr} IN ({ph})")
+                params.update(fp)
+
+        if not where_parts:
+            return await self.get_graph_data()
+
+        where_clause = " AND ".join(where_parts)
+
+        async with self._session() as session:
+            node_result = await session.execute(
+                text(f"""
+                    SELECT id, name, type, properties
+                    FROM graph_node n
+                    WHERE {where_clause}
+                """),
+                params,
+            )
+            node_rows = node_result.fetchall()
+            if not node_rows:
+                return [], []
+
+            node_ids = [row[0] for row in node_rows]
+            nodes = []
+            for row in node_rows:
+                data = {"name": row[1], "type": row[2]}
+                if row[3]:
+                    data.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                nodes.append((row[0], data))
+
+            fn_ph, fn_params = _in_params("fn", node_ids)
+            edge_result = await session.execute(
+                text(f"""
+                    SELECT source_id, target_id, relationship_name, properties
+                    FROM graph_edge
+                    WHERE source_id IN ({fn_ph}) AND target_id IN ({fn_ph})
+                """),
+                fn_params,
+            )
+            edges = []
+            for row in edge_result.fetchall():
+                props = {}
+                if row[3]:
+                    props = row[3] if isinstance(row[3], dict) else json.loads(row[3])
+                edges.append((row[0], row[1], row[2], props))
+
+            return nodes, edges
+
+    async def get_nodeset_subgraph(
+        self, node_type: Type[Any], node_name: List[str], node_name_filter_operator: str = "OR"
+    ) -> Tuple[List[Tuple[str, dict]], List[Tuple[str, str, str, dict]]]:
+        """Retrieve subgraph of matching nodes, their neighbors, and interconnecting edges."""
+        label = node_type.__name__
+
+        name_ph, name_params = _in_params("nm", node_name)
+        name_params["label"] = label
+
+        if node_name_filter_operator == "OR":
+            neighbor_cte = """
+                    neighbor_ids AS (
+                        SELECT DISTINCT CASE
+                            WHEN e.source_id IN (SELECT id FROM primary_nodes)
+                            THEN e.target_id ELSE e.source_id
+                        END AS id
+                        FROM graph_edge e
+                        WHERE e.source_id IN (SELECT id FROM primary_nodes)
+                           OR e.target_id IN (SELECT id FROM primary_nodes)
+                    )"""
+        else:
+            neighbor_cte = """
+                    neighbor_ids AS (
+                        SELECT nbr_id AS id FROM (
+                            SELECT CASE
+                                WHEN e.source_id IN (SELECT id FROM primary_nodes)
+                                THEN e.target_id ELSE e.source_id
+                            END AS nbr_id,
+                            CASE
+                                WHEN e.source_id IN (SELECT id FROM primary_nodes)
+                                THEN e.source_id ELSE e.target_id
+                            END AS primary_id
+                            FROM graph_edge e
+                            WHERE e.source_id IN (SELECT id FROM primary_nodes)
+                               OR e.target_id IN (SELECT id FROM primary_nodes)
+                        ) sub
+                        GROUP BY nbr_id
+                        HAVING COUNT(DISTINCT primary_id) = :primary_count
+                    )"""
+
+        query_str = f"""
+                    WITH primary_nodes AS (
+                        SELECT DISTINCT id
+                        FROM graph_node
+                        WHERE type = :label AND name IN ({name_ph})
+                    ),
+                    {neighbor_cte},
+                    all_ids AS (
+                        SELECT id FROM primary_nodes
+                        UNION
+                        SELECT id FROM neighbor_ids
+                    )
+                    SELECT 'node' AS kind,
+                           n.id, n.name, n.type, n.properties,
+                           NULL AS source_id, NULL AS target_id,
+                           NULL AS relationship_name, NULL AS edge_props
+                    FROM graph_node n
+                    WHERE n.id IN (SELECT id FROM all_ids)
+                    UNION ALL
+                    SELECT 'edge', NULL, NULL, NULL, NULL,
+                           e.source_id, e.target_id,
+                           e.relationship_name, e.properties
+                    FROM graph_edge e
+                    WHERE e.source_id IN (SELECT id FROM all_ids)
+                      AND e.target_id IN (SELECT id FROM all_ids)
+                """
+
+        if node_name_filter_operator != "OR":
+            name_params["primary_count"] = len(node_name)
+
+        async with self._session() as session:
+            result = await session.execute(text(query_str), name_params)
+
+            nodes = []
+            edges = []
+            for row in result.fetchall():
+                if row[0] == "node":
+                    data = {"name": row[2], "type": row[3]}
+                    if row[4]:
+                        data.update(row[4] if isinstance(row[4], dict) else json.loads(row[4]))
+                    nodes.append((row[1], data))
+                else:
+                    props = {}
+                    if row[8]:
+                        props = row[8] if isinstance(row[8], dict) else json.loads(row[8])
+                    edges.append((row[5], row[6], row[7], props))
+
+            return nodes, edges
+
+    async def get_graph_metrics(self, include_optional: bool = False) -> Dict[str, Any]:
+        """Compute graph metrics matching the PostgresAdapter output schema."""
+        async with self._session() as session:
+            n_result = await session.execute(text("SELECT count(*) FROM graph_node"))
+            num_nodes = n_result.scalar()
+            e_result = await session.execute(text("SELECT count(*) FROM graph_edge"))
+            num_edges = e_result.scalar()
+
+            mean_degree = (2 * num_edges) / num_nodes if num_nodes else None
+            edge_density = num_edges / (num_nodes * (num_nodes - 1)) if num_nodes > 1 else 0
+
+            # SQLite supports recursive CTEs for connected components
+            comp_result = await session.execute(
+                text("""
+                WITH RECURSIVE component AS (
+                    SELECT id AS node_id, id AS comp_root
+                    FROM graph_node
+                    UNION
+                    SELECT
+                        CASE WHEN e.source_id = c.node_id THEN e.target_id ELSE e.source_id END,
+                        c.comp_root
+                    FROM component c
+                    JOIN graph_edge e ON e.source_id = c.node_id OR e.target_id = c.node_id
+                ),
+                node_comp AS (
+                    SELECT node_id, MIN(comp_root) AS comp_id
+                    FROM component
+                    GROUP BY node_id
+                )
+                SELECT comp_id, count(*) AS sz
+                FROM node_comp
+                GROUP BY comp_id
+                ORDER BY sz DESC
+            """)
+            )
+            comp_rows = comp_result.fetchall()
+            num_components = len(comp_rows)
+            component_sizes = [row[1] for row in comp_rows]
+
+            metrics = {
+                "num_nodes": num_nodes,
+                "num_edges": num_edges,
+                "mean_degree": mean_degree,
+                "edge_density": edge_density,
+                "num_connected_components": num_components,
+                "sizes_of_connected_components": component_sizes,
+            }
+
+            if include_optional:
+                sl_result = await session.execute(
+                    text("SELECT count(*) FROM graph_edge WHERE source_id = target_id")
+                )
+                metrics["num_selfloops"] = sl_result.scalar()
+                metrics["diameter"] = -1
+                metrics["avg_shortest_path_length"] = -1
+                metrics["avg_clustering"] = -1
+            else:
+                metrics["num_selfloops"] = -1
+                metrics["diameter"] = -1
+                metrics["avg_shortest_path_length"] = -1
+                metrics["avg_clustering"] = -1
+
+            return metrics
+
+    async def get_neighborhood(
+        self,
+        node_ids: List[str],
+        depth: int = 1,
+        edge_types: Optional[List[str]] = None,
+    ) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[Tuple[str, str, str, Dict[str, Any]]]]:
+        """Get the k-hop neighborhood subgraph around seed nodes."""
+        if not node_ids:
+            return [], []
+
+        edge_filter = ""
+        et_params: Dict[str, Any] = {}
+        if edge_types:
+            et_ph, et_params = _in_params("et", edge_types)
+            edge_filter = f"AND e.relationship_name IN ({et_ph})"
+
+        # SQLite has no unnest(); build seed rows via UNION ALL with named params
+        seed_selects = " UNION ALL ".join(
+            [f"SELECT :seed_{i} AS id, 0 AS hops" for i in range(len(node_ids))]
+        )
+        seed_params = {f"seed_{i}": nid for i, nid in enumerate(node_ids)}
+
+        query_str = f"""
+            WITH RECURSIVE neighborhood(id, hops) AS (
+                {seed_selects}
+              UNION
+                SELECT CASE WHEN e.source_id = n.id THEN e.target_id
+                            ELSE e.source_id END,
+                       n.hops + 1
+                FROM neighborhood n
+                JOIN graph_edge e ON (e.source_id = n.id OR e.target_id = n.id)
+                    {edge_filter}
+                WHERE n.hops < :depth
+            ),
+            ids AS (SELECT DISTINCT id FROM neighborhood)
+
+            SELECT 'node' AS kind,
+                   gn.id, gn.name, gn.type, gn.properties,
+                   NULL AS source_id, NULL AS target_id,
+                   NULL AS relationship_name, NULL AS edge_properties
+            FROM graph_node gn
+            JOIN ids ON gn.id = ids.id
+
+            UNION ALL
+
+            SELECT 'edge' AS kind,
+                   NULL, NULL, NULL, NULL,
+                   ge.source_id, ge.target_id,
+                   ge.relationship_name, ge.properties
+            FROM graph_edge ge
+            WHERE ge.source_id IN (SELECT id FROM ids)
+              AND ge.target_id IN (SELECT id FROM ids)
+        """
+
+        params: Dict[str, Any] = {"depth": depth, **seed_params, **et_params}
+
+        async with self._session() as session:
+            result = await session.execute(text(query_str), params)
+
+            nodes = []
+            edges = []
+            for row in result.fetchall():
+                if row.kind == "node":
+                    data = self._parse_node_row(row)
+                    data.pop("id", None)
+                    nodes.append((row.id, data))
+                else:
+                    props = {}
+                    if row.edge_properties is not None:
+                        props = (
+                            row.edge_properties
+                            if isinstance(row.edge_properties, dict)
+                            else json.loads(row.edge_properties)
+                        )
+                    edges.append((row.source_id, row.target_id, row.relationship_name, props))
+
+            return nodes, edges
+
+    async def delete_graph(self) -> None:
+        """Delete all nodes and edges from the graph."""
+        await self.initialize()
+        async with self._write_lock:
+            async with self._session() as session:
+                await session.execute(text("DELETE FROM graph_edge"))
+                await session.execute(text("DELETE FROM graph_node"))
+                await session.commit()
+
+    async def get_triplets_batch(self, offset: int, limit: int) -> List[Dict[str, Any]]:
+        """Retrieve a batch of (source, relationship, target) triplets."""
+        if offset < 0:
+            raise ValueError(f"Offset must be non-negative, got {offset}")
+        if limit < 0:
+            raise ValueError(f"Limit must be non-negative, got {limit}")
+
+        async with self._session() as session:
+            result = await session.execute(
+                text("""
+                    SELECT
+                        s.id, s.name, s.type, s.properties,
+                        e.relationship_name, e.properties AS edge_props,
+                        t.id, t.name, t.type, t.properties
+                    FROM graph_edge e
+                    JOIN graph_node s ON s.id = e.source_id
+                    JOIN graph_node t ON t.id = e.target_id
+                    ORDER BY e.source_id, e.target_id, e.relationship_name
+                    LIMIT :lim OFFSET :off
+                """),
+                {"off": offset, "lim": limit},
+            )
+
+            triplets = []
+            for row in result.fetchall():
+                start_node = {"id": row[0], "name": row[1], "type": row[2]}
+                if row[3]:
+                    start_node.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+
+                rel = {"relationship_name": row[4]}
+                if row[5]:
+                    rel_props = row[5] if isinstance(row[5], dict) else json.loads(row[5])
+                    rel.update(rel_props)
+
+                end_node = {"id": row[6], "name": row[7], "type": row[8]}
+                if row[9]:
+                    end_node.update(row[9] if isinstance(row[9], dict) else json.loads(row[9]))
+
+                triplets.append(
+                    {
+                        "start_node": start_node,
+                        "relationship_properties": rel,
+                        "end_node": end_node,
+                    }
+                )
+            return triplets

--- a/cognee/infrastructure/databases/graph/turso/adapter.py
+++ b/cognee/infrastructure/databases/graph/turso/adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import time
 from uuid import UUID
 from datetime import datetime, timezone
 from contextlib import asynccontextmanager
@@ -9,6 +10,7 @@ from typing import AsyncIterator, Dict, Any, List, Union, Optional, Tuple, Type
 
 from sqlalchemy import text, insert
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.engine import DataPoint
@@ -34,8 +36,20 @@ class TursoAdapter(GraphDBInterface):
 
     _ALLOWED_FILTER_ATTRS = {"id", "name", "type"}
 
-    def __init__(self, connection_string: str) -> None:
-        """Create engine and sessionmaker from a Turso connection string."""
+    def __init__(
+        self,
+        connection_string: str,
+        remote_url: Optional[str] = None,
+        auth_token: Optional[str] = None,
+        client_name: str = "cognee",
+        sync_interval_seconds: float = 5.0,
+    ) -> None:
+        """Create engine and sessionmaker from a Turso connection string.
+
+        If ``remote_url`` is set, the local file at ``connection_string`` is
+        treated as an embedded replica kept in sync with the remote libSQL/Turso
+        database via ``turso.aio.sync.connect()``.
+        """
         # pyturso 0.6.1 omits has_stop on AsyncAdapt_turso_dbapi.
         # SQLAlchemy 2.0.51+ reads this flag in SQLiteDialect_aiosqlite.__init__
         # to decide whether force-close via stop() is available.
@@ -43,25 +57,97 @@ class TursoAdapter(GraphDBInterface):
         # close only — correct since turso.aio has no stop() method.
         try:
             import turso.sqlalchemy.dialect as _turso_dialect
+
             if not hasattr(_turso_dialect.AsyncAdapt_turso_dbapi, "has_stop"):
                 _turso_dialect.AsyncAdapt_turso_dbapi.has_stop = False
         except ImportError:
             pass
 
         self.db_uri = connection_string
-        self.engine = create_async_engine(
-            self.db_uri,
-            json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
-        )
+        self.remote_url = remote_url or None
+        self.auth_token = auth_token or None
+        self.client_name = client_name
+        self.sync_interval_seconds = sync_interval_seconds
+        self._last_pull_monotonic: Optional[float] = None
+
+        if self.remote_url:
+            if "aioturso" not in connection_string:
+                raise ValueError(
+                    "Turso remote sync mode requires the aioturso driver "
+                    "(sqlite+aioturso:///<local replica path>)."
+                )
+
+            def _async_creator_fn(database, **kw):
+                import turso.aio.sync as turso_sync
+
+                return turso_sync.connect(
+                    database,
+                    remote_url=self.remote_url,
+                    auth_token=self.auth_token,
+                    client_name=self.client_name,
+                    bootstrap_if_empty=True,
+                )
+
+            self.engine = create_async_engine(
+                self.db_uri,
+                json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
+                poolclass=StaticPool,
+                connect_args={"async_creator_fn": _async_creator_fn},
+            )
+        else:
+            self.engine = create_async_engine(
+                self.db_uri,
+                json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
+            )
         self.sessionmaker = async_sessionmaker(bind=self.engine, expire_on_commit=False)
         self._write_lock = asyncio.Lock()
 
+    async def _get_sync_connection(self):
+        """Reach the live turso.aio.sync ConnectionSync backing this engine."""
+        async with self.engine.connect() as conn:
+            raw = await conn.get_raw_connection()
+            return raw.driver_connection
+
+    async def _sync_pull(self) -> None:
+        """Pull remote changes into the local replica."""
+        if not self.remote_url:
+            return
+        conn = await self._get_sync_connection()
+        await conn.pull()
+        self._last_pull_monotonic = time.monotonic()
+
+    async def _sync_push(self) -> None:
+        """Push local writes to the remote database."""
+        if not self.remote_url:
+            return
+        conn = await self._get_sync_connection()
+        await conn.push()
+
+    async def _maybe_pull(self) -> None:
+        """Pull remote changes, throttled to at most once per sync_interval_seconds."""
+        if not self.remote_url:
+            return
+        now = time.monotonic()
+        if (
+            self._last_pull_monotonic is not None
+            and (now - self._last_pull_monotonic) < self.sync_interval_seconds
+        ):
+            return
+        await self._sync_pull()
+
     async def close(self) -> None:
         """Dispose connection pool. Called by closing_lru_cache on eviction."""
+        if self.remote_url:
+            try:
+                await self._sync_push()
+            except Exception:
+                logger.warning("Best-effort push before Turso adapter close failed", exc_info=True)
         await self.engine.dispose(close=True)
 
     async def initialize(self) -> None:
         """Create tables and indexes if they do not exist."""
+        if self.remote_url:
+            await self._maybe_pull()
         async with self.engine.begin() as conn:
             # SQLite disables FK enforcement by default; cascade deletes need this
             await conn.execute(text("PRAGMA foreign_keys = ON"))
@@ -70,6 +156,8 @@ class TursoAdapter(GraphDBInterface):
     @asynccontextmanager
     async def _session(self) -> AsyncIterator[Any]:
         """Yield an async session from the underlying engine."""
+        if self.remote_url:
+            await self._maybe_pull()
         async with self.sessionmaker() as session:
             await session.execute(text("PRAGMA foreign_keys = ON"))
             yield session
@@ -160,6 +248,8 @@ class TursoAdapter(GraphDBInterface):
                         stmt = insert(_node_table).prefix_with("OR REPLACE").values(row)
                         await session.execute(stmt)
                 await session.commit()
+            if self.remote_url:
+                await self._sync_push()
 
     async def delete_node(self, node_id: str) -> None:
         """Delete a single node. Delegates to delete_nodes."""
@@ -176,6 +266,8 @@ class TursoAdapter(GraphDBInterface):
                     text(f"DELETE FROM graph_node WHERE id IN ({placeholders})"), params
                 )
                 await session.commit()
+            if self.remote_url:
+                await self._sync_push()
 
     async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a single node by ID."""
@@ -244,6 +336,8 @@ class TursoAdapter(GraphDBInterface):
                         stmt = insert(_edge_table).prefix_with("OR REPLACE").values(row)
                         await session.execute(stmt)
                 await session.commit()
+            if self.remote_url:
+                await self._sync_push()
 
     async def has_edge(self, source_id: str, target_id: str, relationship_name: str) -> bool:
         """Check whether a single edge exists."""
@@ -417,9 +511,7 @@ class TursoAdapter(GraphDBInterface):
 
             ep_ph, ep_params = _in_params("ep", list(endpoint_ids))
             node_result = await session.execute(
-                text(
-                    f"SELECT id, name, type, properties FROM graph_node WHERE id IN ({ep_ph})"
-                ),
+                text(f"SELECT id, name, type, properties FROM graph_node WHERE id IN ({ep_ph})"),
                 ep_params,
             )
             nodes = []
@@ -731,6 +823,8 @@ class TursoAdapter(GraphDBInterface):
                 await session.execute(text("DELETE FROM graph_edge"))
                 await session.execute(text("DELETE FROM graph_node"))
                 await session.commit()
+            if self.remote_url:
+                await self._sync_push()
 
     async def get_triplets_batch(self, offset: int, limit: int) -> List[Dict[str, Any]]:
         """Retrieve a batch of (source, relationship, target) triplets."""

--- a/cognee/infrastructure/databases/graph/turso/tables.py
+++ b/cognee/infrastructure/databases/graph/turso/tables.py
@@ -1,0 +1,44 @@
+"""Schema definitions for the Turso graph adapter (graph_node, graph_edge)."""  
+  
+from sqlalchemy import Table, Column, MetaData, String, DateTime, Index, ForeignKey, func  
+  
+_meta = MetaData()  
+  
+_node_table = Table(  
+    "graph_node",  
+    _meta,  
+    Column("id", String, primary_key=True),  
+    Column("name", String),  
+    Column("type", String),  
+    Column("properties", String),  # JSON stored as TEXT in SQLite  
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),  
+    Column("updated_at", DateTime(timezone=True), server_default=func.now()),  
+)  
+  
+_edge_table = Table(  
+    "graph_edge",  
+    _meta,  
+    Column(  
+        "source_id",  
+        String,  
+        ForeignKey("graph_node.id", ondelete="CASCADE"),  
+        primary_key=True,  
+        nullable=False,  
+    ),  
+    Column(  
+        "target_id",  
+        String,  
+        ForeignKey("graph_node.id", ondelete="CASCADE"),  
+        primary_key=True,  
+        nullable=False,  
+    ),  
+    Column("relationship_name", String, primary_key=True, nullable=False),  
+    Column("properties", String),  # JSON stored as TEXT in SQLite  
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),  
+    Column("updated_at", DateTime(timezone=True), server_default=func.now()),  
+)  
+  
+# Standard indexes for performance  
+Index("idx_edge_source", _edge_table.c.source_id)  
+Index("idx_edge_target", _edge_table.c.target_id)  
+Index("idx_node_type", _node_table.c.type)

--- a/cognee/modules/retrieval/natural_language_retriever.py
+++ b/cognee/modules/retrieval/natural_language_retriever.py
@@ -114,7 +114,7 @@ class NaturalLanguageRetriever(BaseRetriever):
 
         if isinstance(graph_engine, (PostgresAdapter, PostgresHybridAdapter, TursoAdapter)):
             raise SearchTypeNotSupported(
-                "Natural language search is not supported with the Postgres graph backend. "
+                "Natural language search is not supported with the Postgres or Turso graph backends. "
                 "This retriever generates and executes Cypher queries, which require a "
                 "graph-native backend (Neo4j, Ladybug)."
             )

--- a/cognee/modules/retrieval/natural_language_retriever.py
+++ b/cognee/modules/retrieval/natural_language_retriever.py
@@ -107,11 +107,12 @@ class NaturalLanguageRetriever(BaseRetriever):
     async def get_retrieved_objects(self, query: str) -> Any:
         graph_engine = await get_graph_engine()
 
-        # Postgres backends do not support Cypher generation/execution
+        # Postgres and Turso backends do not support Cypher generation/execution
         from cognee.infrastructure.databases.graph.postgres.adapter import PostgresAdapter
         from cognee.infrastructure.databases.hybrid.postgres.adapter import PostgresHybridAdapter
+        from cognee.infrastructure.databases.graph.turso.adapter import TursoAdapter
 
-        if isinstance(graph_engine, (PostgresAdapter, PostgresHybridAdapter)):
+        if isinstance(graph_engine, (PostgresAdapter, PostgresHybridAdapter, TursoAdapter)):
             raise SearchTypeNotSupported(
                 "Natural language search is not supported with the Postgres graph backend. "
                 "This retriever generates and executes Cypher queries, which require a "

--- a/cognee/tests/e2e/turso/test_turso_adapter.py
+++ b/cognee/tests/e2e/turso/test_turso_adapter.py
@@ -1,0 +1,210 @@
+"""Unit tests for TursoAdapter using an in-memory SQLite database."""
+
+import json
+import pytest
+import pytest_asyncio
+
+from cognee.infrastructure.databases.graph.turso.adapter import TursoAdapter
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    """In-memory SQLite adapter — fast, no disk I/O, isolated per test."""
+    a = TursoAdapter(connection_string="sqlite+aiosqlite:///:memory:")
+    await a.initialize()
+    yield a
+    await a.delete_graph()
+    await a.close()
+
+
+@pytest.mark.asyncio
+async def test_is_empty_on_fresh_db(adapter):
+    assert await adapter.is_empty()
+
+
+@pytest.mark.asyncio
+async def test_add_and_get_node(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    node = await adapter.get_node("n1")
+    assert node is not None
+    assert node["name"] == "Alice"
+    assert node["type"] == "Person"
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_bulk(adapter):
+    nodes = [
+        ("n1", {"name": "Alice", "type": "Person"}),
+        ("n2", {"name": "Bob", "type": "Person"}),
+        ("n3", {"name": "Carol", "type": "Person"}),
+    ]
+    await adapter.add_nodes(nodes)
+    results = await adapter.get_nodes(["n1", "n2", "n3"])
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_upsert_node(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n1", {"name": "Alice Updated", "type": "Person"})
+    node = await adapter.get_node("n1")
+    assert node["name"] == "Alice Updated"
+
+
+@pytest.mark.asyncio
+async def test_delete_node(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.delete_node("n1")
+    assert await adapter.get_node("n1") is None
+
+
+@pytest.mark.asyncio
+async def test_add_and_has_edge(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    assert await adapter.has_edge("n1", "n2", "KNOWS")
+    assert not await adapter.has_edge("n2", "n1", "KNOWS")
+
+
+@pytest.mark.asyncio
+async def test_has_edges_returns_found_tuples(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    found = await adapter.has_edges([
+        ("n1", "n2", "KNOWS"),
+        ("n2", "n1", "KNOWS"),   # does not exist
+    ])
+    assert len(found) == 1
+    assert found[0] == ("n1", "n2", "KNOWS")
+
+
+@pytest.mark.asyncio
+async def test_get_edges_returns_src_rel_tgt_tuples(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    edges = await adapter.get_edges("n1")
+    assert len(edges) == 1
+    src, rel, tgt = edges[0]
+    assert isinstance(src, dict) and src["id"] == "n1"
+    assert rel == "KNOWS"
+    assert isinstance(tgt, dict) and tgt["id"] == "n2"
+
+
+@pytest.mark.asyncio
+async def test_get_neighbors(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_node("n3", {"name": "Carol", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    await adapter.add_edge("n1", "n3", "KNOWS")
+
+    neighbors = await adapter.get_neighbors("n1")
+    ids = {n["id"] for n in neighbors}
+    assert ids == {"n2", "n3"}
+
+
+@pytest.mark.asyncio
+async def test_get_connections(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS", {"since": 2020})
+
+    conns = await adapter.get_connections("n1")
+    assert len(conns) == 1
+    src, edge, tgt = conns[0]
+    assert src["id"] == "n1"
+    assert edge["relationship_name"] == "KNOWS"
+    assert tgt["id"] == "n2"
+
+
+@pytest.mark.asyncio
+async def test_get_graph_data_format(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    nodes, edges = await adapter.get_graph_data()
+
+    # nodes must be (id, props_dict) tuples
+    assert all(isinstance(n, tuple) and len(n) == 2 for n in nodes)
+    node_ids = {n[0] for n in nodes}
+    assert node_ids == {"n1", "n2"}
+
+    # edges must be (src, tgt, rel, props) tuples
+    assert all(isinstance(e, tuple) and len(e) == 4 for e in edges)
+    assert edges[0][:3] == ("n1", "n2", "KNOWS")
+
+
+@pytest.mark.asyncio
+async def test_get_graph_metrics(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    metrics = await adapter.get_graph_metrics()
+    assert metrics["num_nodes"] == 2
+    assert metrics["num_edges"] == 1
+    assert "mean_degree" in metrics
+    assert "edge_density" in metrics
+    assert "num_connected_components" in metrics
+
+
+@pytest.mark.asyncio
+async def test_delete_graph(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    await adapter.delete_graph()
+    assert await adapter.is_empty()
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_node("n3", {"name": "Carol", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    await adapter.add_edge("n2", "n3", "KNOWS")
+
+    nodes, edges = await adapter.get_neighborhood(["n1"], depth=1)
+    node_ids = {n[0] for n in nodes}
+    # depth=1: n1 and its direct neighbor n2
+    assert "n1" in node_ids
+    assert "n2" in node_ids
+    assert "n3" not in node_ids
+
+
+@pytest.mark.asyncio
+async def test_get_triplets_batch(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    triplets = await adapter.get_triplets_batch(offset=0, limit=10)
+    assert len(triplets) == 1
+    assert triplets[0]["start_node"]["id"] == "n1"
+    assert triplets[0]["relationship_properties"]["relationship_name"] == "KNOWS"
+    assert triplets[0]["end_node"]["id"] == "n2"
+
+
+@pytest.mark.asyncio
+async def test_cascade_delete_edges_on_node_delete(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    await adapter.delete_node("n1")
+    # Edge should be cascade-deleted
+    edges = await adapter.get_edges("n2")
+    assert len(edges) == 0
+
+
+@pytest.mark.asyncio
+async def test_query_raises_not_implemented(adapter):
+    with pytest.raises(NotImplementedError):
+        await adapter.query("MATCH (n) RETURN n")

--- a/cognee/tests/e2e/turso/test_turso_adapter.py
+++ b/cognee/tests/e2e/turso/test_turso_adapter.py
@@ -1,6 +1,7 @@
 """Unit tests for TursoAdapter using an in-memory SQLite database."""
 
 import json
+import time
 import pytest
 import pytest_asyncio
 
@@ -73,10 +74,12 @@ async def test_has_edges_returns_found_tuples(adapter):
     await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
     await adapter.add_edge("n1", "n2", "KNOWS")
 
-    found = await adapter.has_edges([
-        ("n1", "n2", "KNOWS"),
-        ("n2", "n1", "KNOWS"),   # does not exist
-    ])
+    found = await adapter.has_edges(
+        [
+            ("n1", "n2", "KNOWS"),
+            ("n2", "n1", "KNOWS"),  # does not exist
+        ]
+    )
     assert len(found) == 1
     assert found[0] == ("n1", "n2", "KNOWS")
 
@@ -208,3 +211,39 @@ async def test_cascade_delete_edges_on_node_delete(adapter):
 async def test_query_raises_not_implemented(adapter):
     with pytest.raises(NotImplementedError):
         await adapter.query("MATCH (n) RETURN n")
+
+
+@pytest.mark.asyncio
+async def test_maybe_pull_throttles_repeated_calls(monkeypatch):
+    """_maybe_pull should skip pulling again within sync_interval_seconds.
+
+    No real network/engine connection is exercised: _sync_pull is monkeypatched
+    and the underlying sqlite+aioturso engine is never opened (SQLAlchemy async
+    engines connect lazily), so this needs no live Turso credentials.
+    """
+    remote_adapter = TursoAdapter(
+        connection_string="sqlite+aioturso:///:memory:",
+        remote_url="https://fake-remote.example",
+        auth_token="fake-token",
+        sync_interval_seconds=1000,
+    )
+
+    call_count = 0
+
+    async def fake_sync_pull():
+        nonlocal call_count
+        call_count += 1
+        remote_adapter._last_pull_monotonic = time.monotonic()
+
+    monkeypatch.setattr(remote_adapter, "_sync_pull", fake_sync_pull)
+
+    await remote_adapter._maybe_pull()
+    await remote_adapter._maybe_pull()
+    await remote_adapter._maybe_pull()
+    assert call_count == 1, "repeated calls within sync_interval_seconds should not re-pull"
+
+    remote_adapter.sync_interval_seconds = 0
+    await remote_adapter._maybe_pull()
+    assert call_count == 2, "a call after the interval elapses should pull again"
+
+    await remote_adapter.engine.dispose()

--- a/cognee/tests/e2e/turso/test_turso_remote_sync.py
+++ b/cognee/tests/e2e/turso/test_turso_remote_sync.py
@@ -1,0 +1,86 @@
+"""Live integration tests for Turso remote/embedded-replica sync.
+
+Skipped unless `TEST_TURSO_REMOTE_URL` and `TEST_TURSO_AUTH_TOKEN` are set.
+Configure them to point at a real (ideally disposable/test) Turso database —
+these tests write to and delete from it.
+"""
+
+import os
+import pytest
+import pytest_asyncio
+
+from cognee.infrastructure.databases.graph.turso.adapter import TursoAdapter
+
+TURSO_REMOTE_URL = os.getenv("TEST_TURSO_REMOTE_URL")
+TURSO_AUTH_TOKEN = os.getenv("TEST_TURSO_AUTH_TOKEN")
+
+pytestmark = pytest.mark.skipif(
+    not (TURSO_REMOTE_URL and TURSO_AUTH_TOKEN),
+    reason="TEST_TURSO_REMOTE_URL/TEST_TURSO_AUTH_TOKEN not set; skipping live Turso sync tests",
+)
+
+
+async def _make_adapter(local_path: str) -> TursoAdapter:
+    adapter = TursoAdapter(
+        connection_string=f"sqlite+aioturso:///{local_path}",
+        remote_url=TURSO_REMOTE_URL,
+        auth_token=TURSO_AUTH_TOKEN,
+        sync_interval_seconds=0,  # always pull immediately in tests
+    )
+    await adapter.initialize()
+    return adapter
+
+
+@pytest_asyncio.fixture
+async def replica_a(tmp_path):
+    adapter = await _make_adapter(str(tmp_path / "replica_a.db"))
+    yield adapter
+    await adapter.delete_graph()
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_write_visible_from_second_replica(replica_a, tmp_path):
+    await replica_a.add_node("n1", {"name": "Alice", "type": "Person"})
+    await replica_a.add_node("n2", {"name": "Bob", "type": "Person"})
+    await replica_a.add_edge("n1", "n2", "KNOWS")
+
+    replica_b = await _make_adapter(str(tmp_path / "replica_b.db"))
+    try:
+        await replica_b._sync_pull()
+        node = await replica_b.get_node("n1")
+        assert node is not None
+        assert node["name"] == "Alice"
+        assert await replica_b.has_edge("n1", "n2", "KNOWS")
+    finally:
+        await replica_b.close()
+
+
+@pytest.mark.asyncio
+async def test_fresh_replica_bootstraps_from_remote(replica_a, tmp_path):
+    await replica_a.add_node("n1", {"name": "Alice", "type": "Person"})
+
+    replica_c = await _make_adapter(str(tmp_path / "replica_c.db"))
+    try:
+        node = await replica_c.get_node("n1")
+        assert node is not None
+        assert node["name"] == "Alice"
+    finally:
+        await replica_c.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_propagates_through_push_and_pull(replica_a, tmp_path):
+    await replica_a.add_node("n1", {"name": "Alice", "type": "Person"})
+
+    replica_b = await _make_adapter(str(tmp_path / "replica_b.db"))
+    try:
+        await replica_b._sync_pull()
+        assert await replica_b.get_node("n1") is not None
+
+        await replica_a.delete_node("n1")
+
+        await replica_b._sync_pull()
+        assert await replica_b.get_node("n1") is None
+    finally:
+        await replica_b.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ fastembed = [
 ]
 
 neo4j = ["neo4j>=5.28.0,<6"]
+turso = ["pyturso>=0.6.1"]
 neptune = ["langchain_aws>=0.2.22"]
 postgres = [
     "psycopg2>=2.9.10,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -1403,6 +1403,9 @@ tracing = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
 ]
+turso = [
+    { name = "pyturso" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1513,6 +1516,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1,<2.0.0" },
     { name = "python-magic-bin", marker = "sys_platform == 'win32'", specifier = "<0.5" },
     { name = "python-multipart", specifier = ">=0.0.22,<1.0.0" },
+    { name = "pyturso", marker = "extra == 'turso'", specifier = ">=0.6.1" },
     { name = "rdflib", specifier = ">=7.1.4,<7.2.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.3,<6.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.2,<=0.16.0" },
@@ -1538,7 +1542,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.34.0,<1.0.0" },
     { name = "websockets", specifier = ">=15.0.1,<16.0.0" },
 ]
-provides-extras = ["api", "distributed", "scraping", "fastembed", "neo4j", "neptune", "postgres", "postgres-binary", "notebook", "langchain", "llama-index", "huggingface", "ollama", "mistral", "anthropic", "azure", "deepeval", "posthog", "groq", "llama-cpp", "docs", "codegraph", "evals", "graphiti", "aws", "dlt", "baml", "dev", "debug", "redis", "tracing", "docling"]
+provides-extras = ["api", "distributed", "scraping", "fastembed", "neo4j", "turso", "neptune", "postgres", "postgres-binary", "notebook", "langchain", "llama-index", "huggingface", "ollama", "mistral", "anthropic", "azure", "deepeval", "posthog", "groq", "llama-cpp", "docs", "codegraph", "evals", "graphiti", "aws", "dlt", "baml", "dev", "debug", "redis", "tracing", "docling"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -9414,6 +9418,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
     { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pyturso"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/67/49879858c34e5c861084c611807a56392a15fa0bc7a2c6c43dd88317a919/pyturso-0.6.1.tar.gz", hash = "sha256:f33b2faad0f38af5256fb54457a8cd14aa0c6c17c846e850d7f8e6c5c9d29044", size = 2388457, upload-time = "2026-05-22T15:43:12.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/86/903f06b4b47b795f8f720b5f7692e83a9158c1cbd2a80869e031cb4c2df8/pyturso-0.6.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:5bb0129dd02abb732eebc9154f09123bbb8350ea92b251c4788095bf5b64c789", size = 5902526, upload-time = "2026-05-22T09:45:00.347Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/37/9ab192818cd0f45b8ac76af0a634c1b2261ee582a8723e98f50cc56bcf18/pyturso-0.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:060b07a8c76d16943f65050e3be21c04538da0240c53564d423a030e828aa4c2", size = 5186457, upload-time = "2026-05-22T15:42:12.924Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/b4/0f333d0299f876c10f0fc5a78418e082b5862c313845dd62202c4083df3e/pyturso-0.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caabf0cca238cfcb52e34ed753df968d9d5a1a619891b0d0193655919cec6910", size = 16216193, upload-time = "2026-05-22T15:42:15.26Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a6/538883d13fd7cecad7c6b604819cd19cfad1ecf8442b89acb900287f1c6f/pyturso-0.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fbdf84c72836cbfd64854d68003c25bdcd3991d0674c0d8b27149147a0d48f00", size = 16347253, upload-time = "2026-05-22T15:42:17.8Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b5/dd656a985b6612d3bbe0ad56001bbe2d8848a6c731af3fbbb49b7f77a4d5/pyturso-0.6.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:253b45929aaf59969adf3dc2a94c6ff18cfce4eeba56361238ec7f78d9636c00", size = 5902322, upload-time = "2026-05-22T15:42:20.487Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/af/3811975f7a36db8c59d061d6db1397a61ae7c3a79d49d64633eb9a2161e3/pyturso-0.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:95aea3a9cb3e8630591229a5c8d98b4a6f43635dc2575e93ccbd3c99402a910f", size = 5186260, upload-time = "2026-05-22T15:42:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/41/705e0f7a1bf9495021182afc267479a33b4d7ed2a84cb42007fe7dcf80e9/pyturso-0.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31506f07f06894408b1bd2b0a3d7ea7df5a20069065f76a71f76bfb588e586b7", size = 16216845, upload-time = "2026-05-22T15:42:24.734Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a7/c804661d7bc83e02530099c69c4d5128f2b08dee39781ad8dd43dadac324/pyturso-0.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:386b18e1342924c2d892dc43d03644a320b96aed45630247df892482d1808b85", size = 16349060, upload-time = "2026-05-22T15:42:27.854Z" },
+    { url = "https://files.pythonhosted.org/packages/87/41/e0fa9fb527759028df080953a276b89811cd3e1ccf5275901caeb7d132c4/pyturso-0.6.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9e0c693b49ff733f7cb77518b21c3794a67955d6bd1d632a6abdd4b5eb0816f", size = 5901914, upload-time = "2026-05-22T15:42:30.277Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/5aab0366e7f43d9069488d771597f631264dd3ab52c224306440fb11b6b8/pyturso-0.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:99dcf2a0914776abdfacad213a9bf279999bbc3b58935d10db0258e5d2082dbc", size = 5187249, upload-time = "2026-05-22T15:42:32.033Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5c/7c63e78258686f700526504786f49af9ed58d4804c6e0f0560cea559199c/pyturso-0.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c93f389c5639b1758fbfec924d9d0950869915924bb1280f1db1da40e625fdab", size = 16232544, upload-time = "2026-05-22T15:42:34.362Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/55a2f42709f7b2d99025b83db163c1ca1aceebf7ad6d7e8ec6343e583c3b/pyturso-0.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:013638e8ba1f7bd56efe7d6c01e5c271631c27463392f9f243292ece81efa3f0", size = 16362706, upload-time = "2026-05-22T15:42:38.084Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1d/fa6963dd4d2b23a2b2d07e12b0a87e0df417770a16b8c66826c19b601961/pyturso-0.6.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:847d13b91ad502b401bf7a23536d441197fd82c16010327954e453044032e8ec", size = 5901619, upload-time = "2026-05-22T15:42:40.607Z" },
+    { url = "https://files.pythonhosted.org/packages/15/95/456c8ffed65a6a964e1ca6880a244588db4729f0c79abe42c037d5c40d4a/pyturso-0.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be94ba46332d2a7f01f4c29dfa30f472f51f893c828ee3af794190c630dea157", size = 5186429, upload-time = "2026-05-22T15:42:42.526Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a4/045ccaff725e5d3f3d78265ac56ff11cab793adc2ccdbfb441d96e534f81/pyturso-0.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d76b1cb2afef9bd785ebdaa6d04f43f500eac0c7648e62514ac52b0c545ec1b6", size = 16232575, upload-time = "2026-05-22T15:42:44.84Z" },
+    { url = "https://files.pythonhosted.org/packages/00/04/ad7c9529273d664cf059dd6ad80b507b32caa7d2bcbe06da6d0264653108/pyturso-0.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a93a304eb883a66fd82411f68943c427f18c26264a3d009d92b0ee639ea7f811", size = 16361020, upload-time = "2026-05-22T15:42:47.588Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/28/e6f0cf37cc53a45681556f91f17a5f7dd15737f02375a317bdb0a831c016/pyturso-0.6.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:964890a6280b3e67a84ab24479fac0342b99caa23c52a75ff1e84279b557467f", size = 5899806, upload-time = "2026-05-22T15:42:50.385Z" },
+    { url = "https://files.pythonhosted.org/packages/59/29/cc52192523e07243dd60f9fed650f83c5c23229d5f8dfb0a79e6f50af2d1/pyturso-0.6.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e16cd6af73251cd7d00b0c1f10139f526160a3d7bbf2ff89d2f03e81e3964f2f", size = 5184871, upload-time = "2026-05-22T15:42:52.329Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7b/eaf87196515be9cbe808bfb178db570d4e051a397eedb50ebebb7d051e73/pyturso-0.6.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72cff3ea527e674668db9321f618e65078579c4f423892243d7d079d1b318332", size = 16220304, upload-time = "2026-05-22T15:42:54.317Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/fc/b3aab38ebee7b51fcc9ec5c7482eba187b761cb8b57e858705ca8c5c59f6/pyturso-0.6.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:466d92918a8e8a991f6433ba366d7b630a4ddcc2ec3c9b003629636e18ef611b", size = 16352139, upload-time = "2026-05-22T15:42:57.19Z" },
+    { url = "https://files.pythonhosted.org/packages/68/37/821e12255e9aedd1acdc2aaca540fc9b3b6c799e683f966c26177a2df90d/pyturso-0.6.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ce4f5e41da42d05dc3b1c5ef360530886b9192120986c2f6930ef6ffc4358a5", size = 16213804, upload-time = "2026-05-22T15:43:06.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/8928ad781f01627e98acf775bf2da312cac38860b8976b5984851f805ab6/pyturso-0.6.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:006648939bee3f2794c76128e2b57e36abedf79971a0909b0a3c59ac87a64514", size = 16340889, upload-time = "2026-05-22T15:43:09.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Description

Added Turso/libSQL as new graph DB backend. Started with local-only mode (SQLite-based, via pyturso's async dialect) since that's simplest path to get feature working end-to-end and validate the adapter design before touching sync.

Once local mode worked, added remote support — Turso's embedded-replica model: local SQLite file stays synced with a remote libSQL DB via `turso.aio.sync.connect()`. Reused existing `AioTursoDialect` (`sqlite+aioturso://`) instead of writing separate dialect for sync mode — pyturso doesn't ship an async dialect for sync mode yet (`TursoSyncDialect` is sync/blocking only), and `TursoAdapter`'s query logic is already SQLAlchemy-based, so swapping just connection factory (`async_creator_fn`) was smaller surface than rewriting adapter around a second code path. Pull throttled to 5s default (`GRAPH_DATABASE_SYNC_INTERVAL`) so we're not doing network round-trip on every read; push happens right after each write batch since we want writes visible remotely fast.

While wiring up remote mode I hit a bug in `TursoGraphDatasetDatabaseHandler`: per-dataset local file path it computed didn't match path `context_global_variables.py` actually reads at query time. Local-only mode never hit this since nothing consumed `graph_file_path` there — but remote mode depends on that path being right (it's where the replica lives), so fixed both to agree.

Known v1 limitation: all datasets currently sync against same configured remote URL/token — only the local replica file is per-dataset. Real per-dataset remote isolation is follow-up work.

## Acceptance Criteria

- `GRAPH_DATABASE_PROVIDER=turso` local mode: `GRAPH_DATABASE_URL` = abs path → connects via `sqlite+aioturso:////abs/path`.
- `GRAPH_DATABASE_PROVIDER=turso` + `GRAPH_DATABASE_KEY` set → connects via `turso.aio.sync.connect()` against `GRAPH_DATABASE_URL` (remote libSQL URL), replicating to local file at `GRAPH_FILE_PATH`.
- Pull throttled (default 5s, `GRAPH_DATABASE_SYNC_INTERVAL` configurable); push immediate after each write batch.
- `TursoGraphDatasetDatabaseHandler` per-dataset local file path aligned with path `context_global_variables.py` uses at query time (was previously mismatched — harmless pre-remote, load-bearing now).
- v1 scope: all datasets sync to same remote URL/token; only local replica file is per-dataset (no per-dataset remote DB isolation yet).
- Cypher / natural-language search remain unsupported on Turso (rejected explicitly in `NaturalLanguageRetriever`).
- `cognee/tests/e2e/turso/test_turso_adapter.py` + `test_turso_remote_sync.py` pass.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- add local test-run screenshot -->

## Pre-submission Checklist

- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

