### PR TITLE
fix(ingestion): don't crash on non-absolute /-prefixed strings on Windows

### DIFF
--- a/cognee/tasks/ingestion/save_data_item_to_storage.py
+++ b/cognee/tasks/ingestion/save_data_item_to_storage.py
@@ -69,10 +69,15 @@ async def save_data_item_to_storage(data_item: Union[BinaryIO, str, Any]) -> str
                 raise IngestionError(message="Local files are not accepted.")
 
         # data is an absolute file path
-        elif data_item.startswith("/") or (
-            os.name == "nt" and len(data_item) > 1 and data_item[1] == ":"
-        ):
-            # Handle both Unix absolute paths (/path) and Windows absolute paths (C:\path)
+        elif (
+            data_item.startswith("/")
+            or (os.name == "nt" and len(data_item) > 1 and data_item[1] == ":")
+        ) and Path(os.path.normpath(data_item)).is_absolute():
+            # Handle both Unix absolute paths (/path) and Windows absolute paths (C:\path).
+            # The is_absolute() guard matters on Windows: a POSIX-style "/path" (or a
+            # drive-relative "C:path") normalizes to a *drive-relative* WindowsPath, and
+            # Path.as_uri() raises ValueError for it. Such strings are not usable file
+            # paths on this platform and continue to the relative-path/text handling below.
             if settings.accept_local_file_path:
                 # Normalize path separators before creating file URL
                 normalized_path = os.path.normpath(data_item)

--- a/cognee/tests/unit/tasks/ingestion/test_save_data_item_to_storage.py
+++ b/cognee/tests/unit/tasks/ingestion/test_save_data_item_to_storage.py
@@ -1,0 +1,63 @@
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.tasks.ingestion.save_data_item_to_storage import save_data_item_to_storage
+
+
+@pytest.mark.asyncio
+async def test_existing_absolute_path_returns_file_uri(tmp_path):
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    result = await save_data_item_to_storage(str(file_path))
+
+    assert result == file_path.as_uri()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="POSIX absolute-path semantics")
+async def test_posix_absolute_path_behavior_unchanged_on_posix():
+    # On POSIX, "/"-prefixed strings are genuine absolute paths and convert to
+    # file URIs whether or not the file exists (pre-existing behavior).
+    result = await save_data_item_to_storage("/nonexistent/path/file.txt")
+
+    assert result == "file:///nonexistent/path/file.txt"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "nt", reason="Windows drive-relative path semantics")
+async def test_posix_style_string_falls_back_to_text_on_windows():
+    """A "/"-prefixed string that is not a usable path on Windows is ingested as text.
+
+    Regression test: os.path.normpath("/x") produces a drive-relative
+    WindowsPath, and Path.as_uri() raised ValueError ("relative paths can't
+    be expressed as file URIs") out of add() for any string starting with
+    "/" — both POSIX-style paths and plain text.
+    """
+    with patch(
+        "cognee.tasks.ingestion.save_data_item_to_storage.save_data_to_file",
+        new_callable=AsyncMock,
+        return_value="text-file-path",
+    ) as mock_save:
+        result = await save_data_item_to_storage("/remember to call Bob about the meeting")
+
+    assert result == "text-file-path"
+    mock_save.assert_awaited_once_with("/remember to call Bob about the meeting")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "nt", reason="Windows drive-relative path semantics")
+async def test_drive_relative_string_falls_back_to_text_on_windows():
+    # "C:name.txt" matches the Windows-path arm but is drive-relative, not
+    # absolute; it used to raise the same ValueError from Path.as_uri().
+    with patch(
+        "cognee.tasks.ingestion.save_data_item_to_storage.save_data_to_file",
+        new_callable=AsyncMock,
+        return_value="text-file-path",
+    ) as mock_save:
+        result = await save_data_item_to_storage("C:drive-relative-note.txt")
+
+    assert result == "text-file-path"
+    mock_save.assert_awaited_once()


### PR DESCRIPTION
## Summary

On Windows, `save_data_item_to_storage` crashed with an unhandled `ValueError` for any string starting with `/`:

```
FAIL '/etc/hosts'                              -> ValueError: relative paths can't be expressed as file URIs
FAIL '/remember to call Bob about the meeting' -> ValueError: relative paths can't be expressed as file URIs
```

`os.path.normpath("/etc/hosts")` → `"\\etc\\hosts"` is a **drive-relative** `WindowsPath` (root but no drive, `is_absolute()` is `False`), and `Path.as_uri()` requires an absolute path. The same applies to drive-relative input like `"C:notes.txt"`, which matches the second arm of the condition. So on Windows, `add()` blew up for POSIX-style paths pasted from cross-platform docs *and* for genuine text notes that happen to begin with `/`.

Fixes #3887

## Fix

Guard the absolute-path branch with `Path(os.path.normpath(data_item)).is_absolute()`. Strings that are not usable absolute paths on the current platform now continue down the existing `elif` chain — existing relative file → file URI, otherwise text ingestion — matching how the function already treats every other non-path string.

Behavior is unchanged everywhere else:
- POSIX: `/`-prefixed strings normalize to absolute paths, so the branch behaves exactly as before (covered by a POSIX-only test).
- Windows absolute paths (`C:\...`) still convert to file URIs.
- `accept_local_file_path=False` still raises `IngestionError` for genuine absolute paths.

After the fix on Windows:

```
OK   '/etc/hosts'                              -> 'file:///C:/Users/.../text_ad942c72....txt'   (text ingestion)
OK   '/remember to call Bob about the meeting' -> 'file:///C:/Users/.../text_33709218....txt'   (text ingestion)
```

## Tests

New `cognee/tests/unit/tasks/ingestion/test_save_data_item_to_storage.py`:
- existing absolute path → file URI (all platforms)
- POSIX-only: nonexistent `/`-prefixed path still converts to a file URI (pre-existing behavior pinned)
- Windows-only: POSIX-style string and drive-relative `C:name.txt` fall back to text ingestion instead of raising `ValueError`

```
pytest cognee/tests/unit/tasks/ingestion/test_save_data_item_to_storage.py   (Windows)
3 passed, 1 skipped
```
