### PR TITLE
docs: add migration tutorials for Mem0, Graphiti, Letta, and Zep (#3397, #3398, #3399)

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -1,0 +1,13 @@
+# Cognee Tutorials
+
+This directory contains tutorials and examples for using Cognee.
+
+## Memory Migration Tutorials
+
+Learn how to migrate from other agent and memory frameworks into the Cognee graph format:
+
+| Tutorial | Description |
+|----------|-------------|
+| [Mem0 Migration](./migrate_from_mem0_tutorial.py) | How to import `Mem0` JSON dumps into Cognee. |
+| [Graphiti Migration](./migrate_from_graphiti_tutorial.py) | How to import an OSS `Graphiti` knowledge graph dump into Cognee. |
+| [Letta / Zep Migration](./migrate_from_letta_and_zep_tutorial.py) | How to load `Letta/MemGPT` agent files (`.af`) and `Zep` episodic JSON exports into Cognee. |

--- a/examples/tutorials/migrate_from_graphiti_tutorial.py
+++ b/examples/tutorials/migrate_from_graphiti_tutorial.py
@@ -1,0 +1,76 @@
+import asyncio
+from cognee.api.v1.remember import remember
+from cognee.api.v1.search import search
+from cognee.api.v1.prune import prune_data
+from cognee.modules.migration.sources.zep import GraphitiSource
+
+async def main():
+    print("🧹 Cleaning up old data...")
+    await prune_data()
+
+    print("\n📦 Loading Graphiti export...")
+    # This is a sample Graphiti JSON export containing entities, facts, and episodes.
+    graphiti_dump = {
+        "episodes": [
+            {
+                "uuid": "ep-1",
+                "name": "Meeting 1",
+                "content": "Alice told Bob about the project plan.",
+                "created_at": "2024-05-01T10:00:00Z",
+                "user_id": "user1"
+            }
+        ],
+        "entities": [
+            {
+                "uuid": "ent-1",
+                "name": "Alice",
+                "labels": ["Person", "Entity"],
+                "summary": "Project manager",
+                "created_at": "2024-05-01T10:01:00Z"
+            },
+            {
+                "uuid": "ent-2",
+                "name": "Bob",
+                "labels": ["Person", "Entity"],
+                "summary": "Software engineer",
+                "created_at": "2024-05-01T10:01:00Z"
+            }
+        ],
+        "facts": [
+            {
+                "uuid": "fact-1",
+                "source_node_uuid": "ent-1",
+                "target_node_uuid": "ent-2",
+                "relation": "communicated_with",
+                "fact": "Alice told Bob about the project plan.",
+                "valid_at": "2024-05-01T10:00:00Z",
+                "created_at": "2024-05-01T10:02:00Z",
+                "episodes": ["ep-1"]
+            }
+        ]
+    }
+
+    # Step 1: Import Graphiti export into Cognee.
+    # mode="preserve" or "hybrid" can be used. GraphitiSource defaults to "hybrid".
+    print("📥 Importing Graphiti graph into Cognee...")
+    source = GraphitiSource(graphiti_dump, mode="preserve")
+    await remember(source)
+
+    # Step 2: Query the imported facts/entities
+    print("\n🔍 Querying migrated knowledge graph...")
+    
+    # We can perform a semantic search to recall graph nodes
+    query_text = "Who did Alice communicate with?"
+    print(f"\nQuery: {query_text}")
+    results = await search("SIMILARITY", query_text=query_text)
+    
+    if results:
+        for result in results:
+            print(f"- Found graph item: {result}")
+    else:
+        print("No results found. (Make sure your embeddings are configured properly)")
+        
+    print("\n✅ Graphiti Migration Tutorial Complete!")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/tutorials/migrate_from_letta_and_zep_tutorial.py
+++ b/examples/tutorials/migrate_from_letta_and_zep_tutorial.py
@@ -1,0 +1,88 @@
+import asyncio
+from cognee.api.v1.remember import remember
+from cognee.api.v1.search import search
+from cognee.api.v1.prune import prune_data
+from cognee.modules.migration.sources.letta import LettaSource
+from cognee.modules.migration.sources.zep import ZepSource
+
+async def main():
+    print("🧹 Cleaning up old data...")
+    await prune_data()
+
+    print("\n📦 Loading Letta/MemGPT export...")
+    letta_dump = {
+        "agents": [
+            {
+                "name": "Assistant",
+                "core_memory": [
+                    {
+                        "label": "persona",
+                        "value": "I am a friendly assistant."
+                    },
+                    {
+                        "label": "human",
+                        "value": "User is a data scientist from New York."
+                    }
+                ],
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Can you remind me where I'm from?"
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "You are from New York!"
+                    }
+                ]
+            }
+        ]
+    }
+
+    print("📥 Importing Letta agent into Cognee...")
+    # Letta mode defaults to "re-derive", which processes documents and memory blocks.
+    letta_source = LettaSource(letta_dump, mode="preserve")
+    await remember(letta_source)
+
+    print("\n📦 Loading Zep export...")
+    zep_dump = {
+        "episodes": [
+            {
+                "uuid": "ep-1",
+                "name": "Chat Session",
+                "content": "User discussed their recent trip to Japan.",
+                "created_at": "2024-05-01T10:00:00Z"
+            }
+        ],
+        "entities": [
+            {
+                "uuid": "ent-1",
+                "name": "Japan",
+                "labels": ["Location", "Entity"],
+                "summary": "A country in East Asia."
+            }
+        ],
+        "facts": []
+    }
+
+    print("📥 Importing Zep memories into Cognee...")
+    # Zep mode defaults to "hybrid". We can use "preserve" for direct graph loading.
+    zep_source = ZepSource(zep_dump, mode="preserve")
+    await remember(zep_source)
+
+    # Query the imported memories
+    print("\n🔍 Querying migrated knowledge graph...")
+    
+    query_text = "Where is the user from?"
+    print(f"\nQuery: {query_text}")
+    results = await search("SIMILARITY", query_text=query_text)
+    
+    if results:
+        for result in results:
+            print(f"- Found: {result}")
+    else:
+        print("No results found. (Make sure your embeddings are configured properly)")
+        
+    print("\n✅ Letta & Zep Migration Tutorial Complete!")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/tutorials/migrate_from_mem0_tutorial.py
+++ b/examples/tutorials/migrate_from_mem0_tutorial.py
@@ -1,0 +1,55 @@
+import asyncio
+from cognee.api.v1.remember import remember
+from cognee.api.v1.search import search
+from cognee.api.v1.prune import prune_data
+from cognee.modules.migration.sources.mem0 import Mem0Source
+
+async def main():
+    print("🧹 Cleaning up old data...")
+    await prune_data()
+
+    print("\n📦 Loading Mem0 export...")
+    # This is a sample Mem0 export format.
+    mem0_dump = {
+        "results": [
+            {
+                "id": "m1",
+                "memory": "User prefers dark mode and uses VS Code.",
+                "user_id": "u123",
+                "categories": ["preferences"],
+                "created_at": "2024-05-01T12:00:00Z"
+            },
+            {
+                "id": "m2",
+                "memory": "User is allergic to peanuts.",
+                "user_id": "u123",
+                "categories": ["health"],
+                "created_at": "2024-05-02T15:30:00Z"
+            }
+        ]
+    }
+
+    # Step 1: Import Mem0 export into Cognee.
+    # mode="preserve" maps memories directly to graph nodes (COGXMemory) without LLM extraction.
+    print("📥 Importing Mem0 memories into Cognee...")
+    source = Mem0Source(mem0_dump, mode="preserve")
+    await remember(source)
+
+    # Step 2: Query the imported memories
+    print("\n🔍 Querying migrated memories...")
+    
+    # We can perform a semantic search to recall memories
+    query_text = "What is the user allergic to?"
+    print(f"\nQuery: {query_text}")
+    results = await search("SIMILARITY", query_text=query_text)
+    
+    if results:
+        for result in results:
+            print(f"- Found memory: {result}")
+    else:
+        print("No results found. (Make sure your embeddings are configured properly)")
+        
+    print("\n✅ Mem0 Migration Tutorial Complete!")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Resolves issues #3397, #3398, and #3399 by adding runnable Python tutorial scripts for the Mem0, Graphiti, Letta, and Zep migration sources. Includes a README mapping them out.