### PR TITLE
fix(chunking): align LangchainChunker with the unified max_chunk_size API

### DIFF
--- a/cognee/modules/chunking/LangchainChunker.py
+++ b/cognee/modules/chunking/LangchainChunker.py
@@ -22,11 +22,11 @@ class LangchainChunker(Chunker):
         self,
         document,
         get_text: callable,
-        max_chunk_tokens: int,
+        max_chunk_size: int,
         chunk_size: int = 1024,
         chunk_overlap=10,
     ):
-        super().__init__(document, get_text, max_chunk_tokens, chunk_size)
+        super().__init__(document, get_text, max_chunk_size)
 
         self.splitter = RecursiveCharacterTextSplitter(
             chunk_size=chunk_size,
@@ -41,16 +41,16 @@ class LangchainChunker(Chunker):
             for chunk in self.splitter.split_text(content_text):
                 embedding_engine = get_vector_engine().embedding_engine
                 token_count = embedding_engine.tokenizer.count_tokens(chunk)
-                if token_count <= self.max_chunk_tokens:
+                if token_count <= self.max_chunk_size:
                     yield DocumentChunk(
                         id=uuid5(NAMESPACE_OID, chunk),
                         text=chunk,
-                        word_count=len(chunk.split()),
-                        token_count=token_count,
+                        chunk_size=token_count,
                         is_part_of=self.document,
                         chunk_index=self.chunk_index,
                         cut_type="missing",
                         contains=[],
+                        importance_weight=self.document.importance_weight,
                         document_id=document_id,
                         document_name=document_name,
                         metadata={
@@ -60,5 +60,5 @@ class LangchainChunker(Chunker):
                     self.chunk_index += 1
                 else:
                     raise ValueError(
-                        f"Chunk of {token_count} tokens is larger than the maximum of {self.max_chunk_tokens} tokens. Please reduce chunk_size in RecursiveCharacterTextSplitter."
+                        f"Chunk of {token_count} tokens is larger than the maximum of {self.max_chunk_size} tokens. Please reduce chunk_size in RecursiveCharacterTextSplitter."
                     )

--- a/cognee/tests/unit/modules/chunking/test_langchain_chunker.py
+++ b/cognee/tests/unit/modules/chunking/test_langchain_chunker.py
@@ -1,0 +1,117 @@
+"""Regression tests for LangchainChunker.
+
+LangchainChunker was left targeting the pre-unification chunker API
+(``max_chunk_tokens``, a 4-arg base ``Chunker.__init__``, and
+``word_count``/``token_count`` fields ``DocumentChunk`` does not define), so
+it could not be instantiated at all — neither positionally nor through the
+standard ``Document.read`` call path
+(``chunker_cls(self, max_chunk_size=..., get_text=...)``). These tests pin
+the class to the current API.
+
+The langchain import is guarded so test collection stays safe in
+environments without the ``langchain`` extra installed (the previous fix,
+#2966, was reverted in #3167; its regression test imported langchain
+unconditionally).
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("langchain_text_splitters")
+
+from cognee.modules.chunking.LangchainChunker import LangchainChunker  # noqa: E402
+from cognee.modules.chunking.models.DocumentChunk import DocumentChunk  # noqa: E402
+from cognee.modules.data.processing.document_types import Document  # noqa: E402
+
+
+class _WordCountTokenizer:
+    def count_tokens(self, text: str) -> int:
+        return len(text.split())
+
+
+def _make_document() -> Document:
+    return Document(
+        id=uuid.uuid4(),
+        name="test-document",
+        raw_data_location="/tmp/test-document.txt",
+        external_metadata=None,
+        mime_type="text/plain",
+    )
+
+
+def _mock_vector_engine():
+    engine = MagicMock()
+    engine.embedding_engine.tokenizer = _WordCountTokenizer()
+    return engine
+
+
+def test_constructs_positionally_like_base_chunker():
+    document = _make_document()
+
+    async def get_text():
+        yield "hello world"
+
+    chunker = LangchainChunker(document, get_text, 512)
+
+    assert chunker.max_chunk_size == 512
+    assert chunker.document is document
+
+
+def test_constructs_via_document_read_call_shape():
+    """Every Document.read() builds its chunker with
+    chunker_cls(self, max_chunk_size=..., get_text=...)."""
+    document = _make_document()
+
+    async def get_text():
+        yield "hello world"
+
+    chunker = LangchainChunker(document, max_chunk_size=512, get_text=get_text)
+
+    assert chunker.max_chunk_size == 512
+
+
+@pytest.mark.asyncio
+async def test_read_yields_valid_document_chunks():
+    document = _make_document()
+    text = "one two three four five. " * 40
+
+    async def get_text():
+        yield text
+
+    chunker = LangchainChunker(document, max_chunk_size=512, get_text=get_text)
+
+    with patch(
+        "cognee.modules.chunking.LangchainChunker.get_vector_engine",
+        return_value=_mock_vector_engine(),
+    ):
+        chunks = [chunk async for chunk in chunker.read()]
+
+    assert len(chunks) > 0
+    for index, chunk in enumerate(chunks):
+        assert isinstance(chunk, DocumentChunk)
+        assert chunk.text
+        assert chunk.chunk_size > 0
+        assert chunk.chunk_index == index
+        assert chunk.is_part_of == document
+        assert chunk.document_id == str(document.id)
+
+
+@pytest.mark.asyncio
+async def test_read_raises_for_chunks_over_max_chunk_size():
+    document = _make_document()
+
+    async def get_text():
+        yield "word " * 50
+
+    # splitter chunk_size is large enough that the split chunk exceeds
+    # max_chunk_size, which must raise instead of yielding oversized chunks
+    chunker = LangchainChunker(document, max_chunk_size=3, get_text=get_text, chunk_size=1000)
+
+    with patch(
+        "cognee.modules.chunking.LangchainChunker.get_vector_engine",
+        return_value=_mock_vector_engine(),
+    ):
+        with pytest.raises(ValueError, match="larger than the maximum"):
+            [chunk async for chunk in chunker.read()]


### PR DESCRIPTION
## Summary

`LangchainChunker` could not be instantiated at all on `dev` — it still targeted the pre-unification chunker API:

```
LangchainChunker(doc, get_text, 512)
# TypeError: Chunker.__init__() takes 4 positional arguments but 5 were given

LangchainChunker(doc, max_chunk_size=512, get_text=get_text)   # Document.read call shape
# TypeError: __init__() got an unexpected keyword argument 'max_chunk_size'. Did you mean 'chunk_size'?
```

Three stacked breaks: the constructor parameter was still `max_chunk_tokens` (every `Document.read()` passes `max_chunk_size=`), `super().__init__` passed four args into the three-parameter base, and `read()` referenced the never-assigned `self.max_chunk_tokens` while emitting `word_count`/`token_count` fields `DocumentChunk` does not define (and omitting the required `chunk_size`). The class is user-facing — documented in the `cognify()` docstring and offered in the CLI chunker choices — so selecting it crashed mid-pipeline.

Fixes #3888

## Fix

Re-lands the API alignment from #2966 (credit @dexters1), which was reverted in #3167:

- constructor takes `max_chunk_size` and calls the three-arg `super().__init__`
- `read()` checks `self.max_chunk_size` and emits `DocumentChunk` with `chunk_size=token_count` plus the same field set `TextChunker` produces (including `importance_weight` propagation)

**Why the re-land is now CI-safe:** the reverted PR's regression test imported `LangchainChunker` (and therefore `langchain_text_splitters`) at module level, which breaks test **collection** in any environment without the `langchain` extra — the likely reason for the revert. The tests here are guarded with `pytest.importorskip("langchain_text_splitters")`, so environments without the extra skip cleanly instead of failing collection.

## Tests

New `cognee/tests/unit/modules/chunking/test_langchain_chunker.py`: positional construction, the `Document.read` keyword call shape, `read()` yielding valid `DocumentChunk`s (chunk_size, monotonic indices, document linkage), and the oversized-chunk `ValueError` path.

```
pytest cognee/tests/unit/modules/chunking/
32 passed
```
