### PR TITLE
fix: return empty list for empty Redis latest QA

### DIFF
--- a/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
+++ b/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
@@ -325,7 +325,7 @@ class RedisAdapter(CacheDBInterface):
         session_key = self._session_key(user_id, session_id)
         if last_n == 1:
             data = await self.async_redis.lindex(session_key, -1)
-            return [SessionQAEntry.model_validate_json(data)] if data else None
+            return [SessionQAEntry.model_validate_json(data)] if data else []
         data = await self.async_redis.lrange(session_key, -last_n, -1)
         return [SessionQAEntry.model_validate_json(d) for d in data] if data else []
 

--- a/cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py
@@ -150,6 +150,14 @@ async def test_create_and_get(adapter):
 
 
 @pytest.mark.asyncio
+async def test_empty_session_returns_empty_list_for_all_last_n(adapter):
+    """Empty sessions return [] for every latest-entry window size."""
+    assert await adapter.get_latest_qa_entries("u1", "missing", last_n=1) == []
+    assert await adapter.get_latest_qa_entries("u1", "missing", last_n=5) == []
+    assert await adapter.get_all_qa_entries("u1", "missing") == []
+
+
+@pytest.mark.asyncio
 async def test_create_qa_entry_sets_session_ttl_when_enabled(adapter, redis_store):
     """Session keys receive TTL on create when Redis session TTL is enabled."""
     await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")


### PR DESCRIPTION
## Summary
- return [] instead of None from Redis get_latest_qa_entries(..., last_n=1) when a session has no entries
- add a Redis adapter regression test covering empty latest-entry reads for last_n=1 and larger windows

Fixes #3930.

## Tests
- .\.venv\Scripts\python -m pytest cognee\tests\unit\infrastructure\databases\cache\test_redis_adapter_crud.py (31 passed)

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.