### PR TITLE
fix(chunks): reset row state after blank rows in chunk_by_row

### DIFF
--- a/cognee/tasks/chunks/chunk_by_row.py
+++ b/cognee/tasks/chunks/chunk_by_row.py
@@ -93,9 +93,12 @@ def chunk_by_row(
 
             yield chunk_dict
 
-            # Start a fresh chunk for the next row so its pairs are not
-            # accumulated onto this row's chunk and chunk indices stay
-            # monotonically increasing.
-            current_chunk_list = []
-            current_chunk_size = 0
             chunk_index += 1
+
+        # Start a fresh chunk for the next row so its pairs are not
+        # accumulated onto this row's chunk and chunk indices stay
+        # monotonically increasing. The reset must also run for a blank row
+        # (consecutive separators produce ""), otherwise its empty pair leaks
+        # into the next row's text, size, and chunk_id.
+        current_chunk_list = []
+        current_chunk_size = 0

--- a/cognee/tests/unit/processing/chunks/chunk_by_row_test.py
+++ b/cognee/tests/unit/processing/chunks/chunk_by_row_test.py
@@ -15,6 +15,10 @@ max_chunk_size_vals = [8, 32]
 # called directly). Each row must become its own chunk.
 MULTI_ROW_INPUT = "name: John, age: 30\n\nname: Jane, age: 25"
 
+# Two rows separated by consecutive separators, i.e. with a blank row between
+# them (data.split("\n\n") yields ["...", "", "..."]).
+BLANK_ROW_INPUT = "name: John, age: 30\n\n\n\nname: Jane, age: 25"
+
 
 @pytest.mark.parametrize(
     "input_text,max_chunk_size",
@@ -83,4 +87,29 @@ def test_chunk_by_row_multiple_rows_are_independent():
     assert chunk_indices == list(range(len(chunk_indices)))
 
     # Identical rows must have identical sizes (no accumulation across rows).
+    assert chunks[0]["chunk_size"] == chunks[1]["chunk_size"]
+
+
+def test_chunk_by_row_blank_rows_do_not_leak():
+    """A blank row (from consecutive separators) must not leak into the next row.
+
+    Regression test: the row-state reset ran only when the joined row text was
+    non-empty, so a blank row left an empty pair in the accumulator and the
+    following row's chunk was emitted as ", name: ..." — corrupted text, an
+    inflated chunk_size, and a chunk_id derived from the corrupted text.
+    """
+    chunks = list(chunk_by_row(data=BLANK_ROW_INPUT, max_chunk_size=128))
+
+    # The blank row contributes nothing; both real rows keep their exact text.
+    assert [chunk["text"] for chunk in chunks] == [
+        "name: John, age: 30",
+        "name: Jane, age: 25",
+    ]
+
+    # Indices are monotonically increasing across rows.
+    chunk_indices = [chunk["chunk_index"] for chunk in chunks]
+    assert chunk_indices == list(range(len(chunk_indices)))
+
+    # Structurally identical rows must have identical sizes (no size leakage
+    # from the blank row).
     assert chunks[0]["chunk_size"] == chunks[1]["chunk_size"]


### PR DESCRIPTION
## Summary

`chunk_by_row` reset its per-row accumulator only inside `if current_chunk:`. A blank row (consecutive separators — `data.split("\n\n")` yields `""`) still appended the empty pair and its size, but produced a falsy joined text, so the yield **and the reset** were skipped. The phantom empty pair then leaked into the next row, which was emitted as:

- corrupted text with a leading `", "` (`", b: 2"` instead of `"b: 2"`),
- a `chunk_id` (uuid5) computed over the corrupted text,
- an inflated `chunk_size` carried over from the blank row.

```python
list(chunk_by_row("a: 1\n\n\n\nb: 2", 128))
# before: [('a: 1', 3), (', b: 2', 6)]
# after:  [('a: 1', 3), ('b: 2', 3)]
```

This is the residual case of the cross-row state leak fixed in #2965: that fix (and its regression test) covers non-blank rows, but the reset was still guarded by the joined-text truthiness.

Fixes #3886

## Fix

Run the row-state reset unconditionally after every row; only the yield and `chunk_index` increment stay conditional on non-empty text. Empty pairs *within* a row (e.g. `"a, , b"`) are intentionally untouched — they are needed for exact text reconstruction.

## Tests

New `test_chunk_by_row_blank_rows_do_not_leak` alongside the existing multi-row regression test: exact per-row text, monotonic indices, and equal sizes for structurally identical rows.

```
pytest cognee/tests/unit/processing/chunks/chunk_by_row_test.py
8 passed
```
