### PR TITLE
fix(api): standardize error responses in improve, forget, and recall routers

### DIFF
--- a/cognee/api/v1/forget/routers/get_forget_router.py
+++ b/cognee/api/v1/forget/routers/get_forget_router.py
@@ -4,7 +4,7 @@ from pydantic import ConfigDict, Field
 from fastapi import Depends, APIRouter
 from fastapi.responses import JSONResponse
 
-from cognee.api.DTO import InDTO
+from cognee.api.DTO import InDTO, ErrorResponse
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.shared.utils import send_telemetry
@@ -53,7 +53,13 @@ class ForgetPayloadDTO(InDTO):
 def get_forget_router() -> APIRouter:
     router = APIRouter()
 
-    @router.post("")
+    @router.post(
+        "",
+        responses={
+            422: {"model": ErrorResponse},
+            500: {"model": ErrorResponse},
+        },
+    )
     @log_usage(function_name="POST /v1/forget", log_type="api_endpoint")
     async def forget_endpoint(
         payload: ForgetPayloadDTO, user: User = Depends(get_authenticated_user)
@@ -108,19 +114,23 @@ def get_forget_router() -> APIRouter:
                 user=user,
             )
             return result
-        except ValueError:
+        except ValueError as e:
             return JSONResponse(
                 status_code=422,
-                content={
-                    "error": "Invalid request parameters. Specify dataset or dataset_id, data_id+dataset, or everything=True."
-                },
+                content=ErrorResponse(
+                    error="Invalid request parameters. Specify dataset or dataset_id, data_id+dataset, or everything=True.",
+                    detail=str(e),
+                ).model_dump(),
             )
         except Exception as error:
             logger = get_logger()
             logger.error("Forget endpoint error: %s", error, exc_info=True)
             return JSONResponse(
                 status_code=500,
-                content={"error": "An error occurred during deletion."},
+                content=ErrorResponse(
+                    error="An error occurred during deletion.",
+                    detail=str(error),
+                ).model_dump(),
             )
 
     return router

--- a/cognee/api/v1/improve/routers/get_improve_router.py
+++ b/cognee/api/v1/improve/routers/get_improve_router.py
@@ -1,12 +1,11 @@
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from fastapi import Depends
 from pydantic import Field
 from typing import List, Optional, Union, Literal
 
-from cognee.api.DTO import InDTO
+from cognee.api.DTO import InDTO, ErrorResponse
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.shared.utils import send_telemetry
@@ -37,7 +36,16 @@ class ImprovePayloadDTO(InDTO):
 def get_improve_router() -> APIRouter:
     router = APIRouter()
 
-    @router.post("", response_model=dict)
+    @router.post(
+        "",
+        response_model=dict,
+        responses={
+            400: {"model": ErrorResponse},
+            409: {"model": ErrorResponse},
+            422: {"model": ErrorResponse},
+            500: {"model": ErrorResponse},
+        },
+    )
     @log_usage(function_name="POST /v1/improve", log_type="api_endpoint")
     async def improve(payload: ImprovePayloadDTO, user: User = Depends(get_authenticated_user)):
         """
@@ -60,7 +68,7 @@ def get_improve_router() -> APIRouter:
 
         ## Error Codes
         - **400 Bad Request**: Neither dataset_id nor dataset_name provided
-        - **409 Conflict**: Error during processing
+        - **500 Internal Server Error**: Error during processing
         """
         send_telemetry(
             "Improve API Endpoint Invoked",
@@ -72,9 +80,11 @@ def get_improve_router() -> APIRouter:
         )
 
         if not payload.dataset_id and not payload.dataset_name:
-            raise HTTPException(
+            return JSONResponse(
                 status_code=400,
-                detail="Either datasetId or datasetName must be provided.",
+                content=ErrorResponse(
+                    error="Either datasetId or datasetName must be provided.",
+                ).model_dump(),
             )
 
         try:
@@ -93,13 +103,23 @@ def get_improve_router() -> APIRouter:
             )
 
             if isinstance(improve_run, PipelineRunErrored):
-                return JSONResponse(status_code=420, content=improve_run)
+                detail = getattr(improve_run, "error", None) or str(improve_run)
+                return JSONResponse(
+                    status_code=500,
+                    content=ErrorResponse(
+                        error="Pipeline run errored",
+                        detail=detail,
+                    ).model_dump(),
+                )
             return improve_run
         except Exception as error:
             logger.error("Improve endpoint error: %s", error, exc_info=True)
             return JSONResponse(
-                status_code=409,
-                content={"error": "An error occurred during graph improvement."},
+                status_code=500,
+                content=ErrorResponse(
+                    error="An error occurred during graph improvement.",
+                    detail=str(error),
+                ).model_dump(),
             )
 
     return router

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from pydantic import Field
 
 from cognee import __version__ as cognee_version
-from cognee.api.DTO import InDTO, OutDTO
+from cognee.api.DTO import InDTO, OutDTO, ErrorResponse
 from cognee.api.v1.recall.recall import RecallResponse
 from cognee.exceptions import CogneeValidationError
 from cognee.infrastructure.databases.exceptions import DatabaseNotCreatedError
@@ -104,7 +104,13 @@ def get_recall_router() -> APIRouter:
         user: str
         created_at: datetime
 
