### PR TITLE
fix(config): prevent silent embedding defaults

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/config.py
+++ b/cognee/infrastructure/databases/vector/embeddings/config.py
@@ -1,19 +1,13 @@
 from typing import Optional
 from functools import lru_cache
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from cognee.exceptions import CogneeConfigurationError
 from cognee.shared.logging_utils import get_logger
 
 
 logger = get_logger("embedding_config")
-
-
-# Hard fallback when neither litellm nor fastembed knows the model. This used
-# to be the unconditional default and was the source of the silent
-# "Vector(3072)" mismatch on every non-OpenAI-text-embedding-3-large embedder.
-# Keep it for back-compat (the OpenAI default model still resolves to this via
-# litellm), but log a warning when we hit it without a real lookup.
-_FALLBACK_DIMENSIONS = 3072
 
 
 def _resolve_embedding_dimensions(provider: Optional[str], model: Optional[str]) -> Optional[int]:
@@ -78,7 +72,15 @@ class EmbeddingConfig(BaseSettings):
     embedding_endpoint: Optional[str] = None
     embedding_api_key: Optional[str] = None
     embedding_api_version: Optional[str] = None
-    embedding_max_completion_tokens: Optional[int] = 8191
+    embedding_max_completion_tokens: Optional[int] = Field(
+        default=8191,
+        validation_alias=AliasChoices(
+            "EMBEDDING_MAX_COMPLETION_TOKENS",
+            "embedding_max_completion_tokens",
+            "EMBEDDING_MAX_TOKENS",
+            "embedding_max_tokens",
+        ),
+    )
     embedding_batch_size: Optional[int] = None
     huggingface_tokenizer: Optional[str] = None
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
@@ -89,21 +91,13 @@ class EmbeddingConfig(BaseSettings):
             if derived is not None:
                 self.embedding_dimensions = derived
             else:
