### PR TITLE
test: backend-DB matrix golden flow against a running container (T10)

### DIFF
--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -1,0 +1,43 @@
+name: test | deployment
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  workflow_call:
+    inputs:
+      markers:
+        description: "pytest -m marker expression selecting which deployment tests to run"
+        required: false
+        type: string
+        default: "deployment and not nightly"
+      timeout:
+        description: "Per-test timeout in seconds"
+        required: false
+        type: string
+        default: "600"
+
+jobs:
+  deployment-tests:
+    name: Deployment Tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Build local Docker image
+        run: docker build -t cognee:local .
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Run deployment tests
+        env:
+          COGNEE_DOCKER_IMAGE: cognee:local
+        run: |
+          uv run pytest cognee/tests/deployment/ -v \
+            -m "${{ inputs.markers }}" \
+            --timeout=${{ inputs.timeout }}

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -33,6 +33,14 @@ jobs:
     uses: ./.github/workflows/test_llamacpp.yml
     secrets: inherit
 
+  deployment-neo4j-test:
+    name: Deployment Neo4j Matrix Test
+    uses: ./.github/workflows/deployment_tests.yml
+    with:
+      markers: "deployment and nightly"
+      timeout: "900"
+    secrets: inherit
+
   # ══ Performance: each caller runs BOTH file_based and postgres backends ════
   perf-small-llm:
     name: Performance — 50 Small Documents (real LLM)
