### PR TITLE
fix(storage): deep-copy datapoints in index_data_points to stop metadata aliasing

### DIFF
--- a/cognee/tasks/storage/index_data_points.py
+++ b/cognee/tasks/storage/index_data_points.py
@@ -47,7 +47,7 @@ async def index_data_points(data_points: list[DataPoint], vector_engine=None):
                 await vector_engine.create_vector_index(type_name, field_name)
                 data_points_by_type[type_name][field_name] = []
 
-            indexed_data_point = data_point.model_copy()
+            indexed_data_point = data_point.model_copy(deep=True)
             indexed_data_point.metadata["index_fields"] = [field_name]
             data_points_by_type[type_name][field_name].append(indexed_data_point)
 


### PR DESCRIPTION
## Summary

`index_data_points` corrupts vector embeddings for any `DataPoint` model that declares **more than one** `index_fields` entry: every vector collection except the last field's is populated with embeddings of the **wrong attribute**. This silently degrades semantic search, with no error raised.

## Root cause

`cognee/tasks/storage/index_data_points.py`:

```python
for field_name in data_point.metadata["index_fields"]:
    ...
    indexed_data_point = data_point.model_copy()              # shallow copy
    indexed_data_point.metadata["index_fields"] = [field_name]  # mutates a SHARED dict
```

Pydantic's `model_copy()` (without `deep=True`) shares nested mutable values by reference, so every per-field copy — **and the caller's original object** — share one `metadata` dict. The in-place assignment on line 51 overwrites that shared dict once per field, so after the loop every copy reads back `[last_field]`.

At embed time the adapters resolve the text from `index_fields[0]` while the collection is named by the batch's field:

- `cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py:1283` — `text=getattr(data_point, data_point.metadata["index_fields"][0])`
- `cognee/infrastructure/engine/models/DataPoint.py:228` — `get_embeddable_data` reads `index_fields[0]`

So for a model with `index_fields=["description", "name"]`, the `description` collection is filled with `name` embeddings. The original datapoint is also left with a truncated `index_fields`, so any later re-index drops the other fields.

## Impact

Multi-index-field production models are affected:
- `cognee/tasks/web_scraper/models.py` — `["name", "description", "content"]`
- `cognee/tasks/schema/models.py` — `["description", "name"]`
- `cognee/tasks/temporal_awareness/graphiti_model.py` — `["name", "summary", "content"]`
- `cognee/tasks/translation/models.py` — `["source_language", "translated_text"]`

The default `add → cognify → search` types (DocumentChunk/Entity/EntityType/TextSummary) escape only because they each declare a single index field, which is why this went unnoticed.

## Reproduction

Self-contained repro mirroring the exact code path and the embed-time read:

```python
from pydantic import BaseModel

class TableSchema(BaseModel):
    name: str
    description: str
    metadata: dict = {"index_fields": ["description", "name"]}

dp = TableSchema(name="users_table", description="Stores user account records")

buckets = {}
for field_name in dp.metadata["index_fields"]:
    indexed = dp.model_copy()                       # shallow (current code)
    indexed.metadata["index_fields"] = [field_name]
    buckets[field_name] = indexed

for collection_field, indexed in buckets.items():
    embedded_attr = indexed.metadata["index_fields"][0]   # what embed reads
    status = "OK" if embedded_attr == collection_field else "WRONG"
    print(f"collection TableSchema_{collection_field}: embeds '{embedded_attr}'  [{status}]")
```

Output with the current shallow copy:

```
collection TableSchema_description: embeds 'name'         [WRONG]
collection TableSchema_name:        embeds 'name'         [OK]
```

With `model_copy(deep=True)` both collections embed the correct field.

## Fix

Use `model_copy(deep=True)` so each per-field copy owns its own `metadata` dict. One-line change, no behavior change for the already-correct single-field case.

Note: the same shallow-copy-then-mutate pattern also exists in `cognee/tasks/temporal_awareness/index_graphiti_objects.py` (lines 65 and 92); happy to fold those into this PR if preferred.

## Checks

- `ruff check` and `ruff format --check` pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)