### PR TITLE
fix(retrieval): dedupe extension-round triplets semantically, not by id()

### DIFF
--- a/cognee/modules/retrieval/utils/query_state.py
+++ b/cognee/modules/retrieval/utils/query_state.py
@@ -1,5 +1,25 @@
-from typing import List
+from typing import List, Tuple
+
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
+
+
+def _triplet_key(triplet: Edge) -> Tuple:
+    """Semantic identity of a triplet: (source node id, relationship, target node id).
+
+    Every retrieval round re-projects the graph into fresh Edge instances, so
+    the same logical triplet never keeps its object identity across rounds —
+    identity must be derived from the node ids and the relationship instead.
+    Objects that don't expose the triplet structure fall back to object
+    identity so distinct objects stay distinct.
+    """
+    attributes = getattr(triplet, "attributes", None) or {}
+    relationship = attributes.get("relationship_name") or attributes.get("relationship_type")
+    source_id = getattr(getattr(triplet, "node1", None), "id", None)
+    target_id = getattr(getattr(triplet, "node2", None), "id", None)
+
+    if source_id is None and target_id is None and relationship is None:
+        return ("__object__", id(triplet))
+    return (source_id, relationship, target_id)
 
 
 class QueryState:
@@ -12,12 +32,13 @@ class QueryState:
         self.done = False
 
     def merge_triplets(self, new_triplets: List[Edge]):
-        """Merge new triplets with existing ones, deduplicating by identity."""
-        seen_ids = {id(t) for t in self.triplets}
-        for t in new_triplets:
-            if id(t) not in seen_ids:
-                self.triplets.append(t)
-                seen_ids.add(id(t))
+        """Merge new triplets with existing ones, deduplicating by semantic identity."""
+        seen_keys = {_triplet_key(triplet) for triplet in self.triplets}
+        for triplet in new_triplets:
+            key = _triplet_key(triplet)
+            if key not in seen_keys:
+                self.triplets.append(triplet)
+                seen_keys.add(key)
 
     def check_convergence(self, prev_size: int):
         """Mark done if no new triplets were added."""

--- a/cognee/tests/unit/modules/retrieval/graph_completion_retriever_context_extension_test.py
+++ b/cognee/tests/unit/modules/retrieval/graph_completion_retriever_context_extension_test.py
@@ -14,6 +14,19 @@ def mock_edge():
     return edge
 
 
+def make_semantic_mock_edge():
+    """A mock edge carrying real triplet identity (node ids + relationship).
+
+    Each call returns a distinct instance, mirroring production where every
+    retrieval round re-projects the graph into fresh Edge objects.
+    """
+    edge = MagicMock()
+    edge.node1.id = "node-a"
+    edge.node2.id = "node-b"
+    edge.attributes = {"relationship_name": "related_to"}
+    return edge
+
+
 @pytest.mark.asyncio
 async def test_get_triplets_inherited(mock_edge):
     """Test that get_triplets is inherited from parent class."""
