### PR TITLE
perf(retrieval): bound the vector-search window in batch/scoped triplet search (#3919)

### DIFF
--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -243,8 +243,15 @@ async def brute_force_triplet_search(
         memory_fragment (Optional[CogneeGraph]): Existing memory fragment to reuse.
         node_type: node type to filter
         node_name: node name to filter
-        wide_search_top_k (Optional[int]): Number of initial elements to retrieve from collections.
-            Ignored in batch mode (always None to project full graph).
+        wide_search_top_k (Optional[int]): Bounds the per-collection vector-search window in
+            every mode (batch and node_name-scoped included). This fixes an unbounded
+            limit=None that previously made batch and node_name-scoped searches scan the ENTIRE
+            vector collection (LanceDB count_rows() / PGVector full-table order). Defaults to
+            100, mirroring the single-query default. Pass None to restore the old unbounded
+            full-collection scan (escape hatch). Semantic note: for collections larger than this
+            cap the candidate set is now bounded rather than exhaustive. Out of scope here: batch
+            mode still projects the full graph (relevant_ids_to_filter=None); switching it to an
+            ID-filtered projection is a deliberate follow-up.
         triplet_distance_penalty (Optional[float]): Default distance penalty in graph projection
         feedback_influence (float): Weight of feedback influence in range [0, 1]
 
@@ -275,6 +282,15 @@ async def brute_force_triplet_search(
         )
 
         query_list_length = len(query_batch) if query_batch is not None else None
+        # Vector-search window: bounded so batch and node_name-scoped searches don't scan
+        # the whole collection (LanceDB/PGVector treat limit=None as "return everything",
+        # and batch mode additionally forces a full-graph projection). Latency/memory now
+        # scale with wide_search_top_k, not total DB size. Pass wide_search_top_k=None to
+        # explicitly opt back into an unbounded full-collection scan.
+        vector_search_limit = wide_search_top_k
+        # Graph-projection selector: None => full-graph projection (batch and node_name-scoped
+        # modes); an int => ID-filtered projection (default single-query mode). Behavior here
+        # is unchanged; ID-filtered projection for batch mode is a follow-up.
         wide_search_limit = (
             None if query_list_length else (wide_search_top_k if node_name is None else None)
         )
@@ -303,7 +319,7 @@ async def brute_force_triplet_search(
                 query=None if query_list_length else query,
                 query_batch=query_batch if query_list_length else None,
                 collections=collections,
-                wide_search_limit=wide_search_limit,
+                wide_search_limit=vector_search_limit,
                 node_name=node_name,
                 node_name_filter_operator=node_name_filter_operator,
             )

--- a/cognee/modules/retrieval/utils/node_edge_vector_search.py
+++ b/cognee/modules/retrieval/utils/node_edge_vector_search.py
@@ -59,7 +59,9 @@ class NodeEdgeVectorSearch:
             if query_batch is not None:
                 self.query_list_length = len(query_batch)
                 span.set_attribute("cognee.vector.batch_size", len(query_batch))
-                search_results = await self._run_batch_search(collections, query_batch)
+                search_results = await self._run_batch_search(
+                    collections, query_batch, wide_search_limit
+                )
             else:
                 self.query_list_length = None
                 search_results = await self._run_single_search(
@@ -138,21 +140,30 @@ class NodeEdgeVectorSearch:
                     self.node_distances[collection] = result
 
     async def _run_batch_search(
-        self, collections: List[str], query_batch: List[str]
+        self,
+        collections: List[str],
+        query_batch: List[str],
+        wide_search_limit: Optional[int] = None,
     ) -> List[List[Any]]:
         """Runs batch search across all collections and returns list-of-lists per collection."""
         search_tasks = [
-            self._search_batch_collection(collection, query_batch) for collection in collections
+            self._search_batch_collection(collection, query_batch, wide_search_limit)
+            for collection in collections
         ]
         return await asyncio.gather(*search_tasks)
 
     async def _search_batch_collection(
-        self, collection_name: str, query_batch: List[str]
+        self,
+        collection_name: str,
+        query_batch: List[str],
+        wide_search_limit: Optional[int] = None,
     ) -> List[List[Any]]:
         """Searches one collection with batch queries and returns list-of-lists."""
         try:
             return await self.vector_engine.batch_search(
-                collection_name=collection_name, query_texts=query_batch, limit=None
+                collection_name=collection_name,
+                query_texts=query_batch,
+                limit=wide_search_limit,
             )
         except CollectionNotFoundError:
             return [[]] * len(query_batch)

--- a/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
@@ -74,7 +74,7 @@ async def test_brute_force_triplet_search_wide_search_limit_global_search():
 
 @pytest.mark.asyncio
 async def test_brute_force_triplet_search_wide_search_limit_filtered_search():
-    """Test that wide_search_limit is None for filtered search (node_name provided)."""
+    """Test that node_name-scoped search is capped by wide_search_top_k (not an unbounded None scan)."""
     mock_vector_engine = AsyncMock()
     mock_vector_engine.embedding_engine = AsyncMock()
     mock_vector_engine.embedding_engine.embed_text = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
@@ -90,8 +90,9 @@ async def test_brute_force_triplet_search_wide_search_limit_filtered_search():
             wide_search_top_k=50,
         )
 
+        assert mock_vector_engine.search.call_args_list
         for call in mock_vector_engine.search.call_args_list:
-            assert call[1]["limit"] is None
+            assert call[1]["limit"] == 50
 
 
 @pytest.mark.asyncio
@@ -990,7 +991,7 @@ async def test_brute_force_triplet_search_shape_propagation_to_graph():
 
 @pytest.mark.asyncio
 async def test_brute_force_triplet_search_batch_path_comprehensive():
-    """Test batch mode: returns list-of-lists, skips ID filtering, passes None for wide_search_limit."""
+    """Test batch mode: returns list-of-lists, skips ID filtering, passes a bounded vector limit."""
     mock_vector_engine = AsyncMock()
     mock_vector_engine.embedding_engine = AsyncMock()
 
@@ -1027,7 +1028,9 @@ async def test_brute_force_triplet_search_batch_path_comprehensive():
         ) as mock_get_fragment,
     ):
         result = await brute_force_triplet_search(
-            query_batch=["q1", "q2"], collections=["Entity_name", "EdgeType_relationship_name"]
+            query_batch=["q1", "q2"],
+            collections=["Entity_name", "EdgeType_relationship_name"],
+            wide_search_top_k=25,
         )
 
         assert isinstance(result, list)
