### PR TITLE
feat: implement fuzzy entity deduplication for improved merging of similar entities

### DIFF
--- a/cognee/modules/cognify/config.py
+++ b/cognee/modules/cognify/config.py
@@ -10,6 +10,8 @@ class CognifyConfig(BaseSettings):
     summarization_model: object = SummarizedContent
     triplet_embedding: bool = False
     chunks_per_batch: Optional[int] = None
+    fuzzy_entity_dedup: bool = True
+    fuzzy_entity_dedup_threshold: float = 0.72
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
     def to_dict(self) -> dict:
@@ -18,6 +20,8 @@ class CognifyConfig(BaseSettings):
             "summarization_model": self.summarization_model,
             "triplet_embedding": self.triplet_embedding,
             "chunks_per_batch": self.chunks_per_batch,
+            "fuzzy_entity_dedup": self.fuzzy_entity_dedup,
+            "fuzzy_entity_dedup_threshold": self.fuzzy_entity_dedup_threshold,
         }
 
 

--- a/cognee/modules/graph/utils/__init__.py
+++ b/cognee/modules/graph/utils/__init__.py
@@ -5,5 +5,6 @@ from .get_model_instance_from_graph import get_model_instance_from_graph
 from .retrieve_existing_edges import retrieve_existing_edges
 from .convert_node_to_data_point import convert_node_to_data_point
 from .deduplicate_nodes_and_edges import deduplicate_nodes_and_edges
+from .cluster_fuzzy_duplicate_entities import cluster_fuzzy_duplicate_entities
 from .resolve_edges_to_text import resolve_edges_to_text
 from .get_entity_nodes_from_triplets import get_entity_nodes_from_triplets