@@ -83,6 +91,7 @@ jobs:
     needs: [
       ollama-tests,
       llamacpp-tests,
+      deployment-neo4j-test,
       perf-small-llm,
       perf-small-mock,
       perf-wap-llm,
@@ -96,6 +105,7 @@ jobs:
         run: |
           if [[ "${{ needs.ollama-tests.result }}" == "success" &&
                 "${{ needs.llamacpp-tests.result }}" == "success" &&
+                "${{ needs.deployment-neo4j-test.result }}" == "success" &&
                 "${{ needs.perf-small-llm.result }}" == "success" &&
                 "${{ needs.perf-small-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-llm.result }}" == "success" &&

--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -221,6 +221,11 @@ jobs:
     uses: ./.github/workflows/backend_docker_build_test.yml
     secrets: inherit
 
+  deployment-test:
+    name: Deployment Matrix Test
+    uses: ./.github/workflows/deployment_tests.yml
+    secrets: inherit
+
   temporal-graph-tests:
     name: Temporal Graph Test
     needs: [ build-ci-env ]
@@ -289,6 +294,7 @@ jobs:
       mcp-test,
       docker-compose-test,
       docker-ci-test,
+      deployment-test,
       temporal-graph-tests,
       search-db-tests,
       relational-db-migration-tests,
@@ -316,6 +322,7 @@ jobs:
                 "${{ needs.mcp-test.result }}" == "success" &&
                 "${{ needs.docker-compose-test.result }}" == "success" &&
                 "${{ needs.docker-ci-test.result }}" == "success" &&
+                "${{ needs.deployment-test.result }}" == "success" &&
                 "${{ needs.temporal-graph-tests.result }}" == "success" &&
                 "${{ needs.search-db-tests.result }}" == "success" &&
                 "${{ needs.relational-db-migration-tests.result }}" == "success" &&

--- a/cognee/tests/deployment/__init__.py
+++ b/cognee/tests/deployment/__init__.py
@@ -1,0 +1,5 @@
+"""Deployment end-to-end tests (running-container golden flow).
+
+Opt-in via the `deployment` pytest marker; requires Docker. See
+`test_backend_matrix.py` for the backend-DB matrix (issue #3368 / T10).
+"""

--- a/cognee/tests/deployment/conftest.py
+++ b/cognee/tests/deployment/conftest.py
@@ -1,0 +1,170 @@
+"""Pytest fixtures for deployment end-to-end tests.
+
+Adapted from PR #3563's harness and extended for the backend-DB matrix (T10,
+issue #3368): the ``running_container`` fixture is parametrized by a backend
+"stack" key and brings up the matching database containers before the API
+container.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from cognee.tests.deployment.golden_flow import run_golden_flow, run_remember_recall_flow
+from cognee.tests.deployment.helpers import (
+    build_api_container_cmd,
+    db_env_for_stack,
+    db_host_for_container,
+    get_free_port,
+    resolve_docker_image,
+    start_neo4j_container,
+    start_postgres_container,
+    stop_container,
+    stream_container_logs,
+    wait_for_health,
+)
+from cognee.tests.deployment.mock_llm import start_mock_llm_server, stop_mock_llm_server
+
+# Quiet the very chatty httpx/httpcore wire logs so test output stays readable.
+for _noisy_logger in ("httpx", "httpcore"):
+    logging.getLogger(_noisy_logger).setLevel(logging.WARNING)
+
+DEFAULT_STACK = "sqlite_lancedb_kuzu"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--image",
+        action="store",
+        default=None,
+        help="Docker image for API deployment tests: build, pull, or an image name",
+    )
+
+
+def _use_real_llm() -> bool:
+    return os.getenv("DEPLOYMENT_USE_REAL_LLM", "").lower() in ("true", "1", "yes")
+
+
+@pytest.fixture(scope="session")
+def mock_llm_server():
+    if _use_real_llm():
+        yield None
+        return
+
+    server, _thread, port = start_mock_llm_server()
+    url = f"http://127.0.0.1:{port}/v1"
+    yield url
+    stop_mock_llm_server(server)
+
+
+@pytest.fixture(scope="session")
+def image_name(request):
+    return resolve_docker_image(
+        image_option=request.config.getoption("--image"),
+        env_var="COGNEE_DOCKER_IMAGE",
+        local_tag="cognee:local",
+        published_image="cognee/cognee:latest",
+        build_cmd=["docker", "build", "-t", "cognee:local", "."],
+    )
+
+
+@pytest.fixture
+def running_container(request, mock_llm_server, image_name):
+    """Start the API container (plus any DB containers) for a backend stack.
+
+    Parametrized indirectly with a stack key understood by
+    :func:`cognee.tests.deployment.helpers.db_env_for_stack`. Defaults to the
+    file-based SQLite stack when used without parametrization.
+    """
+    stack = getattr(request, "param", DEFAULT_STACK)
+
+    if _use_real_llm() and mock_llm_server is None:
+        pytest.skip("Real LLM mode requires DEPLOYMENT_USE_REAL_LLM secrets to be configured.")
+
+    started: list[str] = []
+    api_container_name: str | None = None
+    failed = False
+    pg_host = pg_port = neo4j_host = neo4j_bolt = None
+
+    try:
+        if stack in ("postgres_pgvector_postgresgraph", "neo4j_postgres"):
+            pg_name, pg_port = start_postgres_container()
+            started.append(pg_name)
+            pg_host = db_host_for_container()
+        if stack == "neo4j_postgres":
+            neo4j_name, neo4j_bolt = start_neo4j_container()
+            started.append(neo4j_name)
+            neo4j_host = db_host_for_container()
+
+        db_env = db_env_for_stack(
+            stack,
+            pg_host=pg_host,
+            pg_port=pg_port,
+            neo4j_host=neo4j_host,
+            neo4j_bolt_port=neo4j_bolt,
+        )
+
+        host_port = get_free_port()
+        api_container_name = f"cognee-test-{uuid.uuid4().hex[:8]}"
+        cmd = build_api_container_cmd(
+            image_name=image_name,
+            container_name=api_container_name,
+            host_port=host_port,
+            mock_llm_url=mock_llm_server or "",
+            extra_env=db_env,
+        )
+        started.append(api_container_name)
+
+        print(f"Starting [{stack}] container {api_container_name} on port {host_port}...")
+        proc = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
+        if proc.returncode != 0:
+            raise RuntimeError(f"docker run failed to start: {proc.stderr}")
+
+        url = f"http://127.0.0.1:{host_port}"
+        wait_for_health(f"{url}/health", timeout=180.0)
+        yield {
+            "url": url,
+            "port": host_port,
+            "container_name": api_container_name,
+            "stack": stack,
+        }
+    except Exception:
+        failed = True
+        raise
+    finally:
+        test_failed = getattr(getattr(request.node, "rep_call", None), "failed", False)
+        if (failed or test_failed) and api_container_name:
+            print(f"\n--- CONTAINER LOGS FOR {api_container_name} ({stack}) ---")
+            stream_container_logs(api_container_name)
+        for name in reversed(started):
+            stop_container(name)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"rep_{rep.when}", rep)
+
+
+@pytest_asyncio.fixture
+async def api_client(running_container):
+    async with httpx.AsyncClient(base_url=running_container["url"], timeout=120.0) as client:
+        yield client
+
+
+@pytest.fixture
+def golden_flow():
+    return run_golden_flow
+
+
+@pytest.fixture
+def remember_recall_flow():
+    return run_remember_recall_flow

--- a/cognee/tests/deployment/golden_flow.py
+++ b/cognee/tests/deployment/golden_flow.py
@@ -1,0 +1,169 @@
+"""Reusable golden flows for deployment e2e tests.
+
+``run_golden_flow`` (add -> cognify -> search) is adapted from PR #3563.
+``run_remember_recall_flow`` (remember -> recall, on a different dataset) is new
+for T10 (issue #3368).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import httpx
+
+from cognee.tests.deployment.mock_llm import GOLDEN_DOCUMENT, GOLDEN_ENTITY
+
+PIPELINE_COMPLETED = "DATASET_PROCESSING_COMPLETED"
+PIPELINE_ERRORED = "DATASET_PROCESSING_ERRORED"
+
+
+async def register_and_login(
+    client: httpx.AsyncClient,
+    email: str | None = None,
+    password: str = "test_password",
+) -> str:
+    if email is None:
+        email = f"deploy_test_{uuid.uuid4().hex[:8]}@example.com"
+
+    reg_payload = {
+        "email": email,
+        "password": password,
+        "is_active": True,
+        "is_superuser": False,
+        "is_verified": False,
+    }
+    try:
+        await client.post("/api/v1/auth/register", json=reg_payload)
+    except Exception:
+        pass
+
+    resp = await client.post(
+        "/api/v1/auth/login",
+        data={"username": email, "password": password},
+    )
+    resp.raise_for_status()
+    token = resp.json()["access_token"]
+    client.headers["Authorization"] = f"Bearer {token}"
+    return token
+
+
+async def run_golden_flow(client: httpx.AsyncClient, dataset_name: str | None = None) -> str:
+    """Drive add -> cognify -> poll -> search and assert the golden entity is retrievable."""
+    if dataset_name is None:
+        dataset_name = f"deploy_golden_{uuid.uuid4().hex[:8]}"
+
+    await register_and_login(client)
+
+    files = {
+        "data": ("document.txt", GOLDEN_DOCUMENT.encode("utf-8"), "text/plain"),
+    }
+    resp = await client.post("/api/v1/add", data={"datasetName": dataset_name}, files=files)
+    resp.raise_for_status()
+
+    resp = await client.get("/api/v1/datasets")
+    resp.raise_for_status()
+    datasets = resp.json()
+
+    dataset_id = next((ds["id"] for ds in datasets if ds["name"] == dataset_name), None)
+    assert dataset_id is not None, f"Dataset {dataset_name} not found in: {datasets}"
+
+    resp = await client.post(
+        "/api/v1/cognify",
+        json={"datasets": [dataset_name], "run_in_background": True},
+    )
+    resp.raise_for_status()
+
+    status_completed = False
+    for _ in range(120):
+        resp = await client.get(f"/api/v1/datasets/status?dataset={dataset_id}")
+        resp.raise_for_status()
+        status_data = resp.json()
+        status = status_data.get(str(dataset_id))
+        if status == PIPELINE_COMPLETED:
+            status_completed = True
+            break
+        if status == PIPELINE_ERRORED:
+            raise RuntimeError(
+                f"Cognify pipeline failed for dataset {dataset_id}. Status payload: {status_data}"
+            )
+        await asyncio.sleep(1)
+
+    assert status_completed, f"Cognify pipeline did not complete in time for dataset {dataset_id}"
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "search_type": "GRAPH_COMPLETION",
+            "query": "Who developed relativity?",
+            "dataset_ids": [dataset_id],
+        },
+    )
+    resp.raise_for_status()
+    results_gc = resp.json()
+    assert any(GOLDEN_ENTITY in str(item) for item in results_gc), (
+        f"{GOLDEN_ENTITY} not found in GRAPH_COMPLETION results: {results_gc}"
+    )
+
+    resp = await client.post(
+        "/api/v1/search",
+        json={
+            "search_type": "CHUNKS",
+            "query": GOLDEN_ENTITY,
+            "dataset_ids": [dataset_id],
+        },
+    )
+    resp.raise_for_status()
+    results_chunks = resp.json()
+    assert any(GOLDEN_ENTITY in str(item) for item in results_chunks), (
+        f"{GOLDEN_ENTITY} not found in CHUNKS results: {results_chunks}"
+    )
+
+    return dataset_id
+
+
+async def run_remember_recall_flow(
+    client: httpx.AsyncClient, dataset_name: str | None = None
+) -> str:
+    """Drive remember -> recall on a DIFFERENT dataset and assert the entity is recalled.
+
+    ``/api/v1/remember`` (multipart) performs add + cognify in one call; run in
+    blocking mode so the response only returns once the graph is built. ``recall``
+    then retrieves with ``CHUNKS`` so the assertion exercises the backend's real
+    store rather than the (deterministic) mock LLM completion.
+    """
+    if dataset_name is None:
+        dataset_name = f"deploy_recall_{uuid.uuid4().hex[:8]}"
+
+    await register_and_login(client)
+
+    files = {
+        "data": ("memory.txt", GOLDEN_DOCUMENT.encode("utf-8"), "text/plain"),
+    }
+    resp = await client.post(
+        "/api/v1/remember",
+        data={"datasetName": dataset_name},
+        files=files,
+    )
+    resp.raise_for_status()
+    remember_result = resp.json()
+    assert remember_result.get("status") == "completed", (
+        f"remember did not complete successfully: {remember_result}"
+    )
+
+    resp = await client.post(
+        "/api/v1/recall",
+        json={
+            "search_type": "CHUNKS",
+            "query": GOLDEN_ENTITY,
+            "datasets": [dataset_name],
+            "top_k": 15,
+        },
+    )
+    resp.raise_for_status()
+    recall_results = resp.json()
+    assert any(GOLDEN_ENTITY in str(item) for item in recall_results), (
+        f"{GOLDEN_ENTITY} not found in recall results: {recall_results}"
+    )
+
+    return dataset_name

--- a/cognee/tests/deployment/helpers.py
+++ b/cognee/tests/deployment/helpers.py
@@ -1,0 +1,356 @@
+"""Shared helpers for deployment end-to-end tests.
+
+Adapted from the deployment harness proposed in PR #3563, extended for the
+backend-DB matrix (T10, issue #3368): per-stack database container bring-up
+and per-backend environment profiles.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from urllib.parse import urlparse
+
+import httpx
+
+# Database container images and default credentials used by the matrix.
+POSTGRES_IMAGE = "pgvector/pgvector:pg17"
+NEO4J_IMAGE = "neo4j:5.26"
+POSTGRES_USER = "cognee"
+POSTGRES_PASSWORD = "cognee"
+POSTGRES_DB = "cognee_db"
+NEO4J_PASSWORD = "pleaseletmein"
+
+
+def get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def wait_for_health(url: str, timeout: float = 60.0) -> None:
+    """Poll until the service health endpoint reports ready."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            resp = httpx.get(url, timeout=5.0)
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("status") in ("ready", "ok") or data.get("health") == "healthy":
+                    return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise TimeoutError(f"Service at {url} not ready after {timeout}s")
+
+
+def resolve_docker_image(
+    image_option: str | None,
+    env_var: str,
+    local_tag: str,
+    published_image: str,
+    build_cmd: list[str],
+) -> str:
+    image = image_option or os.environ.get(env_var)
+    if not image:
+        image = "build"
+
+    if image == "build":
+        print(f"Building local Docker image '{local_tag}'...")
+        proc = subprocess.run(build_cmd, capture_output=True, text=True, errors="replace")
+        if proc.returncode == 0:
+            print(f"Successfully built local image '{local_tag}'.")
+            return local_tag
+        print(f"Failed to build local Docker image: {proc.stderr}")
+        print(f"Falling back to published image '{published_image}'.")
+        return published_image
+
+    if image == "pull":
+        return published_image
+
+    return image
+
+
+def mock_llm_endpoint_for_container(mock_llm_url: str) -> str:
+    parsed = urlparse(mock_llm_url)
+    mock_llm_port = parsed.port
+    if sys.platform.startswith("linux"):
+        return f"http://127.0.0.1:{mock_llm_port}/v1"
+    return f"http://host.docker.internal:{mock_llm_port}/v1"
+
+
+def db_host_for_container() -> str:
+    """Host alias an API container uses to reach a DB published on the host.
+
+    On Linux the API container runs with ``--network host``, so a DB whose port
+    is published to the host is reachable on ``127.0.0.1``. On macOS/Windows
+    Docker Desktop the container reaches host-published ports via
+    ``host.docker.internal``.
+    """
+    if sys.platform.startswith("linux"):
+        return "127.0.0.1"
+    return "host.docker.internal"
+
+
+# --- Database container bring-up ------------------------------------------
+
+
+def _run_or_raise(cmd: list[str], what: str) -> subprocess.CompletedProcess:
+    proc = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
+    if proc.returncode != 0:
+        raise RuntimeError(f"{what} failed: {proc.stderr or proc.stdout}")
+    return proc
+
+
+def start_postgres_container() -> tuple[str, int]:
+    """Start a pgvector-enabled Postgres and wait until it accepts connections.
+
+    Returns ``(container_name, host_port)`` where ``host_port`` maps to the
+    container's 5432.
+    """
+    name = f"cognee-pg-{uuid.uuid4().hex[:8]}"
+    host_port = get_free_port()
+    cmd = [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        name,
+        "-e",
+        f"POSTGRES_USER={POSTGRES_USER}",
+        "-e",
+        f"POSTGRES_PASSWORD={POSTGRES_PASSWORD}",
+        "-e",
+        f"POSTGRES_DB={POSTGRES_DB}",
+        "-p",
+        f"{host_port}:5432",
+        POSTGRES_IMAGE,
+    ]
+    _run_or_raise(cmd, f"docker run postgres ({name})")
+    _wait_for_postgres(name)
+    return name, host_port
+
+
+def _wait_for_postgres(container_name: str, timeout: float = 90.0) -> None:
+    start = time.time()
+    while time.time() - start < timeout:
+        proc = subprocess.run(
+            ["docker", "exec", container_name, "pg_isready", "-U", POSTGRES_USER],
+            capture_output=True,
+            text=True,
+            errors="replace",
+        )
+        if proc.returncode == 0:
+            return
+        time.sleep(1)
+    raise TimeoutError(f"Postgres container {container_name} not ready after {timeout}s")
+
+
+def start_neo4j_container() -> tuple[str, int]:
+    """Start Neo4j and wait until the bolt endpoint accepts queries.
+
+    Returns ``(container_name, bolt_host_port)`` where ``bolt_host_port`` maps
+    to the container's 7687.
+    """
+    name = f"cognee-neo4j-{uuid.uuid4().hex[:8]}"
+    bolt_port = get_free_port()
+    http_port = get_free_port()
+    cmd = [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        name,
+        "-e",
+        f"NEO4J_AUTH=neo4j/{NEO4J_PASSWORD}",
+        "-p",
+        f"{bolt_port}:7687",
+        "-p",
+        f"{http_port}:7474",
+        NEO4J_IMAGE,
+    ]
+    _run_or_raise(cmd, f"docker run neo4j ({name})")
+    _wait_for_neo4j(name)
+    return name, bolt_port
+
+
+def _wait_for_neo4j(container_name: str, timeout: float = 120.0) -> None:
+    start = time.time()
+    while time.time() - start < timeout:
+        proc = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_name,
+                "cypher-shell",
+                "-u",
+                "neo4j",
+                "-p",
+                NEO4J_PASSWORD,
+                "RETURN 1;",
+            ],
+            capture_output=True,
+            text=True,
+            errors="replace",
+        )
+        if proc.returncode == 0:
+            return
+        time.sleep(2)
+    raise TimeoutError(f"Neo4j container {container_name} not ready after {timeout}s")
+
+
+# --- Per-stack environment profiles ---------------------------------------
+
+
+def _postgres_relational_env(pg_host: str | None, pg_port: int | None) -> list[str]:
+    if not pg_host or not pg_port:
+        raise ValueError("Postgres host/port are required for this stack")
+    return [
+        "DB_PROVIDER=postgres",
+        f"DB_HOST={pg_host}",
+        f"DB_PORT={pg_port}",
+        f"DB_USERNAME={POSTGRES_USER}",
+        f"DB_PASSWORD={POSTGRES_PASSWORD}",
+        f"DB_NAME={POSTGRES_DB}",
+    ]
+
+
+def db_env_for_stack(
+    stack: str,
+    *,
+    pg_host: str | None = None,
+    pg_port: int | None = None,
+    neo4j_host: str | None = None,
+    neo4j_bolt_port: int | None = None,
+) -> list[str]:
+    """Return the ``KEY=VALUE`` backend env entries for a matrix stack.
+
+    Credentials are passed explicitly for every backend so the stacks behave
+    identically whether ``ENABLE_BACKEND_ACCESS_CONTROL`` is on or off (pgvector
+    and postgres-graph only fall back to the relational ``DB_*`` vars when access
+    control is disabled).
+    """
+    if stack == "sqlite_lancedb_kuzu":
+        return [
+            "DB_PROVIDER=sqlite",
+            "VECTOR_DB_PROVIDER=lancedb",
+            "GRAPH_DATABASE_PROVIDER=kuzu",
+        ]
+
+    if stack == "postgres_pgvector_postgresgraph":
+        return _postgres_relational_env(pg_host, pg_port) + [
+            "VECTOR_DB_PROVIDER=pgvector",
+            f"VECTOR_DB_HOST={pg_host}",
+            f"VECTOR_DB_PORT={pg_port}",
+            f"VECTOR_DB_USERNAME={POSTGRES_USER}",
+            f"VECTOR_DB_PASSWORD={POSTGRES_PASSWORD}",
+            f"VECTOR_DB_NAME={POSTGRES_DB}",
+            "GRAPH_DATABASE_PROVIDER=postgres",
+            f"GRAPH_DATABASE_HOST={pg_host}",
+            f"GRAPH_DATABASE_PORT={pg_port}",
+            f"GRAPH_DATABASE_USERNAME={POSTGRES_USER}",
+            f"GRAPH_DATABASE_PASSWORD={POSTGRES_PASSWORD}",
+            f"GRAPH_DATABASE_NAME={POSTGRES_DB}",
+        ]
+
+    if stack == "neo4j_postgres":
+        if not neo4j_host or not neo4j_bolt_port:
+            raise ValueError("Neo4j host/port are required for the neo4j stack")
+        return _postgres_relational_env(pg_host, pg_port) + [
+            "VECTOR_DB_PROVIDER=lancedb",
+            "GRAPH_DATABASE_PROVIDER=neo4j",
+            f"GRAPH_DATABASE_URL=bolt://{neo4j_host}:{neo4j_bolt_port}",
+            "GRAPH_DATABASE_NAME=neo4j",
+            "GRAPH_DATABASE_USERNAME=neo4j",
+            f"GRAPH_DATABASE_PASSWORD={NEO4J_PASSWORD}",
+        ]
+
+    raise ValueError(f"Unknown backend stack: {stack!r}")
+
+
+def build_api_container_cmd(
+    *,
+    image_name: str,
+    container_name: str,
+    host_port: int,
+    mock_llm_url: str,
+    extra_env: list[str] | None = None,
+) -> list[str]:
+    """Build the ``docker run`` command for the API container.
+
+    ``extra_env`` carries the per-stack backend selection (see
+    :func:`db_env_for_stack`); the base env wires the mock LLM/embedding
+    endpoints and skips the startup connection probe (the mock does not answer
+    the ``"test"`` probe).
+    """
+    llm_endpoint = mock_llm_endpoint_for_container(mock_llm_url)
+    env = [
+        "ENV=local",
+        "COGNEE_SKIP_CONNECTION_TEST=true",
+        # Disable session memory so search/recall exercise the permanent graph only
+        # (avoids extra session-analysis LLM calls during retrieval).
+        "CACHING=false",
+        "LLM_PROVIDER=openai",
+        "LLM_MODEL=gpt-5-mini",
+        f"LLM_ENDPOINT={llm_endpoint}",
+        "LLM_API_KEY=mock-key",
+        "EMBEDDING_PROVIDER=openai",
+        "EMBEDDING_MODEL=text-embedding-3-small",
+        "EMBEDDING_DIMENSIONS=1536",
+        f"EMBEDDING_ENDPOINT={llm_endpoint}",
+        "EMBEDDING_API_KEY=mock-key",
+    ]
+    env.extend(extra_env or [])
+
+    cmd = ["docker", "run", "-d", "--name", container_name]
+    if sys.platform.startswith("linux"):
+        cmd.extend(["--network", "host", "-e", f"HTTP_PORT={host_port}"])
+    else:
+        cmd.extend(
+            [
+                "-p",
+                f"{host_port}:8000",
+                "--add-host",
+                "host.docker.internal:host-gateway",
+            ]
+        )
+
+    for entry in env:
+        cmd.extend(["-e", entry])
+
+    cmd.append(image_name)
+    return cmd
+
+
+def fetch_container_logs(container_name: str) -> tuple[str, str]:
+    proc = subprocess.run(
+        ["docker", "logs", container_name],
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    return proc.stdout, proc.stderr
+
+
+def stream_container_logs(container_name: str) -> None:
+    stdout, stderr = fetch_container_logs(container_name)
+    sys.stdout.buffer.write(stdout.encode("utf-8", errors="replace"))
+    sys.stdout.buffer.write(b"\n")
+    sys.stderr.buffer.write(stderr.encode("utf-8", errors="replace"))
+    sys.stderr.buffer.write(b"\n")
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+
+def stop_container(container_name: str) -> None:
+    subprocess.run(["docker", "stop", container_name], capture_output=True)
+    subprocess.run(["docker", "rm", container_name], capture_output=True)
+
+
+def assert_no_tracebacks_in_logs(stdout: str, stderr: str) -> None:
+    assert "Traceback" not in stdout, f"Traceback found in container stdout logs:\n{stdout}"
+    assert "Traceback" not in stderr, f"Traceback found in container stderr logs:\n{stderr}"

--- a/cognee/tests/deployment/mock_llm.py
+++ b/cognee/tests/deployment/mock_llm.py
@@ -1,0 +1,244 @@
+"""In-process OpenAI-compatible mock for deployment e2e tests."""
+
+from __future__ import annotations
+
+import json
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from typing import Any
+
+GOLDEN_DOCUMENT = "Albert Einstein developed the theory of relativity."
+GOLDEN_ENTITY = "Albert Einstein"
+GOLDEN_ANSWER = "Albert Einstein developed the theory of relativity."
+
+
+def _resolve_schema_name(req: dict) -> str:
+    response_format = req.get("response_format") or {}
+    json_schema = response_format.get("json_schema") or {}
+    schema_name = json_schema.get("name", "")
+    if schema_name:
+        return schema_name
+
+    tools = req.get("tools") or []
+    if tools and isinstance(tools, list):
+        schema_name = tools[0].get("function", {}).get("name", "")
+        if schema_name:
+            return schema_name
+
+    functions = req.get("functions") or []
+    if functions and isinstance(functions, list):
+        schema_name = functions[0].get("name", "")
+        if schema_name:
+            return schema_name
+
+    return ""
+
+
+def _extract_response_schema(req: dict) -> dict | None:
+    """Return the JSON schema the caller expects structured output to satisfy, if any."""
+    response_format = req.get("response_format") or {}
+    json_schema = response_format.get("json_schema") or {}
+    if isinstance(json_schema.get("schema"), dict):
+        return json_schema["schema"]
+
+    tools = req.get("tools") or []
+    if tools and isinstance(tools, list):
+        params = tools[0].get("function", {}).get("parameters")
+        if isinstance(params, dict):
+            return params
+
+    functions = req.get("functions") or []
+    if functions and isinstance(functions, list):
+        params = functions[0].get("parameters")
+        if isinstance(params, dict):
+            return params
+
+    return None
+
+
+def _minimal_instance(schema: dict, defs: dict | None = None) -> Any:
+    """Build a minimal JSON-serializable instance that satisfies an arbitrary JSON schema.
+
+    Used so that structured calls whose schema we don't special-case (e.g.
+    SessionTurnAnalysis) still parse cleanly instead of triggering instructor's
+    retry/backoff loop.
+    """
+    if not isinstance(schema, dict):
+        return None
+
+    if defs is None:
+        defs = schema.get("$defs") or schema.get("definitions") or {}
+
+    if "$ref" in schema:
+        ref_name = schema["$ref"].split("/")[-1]
+        return _minimal_instance(defs.get(ref_name, {}), defs)
+
+    for combinator in ("anyOf", "oneOf", "allOf"):
+        options = schema.get(combinator)
+        if options:
+            return _minimal_instance(options[0], defs)
+
+    if schema.get("enum"):
+        return schema["enum"][0]
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((t for t in schema_type if t != "null"), schema_type[0])
+
+    if schema_type == "object" or "properties" in schema:
+        return {
+            key: _minimal_instance(value, defs)
+            for key, value in (schema.get("properties") or {}).items()
+        }
+    if schema_type == "array":
+        return []
+    if schema_type == "string":
+        return ""
+    if schema_type in ("integer", "number"):
+        return 0
+    if schema_type == "boolean":
+        return False
+    return None
+
+
+def build_chat_completion_content(req: dict) -> str:
+    schema_name = _resolve_schema_name(req)
+
+    if schema_name == "DefaultContentPrediction":
+        return json.dumps(
+            {
+                "label": {
+                    "type": "TEXTUAL_DOCUMENTS_USED_FOR_GENERAL_PURPOSES",
+                    "subclass": ["News stories and blog posts"],
+                }
+            }
+        )
+
+    if schema_name == "SummarizedContent":
+        return json.dumps(
+            {
+                "summary": (
+                    "This document covers Albert Einstein and his development of "
+                    "the theory of relativity."
+                ),
+                "description": "",
+            }
+        )
+
+    if schema_name == "KnowledgeGraph":
+        return json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "einstein",
+                        "name": GOLDEN_ENTITY,
+                        "type": "Person",
+                        "description": "A theoretical physicist.",
+                    }
+                ],
+                "edges": [
+                    {
+                        "source_node_id": "einstein",
+                        "target_node_id": "relativity",
+                        "relationship_name": "developed",
+                        "description": GOLDEN_ANSWER,
+                    }
+                ],
+            }
+        )
+
+    if schema_name == "Answer":
+        return json.dumps({"answer": GOLDEN_ANSWER})
+
+    # Any other structured request: synthesize a minimal valid instance from the
+    # requested schema so instructor can parse it. Auxiliary calls such as
+    # SessionTurnAnalysis must not fail validation (that triggers retry backoff
+    # and stalls the request).
+    schema = _extract_response_schema(req)
+    if schema is not None:
+        return json.dumps(_minimal_instance(schema))
+
+    # Plain string completions (e.g. GRAPH_COMPLETION answer with response_model=str).
+    return GOLDEN_ANSWER
+
+
+def build_embeddings_response(req: dict) -> dict:
+    model = req.get("model", "")
+    dim = 3072 if "text-embedding-3-large" in model else 1536
+    inputs = req.get("input", [])
+
+    if isinstance(inputs, list):
+        data_list = [
+            {"object": "embedding", "index": idx, "embedding": [0.1] * dim}
+            for idx in range(len(inputs))
+        ]
+    else:
+        data_list = [{"object": "embedding", "index": 0, "embedding": [0.1] * dim}]
+
+    return {"object": "list", "data": data_list, "model": model}
+
+
+class MockLLMHandler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args) -> None:
+        return
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length).decode("utf-8")
+        try:
+            req = json.loads(body)
+        except json.JSONDecodeError:
+            req = {}
+
+        if self.path.endswith("/chat/completions"):
+            content = build_chat_completion_content(req)
+            resp = {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": req.get("model", "gpt-5-mini"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            }
+            payload = json.dumps(resp).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        if self.path.endswith("/embeddings"):
+            payload = json.dumps(build_embeddings_response(req)).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+def start_mock_llm_server() -> tuple[HTTPServer, Thread, int]:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        port = sock.getsockname()[1]
+
+    server = HTTPServer(("0.0.0.0", port), MockLLMHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, port
+
+
+def stop_mock_llm_server(server: HTTPServer) -> None:
+    server.shutdown()
+    server.server_close()

--- a/cognee/tests/deployment/test_backend_matrix.py
+++ b/cognee/tests/deployment/test_backend_matrix.py
@@ -1,0 +1,53 @@
+"""Backend-DB matrix golden-flow tests (T10, issue #3368).
+
+Runs the same ``add -> cognify -> search`` golden flow and a
+``remember -> recall`` flow against a running API container backed by each
+supported DB stack, asserting the same entity is retrievable regardless of
+backend.
+
+The free, file-/Postgres-based stacks are PR-blocking. The Neo4j stack is
+marked ``nightly`` because it needs heavier external infrastructure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cognee.tests.deployment.golden_flow import run_golden_flow, run_remember_recall_flow
+
+pytestmark = pytest.mark.deployment
+
+# Free backends — PR-blocking.
+FREE_STACKS = ["sqlite_lancedb_kuzu", "postgres_pgvector_postgresgraph"]
+# Heavier external infra — nightly only.
+NIGHTLY_STACKS = ["neo4j_postgres"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("running_container", FREE_STACKS, indirect=True)
+async def test_golden_flow(api_client, running_container):
+    """add -> cognify -> search retrieves the golden entity on each free backend."""
+    await run_golden_flow(api_client)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("running_container", FREE_STACKS, indirect=True)
+async def test_remember_recall(api_client, running_container):
+    """remember -> recall (different dataset) retrieves the golden entity on each free backend."""
+    await run_remember_recall_flow(api_client)
+
+
+@pytest.mark.nightly
+@pytest.mark.asyncio
+@pytest.mark.parametrize("running_container", NIGHTLY_STACKS, indirect=True)
+async def test_golden_flow_nightly(api_client, running_container):
+    """add -> cognify -> search against the Neo4j (+ Postgres) stack."""
+    await run_golden_flow(api_client)
+
+
+@pytest.mark.nightly
+@pytest.mark.asyncio
+@pytest.mark.parametrize("running_container", NIGHTLY_STACKS, indirect=True)
+async def test_remember_recall_nightly(api_client, running_container):
+    """remember -> recall (different dataset) against the Neo4j (+ Postgres) stack."""
+    await run_remember_recall_flow(api_client)

--- a/cognee/tests/deployment/test_harness.py
+++ b/cognee/tests/deployment/test_harness.py
@@ -1,0 +1,52 @@
+"""Docker-free self-tests for the deployment harness mock LLM (T10, issue #3368).
+
+These validate the in-process OpenAI-compatible mock without requiring Docker,
+so the ``deployment`` marker always has fast, dependency-light coverage that runs
+on every PR (including forks) regardless of container availability.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cognee.tests.deployment.mock_llm import (
+    GOLDEN_ANSWER,
+    GOLDEN_ENTITY,
+    build_chat_completion_content,
+    build_embeddings_response,
+)
+
+pytestmark = pytest.mark.deployment
+
+
+def test_knowledge_graph_schema_returns_golden_entity():
+    req = {"response_format": {"json_schema": {"name": "KnowledgeGraph"}}}
+    content = json.loads(build_chat_completion_content(req))
+    assert any(node["name"] == GOLDEN_ENTITY for node in content["nodes"])
+
+
+def test_answer_schema_returns_golden_answer():
+    req = {"response_format": {"json_schema": {"name": "Answer"}}}
+    content = json.loads(build_chat_completion_content(req))
+    assert content["answer"] == GOLDEN_ANSWER
+
+
+def test_schema_name_resolves_from_tools_payload():
+    req = {"tools": [{"function": {"name": "Answer"}}]}
+    content = json.loads(build_chat_completion_content(req))
+    assert content["answer"] == GOLDEN_ANSWER
+
+
+def test_plain_completion_returns_golden_answer():
+    assert build_chat_completion_content({}) == GOLDEN_ANSWER
+
+
+def test_embeddings_dimensions_by_model():
+    small = build_embeddings_response({"model": "text-embedding-3-small", "input": ["a", "b"]})
+    assert len(small["data"]) == 2
+    assert len(small["data"][0]["embedding"]) == 1536
+
+    large = build_embeddings_response({"model": "text-embedding-3-large", "input": ["a"]})
+    assert len(large["data"][0]["embedding"]) == 3072

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,3 +282,9 @@ dev = [
     "pytest-split>=0.11.0,<0.12",
     "ruff>=0.13.1",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "deployment: Deployment end-to-end integration tests (require Docker; opt-in via -m deployment)",
+    "nightly: Heavy or external-infra variants (e.g. Neo4j) intended for nightly runs",
+]


### PR DESCRIPTION
Hi team — here's my take on **T10** (#3368).

## What & why

Our per-adapter unit tests don't tell us whether the whole `add → cognify → search` flow actually survives end-to-end on a given DB stack — an adapter can pass its own tests while the full pipeline is broken against a live container on that specific backend. So this brings up the real API container and drives the documented HTTP flow against each supported backend, then asserts the same entity is retrievable no matter which DB is underneath. I also added a `remember → recall` run on a *separate* dataset, as @dexters1 asked in the issue.

Since the T0 harness (#3358) isn't on `dev` yet, I built on the modular harness from #3563 — the in-process mock-LLM stub, the container/health helpers and the golden flow — vendored under `cognee/tests/deployment/`, and put the matrix on top. If #3358 lands first I'm happy to rebase and drop the vendored copies.

## What's new on top of that harness
- **Per-stack container bring-up** — generalized so it starts the DB containers each stack needs (pgvector Postgres, Neo4j) and injects the right backend env, instead of being hardcoded to SQLite.
- **`remember → recall` flow** — neither existing harness exercised `/remember` or `/recall`.
- **The backend matrix + parametrization** itself.

## Backends covered

| Stack | When it runs |
|---|---|
| SQLite + LanceDB + Kuzu | PR-blocking |
| Postgres + PGVector + Postgres-graph | PR-blocking |
| Neo4j (+ Postgres relational) | nightly (heavier infra) |

The free stacks are wired into `test_suites.yml` (the `notify` gate) so they block PRs; the Neo4j stack goes into `nightly_tests.yml` so it never blocks a PR. Everything runs on the **mock LLM by default** (no API key), and the cross-backend assertion uses `CHUNKS` so it's deterministic and actually exercises each backend's store rather than the LLM output.

One gotcha worth flagging: cognee's session memory is on by default, which makes `search`/`recall` fire a structured `SessionTurnAnalysis` call. I taught the mock to synthesize a valid instance for any schema it doesn't special-case, and run the container with `CACHING=false`, so retrieval hits the permanent graph cleanly.

## Acceptance
- `pytest -m deployment` discovers and runs the deployment tests.
- Free-backend matrix (SQLite & Postgres) passes against a locally-built container with the mock LLM and **no real LLM key**.
- Same golden entity retrievable across both backends, for the golden flow and for `remember → recall`.
- Neo4j variant is nightly, not PR-blocking.
- Containers are always torn down, even on failure.

## Type of change
Tests / CI.

## How to run locally
```bash
docker build -t cognee:local .
COGNEE_DOCKER_IMAGE=cognee:local uv run pytest cognee/tests/deployment/ -v -m "deployment and not nightly"
```

## Local test run

<details>
<summary><code>pytest -m "deployment and not nightly"</code> against a container built from this branch — <b>9 passed</b></summary>

```
collected 11 items / 2 deselected / 9 selected

cognee/tests/deployment/test_backend_matrix.py::test_golden_flow[sqlite_lancedb_kuzu] PASSED [ 11%]
cognee/tests/deployment/test_backend_matrix.py::test_golden_flow[postgres_pgvector_postgresgraph] PASSED [ 22%]
cognee/tests/deployment/test_backend_matrix.py::test_remember_recall[sqlite_lancedb_kuzu] PASSED [ 33%]
cognee/tests/deployment/test_backend_matrix.py::test_remember_recall[postgres_pgvector_postgresgraph] PASSED [ 44%]
cognee/tests/deployment/test_harness.py::test_knowledge_graph_schema_returns_golden_entity PASSED [ 55%]
cognee/tests/deployment/test_harness.py::test_answer_schema_returns_golden_answer PASSED [ 66%]
cognee/tests/deployment/test_harness.py::test_schema_name_resolves_from_tools_payload PASSED [ 77%]
cognee/tests/deployment/test_harness.py::test_plain_completion_returns_golden_answer PASSED [ 88%]
cognee/tests/deployment/test_harness.py::test_embeddings_dimensions_by_model PASSED [100%]

========== 9 passed, 2 deselected, 10 warnings in 200.04s (0:03:20) ==========
```
</details>

<img width="2076" height="1154" alt="t10-tests-full-suite" src="https://github.com/user-attachments/assets/25ec7b46-d5ad-4515-9968-a2f72fe3e2de" />

<img width="1960" height="1120" alt="t10-matrix-summary" src="https://github.com/user-attachments/assets/8b0ec473-6867-4095-8829-6c7c9733f4fe" />

<img width="2059" height="602" alt="t10-tests-sqlite-stack" src="https://github.com/user-attachments/assets/4b967a81-9b81-4e59-a9b9-be577f7f4d93" />


## Pre-submission checklist
- [x] Code follows the project style (ruff check + format pass)
- [x] Tests added
- [x] Tests pass locally
- [x] PR targets `dev`
- [x] Commits are signed off (`git commit -s`)

## Notes
Builds on the deployment-test initiative (#3358 / #3563); vendored here because #3358 isn't merged yet. Linked to #3368.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin
