### PR TITLE
chore(format): fix ruff-format violations in test_image_loader.py

### DIFF
--- a/cognee/tests/test_image_loader.py
+++ b/cognee/tests/test_image_loader.py
@@ -1,9 +1,11 @@
 import pytest
 from cognee.infrastructure.loaders.core.image_loader import ImageLoader
 
+
 @pytest.fixture
 def loader():
     return ImageLoader()
+
 
 def test_image_loader_supported_extensions(loader):
     """Test that supported extensions are lowercase and have no leading dots."""
@@ -12,10 +14,11 @@ def test_image_loader_supported_extensions(loader):
     assert "jpe" in extensions
     assert "png" in extensions
     assert "jpg" in extensions
-    
+
     for ext in extensions:
         assert not ext.startswith(".")
         assert ext == ext.lower()
+
 
 @pytest.mark.parametrize(
     "extension, mime_type, expected",


### PR DESCRIPTION
## Description

`cognee/tests/test_image_loader.py` (merged in #3869) has one line of trailing whitespace and is missing blank lines between top-level definitions, so `pre-commit run --all-files` fails on current `dev`. This breaks the **Code Quality** and **basic checks / Lockfile and Pre-commit Hooks** jobs for every open PR (e.g. #3939), regardless of what the PR touches.

This is the mechanical output of the exact hooks CI runs (`ruff format` at v0.15.11 + `trailing-whitespace`), applied to a clean checkout of `dev` — one file, +4/−1 lines, no behavior change. `ruff check .` and a repo-wide trailing-whitespace scan are clean afterwards.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [x] Other (please specify): CI/formatting fix

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works (formatting-only change)
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