@@ -1042,7 +1045,7 @@ async def test_brute_force_triplet_search_batch_path_comprehensive():
         batch_search_calls = mock_vector_engine.batch_search.call_args_list
         assert len(batch_search_calls) > 0
         for call in batch_search_calls:
-            assert call[1]["limit"] is None
+            assert call[1]["limit"] == 25
 
 
 @pytest.mark.asyncio
@@ -1062,6 +1065,49 @@ async def test_brute_force_triplet_search_batch_error_fallback():
 
         assert result == [[], []]
         assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_brute_force_triplet_search_batch_passes_bounded_limit_by_default():
+    """Regression: batch mode must cap the vector search with a bounded int, never limit=None.
+
+    limit=None makes LanceDB/PGVector return the whole collection per query (and batch mode
+    also forces a full-graph projection), so latency/memory scale with total DB size instead
+    of top_k. The default wide_search_top_k (100) must be threaded into batch_search.
+    """
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.embedding_engine = AsyncMock()
+    mock_vector_engine.batch_search = AsyncMock(return_value=[[], []])
+
+    with patch(
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        await brute_force_triplet_search(query_batch=["q1", "q2"])
+
+        assert mock_vector_engine.batch_search.call_args_list
+        for call in mock_vector_engine.batch_search.call_args_list:
+            limit = call[1]["limit"]
+            assert isinstance(limit, int), f"batch_search got non-int limit: {limit!r}"
+            assert limit == 100  # default wide_search_top_k
+
+
+@pytest.mark.asyncio
+async def test_brute_force_triplet_search_batch_none_opts_into_unbounded():
+    """wide_search_top_k=None remains an explicit escape hatch for a full-collection scan."""
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.embedding_engine = AsyncMock()
+    mock_vector_engine.batch_search = AsyncMock(return_value=[[], []])
+
+    with patch(
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        return_value=mock_vector_engine,
+    ):
+        await brute_force_triplet_search(query_batch=["q1", "q2"], wide_search_top_k=None)
+
+        assert mock_vector_engine.batch_search.call_args_list
+        for call in mock_vector_engine.batch_search.call_args_list:
+            assert call[1]["limit"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #3919.

## Problem
In batch mode (and single-query mode with a `node_name` filter), `brute_force_triplet_search` set the vector-search window to `None`, which the vector adapters treat as "return the whole collection" (`LanceDBAdapter` uses `count_rows()`; `PGVectorAdapter` orders the entire table). Retrieval cost then scaled with **total DB size** instead of `top_k`.

## Fix
Thread a bounded `wide_search_top_k` into the batch/scoped paths in `brute_force_triplet_search` and `node_edge_vector_search`, so the candidate window stays wide enough for reranking but is no longer unbounded.

## Files
- `cognee/modules/retrieval/utils/brute_force_triplet_search.py`
- `cognee/modules/retrieval/utils/node_edge_vector_search.py`
- `cognee/modules/retrieval/test_brute_force_triplet_search.py` — batch + `node_name`-filtered coverage.

Commit is DCO signed-off.

> Scope note: this is a correctness/robustness bound, verifiable by inspection plus the added tests. A full latency benchmark needs a large populated store; flagging that transparently rather than claiming a measured number.
