### PR TITLE
fix(retrieval): apply truth-subspace weighting over the full candidate set (#3653)

### DIFF
--- a/cognee/modules/retrieval/hybrid/chunks.py
+++ b/cognee/modules/retrieval/hybrid/chunks.py
@@ -35,7 +35,7 @@ async def retrieve_hybrid_chunks(
     query_vector: Optional[list[float]] = None,
     use_truth_weight: bool = False,
     q_coords: Optional[list[float]] = None,
-    truth_state_by_id: Optional[dict] = None,
+    graph_engine: Any = None,
     current_truth_epoch: Optional[int] = None,
 ) -> dict[str, Any]:
     candidate_limit = max(0, chunks_top_k * 2)
@@ -80,6 +80,10 @@ async def retrieve_hybrid_chunks(
         )
         attach_source_chunks(pairs, source_chunks)
 
+    truth_state_by_id = await load_candidate_truth_state(
+        graph_engine, pairs, use_truth_weight, q_coords, current_truth_epoch
+    )
+
     ranked_pairs = rank_chunk_summary_pairs(
         pairs,
         chunks_top_k,
@@ -101,6 +105,45 @@ async def retrieve_hybrid_chunks(
         "chunks": [pair["chunk"] for pair in ranked_pairs if pair["chunk"] is not None],
         "chunk_summaries": summary_text_by_chunk_id(ranked_pairs),
     }
+
+
+async def load_candidate_truth_state(
+    graph_engine: Any,
+    pairs: list[dict],
+    use_truth_weight: bool,
+    q_coords: Optional[list[float]],
+    current_truth_epoch: Optional[int],
+) -> Optional[dict]:
+    """Batch-fetch truth alignments for every assembled candidate chunk.
+
+    Keyed over the full candidate set (BM25 + vector + summary source chunks),
+    not just the vector window, so ranking applies a consistent truth factor to
+    every channel. Returns ``None`` (baseline) when the truth weight is off or
+    context is missing, and fails open to baseline on any error.
+    """
+    if not (
+        use_truth_weight
+        and q_coords
+        and current_truth_epoch is not None
+        and graph_engine is not None
+    ):
+        return None
+
+    chunk_ids = []
+    seen = set()
+    for pair in pairs:
+        chunk_id = pair["chunk_id"] or result_id(pair["chunk"])
+        if chunk_id and chunk_id not in seen:
+            seen.add(chunk_id)
+            chunk_ids.append(str(chunk_id))
+    if not chunk_ids:
+        return {}
+
+    try:
+        return await graph_engine.get_node_truth_state(chunk_ids)
+    except Exception as error:
+        logger.debug("Truth-subspace lookup failed; using baseline ranking: %s", error)
+        return None
 
 
 def summary_candidate_limit(chunks_top_k: int, text_summaries_top_k: Optional[int]) -> int:

--- a/cognee/modules/retrieval/hybrid_retriever.py
+++ b/cognee/modules/retrieval/hybrid_retriever.py
@@ -14,7 +14,6 @@ from cognee.modules.retrieval.hybrid.context import (
 )
 from cognee.modules.retrieval.hybrid.entities import build_entities
 from cognee.modules.retrieval.hybrid.facts import edge_rank_by_id, select_facts
-from cognee.modules.retrieval.hybrid.results import result_id
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.modules.retrieval.utils.global_context import (
     format_global_context_prelude,
@@ -84,13 +83,12 @@ class HybridRetriever(BaseRetriever):
         query_embeddings = await self._unified_engine.vector.embedding_engine.embed_text([query])
         query_vector = query_embeddings[0]
 
-        q_coords, truth_state_by_id, current_truth_epoch = await self._build_truth_context(
-            query_vector
-        )
+        q_coords, current_truth_epoch = await self._build_truth_context(query_vector)
 
         chunk_objects, (entities, facts) = await asyncio.gather(
             retrieve_hybrid_chunks(
                 vector_engine=self._unified_engine.vector,
+                graph_engine=self._unified_engine.graph,
                 query=query,
                 chunks_top_k=self.chunks_top_k,
                 text_summaries_top_k=self.text_summaries_top_k,
@@ -100,7 +98,6 @@ class HybridRetriever(BaseRetriever):
                 query_vector=query_vector,
                 use_truth_weight=self.use_truth_weight,
                 q_coords=q_coords,
-                truth_state_by_id=truth_state_by_id,
                 current_truth_epoch=current_truth_epoch,
             ),
             self._retrieve_entities_and_facts(query, query_vector),
@@ -110,59 +107,32 @@ class HybridRetriever(BaseRetriever):
     async def _build_truth_context(self, query_vector: list[float]) -> tuple:
         """Truth-subspace alignment context for the chunk lane.
 
-        Returns ``(q_coords, truth_state_by_id, current_truth_epoch)``. Values
-        are ``None`` when the truth weight is off or centroid slots are absent,
-        so ranking stays at exact baseline. Fails open to baseline on any error.
+        Returns ``(q_coords, current_truth_epoch)``. Both are ``None`` when the
+        truth weight is off or centroid slots are absent, so ranking stays at
+        exact baseline. Fails open to baseline on any error. The per-candidate
+        truth-state map is fetched later, inside the chunk lane, over the full
+        assembled candidate set (BM25 + vector + summary), so every channel gets
+        a consistent truth factor.
         """
         if not self.use_truth_weight:
-            return None, None, None
+            return None, None
 
         try:
             dataset_id = current_dataset_id.get()
             if dataset_id is None:
-                return None, None, None
+                return None, None
 
             centroids = await load_centroids(self._unified_engine.vector, str(dataset_id))
             if not centroids:
-                return None, None, None
+                return None, None
 
             centroid_vectors = [centroid.centroid for centroid in centroids]
             q_coords = pad_coords(align.query_coords(query_vector, centroid_vectors), DEFAULT_K)
             current_truth_epoch = max(centroid.truth_epoch for centroid in centroids)
-
-            candidate_chunk_ids = await self._candidate_chunk_ids(query_vector)
-            if not candidate_chunk_ids:
-                return q_coords, {}, current_truth_epoch
-
-            truth_state_by_id = await self._unified_engine.graph.get_node_truth_state(
-                candidate_chunk_ids
-            )
-            return q_coords, truth_state_by_id, current_truth_epoch
+            return q_coords, current_truth_epoch
         except Exception as error:
             logger.debug("Truth-subspace lookup failed; using baseline ranking: %s", error)
-            return None, None, None
-
-    async def _candidate_chunk_ids(self, query_vector: list[float]) -> list[str]:
-        """Candidate DocumentChunk ids whose truth alignments we batch-fetch.
-
-        Mirrors the chunk lane's vector candidate window so the truth coords map
-        covers the chunks that ranking can surface."""
-        candidate_limit = max(0, self.chunks_top_k * 2)
-        chunk_hits = await search_collection(
-            self._unified_engine.vector,
-            "DocumentChunk_text",
-            "",
-            candidate_limit,
-            self.node_name,
-            self.node_name_filter_operator,
-            query_vector=query_vector,
-        )
-        ids = []
-        for hit in chunk_hits:
-            chunk_id = result_id(hit)
-            if chunk_id:
-                ids.append(str(chunk_id))
-        return ids
+            return None, None
 
     async def _retrieve_entities_and_facts(self, query: str, query_vector: list[float]) -> tuple:
         """Entity lane, run concurrently with the chunk lane so the graph round trip for

--- a/cognee/tests/unit/modules/retrieval/test_hybrid_truth_context.py
+++ b/cognee/tests/unit/modules/retrieval/test_hybrid_truth_context.py
@@ -3,8 +3,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from cognee.context_global_variables import current_dataset_id
+from cognee.modules.retrieval.hybrid.chunks import retrieve_hybrid_chunks
 from cognee.modules.retrieval.hybrid_retriever import HybridRetriever
 from cognee.modules.truth_subspace.models import TruthCentroidPayload
+
+CURRENT_EPOCH = 7
 
 
 def _unified_engine():
@@ -17,8 +20,21 @@ def _unified_engine():
     return engine
 
 
+def _result(result_id="result-id", payload=None):
+    scored_result = MagicMock()
+    scored_result.id = result_id
+    scored_result.payload = payload
+    return scored_result
+
+
+def _chunk_id(chunk):
+    if isinstance(chunk, dict):
+        return chunk.get("id")
+    return chunk.payload.get("id")
+
+
 @pytest.mark.asyncio
-async def test_truth_context_loads_exact_centroid_slots_for_current_dataset():
+async def test_truth_context_returns_query_coords_without_prefetching_truth_state():
     retriever = HybridRetriever(chunks_top_k=1, use_truth_weight=True)
     retriever._unified_engine = _unified_engine()
     centroid_loader = AsyncMock(
@@ -36,25 +52,93 @@ async def test_truth_context_loads_exact_centroid_slots_for_current_dataset():
     token = current_dataset_id.set("dataset-1")
 
     try:
-        with (
-            patch(
-                "cognee.modules.retrieval.hybrid_retriever.load_centroids",
-                centroid_loader,
-            ),
-            patch.object(
-                retriever,
-                "_candidate_chunk_ids",
-                new=AsyncMock(return_value=["chunk-1"]),
-            ),
+        with patch(
+            "cognee.modules.retrieval.hybrid_retriever.load_centroids",
+            centroid_loader,
         ):
-            q_coords, truth_state_by_id, current_truth_epoch = await retriever._build_truth_context(
-                [1.0, 0.0, 0.0]
-            )
+            q_coords, current_truth_epoch = await retriever._build_truth_context([1.0, 0.0, 0.0])
     finally:
         current_dataset_id.reset(token)
 
     centroid_loader.assert_awaited_once_with(retriever._unified_engine.vector, "dataset-1")
-    retriever._unified_engine.graph.get_node_truth_state.assert_awaited_once_with(["chunk-1"])
+    # The truth-state map is now built from the full candidate set inside the chunk
+    # lane, so the context builder must not pre-fetch it from a vector-only window.
+    retriever._unified_engine.graph.get_node_truth_state.assert_not_awaited()
     assert q_coords == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    assert truth_state_by_id == {"chunk-1": {"truth_alignment": [1.0], "truth_epoch": 3}}
     assert current_truth_epoch == 3
+
+
+@pytest.mark.asyncio
+async def test_truth_state_covers_bm25_and_summary_only_candidates():
+    # Regression for #3653: chunks surfaced only via BM25 or the summary channel are
+    # absent from the vector candidate window. The truth-state map must still cover
+    # them so every channel gets a truth factor instead of a neutral 1.0.
+    vector = MagicMock()
+
+    async def search(collection_name, *args, **kwargs):
+        if collection_name == "DocumentChunk_text":
+            return [_result("vector-1", {"id": "vector-1", "text": "Vector chunk"})]
+        if collection_name == "TextSummary_text":
+            return [
+                _result(
+                    "summary-1",
+                    {"id": "summary-1", "text": "Summary", "source_chunk_id": "summary-only"},
+                )
+            ]
+        return []
+
+    async def retrieve(collection_name, ids):
+        if collection_name == "DocumentChunk_text":
+            return [_result("summary-only", {"id": "summary-only", "text": "Summary source"})]
+        return []
+
+    vector.search = AsyncMock(side_effect=search)
+    vector.retrieve = AsyncMock(side_effect=retrieve)
+
+    graph = MagicMock()
+    graph.get_node_truth_state = AsyncMock(
+        return_value={
+            "vector-1": {"truth_alignment": [0.5], "truth_epoch": CURRENT_EPOCH},  # factor 1.0
+            "bm25-only": {"truth_alignment": [0.0], "truth_epoch": CURRENT_EPOCH},  # factor 0.75
+            "summary-only": {"truth_alignment": [0.0], "truth_epoch": CURRENT_EPOCH},  # factor 0.75
+        }
+    )
+
+    bm25_retriever = MagicMock()
+    bm25_retriever.get_retrieved_objects = AsyncMock(
+        return_value=[({"id": "bm25-only", "text": "BM25 chunk"}, 2.0)]
+    )
+
+    with patch(
+        "cognee.modules.retrieval.hybrid.chunks.BM25ChunksRetriever",
+        return_value=bm25_retriever,
+    ):
+        result = await retrieve_hybrid_chunks(
+            vector_engine=vector,
+            graph_engine=graph,
+            query="q",
+            chunks_top_k=3,
+            text_summaries_top_k=None,
+            node_name=None,
+            node_name_filter_operator="OR",
+            use_importance_weight=False,
+            query_vector=[0.1, 0.2],
+            use_truth_weight=True,
+            q_coords=[1.0],
+            current_truth_epoch=CURRENT_EPOCH,
+        )
+
+    # The truth map is fetched over the full assembled candidate set, not just the
+    # vector window: BM25-only and summary-only ids must be included.
+    graph.get_node_truth_state.assert_awaited_once()
+    requested_ids = set(graph.get_node_truth_state.await_args.args[0])
+    assert {"vector-1", "bm25-only", "summary-only"} <= requested_ids
+
+    # The 0.75 truth factor is actually applied to the BM25-only and summary-only
+    # chunks, demoting them below the neutral (1.0) vector chunk. Without the fix
+    # they would keep a neutral 1.0 and tie, leaving vector-1 last by id order.
+    assert [_chunk_id(chunk) for chunk in result["chunks"]] == [
+        "vector-1",
+        "bm25-only",
+        "summary-only",
+    ]


### PR DESCRIPTION
Closes #3653.

## Problem
The hybrid retriever's truth-alignment map (`truth_state_by_id`) is built from a **vector-only** candidate window (`chunks_top_k * 2`). Chunks surfaced through the BM25 or summary channels therefore receive a neutral truth factor, while vector chunks get the `[0.75, 1.25]` multiplier — so identical content is truth-weighted differently depending only on which channel surfaced it.

## Fix
Build the truth-state map over the **full assembled candidate set** (BM25 + vector + summary) instead of a pre-fetched vector-only window, so every candidate is weighted consistently.

## Files
- `cognee/modules/retrieval/hybrid_retriever.py`
- `cognee/modules/retrieval/hybrid/chunks.py`
- `cognee/modules/retrieval/test_hybrid_truth_context.py` — expanded; mocks the vector/graph engines so it runs offline (no DB/LLM/network).

Commit is DCO signed-off.