--- a/cognee/modules/graph/utils/cluster_fuzzy_duplicate_entities.py
+++ b/cognee/modules/graph/utils/cluster_fuzzy_duplicate_entities.py
@@ -1,0 +1,241 @@
+"""Embedding-similarity fuzzy dedup for Entity nodes (issue #3628, Approach B).
+
+Runs as a pre-processing step *before* ``deduplicate_nodes_and_edges`` in
+``add_data_points``. It finds Entity nodes whose ``name`` embeddings are near
+each other (semantic variants like "OpenAI" / "OpenAI Inc.") and collapses them
+onto a single canonical node by rewriting ids — so the existing id-based
+dedup/upsert path merges them for free, with no graph surgery.
+
+Canonical rule (decision (a)): the **first-appearing** node wins.
+  * In-batch cluster  → canonical is the earliest node in ``nodes``; duplicates
+    get their ``.id`` rewritten to it and stay in the list (downstream dedup
+    collapses them). Provenance goes on the canonical's ``metadata["merged_from"]``.
+  * Cross-batch hit   → canonical is the pre-existing graph node (earliest of
+    all). The batch duplicate is **removed** from ``nodes`` (never upserted, so
+    it can't overwrite the existing node) and its edges are remapped. Provenance
+    goes into the returned ``merge_records`` + a log line (the canonical isn't in
+    this batch, so there's nothing to attach ``merged_from`` to).
+"""
+
+from typing import Any
+
+import numpy as np
+
+from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
+from cognee.infrastructure.engine import DataPoint
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("cluster_fuzzy_duplicate_entities")
+
+# Entity name embeddings live in the "{type}_{field}" collection.
+ENTITY_NAME_COLLECTION = "Entity_name"
+
+
+def _is_entity(node: DataPoint) -> bool:
+    return type(node).__name__ == "Entity" and bool(getattr(node, "name", None))
+
+
+def _cosine_similarity_matrix(vectors: list[list[float]]) -> np.ndarray:
+    matrix = np.asarray(vectors, dtype=float)
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0  # avoid divide-by-zero for a zero vector
+    normalized = matrix / norms
+    return normalized @ normalized.T
+
+
+class _UnionFind:
+    """Union-Find that always keeps the *smallest* index as the root, so a
+    cluster's root is its first-appearing member."""
+
+    def __init__(self, size: int):
+        self._parent = list(range(size))
+
+    def find(self, x: int) -> int:
+        while self._parent[x] != x:
+            self._parent[x] = self._parent[self._parent[x]]
+            x = self._parent[x]
+        return x
+
+    def union(self, a: int, b: int) -> None:
+        root_a, root_b = self.find(a), self.find(b)
+        if root_a == root_b:
+            return
+        # Smaller index becomes the root -> first-appearing node is canonical.
+        if root_a < root_b:
+            self._parent[root_b] = root_a
+        else:
+            self._parent[root_a] = root_b
+
+
+def _remap(value: Any, id_map: dict[str, Any]) -> Any:
+    """Replace an id with its canonical, preserving str/UUID element type."""
+    canonical = id_map.get(str(value))
+    if canonical is None:
+        return value
+    return str(canonical) if isinstance(value, str) else canonical
+
+
+async def cluster_fuzzy_duplicate_entities(
+    nodes: list[DataPoint],
+    edges: list[tuple],
+    vector_engine,
+    similarity_threshold: float = 0.72,
+    top_k: int = 5,
+) -> tuple[list[DataPoint], list[tuple], list[dict]]:
+    """Merge fuzzy-duplicate Entity nodes by rewriting ids to a canonical node.
+
+    Returns the (possibly shrunk) ``nodes``, the id-remapped ``edges``, and a
+    list of ``merge_records`` describing every merge for auditing.
+    """
+    merge_records: list[dict] = []
+
+    entity_indices = [i for i, node in enumerate(nodes) if _is_entity(nodes[i])]
+    if len(entity_indices) == 0:
+        return nodes, edges, merge_records
+
+    entities = [nodes[i] for i in entity_indices]
+    names = [entity.name for entity in entities]
+    batch_ids = {str(entity.id) for entity in entities}
+
+    # 1 + 2. In-batch clustering via all-pairs cosine over this batch's names.
+    vectors = await vector_engine.embed_data(names)
+    sim = _cosine_similarity_matrix(vectors)
+
+    uf = _UnionFind(len(entities))
+    for i in range(len(entities)):
+        for j in range(i + 1, len(entities)):
+            if sim[i][j] >= similarity_threshold:
+                uf.union(i, j)
+
+    clusters: dict[int, list[int]] = {}
+    for i in range(len(entities)):
+        clusters.setdefault(uf.find(i), []).append(i)
+
+    # 3. Cross-batch: search each cluster representative against existing graph
+    #    entities. First ingest has no collection yet -> treat as no hits.
+    rep_indices = sorted(clusters.keys())  # cluster roots = first-appearing members
+    cross_hit: dict[int, Any] = {}  # rep index -> (existing_id, existing_name, similarity)
+    try:
+        search_results = await vector_engine.batch_search(
+            ENTITY_NAME_COLLECTION,
+            query_texts=[entities[r].name for r in rep_indices],
+            limit=top_k,
+            include_payload=True,
+        )
+    except CollectionNotFoundError:
+        search_results = None
+
+    if search_results:
+        for rep, results in zip(rep_indices, search_results):
+            for scored in results or []:
+                if str(scored.id) in batch_ids:
+                    continue  # never match our own not-yet-indexed batch nodes
+                similarity = 1.0 - scored.score  # built-in adapters: score = cosine distance
+                if similarity >= similarity_threshold:
+                    existing_name = (scored.payload or {}).get("name")
+                    cross_hit[rep] = (scored.id, existing_name, similarity)
+                    break  # top result over threshold wins
+
+    id_map: dict[str, Any] = {}
+    remove_ids: set[str] = set()
+
+    for root, members in clusters.items():
+        if root in cross_hit:
+            existing_id, existing_name, cross_sim = cross_hit[root]
+            # Whole cluster is a duplicate of a pre-existing node: map every
+            # member onto it and drop them from the batch (don't overwrite it).
+            for m in members:
+                node = entities[m]
+                id_map[str(node.id)] = existing_id
+                remove_ids.add(str(node.id))
+                member_sim = cross_sim if m == root else float(sim[root][m])
+                merge_records.append(
+                    {
+                        "duplicate_id": str(node.id),
+                        "duplicate_name": node.name,
+                        # Losing property value, kept for conflict-resolution audit:
+                        # canonical (first-appearing) wins, this value is discarded.
+                        "duplicate_description": getattr(node, "description", None),
+                        "canonical_id": str(existing_id),
+                        "canonical_name": existing_name,
+                        "similarity": member_sim,
+                        "method": "embedding_similarity",
+                        "threshold": similarity_threshold,
+                        "scope": "cross_batch",
+                    }
+                )
+                logger.info(
+                    "Fuzzy-merged entity into existing graph node",
+                    extra={
+                        "duplicate_id": str(node.id),
+                        "duplicate_name": node.name,
+                        "canonical_id": str(existing_id),
+                        "similarity": member_sim,
+                    },
+                )
+            continue
+
+        if len(members) == 1:
+            continue  # lone entity, nothing to merge
+
+        # In-batch cluster: earliest member is canonical; rewrite the rest.
+        canonical = entities[root]
+        merged_from = list(canonical.metadata.get("merged_from", []))
+        for m in members:
+            if m == root:
+                continue
+            node = entities[m]
+            original_id = str(node.id)
+            member_sim = float(sim[root][m])
+            id_map[original_id] = canonical.id
+            node.id = canonical.id  # dedup will collapse the now-identical ids
+            record = {
+                "duplicate_id": original_id,
+                "duplicate_name": node.name,
+                # Losing property value (canonical keeps its own), kept for audit.
+                "duplicate_description": getattr(node, "description", None),
+                "canonical_id": str(canonical.id),
+                "canonical_name": canonical.name,
+                "similarity": member_sim,
+                "method": "embedding_similarity",
+                "threshold": similarity_threshold,
+                "scope": "in_batch",
+            }
+            merge_records.append(record)
+            merged_from.append(
+                {
+                    "duplicate_id": record["duplicate_id"],
+                    "duplicate_name": record["duplicate_name"],
+                    "duplicate_description": record["duplicate_description"],
+                    "similarity": member_sim,
+                    "method": "embedding_similarity",
+                    "threshold": similarity_threshold,
+                }
+            )
+        if merged_from:
+            canonical.metadata["merged_from"] = merged_from  # type: ignore[typeddict-unknown-key]
+
+    if not id_map:
+        return nodes, edges, merge_records
+
+    # 6. Rewrite edges: tuple endpoints AND the ids embedded in the properties dict.
+    remapped_edges: list[tuple] = []
+    for edge in edges:
+        source, target, relationship, *rest = edge
+        properties = rest[0] if rest else None
+        if isinstance(properties, dict):
+            properties = dict(properties)
+            if "source_node_id" in properties:
+                properties["source_node_id"] = _remap(properties["source_node_id"], id_map)
+            if "target_node_id" in properties:
+                properties["target_node_id"] = _remap(properties["target_node_id"], id_map)
+        new_edge = (_remap(source, id_map), _remap(target, id_map), relationship)
+        if rest:
+            new_edge = new_edge + (properties, *rest[1:])
+        remapped_edges.append(new_edge)
+
+    # Drop cross-batch duplicates so they never reach upsert.
+    if remove_ids:
+        nodes = [node for node in nodes if str(node.id) not in remove_ids]
+
+    return nodes, remapped_edges, merge_records