-                logger.warning(
+                raise CogneeConfigurationError(
                     "Could not auto-derive embedding_dimensions for "
-                    "provider=%r model=%r. Falling back to %d. If your embedder "
-                    "produces vectors of a different size, set EMBEDDING_DIMENSIONS "
-                    "explicitly — otherwise the first write into the vector store "
-                    "will fail with a shape mismatch.",
-                    self.embedding_provider,
-                    self.embedding_model,
-                    _FALLBACK_DIMENSIONS,
+                    f"provider={self.embedding_provider!r} model={self.embedding_model!r}. "
+                    "Set EMBEDDING_DIMENSIONS explicitly for this embedding model."
                 )
-                self.embedding_dimensions = _FALLBACK_DIMENSIONS
 
-        if not self.embedding_batch_size and self.embedding_provider.lower() == "openai":
-            self.embedding_batch_size = 36
-        elif not self.embedding_batch_size:
+        if not self.embedding_batch_size:
             self.embedding_batch_size = 36
 
     def to_dict(self) -> dict:

--- a/cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py
@@ -1,3 +1,4 @@
+from cognee.exceptions import CogneeConfigurationError
 from cognee.infrastructure.databases.vector.embeddings.config import get_embedding_context_config
 from cognee.infrastructure.llm.config import (
     get_llm_context_config,
@@ -22,6 +23,7 @@ def get_embedding_engine() -> EmbeddingEngine:
     """
     config = get_embedding_context_config()
     llm_config = get_llm_context_config()
+    embedding_configured_fields = frozenset(getattr(config, "model_fields_set", set()))
     # Embedding engine has to be a singleton based on configuration to ensure too many requests won't be sent to HuggingFace
     return create_embedding_engine(
         config.embedding_provider,
@@ -35,7 +37,87 @@ def get_embedding_engine() -> EmbeddingEngine:
         config.huggingface_tokenizer,
         llm_config.llm_api_key,
         llm_config.llm_provider,
+        embedding_configured_fields,
     )
+
+
+def _normalize_provider(provider):
+    return provider.lower() if isinstance(provider, str) else provider
+
+
+def _infer_provider_from_model(model):
+    if not isinstance(model, str) or "/" not in model:
+        return None
+
+    return model.split("/", 1)[0].lower()
+
+
+def _embedding_identity_is_explicit(embedding_model, configured_fields):
+    if configured_fields is None:
+        configured_fields = set()
+
+    if "embedding_provider" in configured_fields:
+        return True
+
+    if "embedding_model" in configured_fields and _infer_provider_from_model(embedding_model):
+        return True
+
+    return False
+
+
+def _validate_embedding_engine_config(
+    embedding_provider,
+    embedding_model,
+    embedding_dimensions,
+    llm_provider,
+    embedding_configured_fields,
+):
+    if not embedding_provider or not embedding_model:
+        raise CogneeConfigurationError(
+            "Embedding configuration is incomplete. Set EMBEDDING_PROVIDER and "
+            "EMBEDDING_MODEL explicitly."
+        )
+
+    if embedding_dimensions is None:
+        raise CogneeConfigurationError(
+            "Embedding configuration is missing dimensions. Set EMBEDDING_DIMENSIONS "
+            "explicitly for this embedding model."
+        )
+
+    normalized_llm_provider = _normalize_provider(llm_provider)
+    normalized_embedding_provider = _normalize_provider(embedding_provider)
+    explicit_embedding_identity = _embedding_identity_is_explicit(
+        embedding_model, embedding_configured_fields
+    )
+
+    if (
+        normalized_llm_provider
+        and normalized_llm_provider != "openai"
+        and normalized_embedding_provider == "openai"
+        and not explicit_embedding_identity
+    ):
+        raise CogneeConfigurationError(
+            "LLM_PROVIDER is set to a non-OpenAI provider, but embedding configuration "
+            "is still using Cognee's default OpenAI embeddings. Set EMBEDDING_PROVIDER "
+            "and EMBEDDING_MODEL explicitly, or set an explicit OpenAI embedding model "
+            "and EMBEDDING_API_KEY if you intend to use OpenAI embeddings."
+        )
+
+
+def _get_embedding_api_key(embedding_api_key, llm_api_key, embedding_provider, llm_provider):
+    if embedding_api_key:
+        return embedding_api_key
+
+    normalized_embedding_provider = _normalize_provider(embedding_provider)
+    normalized_llm_provider = _normalize_provider(llm_provider)
+
+    if normalized_embedding_provider == normalized_llm_provider:
+        return llm_api_key
+
+    if normalized_embedding_provider == "openai" and normalized_llm_provider in (None, "openai"):
+        return llm_api_key
+
+    return None
 
 
 @lru_cache
@@ -51,6 +133,7 @@ def create_embedding_engine(
     huggingface_tokenizer,
     llm_api_key,
     llm_provider,
+    embedding_configured_fields=frozenset(),
 ):
     """
     Create and return an embedding engine based on the specified provider.
@@ -79,6 +162,17 @@ def create_embedding_engine(
 
         Returns an instance of an embedding engine based on the specified provider.
     """
+    _validate_embedding_engine_config(
+        embedding_provider,
+        embedding_model,
+        embedding_dimensions,
+        llm_provider,
+        embedding_configured_fields,
+    )
+    api_key = _get_embedding_api_key(
+        embedding_api_key, llm_api_key, embedding_provider, llm_provider
+    )
+
     if embedding_provider == "fastembed":
         from .FastembedEmbeddingEngine import FastembedEmbeddingEngine
 
@@ -109,7 +203,7 @@ def create_embedding_engine(
             dimensions=embedding_dimensions,
             max_completion_tokens=embedding_max_completion_tokens,
             endpoint=embedding_endpoint,
-            api_key=embedding_api_key or llm_api_key,
+            api_key=api_key,
             batch_size=embedding_batch_size,
         )
 
@@ -117,8 +211,7 @@ def create_embedding_engine(
 
     return LiteLLMEmbeddingEngine(
         provider=embedding_provider,
-        api_key=embedding_api_key
-        or (embedding_api_key if llm_provider == "custom" else llm_api_key),
+        api_key=api_key,
         endpoint=embedding_endpoint,
         api_version=embedding_api_version,
         model=embedding_model,

--- a/cognee/tests/unit/infrastructure/databases/vector/test_embedding_config.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_embedding_config.py
@@ -2,9 +2,16 @@
 
 from unittest.mock import patch
 
+import pytest
+
+from cognee.exceptions import CogneeConfigurationError
 from cognee.infrastructure.databases.vector.embeddings.config import (
     EmbeddingConfig,
     _resolve_embedding_dimensions,
+)
+from cognee.infrastructure.databases.vector.embeddings.get_embedding_engine import (
+    _get_embedding_api_key,
+    _validate_embedding_engine_config,
 )
 
 
@@ -57,7 +64,13 @@ def _clear_embedding_env(monkeypatch):
     # CI workflows set EMBEDDING_* env vars (see .github/workflows/basic_tests.yml),
     # and pydantic-settings reads them at construction time — bypassing the
     # class defaults and the auto-resolve path we want to test here.
-    for var in ("EMBEDDING_PROVIDER", "EMBEDDING_MODEL", "EMBEDDING_DIMENSIONS"):
+    for var in (
+        "EMBEDDING_PROVIDER",
+        "EMBEDDING_MODEL",
+        "EMBEDDING_DIMENSIONS",
+        "EMBEDDING_MAX_COMPLETION_TOKENS",
+        "EMBEDDING_MAX_TOKENS",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -80,14 +93,95 @@ def test_config_honors_explicit_dimensions(monkeypatch):
     assert cfg.embedding_dimensions == 384
 
 
-def test_config_falls_back_when_unresolvable(monkeypatch):
-    # Unknown model + unset dimensions falls back to 3072 with a warning,
-    # so existing setups don't crash at import time.
+def test_config_fails_when_unresolvable_dimensions_are_unset(monkeypatch):
+    _clear_embedding_env(monkeypatch)
+
+    with pytest.raises(CogneeConfigurationError, match="Set EMBEDDING_DIMENSIONS"):
+        EmbeddingConfig(
+            _env_file=None,
+            embedding_provider="openai",
+            embedding_model="totally-fake-embedder-zzz",
+            embedding_dimensions=None,
+        )
+
+
+def test_config_allows_unknown_model_with_explicit_dimensions(monkeypatch):
     _clear_embedding_env(monkeypatch)
     cfg = EmbeddingConfig(
         _env_file=None,
-        embedding_provider="openai",
-        embedding_model="totally-fake-embedder-zzz",
-        embedding_dimensions=None,
+        embedding_provider="custom",
+        embedding_model="my-private-embedding-model",
+        embedding_dimensions=1536,
     )
-    assert cfg.embedding_dimensions == 3072
+
+    assert cfg.embedding_dimensions == 1536
+
+
+def test_config_accepts_embedding_max_tokens_alias(monkeypatch):
+    _clear_embedding_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_MAX_TOKENS", "4096")
+
+    cfg = EmbeddingConfig(_env_file=None)
+
+    assert cfg.embedding_max_completion_tokens == 4096
+
+
+def test_config_defaults_embedding_batch_size(monkeypatch):
+    _clear_embedding_env(monkeypatch)
+
+    cfg = EmbeddingConfig(_env_file=None)
+
+    assert cfg.embedding_batch_size == 36
+
+
+def test_engine_validation_rejects_silent_openai_embedding_default_for_non_openai_llm(
+    monkeypatch,
+):
+    _clear_embedding_env(monkeypatch)
+    cfg = EmbeddingConfig(_env_file=None)
+
+    with pytest.raises(CogneeConfigurationError, match="default OpenAI embeddings"):
+        _validate_embedding_engine_config(
+            cfg.embedding_provider,
+            cfg.embedding_model,
+            cfg.embedding_dimensions,
+            "anthropic",
+            cfg.model_fields_set,
+        )
+
+
+def test_engine_validation_allows_explicit_openai_embeddings_with_non_openai_llm(
+    monkeypatch,
+):
+    _clear_embedding_env(monkeypatch)
+    cfg = EmbeddingConfig(
+        _env_file=None,
+        embedding_model="openai/text-embedding-3-large",
+        embedding_dimensions=3072,
+    )
+
+    _validate_embedding_engine_config(
+        cfg.embedding_provider,
+        cfg.embedding_model,
+        cfg.embedding_dimensions,
+        "anthropic",
+        cfg.model_fields_set,
+    )
+
+
+def test_engine_key_fallback_reuses_key_for_same_provider():
+    assert (
+        _get_embedding_api_key(None, "same-provider-key", "openai", "openai")
+        == "same-provider-key"
+    )
+
+
+def test_engine_key_fallback_does_not_reuse_mismatched_llm_key():
+    assert _get_embedding_api_key(None, "anthropic-key", "openai", "anthropic") is None
+
+
+def test_engine_key_fallback_prefers_explicit_embedding_key():
+    assert (
+        _get_embedding_api_key("embedding-key", "llm-key", "openai", "anthropic")
+        == "embedding-key"
+    )


### PR DESCRIPTION
## Summary
- fail fast when embedding dimensions cannot be resolved without explicit EMBEDDING_DIMENSIONS
- reject the silent default OpenAI embedding path when LLM_PROVIDER is non-OpenAI and embeddings were not explicitly configured
- avoid borrowing a mismatched non-OpenAI LLM key for embeddings while preserving same-provider/default OpenAI key reuse
- add EMBEDDING_MAX_TOKENS as an alias and collapse the duplicate embedding batch-size default

Fixes #3383

## Notes
This keeps the default OpenAI quickstart working and preserves valid explicit embedding setups, including intentionally using OpenAI embeddings with a non-OpenAI LLM when the embedding model/key are configured explicitly.

## Tests
- uv run pytest cognee/tests/unit/infrastructure/databases/vector/test_embedding_config.py -q
- uv run pytest cognee/tests/unit/infrastructure/llm/test_embedding_connection_dimensions.py -q
- uv run ruff check cognee/infrastructure/databases/vector/embeddings cognee/tests/unit/infrastructure/databases/vector

## DCO
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.