### PR TITLE
fix(session): surface parameter validation errors in session-context methods

### DIFF
--- a/cognee/infrastructure/session/session_manager.py
+++ b/cognee/infrastructure/session/session_manager.py
@@ -734,13 +734,12 @@ class SessionManager:
         """
         Append one session-context entry (a plain dict carrying a "kind" field).
 
-        Fail-open: returns False when cache unavailable or on any error, never raises.
+        Fail-open on cache-availability and operational errors: returns False when the
+        cache is unavailable or the cache call fails. Invalid parameters raise
+        SessionParameterValidationError, consistent with the rest of SessionManager.
         """
         session_id = self._resolve_session_id(session_id)
-        try:
-            self._validate_session_params(user_id=user_id, session_id=session_id)
-        except Exception:
-            return False
+        self._validate_session_params(user_id=user_id, session_id=session_id)
         if not self.is_available:
             logger.debug("SessionManager: cache unavailable, skipping create_session_context_entry")
             return False
@@ -760,13 +759,12 @@ class SessionManager:
         """
         Return all stored session-context entries (both "context" and "feedback" kinds).
 
-        Fail-open: returns [] when cache unavailable or on any error, never raises.
+        Fail-open on cache-availability and operational errors: returns [] when the cache
+        is unavailable or the cache call fails. Invalid parameters raise
+        SessionParameterValidationError, consistent with the rest of SessionManager.
         """
         session_id = self._resolve_session_id(session_id)
-        try:
-            self._validate_session_params(user_id=user_id, session_id=session_id)
-        except Exception:
-            return []
+        self._validate_session_params(user_id=user_id, session_id=session_id)
         if not self.is_available:
             logger.debug("SessionManager: cache unavailable, returning empty session context")
             return []
@@ -787,13 +785,12 @@ class SessionManager:
         """
         Shallow-merge updates into the session-context entry matching entry["id"].
 
-        Fail-open: returns False when cache unavailable or on any error, never raises.
+        Fail-open on cache-availability and operational errors: returns False when the
+        cache is unavailable or the cache call fails. Invalid parameters raise
+        SessionParameterValidationError, consistent with the rest of SessionManager.
         """
         session_id = self._resolve_session_id(session_id)
-        try:
-            self._validate_session_params(user_id=user_id, session_id=session_id)
-        except Exception:
-            return False
+        self._validate_session_params(user_id=user_id, session_id=session_id)
         if not self.is_available:
             logger.debug("SessionManager: cache unavailable, skipping update_session_context_entry")
             return False
@@ -814,13 +811,12 @@ class SessionManager:
         """
         Delete the entire session-context list for the given session.
 
-        Fail-open: returns False when cache unavailable or on any error, never raises.
+        Fail-open on cache-availability and operational errors: returns False when the
+        cache is unavailable or the cache call fails. Invalid parameters raise
+        SessionParameterValidationError, consistent with the rest of SessionManager.
         """
         session_id = self._resolve_session_id(session_id)
-        try:
-            self._validate_session_params(user_id=user_id, session_id=session_id)
-        except Exception:
-            return False
+        self._validate_session_params(user_id=user_id, session_id=session_id)
         if not self.is_available:
             logger.debug("SessionManager: cache unavailable, skipping delete_session_context")
             return False

--- a/cognee/tests/unit/infrastructure/session/test_session_manager.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_manager.py
@@ -1201,3 +1201,75 @@ class TestSessionManager:
         qa_kw = mock_cache.create_qa_entry.call_args.kwargs
         assert qa_kw["feedback_text"] is None
         assert qa_kw["feedback_score"] is None
