### PR TITLE
feat(security): prevent SSRF by validating target IP spaces in url ingestion (#3814)

### DIFF
--- a/cognee/tasks/web_scraper/utils.py
+++ b/cognee/tasks/web_scraper/utils.py
@@ -5,6 +5,9 @@ both BeautifulSoup for custom extraction rules and Tavily for API-based scraping
 """
 
 import os
+import socket
+import ipaddress
+from urllib.parse import urlparse
 from typing import List, Union
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.web_scraper.types import UrlsToHtmls
@@ -12,6 +15,43 @@ from .default_url_crawler import DefaultUrlCrawler
 from .config import DefaultCrawlerConfig, TavilyConfig
 
 logger = get_logger(__name__)
+
+
+def validate_safe_url(url: str, allow_local: bool = None) -> None:
+    """Prevent SSRF by checking target host against loopback and private IP spaces."""
+    if allow_local is None:
+        allow_local = os.getenv("COGNEE_ALLOW_LOCAL_URLS", "false").lower() in ("true", "1", "yes")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"SSRF Protection: Unsupported scheme '{parsed.scheme}' in URL: {url}")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(f"SSRF Protection: Invalid URL missing hostname: {url}")
+
+    if allow_local:
+        return
+
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+        for addr_info in addr_infos:
+            ip_str = addr_info[4][0]
+            try:
+                ip_obj = ipaddress.ip_address(ip_str)
+            except ValueError:
+                continue
+            if (
+                ip_obj.is_private
+                or ip_obj.is_loopback
+                or ip_obj.is_link_local
+                or ip_obj.is_multicast
+                or ip_obj.is_unspecified
+            ):
+                raise ValueError(
+                    f"SSRF Protection: Access to internal/private IP address '{ip_str}' for host '{hostname}' is denied."
+                )
+    except socket.gaierror as e:
+        raise ValueError(f"SSRF Protection: Could not resolve hostname '{hostname}': {e}") from e
 
 
 async def fetch_page_content(urls: Union[str, List[str]]) -> UrlsToHtmls:
@@ -42,6 +82,8 @@ async def fetch_page_content(urls: Union[str, List[str]]) -> UrlsToHtmls:
             installed.
     """
     url_list = [urls] if isinstance(urls, str) else urls
+    for u in url_list:
+        validate_safe_url(u)
 
     if os.getenv("TAVILY_API_KEY"):
         logger.info("Using Tavily API for url fetching")

--- a/cognee/tests/unit/tasks/test_url_validation.py
+++ b/cognee/tests/unit/tasks/test_url_validation.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+from cognee.tasks.web_scraper.utils import validate_safe_url
+
+
+def test_validate_safe_url_aws_metadata():
+    """Verify that AWS instance metadata service IP is blocked by default."""
+    with pytest.raises(ValueError, match="SSRF Protection"):
+        validate_safe_url("http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+
+
+def test_validate_safe_url_loopback():
+    """Verify that loopback IP addresses and localhost are blocked by default."""
+    with pytest.raises(ValueError, match="SSRF Protection"):
+        validate_safe_url("http://127.0.0.1:8000/admin")
+    with pytest.raises(ValueError, match="SSRF Protection"):
+        validate_safe_url("http://localhost:3000")
+
+
+def test_validate_safe_url_private_networks():
+    """Verify that RFC 1918 private IP address ranges are blocked."""
+    with pytest.raises(ValueError, match="SSRF Protection"):
+        validate_safe_url("http://10.0.0.1/secrets")
+    with pytest.raises(ValueError, match="SSRF Protection"):
+        validate_safe_url("http://172.16.0.100/config")
+    with pytest.raises(ValueError, match="SSRF Protection"):
+        validate_safe_url("http://192.168.1.1/")
+
+
+def test_validate_safe_url_unsupported_scheme():
+    """Verify that non-http/https schemes are rejected."""
+    with pytest.raises(ValueError, match="SSRF Protection: Unsupported scheme"):
+        validate_safe_url("file:///etc/passwd")
+    with pytest.raises(ValueError, match="SSRF Protection: Unsupported scheme"):
+        validate_safe_url("ftp://example.com/file")
+
+
+def test_validate_safe_url_allow_local_env_var(monkeypatch):
+    """Verify that setting COGNEE_ALLOW_LOCAL_URLS allows local/private URLs."""
+    monkeypatch.setenv("COGNEE_ALLOW_LOCAL_URLS", "true")
+    # Should not raise any ValueError when allow_local is enabled via env var
+    validate_safe_url("http://127.0.0.1:8000/admin")
+    validate_safe_url("http://localhost:3000")
+
+
+def test_validate_safe_url_allow_local_param():
+    """Verify that explicit allow_local=True parameter bypasses SSRF check."""
+    validate_safe_url("http://10.0.0.1/secrets", allow_local=True)


### PR DESCRIPTION
## Description
Resolves **Issue #3814** by implementing enterprise-grade Server-Side Request Forgery (SSRF) protection in `fetch_page_content`. 

When AI agents ingest user-supplied URLs via `await cognee.add(url)` or web scraping tasks, outbound requests are now validated against DNS resolution results to prevent access to loopback (`127.0.0.0/8`, `localhost`), link-local cloud metadata (`169.254.0.0/16` AWS/GCP/Azure), RFC 1918 private intranets (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), and unspecified (`0.0.0.0`) IP spaces.

For local development and testing, validation can be bypassed by setting the environment variable `COGNEE_ALLOW_LOCAL_URLS=true` or passing `allow_local=True`.

## Local Test Commands Run
```bash
python -m pytest cognee/tests/unit/tasks/test_url_validation.py -v
python -m ruff check cognee/tasks/web_scraper/utils.py cognee/tests/unit/tasks/test_url_validation.py
python -m ruff format --check cognee/tasks/web_scraper/utils.py cognee/tests/unit/tasks/test_url_validation.py