@@ -239,7 +252,10 @@ async def test_get_completion_context_extension_stops_early(mock_edge):
         patch(
             "cognee.modules.retrieval.graph_completion_retriever.brute_force_triplet_search",
             new_callable=AsyncMock,
-            side_effect=[[mock_edge], [mock_edge]],
+            # Distinct instances of the same logical triplet, as produced by
+            # re-projecting the graph each round — dedupe must be semantic,
+            # not object-identity based.
+            side_effect=[[make_semantic_mock_edge()], [make_semantic_mock_edge()]],
         ) as mock_brute_force_triplet_search,
         patch(
             "cognee.modules.retrieval.graph_completion_retriever.resolve_edges_to_text",
@@ -707,7 +723,11 @@ async def test_get_completion_batch_queries_context_extension_stops_early(mock_e
         patch(
             "cognee.modules.retrieval.graph_completion_retriever.brute_force_triplet_search",
             new_callable=AsyncMock,
-            side_effect=[[[mock_edge], [mock_edge]], [[mock_edge], [mock_edge]]],
+            # Fresh same-identity instances per round (see make_semantic_mock_edge).
+            side_effect=[
+                [[make_semantic_mock_edge()], [make_semantic_mock_edge()]],
+                [[make_semantic_mock_edge()], [make_semantic_mock_edge()]],
+            ],
         ) as mock_brute_force_triplet_search,
         patch(
             "cognee.modules.retrieval.graph_completion_retriever.resolve_edges_to_text",

--- a/cognee/tests/unit/modules/retrieval/query_state_test.py
+++ b/cognee/tests/unit/modules/retrieval/query_state_test.py
@@ -1,0 +1,62 @@
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+from cognee.modules.retrieval.utils.query_state import QueryState
+
+
+def make_triplet(source="node-a", relationship="likes", target="node-b"):
+    """Build a triplet the way graph projection does: fresh instances each call."""
+    source_node = Node(source, {"name": source, "type": "Entity"})
+    target_node = Node(target, {"name": target, "type": "Entity"})
+    return Edge(source_node, target_node, attributes={"relationship_name": relationship})
+
+
+def test_merge_triplets_dedupes_re_retrieved_instances():
+    """The same logical triplet must merge to one entry across rounds.
+
+    Regression test: merge_triplets deduplicated by id(), but every retrieval
+    round re-projects the graph into fresh Edge instances, so a re-retrieved
+    triplet never matched and duplicates accumulated every round.
+    """
+    state = QueryState([make_triplet()], "ctx")
+
+    state.merge_triplets([make_triplet()])
+
+    assert len(state.triplets) == 1
+
+
+def test_merge_triplets_keeps_distinct_relationships():
+    state = QueryState([make_triplet(relationship="works_at")], "ctx")
+
+    state.merge_triplets([make_triplet(relationship="founded")])
+
+    assert len(state.triplets) == 2
+
+
+def test_merge_triplets_keeps_distinct_node_pairs():
+    state = QueryState([make_triplet()], "ctx")
+
+    state.merge_triplets([make_triplet(target="node-c")])
+
+    assert len(state.triplets) == 2
+
+
+def test_convergence_triggers_when_round_adds_nothing_new():
+    """Regression test: with id()-based dedupe, a round returning the same
+    logical triplets still grew the list, so `done` never flipped and context
+    extension always ran the maximum number of rounds."""
+    state = QueryState([make_triplet()], "ctx")
+    prev_size = len(state.triplets)
+
+    state.merge_triplets([make_triplet()])
+    state.check_convergence(prev_size)
+
+    assert state.done
+
+
+def test_no_convergence_when_new_triplet_added():
+    state = QueryState([make_triplet()], "ctx")
+    prev_size = len(state.triplets)
+
+    state.merge_triplets([make_triplet(relationship="founded")])
+    state.check_convergence(prev_size)
+
+    assert not state.done


### PR DESCRIPTION
## Summary

`QueryState.merge_triplets` deduplicated by `id()`. Every extension/CoT round re-projects the graph (`get_triplets_batch` → `brute_force_triplet_search` → fresh `CogneeGraph`), so a re-retrieved triplet is always a new object and the dedupe never matched anything:

- `check_convergence` ("mark done if no new triplets were added") could only fire on an empty round, so `GRAPH_COMPLETION_CONTEXT_EXTENSION` always burned all `context_extension_rounds` (default 4) — four extra LLM completions, graph projections and vector searches per search, even when round 1 already found everything.
- The context handed to the LLM contained the same triplet lines duplicated every round (also affects `GRAPH_COMPLETION_COT`, which merges follow-up triplets through the same helper).

Fixes #3885

## Fix

Dedupe by semantic identity — `(source node id, relationship, target node id)` — which is stable across graph re-projections. Objects that don't expose triplet structure (e.g. bare mocks in existing tests) fall back to object identity, so their behavior is unchanged.

## Tests

- New `query_state_test.py`: same logical triplet re-retrieved as a fresh instance merges to one entry and triggers convergence; distinct relationships and distinct node pairs are kept.
- Strengthened both `stops_early` tests: the mock now returns **distinct instances** of the same logical triplet per round (mirroring production object lifetimes). Before this fix those tests only passed because the mock returned the same object twice — something production cannot do.

```
pytest cognee/tests/unit/modules/retrieval/query_state_test.py \
       cognee/tests/unit/modules/retrieval/graph_completion_retriever_context_extension_test.py
21 passed
```

(The 8 pre-existing failures in `graph_completion_retriever_cot_test.py` reproduce identically on unmodified `dev` — `LLMAPIKeyNotSetError` — and are unrelated.)
