### PR TITLE
fix(db): remove manual connection.close() that rolled back create_table DDL

### DIFF
--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -179,7 +179,6 @@ class SQLAlchemyAdapter:
                     f'CREATE TABLE IF NOT EXISTS {schema_name}."{table_name}" ({", ".join(fields_query_parts)});'
                 )
             )
-            await connection.close()
 
     async def delete_table(self, table_name: str, schema_name: Optional[str] = "public"):
         """


### PR DESCRIPTION
## Description

`SQLAlchemyAdapter.create_table` calls `await connection.close()` **inside** an `async with self.engine.begin()` block:

```python
async with self.engine.begin() as connection:
    await connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema_name};"))
    await connection.execute(
        text(
            f'CREATE TABLE IF NOT EXISTS {schema_name}."{table_name}" ({", ".join(fields_query_parts)});'
        )
    )
    await connection.close()  # <-- rolls back the transaction
```

`engine.begin()` owns the connection lifecycle and commits the transaction on `__aexit__`. Manually closing the connection before the block exits **rolls back** the open transaction instead. On PostgreSQL, where DDL is transactional, the `CREATE SCHEMA` and `CREATE TABLE` statements execute and are then silently discarded — the method returns successfully having created nothing.

SQLite masks the bug because its driver runs DDL in autocommit mode, which is likely why this went unnoticed.

The sibling `delete_table` method directly below already uses the correct pattern (no manual `close()`), so this change also makes the two methods consistent.

## Reproduction

Minimal demonstration of the rollback semantics (DML used because SQLite DDL is autocommit):

```python
import asyncio
from sqlalchemy import text
from sqlalchemy.ext.asyncio import create_async_engine

async def main():
    engine = create_async_engine("sqlite+aiosqlite:///./close_bug_test.db")

    async with engine.begin() as conn:
        await conn.execute(text("CREATE TABLE t (x INTEGER)"))

    # Pattern used in create_table: close() inside engine.begin()
    async with engine.begin() as conn:
        await conn.execute(text("INSERT INTO t VALUES (1)"))
        await conn.close()  # <-- the buggy line

    # Correct pattern: let engine.begin() commit on exit
    async with engine.begin() as conn:
        await conn.execute(text("INSERT INTO t VALUES (2)"))

    async with engine.connect() as conn:
        rows = (await conn.execute(text("SELECT x FROM t ORDER BY x"))).fetchall()
        print("Rows present:", rows)

    await engine.dispose()

asyncio.run(main())
```

Output:

```
Rows present: [(2,)]
```

The write executed before `connection.close()` was rolled back; the identical write without the manual `close()` committed.

## Fix

Remove the `await connection.close()` line and let `engine.begin()` manage the connection lifecycle, matching `delete_table`.