-    @router.get("", response_model=list[RecallHistoryItem])
+    @router.get(
+        "",
+        response_model=list[RecallHistoryItem],
+        responses={
+            500: {"model": ErrorResponse},
+        },
+    )
     async def get_recall_history(user: User = Depends(get_authenticated_user)):
         """Get search/recall history for the authenticated user."""
         send_telemetry(
@@ -121,10 +127,21 @@ def get_recall_router() -> APIRouter:
             logger.error("Recall history error: %s", error, exc_info=True)
             return JSONResponse(
                 status_code=500,
-                content={"error": "An error occurred while fetching recall history."},
+                content=ErrorResponse(
+                    error="An error occurred while fetching recall history.",
+                    detail=str(error),
+                ).model_dump(),
             )
 
-    @router.post("", response_model=list[RecallResponse])
+    @router.post(
+        "",
+        response_model=list[RecallResponse],
+        responses={
+            403: {"model": ErrorResponse},
+            422: {"model": ErrorResponse},
+            500: {"model": ErrorResponse},
+        },
+    )
     @log_usage(function_name="POST /v1/recall", log_type="api_endpoint")
     async def recall(payload: RecallPayloadDTO, user: User = Depends(get_authenticated_user)):
         """
@@ -157,7 +174,7 @@ def get_recall_router() -> APIRouter:
           (default: "auto" — session first when session_id is set, else graph)
 
         ## Error Codes
-        - **409 Conflict**: Error during recall
+        - **500 Internal Server Error**: Error during recall
         - **403 Forbidden**: Permission denied (returns empty list)
         - **422 Unprocessable Entity**: Recall prerequisites not met — ingest data
           first (POST /v1/remember or /v1/add followed by /v1/cognify)
@@ -198,10 +215,10 @@ def get_recall_router() -> APIRouter:
             status_code = getattr(e, "status_code", 422)
             return JSONResponse(
                 status_code=status_code,
-                content={
-                    "error": "Recall prerequisites not met",
-                    "hint": "Run `await cognee.remember(...)` or `await cognee.add(...)` then `await cognee.cognify()` before recalling.",
-                },
+                content=ErrorResponse(
+                    error="Recall prerequisites not met",
+                    detail="Run `await cognee.remember(...)` or `await cognee.add(...)` then `await cognee.cognify()` before recalling.",
+                ).model_dump(),
             )
         except PermissionDeniedError:
             return []
@@ -209,8 +226,11 @@ def get_recall_router() -> APIRouter:
             logger = get_logger()
             logger.error("Recall endpoint error: %s", error, exc_info=True)
             return JSONResponse(
-                status_code=409,
-                content={"error": "An error occurred during recall."},
+                status_code=500,
+                content=ErrorResponse(
+                    error="An error occurred during recall.",
+                    detail=str(error),
+                ).model_dump(),
             )
 
     return router


### PR DESCRIPTION
## Summary

Fixes #3748

Commit 62d294c83 ("Standardized API error responses") updated 5 of the 8 API routers to use the canonical `ErrorResponse` DTO. The `improve`, `forget`, and `recall` routers were missed. This PR brings them in line with the rest.

### Changes across all three routers
- Replace raw `{"error": "..."}` dicts with `ErrorResponse(...).model_dump()`
- Replace non-standard HTTP status codes (`420`, `409`) with `500` for internal errors
- Add `responses={...}` decorator parameter so Swagger UI shows error schemas
- Include exception detail via `ErrorResponse.detail` field

### Router-specific changes

**improve** (`cognee/api/v1/improve/routers/get_improve_router.py`)
- Replace `HTTPException(400)` with `JSONResponse` + `ErrorResponse` (consistent with cognify router pattern)
- Replace `420` status with raw `PipelineRunErrored` object → `500` + `ErrorResponse` with extracted detail
- Replace `409` generic error → `500`
- Remove unused `HTTPException` import

**forget** (`cognee/api/v1/forget/routers/get_forget_router.py`)
- Wrap `422` error dict in `ErrorResponse` with `detail=str(e)`
- Wrap `500` error dict in `ErrorResponse` with `detail=str(error)`

**recall** (`cognee/api/v1/recall/routers/get_recall_router.py`)
- Replace undocumented `"hint"` field with standard `"detail"` field in `422` response
- Replace `409` generic error → `500`
- Add `responses={...}` decorator to GET history endpoint (was missing entirely)
- Wrap `500` history error in `ErrorResponse` with `detail`

### Pattern followed

Matches the pattern established in the already-fixed routers (`cognify`, `add`, `search`, `datasets`, `delete`):
- `ErrorResponse(error="...", detail="...").model_dump()` for all error responses
- Standard HTTP status codes: `400` for bad request, `422` for validation, `500` for internal errors
- `responses={...}` decorator for Swagger UI error schema generation

#### Test plan
- [ ] `ruff check cognee/api/v1/improve/routers/get_improve_router.py cognee/api/v1/forget/routers/get_forget_router.py cognee/api/v1/recall/routers/get_recall_router.py` — passes
- [ ] `ruff format` — no changes needed (3 files left unchanged)
- [ ] Start API server locally and verify Swagger UI shows error schemas for all three endpoints
- [ ] Trigger errors on each endpoint and verify `ErrorResponse` format in response body:
  - `POST /v1/improve` with no dataset → `400` with `ErrorResponse`
  - `POST /v1/improve` with bad LLM config → `500` with `ErrorResponse` (was `420`)
  - `POST /v1/forget` with invalid params → `422` with `ErrorResponse`
  - `POST /v1/recall` with no data ingested → `422` with `ErrorResponse` (no more `hint` field)
  - `POST /v1/recall` with internal error → `500` with `ErrorResponse` (was `409`)

Generated with [Devin](https://devin.ai)