### PR TITLE
fix(retrieval): make LexicalRetriever context work with with_scores=True

### DIFF
--- a/cognee/modules/retrieval/lexical_retriever.py
+++ b/cognee/modules/retrieval/lexical_retriever.py
@@ -149,7 +149,12 @@ class LexicalRetriever(BaseRetriever):
               empty string if none are found.
         """
         if retrieved_objects:
-            payload_texts = [payload["text"] for payload in retrieved_objects]
+            # With with_scores=True, get_retrieved_objects returns
+            # (payload, score) tuples; unwrap them so both modes work.
+            payload_texts = [
+                payload[0]["text"] if isinstance(payload, tuple) else payload["text"]
+                for payload in retrieved_objects
+            ]
             return "\n".join(payload_texts)
         else:
             return ""

--- a/cognee/tests/unit/modules/retrieval/test_lexical_retriever.py
+++ b/cognee/tests/unit/modules/retrieval/test_lexical_retriever.py
@@ -1,0 +1,59 @@
+import pytest
+
+from cognee.modules.retrieval.lexical_retriever import LexicalRetriever, tokenize_words
+
+
+def overlap_scorer(query_tokens, chunk_tokens):
+    return len(set(query_tokens) & set(chunk_tokens))
+
+
+def make_retriever(with_scores: bool) -> LexicalRetriever:
+    retriever = LexicalRetriever(
+        tokenizer=tokenize_words, scorer=overlap_scorer, with_scores=with_scores
+    )
+    # Populate the caches directly, the way initialize() would.
+    retriever.chunks = {
+        "c1": tokenize_words("alpha beta gamma"),
+        "c2": tokenize_words("delta epsilon"),
+    }
+    retriever.payloads = {
+        "c1": {"id": "c1", "text": "alpha beta gamma", "type": "DocumentChunk"},
+        "c2": {"id": "c2", "text": "delta epsilon", "type": "DocumentChunk"},
+    }
+    retriever._initialized = True
+    return retriever
+
+
+@pytest.mark.asyncio
+async def test_get_context_from_objects_without_scores():
+    retriever = make_retriever(with_scores=False)
+
+    objects = await retriever.get_retrieved_objects("alpha")
+    context = await retriever.get_context_from_objects("alpha", objects)
+
+    assert "alpha beta gamma" in context
+
+
+@pytest.mark.asyncio
+async def test_get_context_from_objects_with_scores():
+    """Both constructor modes must work with the inherited get_context flow.
+
+    Regression test: with_scores=True makes get_retrieved_objects return
+    (payload, score) tuples, and get_context_from_objects indexed them as
+    dicts — TypeError: tuple indices must be integers or slices, not str.
+    """
+    retriever = make_retriever(with_scores=True)
+
+    objects = await retriever.get_retrieved_objects("alpha")
+    assert objects and all(isinstance(entry, tuple) for entry in objects)
+
+    context = await retriever.get_context_from_objects("alpha", objects)
+
+    assert "alpha beta gamma" in context
+
+
+@pytest.mark.asyncio
+async def test_get_context_from_objects_empty():
+    retriever = make_retriever(with_scores=True)
+
+    assert await retriever.get_context_from_objects("alpha", []) == ""


### PR DESCRIPTION
## Summary

`LexicalRetriever(with_scores=True)` broke the inherited `get_context(query)` flow: `get_retrieved_objects` returns `(payload, score)` tuples in that mode, but `get_context_from_objects` indexed every element as a dict:

```python
payload_texts = [payload["text"] for payload in retrieved_objects]
# TypeError: tuple indices must be integers or slices, not str
```

So the two features of the same class — score-carrying retrieval and context building — were mutually exclusive.

Fixes #3889

## Fix

Unwrap `(payload, score)` tuples in `get_context_from_objects` so both constructor modes produce the joined chunk texts. No behavior change for `with_scores=False`.

## Tests

New `cognee/tests/unit/modules/retrieval/test_lexical_retriever.py`: context building in both modes (the `with_scores=True` case fails with `TypeError` before this fix) and the empty-objects path.

```
pytest cognee/tests/unit/modules/retrieval/test_lexical_retriever.py
3 passed
```