+
+    # ------------------------------------------------------------------
+    # Session-context methods: parameter validation must surface (not be
+    # swallowed as empty results), while cache-availability and operational
+    # errors stay fail-open. Regression test for the inconsistency where a
+    # malformed user_id/session_id silently returned [] / False, making a
+    # typo indistinguishable from "no data exists".
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_create_session_context_entry_invalid_params_raise(self, sm):
+        """create_session_context_entry raises on empty/whitespace user_id or session_id."""
+        with pytest.raises(SessionParameterValidationError):
+            await sm.create_session_context_entry(
+                user_id="", entry_dump={"kind": "context"}, session_id="s1"
+            )
+        with pytest.raises(SessionParameterValidationError):
+            await sm.create_session_context_entry(
+                user_id="u1", entry_dump={"kind": "context"}, session_id="   "
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_session_context_entries_invalid_params_raise(self, sm):
+        """get_session_context_entries raises on invalid user_id instead of returning []."""
+        with pytest.raises(SessionParameterValidationError):
+            await sm.get_session_context_entries(user_id="", session_id="s1")
+
+    @pytest.mark.asyncio
+    async def test_update_session_context_entry_invalid_params_raise(self, sm):
+        """update_session_context_entry raises on invalid session_id."""
+        with pytest.raises(SessionParameterValidationError):
+            await sm.update_session_context_entry(
+                user_id="u1", entry_id="e1", merge={"x": 1}, session_id=""
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_session_context_invalid_params_raise(self, sm):
+        """delete_session_context raises on invalid user_id."""
+        with pytest.raises(SessionParameterValidationError):
+            await sm.delete_session_context(user_id="  ", session_id="s1")
+
+    @pytest.mark.asyncio
+    async def test_session_context_methods_unavailable_fail_open(self, sm_unavailable):
+        """With cache unavailable, valid calls still fail-open (no raise)."""
+        assert (
+            await sm_unavailable.create_session_context_entry(
+                user_id="u1", entry_dump={"kind": "context"}, session_id="s1"
+            )
+            is False
+        )
+        assert await sm_unavailable.get_session_context_entries(user_id="u1", session_id="s1") == []
+        assert (
+            await sm_unavailable.update_session_context_entry(
+                user_id="u1", entry_id="e1", merge={"x": 1}, session_id="s1"
+            )
+            is False
+        )
+        assert await sm_unavailable.delete_session_context(user_id="u1", session_id="s1") is False
+
+    @pytest.mark.asyncio
+    async def test_get_session_context_entries_cache_error_fails_open(self, sm, mock_cache):
+        """Operational cache errors stay fail-open (return []), unlike invalid params."""
+        mock_cache.get_session_context_entries = AsyncMock(side_effect=Exception("boom"))
+        assert await sm.get_session_context_entries(user_id="u1", session_id="s1") == []
+
+    @pytest.mark.asyncio
+    async def test_get_session_context_entries_valid_delegates_to_cache(self, sm, mock_cache):
+        """Valid params delegate to the cache and return its result."""
+        mock_cache.get_session_context_entries.return_value = [{"kind": "context", "id": "c1"}]
+        result = await sm.get_session_context_entries(user_id="u1", session_id="s1")
+        assert result == [{"kind": "context", "id": "c1"}]
+        mock_cache.get_session_context_entries.assert_awaited_once_with("u1", "s1")


### PR DESCRIPTION
Fixes #3881

`create_session_context_entry`, `get_session_context_entries`, `update_session_context_entry`, and `delete_session_context` wrap `_validate_session_params()` in a bare `except Exception: return False/[]`. An empty or whitespace `user_id`/`session_id` gets silently treated as "no data exists" instead of raising, which makes a typo indistinguishable from an empty session.

Every other method on `SessionManager` (`add_qa`, `get_session`, `update_qa`, `delete_qa`, `delete_session`, etc.) calls the same validator unguarded and lets it raise. This brings the four session-context methods in line with that, while keeping the fail-open behavior for cache-unavailable and cache-call-failure cases (that part of the docstrings stays accurate).

Added tests covering:
- invalid params now raise `SessionParameterValidationError` on all four methods
- cache-unavailable and cache-call-exception paths still fail open (no behavior change there)
- happy path still delegates to the cache correctly

Ran the full session unit suite locally, all green.