### PR TITLE
Feat/mocked examples test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,19 @@ Make sure to run ```shell uv sync ``` in the root cloned folder or set up a virt
 uv run python examples/demos/simple_cognee_example.py
 ```
 
+### Testing examples (mocked, no API key)
+
+Example scripts under `examples/` are covered by fast, deterministic tests that
+mock the LLM and embedding layers, so they run in CI with no API key or network:
+
+```shell
+uv run pytest cognee/tests/examples/ -v
+```
+
+If you add or change an example, add or update its mocked test. See
+[`examples/README.md`](examples/README.md#-testing-examples-mocked-no-api-key)
+for the harness overview and a copy-paste test template.
+
 ## 4. 📤 Submitting Changes
 
 1. Make sure that `pre-commit` and hooks are installed. See `Required tools` section for more information. Try executing `pre-commit run` if you are not sure.

--- a/cognee/tests/examples/conftest.py
+++ b/cognee/tests/examples/conftest.py
@@ -104,6 +104,9 @@ async def isolated_example_env(tmp_path, monkeypatch, mock_llm, mock_embeddings)
     cognee.config.data_root_directory(str(data_dir))
     cognee.config.system_root_directory(str(system_dir))
 
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+
     _clear_engine_caches()
     await _prune_all()
 
@@ -111,3 +114,4 @@ async def isolated_example_env(tmp_path, monkeypatch, mock_llm, mock_embeddings)
 
     await _prune_all()
     _clear_engine_caches()
+    os.chdir(original_cwd)

--- a/cognee/tests/examples/conftest.py
+++ b/cognee/tests/examples/conftest.py
@@ -1,0 +1,113 @@
+"""Shared fixtures for mocked ``examples/`` tests.
+
+The goal: run each example script end to end with zero secrets, no network,
+and deterministic output. Three composable fixtures do this:
+
+* ``mock_llm``        -- patches ``LLMGateway`` (structured output, transcript,
+                         image) so no LLM provider is contacted.
+* ``mock_embeddings`` -- flips cognee's built-in ``MOCK_EMBEDDING`` flag and
+                         clears the cached embedding/vector engines. The real
+                         engine class is still used (keeping its tokenizer);
+                         only the network call is skipped.
+* ``isolated_example_env`` -- points cognee's data/system roots at a per-test
+                         ``tmp_path`` and prunes before/after, so tests can't
+                         see each other's graph/vector/relational state or fight
+                         over Ladybug/LanceDB file locks.
+
+``isolated_example_env`` depends on the other two, so requesting it alone is
+enough to get full isolation + mocking; the canaries list all three explicitly
+for readability.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import pytest_asyncio
+
+from cognee.tests.utils.example_mock_llm import patch_llm_gateway
+
+
+def _clear_engine_caches() -> None:
+    """Drop cached DB/embedding engines so new config/env takes effect."""
+    from cognee.infrastructure.databases.vector.embeddings.get_embedding_engine import (
+        create_embedding_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+
+    for cached in (
+        create_embedding_engine,
+        _create_vector_engine,
+        _create_graph_engine,
+        create_relational_engine,
+    ):
+        try:
+            cached.cache_clear()
+        except Exception:
+            pass
+
+
+async def _prune_all() -> None:
+    import cognee
+
+    try:
+        await cognee.prune.prune_data()
+    except Exception:
+        pass
+    try:
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def mock_llm():
+    """Intercept all ``LLMGateway`` calls with deterministic canned responses."""
+    with patch_llm_gateway():
+        yield
+
+
+@pytest.fixture
+def mock_embeddings(monkeypatch):
+    """Return deterministic (zero) embeddings via cognee's MOCK_EMBEDDING flag."""
+    monkeypatch.setenv("MOCK_EMBEDDING", "true")
+    _clear_engine_caches()
+    yield
+    _clear_engine_caches()
+
+
+@pytest_asyncio.fixture
+async def isolated_example_env(tmp_path, monkeypatch, mock_llm, mock_embeddings):
+    """Per-test data/system isolation with LLM + embedding mocks applied."""
+    import cognee
+
+    # Provider/config env that keeps everything local and key-free.
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    monkeypatch.setenv("LLM_API_KEY", "mock-key-for-testing")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
+    monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")
+    monkeypatch.setenv("LOG_LEVEL", "ERROR")
+
+    data_dir = tmp_path / "data"
+    system_dir = tmp_path / "system"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    system_dir.mkdir(parents=True, exist_ok=True)
+
+    # Point cognee at the tmp roots. system_root_directory cascades to the
+    # relational/graph/vector path configs.
+    cognee.config.data_root_directory(str(data_dir))
+    cognee.config.system_root_directory(str(system_dir))
+
+    _clear_engine_caches()
+    await _prune_all()
+
+    yield tmp_path
+
+    await _prune_all()
+    _clear_engine_caches()

--- a/cognee/tests/examples/test_canaries.py
+++ b/cognee/tests/examples/test_canaries.py
@@ -16,21 +16,24 @@ from __future__ import annotations
 
 import pytest
 
-from cognee.tests.utils.example_runner import import_example
+from cognee.tests.utils.example_runner import import_example, invoke_example_main
 
 pytestmark = pytest.mark.asyncio
 
 
 async def test_recall_core(isolated_example_env):
-    module = import_example("examples/guides/recall_core.py")
-    await module.main()
+    rel_path = "examples/guides/recall_core.py"
+    module = import_example(rel_path)
+    await invoke_example_main(module, rel_path, work_dir=isolated_example_env)
 
 
 async def test_simple_cognee_example(isolated_example_env):
-    module = import_example("examples/demos/simple_cognee_example.py")
-    await module.main()
+    rel_path = "examples/demos/simple_cognee_example.py"
+    module = import_example(rel_path)
+    await invoke_example_main(module, rel_path, work_dir=isolated_example_env)
 
 
 async def test_custom_cognify_pipeline_example(isolated_example_env):
-    module = import_example("examples/custom_pipelines/custom_cognify_pipeline_example.py")
-    await module.main()
+    rel_path = "examples/custom_pipelines/custom_cognify_pipeline_example.py"
+    module = import_example(rel_path)
+    await invoke_example_main(module, rel_path, work_dir=isolated_example_env)

--- a/cognee/tests/examples/test_canaries.py
+++ b/cognee/tests/examples/test_canaries.py
@@ -1,0 +1,36 @@
+"""Canary tests for the mocked-example harness.
+
+These three exercise the harness across increasing pipeline depth so a broken
+mock is caught immediately, before the per-folder suites are added:
+
+* ``recall_core``                 -- high-level remember -> recall API.
+* ``simple_cognee_example``       -- full cognify + GRAPH_COMPLETION recall.
+* ``custom_cognify_pipeline``     -- low-level custom Task pipeline + search.
+
+Each loads the real script from ``examples/`` and awaits its ``main()``; the
+assertion is simply that it runs to completion with no exception under the
+mocked LLM + embedding layers (no API key, no network).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cognee.tests.utils.example_runner import import_example
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_recall_core(isolated_example_env):
+    module = import_example("examples/guides/recall_core.py")
+    await module.main()
+
+
+async def test_simple_cognee_example(isolated_example_env):
+    module = import_example("examples/demos/simple_cognee_example.py")
+    await module.main()
+
+
+async def test_custom_cognify_pipeline_example(isolated_example_env):
+    module = import_example("examples/custom_pipelines/custom_cognify_pipeline_example.py")
+    await module.main()

--- a/cognee/tests/utils/example_mock_llm.py
+++ b/cognee/tests/utils/example_mock_llm.py
@@ -28,17 +28,39 @@ walking ``model_fields``.
 from __future__ import annotations
 
 import enum
+import json
 import typing
 from contextlib import contextmanager
+from types import SimpleNamespace
 from typing import Any, get_args, get_origin
 from unittest.mock import patch
 
 from pydantic import BaseModel
 
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
+    TranscriptionReturnType,
+)
+
 MOCK_ANSWER = "MOCK_ANSWER"
 MOCK_SUMMARY = "Mock summary. This is a deterministic canned response for tests."
 MOCK_TRANSCRIPT = "Mock transcript of the provided audio."
 MOCK_IMAGE_DESCRIPTION = "Mock description of the provided image."
+MOCK_JSON_ANSWER = json.dumps(
+    {
+        "diff_risk_summary": "Mock diff risk summary.",
+        "comment_evaluation": "Mock comment evaluation.",
+        "skill_to_improve": "mock-skill",
+        "score": 0.5,
+        "feedback": "Mock feedback.",
+        "missing_instruction": "Mock instruction.",
+    }
+)
+
+# Fixed UUID-shaped ids for deterministic KnowledgeGraph nodes.
+_NODE_ALICE = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_NODE_BOB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_NODE_PARIS = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+_NODE_NY = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
 
 _LLM_GATEWAY_PATH = "cognee.infrastructure.llm.LLMGateway.LLMGateway"
 
@@ -48,18 +70,27 @@ _LLM_GATEWAY_PATH = "cognee.infrastructure.llm.LLMGateway.LLMGateway"
 # ---------------------------------------------------------------------------
 
 
-def build_mock_response(response_model: Any) -> Any:
+def build_mock_response(
+    response_model: Any,
+    *,
+    text_input: Any = None,
+    system_prompt: Any = None,
+) -> Any:
     """Return a minimal, valid instance of ``response_model``.
 
     Handles ``str`` (the common completion/answer case), the well-known cognee
     response models, and any other Pydantic model via field introspection.
     """
     if response_model is None or response_model is str:
+        if _prompt_requests_json(text_input, system_prompt):
+            return MOCK_JSON_ANSWER
         return MOCK_ANSWER
 
     if not (isinstance(response_model, type) and issubclass(response_model, BaseModel)):
         # Non-pydantic, non-str response models are rare; a string is the
         # safest universally-consumable value.
+        if _prompt_requests_json(text_input, system_prompt):
+            return MOCK_JSON_ANSWER
         return MOCK_ANSWER
 
     field_names = set(getattr(response_model, "model_fields", {}).keys())
@@ -71,8 +102,18 @@ def build_mock_response(response_model: Any) -> Any:
     return _build_generic_model(response_model)
 
 
+def _prompt_requests_json(text_input: Any, system_prompt: Any) -> bool:
+    """Return True when the caller prompt expects a JSON-shaped string answer."""
+    parts: list[str] = []
+    for value in (text_input, system_prompt):
+        if isinstance(value, str):
+            parts.append(value)
+    combined = " ".join(parts).lower()
+    return "json" in combined or "return only json" in combined
+
+
 def _build_knowledge_graph(kg_cls: type[BaseModel]) -> BaseModel:
-    """Build a small, self-consistent KnowledgeGraph (2 nodes, 1 edge)."""
+    """Build a small, self-consistent KnowledgeGraph (people, cities, lives_in)."""
     fields = kg_cls.model_fields
     node_cls = _first_model_arg(fields["nodes"].annotation)
     edge_cls = _first_model_arg(fields["edges"].annotation)
@@ -83,30 +124,53 @@ def _build_knowledge_graph(kg_cls: type[BaseModel]) -> BaseModel:
         nodes = [
             _instantiate(
                 node_cls,
-                id="node_alice",
+                id=_NODE_ALICE,
                 name="Alice",
                 type="Person",
-                description="A person named Alice.",
+                description="A person named Alice who lives in Paris.",
                 label="Person",
             ),
             _instantiate(
                 node_cls,
-                id="node_bob",
+                id=_NODE_BOB,
                 name="Bob",
                 type="Person",
-                description="A person named Bob.",
+                description="A person named Bob who lives in New York.",
                 label="Person",
+            ),
+            _instantiate(
+                node_cls,
+                id=_NODE_PARIS,
+                name="Paris",
+                type="City",
+                description="The city of Paris.",
+                label="City",
+            ),
+            _instantiate(
+                node_cls,
+                id=_NODE_NY,
+                name="New York",
+                type="City",
+                description="The city of New York.",
+                label="City",
             ),
         ]
     if edge_cls is not None:
         edges = [
             _instantiate(
                 edge_cls,
-                source_node_id="node_alice",
-                target_node_id="node_bob",
-                relationship_name="knows",
-                description="Alice knows Bob.",
-            )
+                source_node_id=_NODE_ALICE,
+                target_node_id=_NODE_PARIS,
+                relationship_name="lives_in",
+                description="Alice lives in Paris.",
+            ),
+            _instantiate(
+                edge_cls,
+                source_node_id=_NODE_BOB,
+                target_node_id=_NODE_NY,
+                relationship_name="lives_in",
+                description="Bob lives in New York.",
+            ),
         ]
 
     kwargs: dict[str, Any] = {"nodes": nodes, "edges": edges}
@@ -127,7 +191,8 @@ def _build_generic_model(model_cls: type[BaseModel]) -> BaseModel:
             kwargs[field_name] = MOCK_SUMMARY
             continue
         if not field_info.is_required():
-            # Leave optional/defaulted fields to their defaults.
+            if field_name not in kwargs and _is_list_annotation(field_info.annotation):
+                kwargs[field_name] = []
             continue
         kwargs[field_name] = _value_for_annotation(field_info.annotation)
     try:
@@ -143,13 +208,30 @@ def _instantiate(model_cls: type[BaseModel], **preferred: Any) -> BaseModel:
     declared = set(model_cls.model_fields.keys())
     kwargs = {k: v for k, v in preferred.items() if k in declared}
     for field_name, field_info in model_cls.model_fields.items():
-        if field_name in kwargs or not field_info.is_required():
+        if field_name in kwargs:
+            continue
+        if not field_info.is_required():
+            if _is_list_annotation(field_info.annotation):
+                kwargs[field_name] = []
             continue
         kwargs[field_name] = _value_for_annotation(field_info.annotation)
     try:
         return model_cls(**kwargs)
     except Exception:
         return model_cls.model_construct(**kwargs)
+
+
+def _is_list_annotation(annotation: Any) -> bool:
+    """Return True when ``annotation`` is a list type (including Optional[list[...]])."""
+    if annotation is None:
+        return False
+    origin = get_origin(annotation)
+    if origin in (list, set, tuple, frozenset):
+        return origin is list
+    if origin is typing.Union:
+        non_none = [a for a in get_args(annotation) if a is not type(None)]
+        return len(non_none) == 1 and _is_list_annotation(non_none[0])
+    return False
 
 
 def _value_for_annotation(annotation: Any) -> Any:
@@ -209,6 +291,13 @@ def _is_model(obj: Any) -> bool:
     return isinstance(obj, type) and issubclass(obj, BaseModel)
 
 
+def _mock_completion_content(text: str) -> SimpleNamespace:
+    """Return a litellm-like completion object with ``.choices[0].message.content``."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))],
+    )
+
+
 # ---------------------------------------------------------------------------
 # Patched gateway methods
 # ---------------------------------------------------------------------------
@@ -224,15 +313,20 @@ async def _mock_acreate_structured_output(
     # response_model may arrive positionally (text_input, system_prompt, response_model).
     if response_model is None and args:
         response_model = args[0]
-    return build_mock_response(response_model)
+    return build_mock_response(
+        response_model,
+        text_input=text_input,
+        system_prompt=system_prompt,
+    )
 
 
-async def _mock_create_transcript(*args: Any, **kwargs: Any) -> str:
-    return MOCK_TRANSCRIPT
+async def _mock_create_transcript(*args: Any, **kwargs: Any) -> TranscriptionReturnType:
+    payload = _mock_completion_content(MOCK_TRANSCRIPT)
+    return TranscriptionReturnType(MOCK_TRANSCRIPT, payload)
 
 
-async def _mock_transcribe_image(*args: Any, **kwargs: Any) -> str:
-    return MOCK_IMAGE_DESCRIPTION
+async def _mock_transcribe_image(*args: Any, **kwargs: Any) -> SimpleNamespace:
+    return _mock_completion_content(MOCK_IMAGE_DESCRIPTION)
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/utils/example_mock_llm.py
+++ b/cognee/tests/utils/example_mock_llm.py
@@ -1,0 +1,259 @@
+"""Deterministic LLM mocking harness for cognee example tests.
+
+Every structured LLM call in cognee flows through the single choke point
+``LLMGateway.acreate_structured_output`` in
+``cognee/infrastructure/llm/LLMGateway.py`` (both the Instructor and BAML
+frameworks route through it). Patching that one static method therefore
+intercepts cognify, retrieval/completion, summarization, entity extraction,
+and the direct-gateway calls used by ``examples/guides/low_level_llm.py`` and
+the agentic examples -- no per-call-site patching required.
+
+Transcription and image description use the sibling methods
+``LLMGateway.create_transcript`` / ``LLMGateway.transcribe_image``; these are
+patched too so multimedia examples run offline.
+
+Embeddings are handled separately via cognee's built-in ``MOCK_EMBEDDING``
+flag (see ``example_runner``/``conftest``), NOT by replacing the embedding
+engine -- the real engine keeps its tokenizer, which ``chunk_by_sentence`` and
+the Langchain chunker rely on for token counting.
+
+The core piece is ``build_mock_response(response_model)``: a schema-aware
+factory that returns a minimal, valid instance of whatever Pydantic model a
+call site asked for. Known models get hand-tuned, non-degenerate values (a
+``KnowledgeGraph`` with real nodes/edges so ``add_data_points`` and graph
+retrieval have something to work with); everything else is synthesized by
+walking ``model_fields``.
+"""
+
+from __future__ import annotations
+
+import enum
+import typing
+from contextlib import contextmanager
+from typing import Any, get_args, get_origin
+from unittest.mock import patch
+
+from pydantic import BaseModel
+
+MOCK_ANSWER = "MOCK_ANSWER"
+MOCK_SUMMARY = "Mock summary. This is a deterministic canned response for tests."
+MOCK_TRANSCRIPT = "Mock transcript of the provided audio."
+MOCK_IMAGE_DESCRIPTION = "Mock description of the provided image."
+
+_LLM_GATEWAY_PATH = "cognee.infrastructure.llm.LLMGateway.LLMGateway"
+
+
+# ---------------------------------------------------------------------------
+# Schema-aware response factory
+# ---------------------------------------------------------------------------
+
+
+def build_mock_response(response_model: Any) -> Any:
+    """Return a minimal, valid instance of ``response_model``.
+
+    Handles ``str`` (the common completion/answer case), the well-known cognee
+    response models, and any other Pydantic model via field introspection.
+    """
+    if response_model is None or response_model is str:
+        return MOCK_ANSWER
+
+    if not (isinstance(response_model, type) and issubclass(response_model, BaseModel)):
+        # Non-pydantic, non-str response models are rare; a string is the
+        # safest universally-consumable value.
+        return MOCK_ANSWER
+
+    field_names = set(getattr(response_model, "model_fields", {}).keys())
+
+    # KnowledgeGraph (both the default and Gemini variants expose nodes/edges).
+    if {"nodes", "edges"}.issubset(field_names):
+        return _build_knowledge_graph(response_model)
+
+    return _build_generic_model(response_model)
+
+
+def _build_knowledge_graph(kg_cls: type[BaseModel]) -> BaseModel:
+    """Build a small, self-consistent KnowledgeGraph (2 nodes, 1 edge)."""
+    fields = kg_cls.model_fields
+    node_cls = _first_model_arg(fields["nodes"].annotation)
+    edge_cls = _first_model_arg(fields["edges"].annotation)
+
+    nodes: list[Any] = []
+    edges: list[Any] = []
+    if node_cls is not None:
+        nodes = [
+            _instantiate(
+                node_cls,
+                id="node_alice",
+                name="Alice",
+                type="Person",
+                description="A person named Alice.",
+                label="Person",
+            ),
+            _instantiate(
+                node_cls,
+                id="node_bob",
+                name="Bob",
+                type="Person",
+                description="A person named Bob.",
+                label="Person",
+            ),
+        ]
+    if edge_cls is not None:
+        edges = [
+            _instantiate(
+                edge_cls,
+                source_node_id="node_alice",
+                target_node_id="node_bob",
+                relationship_name="knows",
+                description="Alice knows Bob.",
+            )
+        ]
+
+    kwargs: dict[str, Any] = {"nodes": nodes, "edges": edges}
+    # Gemini variant additionally requires summary/description.
+    if "summary" in fields:
+        kwargs["summary"] = MOCK_SUMMARY
+    if "description" in fields:
+        kwargs["description"] = "Mock knowledge graph description."
+    return kg_cls(**kwargs)
+
+
+def _build_generic_model(model_cls: type[BaseModel]) -> BaseModel:
+    """Instantiate any Pydantic model by synthesizing values for required fields."""
+    kwargs: dict[str, Any] = {}
+    for field_name, field_info in model_cls.model_fields.items():
+        # Special-case a couple of common, semantically meaningful field names.
+        if field_name == "summary":
+            kwargs[field_name] = MOCK_SUMMARY
+            continue
+        if not field_info.is_required():
+            # Leave optional/defaulted fields to their defaults.
+            continue
+        kwargs[field_name] = _value_for_annotation(field_info.annotation)
+    try:
+        return model_cls(**kwargs)
+    except Exception:
+        # Last resort: construct without validation so a mock never blocks a run.
+        return model_cls.model_construct(**kwargs)
+
+
+def _instantiate(model_cls: type[BaseModel], **preferred: Any) -> BaseModel:
+    """Instantiate ``model_cls``, keeping only fields it declares and filling
+    any remaining required fields with synthesized values."""
+    declared = set(model_cls.model_fields.keys())
+    kwargs = {k: v for k, v in preferred.items() if k in declared}
+    for field_name, field_info in model_cls.model_fields.items():
+        if field_name in kwargs or not field_info.is_required():
+            continue
+        kwargs[field_name] = _value_for_annotation(field_info.annotation)
+    try:
+        return model_cls(**kwargs)
+    except Exception:
+        return model_cls.model_construct(**kwargs)
+
+
+def _value_for_annotation(annotation: Any) -> Any:
+    """Synthesize a minimal valid value for a type annotation."""
+    if annotation is None or annotation is type(None):
+        return None
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    # Optional[X] / Union[...] -> first non-None member.
+    if origin is typing.Union:
+        non_none = [a for a in args if a is not type(None)]
+        return _value_for_annotation(non_none[0]) if non_none else None
+
+    if origin in (list, set, tuple, frozenset):
+        member = _first_model_arg(annotation)
+        if member is not None:
+            built = (
+                _build_generic_model(member)
+                if _is_model(member)
+                else _value_for_annotation(args[0])
+            )
+            return [built]
+        return []
+
+    if origin is dict:
+        return {}
+
+    if annotation is str:
+        return MOCK_ANSWER
+    if annotation is bool:
+        return False
+    if annotation is int:
+        return 0
+    if annotation is float:
+        return 0.0
+
+    if _is_model(annotation):
+        return _build_generic_model(annotation)
+
+    if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+        return next(iter(annotation))
+
+    return None
+
+
+def _first_model_arg(annotation: Any) -> type[BaseModel] | None:
+    """Return the first ``BaseModel`` subclass among a generic's type args."""
+    for arg in get_args(annotation):
+        if _is_model(arg):
+            return arg
+    return None
+
+
+def _is_model(obj: Any) -> bool:
+    return isinstance(obj, type) and issubclass(obj, BaseModel)
+
+
+# ---------------------------------------------------------------------------
+# Patched gateway methods
+# ---------------------------------------------------------------------------
+
+
+async def _mock_acreate_structured_output(
+    text_input: Any = None,
+    system_prompt: Any = None,
+    response_model: Any = None,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    # response_model may arrive positionally (text_input, system_prompt, response_model).
+    if response_model is None and args:
+        response_model = args[0]
+    return build_mock_response(response_model)
+
+
+async def _mock_create_transcript(*args: Any, **kwargs: Any) -> str:
+    return MOCK_TRANSCRIPT
+
+
+async def _mock_transcribe_image(*args: Any, **kwargs: Any) -> str:
+    return MOCK_IMAGE_DESCRIPTION
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def patch_llm_gateway():
+    """Patch every LLM method on ``LLMGateway`` so no real provider is hit.
+
+    Because callers reference the class attribute at call time, patching the
+    class methods intercepts all imports of ``LLMGateway`` regardless of where
+    it was imported.
+    """
+    with (
+        patch(
+            f"{_LLM_GATEWAY_PATH}.acreate_structured_output",
+            new=_mock_acreate_structured_output,
+        ),
+        patch(f"{_LLM_GATEWAY_PATH}.create_transcript", new=_mock_create_transcript),
+        patch(f"{_LLM_GATEWAY_PATH}.transcribe_image", new=_mock_transcribe_image),
+    ):
+        yield

--- a/cognee/tests/utils/example_runner.py
+++ b/cognee/tests/utils/example_runner.py
@@ -1,0 +1,101 @@
+"""Helpers for loading and running ``examples/`` scripts inside tests.
+
+``import_example`` loads an example module by file path (so the on-disk script
+is exercised verbatim -- no copy-pasting example logic into tests) and returns
+the imported module, from which a test typically awaits ``module.main()``.
+
+``requires_docker`` / ``requires_aws`` are skip markers for the minority of
+examples that genuinely need an external service; they keep the default suite
+runnable with zero secrets and no daemon.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Mapping
+
+import pytest
+
+# repo root: cognee/tests/utils/example_runner.py -> parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLES_ROOT = REPO_ROOT / "examples"
+
+
+def example_path(rel_path: str) -> Path:
+    """Resolve a path relative to the repo root (accepts ``examples/...``)."""
+    path = (REPO_ROOT / rel_path).resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Example script not found: {path}")
+    return path
+
+
+def import_example(
+    rel_path: str,
+    *,
+    pre_import_env: Mapping[str, str] | None = None,
+    module_name: str | None = None,
+) -> ModuleType:
+    """Import an example script by path and return the module object.
+
+    Parameters
+    ----------
+    rel_path:
+        Path to the script relative to the repo root, e.g.
+        ``"examples/guides/recall_core.py"``.
+    pre_import_env:
+        Environment variables to set *before* the module body executes. Some
+        examples read/mutate ``os.environ`` at import time (e.g. the relational
+        migration demos hardcode ``MIGRATION_DB_PROVIDER`` at line 8), so the
+        override must be in place before ``exec_module`` runs.
+    module_name:
+        Optional explicit module name; defaults to a unique name derived from
+        the path to avoid clobbering ``sys.modules``.
+    """
+    path = example_path(rel_path)
+
+    if pre_import_env:
+        for key, value in pre_import_env.items():
+            os.environ[key] = value
+
+    name = module_name or "cognee_example_" + rel_path.replace("/", "_").replace(".py", "")
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not create import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+
+    # Make sibling modules importable (some examples import neighbouring files).
+    script_dir = str(path.parent)
+    added_to_path = script_dir not in sys.path
+    if added_to_path:
+        sys.path.insert(0, script_dir)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if added_to_path and script_dir in sys.path:
+            sys.path.remove(script_dir)
+    return module
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+def _aws_credentials_available() -> bool:
+    return bool(os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"))
+
+
+def requires_docker(reason: str = "requires a running Docker daemon"):
+    """Skip marker for tests that need Docker (e.g. Testcontainers backends)."""
+    return pytest.mark.skipif(not _docker_available(), reason=reason)
+
+
+def requires_aws(reason: str = "requires AWS credentials"):
+    """Skip marker for tests that need real AWS services (S3, Neptune)."""
+    return pytest.mark.skipif(not _aws_credentials_available(), reason=reason)

--- a/cognee/tests/utils/example_runner.py
+++ b/cognee/tests/utils/example_runner.py
@@ -2,7 +2,7 @@
 
 ``import_example`` loads an example module by file path (so the on-disk script
 is exercised verbatim -- no copy-pasting example logic into tests) and returns
-the imported module, from which a test typically awaits ``module.main()``.
+the imported module, from which a test typically awaits ``invoke_example_main``.
 
 ``requires_docker`` / ``requires_aws`` are skip markers for the minority of
 examples that genuinely need an external service; they keep the default suite
@@ -15,6 +15,7 @@ import importlib.util
 import os
 import shutil
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType
 from typing import Mapping
@@ -32,6 +33,26 @@ def example_path(rel_path: str) -> Path:
     if not path.exists():
         raise FileNotFoundError(f"Example script not found: {path}")
     return path
+
+
+@contextmanager
+def _script_import_context(path: Path):
+    """Isolate import side effects: ``sys.argv``, CWD, and ``sys.path``."""
+    script_dir = str(path.parent)
+    old_argv = sys.argv
+    old_cwd = os.getcwd()
+    added_to_path = script_dir not in sys.path
+    if added_to_path:
+        sys.path.insert(0, script_dir)
+    sys.argv = [str(path)]
+    os.chdir(script_dir)
+    try:
+        yield
+    finally:
+        sys.argv = old_argv
+        os.chdir(old_cwd)
+        if added_to_path and script_dir in sys.path:
+            sys.path.remove(script_dir)
 
 
 def import_example(
@@ -69,18 +90,48 @@ def import_example(
         raise ImportError(f"Could not create import spec for {path}")
     module = importlib.util.module_from_spec(spec)
 
-    # Make sibling modules importable (some examples import neighbouring files).
-    script_dir = str(path.parent)
-    added_to_path = script_dir not in sys.path
-    if added_to_path:
-        sys.path.insert(0, script_dir)
     sys.modules[name] = module
-    try:
+    with _script_import_context(path):
         spec.loader.exec_module(module)
-    finally:
-        if added_to_path and script_dir in sys.path:
-            sys.path.remove(script_dir)
     return module
+
+
+async def invoke_example_main(
+    module: ModuleType,
+    rel_path: str,
+    *,
+    work_dir: Path | None = None,
+    chdir_to_script: bool = False,
+) -> None:
+    """Await ``module.main()`` with pytest-safe ``sys.argv`` and CWD.
+
+    Parameters
+    ----------
+    work_dir:
+        Directory to use as CWD while ``main()`` runs (typically the test
+        ``tmp_path`` sandbox). Defaults to the script directory when
+        ``chdir_to_script`` is True, otherwise the current working directory.
+    chdir_to_script:
+        When True, run ``main()`` with CWD set to the script's parent so
+        examples that read CWD-relative files (e.g. ``prompts/prompt1.txt``)
+        work without per-test workarounds.
+    """
+    path = example_path(rel_path)
+    old_argv = sys.argv
+    old_cwd = os.getcwd()
+    if chdir_to_script:
+        target_dir = path.parent
+    elif work_dir is not None:
+        target_dir = work_dir
+    else:
+        target_dir = Path(old_cwd)
+    sys.argv = [str(path)]
+    os.chdir(target_dir)
+    try:
+        await module.main()
+    finally:
+        sys.argv = old_argv
+        os.chdir(old_cwd)
 
 
 def _docker_available() -> bool:

--- a/examples/README.md
+++ b/examples/README.md
@@ -222,6 +222,33 @@ uv run python examples/demos/simple_cognee_example.py
 For non-OpenAI providers (Anthropic, Bedrock, Ollama, fastembed, …) see
 [the cognee docs](https://docs.cognee.ai) and `.env.template`.
 
+## 🧪 Testing examples (mocked, no API key)
+
+Every example is covered by a fast, deterministic test that runs it end to end
+with the LLM and embedding layers mocked — no API key, no network, no external
+services. The tests live under [`cognee/tests/examples/`](../cognee/tests/examples/)
+and mirror this folder's layout.
+
+```bash
+# Run all mocked example tests (no LLM_API_KEY needed)
+uv run pytest cognee/tests/examples/ -v
+
+# Run just one folder
+uv run pytest cognee/tests/examples/guides/ -v
+```
+
+How the harness works (see [`cognee/tests/utils/example_mock_llm.py`](../cognee/tests/utils/example_mock_llm.py)):
+
+- **LLM** — all structured calls flow through the single choke point
+  `LLMGateway.acreate_structured_output`. The harness patches it (plus
+  `create_transcript` / `transcribe_image`) and returns a minimal, valid
+  instance of whatever Pydantic `response_model` the call site asked for
+  (a real `KnowledgeGraph` with nodes/edges, `"MOCK_ANSWER"` for `str`, etc.).
+- **Embeddings** — cognee's built-in `MOCK_EMBEDDING=true` flag returns zero
+  vectors while keeping the real tokenizer, so chunk boundaries stay correct.
+- **Isolation** — each test gets a `tmp_path` data/system root and prunes
+  before/after, so no shared state and no database file-lock contention.
+
 ## 🤝 Contributing a new example
 
 1. Pick the right folder:
@@ -232,5 +259,26 @@ For non-OpenAI providers (Anthropic, Bedrock, Ollama, fastembed, …) see
 2. Self-contained: an example should run with `uv run python <path>` after `uv sync` and a configured `.env`. No global setup.
 3. Add an entry to the appropriate table above.
 4. If your example demonstrates a feature, add it to the **By feature** cross-index too.
+5. Add a mocked test. Expose an async `main()` in your script, then add a test
+   under [`cognee/tests/examples/`](../cognee/tests/examples/) that loads and runs it:
+
+```python
+import pytest
+from cognee.tests.utils.example_runner import import_example
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_my_example(isolated_example_env):
+    module = import_example("examples/<folder>/my_example.py")
+    await module.main()
+```
+
+The `isolated_example_env` fixture applies the LLM + embedding mocks and a
+`tmp_path`-isolated data/system root. If your example needs an external service
+(Docker, AWS), guard it with `requires_docker()` / `requires_aws()` from
+`cognee.tests.utils.example_runner`, or mock the boundary. If a call site uses a
+custom Pydantic `response_model` the factory doesn't yet handle well, extend
+`build_mock_response` in [`cognee/tests/utils/example_mock_llm.py`](../cognee/tests/utils/example_mock_llm.py).
 
 See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the broader contribution flow.


### PR DESCRIPTION
## Description

Part of #3601. First PR in the series — it adds the reusable LLM/embedding
mocking harness that every subsequent mocked-example test builds on, plus 3
canary tests that prove it works end to end across increasing pipeline depth.

**Why:** the ~70 scripts under `examples/` currently require real API keys, burn
tokens, are non-deterministic, and silently rot when an API or signature
changes. This lands the foundation to run them in CI, fast and free.

**Harness — `cognee/tests/utils/example_mock_llm.py`**
- Patches the single choke point `LLMGateway.acreate_structured_output`, which
  every structured LLM call in cognee flows through (covers both the Instructor
  and BAML frameworks). Also patches `create_transcript` / `transcribe_image`.
- `build_mock_response(response_model)` returns a minimal, valid instance of
  whatever Pydantic model a call site requested: a non-empty `KnowledgeGraph`
  (2 nodes, 1 edge) so `add_data_points` and graph retrieval have real content,
  `"MOCK_ANSWER"` for `str`, and field-introspection for the long tail of
  custom models in `pocs/` and `custom_pipelines/`.

**Embeddings** — uses cognee's built-in `MOCK_EMBEDDING=true` flag (zero
vectors) instead of replacing the embedding engine, so the real tokenizer is
preserved and chunk boundaries stay correct.

**Isolation — `cognee/tests/examples/conftest.py`**
- `isolated_example_env` gives each test a `tmp_path` data/system root, applies
  the LLM + embedding mocks, and prunes before/after. Modeled on
  `cognee/tests/test_permissions.py`. No shared state, no DB file-lock contention.

**Runner — `cognee/tests/utils/example_runner.py`**
- `import_example()` loads and runs the on-disk example verbatim (no example
  logic copied into tests). `requires_docker` / `requires_aws` skip markers are
  ready for the backend PRs.

**Docs** — `examples/README.md` gets a "Testing examples" section with a
copy-paste test template; `CONTRIBUTING.md` gets a note under Running Tests.

Note: #3640 and #3744 propose guides-only harnesses; this PR takes the
choke-point + `MOCK_EMBEDDING` approach and is structured as the foundation for
the full 6-PR series covering all of `examples/`.

## Acceptance Criteria

This PR delivers the harness foundation from #3601. Progress toward the issue's
full acceptance criteria:

- [x] A documented, reusable LLM/embedding mocking harness lives in the test suite
- [x] The harness runs with no real API keys and is deterministic
- [x] Tests fail loudly when an example breaks (import error, signature change, runtime exception)
- [x] A short `examples/README` / `CONTRIBUTING` note explains how to add a mocked test
- [ ] Every script under `examples/` has a corresponding mocked test *(follow-up PRs 2–5)*
- [ ] The whole suite is wired into CI *(follow-up PR 6, which will close #3601)*

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Full mocked example suite passing with **no LLM API key** in the environment
(`LLM keys in env: (none)`), fast and deterministic:
<img width="1846" height="768" alt="cognee" src="https://github.com/user-attachments/assets/5c525557-df8e-4036-a908-eae795e7fdf5" />


## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR (See CONTRIBUTING.md)
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.