### PR TITLE
fix(chunks): reset row state after blank rows in chunk_by_row

### DIFF
--- a/cognee/tasks/chunks/chunk_by_row.py
+++ b/cognee/tasks/chunks/chunk_by_row.py
@@ -93,9 +93,12 @@ def chunk_by_row(
 
             yield chunk_dict
 
-            # Start a fresh chunk for the next row so its pairs are not
-            # accumulated onto this row's chunk and chunk indices stay
-            # monotonically increasing.
-            current_chunk_list = []
-            current_chunk_size = 0
             chunk_index += 1
+
+        # Start a fresh chunk for the next row so its pairs are not
+        # accumulated onto this row's chunk and chunk indices stay
+        # monotonically increasing. The reset must also run for a blank row
+        # (consecutive separators produce ""), otherwise its empty pair leaks
+        # into the next row's text, size, and chunk_id.
+        current_chunk_list = []
+        current_chunk_size = 0

--- a/cognee/tests/unit/processing/chunks/chunk_by_row_test.py
+++ b/cognee/tests/unit/processing/chunks/chunk_by_row_test.py
@@ -15,6 +15,10 @@ max_chunk_size_vals = [8, 32]
 # called directly). Each row must become its own chunk.
 MULTI_ROW_INPUT = "name: John, age: 30\n\nname: Jane, age: 25"
 
+# Two rows separated by consecutive separators, i.e. with a blank row between
+# them (data.split("\n\n") yields ["...", "", "..."]).
+BLANK_ROW_INPUT = "name: John, age: 30\n\n\n\nname: Jane, age: 25"
+
 
 @pytest.mark.parametrize(
     "input_text,max_chunk_size",
@@ -83,4 +87,29 @@ def test_chunk_by_row_multiple_rows_are_independent():
     assert chunk_indices == list(range(len(chunk_indices)))
 
     # Identical rows must have identical sizes (no accumulation across rows).
+    assert chunks[0]["chunk_size"] == chunks[1]["chunk_size"]
+
+
+def test_chunk_by_row_blank_rows_do_not_leak():
+    """A blank row (from consecutive separators) must not leak into the next row.
+
+    Regression test: the row-state reset ran only when the joined row text was
+    non-empty, so a blank row left an empty pair in the accumulator and the
+    following row's chunk was emitted as ", name: ..." — corrupted text, an
+    inflated chunk_size, and a chunk_id derived from the corrupted text.
+    """
+    chunks = list(chunk_by_row(data=BLANK_ROW_INPUT, max_chunk_size=128))
+
+    # The blank row contributes nothing; both real rows keep their exact text.
+    assert [chunk["text"] for chunk in chunks] == [
+        "name: John, age: 30",
+        "name: Jane, age: 25",
+    ]
+
+    # Indices are monotonically increasing across rows.
+    chunk_indices = [chunk["chunk_index"] for chunk in chunks]
+    assert chunk_indices == list(range(len(chunk_indices)))
+
+    # Structurally identical rows must have identical sizes (no size leakage
+    # from the blank row).
     assert chunks[0]["chunk_size"] == chunks[1]["chunk_size"]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

Maintainer re-submission of #3891 by @divygoyal — fork PRs receive no repo secrets, so the test suite cannot run against them. The contributor's commit is preserved verbatim (336b4e3) for attribution. Supersedes #3891. Fixes #3886. Linear: SDK-134.

`chunk_by_row` reset its per-row accumulator only inside `if current_chunk:`. A blank row — `data.split("\n\n")` yields `""` for consecutive separators — still appended the empty pair and its size to the accumulator, but produced a falsy joined text, so the yield **and the reset** were skipped. The phantom empty pair then leaked into the next row, which was emitted with:

- corrupted text with a leading `", "` (`", b: 2"` instead of `"b: 2"`),
- a `chunk_id` (uuid5) computed over the corrupted text,
- an inflated `chunk_size` whenever the empty pair is counted (e.g. the no-tokenizer fallback counts every pair as 3).

The leaked nonzero size could also trip the max-size cut branch on the next row's first pair — and that branch has no truthiness guard, so it could emit an empty-text chunk outright.

**Fix**: run the row-state reset unconditionally after every row; only the yield and the `chunk_index` increment stay conditional on non-empty text. Blank rows therefore contribute nothing and consume no index (indices stay contiguous). Empty pairs *within* a row (e.g. `"a, , b"`) are intentionally untouched — `", ".join()` needs them for exact text reconstruction.

This is the residual case of the cross-row state leak fixed in #2965: that fix covers non-blank rows, but the reset was still guarded by the joined-text truthiness.

## Acceptance Criteria

- A blank row must not leak into the following row's text, `chunk_size`, or `chunk_id`, and `chunk_index` stays monotonically increasing. Verified on latest `dev` (909266caf):

```python
list(chunk_by_row("a: 1\n\n\n\nb: 2", 128))
# before: ('a: 1', chunk_index 0), (', b: 2', chunk_index 1)   <- corrupted text + wrong chunk_id
# after:  ('a: 1', chunk_index 0), ('b: 2', chunk_index 1)
```

- Non-blank rows behave identically to before (yield, index increment, then reset).
- New regression test `test_chunk_by_row_blank_rows_do_not_leak` fails against the unfixed source and passes with the fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Local test runs on latest `dev` with the change applied:

```
$ pytest cognee/tests/unit/processing/chunks/chunk_by_row_test.py -q
8 passed, 167 warnings in 0.02s

$ pytest cognee/tests/unit/processing/chunks/ -q
296 passed, 477 warnings in 0.21s
```

`ruff check` and `ruff format --check` pass on both changed files.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
