### PR TITLE
fix(retrieval): score neighborhood expansion nodes by id

### DIFF
--- a/cognee/modules/retrieval/utils/brute_force_triplet_search.py
+++ b/cognee/modules/retrieval/utils/brute_force_triplet_search.py
@@ -169,36 +169,40 @@ async def _get_top_triplet_importances(
         )
 
         # Re-score expansion nodes discovered via neighborhood traversal.
-        # These nodes have no vector scores yet — run an ID-filtered vector
-        # search so they participate in triplet ranking instead of getting
-        # the default penalty score.
+        # These nodes have no vector scores yet, so without this they keep the
+        # default triplet_distance_penalty and always rank last.
+        #
+        # This only runs in single-query mode: query_vector is set for a single
+        # query only (batch mode leaves it None) and relevant_node_ids is empty
+        # in batch mode, so node_distances here is always a flat list.
         if (
             neighborhood_depth is not None
             and relevant_node_ids
             and vector_search.query_vector is not None
         ):
             seed_set = set(relevant_node_ids)
-            expansion_ids = [nid for nid in memory_fragment.nodes if nid not in seed_set]
+            expansion_ids = {
+                str(node_id) for node_id in memory_fragment.nodes if str(node_id) not in seed_set
+            }
             if expansion_ids:
                 for collection_name in list(vector_search.node_distances.keys()):
                     try:
