### PR TITLE
feat(retrieval): include source document path in citation references (#3844)

### DIFF
--- a/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
+++ b/cognee/infrastructure/databases/hybrid/neptune_analytics/NeptuneAnalyticsAdapter.py
@@ -41,6 +41,7 @@ class IndexSchema(DataPoint):
     # compatible with every indexed DataPoint type.
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    document_path: Optional[str] = None
     chunk_index: Optional[int] = None
     source_chunk_id: Optional[str] = None
     importance_weight: Optional[float] = 0.5
@@ -478,6 +479,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                     # fall back to None instead of raising.
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
+                    document_path=getattr(data_point, "document_path", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
                     source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),
@@ -557,6 +559,7 @@ class NeptuneAnalyticsAdapter(NeptuneGraphDB, VectorDBInterface):
                     text=getattr(dp, field_name),
                     document_id=getattr(dp, "document_id", None),
                     document_name=getattr(dp, "document_name", None),
+                    document_path=getattr(dp, "document_path", None),
                     chunk_index=getattr(dp, "chunk_index", None),
                     source_chunk_id=getattr(dp, "source_chunk_id", None),
                     importance_weight=getattr(dp, "importance_weight", None),

--- a/cognee/infrastructure/databases/hybrid/postgres/adapter.py
+++ b/cognee/infrastructure/databases/hybrid/postgres/adapter.py
@@ -338,6 +338,7 @@ class PostgresHybridAdapter(GraphDBInterface, VectorDBInterface):
                     # Reference scalars for search "Evidence"; None for non-chunks.
                     document_id=getattr(dp, "document_id", None),
                     document_name=getattr(dp, "document_name", None),
+                    document_path=getattr(dp, "document_path", None),
                     chunk_index=getattr(dp, "chunk_index", None),
                     source_chunk_id=getattr(dp, "source_chunk_id", None),
                     importance_weight=getattr(dp, "importance_weight", None),

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -71,6 +71,7 @@ class IndexSchema(DataPoint):
     # compatible with every indexed DataPoint type.
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    document_path: Optional[str] = None
     chunk_index: Optional[int] = None
     source_chunk_id: Optional[str] = None
     importance_weight: Optional[float] = 0.5
@@ -1286,6 +1287,7 @@ class LanceDBAdapter(VectorDBInterface):
                     # fall back to None instead of raising.
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
+                    document_path=getattr(data_point, "document_path", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
                     source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -54,6 +54,7 @@ class IndexSchema(DataPoint):
     # compatible with every indexed DataPoint type.
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    document_path: Optional[str] = None
     chunk_index: Optional[int] = None
     source_chunk_id: Optional[str] = None
     importance_weight: Optional[float] = 0.5
@@ -397,6 +398,7 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
                     # fall back to None instead of raising.
                     document_id=getattr(data_point, "document_id", None),
                     document_name=getattr(data_point, "document_name", None),
+                    document_path=getattr(data_point, "document_path", None),
                     chunk_index=getattr(data_point, "chunk_index", None),
                     source_chunk_id=getattr(data_point, "source_chunk_id", None),
                     importance_weight=getattr(data_point, "importance_weight", None),

--- a/cognee/modules/chunking/CsvChunker.py
+++ b/cognee/modules/chunking/CsvChunker.py
@@ -13,6 +13,7 @@ class CsvChunker(Chunker):
     async def read(self):
         document_id = str(self.document.id)
         document_name = self.document.name or basename(self.document.raw_data_location)
+        document_path = self.document.raw_data_location
         async for content_text in self.get_text():
             if content_text is None:
                 continue
@@ -29,6 +30,7 @@ class CsvChunker(Chunker):
                         contains=[],
                         document_id=document_id,
                         document_name=document_name,
+                        document_path=document_path,
                         metadata={
                             "index_fields": ["text"],
                         },

--- a/cognee/modules/chunking/LangchainChunker.py
+++ b/cognee/modules/chunking/LangchainChunker.py
@@ -37,6 +37,7 @@ class LangchainChunker(Chunker):
     async def read(self):
         document_id = str(self.document.id)
         document_name = self.document.name or basename(self.document.raw_data_location)
+        document_path = self.document.raw_data_location
         async for content_text in self.get_text():
             for chunk in self.splitter.split_text(content_text):
                 embedding_engine = get_vector_engine().embedding_engine
@@ -53,6 +54,7 @@ class LangchainChunker(Chunker):
                         contains=[],
                         document_id=document_id,
                         document_name=document_name,
+                        document_path=document_path,
                         metadata={
                             "index_fields": ["text"],
                         },

--- a/cognee/modules/chunking/TextChunker.py
+++ b/cognee/modules/chunking/TextChunker.py
@@ -13,6 +13,7 @@ class TextChunker(Chunker):
     async def read(self):
         document_id = str(self.document.id)
         document_name = self.document.name or basename(self.document.raw_data_location)
+        document_path = self.document.raw_data_location
         paragraph_chunks = []
         async for content_text in self.get_text():
             for chunk_data in chunk_by_paragraph(
@@ -36,6 +37,7 @@ class TextChunker(Chunker):
                             importance_weight=self.document.importance_weight,
                             document_id=document_id,
                             document_name=document_name,
+                            document_path=document_path,
                             metadata={
                                 "index_fields": ["text"],
                             },
@@ -58,6 +60,7 @@ class TextChunker(Chunker):
                                 importance_weight=self.document.importance_weight,
                                 document_id=document_id,
                                 document_name=document_name,
+                                document_path=document_path,
                                 metadata={
                                     "index_fields": ["text"],
                                 },
@@ -83,6 +86,7 @@ class TextChunker(Chunker):
                     importance_weight=self.document.importance_weight,
                     document_id=document_id,
                     document_name=document_name,
+                    document_path=document_path,
                     metadata={"index_fields": ["text"]},
                 )
             except Exception as e:

--- a/cognee/modules/chunking/models/DocumentChunk.py
+++ b/cognee/modules/chunking/models/DocumentChunk.py
@@ -38,6 +38,9 @@ class DocumentChunk(DataPoint):
     importance_weight: Optional[float] = 0.5
     document_id: Optional[str] = None
     document_name: Optional[str] = None
+    # Full source location of the document (e.g. "src/api/routes.py"), so a
+    # citation can be resolved to the exact file even when basenames collide.
+    document_path: Optional[str] = None
     # Optional truth-alignment fields; never embedded (kept out of index_fields)
     # and not part of id/dedup.
     truth_alignment: Optional[list[float]] = None

--- a/cognee/modules/chunking/text_chunker_with_overlap.py
+++ b/cognee/modules/chunking/text_chunker_with_overlap.py
@@ -80,6 +80,7 @@ class TextChunkerWithOverlap(Chunker):
                 contains=[],
                 document_id=str(self.document.id),
                 document_name=self.document_name,
+                document_path=self.document.raw_data_location,
                 metadata={"index_fields": ["text"]},
             )
         except Exception as e:

--- a/cognee/modules/data/processing/document_types/DltRowDocument.py
+++ b/cognee/modules/data/processing/document_types/DltRowDocument.py
@@ -37,4 +37,5 @@ class DltRowDocument(Document):
             contains=[],
             document_id=str(self.id),
             document_name=self.name or basename(self.raw_data_location),
+            document_path=self.raw_data_location,
         )

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -133,18 +133,24 @@ def _get_payload(obj: Any) -> Optional[dict]:
     return None
 
 
