### PR TITLE
fix(retrieval): match temporal event scores by str id

### DIFF
--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -107,12 +107,15 @@ class TemporalRetriever(GraphCompletionRetriever):
         return time_from, time_to
 
     async def filter_top_k_events(self, relevant_events, scored_results):
-        # Build a score lookup from vector search results
-        score_lookup = {res.id: res.score for res in scored_results}
+        # Build a score lookup from vector search results.
+        # ScoredResult.id is a UUID while event["id"] arrives from the graph as a string,
+        # so both sides must be normalized to str or every lookup misses and all events
+        # collapse to float("inf"), discarding the vector-similarity ranking.
+        score_lookup = {str(res.id): res.score for res in scored_results}
 
         events_with_scores = []
         for event in relevant_events[0]["events"]:
-            score = score_lookup.get(event["id"], float("inf"))
+            score = score_lookup.get(str(event["id"]), float("inf"))
             events_with_scores.append({**event, "score": score})
 
         events_with_scores.sort(key=itemgetter("score"))

--- a/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
@@ -103,6 +103,49 @@ async def test_filter_top_k_events_includes_unknown_as_infinite_but_not_in_top_k
     assert all(e["score"] != float("inf") for e in top)
 
 
+# Regression test: in production, ScoredResult.id is a UUID while event["id"] arrives from
+# the graph as a string. filter_top_k_events must normalize both sides to str; otherwise the
+# score lookup misses on every event, all scores become inf, and the vector-similarity
+# ranking is silently discarded (events come back in graph order instead of by relevance).
+# The other tests use string ids on both sides, so they never catch this.
+@pytest.mark.asyncio
+async def test_filter_top_k_events_matches_uuid_scored_results_against_str_event_ids():
+    from uuid import uuid4
+    from cognee.infrastructure.databases.vector.models.ScoredResult import ScoredResult
+
+    tr = TemporalRetriever(top_k=2)
+
+    id_first = uuid4()  # best match (lowest distance)
+    id_second = uuid4()
+    id_third = uuid4()  # not present in the vector results
+
+    # Event ids come from the graph as strings (str() of the node UUID).
+    relevant_events = [
+        {
+            "events": [
+                {"id": str(id_third), "description": "Third - not scored"},
+                {"id": str(id_second), "description": "Second"},
+                {"id": str(id_first), "description": "First"},
+            ]
+        }
+    ]
+
+    # Real ScoredResult objects: .id is a UUID (not a str).
+    scored_results = [
+        ScoredResult(id=id_first, score=0.10, payload={}),
+        ScoredResult(id=id_second, score=0.50, payload={}),
+    ]
+
+    top = await tr.filter_top_k_events(relevant_events, scored_results)
+
+    # Before the fix (UUID keys vs str lookup) every score is inf and the stable sort keeps
+    # graph order -> [third, second]. After the fix the lookup matches, so the two scored
+    # events are returned ordered by ascending distance.
+    assert [e["id"] for e in top] == [str(id_first), str(id_second)]
+    assert top[0]["score"] == 0.10
+    assert top[1]["score"] == 0.50
+
+
 # Test descriptions_to_string with unicode and newlines
 def test_descriptions_to_string_unicode_and_newlines():
     tr = TemporalRetriever()


### PR DESCRIPTION
## Description

`filter_top_k_events` in the temporal retriever built its score lookup with `ScoredResult.id` (a `UUID`) as the key, but looked it up with `event["id"]`, which comes from the graph as a `str`. So the lookup always missed, every event got `float("inf")`, and the sort no longer ordered events by relevance. `TEMPORAL` search returned them in graph order instead. Fixed by converting both sides to `str`.

Closes #3909
Supersedes #3910 (replaces #3939, which GitHub auto-closed when its head branch was renamed to reference COG-5779)

## Acceptance Criteria

- Temporal events are ranked by their vector score again.
- Includes a regression test that uses a real `UUID`-typed `ScoredResult` against string event ids. Verified locally red/green: the new test fails on current `dev` (events come back in graph order) and passes with the fix; the five pre-existing `filter_top_k` tests keep passing.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin. The commit is the original author's, carrying their `Signed-off-by: goodnight <mohammedarbinsibi@gmail.com>` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
