### PR TITLE
COG-5251: ci: require a Linear issue reference on internal PRs

### DIFF
--- a/.github/workflows/require-linear-issue.yml
+++ b/.github/workflows/require-linear-issue.yml
@@ -1,0 +1,40 @@
+name: Require Linear issue
+
+# Every INTERNAL PR must reference a Linear issue (e.g. COG-123) in its title or
+# branch name — that is how Linear links a PR to a ticket. Since Linear does not
+# gate merges, enforcement is a required GitHub status check: this job fails when a
+# PR has no Linear key, and branch protection blocks the merge until it passes.
+#
+# Fork / external-contributor PRs are intentionally SKIPPED: they have no Linear
+# access, and a skipped required check counts as passing, so this never blocks the
+# community. Mark the `linear-issue-check` job as a required status check on
+# `main` and `dev` in branch protection.
+
+on:
+  pull_request:
+    # `synchronize` matters: a required check must re-run on the latest commit.
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  linear-issue-check: # this job name is what you mark "required" in branch protection
+    # Enforce for internal PRs only. Fork PRs (head repo != base repo) skip this job;
+    # a skipped required check is treated as passing, so external PRs are not blocked.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR title or branch must reference a Linear issue
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          # List ALL your Linear team prefixes — verify against Linear ▸ Settings ▸ Teams.
+          KEYS='COG|SDK|CLO|COM|ENG'
+          if echo "$PR_TITLE $HEAD_REF" | grep -Eiq "\b(${KEYS})-[0-9]+\b"; then
+            echo "Linear issue reference found."
+          else
+            echo "::error::PR title or branch must reference a Linear issue, e.g. COG-123."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,6 +434,12 @@ git pull origin dev
 git checkout -b feature/your-feature-name
 ```
 
+**Core-team PRs must reference a Linear issue.** Put the issue key (e.g. `COG-123`)
+in the PR title or the branch name so Linear links the PR to its ticket. This is
+enforced by the `Require Linear issue` workflow (`linear-issue-check`), a required
+status check. Fork / external-contributor PRs are exempt (the check skips them), so
+this rule applies only to internal PRs.
+
 ## Code Style
 
 - **Formatter**: Ruff (configured in `pyproject.toml`)


### PR DESCRIPTION
## What
Adds `.github/workflows/require-linear-issue.yml` — a required status check (`linear-issue-check`) that fails when an **internal** PR's title or branch does not reference a Linear issue key (e.g. `COG-123`). Also documents the rule in `CLAUDE.md`.

## Why
Linear does not gate merges, so PR ↔ ticket linkage is enforced as a GitHub required status check, blocked by branch protection. Closes **COG-5251**.

## Internal-only by design
The job is guarded with `if: github.event.pull_request.head.repo.full_name == github.repository`, so **fork / external-contributor PRs skip it** — and a skipped required check counts as passing, so the community is never blocked by a rule they can't satisfy (no Linear access).

## Follow-up for a repo admin (not code)
1. **Verify the team prefixes** in `KEYS` (currently `COG|SDK|CLO|COM|ENG`) against **Linear ▸ Settings ▸ Teams** — extra prefixes are harmless, but a missing real one would wrongly block valid PRs.
2. **Mark `linear-issue-check` as required** on `dev` and `main` (Settings ▸ Branches ▸ require status checks). It appears in the picker after it has run once — this PR triggers it.
