### PR TITLE
fix: preserve centroid slot identity across gaps in truth-subspace rebuild (#3867)

### DIFF
--- a/cognee/modules/truth_subspace/centroids.py
+++ b/cognee/modules/truth_subspace/centroids.py
@@ -92,29 +92,48 @@ def extend_centroids_with_learning_vectors(
     if updated_at is None:
         updated_at = int(datetime.now(timezone.utc).timestamp() * 1000)
 
-    slots = [
-        {
+    # Key the working set by the centroid's *own* slot so identity is preserved.
+    # ``centroid_id(dataset_id, slot)`` is the vector-store point id, so renumbering
+    # a slot silently overwrites/orphans persisted points. Slots outside ``[0, k)``
+    # can never be reloaded (``load_centroids`` reads ``range(k)``), so they are
+    # dropped rather than folded into a live slot.
+    slots: dict[int, dict] = {}
+    for centroid in sorted(existing_centroids, key=lambda centroid: centroid.slot):
+        slot_index = int(centroid.slot)
+        if slot_index < 0 or slot_index >= k or slot_index in slots or len(slots) >= k:
+            continue
+        slots[slot_index] = {
             "centroid": list(centroid.centroid),
             "count": int(centroid.count),
             "learning_ids": list(centroid.learning_ids),
         }
-        for centroid in sorted(existing_centroids, key=lambda centroid: centroid.slot)[:k]
-    ]
-    seen_learning_ids = {learning_id for slot in slots for learning_id in slot["learning_ids"]}
+    seen_learning_ids = {
+        learning_id for slot in slots.values() for learning_id in slot["learning_ids"]
+    }
+
+    def _next_free_slot() -> int:
+        # Fill the lowest free slot first: reuses gaps left by dropped centroids
+        # and keeps the happy-path assignment (0, 1, 2, …) unchanged.
+        for candidate in range(k):
+            if candidate not in slots:
+                return candidate
+        return -1  # unreachable: only called while len(slots) < k
 
     for new_learning_id, vector in learning_vectors:
         if new_learning_id in seen_learning_ids:
             continue
         normalized_vector = normalize(vector)
         if len(slots) < k:
-            slots.append(
-                {"centroid": normalized_vector, "count": 1, "learning_ids": [new_learning_id]}
-            )
+            slots[_next_free_slot()] = {
+                "centroid": normalized_vector,
+                "count": 1,
+                "learning_ids": [new_learning_id],
+            }
             seen_learning_ids.add(new_learning_id)
             continue
 
         nearest_slot = max(
-            range(len(slots)),
+            slots,
             key=lambda index: cosine(normalized_vector, slots[index]["centroid"]),
         )
         slot = slots[nearest_slot]
@@ -133,7 +152,7 @@ def extend_centroids_with_learning_vectors(
             centroid=list(slot["centroid"]),
             learning_ids=list(slot["learning_ids"]),
         )
-        for slot_index, slot in enumerate(slots)
+        for slot_index, slot in sorted(slots.items())
     ]
 
 

--- a/cognee/tests/unit/truth_subspace/test_centroids.py
+++ b/cognee/tests/unit/truth_subspace/test_centroids.py
@@ -14,6 +14,7 @@ from cognee.modules.truth_subspace.centroids import (
     unique_learning_vectors,
     weighted_centroid,
 )
+from cognee.modules.truth_subspace.models import TruthCentroidPayload
 
 
 def test_centroid_id_is_deterministic_uuid():
@@ -123,3 +124,87 @@ def test_centroids_changed_detects_count_or_vector_changes():
     )
 
     assert centroids_changed(old, new) is True
+
+
+def test_extend_centroids_preserves_slot_identity_across_gaps():
+    built = build_centroids_from_learning_vectors(
+        "dataset-1",
+        [("a", [1.0, 0.0]), ("b", [0.0, 1.0]), ("c", [1.0, 1.0])],
+        truth_epoch=1,
+        updated_at=123,
+        k=4,
+    )
+    assert [centroid.slot for centroid in built] == [0, 1, 2]
+
+    # Simulate slot 1 having gone missing from the vector store (e.g. a dropped
+    # or unparseable row), leaving a gap between the survivors at slots 0 and 2.
+    gapped = [centroid for centroid in built if centroid.slot != 1]
+    assert [centroid.slot for centroid in gapped] == [0, 2]
+
+    # Re-running with no new learnings must NOT positionally renumber the
+    # survivors: slot 2 has to stay slot 2 or its persisted point id moves.
+    rebuilt = extend_centroids_with_learning_vectors(
+        "dataset-1",
+        gapped,
+        [],
+        truth_epoch=2,
+        updated_at=456,
+        k=4,
+    )
+    assert [centroid.slot for centroid in rebuilt] == [0, 2]
+
+    original_slot2 = next(centroid for centroid in built if centroid.slot == 2)
+    rebuilt_slot2 = next(centroid for centroid in rebuilt if centroid.slot == 2)
+    assert rebuilt_slot2.learning_ids == original_slot2.learning_ids
+    assert rebuilt_slot2.centroid == original_slot2.centroid
+    assert centroid_id("dataset-1", rebuilt_slot2.slot) == centroid_id("dataset-1", 2)
+
+
+def test_extend_centroids_fills_gap_before_appending():
+    built = build_centroids_from_learning_vectors(
+        "dataset-1",
+        [("a", [1.0, 0.0]), ("b", [0.0, 1.0]), ("c", [1.0, 1.0])],
+        truth_epoch=1,
+        updated_at=123,
+        k=4,
+    )
+    gapped = [centroid for centroid in built if centroid.slot != 1]
+
+    rebuilt = extend_centroids_with_learning_vectors(
+        "dataset-1",
+        gapped,
+        [("d", [0.2, 0.9])],
+        truth_epoch=2,
+        updated_at=456,
+        k=4,
+    )
+
+    # The new learning reuses the freed slot 1 instead of colliding with slot 2.
+    assert sorted(centroid.slot for centroid in rebuilt) == [0, 1, 2]
+    filled = next(centroid for centroid in rebuilt if centroid.slot == 1)
+    assert filled.learning_ids == ["d"]
+
+
+def test_extend_centroids_drops_slots_outside_addressable_range():
+    # A slot >= k can never be reloaded by load_centroids (it reads range(k)),
+    # so it must be dropped, never renumbered into a live slot.
+    out_of_range = TruthCentroidPayload(
+        dataset_id="dataset-1",
+        slot=9,
+        count=1,
+        truth_epoch=1,
+        updated_at=123,
+        centroid=[1.0, 0.0],
+        learning_ids=["x"],
+    )
+    rebuilt = extend_centroids_with_learning_vectors(
+        "dataset-1",
+        [out_of_range],
+        [("y", [0.0, 1.0])],
+        truth_epoch=2,
+        updated_at=456,
+        k=4,
+    )
+
+    assert [centroid.slot for centroid in rebuilt] == [0]
+    assert rebuilt[0].learning_ids == ["y"]


### PR DESCRIPTION
## What & why

Fixes #3867.

`extend_centroids_with_learning_vectors` sorted existing centroids by slot but then re-emitted them with `enumerate()`, so any **gap** in the existing slot numbers was positionally renumbered:

```
existing slots [0, 2, 3]  ->  emitted slots [0, 1, 2]
```

Because `centroid_id(dataset_id, slot)` derives the vector-store point id from the slot number, renumbering silently:
- **overwrites** the point at the reused slot id with a different centroid's data, and
- **orphans** the highest old slot id (stale data left behind).

This violates the module's stated invariant that "slot `i` always means the centroid stored in slot `i`."

## The fix

- Key the working set by each centroid's **own** slot, so existing identities are preserved across rebuilds regardless of gaps.
- New centroids **fill the lowest free slot first**, reusing a freed gap before appending — which keeps the happy-path assignment (`0, 1, 2, …`) and the existing determinism guarantees byte-for-byte identical.
- Slots outside `[0, k)` are **dropped** (not folded into a live slot), since `load_centroids` only reads `range(k)` and can never reload them — folding them in would just reintroduce the overwrite.

## On reachability

As the issue notes, the normal write path always emits contiguous slots, so a gap only arises defensively — e.g. `load_centroids` skipping an unparseable / `dataset_id`-mismatched row, or a point deleted out-of-band. This PR makes the rebuild safe in those cases; it doesn't change happy-path behavior.

## Tests

Added three regression tests (all fail on `dev`, pass here):
- `test_extend_centroids_preserves_slot_identity_across_gaps` — a survivor at slot 2 stays slot 2 (and keeps its point id) instead of being renumbered to 1.
- `test_extend_centroids_fills_gap_before_appending` — a new learning reuses the freed slot 1 rather than colliding with slot 2.
- `test_extend_centroids_drops_slots_outside_addressable_range` — a slot `>= k` is dropped, not renumbered.

The full `test_centroids.py` suite (14 tests) passes, and `ruff format` / `ruff check` are clean.