-                        extra_scores = await vector_search.vector_engine.search(
+                        # search() has no id filter (node_name filters on
+                        # belongs_to_set, which never holds a node's own id), so
+                        # score the collection against the query and keep only
+                        # the expansion nodes.
+                        collection_scores = await vector_search.vector_engine.search(
                             collection_name=collection_name,
                             query_vector=vector_search.query_vector,
-                            limit=len(expansion_ids),
-                            node_name=expansion_ids,
+                            limit=None,
                         )
-                        if extra_scores:
-                            if vector_search.query_list_length is None:
-                                vector_search.node_distances[collection_name].extend(extra_scores)
-                            else:
-                                for qi, per_query in enumerate(extra_scores):
-                                    if qi < len(vector_search.node_distances[collection_name]):
-                                        vector_search.node_distances[collection_name][qi].extend(
-                                            per_query
-                                        )
                     except CollectionNotFoundError:
-                        pass
+                        continue
+                    extra_scores = [
+                        score for score in collection_scores if str(score.id) in expansion_ids
+                    ]
+                    if extra_scores:
+                        vector_search.node_distances[collection_name].extend(extra_scores)
 
     await memory_fragment.map_vector_distances_to_graph_nodes(
         node_distances=vector_search.node_distances, query_list_length=query_list_length

--- a/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
@@ -1102,3 +1102,72 @@ async def test_cognee_graph_mapping_batch_shapes():
     assert node1.attributes.get("vector_distance") == [0.95, 6.5]
     assert node2.attributes.get("vector_distance") == [6.5, 0.87]
     assert edge.attributes.get("vector_distance") == [0.92, 0.88]
+
+
+@pytest.mark.asyncio
+async def test_neighborhood_expansion_rescored_by_id_not_belongs_to_set():
+    """Regression: neighborhood expansion nodes must be re-scored with a real vector
+    search and filtered to their own ids.
+
+    The old code passed the expansion ids as node_name, which filters on
+    belongs_to_set (never a node's own id), so the search matched nothing and the
+    expansion nodes stayed at the default penalty. The fix runs an unfiltered search
+    and keeps only the expansion ids client-side.
+    """
+    SEED_ID = "seed-1"
+    EXP_ID = "expansion-1"
+    OTHER_ID = "unrelated-1"
+
+    def search_side_effect(*args, **kwargs):
+        # Re-score pass: unfiltered search (limit=None, no node_name). Returns the
+        # expansion node plus an unrelated node, to prove only expansion ids are kept.
+        if kwargs.get("limit") is None:
+            return [MockScoredResult(EXP_ID, 0.05), MockScoredResult(OTHER_ID, 0.01)]
+        # Initial wide search: the seed node lives in Entity_name.
+        if kwargs.get("collection_name") == "Entity_name":
+            return [MockScoredResult(SEED_ID, 0.20)]
+        return []
+
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.embedding_engine = AsyncMock()
+    mock_vector_engine.embedding_engine.embed_text = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+    mock_vector_engine.search = AsyncMock(side_effect=search_side_effect)
+
+    mock_fragment = AsyncMock(
+        nodes={SEED_ID: object(), EXP_ID: object()},
+        map_vector_distances_to_graph_nodes=AsyncMock(),
+        map_vector_distances_to_graph_edges=AsyncMock(),
+        calculate_top_triplet_importances=AsyncMock(return_value=[]),
+    )
+
+    with (
+        patch(
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            return_value=mock_vector_engine,
+        ),
+        patch(
+            "cognee.modules.retrieval.utils.brute_force_triplet_search.get_memory_fragment",
+            return_value=mock_fragment,
+        ),
+    ):
+        await brute_force_triplet_search(
+            query="test", node_name=None, neighborhood_depth=1, wide_search_top_k=10
+        )
+
+    # The re-score pass must use an unfiltered search (limit=None) with no node_name,
+    # never node_name=expansion_ids (the belongs_to_set filter that matched nothing).
+    rescore_calls = [
+        call for call in mock_vector_engine.search.call_args_list if call[1].get("limit") is None
+    ]
+    assert rescore_calls, "expected an unfiltered re-score search for expansion nodes"
+    for call in rescore_calls:
+        assert call[1].get("node_name") is None
+
+    # The expansion node's real score must reach the graph mapping; the unrelated node must not.
+    node_distances = mock_fragment.map_vector_distances_to_graph_nodes.call_args[1][
+        "node_distances"
+    ]
+    scored_ids = {str(result.id) for results in node_distances.values() for result in results}
+    assert EXP_ID in scored_ids
+    assert OTHER_ID not in scored_ids
+    assert SEED_ID in scored_ids


### PR DESCRIPTION
## Description

Maintainer re-submission of #3913 by @Goodnight77 — fork PRs don't receive repo secrets, so the test suite can't run there. The head commit (f69e7c4) is the contributor's original commit, unchanged, to preserve authorship and their Signed-off-by.

Original description (from #3913):

> The neighborhood re-scoring step in `brute_force_triplet_search` passed the expansion node ids as `node_name`. But `node_name` filters on `belongs_to_set`, which never contains a node's own id, so that search always returned nothing and the expansion nodes kept the default `triplet_distance_penalty` and ranked last. That is the opposite of what the block is for.
>
> I changed it to run an unfiltered vector search and keep only the expansion ids. I also removed the batch branch in that block, since it can't run: `query_vector` is only set for a single query (batch mode leaves it `None`), so `node_distances` there is always a flat list.

Closes #3914
Supersedes #3913

## Acceptance Criteria

* Neighborhood-expanded nodes get real vector scores instead of the default penalty.
* Regression test checks the re-score search runs unfiltered (no `node_name`) and that the expansion node's score reaches the graph mapping while unrelated nodes are filtered out.

Review verification (this commit merged onto latest `dev`, f40e94043):

* `cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py`: 41 passed.
* The new regression test fails on unfixed `dev` at the intended assertion ("expected an unfiltered re-score search for expansion nodes") and passes with the fix.
* `node_name` → `belongs_to_set` filter confirmed in both adapters (LanceDB `array_has_any`, PGVector JSONB `?|`); `limit=None` means full-collection scoring in both, matching the existing `batch_search` convention.
* `ruff check` and `ruff format --check` clean on both changed files.

Known trade-off (called out by the author in #3913): the re-score pass scores the whole collection and filters client-side, since `search()` has no id filter today. Neighborhood expansion is opt-in (`neighborhood_depth` defaults to `None`). Adding an id filter to the vector adapters can be a follow-up.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

`pytest cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py -q`:

```
41 passed
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
