### PR TITLE
fix: restore synchronous get_vector_engine() for backward compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,10 +512,10 @@ task = Task(my_custom_task)
 ### Accessing Databases Directly
 ```python
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 
 graph_engine = await get_graph_engine()
-vector_engine = await get_vector_engine()
+vector_engine = await get_vector_engine_async()
 ```
 
 ### Using LLM Gateway

--- a/cognee-mcp/src/codingagents/coding_rule_associations.py
+++ b/cognee-mcp/src/codingagents/coding_rule_associations.py
@@ -1,7 +1,7 @@
 from uuid import NAMESPACE_OID, uuid5
 
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 
 from cognee.infrastructure.llm.prompts import render_prompt
 from cognee.low_level import DataPoint
@@ -54,7 +54,7 @@ async def get_existing_rules(rules_nodeset_name: str) -> str:
 
 
 async def get_origin_edges(data: str, rules: List[Rule]) -> list[Any]:
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     origin_chunk = await vector_engine.search("DocumentChunk_text", data, limit=1)
 

--- a/cognee/api/v1/health/health.py
+++ b/cognee/api/v1/health/health.py
@@ -80,11 +80,13 @@ class HealthChecker:
         """Check vector database health."""
         start_time = time.time()
         try:
-            from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine
+            from cognee.infrastructure.databases.vector.get_vector_engine import (
+                get_vector_engine_async,
+            )
             from cognee.infrastructure.databases.vector.config import get_vectordb_config
 
             config = get_vectordb_config()
-            engine = await get_vector_engine()
+            engine = await get_vector_engine_async()
 
             # Test basic operation - just check if engine is accessible
             if hasattr(engine, "health_check"):

--- a/cognee/infrastructure/databases/unified/get_unified_engine.py
+++ b/cognee/infrastructure/databases/unified/get_unified_engine.py
@@ -1,7 +1,7 @@
 from cognee.infrastructure.databases.graph.config import get_graph_context_config
 from cognee.infrastructure.databases.vector.config import get_vectordb_context_config
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 
 from .capabilities import EngineCapability
 from .unified_store_engine import UnifiedStoreEngine
@@ -27,7 +27,7 @@ def _is_hybrid_provider(graph_config: dict, vector_config: dict) -> bool:
 async def _create_hybrid_adapter(graph_config: dict, vector_config: dict):
     """Create a single adapter instance for a hybrid backend.
 
-    For pghybrid, reuses the cached PGVectorAdapter from get_vector_engine()
+    For pghybrid, reuses the cached PGVectorAdapter from get_vector_engine_async()
     (requires VECTOR_DB_PROVIDER=pgvector) so that metadata caches persist
     across calls.
     """
@@ -75,7 +75,7 @@ async def _create_hybrid_adapter(graph_config: dict, vector_config: dict):
 
         # Vector adapter: reuse the cached PGVectorAdapter from the
         # vector engine factory. This requires VECTOR_DB_PROVIDER=pgvector.
