### PR TITLE
fix(cache): return [] not None from Redis get_latest_qa_entries on empty session

### DIFF
--- a/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
+++ b/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
@@ -321,11 +321,15 @@ class RedisAdapter(CacheDBInterface):
     ) -> list[SessionQAEntry]:
         """
         Retrieve the most recent Q/A/context triplet(s) for the given session.
+
+        Returns [] when the session has no entries, for every last_n (matches the
+        SQL/FS adapters and the declared return type; the last_n=1 fast path must
+        not leak None).
         """
         session_key = self._session_key(user_id, session_id)
         if last_n == 1:
             data = await self.async_redis.lindex(session_key, -1)
-            return [SessionQAEntry.model_validate_json(data)] if data else None
+            return [SessionQAEntry.model_validate_json(data)] if data else []
         data = await self.async_redis.lrange(session_key, -last_n, -1)
         return [SessionQAEntry.model_validate_json(d) for d in data] if data else []
 

--- a/cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py
@@ -584,3 +584,11 @@ async def test_get_qa_entries_by_ids_returns_matching_rows_in_chronological_orde
     entries = await adapter.get_qa_entries_by_ids("u1", "s1", ["id3", "missing", "id1"])
 
     assert [entry.qa_id for entry in entries] == ["id1", "id3"]
+
+
+@pytest.mark.asyncio
+async def test_empty_session_returns_empty_list_for_all_last_n(adapter):
+    """[] on empty for every last_n value, including last_n=1 (matches SQL/FS, not a None quirk)."""
+    assert await adapter.get_latest_qa_entries("u1", "missing", last_n=1) == []
+    assert await adapter.get_latest_qa_entries("u1", "missing", last_n=5) == []
+    assert await adapter.get_all_qa_entries("u1", "missing") == []


### PR DESCRIPTION
## Description

While reading through the session-cache backends I noticed that `get_latest_qa_entries` is annotated `-> list[SessionQAEntry]` and is meant to behave the same across the SQL, FS and Redis adapters, but the Redis adapter breaks that contract on one path: for an empty session with `last_n == 1` it returns `None` instead of `[]`.

What convinced me this is a real contract violation and not intended behaviour is that the repository already documents the intended contract and even calls out this exact divergence. The SQL adapter test asserts `[]` on empty for every `last_n` with the comment *"including last_n=1 (FS-style, not Redis quirk)"* (`test_sql_adapter_crud.py`). So the SQL backend was deliberately written to avoid the quirk, but the Redis adapter that still has it was never updated.

It matters because `last_n == 1` is the hot path: every session turn calls `get_session(..., last_n=1)` to load the previous entry, which routes into `get_latest_qa_entries(..., last_n=1)`. Today `SessionManager.get_session` only survives an empty session on Redis because it carries a defensive `if entries is None:` branch that exists solely to work around this behaviour. Any other caller that iterates the result (including the backward-compatible `get_latest_qa`) would instead raise `TypeError: 'NoneType' object is not iterable` on Redis while working correctly on SQLite and FS.

The fix is intentionally minimal: return `[]` instead of `None` in the `last_n == 1` branch so that it matches the general `lrange` path, the SQL and FS adapters, and the declared return type. The `lindex` fast path is preserved because it is an intentional optimisation for the common `last_n == 1` case.

Out of scope (so it isn't lost): the same method returns all entries when `last_n <= 0` on Redis/FS (`lrange(key, -0, -1)`), whereas SQL returns `[]`. That path is already guarded by `SessionManager._validate_session_params`, which rejects `last_n < 1`, so it is left unchanged in this PR.

Closes #3930.

## Acceptance Criteria

* `RedisAdapter.get_latest_qa_entries` returns `[]` (never `None`) for an empty or unknown session, regardless of `last_n`, matching the SQL/FS adapters and the declared `-> list[SessionQAEntry]` return type.
* Added a regression test, `test_empty_session_returns_empty_list_for_all_last_n`, in `test_redis_adapter_crud.py` mirroring the existing SQL contract test. The test fails before the fix and passes afterwards.
* No behaviour changes for non-empty sessions.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Code refactoring
* [ ] Other (please specify):

## Screenshots

Local run of the session-cache adapter unit tests (Redis + SQL + FS) against the `dev` branch:

```text
$ pytest cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py \
         cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py \
         cognee/tests/unit/infrastructure/databases/cache/test_fs_adapter_crud.py -q

104 passed in 3.15s
```

## Pre-submission Checklist

* [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
* [x] **This PR contains minimal changes necessary to address the issue/feature**
* [x] My code follows the project's coding standards and style guidelines
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if applicable)
* [x] All new and existing tests pass
* [x] I have searched existing PRs to ensure this change hasn't been submitted already
* [x] I have linked any relevant issues in the description
* [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