-def _provenance_suffix(data_id: Optional[str], chunk_id: Optional[str]) -> str:
-    """Render a '(data_id: …, chunk_id: …)' annotation for whichever ids exist.
+def _provenance_suffix(
+    data_id: Optional[str], chunk_id: Optional[str], document_path: Optional[str] = None
+) -> str:
+    """Render a '(data_id: …, chunk_id: …, path: …)' annotation for whichever fields exist.
 
-    Lets a reader map the citation back to the ingested data item and the exact
-    cited chunk, instead of only a (possibly auto-generated) document name and a
-    positional chunk number.
+    Lets a reader map the citation back to the ingested data item, the exact
+    cited chunk, and the source file's full path — instead of only a (possibly
+    auto-generated) document name and a positional chunk number. The path
+    disambiguates same-basename files (README.md, __init__.py, …) that the
+    display name alone cannot tell apart.
     """
     parts = []
     if data_id:
         parts.append(f"data_id: {data_id}")
     if chunk_id:
         parts.append(f"chunk_id: {chunk_id}")
+    if document_path:
+        parts.append(f"path: {document_path}")
     return f" ({', '.join(parts)})" if parts else ""
 
 
@@ -216,8 +222,8 @@ def format_chunk_references(
             # rather than presenting unverifiable retrieval order as provenance.
             return ""
 
-    # (overlap_score, document_name, number, text, data_id, chunk_id) per candidate.
-    candidates: List[Tuple[int, str, int, str, Optional[str], Optional[str]]] = []
+    # (overlap_score, document_name, number, text, data_id, chunk_id, document_path) per candidate.
+    candidates: List[Tuple[int, str, int, str, Optional[str], Optional[str], Optional[str]]] = []
     seen: set = set()
 
     for obj in iterator:
@@ -239,6 +245,10 @@ def format_chunk_references(
         # Document.id = data.id), i.e. the dataId a caller needs to map a
         # citation back to the document they ingested.
         data_id = _clean_str(payload.get("document_id"))
+        # Full source location (e.g. "src/api/routes.py"), so a citing client can
+        # resolve the exact file even when several share a basename. Additive:
+        # absent for data indexed before this field existed.
+        document_path = _clean_str(payload.get("document_path"))
 
         dedup_key = chunk_id or f"{document_name}#{number}"
         if dedup_key in seen:
@@ -254,7 +264,7 @@ def format_chunk_references(
                 # certainly not a source of the answer.
                 continue
 
-        candidates.append((score, document_name, number, text, data_id, chunk_id))
+        candidates.append((score, document_name, number, text, data_id, chunk_id, document_path))
 
     if not candidates:
         return ""
@@ -266,8 +276,10 @@ def format_chunk_references(
     max_bullets = _clamp_limit(limit)
     bullets = [
         f"- chunk {number} of document {document_name}"
-        f'{_provenance_suffix(data_id, chunk_id)}: "{_snippet(text)}"'
-        for _, document_name, number, text, data_id, chunk_id in candidates[:max_bullets]
+        f'{_provenance_suffix(data_id, chunk_id, document_path)}: "{_snippet(text)}"'
+        for _, document_name, number, text, data_id, chunk_id, document_path in candidates[
+            :max_bullets
+        ]
     ]
 
     return EVIDENCE_HEADER + "\n" + "\n".join(bullets)

--- a/cognee/tests/unit/modules/retrieval/test_include_references_wiring.py
+++ b/cognee/tests/unit/modules/retrieval/test_include_references_wiring.py
@@ -183,6 +183,36 @@ async def test_completion_references_skipped_for_non_str_response_model():
     assert completion == [model_obj]
 
 
+def test_completion_references_include_source_path_when_present():
+    """A chunk carrying document_path surfaces it in the provenance suffix (#3844)."""
+    from cognee.modules.retrieval.utils.references import format_chunk_references
+
+    obj = MagicMock()
+    obj.id = "chunk-1"
+    obj.payload = {
+        "document_name": "composer.json",
+        "document_path": "packages/api/composer.json",
+        "chunk_index": 2,
+        "text": "Revenue grew 12 percent year over year.",
+    }
+
+    evidence = format_chunk_references([obj], answer=MOCK_ANSWER)
+
+    # Basename prose is unchanged; the full path is added to the annotation.
+    assert "- chunk 3 of document composer.json (" in evidence
+    assert "path: packages/api/composer.json" in evidence
+
+
+def test_completion_references_omit_path_for_old_payloads():
+    """Payloads without document_path render exactly as before (backward compatible)."""
+    from cognee.modules.retrieval.utils.references import format_chunk_references
+
+    evidence = format_chunk_references([_chunk_scored()], answer=MOCK_ANSWER)
+
+    assert "- chunk 1 of document report.pdf (chunk_id: chunk-1):" in evidence
+    assert "path:" not in evidence
+
+
 # ---------------------------------------------------------------------------
 # GraphCompletionRetriever (answer-grounded chunk evidence)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Closes #3844.

`recall(..., include_references=True)` identified each cited source by **basename only** — `chunk 3 of document composer.json (chunk_id: …)`. Any client that resolves a citation back to a file (the VS Code project-memory extension in #3622, the Integrations Hub, dashboards) can't disambiguate the many files that share a basename (`README.md`, `__init__.py`, `composer.json`).

This carries the source location through to the citation and renders it in the Evidence provenance suffix:

```
- chunk 3 of document composer.json (chunk_id: abc, path: packages/api/composer.json): "..."
```

## How

`Document.raw_data_location` already holds the full path. It is now:

1. copied onto `DocumentChunk.document_path` at chunk creation (all chunkers: Text, TextWithOverlap, Csv, Langchain, DltRowDocument), next to the existing `document_name`/`document_id`;
2. carried into the vector `IndexSchema` of every adapter that already carries the reference scalars (LanceDB, PGVector, Postgres-hybrid, Neptune) via the same `getattr(dp, "document_path", None)` pattern, so non-chunk data points stay `None`;
3. rendered in `references.py` by extending `_provenance_suffix` to append `path: <path>` when present.

## Backward compatible / additive

- The `chunk N of document <name>` prose is **byte-identical**; `path:` is only appended to the existing parenthetical annotation.
- Data indexed before this field existed has no `document_path` in its payload and renders exactly as before (the field defaults to `None` everywhere).
- Non-string / non-chunk paths are unaffected.

## Tests

Extended `cognee/tests/unit/modules/retrieval/test_include_references_wiring.py` (LLM-free, offline):
- a chunk carrying `document_path` surfaces `path: packages/api/composer.json` in the suffix while the basename prose is unchanged;
- a payload **without** `document_path` renders identically to before (backward-compat guard).

```
13 passed
```
ruff format + ruff check clean.

## Scope note

This implements the additive path in the existing prose Evidence block (the smaller, backward-compatible half of the issue). A fully structured `references` field (`{document_name, path, chunk_id, snippet}`) is a natural follow-up and can build on the `document_path` plumbing added here.