--- a/cognee/tasks/storage/add_data_points.py
+++ b/cognee/tasks/storage/add_data_points.py
@@ -6,8 +6,10 @@ from cognee.infrastructure.engine import DataPoint
 from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.databases.unified.capabilities import EngineCapability
 from cognee.infrastructure.databases.relational import get_async_session
+from cognee.modules.cognify.config import get_cognify_config
 from cognee.modules.graph.methods import upsert_edges, upsert_nodes
 from cognee.modules.graph.utils import (
+    cluster_fuzzy_duplicate_entities,
     deduplicate_nodes_and_edges,
     ensure_default_edge_properties,
     get_graph_from_model,
@@ -77,6 +79,22 @@ async def add_data_points(
         nodes.extend(result_nodes)
         edges.extend(result_edges)
 
+    unified = await get_unified_engine()
+    graph_engine = unified.graph
+    vector_engine = unified.vector
+    use_hybrid = unified.has_capability(EngineCapability.HYBRID_WRITE)
+
+    cognify_config = get_cognify_config()
+    if cognify_config.fuzzy_entity_dedup:
+        # Must run before deduplicate_nodes_and_edges: it rewrites duplicate ids
+        # onto a canonical id so the exact-id dedup below collapses them for free.
+        nodes, edges, _fuzzy_merge_records = await cluster_fuzzy_duplicate_entities(
+            nodes,
+            edges,
+            vector_engine,
+            similarity_threshold=cognify_config.fuzzy_entity_dedup_threshold,
+        )
+
     nodes, edges = deduplicate_nodes_and_edges(nodes, edges)
 
     edges = ensure_default_edge_properties(edges, nodes=nodes)
@@ -85,11 +103,6 @@ async def add_data_points(
         if isinstance(custom_edges, list) and custom_edges
         else None
     )
-
-    unified = await get_unified_engine()
-    graph_engine = unified.graph
-    vector_engine = unified.vector
-    use_hybrid = unified.has_capability(EngineCapability.HYBRID_WRITE)
 
     if user and dataset and data_item:
         # Single session for all upserts: one transaction, one commit. The

--- a/cognee/tests/unit/modules/graph/test_cluster_fuzzy_duplicate_entities.py
+++ b/cognee/tests/unit/modules/graph/test_cluster_fuzzy_duplicate_entities.py
@@ -1,0 +1,500 @@
+"""Unit tests for cluster_fuzzy_duplicate_entities (issue #3628, Approach B).
+
+All data here is synthetic. The embedding engine is faked: `embed_data` returns
+hand-picked vectors so cosine similarity is fully under test control, and
+`batch_search` returns hand-built `ScoredResult`s. No real API is called.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
+from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.cognify.config import get_cognify_config
+from cognee.modules.engine.models import Entity
+from cognee.modules.graph.utils import (
+    cluster_fuzzy_duplicate_entities,
+    deduplicate_nodes_and_edges,
+)
+
+
+# --- synthetic embedding space --------------------------------------------
+# Unit vectors on a 2D arc, chosen so every cosine similarity is exact and
+# obvious. Angles from [1,0,0]: OpenAI 0deg, OpenAI Inc. 16.26deg, Open AI
+# 32.52deg. So:
+#   cos(OpenAI, OpenAI Inc.)      ~ 0.96   (high)
+#   cos(OpenAI Inc., Open AI)     ~ 0.96   (high)
+#   cos(OpenAI, Open AI)          ~ 0.843  (BELOW 0.95 -> tests transitivity)
+#   cos(OpenAI, Google)           = 0.0    (orthogonal)
+# A name not listed falls back to a zero vector (cosine 0 with everything).
+_VECTORS = {
+    "OpenAI": [1.0, 0.0, 0.0],
+    "OpenAI Inc.": [0.96, 0.28, 0.0],  # unit: 0.96^2 + 0.28^2 == 1
+    "Open AI": [0.8431, 0.5378, 0.0],
+    "Google": [0.0, 1.0, 0.0],
+    "Microsoft": [0.0, 0.0, 1.0],
+}
+
+
+def _vector_for(name: str) -> list[float]:
+    return _VECTORS.get(name, [0.0, 0.0, 0.0])
+
+
+def _fake_vector_engine(search_results=None, search_error=None):
+    engine = MagicMock()
+    engine.embed_data = AsyncMock(side_effect=lambda names: [_vector_for(n) for n in names])
+    if search_error is not None:
+        engine.batch_search = AsyncMock(side_effect=search_error)
+    else:
+        engine.batch_search = AsyncMock(return_value=search_results or [])
+    return engine
+
+
+def _entity(name: str, description: str = "") -> Entity:
+    return Entity(name=name, description=description or f"desc of {name}")
+
+
+def _edge(source, target, rel="related_to"):
+    """Edge tuple mirroring production shape, with ids embedded in properties."""
+    return (
+        source.id,
+        target.id,
+        rel,
+        {"source_node_id": source.id, "target_node_id": target.id, "relationship_name": rel},
+    )
+
+
+# --- in-batch clustering ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_in_batch_high_similarity_pair_merges_onto_first():
+    canonical = _entity("OpenAI")
+    dup = _entity("OpenAI Inc.")
+    other = _entity("Google")
+    # Edge from a chunk-like node into the duplicate, plus its properties.
+    edge = _edge(dup, other)
+
+    nodes = [canonical, dup, other]
+    engine = _fake_vector_engine()
+
+    result_nodes, result_edges, records = await cluster_fuzzy_duplicate_entities(
+        nodes, [edge], engine, similarity_threshold=0.95
+    )
+
+    # Duplicate's id was rewritten to the first-appearing canonical.
+    assert dup.id == canonical.id
+    assert other.id != canonical.id  # low similarity, untouched
+
+    # Edge endpoint AND embedded properties ids were remapped.
+    remapped = result_edges[0]
+    assert remapped[0] == canonical.id
+    assert remapped[3]["source_node_id"] == canonical.id
+    assert remapped[3]["target_node_id"] == other.id
+
+    # One in-batch merge recorded.
+    assert len(records) == 1
+    assert records[0]["scope"] == "in_batch"
+    assert records[0]["duplicate_name"] == "OpenAI Inc."
+    assert records[0]["canonical_id"] == str(canonical.id)
+
+    # Downstream dedup (unchanged) collapses the now-identical ids to one node.
+    final_nodes, _ = deduplicate_nodes_and_edges(result_nodes, result_edges)
+    entity_ids = {str(n.id) for n in final_nodes if type(n).__name__ == "Entity"}
+    assert str(canonical.id) in entity_ids
+    assert len([n for n in final_nodes if str(n.id) == str(canonical.id)]) == 1
+
+
+@pytest.mark.asyncio
+async def test_low_similarity_pair_not_merged():
+    a = _entity("OpenAI")
+    b = _entity("Google")
+    nodes = [a, b]
+    engine = _fake_vector_engine()
+
+    result_nodes, _, records = await cluster_fuzzy_duplicate_entities(
+        nodes, [], engine, similarity_threshold=0.95
+    )
+
+    assert a.id != b.id
+    assert records == []
+    assert len(result_nodes) == 2
+
+
+@pytest.mark.asyncio
+async def test_merged_from_provenance_written_on_canonical():
+    canonical = _entity("OpenAI")
+    dup = _entity("OpenAI Inc.")
+    engine = _fake_vector_engine()
+
+    await cluster_fuzzy_duplicate_entities([canonical, dup], [], engine, similarity_threshold=0.95)
+
+    merged_from = canonical.metadata["merged_from"]
+    assert len(merged_from) == 1
+    entry = merged_from[0]
+    assert entry["duplicate_name"] == "OpenAI Inc."
+    assert entry["method"] == "embedding_similarity"
+    assert entry["similarity"] >= 0.95
+    assert entry["threshold"] == 0.95
+
+
+@pytest.mark.asyncio
+async def test_union_find_transitive_clustering():
+    # A~B high, B~C high, but A~C is below threshold. Union-Find still groups
+    # all three, and everything merges onto the first-appearing node (A).
+    a = _entity("OpenAI")  # [1, 0, 0]
+    b = _entity("OpenAI Inc.")  # ~ a and ~ c
+    c = _entity("Open AI")  # ~ b, slightly further from a
+    engine = _fake_vector_engine()
+
+    result_nodes, _, records = await cluster_fuzzy_duplicate_entities(
+        [a, b, c], [], engine, similarity_threshold=0.95
+    )
+
+    assert b.id == a.id
+    assert c.id == a.id
+    assert {r["duplicate_name"] for r in records} == {"OpenAI Inc.", "Open AI"}
+
+    final_nodes, _ = deduplicate_nodes_and_edges(result_nodes, [])
+    assert len([n for n in final_nodes if str(n.id) == str(a.id)]) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "threshold, should_merge",
+    [(0.90, True), (0.95, True), (0.97, False)],
+)
+async def test_threshold_boundary(threshold, should_merge):
+    canonical = _entity("OpenAI")  # [1, 0, 0]
+    dup = _entity("OpenAI Inc.")  # cos ~ 0.96
+    engine = _fake_vector_engine()
+
+    _, _, records = await cluster_fuzzy_duplicate_entities(
+        [canonical, dup], [], engine, similarity_threshold=threshold
+    )
+
+    assert bool(records) is should_merge
+
+
+# --- cross-batch matching against existing graph nodes ---------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_batch_merges_into_existing_and_removes_duplicate():
+    existing_id = uuid4()
+    dup = _entity("OpenAI Inc.")
+    other = _entity("Google")
+    edge = _edge(dup, other)
+
+    # batch_search returns the pre-existing "OpenAI" node for the first query
+    # (the dup's cluster rep) and nothing for the second (Google).
+    search_results = [
+        [ScoredResult(id=existing_id, score=0.02, payload={"name": "OpenAI"})],  # sim 0.98
+        [],
+    ]
+    engine = _fake_vector_engine(search_results=search_results)
+
+    result_nodes, result_edges, records = await cluster_fuzzy_duplicate_entities(
+        [dup, other], [edge], engine, similarity_threshold=0.95
+    )
+
+    # The batch duplicate is REMOVED so it can never overwrite the existing node.
+    assert dup not in result_nodes
+    assert other in result_nodes
+
+    # Its edge now points at the existing node (tuple + properties).
+    remapped = result_edges[0]
+    assert remapped[0] == existing_id
+    assert remapped[3]["source_node_id"] == existing_id
+
+    # Cross-batch provenance lives in the returned records (canonical isn't in
+    # this batch, so there's no node to attach merged_from to).
+    assert len(records) == 1
+    assert records[0]["scope"] == "cross_batch"
+    assert records[0]["canonical_id"] == str(existing_id)
+    assert records[0]["canonical_name"] == "OpenAI"
+
+
+@pytest.mark.asyncio
+async def test_cross_batch_below_threshold_is_ignored():
+    existing_id = uuid4()
+    dup = _entity("OpenAI Inc.")
+    # Existing match, but distance too large -> similarity 0.80 < 0.95.
+    search_results = [[ScoredResult(id=existing_id, score=0.20, payload={"name": "Something"})]]
+    engine = _fake_vector_engine(search_results=search_results)
+
+    result_nodes, _, records = await cluster_fuzzy_duplicate_entities(
+        [dup], [], engine, similarity_threshold=0.95
+    )
+
+    assert dup in result_nodes
+    assert records == []
+
+
+@pytest.mark.asyncio
+async def test_batch_search_own_batch_id_is_not_a_cross_hit():
+    # A degenerate adapter that echoes the query's own (not-yet-indexed) id must
+    # not be treated as a cross-batch match.
+    dup = _entity("OpenAI Inc.")
+    search_results = [[ScoredResult(id=dup.id, score=0.0, payload={"name": "OpenAI Inc."})]]
+    engine = _fake_vector_engine(search_results=search_results)
+
+    result_nodes, _, records = await cluster_fuzzy_duplicate_entities(
+        [dup], [], engine, similarity_threshold=0.95
+    )
+
+    assert dup in result_nodes
+    assert records == []
+
+
+@pytest.mark.asyncio
+async def test_collection_not_found_falls_back_to_in_batch():
+    # First ingest: the Entity_name collection doesn't exist yet. The function
+    # must not crash and should still do in-batch clustering.
+    canonical = _entity("OpenAI")
+    dup = _entity("OpenAI Inc.")
+    engine = _fake_vector_engine(search_error=CollectionNotFoundError("Collection not found!"))
+
+    result_nodes, _, records = await cluster_fuzzy_duplicate_entities(
+        [canonical, dup], [], engine, similarity_threshold=0.95
+    )
+
+    assert dup.id == canonical.id  # in-batch merge still happened
+    assert len(records) == 1
+    assert records[0]["scope"] == "in_batch"
+
+
+# --- blocking / non-entity handling ---------------------------------------
+
+
+class _NonEntity(DataPoint):
+    name: str
+    metadata: dict = {"index_fields": ["name"]}
+
+
+@pytest.mark.asyncio
+async def test_non_entity_nodes_are_skipped():
+    # A same-named non-Entity node must not participate in fuzzy clustering.
+    chunk = _NonEntity(name="OpenAI")
+    entity = _entity("OpenAI")
+    engine = _fake_vector_engine()
+
+    result_nodes, _, records = await cluster_fuzzy_duplicate_entities(
+        [chunk, entity], [], engine, similarity_threshold=0.95
+    )
+
+    assert records == []
+    assert chunk in result_nodes and entity in result_nodes
+    # Only entity names get embedded (blocking narrows the candidate set).
+    engine.embed_data.assert_awaited_once_with(["OpenAI"])
+
+
+@pytest.mark.asyncio
+async def test_no_entities_returns_inputs_unchanged():
+    chunk = _NonEntity(name="whatever")
+    engine = _fake_vector_engine()
+
+    result_nodes, result_edges, records = await cluster_fuzzy_duplicate_entities(
+        [chunk], [], engine, similarity_threshold=0.95
+    )
+
+    assert result_nodes == [chunk]
+    assert records == []
+    engine.embed_data.assert_not_called()
+
+
+# --- shared-fixture precision/recall (deterministic lexical proxy) ----------
+
+_FIXTURE = (
+    Path(__file__).resolve().parents[5]
+    / "examples/pocs/post_extraction_canonicalization/data/example2"
+    / "expected_disambiguation_entities.txt"
+)
+
+
+def _bigram_vectors(names: list[str]) -> list[list[float]]:
+    """Deterministic char-bigram frequency vectors.
+
+    A reproducible *lexical* proxy for a real embedding engine, so precision/
+    recall is stable in CI with no API call. Absolute numbers differ from
+    production semantic embeddings (bigram overlap != semantic distance, and
+    the calibrated threshold below is proxy-specific, not the production 0.95);
+    this test guards the clustering logic and the precision/recall harness, and
+    can be re-pointed at real embeddings offline for production numbers.
+    """
+
+    def bigrams(s: str) -> list[str]:
+        s = s.lower()
+        return [s[i : i + 2] for i in range(len(s) - 1)]
+
+    vocab = sorted({b for n in names for b in bigrams(n)})
+    index = {b: i for i, b in enumerate(vocab)}
+    vectors = []
+    for name in names:
+        vector = [0.0] * len(vocab)
+        for b in bigrams(name):
+            vector[index[b]] += 1.0
+        vectors.append(vector)
+    return vectors
+
+
+def _lexical_engine():
+    engine = MagicMock()
+    engine.embed_data = AsyncMock(side_effect=lambda names: _bigram_vectors(names))
+    engine.batch_search = AsyncMock(return_value=[])  # in-batch clustering only
+    return engine
+
+
+def _pair_precision_recall(entities, gt_labels):
+    """Precision/recall of merge decisions.
+
+    A 'merge' is a pair of entities that ended up sharing a canonical id,
+    scored against ground-truth cluster labels.
+    """
+    ids = [str(e.id) for e in entities]
+    tp = fp = fn = 0
+    for i in range(len(entities)):
+        for j in range(i + 1, len(entities)):
+            predicted_same = ids[i] == ids[j]
+            truth_same = gt_labels[i] == gt_labels[j]
+            if predicted_same and truth_same:
+                tp += 1
+            elif predicted_same and not truth_same:
+                fp += 1
+            elif not predicted_same and truth_same:
+                fn += 1
+    precision = tp / (tp + fp) if (tp + fp) else 1.0
+    recall = tp / (tp + fn) if (tp + fn) else 1.0
+    return precision, recall
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _FIXTURE.exists(), reason="shared fixture not found")
+async def test_precision_recall_on_shared_fixture():
+    # 12 known "OpenAI" variants (all one ground-truth entity) + 3 distractors.
+    variants = [line.strip() for line in _FIXTURE.read_text().splitlines() if line.strip()]
+    distractors = ["Google", "Microsoft", "Tesla"]
+    names = variants + distractors
+    gt_labels = ["openai"] * len(variants) + distractors
+
+    entities = [_entity(n) for n in names]
+    # Threshold calibrated to the lexical proxy, NOT the production 0.95.
+    await cluster_fuzzy_duplicate_entities(
+        entities, [], _lexical_engine(), similarity_threshold=0.6
+    )
+
+    precision, recall = _pair_precision_recall(entities, gt_labels)
+
+    # Conservative by design: zero false merges (distractors never merge in).
+    assert precision == 1.0
+    # Partial recall: catches close lexical variants, misses distant ones
+    # ("the ai lab", "the a.i. lab", ...) — the documented threshold tradeoff.
+    assert 0.5 < recall < 1.0
+
+    # The obvious variants collapse into one cluster.
+    by_id: dict[str, set[str]] = {}
+    for e in entities:
+        by_id.setdefault(str(e.id), set()).add(e.name.lower())
+    openai_cluster = max(by_id.values(), key=len)
+    assert {"openai", "open ai", "openai hq"} <= openai_cluster
+    # Recall < 1: the 12 true duplicates do NOT all collapse into one node —
+    # lexically-distant variants stay separate (the documented tradeoff).
+    variant_ids = {str(entities[i].id) for i in range(len(variants))}
+    assert len(variant_ids) > 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _FIXTURE.exists(), reason="shared fixture not found")
+@pytest.mark.skipif(
+    not (os.getenv("LLM_API_KEY") or os.getenv("EMBEDDING_API_KEY")),
+    reason="requires a real LLM_API_KEY/EMBEDDING_API_KEY — opt-in, not run in CI",
+)
+async def test_precision_recall_with_real_embeddings():
+    """One-time report: real embedding-provider precision/recall on the shared
+    fixture, at the shipped production threshold (config default). Skipped
+    unless a real API key is set locally (see the PR doc for how to set
+    LLM_API_KEY without pasting it anywhere). Not part of CI — the
+    deterministic lexical-proxy test above is what CI runs.
+
+    Threshold history: calibrated against text-embedding-3-large on this same
+    fixture — precision=1.0/recall=1.0 held for 0.50-0.60, recall collapsed to
+    0.682 at 0.65, 0.439 at 0.70-0.72, and 0.242 at 0.80; precision started
+    degrading below 0.45 (unrelated companies merging). Shipped default is
+    0.72, not the precision/recall-optimal 0.50-0.60 band: at low thresholds,
+    Union-Find transitivity chains merges through intermediate names (observed
+    root<->member direct similarity as low as ~0.50), which raises the risk of
+    an unrelated "bridge" name over-merging two different entities on a larger,
+    noisier real dataset. 0.72 trades recall for shorter/rarer chains — though
+    even at 0.72 a single-hop bridge was observed ("open ai" merged via
+    "openai", 0.7283, despite a direct similarity to the cluster root of only
+    0.6167), so transitivity risk is reduced, not eliminated, by the threshold
+    alone. Known model-specific weak spot: abbreviation-expansion variants
+    (e.g. "NASA" vs "The National Aeronautics and Space Administration") score
+    systematically lower (~0.55-0.68) than spelling variants and are missed
+    entirely at this threshold. See cognee/modules/cognify/config.py for the
+    full rationale.
+
+    Run with `-s` to see the printed numbers:
+        pytest .../test_cluster_fuzzy_duplicate_entities.py::test_precision_recall_with_real_embeddings -s
+    """
+    variants = [line.strip() for line in _FIXTURE.read_text().splitlines() if line.strip()]
+    distractors = ["Google", "Microsoft", "Tesla"]
+    names = variants + distractors
+    gt_labels = ["openai"] * len(variants) + distractors
+
+    entities = [_entity(n) for n in names]
+    vector_engine = await get_vector_engine()  # real embedding provider, from .env
+    threshold = get_cognify_config().fuzzy_entity_dedup_threshold
+    await cluster_fuzzy_duplicate_entities(
+        entities, [], vector_engine, similarity_threshold=threshold
+    )
+
+    precision, recall = _pair_precision_recall(entities, gt_labels)
+
+    # NOTE: one-time report for the issue #3628 comparison table. Comment this
+    # print out (or delete it) once the numbers are recorded there — it's not
+    # needed for the test to pass, only to surface the numbers with `-s`.
+    print(
+        f"\n[Approach B / real embeddings] threshold={threshold:.2f} "
+        f"precision={precision:.3f} recall={recall:.3f}"
+    )
+
+    # Regression guard at the shipped default, measured on this fixture.
+    # Recall is intentionally low here (precision/safety over coverage — see
+    # docstring); banded rather than exact to tolerate minor embedding drift.
+    assert precision == 1.0
+    assert 0.30 < recall < 0.55
+
+
+# --- property conflict resolution (strict reading: show conflict handling) --
+
+
+@pytest.mark.asyncio
+async def test_property_conflict_resolution_first_appearing_wins():
+    # Two mentions of the same entity carry conflicting descriptions — a
+    # contradiction surfaced at merge time. Policy: first-appearing wins; the
+    # losing value is recorded in provenance for audit / reversal.
+    canonical = _entity("OpenAI", description="AI research company, SF")
+    dup = _entity("OpenAI Inc.", description="Delaware C-corp, founded 2015")
+
+    engine = _fake_vector_engine()  # controlled vectors: cos ~0.96, they merge
+    result_nodes, _, records = await cluster_fuzzy_duplicate_entities(
+        [canonical, dup], [], engine, similarity_threshold=0.95
+    )
+
+    # Winner keeps its own description; loser's is discarded, not blended.
+    survivors = [n for n in result_nodes if str(n.id) == str(canonical.id)]
+    assert survivors and survivors[0].description == "AI research company, SF"
+    # The discarded conflicting value is auditable in the merge record...
+    assert records[0]["duplicate_description"] == "Delaware C-corp, founded 2015"
+    # ...and persisted on the canonical node for audit / reversal.
+    assert (
+        canonical.metadata["merged_from"][0]["duplicate_description"]
+        == "Delaware C-corp, founded 2015"
+    )

--- a/cognee/tests/unit/tasks/storage/test_add_data_points.py
+++ b/cognee/tests/unit/tasks/storage/test_add_data_points.py
@@ -588,3 +588,82 @@ async def test_add_data_points_relational_upserts_happen_before_graph_and_vector
     )
     assert call_order[:3] == ["upsert_nodes", "upsert_edges", "upsert_edges"]
     assert first_graph_index >= 3
+
+
+@pytest.mark.asyncio
+@patch.object(adp_module, "index_graph_edges")
+@patch.object(adp_module, "index_data_points")
+@patch.object(adp_module, "get_cognify_config")
+@patch.object(adp_module, "cluster_fuzzy_duplicate_entities")
+@patch.object(adp_module, "get_unified_engine")
+@patch.object(adp_module, "deduplicate_nodes_and_edges")
+@patch.object(adp_module, "get_graph_from_model")
+async def test_add_data_points_runs_fuzzy_dedup_before_exact_dedup(
+    mock_get_graph,
+    mock_dedup,
+    mock_get_unified,
+    mock_fuzzy_dedup,
+    mock_get_config,
+    mock_index_nodes,
+    mock_index_edges,
+):
+    """Wiring check: fuzzy dedup runs (enabled by default), feeding its output
+    into the existing exact-id dedup, with the unified engine's vector_engine."""
+    dp1 = SimplePoint(text="first")
+    dp2 = SimplePoint(text="second")
+    edge1 = (str(dp1.id), str(dp2.id), "related_to", {"edge_text": "connects"})
+
+    mock_get_graph.side_effect = [([dp1], [edge1]), ([dp2], [])]
+    unified, graph_engine, vector_engine = _make_unified_mock()
+    mock_get_unified.return_value = unified
+    mock_get_config.return_value = SimpleNamespace(
+        fuzzy_entity_dedup=True, fuzzy_entity_dedup_threshold=0.95
+    )
+
+    fuzzy_nodes = [dp1]  # simulate dp2 being merged away
+    fuzzy_edges = [edge1]
+    mock_fuzzy_dedup.return_value = (fuzzy_nodes, fuzzy_edges, [{"duplicate_id": str(dp2.id)}])
+    mock_dedup.side_effect = lambda n, e: (n, e)
+
+    await add_data_points([dp1, dp2])
+
+    mock_fuzzy_dedup.assert_awaited_once()
+    call_args = mock_fuzzy_dedup.await_args
+    assert call_args.args[0] == [dp1, dp2]  # nodes, pre-fuzzy-merge
+    assert call_args.args[2] is vector_engine
+    assert call_args.kwargs["similarity_threshold"] == 0.95
+
+    # Exact dedup receives the fuzzy-merged output, not the raw pre-merge lists.
+    mock_dedup.assert_called_once_with(fuzzy_nodes, fuzzy_edges)
+
+
+@pytest.mark.asyncio
+@patch.object(adp_module, "index_graph_edges")
+@patch.object(adp_module, "index_data_points")
+@patch.object(adp_module, "get_cognify_config")
+@patch.object(adp_module, "cluster_fuzzy_duplicate_entities")
+@patch.object(adp_module, "get_unified_engine")
+@patch.object(adp_module, "deduplicate_nodes_and_edges")
+@patch.object(adp_module, "get_graph_from_model")
+async def test_add_data_points_skips_fuzzy_dedup_when_disabled(
+    mock_get_graph,
+    mock_dedup,
+    mock_get_unified,
+    mock_fuzzy_dedup,
+    mock_get_config,
+    mock_index_nodes,
+    mock_index_edges,
+):
+    dp = SimplePoint(text="only")
+    mock_get_graph.side_effect = [([dp], [])]
+    unified, graph_engine, vector_engine = _make_unified_mock()
+    mock_get_unified.return_value = unified
+    mock_get_config.return_value = SimpleNamespace(
+        fuzzy_entity_dedup=False, fuzzy_entity_dedup_threshold=0.95
+    )
+    mock_dedup.side_effect = lambda n, e: (n, e)
+
+    await add_data_points([dp])
+
+    mock_fuzzy_dedup.assert_not_called()
+    mock_dedup.assert_called_once_with([dp], [])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->
The PR is for Issue #3628 - Contradiction & dedup resolution, Approach B: embedding-similarity clustering
Issue: The current dedup is id-based. The entities are deduped into one if they are the same after normalisation. 
Solution: Add an extra step in add_data_points. Applied embedding and semantic search for clustering entities. Provenance is kept during dedup. No new parallel path was created. 


## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->
- Expand current dedup path: insert an extra step to add_data_points. No new parallel path created.
- Clustering based on blocking + embedding similarity threshold. Keep provenance when combining entities.
- Provide precision/recall test results (see screenshots).
- Reversible dedup process: I keep the original id/name. However, there is a known limitation in cross-batch provenance.
- Passed all tests (see screenshots).

## Results & Findings
| threshold | precision | recall |
|---|---|---|
| 0.50 – 0.60 | 1.000 | 1.000 |
| 0.65 | 1.000 | 0.682 |
| **0.72 (shipped)** | **1.000** | **0.439** |
| 0.80 | 1.000 | 0.242 |
| 0.95 (original proposal) | 1.000 | 0.000 |

After checking the actual sample output in the tests, I suggest using 0.72 as the threshold. Threshold 0.5–0.6 has a perfect score. However, that does not mean all entities are deduped perfectly. The perfect score comes from the Union-Find clustering method: if A and B are alike, and B and C are alike, then A and C will be clustered into the same group, even if A and C are not alike when compared directly.

An example: "openai" and "openai labs" are clustered into the same group (similarity 0.8506), and "openai labs" and "the ai lab" are clustered into the same group (similarity 0.6628). Then "openai" and "the ai lab" end up in the same group too, even though comparing them directly gives only 0.5368, well below the threshold, and we would not normally think they're the same based on that direct comparison alone.

The learning here is that the "bridge" (in this case "openai labs") is important. A "good bridge" can prevent "clustering drift". We could use a higher threshold to select good bridges, especially since the first few connections have a high impact on whether the following entities drift or not.

## Limitations
- Semantic search successfully dedups most entities, but for abbreviations, the simple similarity calculation is not enough, e.g. NASA vs. National Aeronautics and Space Administration.
- Small sample size could lead to bias on the best threshold.


## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->
<img width="1815" height="418" alt="01-fuzzy-dedup-tests-16-passed" src="https://github.com/user-attachments/assets/52eef637-06fc-4455-8847-95e050e7648c" />

<img width="2338" height="819" alt="02-add-data-points-tests-38-passed" src="https://github.com/user-attachments/assets/e57568df-7748-48ab-bc60-72fcd0c28d74" />

<img width="2272" height="417" alt="03-real-embedding-precision-recall" src="https://github.com/user-attachments/assets/002072ef-ac3f-47a0-b2e5-bb8bc4199ef4" />

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.