-        vector_adapter = await get_vector_engine()
+        vector_adapter = await get_vector_engine_async()
 
         return PostgresHybridAdapter(
             graph_adapter=graph_adapter,
@@ -88,7 +88,7 @@ async def _create_hybrid_adapter(graph_config: dict, vector_config: dict):
 async def get_unified_engine() -> UnifiedStoreEngine:
     """Build a UnifiedStoreEngine for the current async context.
 
-    - Reads the same context variables as get_graph_engine / get_vector_engine
+    - Reads the same context variables as get_graph_engine / get_vector_engine_async
       so multi-tenant routing works identically.
     - Detects hybrid providers (where graph and vector share a backend) and
       creates a single adapter instance with HYBRID_* capabilities.
@@ -96,7 +96,7 @@ async def get_unified_engine() -> UnifiedStoreEngine:
 
     This function is NOT cached itself because it must respect per-request
     ContextVar values.  The underlying engine factories (get_graph_engine,
-    get_vector_engine) do their own caching.
+    get_vector_engine_async) do their own caching.
     """
     graph_config = get_graph_context_config()
     vector_config = get_vectordb_context_config()
@@ -117,7 +117,7 @@ async def get_unified_engine() -> UnifiedStoreEngine:
         )
 
     graph_engine = await get_graph_engine()
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     return UnifiedStoreEngine(
         graph_engine=graph_engine,

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -286,7 +286,7 @@ class _LeasedValueProxy:
                 async def await_with_lease(_self=self):
                     # The closure keeps ``self`` alive until the awaitable
                     # completes, which matters for one-liners like
-                    # ``await get_vector_engine().search(...)``.
+                    # ``await get_vector_engine_async().search(...)``.
                     return await result
 
                 return await_with_lease()

--- a/cognee/infrastructure/databases/vector/__init__.py
+++ b/cognee/infrastructure/databases/vector/__init__.py
@@ -2,5 +2,5 @@ from .models.VectorConfig import VectorConfig
 from .models.CollectionConfig import CollectionConfig
 from .vector_db_interface import VectorDBInterface
 from .config import get_vectordb_config
-from .get_vector_engine import get_vector_engine
+from .get_vector_engine import get_vector_engine, get_vector_engine_async
 from .use_vector_adapter import use_vector_adapter

--- a/cognee/infrastructure/databases/vector/get_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/get_vector_engine.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .config import get_vectordb_context_config
 from .create_vector_engine import create_vector_engine
 
@@ -81,7 +83,50 @@ class _VectorEngineHandle:
         return f"<VectorEngineHandle config={self._config!r}>"
 
 
-async def get_vector_engine():
-    # ``async`` so every call site ``await``s it (matching the async resolution
-    # surface); resolution itself stays synchronous inside the handle.
+def _new_vector_engine_handle() -> _VectorEngineHandle:
     return _VectorEngineHandle(get_vectordb_context_config())
+
+
+async def get_vector_engine_async() -> _VectorEngineHandle:
+    """Return the vector engine adapter. **This is the canonical way to obtain the
+    adapter** — use it (and ``await`` it) everywhere inside cognee and in async
+    application code, alongside ``await get_graph_engine()``.
+
+    The ``async`` signature exists to keep a uniform "await the engine getter"
+    contract with ``get_graph_engine()`` (which genuinely awaits — Kuzu/Ladybug
+    take an exclusive on-disk file lock, so it must wait for an in-flight close
+    before reopening). Vector resolution itself is synchronous: LanceDB connects
+    via ``connect_async`` without taking that lock, so there is no in-flight-close
+    race to await here. Do not "restore symmetry" by adding an ``acreate`` path —
+    it was tried and deliberately walked back (see #3708) because it is a no-op
+    for LanceDB.
+    """
+    return _new_vector_engine_handle()
+
+
+def get_vector_engine() -> _VectorEngineHandle:
+    """Deprecated synchronous accessor kept for backward compatibility.
+
+    .. deprecated::
+        Use ``await get_vector_engine_async()`` instead. This shim exists so
+        existing downstream code that calls ``get_vector_engine()`` without
+        ``await`` (e.g. cognee-community adapters pinned to older releases) keeps
+        working after vector resolution was moved to the async surface.
+
+    Safe to call synchronously from any context — no running event loop is
+    required — because constructing the handle does no async work (see
+    ``get_vector_engine_async`` for why vector needs no async resolution).
+
+    Note, however, that the *returned adapter* only works inside a running
+    asyncio event loop: its operations (``embed_text``, ``get_connection``,
+    ``search``, ...) are coroutines that must be awaited. So this getter is only
+    useful to code that will ``await`` the adapter's methods within an event loop.
+    """
+    warnings.warn(
+        "get_vector_engine() is deprecated; use `await get_vector_engine_async()` "
+        "instead. The returned adapter's methods are async and must be awaited "
+        "inside a running event loop.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _new_vector_engine_handle()

--- a/cognee/infrastructure/databases/vector/pgvector/create_db_and_tables.py
+++ b/cognee/infrastructure/databases/vector/pgvector/create_db_and_tables.py
@@ -1,13 +1,13 @@
 from sqlalchemy import text
 
-from ..get_vector_engine import get_vector_engine, get_vectordb_context_config
+from ..get_vector_engine import get_vector_engine_async, get_vectordb_context_config
 from cognee.context_global_variables import backend_access_control_enabled
 
 
 async def create_db_and_tables():
     # Get appropriate vector db configuration based on current async context
     vector_config = get_vectordb_context_config()
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     if vector_config["vector_db_provider"] == "pgvector" and not backend_access_control_enabled():
         async with vector_engine.engine.begin() as connection:

--- a/cognee/infrastructure/llm/utils.py
+++ b/cognee/infrastructure/llm/utils.py
@@ -30,10 +30,10 @@ async def get_max_chunk_tokens() -> int:
           maximum tokens.
     """
     # NOTE: Import must be done in function to avoid circular import issue
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
 
     # Calculate max chunk size based on the following formula
-    embedding_engine = (await get_vector_engine()).embedding_engine
+    embedding_engine = (await get_vector_engine_async()).embedding_engine
     llm_client = get_llm_client(raise_api_key_error=False)
 
     # We need to make sure chunk size won't take more than half of LLM max context token size
@@ -124,10 +124,10 @@ async def test_embedding_connection() -> int:
     """
     try:
         # NOTE: Vector engine import must be done in function to avoid circular import issue
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
         logger.info("Testing connection to Embedding endpoint...")
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         embedding_vectors = await asyncio.wait_for(
             vector_engine.embedding_engine.embed_text(["test"]),
             timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
@@ -164,7 +164,7 @@ async def determine_embedding_dimensions(detected_dimensions: int) -> None:
         return
 
     # NOTE: Imports inside function to avoid circular imports.
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
     from cognee.infrastructure.databases.vector.embeddings.config import get_embedding_config
 
     embedding_config = get_embedding_config()
@@ -172,7 +172,7 @@ async def determine_embedding_dimensions(detected_dimensions: int) -> None:
         embedding_config.embedding_dimensions = detected_dimensions
 
         # Keep active engine in sync in this process.
-        embedding_engine = (await get_vector_engine()).embedding_engine
+        embedding_engine = (await get_vector_engine_async()).embedding_engine
         if hasattr(embedding_engine, "dimensions"):
             embedding_engine.dimensions = detected_dimensions
 

--- a/cognee/infrastructure/session/session_embeddings.py
+++ b/cognee/infrastructure/session/session_embeddings.py
@@ -127,9 +127,9 @@ async def search_session_qa_ids(
         return []
 
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         results = await vector_engine.search(
             SESSION_QA_VECTOR_COLLECTION,
             query_text=query_text,
@@ -150,9 +150,9 @@ async def search_session_qa_ids(
 async def delete_session_qa_vector(*, qa_id: str) -> None:
     """Delete one cached QA turn from the vector engine. Fail-open."""
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         await vector_engine.delete_data_points(SESSION_QA_VECTOR_COLLECTION, [UUID(qa_id)])
     except Exception as error:
         logger.warning("Session QA vector delete failed open: %s", error)
@@ -161,9 +161,9 @@ async def delete_session_qa_vector(*, qa_id: str) -> None:
 async def delete_session_qa_vectors(*, user_id: str, session_id: str) -> None:
     """Remove all QA vector rows for a session by stripping its scope tag. Fail-open."""
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         await vector_engine.remove_belongs_to_set_tags(
             [session_scope_tag(user_id, session_id)],
         )

--- a/cognee/modules/chunking/LangchainChunker.py
+++ b/cognee/modules/chunking/LangchainChunker.py
@@ -5,7 +5,7 @@ from uuid import NAMESPACE_OID, uuid5
 from cognee.modules.chunking.Chunker import Chunker
 from .models.DocumentChunk import DocumentChunk
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 
 logger = get_logger()
 
@@ -39,7 +39,7 @@ class LangchainChunker(Chunker):
         document_name = self.document.name or basename(self.document.raw_data_location)
         # Resolve the embedding engine once — it's the same for every chunk, so
         # resolving it per chunk inside the loops just adds await/lookup overhead.
-        embedding_engine = (await get_vector_engine()).embedding_engine
+        embedding_engine = (await get_vector_engine_async()).embedding_engine
         async for content_text in self.get_text():
             for chunk in self.splitter.split_text(content_text):
                 token_count = embedding_engine.tokenizer.count_tokens(chunk)

--- a/cognee/modules/data/deletion/prune_system.py
+++ b/cognee/modules/data/deletion/prune_system.py
@@ -2,7 +2,7 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from cognee.infrastructure.databases.exceptions import EntityNotFoundError
 from cognee.context_global_variables import backend_access_control_enabled
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph.get_graph_engine import (
     _create_graph_engine,
     get_graph_engine,
@@ -67,7 +67,7 @@ async def prune_system(graph=True, vector=True, metadata=True, cache=True):
         await prune_graph_databases()
 
     if vector and not backend_access_control_enabled():
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         await vector_engine.prune()
     elif vector and backend_access_control_enabled():
         await prune_vector_databases()

--- a/cognee/modules/data/processing/has_new_chunks.py
+++ b/cognee/modules/data/processing/has_new_chunks.py
@@ -1,11 +1,11 @@
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.chunking import DocumentChunk
 
 
 async def has_new_chunks(
     data_chunks: list[DocumentChunk], collection_name: str
 ) -> list[DocumentChunk]:
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     if not await vector_engine.has_collection(collection_name):
         # There is no collection created,

--- a/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
+++ b/cognee/modules/graph/methods/delete_data_nodes_and_edges.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from cognee.context_global_variables import backend_access_control_enabled
 from cognee.infrastructure.databases.graph.get_graph_engine import get_graph_engine
-from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine
+from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine_async
 from cognee.modules.graph.legacy.has_edges_in_legacy_ledger import has_edges_in_legacy_ledger
 from cognee.modules.graph.legacy.has_nodes_in_legacy_ledger import has_nodes_in_legacy_ledger
 from cognee.modules.graph.methods import (
@@ -100,7 +100,7 @@ async def delete_data_nodes_and_edges(dataset_id: UUID, data_id: UUID, user_id: 
                 e,
             )
         try:
-            vector_engine = await get_vector_engine()
+            vector_engine = await get_vector_engine_async()
             await vector_engine.remove_belongs_to_set_tags(
                 orphaned_nodeset_labels, node_ids=slug_ids
             )

--- a/cognee/modules/graph/methods/delete_from_graph_and_vector.py
+++ b/cognee/modules/graph/methods/delete_from_graph_and_vector.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 from cognee.infrastructure.databases.graph.get_graph_engine import get_graph_engine
-from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine
+from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine_async
 from cognee.modules.graph.legacy.mark_ledger_as_deleted import (
     mark_ledger_edges_as_deleted,
     mark_ledger_nodes_as_deleted,
@@ -76,7 +76,7 @@ async def delete_from_graph_and_vector(
             collection_name = f"{node.type}_{indexed_field}"
             affected_vector_collections.setdefault(collection_name, []).append(node)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     for collection, nodes in affected_vector_collections.items():
         await vector_engine.delete_data_points(collection, [str(node.slug) for node in nodes])
 

--- a/cognee/modules/graph/methods/legacy_delete.py
+++ b/cognee/modules/graph/methods/legacy_delete.py
@@ -7,7 +7,7 @@ from cognee.modules.data.models import Data
 from cognee.modules.graph.models.EdgeType import EdgeType
 from cognee.modules.graph.utils.prepare_edges_for_storage import get_edge_retrieval_text
 from cognee.shared.logging_utils import get_logger
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.graph.utils.convert_node_to_data_point import get_all_subclasses
 
 
@@ -30,7 +30,7 @@ async def legacy_delete(data: Data, mode: str = "soft"):
     deleted_node_ids = await delete_document_subgraph(data.id, mode)
 
     # Delete from vector database
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     # Determine vector collections dynamically
     subclasses = get_all_subclasses(DataPoint)

--- a/cognee/modules/migrations/runner.py
+++ b/cognee/modules/migrations/runner.py
@@ -43,7 +43,7 @@ from cognee.context_global_variables import (
 )
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.data.methods.get_dataset_databases import get_dataset_databases
 from cognee.modules.users.models import DatasetDatabase
 
@@ -354,9 +354,9 @@ async def _run_global_migrations(
             await _stamp_global(db_engine, revision)
 
         # No context override: without access control, get_graph_engine /
-        # get_vector_engine resolve the global databases directly.
+        # get_vector_engine_async resolve the global databases directly.
         graph_engine = await get_graph_engine()
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         migration_context = MigrationContext(
             graph_engine=graph_engine,
             vector_engine=vector_engine,
@@ -411,7 +411,7 @@ async def _migrate_dataset(
     # per-dataset context — the same way every other operation does.
     async with set_database_global_context_variables(row.dataset_id, row.owner_id):
         graph_engine = await get_graph_engine()
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         migration_context = MigrationContext(
             graph_engine=graph_engine,
             vector_engine=vector_engine,
@@ -552,7 +552,7 @@ async def _downgrade_dataset(db_engine, row, target: Optional[str]) -> Optional[
 
     async with set_database_global_context_variables(row.dataset_id, row.owner_id):
         graph_engine = await get_graph_engine()
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         migration_context = MigrationContext(
             graph_engine=graph_engine,
             vector_engine=vector_engine,
@@ -606,7 +606,7 @@ async def downgrade_database_migrations(
                 await _stamp_global(db_engine, revision)
 
             graph_engine = await get_graph_engine()
-            vector_engine = await get_vector_engine()
+            vector_engine = await get_vector_engine_async()
             migration_context = MigrationContext(
                 graph_engine=graph_engine,
                 vector_engine=vector_engine,

--- a/cognee/modules/retrieval/completion_retriever.py
+++ b/cognee/modules/retrieval/completion_retriever.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Type
 
 from cognee.shared.logging_utils import get_logger
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.infrastructure.session.get_session_manager import get_session_manager
 from cognee.modules.retrieval.base_retriever import BaseRetriever
@@ -40,7 +40,7 @@ class CompletionRetriever(BaseRetriever):
         self.include_references = include_references
 
     async def get_retrieved_objects(self, query: str) -> Any:
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
 
         try:
             found_chunks = await vector_engine.search(

--- a/cognee/modules/retrieval/triplet_retriever.py
+++ b/cognee/modules/retrieval/triplet_retriever.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Type, Union
 
 from cognee.shared.logging_utils import get_logger
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.infrastructure.session.get_session_manager import get_session_manager
 from cognee.modules.retrieval.base_retriever import BaseRetriever
@@ -60,7 +60,7 @@ class TripletRetriever(BaseRetriever):
 
             - Any: A list containing the retrieved triplets, or an empty list if none are found.
         """
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
 
         try:
             if not await vector_engine.has_collection(collection_name="Triplet_text"):

--- a/cognee/modules/retrieval/utils/description_to_codepart_search.py
+++ b/cognee/modules/retrieval/utils/description_to_codepart_search.py
@@ -3,7 +3,7 @@ from cognee.shared.logging_utils import get_logger, setup_logging, ERROR
 
 from typing import List
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
 from cognee.modules.users.methods import get_default_user
 from cognee.modules.users.models import User
@@ -49,7 +49,7 @@ async def code_description_to_code_part(
         raise ValueError("top_k must be a positive integer.")
 
     try:
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         graph_engine = await get_graph_engine()
     except Exception as init_error:
         logger.error("Failed to initialize engines: %s", init_error, exc_info=True)

--- a/cognee/modules/retrieval/utils/node_edge_vector_search.py
+++ b/cognee/modules/retrieval/utils/node_edge_vector_search.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 
 from cognee.shared.logging_utils import get_logger, ERROR
 from cognee.infrastructure.databases.vector.exceptions import CollectionNotFoundError
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.observability import new_span, COGNEE_VECTOR_COLLECTION
 
 logger = get_logger(level=ERROR)
@@ -15,7 +15,7 @@ class NodeEdgeVectorSearch:
 
     def __init__(self, edge_collection: str = "EdgeType_relationship_name", vector_engine=None):
         self.edge_collection = edge_collection
-        # ``get_vector_engine()`` is async, so this sync ``__init__`` can't
+        # ``get_vector_engine_async()`` is async, so this sync ``__init__`` can't
         # eagerly resolve it. Keep the (possibly-None) injected engine and
         # resolve lazily in the first async method via ``_get_vector_engine()``.
         self.vector_engine = vector_engine
@@ -27,7 +27,7 @@ class NodeEdgeVectorSearch:
     async def _get_vector_engine(self):
         if self.vector_engine is None:
             try:
-                self.vector_engine = await get_vector_engine()
+                self.vector_engine = await get_vector_engine_async()
             except Exception as e:
                 logger.error("Failed to initialize vector engine: %s", e)
                 raise RuntimeError("Initialization error") from e

--- a/cognee/modules/retrieval/utils/references.py
+++ b/cognee/modules/retrieval/utils/references.py
@@ -352,9 +352,9 @@ async def append_answer_grounded_evidence(completions: List[Any], enabled: bool)
         return completions
 
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
     except Exception as error:
         logger.debug(f"Unable to obtain vector engine for references: {error}")
         return completions

--- a/cognee/modules/session_distillation/distill.py
+++ b/cognee/modules/session_distillation/distill.py
@@ -19,7 +19,7 @@ from uuid import UUID
 
 from cognee.context_global_variables import session_user, set_database_global_context_variables
 from cognee.exceptions import CogneeValidationError
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.llm.LLMGateway import LLMGateway
 from cognee.infrastructure.llm.prompts import read_query_prompt
 from cognee.infrastructure.session.get_session_manager import get_session_manager
@@ -324,7 +324,7 @@ async def accept_proposed_lessons(
 ) -> List[WrittenLesson]:
     entries_by_id = {entry.id: entry for entry in context_entries}
     async with set_database_global_context_variables(scope.dataset.id, scope.dataset.owner_id):
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
 
         def write_lesson(lesson: ProposedLesson):
             return lambda: evaluate_proposed_lesson(

--- a/cognee/modules/truth_subspace/build.py
+++ b/cognee/modules/truth_subspace/build.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 from cognee.context_global_variables import session_user, set_database_global_context_variables
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.vector.embeddings.get_embedding_engine import (
     get_embedding_engine,
 )
@@ -124,7 +124,7 @@ async def build_truth_subspace(
         return empty_result
 
     async with set_database_global_context_variables(dataset_obj.id, dataset_obj.owner_id):
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         graph_engine = await get_graph_engine()
 
         # Step 1: accepted learning statements from session_learnings.

--- a/cognee/tasks/chunks/create_chunk_associations.py
+++ b/cognee/tasks/chunks/create_chunk_associations.py
@@ -10,7 +10,7 @@ from typing import AsyncGenerator, List, Optional, Union
 from pydantic import BaseModel, Field
 
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.llm import LLMGateway
 from cognee.infrastructure.llm.prompts import render_prompt, read_query_prompt
 from cognee.shared.logging_utils import get_logger
@@ -150,7 +150,7 @@ async def create_chunk_associations(
         f"Creating associations for {len(valid_chunks)} chunks with threshold {similarity_threshold}"
     )
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     id_to_text = {}
     for chunk_text in valid_chunks:

--- a/cognee/tasks/cleanup/cleanup_unused_data.py
+++ b/cognee/tasks/cleanup/cleanup_unused_data.py
@@ -12,7 +12,7 @@ from typing import Optional, Dict, Any
 from uuid import UUID
 import os
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.data.models import Data, DatasetData
 from cognee.shared.logging_utils import get_logger

--- a/cognee/tasks/codingagents/coding_rule_associations.py
+++ b/cognee/tasks/codingagents/coding_rule_associations.py
@@ -1,7 +1,7 @@
 from uuid import NAMESPACE_OID, uuid5
 
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 
 from cognee.low_level import DataPoint
 from cognee.infrastructure.llm.prompts import render_prompt
@@ -52,7 +52,7 @@ async def get_existing_rules(rules_nodeset_name: str) -> List[str]:
 
 
 async def get_origin_edges(data: str, rules: List[Rule]) -> list[Any]:
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     origin_chunk = await vector_engine.search("DocumentChunk_text", data, limit=1)
 

--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from cognee.shared.logging_utils import get_logger
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.engine import DataPoint
 
 logger = get_logger("index_data_points")
@@ -18,14 +18,14 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
         data_points: List of DataPoint objects to index. Each DataPoint's metadata must
                      contain an 'index_fields' list specifying which fields to embed.
         vector_engine: Optional pre-created vector engine. Falls back to
-                       ``get_vector_engine()`` when not supplied.
+                       ``get_vector_engine_async()`` when not supplied.
 
     Returns:
         The original data_points list.
     """
     data_points_by_type = {}
 
-    vector_engine = vector_engine or await get_vector_engine()
+    vector_engine = vector_engine or await get_vector_engine_async()
 
     for data_point in data_points:
         # Skip non-DataPoint objects (e.g. CogneeGraph) that may be

--- a/cognee/tasks/temporal_awareness/index_graphiti_objects.py
+++ b/cognee/tasks/temporal_awareness/index_graphiti_objects.py
@@ -2,7 +2,7 @@ from cognee.shared.logging_utils import get_logger, ERROR
 from collections import Counter
 
 from cognee.tasks.temporal_awareness.graphiti_model import GraphitiNode
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.modules.graph.models.EdgeType import EdgeType
 
@@ -14,7 +14,7 @@ async def index_and_transform_graphiti_nodes_and_edges():
         created_indexes = {}
         index_points = {}
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         graph_engine = await get_graph_engine()
     except Exception as e:
         logger.error("Failed to initialize engines: %s", e)

--- a/cognee/tests/e2e/postgres/test_graphdb_shared.py
+++ b/cognee/tests/e2e/postgres/test_graphdb_shared.py
@@ -81,9 +81,9 @@ async def run_graph_db_test(provider: str):
         assert not is_empty, f"{provider}: graph should not be empty after cognify"
 
         # Search via vector to get a node name for graph queries
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         random_node = (
             await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
         )[0]

--- a/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_persistence_memify_integration.py
@@ -33,9 +33,9 @@ def _reset_cache_backend_caches():
 
 async def _reset_engines_and_prune() -> None:
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py
+++ b/cognee/tests/integration/modules/agent_memory/test_agent_memory_integration.py
@@ -23,9 +23,9 @@ from cognee.infrastructure.session.session_manager import SessionManager
 async def _reset_engines_and_prune() -> None:
     """Reset database engine caches and clear persisted test state."""
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/integration/retrieval/test_chunks_retriever.py
+++ b/cognee/tests/integration/retrieval/test_chunks_retriever.py
@@ -7,7 +7,7 @@ import cognee
 
 from cognee.low_level import setup
 from cognee.tasks.storage import add_data_points
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.modules.data.processing.document_types import TextDocument
 from cognee.modules.retrieval.chunks_retriever import ChunksRetriever
@@ -320,7 +320,7 @@ async def test_chunks_retriever_on_empty_graph(setup_test_environment_empty):
     retriever = ChunksRetriever()
     query = "Christina Mayer"
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     await vector_engine.create_collection(
         "DocumentChunk_text", payload_schema=DocumentChunkWithEntities
     )
@@ -341,7 +341,7 @@ async def test_chunks_retriever_context_on_empty_graph(setup_test_environment_em
     retriever = ChunksRetriever()
     query = "Christina Mayer"
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     await vector_engine.create_collection(
         "DocumentChunk_text", payload_schema=DocumentChunkWithEntities
     )

--- a/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
+++ b/cognee/tests/integration/retrieval/test_rag_completion_retriever.py
@@ -7,7 +7,7 @@ import cognee
 
 from cognee.low_level import setup
 from cognee.tasks.storage import add_data_points
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.modules.data.processing.document_types import TextDocument
 from cognee.modules.retrieval.exceptions.exceptions import NoDataError
@@ -323,7 +323,7 @@ async def test_get_rag_completion_context_on_empty_graph(setup_test_environment_
     with pytest.raises(NoDataError):
         await retriever.get_retrieved_objects(query)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     await vector_engine.create_collection(
         "DocumentChunk_text", payload_schema=DocumentChunkWithEntities
     )

--- a/cognee/tests/integration/retrieval/test_summaries_retriever.py
+++ b/cognee/tests/integration/retrieval/test_summaries_retriever.py
@@ -6,7 +6,7 @@ import cognee
 
 from cognee.low_level import setup
 from cognee.tasks.storage import add_data_points
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.tasks.summarization.models import TextSummary
 from cognee.modules.data.processing.document_types import TextDocument
@@ -195,7 +195,7 @@ async def test_summaries_retriever_on_empty_graph(setup_test_environment_empty):
     with pytest.raises(NoDataError):
         await retriever.get_retrieved_objects(query)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     await vector_engine.create_vector_index("TextSummary", "text")
 
     summaries = await retriever.get_retrieved_objects(query)

--- a/cognee/tests/migrations/test_migration_lockstep.py
+++ b/cognee/tests/migrations/test_migration_lockstep.py
@@ -35,7 +35,7 @@ from cognee.context_global_variables import (
 )
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.engine.utils.generate_node_id import generate_node_id
 from cognee.modules.data.methods.get_dataset_databases import get_dataset_databases
 from cognee.modules.data.models import Data, Dataset
@@ -65,7 +65,7 @@ def _triplet_id(source: str, rel: str, target: str) -> str:
 async def verify(stage: str):
     async with _store_context():
         graph_engine = await get_graph_engine()
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         nodes, edges = await graph_engine.get_graph_data()
 
         node_ids = {nid for nid, _ in nodes}

--- a/cognee/tests/test_agent_memory_e2e.py
+++ b/cognee/tests/test_agent_memory_e2e.py
@@ -20,9 +20,9 @@ from cognee.modules.users.permissions.methods import authorized_give_permission_
 async def _reset_engines_and_prune() -> None:
     """Reset cached engines and clear persisted test state."""
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/test_conversation_history.py
+++ b/cognee/tests/test_conversation_history.py
@@ -341,9 +341,9 @@ async def main():
         f"Number of DocumentChunk ndoes in the graph is incorrect, found {type_counts.get('DocumentChunk', 0)} but there should be exactly 4 (2 original documents, 2 sessions)."
     )
 
-    from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine
+    from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine_async
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     collection_size = await vector_engine.search(
         collection_name="DocumentChunk_text",
         query_text="test",

--- a/cognee/tests/test_delete_dataset_ladybug.py
+++ b/cognee/tests/test_delete_dataset_ladybug.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import set_database_global_context_variables
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.engine.operations.setup import setup
@@ -108,7 +108,7 @@ async def test_delete_dataset_ladybug(mock_create_structured_output: AsyncMock):
 
     mock_create_structured_output.side_effect = mock_llm_output
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")
@@ -182,7 +182,7 @@ async def test_delete_dataset_ladybug(mock_create_structured_output: AsyncMock):
     nodes, edges = await graph_engine.get_graph_data()
     assert len(nodes) == 0 and len(edges) == 0, "Nodes and edges are not deleted."
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     for collection_name, initial_nodes in johns_initial_nodes_by_collection.items():
         query_node_ids = [

--- a/cognee/tests/test_delete_dataset_neo4j.py
+++ b/cognee/tests/test_delete_dataset_neo4j.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import cognee
 from cognee.api.v1.datasets import datasets
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.engine.operations.setup import setup
@@ -111,7 +111,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     mock_create_structured_output.side_effect = mock_llm_output
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")
@@ -187,7 +187,7 @@ async def main(mock_create_structured_output: AsyncMock):
             after_delete_nodes_by_vector_collection[collection_name] = []
         after_delete_nodes_by_vector_collection[collection_name].append(node)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     removed_node_ids = initial_node_ids - after_first_delete_node_ids
 

--- a/cognee/tests/test_delete_default_graph.py
+++ b/cognee/tests/test_delete_default_graph.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import set_database_global_context_variables
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
 from cognee.modules.data.processing.document_types.TextDocument import TextDocument
@@ -133,7 +133,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     await set_database_global_context_variables("main_dataset", user.id)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("Entity_name")
     assert not await vector_engine.has_collection("DocumentChunk_text")

--- a/cognee/tests/test_delete_default_graph_non_mocked.py
+++ b/cognee/tests/test_delete_default_graph_non_mocked.py
@@ -5,7 +5,7 @@ import pathlib
 import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import backend_access_control_enabled
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.modules.engine.operations.setup import setup
 from cognee.modules.graph.methods import (
@@ -60,7 +60,7 @@ async def main():
     )
     maries_data_id = add_result.data_ingestion_info[0]["data_id"]
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_delete_default_graph_with_legacy_data_1.py
+++ b/cognee/tests/test_delete_default_graph_with_legacy_data_1.py
@@ -8,7 +8,7 @@ import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.chunking.models import DocumentChunk
@@ -160,7 +160,7 @@ async def main(mock_create_structured_output: AsyncMock):
     user = await get_default_user()
     await set_database_global_context_variables("main_dataset", user.id)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_delete_default_graph_with_legacy_data_2.py
+++ b/cognee/tests/test_delete_default_graph_with_legacy_data_2.py
@@ -8,7 +8,7 @@ import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.chunking.models import DocumentChunk
@@ -137,7 +137,7 @@ async def main(mock_create_structured_output: AsyncMock):
     user = await get_default_user()
     await set_database_global_context_variables("main_dataset", user.id)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_delete_two_users_same_dataset.py
+++ b/cognee/tests/test_delete_two_users_same_dataset.py
@@ -9,7 +9,7 @@ import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.chunking.models import DocumentChunk
@@ -83,7 +83,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     assert len(nodes) == 0 and len(edges) == 0, "Graph is not empty."
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_delete_two_users_with_legacy_data.py
+++ b/cognee/tests/test_delete_two_users_with_legacy_data.py
@@ -9,7 +9,7 @@ import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.relational import get_relational_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.chunking.models import DocumentChunk
@@ -79,7 +79,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     assert len(nodes) == 0 and len(edges) == 0, "Graph is not empty."
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")
@@ -104,7 +104,7 @@ async def main(mock_create_structured_output: AsyncMock):
 
     assert len(nodes) == 0 and len(edges) == 0, "Graph is not empty."
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     assert not await vector_engine.has_collection("EdgeType_relationship_name")
     assert not await vector_engine.has_collection("Entity_name")

--- a/cognee/tests/test_edge_centered_payload.py
+++ b/cognee/tests/test_edge_centered_payload.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import cognee
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.search.types import SearchType
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.ontology.rdf_xml.RDFLibOntologyResolver import RDFLibOntologyResolver
@@ -135,7 +135,7 @@ async def main():
         graph_engine = await get_graph_engine()
         nodes_phase2, edges_phase2 = await graph_engine.get_graph_data()
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         triplets_phase2 = await vector_engine.search(
             query_text="technology", limit=None, collection_name="Triplet_text"
         )

--- a/cognee/tests/test_kuzu.py
+++ b/cognee/tests/test_kuzu.py
@@ -75,9 +75,9 @@ async def main():
 
         assert not is_empty, "Ladybug graph database should not be empty"
 
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         random_node = (
             await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
         )[0]

--- a/cognee/tests/test_lancedb.py
+++ b/cognee/tests/test_lancedb.py
@@ -71,9 +71,9 @@ async def test_getting_of_documents(dataset_id_1):
 async def test_vector_engine_search_none_limit():
     query_text = "Tell me about Quantum computers"
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     collection_name = "Entity_name"
 
     query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
@@ -110,9 +110,9 @@ async def test_vector_engine_search_with_nodeset_filtering():
     node_set = ["NLP", "Quantum"]
     query_text = "Tell me about NLP"
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
 
     # Search with "OR" operator
@@ -250,14 +250,14 @@ async def main():
 
     await cognee.cognify([dataset_name_2, dataset_name_1])
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
     from cognee.modules.data.methods import get_datasets_by_name
 
     user = await get_default_user()
     dataset_1 = (await get_datasets_by_name([dataset_name_1], user.id))[0]
     await test_getting_of_documents(dataset_1.id)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     random_node = (
         await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
     )[0]

--- a/cognee/tests/test_library.py
+++ b/cognee/tests/test_library.py
@@ -51,9 +51,9 @@ async def main():
 
     cognify_run_info = await cognee.cognify([dataset_name])
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     random_node = (await vector_engine.search("Entity_name", "AI", include_payload=True))[0]
     random_node_name = random_node.payload["text"]
 

--- a/cognee/tests/test_neo4j.py
+++ b/cognee/tests/test_neo4j.py
@@ -66,9 +66,9 @@ async def main():
 
     assert not is_empty, "Graph shouldn't be empty"
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     random_node = (
         await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
     )[0]

--- a/cognee/tests/test_neptune_analytics_vector.py
+++ b/cognee/tests/test_neptune_analytics_vector.py
@@ -7,7 +7,7 @@ from cognee.modules.search.operations import get_history
 from cognee.modules.users.methods import get_default_user
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.search.types import SearchType
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.hybrid.neptune_analytics.NeptuneAnalyticsAdapter import (
     NeptuneAnalyticsAdapter,
     IndexSchema,
@@ -51,7 +51,7 @@ async def main():
 
     await cognee.cognify([dataset_name])
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     random_node = (
         await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
     )[0]
@@ -95,17 +95,17 @@ async def vector_backend_api_test():
     # When URL is absent
     cognee.config.set_vector_db_url(None)
     with pytest.raises(OSError):
-        await get_vector_engine()
+        await get_vector_engine_async()
 
     # Assert invalid graph ID.
     cognee.config.set_vector_db_url("invalid_url")
     with pytest.raises(ValueError):
-        await get_vector_engine()
+        await get_vector_engine_async()
 
     # Return a valid engine object with valid URL.
     graph_id = os.getenv("GRAPH_ID", "")
     cognee.config.set_vector_db_url(f"neptune-graph://{graph_id}")
-    engine = await get_vector_engine()
+    engine = await get_vector_engine_async()
     assert isinstance(engine, NeptuneAnalyticsAdapter)
 
     TEST_COLLECTION_NAME = "test"

--- a/cognee/tests/test_permissions.py
+++ b/cognee/tests/test_permissions.py
@@ -35,9 +35,9 @@ def _extract_dataset_id_from_remember(remember_result):
 async def _reset_engines_and_prune() -> None:
     """Reset db engine caches and prune data/system."""
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/test_pgvector.py
+++ b/cognee/tests/test_pgvector.py
@@ -71,9 +71,9 @@ async def test_getting_of_documents(dataset_id_1):
 async def test_vector_engine_search_none_limit():
     query_text = "Tell me about Quantum computers"
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     collection_name = "Entity_name"
 
@@ -111,9 +111,9 @@ async def test_vector_engine_search_with_nodeset_filtering():
     node_set = ["NLP", "Quantum"]
     query_text = "Tell me about NLP"
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     query_vector = (await vector_engine.embedding_engine.embed_text([query_text]))[0]
 
     # Search with "OR" operator
@@ -266,14 +266,14 @@ async def main():
 
     await cognee.cognify([dataset_name_2, dataset_name_1])
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
     from cognee.modules.data.methods import get_datasets_by_name
 
     user = await get_default_user()
     dataset_1 = (await get_datasets_by_name([dataset_name_1], user.id))[0]
     await test_getting_of_documents(dataset_1.id)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     random_node = (
         await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
     )[0]

--- a/cognee/tests/test_remote_kuzu.py
+++ b/cognee/tests/test_remote_kuzu.py
@@ -70,9 +70,9 @@ async def main():
 
         await cognee.cognify([dataset_name])
 
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         random_node = (
             await vector_engine.search("Entity_name", "Quantum computer", include_payload=True)
         )[0]

--- a/cognee/tests/test_s3_file_storage.py
+++ b/cognee/tests/test_s3_file_storage.py
@@ -40,9 +40,9 @@ async def main():
 
     await cognee.cognify([dataset_name])
 
-    from cognee.infrastructure.databases.vector import get_vector_engine
+    from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     random_node = (await vector_engine.search("Entity_name", "AI", include_payload=True))[0]
     random_node_name = random_node.payload["text"]
 

--- a/cognee/tests/test_search_db.py
+++ b/cognee/tests/test_search_db.py
@@ -7,7 +7,7 @@ from collections import Counter
 
 import cognee
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
 from cognee.modules.retrieval.graph_completion_context_extension_retriever import (
@@ -40,9 +40,9 @@ async def _reset_engines_and_prune() -> None:
     """
     # Dispose of existing engines and clear caches to ensure fresh instances for each test
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         # Dispose SQLAlchemy engine connection pool if it exists
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
@@ -139,7 +139,7 @@ async def setup_test_environment():
     await create_triplet_embeddings(user=user, dataset=dataset_name, triplets_batch_size=5)
 
     # Check if Triplet_text collection was created
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     has_collection = await vector_engine.has_collection(collection_name="Triplet_text")
     logger.info(f"Triplet_text collection exists after creation: {has_collection}")
 
@@ -171,7 +171,7 @@ async def e2e_state(_disable_session_turn_gating):
     graph_engine = await get_graph_engine()
     _nodes, edges = await graph_engine.get_graph_data()
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     collection = await vector_engine.search(
         collection_name="Triplet_text",
         query_text="Test",

--- a/cognee/tests/test_shared_node_preservation.py
+++ b/cognee/tests/test_shared_node_preservation.py
@@ -23,7 +23,7 @@ import cognee
 from cognee.api.v1.datasets import datasets
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.engine import DataPoint
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.chunking.models.DocumentChunk import DocumentChunk
@@ -261,7 +261,7 @@ async def test_shared_entity_preserved_across_documents(mock_create_structured_o
     logger.info("✅ Germany→Netherlands edge deleted")
 
     # Verify vector indices match graph state
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     # Check if Germany is still in vector index
     if await vector_engine.has_collection("Entity_name"):

--- a/cognee/tests/test_usage_logger_e2e.py
+++ b/cognee/tests/test_usage_logger_e2e.py
@@ -14,9 +14,9 @@ from cognee.modules.users.methods import get_default_user, get_authenticated_use
 async def _reset_engines_and_prune():
     """Reset db engine caches and prune data/system."""
     try:
-        from cognee.infrastructure.databases.vector import get_vector_engine
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
 
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         if hasattr(vector_engine, "engine") and hasattr(vector_engine.engine, "dispose"):
             await vector_engine.engine.dispose(close=True)
     except Exception:

--- a/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
+++ b/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
@@ -48,19 +48,35 @@ class _AsyncWorker(_Closeable):
 
 class _SlowSubprocessWorker:
     """Stub modeling a subprocess-backed adapter: it advertises
-    ``_subprocess_mode`` (so its close runs off-loop) and its async close takes
-    measurable time, like tearing down a worker process / releasing a file lock.
+    ``_subprocess_mode`` (so its close runs off-loop) and its async close is
+    gated so a test can observe it mid-flight, like tearing down a worker
+    process / releasing a file lock.
+
+    When ``started``/``release`` events are supplied, ``close`` sets ``started``
+    the instant it begins and then blocks until ``release`` is set, instead of
+    sleeping a fixed amount. This removes the wall-clock race where a slow
+    ``gc.collect()`` on a loaded CI runner let the fixed-sleep close finish
+    before the test could assert it was in flight (``assert True is False``).
+    Without the events the close completes immediately.
     """
 
-    def __init__(self, name=""):
+    def __init__(self, name="", started=None, release=None):
         self.name = name
         self.closed = False
         self._subprocess_mode = True
+        self._started = started
+        self._release = release
 
     async def close(self):
         import asyncio
 
-        await asyncio.sleep(0.2)
+        if self._started is not None:
+            self._started.set()
+        if self._release is not None:
+            # Block a worker thread (not the off-loop) until the test releases
+            # us. The 30s timeout is only a safety net so a buggy test that
+            # never releases fails instead of hanging CI forever.
+            await asyncio.get_running_loop().run_in_executor(None, self._release.wait, 30)
         self.closed = True
 
 
@@ -80,6 +96,23 @@ class _ThreadRecordingWorker:
         import threading
 
         self.closed_on = threading.current_thread().name
+
+
+async def _wait_until(predicate, timeout=5.0):
+    """Poll ``predicate`` on the running loop until it is truthy or ``timeout``
+    seconds elapse. Used instead of a fixed sleep so assertions about off-loop
+    close progress don't depend on wall-clock timing (which flakes on loaded
+    CI runners). Returns the final predicate value.
+    """
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.005)
+    return predicate()
 
 
 # -- ClosingLRUCache: basic caching -----------------------------------------
@@ -320,21 +353,27 @@ def test_subprocess_close_runs_off_loop_and_is_tracked():
     the close is registered in the cache's closing registry until it finishes.
     """
     import asyncio
+    import threading
 
     cache = ClosingLRUCache(maxsize=4)
 
     async def run():
-        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first"))
+        started = threading.Event()
+        release = threading.Event()
+        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first", started, release))
         raw = proxy.__wrapped__
         cache.evict("k")
         del proxy
         gc.collect()
-        # Close started off-loop (still running due to the 0.2s sleep) and is
-        # tracked. The loop is NOT blocked, so the registry entry is visible.
+        # Wait until the close has actually begun off-loop (deterministic). It is
+        # gated on ``release``, so it cannot have finished — and because the loop
+        # is NOT blocked, the registry entry is visible.
+        assert await _wait_until(started.is_set)
         assert raw.closed is False
         assert "k" in cache._closing
-        # Wait for it to finish and confirm the registry self-cleans.
-        await asyncio.sleep(0.4)
+        # Release it, then confirm it finishes and the registry self-cleans.
+        release.set()
+        assert await _wait_until(lambda: raw.closed and "k" not in cache._closing)
         assert raw.closed is True
         assert "k" not in cache._closing
 
@@ -348,19 +387,32 @@ def test_aget_or_create_waits_for_in_flight_close():
     for the file lock.
     """
     import asyncio
+    import threading
 
     cache = ClosingLRUCache(maxsize=4)
 
     async def run():
-        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first"))
+        started = threading.Event()
+        release = threading.Event()
+        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first", started, release))
         raw_first = proxy.__wrapped__
         cache.evict("k")
         del proxy
         gc.collect()
-        assert raw_first.closed is False  # close in flight
+        assert await _wait_until(started.is_set)
+        assert raw_first.closed is False  # gated -> definitely in flight
 
-        second = await cache.aget_or_create("k", lambda: _SlowSubprocessWorker("second"))
-        # The await must not return until the first close completed.
+        # ``aget_or_create`` must not return until the in-flight close finishes.
+        # Release the close only after a short delay, so aget_or_create is forced
+        # to wait for it (deterministically, without a wall-clock in-flight race).
+        async def _release_soon():
+            await asyncio.sleep(0.05)
+            release.set()
+
+        _, second = await asyncio.gather(
+            _release_soon(),
+            cache.aget_or_create("k", lambda: _SlowSubprocessWorker("second")),
+        )
         assert raw_first.closed is True
         assert second.__wrapped__.name == "second"
 
@@ -389,16 +441,20 @@ def test_aget_or_create_concurrent_callers_single_construction():
     must all wait on the one in-flight close and then resolve to a single newly
     constructed value — no thundering-herd of duplicate workers."""
     import asyncio
+    import threading
 
     cache = ClosingLRUCache(maxsize=4)
 
     async def run():
-        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first"))
+        started = threading.Event()
+        release = threading.Event()
+        proxy = cache.get_or_create("k", lambda: _SlowSubprocessWorker("first", started, release))
         raw_first = proxy.__wrapped__
         cache.evict("k")
         del proxy
         gc.collect()
-        assert raw_first.closed is False  # close in flight
+        assert await _wait_until(started.is_set)
+        assert raw_first.closed is False  # gated -> definitely in flight
 
         constructed = []
 
@@ -407,7 +463,13 @@ def test_aget_or_create_concurrent_callers_single_construction():
             constructed.append(w)
             return w
 
+        async def _release_soon():
+            await asyncio.sleep(0.05)
+            release.set()
+
+        release_task = asyncio.ensure_future(_release_soon())
         results = await asyncio.gather(*[cache.aget_or_create("k", factory) for _ in range(10)])
+        await release_task
 
         assert len(constructed) == 1, "exactly one new value should be constructed"
         assert all(r.__wrapped__ is results[0].__wrapped__ for r in results)

--- a/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_data_points.py
@@ -22,7 +22,7 @@ async def test_index_data_points_calls_vector_engine():
 
     with patch.dict(
         index_data_points.__globals__,
-        {"get_vector_engine": _get_vector_engine},
+        {"get_vector_engine_async": _get_vector_engine},
     ):
         await index_data_points(data_points)
 

--- a/cognee/tests/unit/infrastructure/databases/test_index_graph_edges.py
+++ b/cognee/tests/unit/infrastructure/databases/test_index_graph_edges.py
@@ -107,7 +107,7 @@ async def test_index_graph_edges_initialization_error():
         index_graph_edges.__globals__,
         {
             "get_graph_engine": AsyncMock(side_effect=Exception("Graph engine failed")),
-            "get_vector_engine": AsyncMock(return_value=AsyncMock()),
+            "get_vector_engine_async": AsyncMock(return_value=AsyncMock()),
         },
     ):
         with pytest.raises(RuntimeError, match="Graph edge indexing error"):

--- a/cognee/tests/unit/infrastructure/llm/test_embedding_connection_dimensions.py
+++ b/cognee/tests/unit/infrastructure/llm/test_embedding_connection_dimensions.py
@@ -24,7 +24,7 @@ async def test_embedding_connection_returns_detected_dimensions(monkeypatch):
     async def _get_vector_engine():
         return fake_vector_engine
 
-    monkeypatch.setattr(vector_module, "get_vector_engine", _get_vector_engine)
+    monkeypatch.setattr(vector_module, "get_vector_engine_async", _get_vector_engine)
     assert await llm_utils.test_embedding_connection() == 3
 
 
@@ -42,7 +42,7 @@ async def test_determine_embedding_dimensions_uses_env_dimensions_when_provided(
     async def _get_vector_engine():
         return fake_vector_engine
 
-    monkeypatch.setattr(vector_module, "get_vector_engine", _get_vector_engine)
+    monkeypatch.setattr(vector_module, "get_vector_engine_async", _get_vector_engine)
     monkeypatch.setattr(
         embedding_config_module, "get_embedding_config", lambda: fake_embedding_config
     )
@@ -69,7 +69,7 @@ async def test_determine_embedding_dimensions_uses_detected_dimensions_when_env_
     async def _get_vector_engine():
         return fake_vector_engine
 
-    monkeypatch.setattr(vector_module, "get_vector_engine", _get_vector_engine)
+    monkeypatch.setattr(vector_module, "get_vector_engine_async", _get_vector_engine)
     monkeypatch.setattr(
         embedding_config_module, "get_embedding_config", lambda: fake_embedding_config
     )

--- a/cognee/tests/unit/infrastructure/session/test_session_embeddings.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_embeddings.py
@@ -226,7 +226,7 @@ class TestSessionQaVectorHelpers:
             return vector_engine
 
         monkeypatch.setattr(
-            "cognee.infrastructure.databases.vector.get_vector_engine",
+            "cognee.infrastructure.databases.vector.get_vector_engine_async",
             _get_vector_engine,
         )
 
@@ -258,7 +258,7 @@ class TestSessionQaVectorHelpers:
             return vector_engine
 
         monkeypatch.setattr(
-            "cognee.infrastructure.databases.vector.get_vector_engine",
+            "cognee.infrastructure.databases.vector.get_vector_engine_async",
             _get_vector_engine,
         )
 
@@ -285,7 +285,7 @@ class TestSessionQaVectorHelpers:
             return vector_engine
 
         monkeypatch.setattr(
-            "cognee.infrastructure.databases.vector.get_vector_engine",
+            "cognee.infrastructure.databases.vector.get_vector_engine_async",
             _get_vector_engine,
         )
 
@@ -308,7 +308,7 @@ class TestSessionQaVectorHelpers:
             return vector_engine
 
         monkeypatch.setattr(
-            "cognee.infrastructure.databases.vector.get_vector_engine",
+            "cognee.infrastructure.databases.vector.get_vector_engine_async",
             _get_vector_engine,
         )
 

--- a/cognee/tests/unit/modules/graph/test_delete_detag_nodeset.py
+++ b/cognee/tests/unit/modules/graph/test_delete_detag_nodeset.py
@@ -50,7 +50,7 @@ async def test_detag_called_with_removed_nodeset_names():
         ),
         patch.object(
             delete_from_graph_and_vector_module,
-            "get_vector_engine",
+            "get_vector_engine_async",
             AsyncMock(return_value=vector_engine),
         ),
         patch.object(
@@ -92,7 +92,7 @@ async def test_detag_skipped_when_no_nodeset_in_batch():
         ),
         patch.object(
             delete_from_graph_and_vector_module,
-            "get_vector_engine",
+            "get_vector_engine_async",
             AsyncMock(return_value=vector_engine),
         ),
         patch.object(
@@ -140,7 +140,7 @@ async def test_delete_uses_edge_text_for_edge_type_delete_ids():
         ),
         patch.object(
             delete_from_graph_and_vector_module,
-            "get_vector_engine",
+            "get_vector_engine_async",
             AsyncMock(return_value=vector_engine),
         ),
         patch.object(

--- a/cognee/tests/unit/modules/migrations/test_database_migrations.py
+++ b/cognee/tests/unit/modules/migrations/test_database_migrations.py
@@ -372,7 +372,7 @@ def test_adapter_storage_sync_runs_on_version_change_even_at_chain_head(monkeypa
             return fake_vector
 
         monkeypatch.setattr(runner, "get_graph_engine", _fake_graph)
-        monkeypatch.setattr(runner, "get_vector_engine", _fake_vector)
+        monkeypatch.setattr(runner, "get_vector_engine_async", _fake_vector)
 
         # version changed (0.0.0-old != 9.9.9-new) -> adapter sync runs once,
         # even though the chain is at head (no data migration applied).

--- a/cognee/tests/unit/modules/retrieval/rag_completion_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/rag_completion_retriever_test.py
@@ -27,7 +27,7 @@ async def test_get_context_success(mock_vector_engine):
     retriever = CompletionRetriever(top_k=2)
 
     with patch(
-        "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+        "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         objects = await retriever.get_retrieved_objects("test query")
@@ -47,7 +47,7 @@ async def test_get_context_collection_not_found_error(mock_vector_engine):
     retriever = CompletionRetriever()
 
     with patch(
-        "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+        "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         with pytest.raises(NoDataError, match="No data found"):
@@ -62,7 +62,7 @@ async def test_get_context_empty_results(mock_vector_engine):
     retriever = CompletionRetriever()
 
     with patch(
-        "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+        "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         context = await retriever.get_context_from_objects("test query", [])
@@ -82,7 +82,7 @@ async def test_get_context_top_k_limit(mock_vector_engine):
     retriever = CompletionRetriever(top_k=2)
 
     with patch(
-        "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+        "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         objects = await retriever.get_retrieved_objects("test query")
@@ -104,7 +104,7 @@ async def test_get_context_single_chunk(mock_vector_engine):
     retriever = CompletionRetriever()
 
     with patch(
-        "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+        "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         objects = await retriever.get_retrieved_objects("test query")
@@ -124,7 +124,7 @@ async def test_get_completion_without_session(mock_vector_engine):
 
     with (
         patch(
-            "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+            "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -183,7 +183,7 @@ async def test_get_completion_with_session(mock_vector_engine):
 
     with (
         patch(
-            "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+            "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -223,7 +223,7 @@ async def test_get_completion_with_session_no_user_id(mock_vector_engine):
 
     with (
         patch(
-            "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+            "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -260,7 +260,7 @@ async def test_get_completion_with_response_model(mock_vector_engine):
 
     with (
         patch(
-            "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+            "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -318,7 +318,7 @@ async def test_get_context_missing_text_key(mock_vector_engine):
     retriever = CompletionRetriever()
 
     with patch(
-        "cognee.modules.retrieval.completion_retriever.get_vector_engine",
+        "cognee.modules.retrieval.completion_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         with pytest.raises(KeyError):

--- a/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
+++ b/cognee/tests/unit/modules/retrieval/test_brute_force_triplet_search.py
@@ -59,7 +59,7 @@ async def test_brute_force_triplet_search_wide_search_limit_global_search():
     mock_vector_engine.search = AsyncMock(return_value=[])
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         await brute_force_triplet_search(
@@ -81,7 +81,7 @@ async def test_brute_force_triplet_search_wide_search_limit_filtered_search():
     mock_vector_engine.search = AsyncMock(return_value=[])
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         await brute_force_triplet_search(
@@ -103,7 +103,7 @@ async def test_brute_force_triplet_search_wide_search_default():
     mock_vector_engine.search = AsyncMock(return_value=[])
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         await brute_force_triplet_search(query="test", node_name=None)
@@ -121,7 +121,7 @@ async def test_brute_force_triplet_search_default_collections():
     mock_vector_engine.search = AsyncMock(return_value=[])
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         await brute_force_triplet_search(query="test")
@@ -151,7 +151,7 @@ async def test_brute_force_triplet_search_custom_collections():
     custom_collections = ["CustomCol1", "CustomCol2"]
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         await brute_force_triplet_search(query="test", collections=custom_collections)
@@ -173,7 +173,7 @@ async def test_brute_force_triplet_search_always_includes_edge_collection():
     collections_without_edge = ["Entity_name", "TextSummary_text"]
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         await brute_force_triplet_search(query="test", collections=collections_without_edge)
@@ -196,7 +196,7 @@ async def test_brute_force_triplet_search_all_collections_empty():
     mock_vector_engine.search = AsyncMock(return_value=[])
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         results = await brute_force_triplet_search(query="test")
@@ -218,7 +218,7 @@ async def test_brute_force_triplet_search_embeds_query():
     mock_vector_engine.search = AsyncMock(return_value=[])
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         await brute_force_triplet_search(query=query_text)
@@ -251,7 +251,7 @@ async def test_brute_force_triplet_search_extracts_node_ids_global_search():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -281,7 +281,7 @@ async def test_brute_force_triplet_search_reuses_provided_fragment():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -313,7 +313,7 @@ async def test_brute_force_triplet_search_creates_fragment_when_not_provided():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -342,7 +342,7 @@ async def test_brute_force_triplet_search_passes_top_k_to_importance_calculation
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -481,7 +481,7 @@ async def test_brute_force_triplet_search_deduplicates_node_ids():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -522,7 +522,7 @@ async def test_brute_force_triplet_search_excludes_edge_collection():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -574,7 +574,7 @@ async def test_brute_force_triplet_search_skips_nodes_without_ids():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -615,7 +615,7 @@ async def test_brute_force_triplet_search_handles_tuple_results():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -657,7 +657,7 @@ async def test_brute_force_triplet_search_mixed_empty_collections():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -740,7 +740,7 @@ async def test_brute_force_triplet_search_vector_engine_init_error():
     """Test brute_force_triplet_search handles vector engine initialization error (lines 145-147)."""
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine"
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async"
         ) as mock_get_vector_engine,
     ):
         mock_get_vector_engine.side_effect = Exception("Initialization error")
@@ -767,7 +767,7 @@ async def test_brute_force_triplet_search_collection_not_found_error():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -794,7 +794,7 @@ async def test_brute_force_triplet_search_generic_exception():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
     ):
@@ -820,7 +820,7 @@ async def test_brute_force_triplet_search_with_node_name_sets_relevant_ids_to_no
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -855,7 +855,7 @@ async def test_brute_force_triplet_search_collection_not_found_at_top_level():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -884,7 +884,7 @@ async def test_brute_force_triplet_search_single_query_regression():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -923,7 +923,7 @@ async def test_brute_force_triplet_search_batch_wiring_happy_path():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -962,7 +962,7 @@ async def test_brute_force_triplet_search_shape_propagation_to_graph():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -1018,7 +1018,7 @@ async def test_brute_force_triplet_search_batch_path_comprehensive():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -1055,7 +1055,7 @@ async def test_brute_force_triplet_search_batch_error_fallback():
     )
 
     with patch(
-        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine",
+        "cognee.modules.retrieval.utils.node_edge_vector_search.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         result = await brute_force_triplet_search(query_batch=["q1", "q2"])

--- a/cognee/tests/unit/modules/retrieval/test_include_references_wiring.py
+++ b/cognee/tests/unit/modules/retrieval/test_include_references_wiring.py
@@ -190,7 +190,7 @@ async def test_completion_references_skipped_for_non_str_response_model():
 
 def _patch_vector_engine(engine):
     return patch(
-        "cognee.infrastructure.databases.vector.get_vector_engine",
+        "cognee.infrastructure.databases.vector.get_vector_engine_async",
         return_value=engine,
     )
 

--- a/cognee/tests/unit/modules/retrieval/triplet_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/triplet_retriever_test.py
@@ -29,7 +29,7 @@ async def test_get_context_success(mock_vector_engine):
     retriever = TripletRetriever(top_k=5)
 
     with patch(
-        "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+        "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         objects = await retriever.get_retrieved_objects("test query")
@@ -50,7 +50,7 @@ async def test_get_objects_no_collection(mock_vector_engine):
     retriever = TripletRetriever()
 
     with patch(
-        "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+        "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         with pytest.raises(NoDataError, match="create_triplet_embeddings"):
@@ -65,7 +65,7 @@ async def test_get_context_empty_results(mock_vector_engine):
     retriever = TripletRetriever()
 
     with patch(
-        "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+        "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         context = await retriever.get_context_from_objects("test query", [])
@@ -81,7 +81,7 @@ async def test_get_objects_collection_not_found_error(mock_vector_engine):
     retriever = TripletRetriever()
 
     with patch(
-        "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+        "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         with pytest.raises(NoDataError, match="No data found"):
@@ -99,7 +99,7 @@ async def test_get_context_empty_payload_text(mock_vector_engine):
     retriever = TripletRetriever()
 
     with patch(
-        "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+        "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         with pytest.raises(KeyError):
@@ -118,7 +118,7 @@ async def test_get_context_single_triplet(mock_vector_engine):
     retriever = TripletRetriever()
 
     with patch(
-        "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+        "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
         return_value=mock_vector_engine,
     ):
         objects = await retriever.get_retrieved_objects("test query")
@@ -166,7 +166,7 @@ async def test_get_completion_without_context(mock_vector_engine):
 
     with (
         patch(
-            "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+            "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -226,7 +226,7 @@ async def test_get_completion_with_session(mock_vector_engine):
 
     with (
         patch(
-            "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+            "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -276,7 +276,7 @@ async def test_get_completion_with_session_no_user_id(mock_vector_engine):
 
     with (
         patch(
-            "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+            "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -316,7 +316,7 @@ async def test_get_completion_with_response_model(mock_vector_engine):
 
     with (
         patch(
-            "cognee.modules.retrieval.triplet_retriever.get_vector_engine",
+            "cognee.modules.retrieval.triplet_retriever.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(

--- a/cognee/tests/unit/modules/retriever/test_description_to_codepart_search.py
+++ b/cognee/tests/unit/modules/retriever/test_description_to_codepart_search.py
@@ -13,7 +13,7 @@ async def test_code_description_to_code_part_no_results():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.description_to_codepart_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.description_to_codepart_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(
@@ -70,7 +70,7 @@ async def test_code_description_to_code_part_initialization_error():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.description_to_codepart_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.description_to_codepart_search.get_vector_engine_async",
             side_effect=Exception("Engine init failed"),
         ),
         patch(
@@ -99,7 +99,7 @@ async def test_code_description_to_code_part_execution_error():
 
     with (
         patch(
-            "cognee.modules.retrieval.utils.description_to_codepart_search.get_vector_engine",
+            "cognee.modules.retrieval.utils.description_to_codepart_search.get_vector_engine_async",
             return_value=mock_vector_engine,
         ),
         patch(

--- a/cognee/tests/unit/truth_subspace/test_build_centroid_slots.py
+++ b/cognee/tests/unit/truth_subspace/test_build_centroid_slots.py
@@ -51,7 +51,7 @@ async def _run_build(monkeypatch, session_ids=None):
             new=AsyncMock(return_value=[dataset]),
         ),
         patch(
-            "cognee.modules.truth_subspace.build.get_vector_engine",
+            "cognee.modules.truth_subspace.build.get_vector_engine_async",
             new=AsyncMock(return_value=vector_engine),
         ),
         patch(

--- a/cognee/tests/utils/assert_edges_vector_index_not_present.py
+++ b/cognee/tests/utils/assert_edges_vector_index_not_present.py
@@ -1,11 +1,11 @@
 from uuid import UUID
 from typing import Dict, List, Tuple
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.graph.models.EdgeType import EdgeType
 
 
 async def assert_edges_vector_index_not_present(relationships: List[Tuple[UUID, UUID, str, Dict]]):
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     query_edge_ids = {
         str(EdgeType.id_for(relationship[2])): relationship[2] for relationship in relationships

--- a/cognee/tests/utils/assert_edges_vector_index_present.py
+++ b/cognee/tests/utils/assert_edges_vector_index_present.py
@@ -2,7 +2,7 @@ from uuid import UUID
 from typing import Dict, List, Tuple
 
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.modules.engine.utils import generate_node_name
 from cognee.modules.graph.models.EdgeType import EdgeType
 from cognee.modules.graph.utils.prepare_edges_for_storage import get_edge_retrieval_text
@@ -36,7 +36,7 @@ def format_relationship(
 async def assert_edges_vector_index_present(
     relationships: List[Tuple[UUID, UUID, str, Dict]], convert_to_new_format: bool = True
 ):
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     graph_engine = await get_graph_engine()
     nodes, graph_edges = await graph_engine.get_graph_data()

--- a/cognee/tests/utils/assert_nodes_vector_index_not_present.py
+++ b/cognee/tests/utils/assert_nodes_vector_index_not_present.py
@@ -1,10 +1,10 @@
 from typing import List
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.engine.models.DataPoint import DataPoint
 
 
 async def assert_nodes_vector_index_not_present(data_points: List[DataPoint]):
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     data_points_by_vector_collection = {}
 

--- a/cognee/tests/utils/assert_nodes_vector_index_present.py
+++ b/cognee/tests/utils/assert_nodes_vector_index_present.py
@@ -1,10 +1,10 @@
 from typing import List
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.engine.models.DataPoint import DataPoint
 
 
 async def assert_nodes_vector_index_present(data_points: List[DataPoint]):
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
 
     data_points_by_vector_collection = {}
 

--- a/distributed/workers/data_point_saving_worker.py
+++ b/distributed/workers/data_point_saving_worker.py
@@ -10,7 +10,7 @@ from distributed.modal_image import image
 from distributed.queues import add_data_points_queue
 
 from cognee.shared.logging_utils import get_logger
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 
 logger = get_logger("data_point_saving_worker")
 
@@ -52,7 +52,7 @@ secret_name = os.environ.get("MODAL_SECRET_NAME", "distributed_cognee")
 )
 async def data_point_saving_worker():
     print("Started processing of data points; starting vector engine queue.")
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     # Defines how many data packets do we glue together from the modal queue before embedding call and ingestion
     BATCH_SIZE = 25
     stop_seen = False

--- a/examples/demos/truth_centroid_slots_demo.py
+++ b/examples/demos/truth_centroid_slots_demo.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 import cognee
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.databases.vector.embeddings.get_embedding_engine import (
     get_embedding_engine,
 )
@@ -96,7 +96,7 @@ async def hybrid_order(dataset_obj, use_truth_weight: bool) -> list[str]:
 
 async def graph_truth_table(dataset_obj):
     async with set_database_global_context_variables(dataset_obj.id, dataset_obj.owner_id):
-        vector_engine = await get_vector_engine()
+        vector_engine = await get_vector_engine_async()
         graph_engine = await get_graph_engine()
         centroids = await load_centroids(vector_engine, str(dataset_obj.id), K)
         nodes, _edges = await graph_engine.get_graph_data()

--- a/examples/pocs/disambiguation/extract_graph_from_data_with_entity_disambiguation.py
+++ b/examples/pocs/disambiguation/extract_graph_from_data_with_entity_disambiguation.py
@@ -24,7 +24,7 @@ from cognee.tasks.graph.exceptions import (
     InvalidOntologyAdapterError,
 )
 
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 
 
 def _stamp_provenance_deep(data, pipeline_name, task_name, visited=None):
@@ -120,7 +120,7 @@ async def integrate_chunk_graphs(
 
 
 async def build_prompt(chunk, vector_search_limit, custom_prompt) -> Optional[str]:
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     exists = await vector_engine.has_collection(collection_name="Entity_name")
 
     if not (exists and custom_prompt):

--- a/examples/pocs/post_extraction_canonicalization/post_extraction_canonicalization.py
+++ b/examples/pocs/post_extraction_canonicalization/post_extraction_canonicalization.py
@@ -9,7 +9,7 @@ from pandas import DataFrame
 from pydantic import BaseModel
 
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.llm.extraction import extract_content_graph
 from cognee.modules.chunking.models import DocumentChunk
 
@@ -83,7 +83,7 @@ async def cache_and_replace_nodes(graphs, **kwargs):
     similarity_threshold = kwargs.get("similarity_threshold", 1.0)
     stats = kwargs.get("stats", None)
 
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     df_new = pd.DataFrame()
     for graph in graphs:
         await asyncio.gather(

--- a/examples/pocs/prefetch_disambiguation/prefetch_disambiguation.py
+++ b/examples/pocs/prefetch_disambiguation/prefetch_disambiguation.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from nltk.tokenize import sent_tokenize
 
 from cognee.infrastructure.databases.graph import get_graph_engine
-from cognee.infrastructure.databases.vector import get_vector_engine
+from cognee.infrastructure.databases.vector import get_vector_engine_async
 from cognee.infrastructure.llm.extraction import extract_content_graph
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.modules.engine.models import Entity, EntityType
@@ -127,7 +127,7 @@ async def _build_chunk_graphs_and_prompts(
     }
 
     chunk_texts = [chunk.text for chunk in data_chunks]
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     chunk_embeddings = await vector_engine.embedding_engine.embed_text(chunk_texts)
     chunk_prompts = [
         _build_disambiguation_prompt(chunk_embedding, df, vector_search_limit, custom_prompt)
@@ -201,7 +201,7 @@ async def cache_entity_embeddings(graphs, **kwargs) -> None:
     df = kwargs.get("df", None)
     if df is None:
         return
-    vector_engine = await get_vector_engine()
+    vector_engine = await get_vector_engine_async()
     df_new = pd.DataFrame()
     for graph in graphs:
         entity_names = [node.name for node in graph.nodes]

--- a/notebooks/cognee_demo.ipynb
+++ b/notebooks/cognee_demo.ipynb
@@ -1133,9 +1133,9 @@
     "    ]\n",
     "\n",
     "\n",
-    "from cognee.infrastructure.databases.vector import get_vector_engine\n",
+    "from cognee.infrastructure.databases.vector import get_vector_engine_async\n",
     "\n",
-    "vector_engine = get_vector_engine()\n",
+    "vector_engine = await get_vector_engine_async()\n",
     "results = await search(vector_engine, \"Entity_name\", \"sarah.nguyen@example.com\")\n",
     "for result in results:\n",
     "    print(result)"


### PR DESCRIPTION
## Summary

On `dev`, `get_vector_engine()` was moved to the async surface (for call-site symmetry with the genuinely-async `get_graph_engine()`). That is a **breaking change** for downstream code that calls it synchronously without `await` — e.g. cognee-community adapters pinned to released cognee (`cognee==1.1.0`), user scripts, and the demo notebook. In every **released** version (v1.1.0 → v1.2.2) `get_vector_engine()` is synchronous, so real consumers call it synchronously.

Crucially, vector engine resolution does **no real async work**: the handle resolves via the synchronous `create_vector_engine` (LanceDB connects via `connect_async` without taking the exclusive on-disk file lock that motivated the graph async path). An `acreate_vector_engine` path was tried on this line of work and deliberately walked back in #3708 because it is a no-op for LanceDB. So backward compatibility needs **no loop-blocking / `asyncio.run`** — the sync shim simply returns the handle and works in any context.

## Changes

- **Rename** the async accessor to `get_vector_engine_async()` (canonical; `await` it everywhere internally, alongside `await get_graph_engine()`). Its docstring documents that the `async` is for call-site symmetry only and warns against reintroducing an `acreate` path.
- **Reintroduce `get_vector_engine()`** as a synchronous, deprecated shim that returns the same `_VectorEngineHandle` and emits `DeprecationWarning`. The returned adapter's methods are coroutines, so it is only useful to code that will `await` those methods inside a running event loop.
- **Export both names** from the vector package `__init__`.
- **Repoint all internal call sites, imports, and test mock/patch targets** to `get_vector_engine_async()` (module-path imports of the `get_vector_engine` file are preserved — only the imported symbol changed).
- Fix stale comments, the `CLAUDE.md` example, and `notebooks/cognee_demo.ipynb` (it did `get_vector_engine()` un-awaited inside an async cell — now `await get_vector_engine_async()`).
- **De-flake `test_closing_lru_cache.py`** off-loop close tests: they asserted `raw.closed is False` right after eviction, relying on a fixed `sleep(0.2)` close still being in flight. On a loaded CI runner (full unit suite ~615s) the intervening `gc.collect()` can exceed 200ms, finishing the close first (`assert True is False`, seen on Unit tests 3.12.x). Replaced the fixed sleep with an explicit start/release gate so no assertion depends on wall-clock timing.

## Compatibility note

`get_vector_engine()` reverts to **synchronous**. Code written against the *unreleased* async form on `dev` (`await get_vector_engine()`) should switch to `await get_vector_engine_async()`. No released version exposed the async form, so released consumers are unaffected.

## Verification

- Smoke test: `get_vector_engine_async` is a coroutine fn; `get_vector_engine` is not and emits `DeprecationWarning`; both return `_VectorEngineHandle`.
- Residual scan: zero `await get_vector_engine()` remain (awaiting the sync shim would be a bug).
- At-risk mock suites pass: `test_index_data_points`, `test_index_graph_edges`, `test_database_migrations`, `test_embedding_connection_dimensions`, `test_session_embeddings` (57 passed) + `test_brute_force_triplet_search` (40 passed).
- `test_closing_lru_cache.py`: 34/34 pass, run 5× with no flakes.
- `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRxjSjFeH3ih9RTZBpGcJC