### PR TITLE
feat(provenance): lineage query API, visualization and recall citations

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -176,6 +176,19 @@ VECTOR_DATASET_DATABASE_HANDLER="lancedb"
 #ONTOLOGY_FILE_PATH=YOUR_FULL_FILE_PATH
 
 ################################################################################
+#  Provenance Lineage
+#  Materialize source lineage as first-class graph edges so every extracted
+#  node is traceable to its source: <node> -derived_from-> Document and
+#  Document -in_dataset-> Dataset. On by default; set to false to reproduce the
+#  pre-lineage graph exactly.
+################################################################################
+
+#PROVENANCE_LINEAGE=true
+# How far up the lineage is materialized: "document" (node -> Document only) or
+# "dataset" (also Document -> Dataset). Default: dataset.
+#PROVENANCE_LINEAGE_DEPTH=dataset
+
+################################################################################
 #  Database Adapter Caching
 #  Max graph / vector / relational engine instances held in the LRU cache
 #  (one per unique connection key, e.g. per dataset in multi-tenant mode).

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -468,6 +468,33 @@ jobs:
           EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
         run: uv run python ./cognee/tests/test_delete_default_graph.py
 
+  test-provenance-lineage-on-default-graph:
+    name: Provenance lineage default graph test
+    runs-on: ubuntu-22.04
+    container: ${{ inputs.ci-image != '' && fromJSON(format('{{"image":"{0}","credentials":{{"username":"{1}","password":"{2}"}}}}', inputs.ci-image, github.actor, github.token)) || null }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Run provenance lineage on default graph
+        env:
+          ENV: 'dev'
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          LLM_ENDPOINT: ${{ secrets.LLM_ENDPOINT }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          LLM_API_VERSION: ${{ secrets.LLM_API_VERSION }}
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+        run: uv run python ./cognee/tests/test_provenance_lineage_default_graph.py
+
   test-deletion-on-default-graph-non-mocked:
     name: Delete default graph data test (non-mocked)
     runs-on: ubuntu-22.04

--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -36,6 +36,7 @@ from .api.v1.visualize import (
     get_memory_provenance_graph,
     visualize_memory_provenance,
 )
+from .modules.graph.methods import get_source_lineage, get_derived_nodes
 from cognee.modules.visualization.cognee_network_visualization import (
     cognee_network_visualization,
 )

--- a/cognee/api/v1/visualize/memory_provenance.py
+++ b/cognee/api/v1/visualize/memory_provenance.py
@@ -100,6 +100,10 @@ class MemoryPayload(TypedDict, total=False):
     nodes: List[Tuple[str, Dict[str, Any]]]
     edges: List[Tuple[str, str, str, Dict[str, Any]]]
     links: List[Dict[str, Any]]
+    # Maps a memory node id to an actor node id it should collapse onto. Used to
+    # fold the lineage DatasetNode onto its actor "dataset:<id>" node so the
+    # provenance lineage attaches to the ownership graph instead of duplicating it.
+    aliases: Dict[str, str]
 
 
 def build_provenance_graph(
@@ -210,13 +214,19 @@ def build_provenance_graph(
 
     # ── Optional memory layer ────────────────────────────────────────
     if memory:
+        aliases = memory.get("aliases") or {}
         for node_id, props in memory.get("nodes") or []:
             nid = str(node_id)
+            # An aliased node collapses onto an existing actor node, so it is not
+            # added as its own memory node.
+            if nid in aliases:
+                continue
             if nid not in nodes:
                 nodes[nid] = Node(nid, dict(props))
         for source, target, relation, eprops in memory.get("edges") or []:
-            s, t = str(source), str(target)
-            if s in nodes and t in nodes:
+            s = aliases.get(str(source), str(source))
+            t = aliases.get(str(target), str(target))
+            if s in nodes and t in nodes and s != t:
                 key = (s, t, relation)
                 if key not in seen_edges:
                     seen_edges.add(key)
@@ -337,6 +347,7 @@ async def _read_memory_relational(
     nodes: List[Tuple[str, Dict[str, Any]]] = []
     edges: List[Tuple[str, str, str, Dict[str, Any]]] = []
     links: List[Dict[str, Any]] = []
+    aliases: Dict[str, str] = {}
     node_ids: set = set()
     try:
         db_engine = get_relational_engine()
@@ -352,6 +363,13 @@ async def _read_memory_relational(
                 nodes.append(
                     Node(node_id, {"type": row.type or "Node", "name": row.label or str(row.slug)})
                 )
+                # The lineage DatasetNode represents the same dataset as the actor
+                # "dataset:<id>" node, so collapse it onto that node. It stays in
+                # node_ids above so its in_dataset edge survives the scope filter,
+                # and it has no source file, so no "mentions" link is emitted.
+                if row.type == "DatasetNode" and row.dataset_id is not None:
+                    aliases[node_id] = f"dataset:{row.dataset_id}"
+                    continue
                 if row.data_id is not None:
                     links.append(
                         {
@@ -374,7 +392,7 @@ async def _read_memory_relational(
 
     if not nodes:
         return None
-    return {"nodes": nodes, "edges": edges, "links": links}
+    return {"nodes": nodes, "edges": edges, "links": links, "aliases": aliases}
 
 
 async def get_memory_provenance_graph(

--- a/cognee/modules/engine/models/DatasetNode.py
+++ b/cognee/modules/engine/models/DatasetNode.py
@@ -2,16 +2,15 @@ from cognee.infrastructure.engine import DataPoint
 
 
 class DatasetNode(DataPoint):
-    """Provenance lineage node representing a dataset in the knowledge graph.
+    """Graph node that represents a dataset.
 
-    Emitted by the provenance lineage layer (see
-    ``cognee.tasks.storage.provenance_lineage``) so every extracted node has an
-    in-graph path up to the dataset it originated from. Its id is derived
-    deterministically from the dataset id, so a single DatasetNode is shared and
-    deduplicated across every data item in the same dataset.
+    The provenance lineage layer (see ``cognee.tasks.storage.provenance_lineage``)
+    creates one of these per dataset so every extracted node has a path in the
+    graph up to its dataset. The id is derived from the dataset id, so a single
+    node is shared across every data item in the same dataset.
 
-    Like ``NodeSet`` it declares no ``index_fields``, so it is a structural
-    graph-only node and is not embedded into the vector store.
+    It declares no ``index_fields``, so like ``NodeSet`` it is a structural node
+    that lives only in the graph and is not embedded into the vector store.
     """
 
     name: str

--- a/cognee/modules/engine/models/DatasetNode.py
+++ b/cognee/modules/engine/models/DatasetNode.py
@@ -1,0 +1,17 @@
+from cognee.infrastructure.engine import DataPoint
+
+
+class DatasetNode(DataPoint):
+    """Provenance lineage node representing a dataset in the knowledge graph.
+
+    Emitted by the provenance lineage layer (see
+    ``cognee.tasks.storage.provenance_lineage``) so every extracted node has an
+    in-graph path up to the dataset it originated from. Its id is derived
+    deterministically from the dataset id, so a single DatasetNode is shared and
+    deduplicated across every data item in the same dataset.
+
+    Like ``NodeSet`` it declares no ``index_fields``, so it is a structural
+    graph-only node and is not embedded into the vector store.
+    """
+
+    name: str

--- a/cognee/modules/engine/models/__init__.py
+++ b/cognee/modules/engine/models/__init__.py
@@ -3,6 +3,7 @@ from .EntityType import EntityType
 from .TableRow import TableRow
 from .TableType import TableType
 from .node_set import NodeSet
+from .DatasetNode import DatasetNode
 from .ColumnValue import ColumnValue
 from .Timestamp import Timestamp
 from .Interval import Interval

--- a/cognee/modules/graph/methods/__init__.py
+++ b/cognee/modules/graph/methods/__init__.py
@@ -1,4 +1,5 @@
 from .get_formatted_graph_data import get_formatted_graph_data
+from .get_node_lineage import get_source_lineage, get_derived_nodes
 
 from .upsert_edges import upsert_edges
 from .upsert_nodes import upsert_nodes

--- a/cognee/modules/graph/methods/get_node_lineage.py
+++ b/cognee/modules/graph/methods/get_node_lineage.py
@@ -1,0 +1,116 @@
+"""Read the provenance lineage of a graph node.
+
+The provenance lineage layer (see ``cognee.tasks.storage.provenance_lineage``)
+writes ``derived_from`` and ``in_dataset`` edges during ingestion. This module
+reads those edges back to answer two questions:
+
+* ``get_source_lineage(node_id)``: what produced this node. It returns the source
+  documents the node was derived from and the datasets those documents belong to.
+* ``get_derived_nodes(source_id)``: what was produced from this source. Given a
+  Document it returns the nodes derived from it, and given a Dataset it returns
+  the documents in it.
+
+Both read from the graph engine's ``get_connections``, which returns each edge as
+a ``(node, edge, neighbor)`` tuple. The edge properties carry ``source_node_id``
+and ``target_node_id``, so the direction of each edge is known regardless of the
+order the backend returns the endpoints in.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from cognee.infrastructure.databases.graph.get_graph_engine import get_graph_engine
+from cognee.tasks.storage.provenance_lineage import (
+    DERIVED_FROM_RELATIONSHIP,
+    IN_DATASET_RELATIONSHIP,
+)
+
+
+def _node_id(node: Optional[Dict[str, Any]]) -> str:
+    return str((node or {}).get("id"))
+
+
+def _neighbors_by_relationship(
+    connections: List[Any],
+    node_id: str,
+    relationship_name: str,
+    outgoing: bool,
+) -> List[Dict[str, Any]]:
+    """Return the neighbor nodes reached over edges of one relationship type.
+
+    ``connections`` is the output of ``get_connections(node_id)``: a list of
+    ``(node, edge, neighbor)`` tuples. When ``outgoing`` is True this keeps edges
+    that start at ``node_id`` (node is the source), and when False it keeps edges
+    that end at ``node_id`` (node is the target). The neighbor returned is always
+    the endpoint that is not ``node_id``.
+    """
+    node_key = str(node_id)
+    neighbors = []
+    for source, edge, target in connections:
+        if not isinstance(edge, dict) or edge.get("relationship_name") != relationship_name:
+            continue
+        edge_source = str(edge.get("source_node_id", _node_id(source)))
+        edge_target = str(edge.get("target_node_id", _node_id(target)))
+        if outgoing and edge_source == node_key:
+            neighbors.append(target if _node_id(target) != node_key else source)
+        elif not outgoing and edge_target == node_key:
+            neighbors.append(source if _node_id(source) != node_key else target)
+    return neighbors
+
+
+def _dedupe_by_id(nodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    seen = set()
+    unique = []
+    for node in nodes:
+        key = _node_id(node)
+        if key not in seen:
+            seen.add(key)
+            unique.append(node)
+    return unique
+
+
+async def get_source_lineage(node_id: Any, graph_engine=None) -> Dict[str, List[Dict[str, Any]]]:
+    """Return the documents and datasets a node was produced from.
+
+    The result is ``{"documents": [...], "datasets": [...]}`` where each entry is
+    a node record with ``id``, ``name`` and ``type``. Datasets are collected by
+    following the ``in_dataset`` edge from each source document.
+    """
+    engine = graph_engine or await get_graph_engine()
+
+    node_connections = await engine.get_connections(str(node_id))
+    documents = _dedupe_by_id(
+        _neighbors_by_relationship(
+            node_connections, node_id, DERIVED_FROM_RELATIONSHIP, outgoing=True
+        )
+    )
+
+    datasets: List[Dict[str, Any]] = []
+    for document in documents:
+        document_id = _node_id(document)
+        document_connections = await engine.get_connections(document_id)
+        datasets.extend(
+            _neighbors_by_relationship(
+                document_connections, document_id, IN_DATASET_RELATIONSHIP, outgoing=True
+            )
+        )
+
+    return {"documents": documents, "datasets": _dedupe_by_id(datasets)}
+
+
+async def get_derived_nodes(source_id: Any, graph_engine=None) -> List[Dict[str, Any]]:
+    """Return the nodes produced from a source (a Document or a Dataset).
+
+    For a Document this is the nodes that have a ``derived_from`` edge to it. For
+    a Dataset this is the documents that have an ``in_dataset`` edge to it. Both
+    are included so the function works for either kind of source.
+    """
+    engine = graph_engine or await get_graph_engine()
+
+    connections = await engine.get_connections(str(source_id))
+    derived = _neighbors_by_relationship(
+        connections, source_id, DERIVED_FROM_RELATIONSHIP, outgoing=False
+    )
+    documents = _neighbors_by_relationship(
+        connections, source_id, IN_DATASET_RELATIONSHIP, outgoing=False
+    )
+    return _dedupe_by_id(derived + documents)

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -168,7 +168,10 @@ def _significant_terms(text: str) -> Set[str]:
 
 
 def format_chunk_references(
-    retrieved_objects: Any, answer: Optional[str] = None, limit: int = 5
+    retrieved_objects: Any,
+    answer: Optional[str] = None,
+    limit: int = 5,
+    dataset_names: Optional[dict] = None,
 ) -> str:
     """Build an Evidence block from retrieved vector payloads, grounded in the answer.
 
@@ -193,6 +196,10 @@ def format_chunk_references(
         None, candidates keep their retrieval order unfiltered.
     limit:
         Desired maximum number of bullets, clamped into the 3-5 range.
+    dataset_names:
+        Optional map of chunk id to source dataset name. When a chunk's dataset
+        is present, the bullet reads "in dataset <name>". When omitted the bullet
+        is rendered exactly as before.
 
     Returns
     -------
@@ -264,13 +271,46 @@ def format_chunk_references(
         candidates.sort(key=lambda candidate: -candidate[0])
 
     max_bullets = _clamp_limit(limit)
-    bullets = [
-        f"- chunk {number} of document {document_name}"
-        f'{_provenance_suffix(data_id, chunk_id)}: "{_snippet(text)}"'
-        for _, document_name, number, text, data_id, chunk_id in candidates[:max_bullets]
-    ]
+    dataset_names = dataset_names or {}
+    bullets = []
+    for _, document_name, number, text, data_id, chunk_id in candidates[:max_bullets]:
+        location = f"chunk {number} of document {document_name}"
+        dataset_name = dataset_names.get(chunk_id)
+        if dataset_name:
+            location += f" in dataset {dataset_name}"
+        bullets.append(f'- {location}{_provenance_suffix(data_id, chunk_id)}: "{_snippet(text)}"')
 
     return EVIDENCE_HEADER + "\n" + "\n".join(bullets)
+
+
+async def _resolve_chunk_datasets(chunks: List[Any]) -> dict:
+    """Map each chunk id to its source dataset name via the lineage edges.
+
+    Uses the provenance lineage query API to follow a chunk up to its dataset.
+    Best-effort: any failure degrades to no dataset, so Evidence still renders.
+    """
+    try:
+        from cognee.modules.graph.methods import get_source_lineage
+    except Exception as error:
+        logger.debug(f"Lineage lookup unavailable for references: {error}")
+        return {}
+
+    dataset_names: dict = {}
+    for chunk in chunks:
+        payload = _get_payload(chunk) or {}
+        chunk_id = _chunk_id(chunk, payload)
+        if not chunk_id or chunk_id in dataset_names:
+            continue
+        try:
+            lineage = await get_source_lineage(chunk_id)
+        except Exception as error:
+            logger.debug(f"Lineage lookup failed for chunk {chunk_id}: {error}")
+            continue
+        datasets = lineage.get("datasets") or []
+        name = _clean_str(datasets[0].get("name")) if datasets else None
+        if name:
+            dataset_names[chunk_id] = name
+    return dataset_names
 
 
 async def build_answer_grounded_chunk_references(
@@ -315,7 +355,10 @@ async def build_answer_grounded_chunk_references(
         logger.debug(f"Answer-grounded chunk search failed: {error}")
         return ""
 
-    return format_chunk_references(found_chunks, answer=cleaned_answer, limit=limit)
+    dataset_names = await _resolve_chunk_datasets(found_chunks)
+    return format_chunk_references(
+        found_chunks, answer=cleaned_answer, limit=limit, dataset_names=dataset_names
+    )
 
 
 def append_chunk_evidence(

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -80,12 +80,10 @@ async def add_data_points(
 
     nodes, edges = deduplicate_nodes_and_edges(nodes, edges)
 
-    # Provenance lineage (on by default): make every node traceable to its source
-    # Document (<node> -derived_from-> Document) and up to its Dataset
-    # (Document -in_dataset-> Dataset). Added before ensure_default_edge_properties
-    # so the lineage edges pick up the same default properties, and before the
-    # upsert block so they are written and forget-tracked through the existing
-    # ledger path.
+    # Add provenance lineage edges so every node is traceable to its source
+    # Document and up to its Dataset. This runs before ensure_default_edge_properties
+    # so the new edges get the same default properties, and before the upsert block
+    # so they are written and tracked for deletion through the existing ledger path.
     lineage_nodes, lineage_edges = build_provenance_lineage(nodes, dataset, data_item)
     nodes.extend(lineage_nodes)
     edges.extend(lineage_edges)

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -14,6 +14,7 @@ from cognee.modules.graph.utils import (
 )
 from .index_data_points import index_data_points
 from .index_graph_edges import index_graph_edges
+from .provenance_lineage import build_dataset_lineage, get_provenance_config
 from cognee.modules.engine.models import Triplet
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.storage.exceptions import (
@@ -78,6 +79,16 @@ async def add_data_points(
         edges.extend(result_edges)
 
     nodes, edges = deduplicate_nodes_and_edges(nodes, edges)
+
+    # Provenance lineage (on by default): add the Dataset tier so every node has
+    # an in-graph path up to its dataset (Document -in_dataset-> Dataset). Added
+    # before ensure_default_edge_properties so the lineage edge picks up the same
+    # default properties, and before the upsert block so it is written and
+    # forget-tracked through the existing ledger path.
+    if get_provenance_config().provenance_lineage:
+        lineage_nodes, lineage_edges = build_dataset_lineage(nodes, dataset, data_item)
+        nodes.extend(lineage_nodes)
+        edges.extend(lineage_edges)
 
     edges = ensure_default_edge_properties(edges, nodes=nodes)
     custom_edges = (

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -14,7 +14,7 @@ from cognee.modules.graph.utils import (
 )
 from .index_data_points import index_data_points
 from .index_graph_edges import index_graph_edges
-from .provenance_lineage import build_dataset_lineage, get_provenance_config
+from .provenance_lineage import build_provenance_lineage
 from cognee.modules.engine.models import Triplet
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.storage.exceptions import (
@@ -80,15 +80,15 @@ async def add_data_points(
 
     nodes, edges = deduplicate_nodes_and_edges(nodes, edges)
 
-    # Provenance lineage (on by default): add the Dataset tier so every node has
-    # an in-graph path up to its dataset (Document -in_dataset-> Dataset). Added
-    # before ensure_default_edge_properties so the lineage edge picks up the same
-    # default properties, and before the upsert block so it is written and
-    # forget-tracked through the existing ledger path.
-    if get_provenance_config().provenance_lineage:
-        lineage_nodes, lineage_edges = build_dataset_lineage(nodes, dataset, data_item)
-        nodes.extend(lineage_nodes)
-        edges.extend(lineage_edges)
+    # Provenance lineage (on by default): make every node traceable to its source
+    # Document (<node> -derived_from-> Document) and up to its Dataset
+    # (Document -in_dataset-> Dataset). Added before ensure_default_edge_properties
+    # so the lineage edges pick up the same default properties, and before the
+    # upsert block so they are written and forget-tracked through the existing
+    # ledger path.
+    lineage_nodes, lineage_edges = build_provenance_lineage(nodes, dataset, data_item)
+    nodes.extend(lineage_nodes)
+    edges.extend(lineage_edges)
 
     edges = ensure_default_edge_properties(edges, nodes=nodes)
     custom_edges = (

--- a/cognee/tasks/storage/provenance_lineage.py
+++ b/cognee/tasks/storage/provenance_lineage.py
@@ -1,56 +1,84 @@
 """Provenance lineage layer: materialize source lineage as first-class graph edges.
 
 Provenance is already captured in three separate places today: ``source_*``
-fields stamped on every DataPoint, the relational ``nodes``/``edges`` ledger
-(``data_id``/``dataset_id`` on every row), and domain edges such as
-``is_part_of`` / ``made_from``. Those give a traversable lineage from an
-extracted node up to its Document, but the chain stops there: a Dataset is not a
-graph node, so there is no in-graph path from a Document to the dataset it
-belongs to.
+fields stamped on every DataPoint (lossy — first write wins), the relational
+``nodes``/``edges`` ledger (``data_id``/``dataset_id`` on every row), and domain
+edges such as ``is_part_of`` / ``made_from`` (schema-specific, and the chain
+stops at the Document — a Dataset is not a graph node). None of these is a single,
+uniform, in-graph contract that answers "what produced this node" for *every*
+node type.
 
-This module adds that missing Dataset tier. For each ingested data item it emits
-one deduplicated ``DatasetNode`` plus a ``Document -in_dataset-> Dataset`` edge,
-so every node can be traced up to its dataset by graph traversal (not only by a
-relational lookup).
+This module adds that contract. For each ingested data item it emits, on top of
+what already exists:
+
+* one ``<node> -derived_from-> Document`` edge for every extracted content node,
+  so every node type (including ones with no domain source edge, e.g.
+  ``EntityType``, or custom-model nodes) is uniformly traceable to its source
+  Document. Because an extracted node that recurs across data items is written
+  once per data item (its id is deterministic), a *merged* node accumulates one
+  ``derived_from`` edge per contributing Document — i.e. many-to-many provenance,
+  the case the lossy ``source_*`` fields get wrong.
+* one deduplicated ``DatasetNode`` plus a ``Document -in_dataset-> Dataset`` edge,
+  completing the chain up to the dataset.
 
 The layer is on by default and configurable via ``PROVENANCE_LINEAGE`` /
 ``PROVENANCE_LINEAGE_DEPTH``. Lineage edges carry a ``provenance=True`` property
-so they form a queryable, reserved contract without relying on a namespaced
-relationship name (relationship names are used as native edge types by some
-backends, e.g. Neo4j, so a plain underscore name is the safe choice).
+so they form a queryable, reserved contract that can be traversed/filtered
+generically, without relying on a namespaced relationship name (relationship
+names are used as native edge types by some backends, e.g. Neo4j, so a plain
+underscore name is the safe choice).
+
+Overhead is bounded: the only new node is the DatasetNode (one per dataset, not
+embedded — it declares no ``index_fields``), and every lineage edge shares a
+constant ``edge_text`` equal to its relationship name, so the N ``derived_from``
+edges collapse to a single embedded ``EdgeType`` in ``index_graph_edges`` rather
+than N distinct ones.
 """
 
 from datetime import datetime, timezone
 from functools import lru_cache
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.engine.models.DatasetNode import DatasetNode
 from cognee.modules.engine.utils import generate_node_id
+from cognee.shared.logging_utils import get_logger
 
-# Relationship name for the Document -> Dataset lineage edge. Kept underscore
-# style (not, e.g., "prov:in") so it is safe as a native relationship type
-# across all graph backends. The reserved-provenance contract is expressed by
-# the ``provenance`` edge property below, not by the relationship name.
+logger = get_logger("provenance_lineage")
+
+# Relationship name for a ``<node> -> Document`` provenance edge.
+DERIVED_FROM_RELATIONSHIP = "derived_from"
+
+# Relationship name for the ``Document -> Dataset`` provenance edge. Kept
+# underscore style (not, e.g., "prov:in") so it is safe as a native relationship
+# type across all graph backends. The reserved-provenance contract is expressed
+# by the ``provenance`` edge property, not by the relationship name.
 IN_DATASET_RELATIONSHIP = "in_dataset"
 
-# Property flag marking an edge as part of the provenance lineage layer, so it
-# can be traversed/filtered generically ("what produced this / what depends on
-# this source") without knowing the domain schema.
+# Property flag marking an edge as part of the provenance lineage layer.
 PROVENANCE_EDGE_FLAG = "provenance"
 
-VALID_DEPTHS = ("chunk", "document", "dataset")
+# Graph node ``type`` values that are structural (not extracted content) and so
+# must not be given a ``derived_from`` edge to a Document. ``DatasetNode`` is the
+# dataset tier itself; ``NodeSet`` is a cross-document tag, so anchoring it to a
+# single Document would be misleading.
+_STRUCTURAL_TYPES = frozenset({"DatasetNode", "NodeSet"})
+
+# Depth controls how far up the synthetic lineage is materialized:
+#   "document" — only ``<node> -derived_from-> Document`` edges.
+#   "dataset"  — also ``Document -in_dataset-> Dataset`` (the default, full chain).
+VALID_DEPTHS = ("document", "dataset")
+DEFAULT_DEPTH = "dataset"
 
 
 class ProvenanceConfig(BaseSettings):
     # PROVENANCE_LINEAGE — when True (default) the base pipeline materializes the
     # source lineage subgraph. False reproduces the pre-lineage behavior exactly.
     provenance_lineage: bool = True
-    # PROVENANCE_LINEAGE_DEPTH — how far up the lineage is materialized. "dataset"
-    # (default) adds the Document -> Dataset tier. Bounds ingest overhead.
-    provenance_lineage_depth: str = "dataset"
+    # PROVENANCE_LINEAGE_DEPTH — "document" or "dataset" (default). See VALID_DEPTHS.
+    provenance_lineage_depth: str = DEFAULT_DEPTH
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
@@ -58,6 +86,34 @@ class ProvenanceConfig(BaseSettings):
 @lru_cache
 def get_provenance_config() -> ProvenanceConfig:
     return ProvenanceConfig()
+
+
+def _normalize_depth(depth: Optional[str]) -> str:
+    """Return a valid depth, falling back to the default for unknown values."""
+    if depth in VALID_DEPTHS:
+        return depth
+    logger.warning("Unknown PROVENANCE_LINEAGE_DEPTH %r; falling back to %r.", depth, DEFAULT_DEPTH)
+    return DEFAULT_DEPTH
+
+
+def _provenance_edge(
+    source_id: Any, target_id: Any, relationship_name: str
+) -> Tuple[Any, Any, str, dict]:
+    """Build a provenance edge tuple in ``(source, target, name, properties)`` shape.
+
+    ``edge_text`` is set to the relationship name (a small constant set) so that
+    ``index_graph_edges`` collapses all edges of one relationship into a single
+    embedded ``EdgeType`` instead of one per edge.
+    """
+    properties = {
+        "source_node_id": source_id,
+        "target_node_id": target_id,
+        "relationship_name": relationship_name,
+        "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+        "edge_text": relationship_name,
+        PROVENANCE_EDGE_FLAG: True,
+    }
+    return (source_id, target_id, relationship_name, properties)
 
 
 def dataset_lineage_node_id(dataset_id: Any):
@@ -69,6 +125,43 @@ def dataset_lineage_node_id(dataset_id: Any):
     return generate_node_id(f"DatasetNode:{dataset_id}")
 
 
+def _is_structural(node: DataPoint) -> bool:
+    return getattr(node, "type", None) in _STRUCTURAL_TYPES
+
+
+def build_source_lineage(
+    nodes: List[DataPoint],
+    data_item: Any,
+) -> List[Tuple[Any, Any, str, dict]]:
+    """Build ``<node> -derived_from-> Document`` edges for every content node.
+
+    The Document graph node id equals ``data_item.id`` (cognify constructs
+    ``Document(id=data_item.id)``). Every node in this batch belongs to that
+    Document, so each content node gets one ``derived_from`` edge to it. The
+    Document node itself and structural nodes (Dataset/NodeSet) are skipped.
+
+    Returns an empty list when the Document node is not present in ``nodes``
+    (nothing to anchor to).
+    """
+    if data_item is None:
+        return []
+    document_id = getattr(data_item, "id", None)
+    if document_id is None:
+        return []
+
+    node_ids = {str(node.id) for node in nodes}
+    if str(document_id) not in node_ids:
+        return []
+
+    document_key = str(document_id)
+    edges = []
+    for node in nodes:
+        if str(node.id) == document_key or _is_structural(node):
+            continue
+        edges.append(_provenance_edge(node.id, document_id, DERIVED_FROM_RELATIONSHIP))
+    return edges
+
+
 def build_dataset_lineage(
     nodes: List[DataPoint],
     dataset: Any,
@@ -76,14 +169,10 @@ def build_dataset_lineage(
 ) -> Tuple[List[DataPoint], List[Tuple[Any, Any, str, dict]]]:
     """Build the Dataset tier of the provenance lineage subgraph.
 
-    Returns ``(extra_nodes, extra_edges)`` to append before the graph write: one
-    deduplicated ``DatasetNode`` plus a ``Document -in_dataset-> Dataset`` edge.
-
-    The Document graph node id equals ``data_item.id`` (cognify constructs
-    ``Document(id=data_item.id)``), so the edge source is ``data_item.id``. The
-    edge is emitted only when that Document node is actually present in
-    ``nodes``, to avoid a dangling endpoint (e.g. custom pipelines that do not
-    materialize a Document node in this batch).
+    Returns ``(extra_nodes, extra_edges)``: one deduplicated ``DatasetNode`` plus
+    a ``Document -in_dataset-> Dataset`` edge. Emitted only when the Document node
+    (id ``== data_item.id``) is present in ``nodes``, to avoid a dangling
+    endpoint (e.g. custom pipelines that do not materialize a Document node).
     """
     if dataset is None or data_item is None:
         return [], []
@@ -95,20 +184,44 @@ def build_dataset_lineage(
 
     node_ids = {str(node.id) for node in nodes}
     if str(document_id) not in node_ids:
-        # No Document node materialized in this batch: nothing to anchor to.
         return [], []
 
     node_id = dataset_lineage_node_id(dataset_id)
     dataset_name = getattr(dataset, "name", None) or str(dataset_id)
     dataset_node = DatasetNode(id=node_id, name=dataset_name)
-
-    edge_properties = {
-        "source_node_id": document_id,
-        "target_node_id": node_id,
-        "relationship_name": IN_DATASET_RELATIONSHIP,
-        "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
-        PROVENANCE_EDGE_FLAG: True,
-    }
-    edge = (document_id, node_id, IN_DATASET_RELATIONSHIP, edge_properties)
+    edge = _provenance_edge(document_id, node_id, IN_DATASET_RELATIONSHIP)
 
     return [dataset_node], [edge]
+
+
+def build_provenance_lineage(
+    nodes: List[DataPoint],
+    dataset: Any,
+    data_item: Any,
+    config: Optional[ProvenanceConfig] = None,
+) -> Tuple[List[DataPoint], List[Tuple[Any, Any, str, dict]]]:
+    """Assemble the full provenance lineage layer for one ``add_data_points`` batch.
+
+    Returns ``(extra_nodes, extra_edges)`` to append to the graph write before the
+    upsert, so the layer is written and forget-tracked through the existing ledger
+    path. Honors ``PROVENANCE_LINEAGE_DEPTH``.
+    """
+    config = config or get_provenance_config()
+    if not config.provenance_lineage:
+        return [], []
+
+    depth = _normalize_depth(config.provenance_lineage_depth)
+
+    extra_nodes: List[DataPoint] = []
+    extra_edges: List[Tuple[Any, Any, str, dict]] = []
+
+    # <node> -derived_from-> Document (both depths).
+    extra_edges.extend(build_source_lineage(nodes, data_item))
+
+    # Document -in_dataset-> Dataset (dataset depth only).
+    if depth == "dataset":
+        dataset_nodes, dataset_edges = build_dataset_lineage(nodes, dataset, data_item)
+        extra_nodes.extend(dataset_nodes)
+        extra_edges.extend(dataset_edges)
+
+    return extra_nodes, extra_edges

--- a/cognee/tasks/storage/provenance_lineage.py
+++ b/cognee/tasks/storage/provenance_lineage.py
@@ -1,38 +1,31 @@
-"""Provenance lineage layer: materialize source lineage as first-class graph edges.
+"""Provenance lineage layer.
 
-Provenance is already captured in three separate places today: ``source_*``
-fields stamped on every DataPoint (lossy — first write wins), the relational
-``nodes``/``edges`` ledger (``data_id``/``dataset_id`` on every row), and domain
-edges such as ``is_part_of`` / ``made_from`` (schema-specific, and the chain
-stops at the Document — a Dataset is not a graph node). None of these is a single,
-uniform, in-graph contract that answers "what produced this node" for *every*
-node type.
+This layer records where each graph node came from by adding explicit lineage
+edges during ingestion:
 
-This module adds that contract. For each ingested data item it emits, on top of
-what already exists:
+    <node> -derived_from-> Document -in_dataset-> Dataset
 
-* one ``<node> -derived_from-> Document`` edge for every extracted content node,
-  so every node type (including ones with no domain source edge, e.g.
-  ``EntityType``, or custom-model nodes) is uniformly traceable to its source
-  Document. Because an extracted node that recurs across data items is written
-  once per data item (its id is deterministic), a *merged* node accumulates one
-  ``derived_from`` edge per contributing Document — i.e. many-to-many provenance,
-  the case the lossy ``source_*`` fields get wrong.
-* one deduplicated ``DatasetNode`` plus a ``Document -in_dataset-> Dataset`` edge,
-  completing the chain up to the dataset.
+Cognee already stamps ``source_*`` fields on data points and stores
+``data_id``/``dataset_id`` on the relational node and edge rows, but those fields
+only keep the first source and a Dataset is not represented as a graph node. This
+module fills both gaps. Every extracted node gets a ``derived_from`` edge to its
+source Document, and each Document gets an ``in_dataset`` edge to a single shared
+Dataset node. Because a node that recurs across data items is written once per
+data item, a merged node ends up with one ``derived_from`` edge per contributing
+Document, which is the many-to-many case the ``source_*`` fields cannot express.
 
-The layer is on by default and configurable via ``PROVENANCE_LINEAGE`` /
-``PROVENANCE_LINEAGE_DEPTH``. Lineage edges carry a ``provenance=True`` property
-so they form a queryable, reserved contract that can be traversed/filtered
-generically, without relying on a namespaced relationship name (relationship
-names are used as native edge types by some backends, e.g. Neo4j, so a plain
-underscore name is the safe choice).
+The layer is on by default and is controlled by ``PROVENANCE_LINEAGE`` and
+``PROVENANCE_LINEAGE_DEPTH``. Every lineage edge carries a ``provenance=True``
+property so callers can traverse or filter the layer without knowing the domain
+schema. The relationship names use underscores rather than a namespaced form
+(for example ``prov:in``) because some backends, such as Neo4j, use the
+relationship name as a native edge type.
 
-Overhead is bounded: the only new node is the DatasetNode (one per dataset, not
-embedded — it declares no ``index_fields``), and every lineage edge shares a
-constant ``edge_text`` equal to its relationship name, so the N ``derived_from``
-edges collapse to a single embedded ``EdgeType`` in ``index_graph_edges`` rather
-than N distinct ones.
+The overhead is small. The only new node is the Dataset node (one per dataset,
+and it is not embedded because it declares no ``index_fields``). Every lineage
+edge shares a constant ``edge_text`` equal to its relationship name, so the
+``derived_from`` edges collapse to a single embedded ``EdgeType`` in
+``index_graph_edges`` instead of one per edge.
 """
 
 from datetime import datetime, timezone
@@ -48,36 +41,33 @@ from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("provenance_lineage")
 
-# Relationship name for a ``<node> -> Document`` provenance edge.
+# Relationship name for a <node> -> Document provenance edge.
 DERIVED_FROM_RELATIONSHIP = "derived_from"
 
-# Relationship name for the ``Document -> Dataset`` provenance edge. Kept
-# underscore style (not, e.g., "prov:in") so it is safe as a native relationship
-# type across all graph backends. The reserved-provenance contract is expressed
-# by the ``provenance`` edge property, not by the relationship name.
+# Relationship name for the Document -> Dataset provenance edge.
 IN_DATASET_RELATIONSHIP = "in_dataset"
 
-# Property flag marking an edge as part of the provenance lineage layer.
+# Edge property that marks an edge as part of the provenance lineage layer.
 PROVENANCE_EDGE_FLAG = "provenance"
 
-# Graph node ``type`` values that are structural (not extracted content) and so
-# must not be given a ``derived_from`` edge to a Document. ``DatasetNode`` is the
-# dataset tier itself; ``NodeSet`` is a cross-document tag, so anchoring it to a
-# single Document would be misleading.
+# Graph node types that are structural rather than extracted content. They do not
+# get a derived_from edge to a Document. DatasetNode is the dataset tier itself,
+# and NodeSet is a tag that spans documents, so anchoring it to one document would
+# be misleading.
 _STRUCTURAL_TYPES = frozenset({"DatasetNode", "NodeSet"})
 
-# Depth controls how far up the synthetic lineage is materialized:
-#   "document" — only ``<node> -derived_from-> Document`` edges.
-#   "dataset"  — also ``Document -in_dataset-> Dataset`` (the default, full chain).
+# Depth controls how far up the lineage is built. "document" adds only the
+# <node> -> Document edges. "dataset" also adds the Document -> Dataset edge and
+# is the default.
 VALID_DEPTHS = ("document", "dataset")
 DEFAULT_DEPTH = "dataset"
 
 
 class ProvenanceConfig(BaseSettings):
-    # PROVENANCE_LINEAGE — when True (default) the base pipeline materializes the
-    # source lineage subgraph. False reproduces the pre-lineage behavior exactly.
+    # When True (the default) the base pipeline builds the lineage layer. Set to
+    # False to reproduce the pre-lineage graph exactly.
     provenance_lineage: bool = True
-    # PROVENANCE_LINEAGE_DEPTH — "document" or "dataset" (default). See VALID_DEPTHS.
+    # How far up the lineage is built: "document" or "dataset" (the default).
     provenance_lineage_depth: str = DEFAULT_DEPTH
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
@@ -99,11 +89,11 @@ def _normalize_depth(depth: Optional[str]) -> str:
 def _provenance_edge(
     source_id: Any, target_id: Any, relationship_name: str
 ) -> Tuple[Any, Any, str, dict]:
-    """Build a provenance edge tuple in ``(source, target, name, properties)`` shape.
+    """Build a provenance edge tuple of (source, target, name, properties).
 
-    ``edge_text`` is set to the relationship name (a small constant set) so that
-    ``index_graph_edges`` collapses all edges of one relationship into a single
-    embedded ``EdgeType`` instead of one per edge.
+    edge_text is set to the relationship name so that index_graph_edges, which
+    embeds distinct edge_text values, collapses all edges of one relationship
+    into a single EdgeType instead of one per edge.
     """
     properties = {
         "source_node_id": source_id,
@@ -117,10 +107,10 @@ def _provenance_edge(
 
 
 def dataset_lineage_node_id(dataset_id: Any):
-    """Deterministic id for a dataset's lineage node.
+    """Return the deterministic id for a dataset's lineage node.
 
-    Derived from the dataset id so a single DatasetNode is shared across every
-    data item in the dataset (one Dataset node, not one per document).
+    The id is derived from the dataset id so a single Dataset node is shared
+    across every data item in the dataset.
     """
     return generate_node_id(f"DatasetNode:{dataset_id}")
 
@@ -133,15 +123,15 @@ def build_source_lineage(
     nodes: List[DataPoint],
     data_item: Any,
 ) -> List[Tuple[Any, Any, str, dict]]:
-    """Build ``<node> -derived_from-> Document`` edges for every content node.
+    """Build a derived_from edge from every content node to its source Document.
 
-    The Document graph node id equals ``data_item.id`` (cognify constructs
-    ``Document(id=data_item.id)``). Every node in this batch belongs to that
-    Document, so each content node gets one ``derived_from`` edge to it. The
-    Document node itself and structural nodes (Dataset/NodeSet) are skipped.
+    The Document node id equals ``data_item.id`` because cognify constructs the
+    Document with ``id=data_item.id``. Every node in this batch belongs to that
+    Document, so each content node gets one derived_from edge to it. The Document
+    node itself and structural nodes such as Dataset and NodeSet are skipped.
 
-    Returns an empty list when the Document node is not present in ``nodes``
-    (nothing to anchor to).
+    Returns an empty list when the Document node is not present in ``nodes``,
+    which avoids creating an edge with a missing endpoint.
     """
     if data_item is None:
         return []
@@ -167,12 +157,12 @@ def build_dataset_lineage(
     dataset: Any,
     data_item: Any,
 ) -> Tuple[List[DataPoint], List[Tuple[Any, Any, str, dict]]]:
-    """Build the Dataset tier of the provenance lineage subgraph.
+    """Build the dataset tier: a Dataset node and a Document -> Dataset edge.
 
-    Returns ``(extra_nodes, extra_edges)``: one deduplicated ``DatasetNode`` plus
-    a ``Document -in_dataset-> Dataset`` edge. Emitted only when the Document node
-    (id ``== data_item.id``) is present in ``nodes``, to avoid a dangling
-    endpoint (e.g. custom pipelines that do not materialize a Document node).
+    Returns ``(extra_nodes, extra_edges)`` with one shared Dataset node and one
+    ``in_dataset`` edge. The edge is produced only when the Document node
+    (id ``== data_item.id``) is present in ``nodes``, which avoids creating an
+    edge with a missing endpoint for pipelines that do not materialize a Document.
     """
     if dataset is None or data_item is None:
         return [], []
@@ -200,11 +190,11 @@ def build_provenance_lineage(
     data_item: Any,
     config: Optional[ProvenanceConfig] = None,
 ) -> Tuple[List[DataPoint], List[Tuple[Any, Any, str, dict]]]:
-    """Assemble the full provenance lineage layer for one ``add_data_points`` batch.
+    """Build the full lineage layer for one add_data_points batch.
 
-    Returns ``(extra_nodes, extra_edges)`` to append to the graph write before the
-    upsert, so the layer is written and forget-tracked through the existing ledger
-    path. Honors ``PROVENANCE_LINEAGE_DEPTH``.
+    Returns ``(extra_nodes, extra_edges)`` to append before the upsert, so the
+    edges are written and tracked for deletion through the existing ledger path.
+    The result respects ``PROVENANCE_LINEAGE_DEPTH``.
     """
     config = config or get_provenance_config()
     if not config.provenance_lineage:
@@ -215,10 +205,8 @@ def build_provenance_lineage(
     extra_nodes: List[DataPoint] = []
     extra_edges: List[Tuple[Any, Any, str, dict]] = []
 
-    # <node> -derived_from-> Document (both depths).
     extra_edges.extend(build_source_lineage(nodes, data_item))
 
-    # Document -in_dataset-> Dataset (dataset depth only).
     if depth == "dataset":
         dataset_nodes, dataset_edges = build_dataset_lineage(nodes, dataset, data_item)
         extra_nodes.extend(dataset_nodes)

--- a/cognee/tasks/storage/provenance_lineage.py
+++ b/cognee/tasks/storage/provenance_lineage.py
@@ -1,0 +1,114 @@
+"""Provenance lineage layer: materialize source lineage as first-class graph edges.
+
+Provenance is already captured in three separate places today: ``source_*``
+fields stamped on every DataPoint, the relational ``nodes``/``edges`` ledger
+(``data_id``/``dataset_id`` on every row), and domain edges such as
+``is_part_of`` / ``made_from``. Those give a traversable lineage from an
+extracted node up to its Document, but the chain stops there: a Dataset is not a
+graph node, so there is no in-graph path from a Document to the dataset it
+belongs to.
+
+This module adds that missing Dataset tier. For each ingested data item it emits
+one deduplicated ``DatasetNode`` plus a ``Document -in_dataset-> Dataset`` edge,
+so every node can be traced up to its dataset by graph traversal (not only by a
+relational lookup).
+
+The layer is on by default and configurable via ``PROVENANCE_LINEAGE`` /
+``PROVENANCE_LINEAGE_DEPTH``. Lineage edges carry a ``provenance=True`` property
+so they form a queryable, reserved contract without relying on a namespaced
+relationship name (relationship names are used as native edge types by some
+backends, e.g. Neo4j, so a plain underscore name is the safe choice).
+"""
+
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import Any, List, Tuple
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.engine.models.DatasetNode import DatasetNode
+from cognee.modules.engine.utils import generate_node_id
+
+# Relationship name for the Document -> Dataset lineage edge. Kept underscore
+# style (not, e.g., "prov:in") so it is safe as a native relationship type
+# across all graph backends. The reserved-provenance contract is expressed by
+# the ``provenance`` edge property below, not by the relationship name.
+IN_DATASET_RELATIONSHIP = "in_dataset"
+
+# Property flag marking an edge as part of the provenance lineage layer, so it
+# can be traversed/filtered generically ("what produced this / what depends on
+# this source") without knowing the domain schema.
+PROVENANCE_EDGE_FLAG = "provenance"
+
+VALID_DEPTHS = ("chunk", "document", "dataset")
+
+
+class ProvenanceConfig(BaseSettings):
+    # PROVENANCE_LINEAGE — when True (default) the base pipeline materializes the
+    # source lineage subgraph. False reproduces the pre-lineage behavior exactly.
+    provenance_lineage: bool = True
+    # PROVENANCE_LINEAGE_DEPTH — how far up the lineage is materialized. "dataset"
+    # (default) adds the Document -> Dataset tier. Bounds ingest overhead.
+    provenance_lineage_depth: str = "dataset"
+
+    model_config = SettingsConfigDict(env_file=".env", extra="allow")
+
+
+@lru_cache
+def get_provenance_config() -> ProvenanceConfig:
+    return ProvenanceConfig()
+
+
+def dataset_lineage_node_id(dataset_id: Any):
+    """Deterministic id for a dataset's lineage node.
+
+    Derived from the dataset id so a single DatasetNode is shared across every
+    data item in the dataset (one Dataset node, not one per document).
+    """
+    return generate_node_id(f"DatasetNode:{dataset_id}")
+
+
+def build_dataset_lineage(
+    nodes: List[DataPoint],
+    dataset: Any,
+    data_item: Any,
+) -> Tuple[List[DataPoint], List[Tuple[Any, Any, str, dict]]]:
+    """Build the Dataset tier of the provenance lineage subgraph.
+
+    Returns ``(extra_nodes, extra_edges)`` to append before the graph write: one
+    deduplicated ``DatasetNode`` plus a ``Document -in_dataset-> Dataset`` edge.
+
+    The Document graph node id equals ``data_item.id`` (cognify constructs
+    ``Document(id=data_item.id)``), so the edge source is ``data_item.id``. The
+    edge is emitted only when that Document node is actually present in
+    ``nodes``, to avoid a dangling endpoint (e.g. custom pipelines that do not
+    materialize a Document node in this batch).
+    """
+    if dataset is None or data_item is None:
+        return [], []
+
+    dataset_id = getattr(dataset, "id", None)
+    document_id = getattr(data_item, "id", None)
+    if dataset_id is None or document_id is None:
+        return [], []
+
+    node_ids = {str(node.id) for node in nodes}
+    if str(document_id) not in node_ids:
+        # No Document node materialized in this batch: nothing to anchor to.
+        return [], []
+
+    node_id = dataset_lineage_node_id(dataset_id)
+    dataset_name = getattr(dataset, "name", None) or str(dataset_id)
+    dataset_node = DatasetNode(id=node_id, name=dataset_name)
+
+    edge_properties = {
+        "source_node_id": document_id,
+        "target_node_id": node_id,
+        "relationship_name": IN_DATASET_RELATIONSHIP,
+        "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+        PROVENANCE_EDGE_FLAG: True,
+    }
+    edge = (document_id, node_id, IN_DATASET_RELATIONSHIP, edge_properties)
+
+    return [dataset_node], [edge]

--- a/cognee/tests/test_provenance_lineage_default_graph.py
+++ b/cognee/tests/test_provenance_lineage_default_graph.py
@@ -26,6 +26,7 @@ import pytest
 import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import set_database_global_context_variables
+from cognee.infrastructure.databases.vector import get_vector_engine
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.modules.data.processing.document_types.TextDocument import TextDocument
@@ -35,6 +36,7 @@ from cognee.modules.engine.operations.setup import setup
 from cognee.modules.users.methods import get_default_user
 from cognee.shared.data_models import KnowledgeGraph, Node, Edge, SummarizedContent
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.retrieval.utils.references import build_answer_grounded_chunk_references
 from cognee.tasks.storage.provenance_lineage import (
     DERIVED_FROM_RELATIONSHIP,
     IN_DATASET_RELATIONSHIP,
@@ -214,6 +216,13 @@ async def main(mock_create_structured_output: AsyncMock):
     # Many-to-many: the shared entity derives from BOTH documents.
     await assert_graph_edges_present(_derived_from(shared_entities, johns_document.id))
     await assert_graph_edges_present(_derived_from(shared_entities, maries_document.id))
+
+    # Provenance survives recall: an answer-grounded reference follows the lineage
+    # edges back to the source dataset.
+    evidence = await build_answer_grounded_chunk_references(
+        "John works for Apple", get_vector_engine()
+    )
+    assert "in dataset main_dataset" in evidence
 
     # ── Delete John's data: John's lineage gone, shared + Marie survive ───────
 

--- a/cognee/tests/test_provenance_lineage_default_graph.py
+++ b/cognee/tests/test_provenance_lineage_default_graph.py
@@ -1,0 +1,252 @@
+"""End-to-end provenance lineage test on the default graph (mocked LLM).
+
+Runs a real ``add`` + ``cognify`` with a mocked LLM (deterministic, per the
+#3601 harness) over two documents that share an entity ("Apple"), then asserts
+the provenance lineage layer added by ``cognee.tasks.storage.provenance_lineage``:
+
+* every extracted node has a ``derived_from`` edge to its source Document;
+* each Document has an ``in_dataset`` edge to a single shared ``DatasetNode``;
+* the shared entity has ``derived_from`` edges to BOTH documents (many-to-many);
+* deleting one document removes exactly that document's lineage while the shared
+  entity (co-owned) and the other document's lineage survive;
+* deleting the last document removes the remaining lineage and the DatasetNode.
+
+Like the sibling ``test_delete_default_graph.py`` this is a standalone script
+(``main`` is not collected by pytest) and runs in the e2e CI workflow, which
+provides the embedding backend.
+"""
+
+import os
+import pathlib
+from uuid import NAMESPACE_OID, uuid5
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import cognee
+from cognee.api.v1.datasets import datasets
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.infrastructure.llm import LLMGateway
+from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
+from cognee.modules.data.processing.document_types.TextDocument import TextDocument
+from cognee.modules.engine.models import Entity
+from cognee.modules.engine.models.DatasetNode import DatasetNode
+from cognee.modules.engine.operations.setup import setup
+from cognee.modules.users.methods import get_default_user
+from cognee.shared.data_models import KnowledgeGraph, Node, Edge, SummarizedContent
+from cognee.shared.logging_utils import get_logger
+from cognee.tasks.storage.provenance_lineage import (
+    DERIVED_FROM_RELATIONSHIP,
+    IN_DATASET_RELATIONSHIP,
+    dataset_lineage_node_id,
+)
+from cognee.tests.utils.assert_graph_edges_not_present import assert_graph_edges_not_present
+from cognee.tests.utils.assert_graph_edges_present import assert_graph_edges_present
+from cognee.tests.utils.assert_graph_nodes_not_present import assert_graph_nodes_not_present
+from cognee.tests.utils.assert_graph_nodes_present import assert_graph_nodes_present
+from cognee.tests.utils.extract_entities import extract_entities
+from cognee.tests.utils.extract_summary import extract_summary
+from cognee.tests.utils.filter_overlapping_entities import filter_overlapping_entities
+
+logger = get_logger()
+
+
+def _derived_from(nodes, document_id):
+    """Provenance edges: each content node -derived_from-> its Document."""
+    return [(node.id, document_id, DERIVED_FROM_RELATIONSHIP) for node in nodes]
+
+
+@pytest.mark.asyncio
+@patch.object(LLMGateway, "acreate_structured_output", new_callable=AsyncMock)
+async def main(mock_create_structured_output: AsyncMock):
+    data_directory_path = os.path.join(
+        pathlib.Path(__file__).parent, ".data_storage/test_provenance_lineage_default_graph"
+    )
+    cognee.config.data_root_directory(data_directory_path)
+
+    cognee_directory_path = os.path.join(
+        pathlib.Path(__file__).parent, ".cognee_system/test_provenance_lineage_default_graph"
+    )
+    cognee.config.system_root_directory(cognee_directory_path)
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await setup()
+
+    def mock_llm_output(text_input: str, system_prompt: str, response_model):
+        if text_input == "test":  # LLM connection test
+            return "test"
+
+        if "John" in text_input and response_model == SummarizedContent:
+            return SummarizedContent(
+                summary="Summary of John's work.", description="Summary of John's work."
+            )
+        if "Marie" in text_input and response_model == SummarizedContent:
+            return SummarizedContent(
+                summary="Summary of Marie's work.", description="Summary of Marie's work."
+            )
+
+        if "Marie" in text_input and response_model == KnowledgeGraph:
+            return KnowledgeGraph(
+                nodes=[
+                    Node(id="Marie", name="Marie", type="Person", description="Marie is a person"),
+                    Node(
+                        id="Apple", name="Apple", type="Company", description="Apple is a company"
+                    ),
+                    Node(
+                        id="MacOS",
+                        name="MacOS",
+                        type="Product",
+                        description="MacOS is Apple's operating system",
+                    ),
+                ],
+                edges=[
+                    Edge(
+                        source_node_id="Marie",
+                        target_node_id="Apple",
+                        relationship_name="works_for",
+                    ),
+                    Edge(
+                        source_node_id="Marie", target_node_id="MacOS", relationship_name="works_on"
+                    ),
+                ],
+            )
+        if "John" in text_input and response_model == KnowledgeGraph:
+            return KnowledgeGraph(
+                nodes=[
+                    Node(id="John", name="John", type="Person", description="John is a person"),
+                    Node(
+                        id="Apple", name="Apple", type="Company", description="Apple is a company"
+                    ),
+                    Node(
+                        id="Food for Hungry",
+                        name="Food for Hungry",
+                        type="Non-profit organization",
+                        description="Food for Hungry is a non-profit organization",
+                    ),
+                ],
+                edges=[
+                    Edge(
+                        source_node_id="John", target_node_id="Apple", relationship_name="works_for"
+                    ),
+                    Edge(
+                        source_node_id="John",
+                        target_node_id="Food for Hungry",
+                        relationship_name="works_for",
+                    ),
+                ],
+            )
+
+    mock_create_structured_output.side_effect = mock_llm_output
+
+    user = await get_default_user()
+    await set_database_global_context_variables("main_dataset", user.id)
+
+    johns_text = "John works for Apple. He is also affiliated with a non-profit organization called 'Food for Hungry'"
+    johns_data_id = (await cognee.add(johns_text)).data_ingestion_info[0]["data_id"]
+
+    maries_text = "Marie works for Apple as well. She is a software engineer on MacOS project."
+    maries_data_id = (await cognee.add(maries_text)).data_ingestion_info[0]["data_id"]
+
+    cognify_result: dict = await cognee.cognify()
+    dataset_id = list(cognify_result.keys())[0]
+    dataset_node_id = dataset_lineage_node_id(dataset_id)
+
+    # Reconstruct the graph objects deterministically (same ids the pipeline used).
+    johns_document = TextDocument(
+        id=johns_data_id,
+        name="John's Work",
+        raw_data_location="johns_data_location",
+        external_metadata="",
+    )
+    johns_chunk = DocumentChunk(
+        id=uuid5(NAMESPACE_OID, f"{str(johns_data_id)}-0"),
+        text=johns_text,
+        chunk_size=14,
+        chunk_index=0,
+        cut_type="sentence_end",
+        is_part_of=johns_document,
+    )
+    johns_summary = extract_summary(johns_chunk, mock_llm_output("John", "", SummarizedContent))  # type: ignore
+
+    maries_document = TextDocument(
+        id=maries_data_id,
+        name="Marie's Work",
+        raw_data_location="maries_data_location",
+        external_metadata="",
+    )
+    maries_chunk = DocumentChunk(
+        id=uuid5(NAMESPACE_OID, f"{str(maries_data_id)}-0"),
+        text=maries_text,
+        chunk_size=14,
+        chunk_index=0,
+        cut_type="sentence_end",
+        is_part_of=maries_document,
+    )
+    maries_summary = extract_summary(maries_chunk, mock_llm_output("Marie", "", SummarizedContent))  # type: ignore
+
+    johns_entities = extract_entities(mock_llm_output("John", "", KnowledgeGraph))  # type: ignore
+    maries_entities = extract_entities(mock_llm_output("Marie", "", KnowledgeGraph))  # type: ignore
+    overlapping_entities, johns_entities, maries_entities = filter_overlapping_entities(
+        johns_entities, maries_entities
+    )
+    # "Apple" is extracted from both documents, so it is a shared/merged node.
+    shared_entities = [e for e in overlapping_entities if isinstance(e, Entity)]
+
+    johns_nodes = [johns_chunk, johns_summary, *johns_entities]
+    maries_nodes = [maries_chunk, maries_summary, *maries_entities]
+
+    # ── After cognify: full lineage present ──────────────────────────────────
+
+    # One shared DatasetNode, reachable from both documents.
+    await assert_graph_nodes_present([DatasetNode(id=dataset_node_id, name="main_dataset")])
+    await assert_graph_edges_present(
+        [
+            (johns_document.id, dataset_node_id, IN_DATASET_RELATIONSHIP),
+            (maries_document.id, dataset_node_id, IN_DATASET_RELATIONSHIP),
+        ]
+    )
+
+    # Every extracted node traces to its source Document.
+    await assert_graph_edges_present(_derived_from(johns_nodes, johns_document.id))
+    await assert_graph_edges_present(_derived_from(maries_nodes, maries_document.id))
+
+    # Many-to-many: the shared entity derives from BOTH documents.
+    await assert_graph_edges_present(_derived_from(shared_entities, johns_document.id))
+    await assert_graph_edges_present(_derived_from(shared_entities, maries_document.id))
+
+    # ── Delete John's data: John's lineage gone, shared + Marie survive ───────
+
+    await datasets.delete_data(dataset_id, johns_data_id, user)  # type: ignore
+
+    await assert_graph_edges_not_present(_derived_from(johns_nodes, johns_document.id))
+    await assert_graph_edges_not_present(
+        [(johns_document.id, dataset_node_id, IN_DATASET_RELATIONSHIP)]
+    )
+    # The shared entity loses its John anchor but keeps its Marie anchor.
+    await assert_graph_edges_not_present(_derived_from(shared_entities, johns_document.id))
+    await assert_graph_nodes_present(shared_entities)
+    await assert_graph_edges_present(_derived_from(shared_entities, maries_document.id))
+
+    # Marie's lineage and the shared DatasetNode remain intact.
+    await assert_graph_edges_present(_derived_from(maries_nodes, maries_document.id))
+    await assert_graph_edges_present(
+        [(maries_document.id, dataset_node_id, IN_DATASET_RELATIONSHIP)]
+    )
+    await assert_graph_nodes_present([DatasetNode(id=dataset_node_id, name="main_dataset")])
+
+    # ── Delete Marie's data: everything provenance-related gone ───────────────
+
+    await datasets.delete_data(dataset_id, maries_data_id, user)  # type: ignore
+
+    await assert_graph_edges_not_present(_derived_from(maries_nodes, maries_document.id))
+    await assert_graph_edges_not_present(
+        [(maries_document.id, dataset_node_id, IN_DATASET_RELATIONSHIP)]
+    )
+    await assert_graph_nodes_not_present([DatasetNode(id=dataset_node_id, name="main_dataset")])
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/cognee/tests/unit/api/test_memory_provenance.py
+++ b/cognee/tests/unit/api/test_memory_provenance.py
@@ -116,3 +116,41 @@ def test_dangling_references_are_skipped():
         datasets=[{"id": "D1", "name": "Fleet", "owner_id": "U9", "tenant_id": "T"}],
     )
     assert not any(t == "dataset:D1" and rel == "owns" for _, t, rel in edges)
+
+
+def test_lineage_edges_render_in_memory_layer():
+    _, edges = _build(
+        memory={
+            "nodes": [
+                ("alice", {"type": "Entity", "name": "Alice"}),
+                ("doc1", {"type": "TextDocument", "name": "a.txt"}),
+                ("dsnode", {"type": "DatasetNode", "name": "Fleet Ops"}),
+            ],
+            "edges": [
+                ("alice", "doc1", "derived_from", {}),
+                ("doc1", "dsnode", "in_dataset", {}),
+            ],
+            "aliases": {"dsnode": "dataset:D1"},
+        }
+    )
+    assert ("alice", "doc1", "derived_from") in edges
+    # in_dataset is redirected onto the actor dataset node.
+    assert ("doc1", "dataset:D1", "in_dataset") in edges
+
+
+def test_lineage_dataset_node_collapses_onto_actor_dataset():
+    node_types, edges = _build(
+        memory={
+            "nodes": [
+                ("doc1", {"type": "TextDocument", "name": "a.txt"}),
+                ("dsnode", {"type": "DatasetNode", "name": "Fleet Ops"}),
+            ],
+            "edges": [("doc1", "dsnode", "in_dataset", {})],
+            "aliases": {"dsnode": "dataset:D1"},
+        }
+    )
+    # The memory DatasetNode is not added as its own node.
+    assert "dsnode" not in node_types
+    # The actor dataset node stays and receives the in_dataset edge.
+    assert node_types["dataset:D1"] == "Dataset"
+    assert ("doc1", "dataset:D1", "in_dataset") in edges

--- a/cognee/tests/unit/modules/graph/test_get_node_lineage.py
+++ b/cognee/tests/unit/modules/graph/test_get_node_lineage.py
@@ -1,0 +1,122 @@
+"""Unit tests for the provenance lineage query API.
+
+These use a small fake graph engine so they stay offline and deterministic. The
+fake returns connections in the same shape as ``get_connections``: a list of
+``(node, edge, neighbor)`` tuples where the edge dict carries ``relationship_name``,
+``source_node_id`` and ``target_node_id``.
+"""
+
+import pytest
+
+from cognee.modules.graph.methods.get_node_lineage import (
+    get_derived_nodes,
+    get_source_lineage,
+)
+from cognee.tasks.storage.provenance_lineage import (
+    DERIVED_FROM_RELATIONSHIP,
+    IN_DATASET_RELATIONSHIP,
+)
+
+
+def _node(node_id, name, node_type):
+    return {"id": node_id, "name": name, "type": node_type}
+
+
+def _edge(source_id, target_id, relationship_name):
+    return {
+        "relationship_name": relationship_name,
+        "source_node_id": source_id,
+        "target_node_id": target_id,
+    }
+
+
+class FakeGraphEngine:
+    """Returns canned connections keyed by the queried node id.
+
+    ``connections[node_id]`` is a list of ``(node, edge, neighbor)`` tuples, with
+    the queried node as the first element (matching the default backend).
+    """
+
+    def __init__(self, connections):
+        self.connections = connections
+
+    async def get_connections(self, node_id):
+        return self.connections.get(str(node_id), [])
+
+
+# A small graph:
+#   alice -derived_from-> doc1 -in_dataset-> ds
+#   bob   -derived_from-> doc1
+# alice is a shared entity that also appears in doc2 -in_dataset-> ds.
+DS = _node("ds", "fleet_ops", "DatasetNode")
+DOC1 = _node("doc1", "a.txt", "TextDocument")
+DOC2 = _node("doc2", "b.txt", "TextDocument")
+ALICE = _node("alice", "Alice", "Entity")
+BOB = _node("bob", "Bob", "Entity")
+
+
+def _engine():
+    return FakeGraphEngine(
+        {
+            "alice": [
+                (ALICE, _edge("alice", "doc1", DERIVED_FROM_RELATIONSHIP), DOC1),
+                (ALICE, _edge("alice", "doc2", DERIVED_FROM_RELATIONSHIP), DOC2),
+            ],
+            "bob": [
+                (BOB, _edge("bob", "doc1", DERIVED_FROM_RELATIONSHIP), DOC1),
+            ],
+            "doc1": [
+                (DOC1, _edge("alice", "doc1", DERIVED_FROM_RELATIONSHIP), ALICE),
+                (DOC1, _edge("bob", "doc1", DERIVED_FROM_RELATIONSHIP), BOB),
+                (DOC1, _edge("doc1", "ds", IN_DATASET_RELATIONSHIP), DS),
+            ],
+            "doc2": [
+                (DOC2, _edge("alice", "doc2", DERIVED_FROM_RELATIONSHIP), ALICE),
+                (DOC2, _edge("doc2", "ds", IN_DATASET_RELATIONSHIP), DS),
+            ],
+            "ds": [
+                (DS, _edge("doc1", "ds", IN_DATASET_RELATIONSHIP), DOC1),
+                (DS, _edge("doc2", "ds", IN_DATASET_RELATIONSHIP), DOC2),
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_source_lineage_returns_documents_and_datasets():
+    lineage = await get_source_lineage("alice", graph_engine=_engine())
+
+    assert {d["id"] for d in lineage["documents"]} == {"doc1", "doc2"}
+    assert {d["id"] for d in lineage["datasets"]} == {"ds"}
+
+
+@pytest.mark.asyncio
+async def test_source_lineage_deduplicates_shared_dataset():
+    """alice derives from two documents in the same dataset; ds appears once."""
+    lineage = await get_source_lineage("alice", graph_engine=_engine())
+    assert len(lineage["datasets"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_source_lineage_empty_for_node_without_lineage():
+    lineage = await get_source_lineage("unknown", graph_engine=_engine())
+    assert lineage == {"documents": [], "datasets": []}
+
+
+@pytest.mark.asyncio
+async def test_derived_nodes_for_document():
+    derived = await get_derived_nodes("doc1", graph_engine=_engine())
+    assert {n["id"] for n in derived} == {"alice", "bob"}
+
+
+@pytest.mark.asyncio
+async def test_derived_nodes_for_dataset_returns_documents():
+    derived = await get_derived_nodes("ds", graph_engine=_engine())
+    assert {n["id"] for n in derived} == {"doc1", "doc2"}
+
+
+@pytest.mark.asyncio
+async def test_derived_nodes_ignores_outgoing_edges():
+    """Querying a leaf entity yields nothing (its derived_from is outgoing)."""
+    derived = await get_derived_nodes("alice", graph_engine=_engine())
+    assert derived == []

--- a/cognee/tests/unit/modules/retrieval/test_references_helpers.py
+++ b/cognee/tests/unit/modules/retrieval/test_references_helpers.py
@@ -71,6 +71,26 @@ def test_format_chunk_references_includes_data_id_and_chunk_id():
     )
 
 
+def test_format_chunk_references_includes_dataset_when_provided():
+    """A chunk's source dataset is rendered when its name is supplied."""
+    result = format_chunk_references(
+        [_payload(id="chunk-9")], dataset_names={"chunk-9": "Fleet Ops"}
+    )
+
+    assert (
+        "- chunk 5 of document annual_report.pdf in dataset Fleet Ops (chunk_id: chunk-9):"
+        in result
+    )
+
+
+def test_format_chunk_references_omits_dataset_when_absent():
+    """Without a dataset mapping the bullet is unchanged (backward compatible)."""
+    result = format_chunk_references([_payload(id="chunk-9")])
+
+    assert "in dataset" not in result
+    assert "- chunk 5 of document annual_report.pdf (chunk_id: chunk-9):" in result
+
+
 def test_format_chunk_references_empty_when_document_name_missing():
     """Old-data case: missing document_name -> entry skipped -> empty string."""
     payload = _payload()

--- a/cognee/tests/unit/tasks/storage/test_provenance_lineage.py
+++ b/cognee/tests/unit/tasks/storage/test_provenance_lineage.py
@@ -1,7 +1,8 @@
-"""Unit tests for the Dataset tier of the provenance lineage layer.
+"""Unit tests for the provenance lineage layer.
 
-Pure and DB/LLM-free: they exercise ``build_dataset_lineage`` directly on plain
-DataPoints and lightweight dataset/data-item stand-ins.
+Pure and DB/LLM-free: they exercise the lineage builders (source tier, dataset
+tier, and the depth-aware orchestrator) directly on plain DataPoints and
+lightweight dataset/data-item stand-ins.
 """
 
 from types import SimpleNamespace
@@ -10,9 +11,13 @@ from uuid import uuid4
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.engine.models.DatasetNode import DatasetNode
 from cognee.tasks.storage.provenance_lineage import (
+    DERIVED_FROM_RELATIONSHIP,
     IN_DATASET_RELATIONSHIP,
     PROVENANCE_EDGE_FLAG,
+    ProvenanceConfig,
     build_dataset_lineage,
+    build_provenance_lineage,
+    build_source_lineage,
     dataset_lineage_node_id,
 )
 
@@ -28,6 +33,18 @@ def _dataset(dataset_id, name="Fleet Ops"):
 
 def _data_item(document_id):
     return SimpleNamespace(id=document_id)
+
+
+def _content_node(node_id=None):
+    """A non-structural extracted node (type defaults to 'DataPoint')."""
+    return DataPoint(id=node_id or uuid4())
+
+
+def _typed_node(type_name, node_id=None):
+    """A node with an explicit graph ``type`` (used to simulate structural nodes)."""
+    node = DataPoint(id=node_id or uuid4())
+    object.__setattr__(node, "type", type_name)
+    return node
 
 
 def test_emits_dataset_node_and_in_dataset_edge():
@@ -98,3 +115,121 @@ def test_returns_empty_when_dataset_or_data_item_missing():
     nodes = [_document_node(document_id)]
     assert build_dataset_lineage(nodes, None, _data_item(document_id)) == ([], [])
     assert build_dataset_lineage(nodes, _dataset(uuid4()), None) == ([], [])
+
+
+# ── Source tier: <node> -derived_from-> Document ──
+
+
+def test_source_lineage_links_every_content_node_to_document():
+    document_id = uuid4()
+    e1, e2 = _content_node(), _content_node()
+    nodes = [_document_node(document_id), e1, e2]
+
+    edges = build_source_lineage(nodes, _data_item(document_id))
+
+    triples = {(source, target, rel) for source, target, rel, _ in edges}
+    assert (e1.id, document_id, DERIVED_FROM_RELATIONSHIP) in triples
+    assert (e2.id, document_id, DERIVED_FROM_RELATIONSHIP) in triples
+    # The Document is not linked to itself, and every edge is flagged.
+    assert len(edges) == 2
+    assert all(props[PROVENANCE_EDGE_FLAG] is True for *_, props in edges)
+
+
+def test_source_lineage_skips_structural_nodes():
+    document_id = uuid4()
+    content = _content_node()
+    nodes = [
+        _document_node(document_id),
+        content,
+        _typed_node("NodeSet"),
+        _typed_node("DatasetNode"),
+    ]
+
+    edges = build_source_lineage(nodes, _data_item(document_id))
+
+    assert {source for source, *_ in edges} == {content.id}
+
+
+def test_source_lineage_empty_when_document_absent():
+    assert build_source_lineage([_content_node()], _data_item(uuid4())) == []
+
+
+def test_source_lineage_edge_text_is_constant():
+    """All derived_from edges share one edge_text so they collapse to one EdgeType."""
+    document_id = uuid4()
+    nodes = [_document_node(document_id), _content_node(), _content_node()]
+
+    edges = build_source_lineage(nodes, _data_item(document_id))
+
+    assert {props["edge_text"] for *_, props in edges} == {DERIVED_FROM_RELATIONSHIP}
+
+
+def test_merged_node_accumulates_derived_from_per_document():
+    """A node recurring across data items gets one derived_from edge per Document."""
+    shared_id = uuid4()
+    doc_a, doc_b = uuid4(), uuid4()
+
+    edges_a = build_source_lineage(
+        [_document_node(doc_a), _content_node(shared_id)], _data_item(doc_a)
+    )
+    edges_b = build_source_lineage(
+        [_document_node(doc_b), _content_node(shared_id)], _data_item(doc_b)
+    )
+
+    triples = {(source, target, rel) for source, target, rel, _ in edges_a + edges_b}
+    assert (shared_id, doc_a, DERIVED_FROM_RELATIONSHIP) in triples
+    assert (shared_id, doc_b, DERIVED_FROM_RELATIONSHIP) in triples
+
+
+# ── Orchestrator + depth ──
+
+
+def test_dataset_depth_includes_both_tiers():
+    document_id = uuid4()
+    nodes = [_document_node(document_id), _content_node()]
+    config = ProvenanceConfig(provenance_lineage=True, provenance_lineage_depth="dataset")
+
+    extra_nodes, extra_edges = build_provenance_lineage(
+        nodes, _dataset(uuid4()), _data_item(document_id), config
+    )
+
+    rels = {edge[2] for edge in extra_edges}
+    assert rels == {DERIVED_FROM_RELATIONSHIP, IN_DATASET_RELATIONSHIP}
+    assert any(isinstance(node, DatasetNode) for node in extra_nodes)
+
+
+def test_document_depth_excludes_dataset_tier():
+    document_id = uuid4()
+    nodes = [_document_node(document_id), _content_node()]
+    config = ProvenanceConfig(provenance_lineage=True, provenance_lineage_depth="document")
+
+    extra_nodes, extra_edges = build_provenance_lineage(
+        nodes, _dataset(uuid4()), _data_item(document_id), config
+    )
+
+    assert {edge[2] for edge in extra_edges} == {DERIVED_FROM_RELATIONSHIP}
+    assert extra_nodes == []
+
+
+def test_disabled_flag_returns_empty():
+    document_id = uuid4()
+    nodes = [_document_node(document_id), _content_node()]
+    config = ProvenanceConfig(provenance_lineage=False)
+
+    assert build_provenance_lineage(nodes, _dataset(uuid4()), _data_item(document_id), config) == (
+        [],
+        [],
+    )
+
+
+def test_unknown_depth_falls_back_to_dataset():
+    document_id = uuid4()
+    nodes = [_document_node(document_id), _content_node()]
+    config = ProvenanceConfig(provenance_lineage=True, provenance_lineage_depth="bogus")
+
+    _, extra_edges = build_provenance_lineage(
+        nodes, _dataset(uuid4()), _data_item(document_id), config
+    )
+
+    # Fell back to the default (dataset) depth, so the dataset tier is present.
+    assert IN_DATASET_RELATIONSHIP in {edge[2] for edge in extra_edges}

--- a/cognee/tests/unit/tasks/storage/test_provenance_lineage.py
+++ b/cognee/tests/unit/tasks/storage/test_provenance_lineage.py
@@ -1,0 +1,100 @@
+"""Unit tests for the Dataset tier of the provenance lineage layer.
+
+Pure and DB/LLM-free: they exercise ``build_dataset_lineage`` directly on plain
+DataPoints and lightweight dataset/data-item stand-ins.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.engine.models.DatasetNode import DatasetNode
+from cognee.tasks.storage.provenance_lineage import (
+    IN_DATASET_RELATIONSHIP,
+    PROVENANCE_EDGE_FLAG,
+    build_dataset_lineage,
+    dataset_lineage_node_id,
+)
+
+
+def _document_node(document_id):
+    """A minimal stand-in for the Document graph node (id == data_item.id)."""
+    return DataPoint(id=document_id)
+
+
+def _dataset(dataset_id, name="Fleet Ops"):
+    return SimpleNamespace(id=dataset_id, name=name)
+
+
+def _data_item(document_id):
+    return SimpleNamespace(id=document_id)
+
+
+def test_emits_dataset_node_and_in_dataset_edge():
+    document_id = uuid4()
+    dataset_id = uuid4()
+    nodes = [_document_node(document_id)]
+
+    extra_nodes, extra_edges = build_dataset_lineage(
+        nodes, _dataset(dataset_id), _data_item(document_id)
+    )
+
+    assert len(extra_nodes) == 1
+    assert isinstance(extra_nodes[0], DatasetNode)
+    assert extra_nodes[0].name == "Fleet Ops"
+
+    assert len(extra_edges) == 1
+    source, target, relationship, properties = extra_edges[0]
+    assert source == document_id
+    assert target == dataset_lineage_node_id(dataset_id)
+    assert relationship == IN_DATASET_RELATIONSHIP
+    assert properties[PROVENANCE_EDGE_FLAG] is True
+
+
+def test_dataset_node_id_is_deterministic_and_shared():
+    """Same dataset id -> same lineage node id, so the node dedups across data items."""
+    dataset_id = uuid4()
+    doc_a, doc_b = uuid4(), uuid4()
+
+    nodes_a, _ = build_dataset_lineage(
+        [_document_node(doc_a)], _dataset(dataset_id), _data_item(doc_a)
+    )
+    nodes_b, _ = build_dataset_lineage(
+        [_document_node(doc_b)], _dataset(dataset_id), _data_item(doc_b)
+    )
+
+    assert nodes_a[0].id == nodes_b[0].id == dataset_lineage_node_id(dataset_id)
+
+
+def test_different_datasets_get_distinct_nodes():
+    doc = uuid4()
+    nodes_1, _ = build_dataset_lineage([_document_node(doc)], _dataset(uuid4()), _data_item(doc))
+    nodes_2, _ = build_dataset_lineage([_document_node(doc)], _dataset(uuid4()), _data_item(doc))
+    assert nodes_1[0].id != nodes_2[0].id
+
+
+def test_no_edge_when_document_node_absent():
+    """Without the Document node in the batch, no dangling edge is produced."""
+    extra_nodes, extra_edges = build_dataset_lineage(
+        [_document_node(uuid4())], _dataset(uuid4()), _data_item(uuid4())
+    )
+    assert extra_nodes == []
+    assert extra_edges == []
+
+
+def test_falls_back_to_dataset_id_when_name_missing():
+    document_id = uuid4()
+    dataset_id = uuid4()
+    dataset = SimpleNamespace(id=dataset_id, name=None)
+
+    extra_nodes, _ = build_dataset_lineage(
+        [_document_node(document_id)], dataset, _data_item(document_id)
+    )
+    assert extra_nodes[0].name == str(dataset_id)
+
+
+def test_returns_empty_when_dataset_or_data_item_missing():
+    document_id = uuid4()
+    nodes = [_document_node(document_id)]
+    assert build_dataset_lineage(nodes, None, _data_item(document_id)) == ([], [])
+    assert build_dataset_lineage(nodes, _dataset(uuid4()), None) == ([], [])


### PR DESCRIPTION
## Description

Depends on #3866. Because that PR is not merged into `dev` yet, the diff here also shows its commits. Please review only the three commits on top: the lineage query API, the visualization change and the recall citation change. Once #3866 merges, this diff will show only those.

Scope: PR 2 of 2 for #3633 (surfacing). #3866 added the lineage edges (`<node> -derived_from-> Document -in_dataset-> Dataset`). This PR makes them usable in three ways.

**Query API:** `get_source_lineage(node_id)` returns the documents and datasets a node came from, and `get_derived_nodes(source_id)` returns what was produced from a document or dataset (for audit). Both read the edges back through `get_connections` and take direction from the edge's `source_node_id`/`target_node_id`, so they work on any backend. Exported from the `cognee` package. The core logic is pure and is tested with a fake engine, so it runs in the normal unit suite.

**Visualization:** The lineage `DatasetNode` was showing up as a second dataset node next to the actor `dataset:<id>` node. This collapses it onto the actor node (via an alias in the relational reader), so the lineage attaches to the ownership graph instead of duplicating it.

**Recall citations:** When references are enabled, a retrieved chunk's citation now names its source dataset, resolved by following the lineage edges ("in dataset `<name>`"). This is the #3604 citation case. It is backward compatible: without a dataset the bullet is unchanged.

Closes #3633.

## Acceptance Criteria

- `get_source_lineage` returns source documents and datasets, deduplicated across documents in the same dataset. `get_derived_nodes` returns the reverse.
- The memory-provenance graph shows the lineage attached to a single dataset node, not a duplicate.
- A retrieved result can be traced to its source at recall time, and the source dataset appears in the citation.

**Proof:**

- Unit tests: `test_get_node_lineage.py` (both query functions, dedupe, and correct direction even when the backend returns endpoints in reverse order), `test_memory_provenance.py` (lineage renders, DatasetNode collapses), and `test_references_helpers.py` (dataset rendered when present, unchanged when absent).
- An assertion in the e2e test (`test_provenance_lineage_default_graph.py`) checks that after a real cognify an answer-grounded reference traces back to the source dataset, so provenance survives recall.
- The broader `unit/modules/retrieval`, `unit/modules/graph`, `unit/api` and `unit/tasks` runs pass with no new failures compared to `dev`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots

<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING -->

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass
- [x] I have linked the relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.