### PR TITLE
fix(deps): move pylance from runtime to dev optional dependencies

### DIFF
--- a/cognee/tests/unit/test_pyproject_dependencies.py
+++ b/cognee/tests/unit/test_pyproject_dependencies.py
@@ -1,0 +1,40 @@
+"""Regression test: pylance must not be in core runtime dependencies.
+
+pylance provides the `lance` module used by lancedb, but it is not
+imported directly by cognee code. It should be in optional/dev deps,
+not in the core [project].dependencies list (issue #3827).
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import tomllib
+
+
+@pytest.fixture
+def pyproject_data():
+    pyproject_path = pathlib.Path(__file__).resolve().parents[3] / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        return tomllib.load(f)
+
+
+def test_pylance_not_in_runtime_dependencies(pyproject_data):
+    """pylance must not appear in [project].dependencies."""
+    runtime_deps = pyproject_data.get("project", {}).get("dependencies", [])
+    pylance_deps = [d for d in runtime_deps if d.strip().lower().startswith("pylance")]
+    assert pylance_deps == [], (
+        f"pylance should not be in [project].dependencies (runtime). "
+        f"Found: {pylance_deps}. Move it to [project.optional-dependencies.dev]."
+    )
+
+
+def test_pylance_in_dev_dependencies(pyproject_data):
+    """pylance should be available in the dev optional dependencies."""
+    dev_deps = pyproject_data.get("project", {}).get("optional-dependencies", {}).get("dev", [])
+    pylance_deps = [d for d in dev_deps if d.strip().lower().startswith("pylance")]
+    assert len(pylance_deps) >= 1, (
+        "pylance should be listed in [project.optional-dependencies.dev] "
+        "so it is available for development/testing with lancedb."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "fastapi-users[sqlalchemy]>=15.0.2",
     "structlog>=25.2.0,<26",
     "pympler>=1.1,<2.0.0",
-    "pylance>=0.22.0,<=0.36.0",
     "ladybug>=0.16.0,<0.18",
     "python-magic-bin<0.5 ; platform_system == 'Windows'", # Only needed for Windows
     "networkx>=3.4.2,<4",
@@ -172,6 +171,11 @@ dev = [
     "mkdocs-minify-plugin>=0.8.0,<0.9",
     "mkdocstrings[python]>=0.26.2,<0.27",
     "ty>=0.0.31,<0.1.0",
+    # pylance provides the `lance` module used by lancedb. It is not
+    # imported directly by cognee code — lancedb imports it lazily — so
+    # it does not belong in the core runtime dependency list. Moved here
+    # from [project].dependencies (see issue #3827).
+    "pylance>=0.22.0,<=0.36.0",
 ]
 debug = ["debugpy>=1.8.9,<2.0.0"]
 redis = ["redis>=5.0.3,<6.0.0"]


### PR DESCRIPTION
## Summary

`pylance` was listed in `[project].dependencies` (the core runtime dependency list), but it is not imported directly by any cognee code. The `pylance` package provides the `lance` module, which is imported lazily by `lancedb` (inside functions, not at module level). Having it as a hard runtime dependency:

- Bloats installs for users who don't use the lance vector backend
- Breaks packaging (pylance is a native library with platform-specific wheels)
- Conflicts with lancedb's own optional `pylance` extra (which requires `>=5.0.0b5`, while cognee pins was `<=0.36.0`)

### The fix
- Removed `pylance` from `[project].dependencies`
- Moved it to `[project.optional-dependencies.dev]` so it's available for development/testing with lancedb
- Added a regression test (`test_pyproject_dependencies.py`) that asserts pylance is NOT in runtime deps and IS in dev deps

## Test plan
- [x] Added 2 regression tests in `test_pyproject_dependencies.py`
- [x] All tests pass: `uv run pytest cognee/tests/unit/test_pyproject_dependencies.py -v`
- [x] `ruff check` and `ruff format` pass

Fixes #3827

Signed-off-by: Udi Ngethe <ungethe@gmail.com>
