### PR TITLE
feat(llm): reuse host harness LLM via MCP sampling (LLM_PROVIDER=mcp-sampling) [SDK-139]

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -627,10 +627,12 @@ WEB_SCRAPER_MAX_DELAY=10.0
 
 ########## MCP sampling (reuse the host harness LLM, no API key) ##############
 # Only for running cognee AS an MCP server (cognee-mcp) inside a host that
-# grants the `sampling` capability (Claude Code, Cursor, ...). LLM completions
-# are delegated to the host via `sampling/createMessage`, so no LLM_API_KEY is
-# needed. Structured output is done by embedding the JSON Schema in the prompt
-# and validating/repairing the reply (the protocol returns free text only).
+# grants the `sampling` capability. LLM completions are delegated to the host
+# via `sampling/createMessage`, so no LLM_API_KEY is needed. Structured output
+# is done by embedding the JSON Schema in the prompt and validating/repairing
+# the reply (the protocol returns free text only).
+# Host support varies: as of early 2026 Claude Code does NOT yet grant sampling
+# (github.com/anthropics/claude-code/issues/1785); check your host's MCP docs.
 # Note: embeddings are NOT covered by sampling; set an embedding provider (or a
 # local one) if you use vector search. Falls back to a clear error when no host
 # sampling session is available.

--- a/.env.template
+++ b/.env.template
@@ -624,3 +624,15 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #EMBEDDING_API_VERSION=""
 #EMBEDDING_DIMENSIONS=3072
 #EMBEDDING_MAX_COMPLETION_TOKENS=8191
+
+########## MCP sampling (reuse the host harness LLM, no API key) ##############
+# Only for running cognee AS an MCP server (cognee-mcp) inside a host that
+# grants the `sampling` capability (Claude Code, Cursor, ...). LLM completions
+# are delegated to the host via `sampling/createMessage`, so no LLM_API_KEY is
+# needed. Structured output is done by embedding the JSON Schema in the prompt
+# and validating/repairing the reply (the protocol returns free text only).
+# Note: embeddings are NOT covered by sampling; set an embedding provider (or a
+# local one) if you use vector search. Falls back to a clear error when no host
+# sampling session is available.
+#LLM_PROVIDER="mcp-sampling"
+#LLM_MODEL="host-default"  # hint only; the host chooses the actual model

--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -95,6 +95,12 @@ Please refer to our documentation [here](https://docs.cognee.ai/how-to-guides/de
 You can do more advanced configurations by creating .env file using our <a href="https://github.com/topoteretes/cognee/blob/main/.env.template">template.</a>
 To use different LLM providers / database configurations, and for more info check out our <a href="https://docs.cognee.ai">documentation</a>.
 
+> **No API key?** If your MCP host grants the `sampling` capability, `LLM_PROVIDER="mcp-sampling"`
+> delegates completions to the host's own model, so no `LLM_API_KEY` is needed (embeddings still
+> need a provider). Host support varies — as of early 2026 Claude Code does not yet grant sampling
+> ([anthropics/claude-code#1785](https://github.com/anthropics/claude-code/issues/1785)). See the
+> "MCP sampling" section of the .env template.
+
 
 ## 🐳 Docker Usage
 

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -81,3 +81,22 @@ class MissingSystemPromptPathError(CogneeValidationError):
     ) -> None:
         message = "No system prompt path provided."
         super().__init__(message, name)
+
+
+class MCPSamplingUnavailableError(CogneeValidationError):
+    """
+    Raised when `LLM_PROVIDER=mcp-sampling` is selected but no host MCP sampling
+    session is available (cognee is not running inside an MCP server, or the host
+    did not grant the `sampling` capability).
+    """
+
+    def __init__(
+        self,
+        message: str = (
+            "No MCP sampling session is available. LLM_PROVIDER=mcp-sampling only works while "
+            "cognee runs as an MCP server inside a host that grants the `sampling` capability "
+            "(e.g. Claude Code / Cursor). Set LLM_PROVIDER to a provider with credentials, or "
+            "run inside such a host."
+        ),
+    ) -> None:
+        super().__init__(message=message, name="MCPSamplingUnavailableError")

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -95,7 +95,7 @@ class MCPSamplingUnavailableError(CogneeValidationError):
         message: str = (
             "No MCP sampling session is available. LLM_PROVIDER=mcp-sampling only works while "
             "cognee runs as an MCP server inside a host that grants the `sampling` capability "
-            "(e.g. Claude Code / Cursor). Set LLM_PROVIDER to a provider with credentials, or "
+            "(support varies by host). Set LLM_PROVIDER to a provider with credentials, or "
             "run inside such a host."
         ),
     ) -> None:

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -359,12 +359,12 @@ def _get_llm_client_cached(cache_key: _LLMClientCacheKey) -> LLMInterface:
 
     elif provider == LLMProvider.MCP_SAMPLING:
         from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mcp_sampling.adapter import (
-            McpSamplingAdapter,
+            MCPSamplingAdapter,
         )
 
         # No API key / endpoint: completions are delegated to the host MCP
         # session. `model` is only a preference hint.
-        return McpSamplingAdapter(
+        return MCPSamplingAdapter(
             model=cache_key.model,
             max_completion_tokens=max_completion_tokens,
         )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/get_llm_client.py
@@ -90,6 +90,8 @@ class LLMProvider(Enum):
     AZURE = "azure"
     BEDROCK = "bedrock"
     LLAMA_CPP = "llama_cpp"
+    # Delegates completions to the host harness via MCP sampling (no API key).
+    MCP_SAMPLING = "mcp-sampling"
 
 
 _API_KEY_REQUIRED_PROVIDERS = {
@@ -353,6 +355,18 @@ def _get_llm_client_cached(cache_key: _LLMClientCacheKey) -> LLMInterface:
             n_gpu_layers=cache_key.llama_cpp_n_gpu_layers,
             chat_format=cache_key.llama_cpp_chat_format,
             llm_args=llm_args,
+        )
+
+    elif provider == LLMProvider.MCP_SAMPLING:
+        from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mcp_sampling.adapter import (
+            McpSamplingAdapter,
+        )
+
+        # No API key / endpoint: completions are delegated to the host MCP
+        # session. `model` is only a preference hint.
+        return McpSamplingAdapter(
+            model=cache_key.model,
+            max_completion_tokens=max_completion_tokens,
         )
     else:
         raise UnsupportedLLMProviderError(provider)

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/__init__.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/__init__.py
@@ -1,0 +1,20 @@
+"""MCP-sampling LLM backend.
+
+Reuses the host harness's LLM connection (Claude Code / Cursor / …) via the MCP
+`sampling/createMessage` capability instead of a separate provider client, so no
+`LLM_API_KEY` is needed when the host grants sampling. See issue #3644.
+"""
+
+from .adapter import McpSamplingAdapter
+from .session_context import (
+    get_sampling_session,
+    reset_sampling_session,
+    set_sampling_session,
+)
+
+__all__ = [
+    "McpSamplingAdapter",
+    "get_sampling_session",
+    "set_sampling_session",
+    "reset_sampling_session",
+]

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/__init__.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/__init__.py
@@ -1,20 +1,6 @@
 """MCP-sampling LLM backend.
 
 Reuses the host harness's LLM connection (Claude Code / Cursor / …) via the MCP
-`sampling/createMessage` capability instead of a separate provider client, so no
-`LLM_API_KEY` is needed when the host grants sampling. See issue #3644.
+``sampling/createMessage`` capability instead of a separate provider client, so no
+``LLM_API_KEY`` is needed when the host grants sampling. See issue #3644.
 """
-
-from .adapter import McpSamplingAdapter
-from .session_context import (
-    get_sampling_session,
-    reset_sampling_session,
-    set_sampling_session,
-)
-
-__all__ = [
-    "McpSamplingAdapter",
-    "get_sampling_session",
-    "set_sampling_session",
-    "reset_sampling_session",
-]

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/__init__.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/__init__.py
@@ -1,6 +1,6 @@
 """MCP-sampling LLM backend.
 
-Reuses the host harness's LLM connection (Claude Code / Cursor / …) via the MCP
+Reuses the host harness's LLM connection via the MCP
 ``sampling/createMessage`` capability instead of a separate provider client, so no
 ``LLM_API_KEY`` is needed when the host grants sampling. See issue #3644.
 """

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
@@ -1,0 +1,151 @@
+"""LLM adapter that delegates completions to the host via MCP sampling.
+
+When cognee runs as an MCP server, this adapter routes structured-output requests
+through the host client's ``sampling/createMessage`` capability instead of a
+provider API, so no ``LLM_API_KEY`` is needed (issue #3644).
+
+Limitations, documented honestly:
+
+* MCP sampling returns **free text** — the protocol guarantees no JSON-schema or
+  tool mode. Structured output is therefore produced by embedding the response
+  model's JSON Schema in the prompt and validating/repairing the reply, rather
+  than relying on native schema enforcement.
+* The sampling call must run in the server process, inside the MCP request scope
+  (that is where the client connection lives). LLM calls that cognee runs in a
+  detached background task or subprocess cannot reach the host session and will
+  raise :class:`MCPSamplingUnavailableError`.
+* Audio transcription and image description have no sampling equivalent.
+"""
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from cognee.infrastructure.llm.exceptions import MCPSamplingUnavailableError
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
+    LLMInterface,
+)
+from cognee.shared.logging_utils import get_logger
+
+from .session_context import get_sampling_session
+
+logger = get_logger()
+
+
+def _extract_json(text: str) -> str:
+    """Best-effort extraction of a JSON object from a free-text sampling reply.
+
+    Hosts often wrap JSON in Markdown fences or add prose; take the substring
+    between the first ``{`` and the last ``}`` after stripping code fences.
+    """
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        # Drop the opening fence (``` or ```json) and the trailing fence.
+        cleaned = cleaned.split("\n", 1)[-1] if "\n" in cleaned else cleaned
+        if cleaned.endswith("```"):
+            cleaned = cleaned[: -len("```")]
+        cleaned = cleaned.strip()
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        return cleaned[start : end + 1]
+    return cleaned
+
+
+def _result_text(result: Any) -> str:
+    """Pull the text out of an MCP ``CreateMessageResult`` (duck-typed)."""
+    content = getattr(result, "content", result)
+    if isinstance(content, list):
+        parts = [getattr(block, "text", "") for block in content]
+        return "".join(p for p in parts if p)
+    text = getattr(content, "text", None)
+    return text if text is not None else str(content)
+
+
+class McpSamplingAdapter(LLMInterface):
+    """Delegate completions to the host harness via MCP sampling."""
+
+    def __init__(
+        self,
+        model: str,
+        max_completion_tokens: int,
+        structured_output_retries: int = 5,
+    ) -> None:
+        # `model` is a preference hint only; the host chooses the actual model.
+        self.model = model
+        self.max_completion_tokens = max_completion_tokens
+        self.structured_output_retries = max(1, structured_output_retries)
+
+    async def _sample(self, session: Any, system_prompt: str, user_text: str) -> str:
+        """One ``sampling/createMessage`` round trip; returns the reply text."""
+        messages = [{"role": "user", "content": {"type": "text", "text": user_text}}]
+        result = await session.create_message(
+            messages=messages,
+            max_tokens=self.max_completion_tokens,
+            system_prompt=system_prompt,
+        )
+        return _result_text(result)
+
+    async def acreate_structured_output(
+        self, text_input: str, system_prompt: str, response_model: type
+    ) -> Any:
+        session = get_sampling_session()
+        if session is None:
+            raise MCPSamplingUnavailableError()
+
+        # Plain-string responses need no schema.
+        if response_model is str:
+            return await self._sample(session, system_prompt, text_input)
+
+        if not (isinstance(response_model, type) and issubclass(response_model, BaseModel)):
+            raise TypeError(
+                "McpSamplingAdapter.acreate_structured_output expects a Pydantic model or `str`, "
+                f"got {response_model!r}"
+            )
+
+        schema = json.dumps(response_model.model_json_schema())
+        schema_instructions = (
+            "Respond with ONLY a single JSON object that validates against this JSON Schema. "
+            "Do not include any prose, explanation, or Markdown code fences.\n\n"
+            f"JSON Schema:\n{schema}"
+        )
+        prompt = f"{system_prompt}\n\n{schema_instructions}"
+
+        last_error: Exception | None = None
+        for attempt in range(self.structured_output_retries):
+            raw = await self._sample(session, prompt, text_input)
+            candidate = _extract_json(raw)
+            try:
+                return response_model.model_validate_json(candidate)
+            except (ValidationError, ValueError) as error:
+                last_error = error
+                logger.warning(
+                    "MCP sampling structured output failed validation (attempt %d/%d): %s",
+                    attempt + 1,
+                    self.structured_output_retries,
+                    error,
+                )
+                # Repair prompt: show the model its error and ask for corrected JSON.
+                prompt = (
+                    f"{system_prompt}\n\n{schema_instructions}\n\n"
+                    "Your previous response did not validate against the schema: "
+                    f"{error}. Return corrected JSON only."
+                )
+
+        raise ValueError(
+            "MCP sampling could not produce structured output matching "
+            f"{response_model.__name__} after {self.structured_output_retries} attempts. "
+            f"Last error: {last_error}"
+        )
+
+    async def create_transcript(self, input: str):
+        """Audio transcription has no MCP sampling equivalent — graceful no-audio."""
+        logger.debug("create_transcript is not supported over MCP sampling; returning None")
+        return None
+
+    async def transcribe_image(self, input: str) -> Any:
+        raise NotImplementedError(
+            "Image description is not supported over MCP sampling. Configure a vision-capable "
+            "LLM provider instead."
+        )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
@@ -1,20 +1,13 @@
 """LLM adapter that delegates completions to the host via MCP sampling.
 
-When cognee runs as an MCP server, this adapter routes structured-output requests
-through the host client's ``sampling/createMessage`` capability instead of a
-provider API, so no ``LLM_API_KEY`` is needed (issue #3644).
+When cognee runs as an MCP server, this routes structured-output requests through
+the host client's ``sampling/createMessage`` capability instead of a provider API,
+so no ``LLM_API_KEY`` is needed (issue #3644).
 
-Limitations, documented honestly:
-
-* MCP sampling returns **free text** — the protocol guarantees no JSON-schema or
-  tool mode. Structured output is therefore produced by embedding the response
-  model's JSON Schema in the prompt and validating/repairing the reply, rather
-  than relying on native schema enforcement.
-* The sampling call must run in the server process, inside the MCP request scope
-  (that is where the client connection lives). LLM calls that cognee runs in a
-  detached background task or subprocess cannot reach the host session and will
-  raise :class:`MCPSamplingUnavailableError`.
-* Audio transcription and image description have no sampling equivalent.
+MCP sampling returns free text — the protocol guarantees no JSON-schema or tool
+mode — so structured output is produced by embedding the response model's JSON
+Schema in the prompt and validating/repairing the reply. Audio transcription and
+image description have no sampling equivalent.
 """
 
 import json
@@ -26,6 +19,9 @@ from cognee.infrastructure.llm.exceptions import MCPSamplingUnavailableError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
 )
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
+    TranscriptionReturnType,
+)
 from cognee.shared.logging_utils import get_logger
 
 from .session_context import get_sampling_session
@@ -34,36 +30,19 @@ logger = get_logger()
 
 
 def _extract_json(text: str) -> str:
-    """Best-effort extraction of a JSON object from a free-text sampling reply.
+    """Extract a JSON object from a free-text reply that may be fenced or prosey.
 
-    Hosts often wrap JSON in Markdown fences or add prose; take the substring
-    between the first ``{`` and the last ``}`` after stripping code fences.
+    Takes the substring between the first ``{`` and the last ``}``; that alone
+    strips Markdown code fences and surrounding prose.
     """
-    cleaned = text.strip()
-    if cleaned.startswith("```"):
-        # Drop the opening fence (``` or ```json) and the trailing fence.
-        cleaned = cleaned.split("\n", 1)[-1] if "\n" in cleaned else cleaned
-        if cleaned.endswith("```"):
-            cleaned = cleaned[: -len("```")]
-        cleaned = cleaned.strip()
-    start = cleaned.find("{")
-    end = cleaned.rfind("}")
-    if start != -1 and end != -1 and end > start:
-        return cleaned[start : end + 1]
-    return cleaned
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        return text[start : end + 1]
+    return text.strip()
 
 
-def _result_text(result: Any) -> str:
-    """Pull the text out of an MCP ``CreateMessageResult`` (duck-typed)."""
-    content = getattr(result, "content", result)
-    if isinstance(content, list):
-        parts = [getattr(block, "text", "") for block in content]
-        return "".join(p for p in parts if p)
-    text = getattr(content, "text", None)
-    return text if text is not None else str(content)
-
-
-class McpSamplingAdapter(LLMInterface):
+class MCPSamplingAdapter(LLMInterface):
     """Delegate completions to the host harness via MCP sampling."""
 
     def __init__(
@@ -79,17 +58,42 @@ class McpSamplingAdapter(LLMInterface):
 
     async def _sample(self, session: Any, system_prompt: str, user_text: str) -> str:
         """One ``sampling/createMessage`` round trip; returns the reply text."""
-        messages = [{"role": "user", "content": {"type": "text", "text": user_text}}]
         result = await session.create_message(
-            messages=messages,
+            messages=[{"role": "user", "content": {"type": "text", "text": user_text}}],
             max_tokens=self.max_completion_tokens,
             system_prompt=system_prompt,
         )
-        return _result_text(result)
+        # CreateMessageResult.content is a single text block.
+        text = getattr(result.content, "text", None)
+        return text if text is not None else str(result.content)
 
     async def acreate_structured_output(
-        self, text_input: str, system_prompt: str, response_model: type
-    ) -> Any:
+        self,
+        text_input: str,
+        system_prompt: str,
+        response_model: type[BaseModel | str],
+        **kwargs: Any,
+    ) -> BaseModel | str:
+        """
+        Generate structured output by delegating to the host via MCP sampling.
+
+        The response model's JSON Schema is embedded in the prompt and the host's
+        free-text reply is validated (and repaired on failure) against it.
+
+        Parameters:
+        -----------
+
+            - text_input (str): The input text from the user to be processed.
+            - system_prompt (str): The system prompt that guides the model's response.
+            - response_model (type[BaseModel | str]): The model type that structures the
+              response, or ``str`` for a plain-text reply.
+
+        Returns:
+        --------
+
+            - BaseModel | str: The validated structured output, or the raw reply text when
+              ``response_model`` is ``str``.
+        """
         session = get_sampling_session()
         if session is None:
             raise MCPSamplingUnavailableError()
@@ -100,37 +104,33 @@ class McpSamplingAdapter(LLMInterface):
 
         if not (isinstance(response_model, type) and issubclass(response_model, BaseModel)):
             raise TypeError(
-                "McpSamplingAdapter.acreate_structured_output expects a Pydantic model or `str`, "
+                "MCPSamplingAdapter.acreate_structured_output expects a Pydantic model or `str`, "
                 f"got {response_model!r}"
             )
 
         schema = json.dumps(response_model.model_json_schema())
-        schema_instructions = (
+        instructions = (
             "Respond with ONLY a single JSON object that validates against this JSON Schema. "
             "Do not include any prose, explanation, or Markdown code fences.\n\n"
             f"JSON Schema:\n{schema}"
         )
-        prompt = f"{system_prompt}\n\n{schema_instructions}"
+        prompt = f"{system_prompt}\n\n{instructions}"
 
         last_error: Exception | None = None
         for attempt in range(self.structured_output_retries):
             raw = await self._sample(session, prompt, text_input)
-            candidate = _extract_json(raw)
             try:
-                return response_model.model_validate_json(candidate)
+                return response_model.model_validate_json(_extract_json(raw))
             except (ValidationError, ValueError) as error:
                 last_error = error
                 logger.warning(
-                    "MCP sampling structured output failed validation (attempt %d/%d): %s",
-                    attempt + 1,
-                    self.structured_output_retries,
-                    error,
+                    f"MCP sampling structured output failed validation "
+                    f"(attempt {attempt + 1}/{self.structured_output_retries}): {error}"
                 )
-                # Repair prompt: show the model its error and ask for corrected JSON.
+                # Repair: show the validation error and ask for corrected JSON.
                 prompt = (
-                    f"{system_prompt}\n\n{schema_instructions}\n\n"
-                    "Your previous response did not validate against the schema: "
-                    f"{error}. Return corrected JSON only."
+                    f"{system_prompt}\n\n{instructions}\n\n"
+                    f"The previous response did not validate: {error}. Return corrected JSON only."
                 )
 
         raise ValueError(
@@ -139,12 +139,13 @@ class McpSamplingAdapter(LLMInterface):
             f"Last error: {last_error}"
         )
 
-    async def create_transcript(self, input: str):
+    async def create_transcript(self, input: str) -> TranscriptionReturnType | None:
         """Audio transcription has no MCP sampling equivalent — graceful no-audio."""
         logger.debug("create_transcript is not supported over MCP sampling; returning None")
         return None
 
     async def transcribe_image(self, input: str) -> Any:
+        """Image description has no MCP sampling equivalent; use a vision-capable provider."""
         raise NotImplementedError(
             "Image description is not supported over MCP sampling. Configure a vision-capable "
             "LLM provider instead."

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
@@ -58,8 +58,22 @@ class MCPSamplingAdapter(LLMInterface):
 
     async def _sample(self, session: Any, system_prompt: str, user_text: str) -> str:
         """One ``sampling/createMessage`` round trip; returns the reply text."""
+        # Messages must be typed: ``ServerSession.create_message`` validates them
+        # (SEP-1577, ``msg.content_as_list``) before pydantic coercion, so plain
+        # dicts crash on mcp >= 1.25. mcp is installed in any real sampling
+        # deployment; the dict fallback only ever reaches mock sessions in
+        # environments without mcp.
+        try:
+            from mcp.types import SamplingMessage, TextContent  # ty:ignore[unresolved-import]
+
+            messages: list[Any] = [
+                SamplingMessage(role="user", content=TextContent(type="text", text=user_text))
+            ]
+        except ImportError:
+            messages = [{"role": "user", "content": {"type": "text", "text": user_text}}]
+
         result = await session.create_message(
-            messages=[{"role": "user", "content": {"type": "text", "text": user_text}}],
+            messages=messages,
             max_tokens=self.max_completion_tokens,
             system_prompt=system_prompt,
         )

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/session_context.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/session_context.py
@@ -1,7 +1,7 @@
 """Access to the host MCP sampling session.
 
-When cognee runs as an MCP server (``cognee-mcp``), the host client (Claude Code,
-Cursor, …) can grant a ``sampling/createMessage`` capability. That call must
+When cognee runs as an MCP server (``cognee-mcp``), the host client can grant a
+``sampling/createMessage`` capability (support varies by host). That call must
 happen in the server process within the request, where the client connection
 lives. This module lets the LLM adapter — built deep in the gateway, far from the
 MCP request handler — reach that session without threading it through every

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/session_context.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/session_context.py
@@ -1,0 +1,60 @@
+"""Access to the host MCP sampling session.
+
+When cognee runs as an MCP server (``cognee-mcp``), the host client (Claude Code,
+Cursor, Opencode, …) can grant a ``sampling/createMessage`` capability. The
+sampling call must happen in the server process, within the request, where the
+client connection lives. This module lets the [`McpSamplingAdapter`], built deep
+inside the LLM gateway and far from the MCP request handler, reach that session
+without every pipeline task threading it down explicitly.
+
+Two ways the session becomes visible here:
+
+1. Explicit — a caller (or a test) binds it with :func:`set_sampling_session`.
+2. Automatic — when running inside an MCP server, :func:`get_sampling_session`
+   falls back to the MCP SDK's per-request context
+   (``mcp.server.lowlevel.server.request_ctx``). ``mcp`` is imported lazily so
+   core cognee keeps no hard dependency on it.
+"""
+
+from contextvars import ContextVar, Token
+from typing import Any, Optional
+
+# The active MCP sampling session for the current request/task, or None.
+_sampling_session: ContextVar[Optional[Any]] = ContextVar(
+    "cognee_mcp_sampling_session", default=None
+)
+
+
+def set_sampling_session(session: Any) -> Token:
+    """Bind ``session`` as the active MCP sampling session.
+
+    Returns a token that :func:`reset_sampling_session` can use to restore the
+    previous value (contextvar semantics), so binding is scoped and re-entrant.
+    """
+    return _sampling_session.set(session)
+
+
+def reset_sampling_session(token: Token) -> None:
+    """Undo a previous :func:`set_sampling_session` using its token."""
+    _sampling_session.reset(token)
+
+
+def get_sampling_session() -> Optional[Any]:
+    """Return the active MCP sampling session, or ``None`` if unavailable.
+
+    Prefers an explicitly bound session; otherwise, when running inside an MCP
+    server, falls back to the SDK's per-request context so in-request LLM calls
+    pick up the host session automatically.
+    """
+    session = _sampling_session.get()
+    if session is not None:
+        return session
+
+    try:
+        from mcp.server.lowlevel.server import request_ctx  # type: ignore
+
+        ctx = request_ctx.get()
+    except (ImportError, LookupError):
+        return None
+
+    return getattr(ctx, "session", None)

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/session_context.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/session_context.py
@@ -1,60 +1,54 @@
 """Access to the host MCP sampling session.
 
 When cognee runs as an MCP server (``cognee-mcp``), the host client (Claude Code,
-Cursor, Opencode, …) can grant a ``sampling/createMessage`` capability. The
-sampling call must happen in the server process, within the request, where the
-client connection lives. This module lets the [`McpSamplingAdapter`], built deep
-inside the LLM gateway and far from the MCP request handler, reach that session
-without every pipeline task threading it down explicitly.
+Cursor, …) can grant a ``sampling/createMessage`` capability. That call must
+happen in the server process within the request, where the client connection
+lives. This module lets the LLM adapter — built deep in the gateway, far from the
+MCP request handler — reach that session without threading it through every
+pipeline task.
 
-Two ways the session becomes visible here:
-
-1. Explicit — a caller (or a test) binds it with :func:`set_sampling_session`.
-2. Automatic — when running inside an MCP server, :func:`get_sampling_session`
-   falls back to the MCP SDK's per-request context
-   (``mcp.server.lowlevel.server.request_ctx``). ``mcp`` is imported lazily so
-   core cognee keeps no hard dependency on it.
+``get_sampling_session`` reads the MCP SDK's per-request context and confirms the
+client actually granted sampling. ``mcp`` is imported lazily, so core cognee
+keeps no hard dependency on it.
 """
 
-from contextvars import ContextVar, Token
-from typing import Any, Optional
-
-# The active MCP sampling session for the current request/task, or None.
-_sampling_session: ContextVar[Optional[Any]] = ContextVar(
-    "cognee_mcp_sampling_session", default=None
-)
+from typing import Any
 
 
-def set_sampling_session(session: Any) -> Token:
-    """Bind ``session`` as the active MCP sampling session.
+def _client_granted_sampling(session: Any) -> bool:
+    """Whether the connected MCP client granted the ``sampling`` capability.
 
-    Returns a token that :func:`reset_sampling_session` can use to restore the
-    previous value (contextvar semantics), so binding is scoped and re-entrant.
+    Real MCP sessions expose ``check_client_capability``; a session stand-in that
+    does not is assumed usable. The host SDK does not verify this grant before
+    issuing ``sampling/createMessage``, so checking here lets cognee fail with a
+    clear error instead of a raw protocol error.
     """
-    return _sampling_session.set(session)
+    check = getattr(session, "check_client_capability", None)
+    if check is None:
+        return True
+
+    from mcp.types import ClientCapabilities, SamplingCapability  # ty:ignore[unresolved-import]
+
+    return bool(check(ClientCapabilities(sampling=SamplingCapability())))
 
 
-def reset_sampling_session(token: Token) -> None:
-    """Undo a previous :func:`set_sampling_session` using its token."""
-    _sampling_session.reset(token)
+def get_sampling_session() -> Any | None:
+    """Return a usable host MCP sampling session, or ``None`` if unavailable.
 
-
-def get_sampling_session() -> Optional[Any]:
-    """Return the active MCP sampling session, or ``None`` if unavailable.
-
-    Prefers an explicitly bound session; otherwise, when running inside an MCP
-    server, falls back to the SDK's per-request context so in-request LLM calls
-    pick up the host session automatically.
+    Falls back to the SDK's per-request context so in-request LLM calls (and
+    background tasks that copy that context) pick up the host session
+    automatically, and returns ``None`` unless the client granted sampling.
     """
-    session = _sampling_session.get()
-    if session is not None:
-        return session
-
     try:
-        from mcp.server.lowlevel.server import request_ctx  # type: ignore
-
+        from mcp.server.lowlevel.server import request_ctx  # ty:ignore[unresolved-import]
+    except ImportError:
+        return None
+    try:
         ctx = request_ctx.get()
-    except (ImportError, LookupError):
+    except LookupError:
         return None
 
-    return getattr(ctx, "session", None)
+    session = getattr(ctx, "session", None)
+    if session is None or not _client_granted_sampling(session):
+        return None
+    return session

--- a/cognee/tests/unit/infrastructure/llm/test_mcp_sampling_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_mcp_sampling_adapter.py
@@ -1,0 +1,152 @@
+"""Tests for the MCP-sampling LLM backend (issue #3644).
+
+The adapter delegates completions to a host MCP session via
+``sampling/createMessage``. These tests use a mock session (no real MCP host and
+no LLM_API_KEY) to pin the behaviour that matters:
+
+* structured output is produced from free-text replies by embedding the JSON
+  Schema and validating the reply;
+* a malformed reply triggers a repair retry rather than failing outright;
+* ``str`` response models pass the text through untouched;
+* when no host session is bound, the adapter raises
+  ``MCPSamplingUnavailableError`` instead of silently doing nothing.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.infrastructure.llm.exceptions import MCPSamplingUnavailableError
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mcp_sampling import (
+    McpSamplingAdapter,
+    reset_sampling_session,
+    set_sampling_session,
+)
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+def _reply(text: str) -> SimpleNamespace:
+    """Mimic an MCP ``CreateMessageResult`` (``.content.text``)."""
+    return SimpleNamespace(content=SimpleNamespace(type="text", text=text))
+
+
+def _mock_session(*replies: str) -> AsyncMock:
+    """A session whose ``create_message`` returns the given replies in order."""
+    session = AsyncMock()
+    session.create_message.side_effect = [_reply(r) for r in replies]
+    return session
+
+
+@pytest.mark.asyncio
+async def test_structured_output_from_sampling_reply():
+    session = _mock_session('{"name": "Ada", "age": 36}')
+    token = set_sampling_session(session)
+    try:
+        adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=256)
+        result = await adapter.acreate_structured_output(
+            text_input="Ada Lovelace, 36",
+            system_prompt="Extract the person.",
+            response_model=_Person,
+        )
+    finally:
+        reset_sampling_session(token)
+
+    assert isinstance(result, _Person)
+    assert result.name == "Ada" and result.age == 36
+    # The JSON Schema must have been embedded in the system prompt sent to the host.
+    kwargs = session.create_message.call_args.kwargs
+    assert "JSON Schema" in kwargs["system_prompt"]
+    assert kwargs["max_tokens"] == 256
+
+
+@pytest.mark.asyncio
+async def test_markdown_fenced_reply_is_parsed():
+    session = _mock_session('```json\n{"name": "Grace", "age": 45}\n```')
+    token = set_sampling_session(session)
+    try:
+        adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=128)
+        result = await adapter.acreate_structured_output(
+            text_input="Grace Hopper, 45", system_prompt="Extract.", response_model=_Person
+        )
+    finally:
+        reset_sampling_session(token)
+
+    assert result.name == "Grace" and result.age == 45
+
+
+@pytest.mark.asyncio
+async def test_invalid_reply_triggers_repair_retry():
+    session = _mock_session("not json at all", '{"name": "Alan", "age": 41}')
+    token = set_sampling_session(session)
+    try:
+        adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=128)
+        result = await adapter.acreate_structured_output(
+            text_input="Alan Turing, 41", system_prompt="Extract.", response_model=_Person
+        )
+    finally:
+        reset_sampling_session(token)
+
+    assert result.name == "Alan" and result.age == 41
+    assert session.create_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_str_response_model_passes_text_through():
+    session = _mock_session("just some prose")
+    token = set_sampling_session(session)
+    try:
+        adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=64)
+        result = await adapter.acreate_structured_output(
+            text_input="say something", system_prompt="You are terse.", response_model=str
+        )
+    finally:
+        reset_sampling_session(token)
+
+    assert result == "just some prose"
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_retries_exhausted():
+    session = _mock_session("nope", "still nope")
+    token = set_sampling_session(session)
+    try:
+        adapter = McpSamplingAdapter(
+            model="host-default", max_completion_tokens=64, structured_output_retries=2
+        )
+        with pytest.raises(ValueError, match="could not produce structured output"):
+            await adapter.acreate_structured_output(
+                text_input="x", system_prompt="Extract.", response_model=_Person
+            )
+    finally:
+        reset_sampling_session(token)
+
+    assert session.create_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_raises_when_no_session_available():
+    # No session bound and not running inside an MCP server.
+    adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=64)
+    with pytest.raises(MCPSamplingUnavailableError):
+        await adapter.acreate_structured_output(
+            text_input="x", system_prompt="Extract.", response_model=_Person
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_transcript_returns_none():
+    adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=64)
+    assert await adapter.create_transcript("audio.wav") is None
+
+
+@pytest.mark.asyncio
+async def test_transcribe_image_not_supported():
+    adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=64)
+    with pytest.raises(NotImplementedError):
+        await adapter.transcribe_image("image.png")

--- a/cognee/tests/unit/infrastructure/llm/test_mcp_sampling_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_mcp_sampling_adapter.py
@@ -103,6 +103,9 @@ async def test_invalid_reply_triggers_repair_retry(monkeypatch):
 
     assert result.name == "Alan" and result.age == 41
     assert session.create_message.await_count == 2
+    # The retry must carry the repair feedback, not just resend the original prompt.
+    retry_kwargs = session.create_message.call_args_list[1].kwargs
+    assert "did not validate" in retry_kwargs["system_prompt"]
 
 
 @pytest.mark.asyncio
@@ -210,10 +213,14 @@ def test_factory_builds_mcp_sampling_adapter_without_api_key():
         llm_provider="mcp-sampling", llm_model="host-default", llm_api_key=None, llm_endpoint=""
     )
     token = llm_config_ctx.set(config)
+    # Keep the process-global adapter LRU cache hermetic, like the sibling
+    # factory tests (test_llm_global_cache, test_stage_routing).
+    _get_llm_client_cached.cache_clear()
     try:
         client = _get_llm_client_cached(_build_llm_client_cache_key(config, 256))
     finally:
         llm_config_ctx.reset(token)
+        _get_llm_client_cached.cache_clear()
 
     assert isinstance(client, MCPSamplingAdapter)
     assert client.model == "host-default"
@@ -237,6 +244,7 @@ class _CapabilitySession:
         self._granted = granted
         self._reply = reply
         self.create_message_calls = 0
+        self.last_create_message_kwargs: dict = {}
 
     def check_client_capability(self, capability) -> bool:
         return self._granted
@@ -245,6 +253,7 @@ class _CapabilitySession:
         from mcp.types import CreateMessageResult, TextContent
 
         self.create_message_calls += 1
+        self.last_create_message_kwargs = kwargs
         return CreateMessageResult(
             role="assistant",
             content=TextContent(type="text", text=self._reply),
@@ -305,8 +314,10 @@ async def test_auto_session_used_when_sampling_granted():
     # CreateMessageResult parsed into the response model.
     pytest.importorskip("mcp")
     from mcp.server.lowlevel.server import request_ctx
+    from mcp.types import SamplingMessage
 
-    token = _request_ctx_token(_CapabilitySession(granted=True))
+    session = _CapabilitySession(granted=True)
+    token = _request_ctx_token(session)
     try:
         adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=128)
         result = await adapter.acreate_structured_output(
@@ -316,3 +327,8 @@ async def test_auto_session_used_when_sampling_granted():
         request_ctx.reset(token)
 
     assert result.name == "Ada" and result.age == 36
+    # Messages must be typed SamplingMessage objects: the real SDK validates them
+    # before pydantic coercion (SEP-1577), so plain dicts crash create_message.
+    messages = session.last_create_message_kwargs["messages"]
+    assert isinstance(messages[0], SamplingMessage)
+    assert messages[0].content.text == "Ada Lovelace, 36"

--- a/cognee/tests/unit/infrastructure/llm/test_mcp_sampling_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_mcp_sampling_adapter.py
@@ -1,15 +1,21 @@
 """Tests for the MCP-sampling LLM backend (issue #3644).
 
 The adapter delegates completions to a host MCP session via
-``sampling/createMessage``. These tests use a mock session (no real MCP host and
-no LLM_API_KEY) to pin the behaviour that matters:
+``sampling/createMessage``. Core behaviour is pinned with a mock session (no real
+MCP host, no LLM_API_KEY): the mock is injected by patching
+``get_sampling_session`` where the adapter calls it, so these tests run without
+``mcp`` installed.
 
 * structured output is produced from free-text replies by embedding the JSON
   Schema and validating the reply;
 * a malformed reply triggers a repair retry rather than failing outright;
 * ``str`` response models pass the text through untouched;
-* when no host session is bound, the adapter raises
+* the factory builds the adapter with no API key;
+* when no host session is available, the adapter raises
   ``MCPSamplingUnavailableError`` instead of silently doing nothing.
+
+The capability-gating tests additionally exercise the automatic per-request
+resolution against the real MCP SDK, and skip when ``mcp`` is not installed.
 """
 
 from types import SimpleNamespace
@@ -20,9 +26,13 @@ from pydantic import BaseModel
 
 from cognee.infrastructure.llm.exceptions import MCPSamplingUnavailableError
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mcp_sampling import (
-    McpSamplingAdapter,
-    reset_sampling_session,
-    set_sampling_session,
+    adapter as adapter_module,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mcp_sampling.adapter import (
+    MCPSamplingAdapter,
+)
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.mcp_sampling.session_context import (
+    get_sampling_session,
 )
 
 
@@ -32,7 +42,7 @@ class _Person(BaseModel):
 
 
 def _reply(text: str) -> SimpleNamespace:
-    """Mimic an MCP ``CreateMessageResult`` (``.content.text``)."""
+    """Mimic an MCP ``CreateMessageResult`` (single ``content`` block)."""
     return SimpleNamespace(content=SimpleNamespace(type="text", text=text))
 
 
@@ -43,19 +53,22 @@ def _mock_session(*replies: str) -> AsyncMock:
     return session
 
 
+def _bind(monkeypatch, session) -> None:
+    """Make the adapter see ``session`` (or ``None``) as the active host session."""
+    monkeypatch.setattr(adapter_module, "get_sampling_session", lambda: session)
+
+
 @pytest.mark.asyncio
-async def test_structured_output_from_sampling_reply():
+async def test_structured_output_from_sampling_reply(monkeypatch):
     session = _mock_session('{"name": "Ada", "age": 36}')
-    token = set_sampling_session(session)
-    try:
-        adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=256)
-        result = await adapter.acreate_structured_output(
-            text_input="Ada Lovelace, 36",
-            system_prompt="Extract the person.",
-            response_model=_Person,
-        )
-    finally:
-        reset_sampling_session(token)
+    _bind(monkeypatch, session)
+
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=256)
+    result = await adapter.acreate_structured_output(
+        text_input="Ada Lovelace, 36",
+        system_prompt="Extract the person.",
+        response_model=_Person,
+    )
 
     assert isinstance(result, _Person)
     assert result.name == "Ada" and result.age == 36
@@ -66,73 +79,97 @@ async def test_structured_output_from_sampling_reply():
 
 
 @pytest.mark.asyncio
-async def test_markdown_fenced_reply_is_parsed():
+async def test_markdown_fenced_reply_is_parsed(monkeypatch):
     session = _mock_session('```json\n{"name": "Grace", "age": 45}\n```')
-    token = set_sampling_session(session)
-    try:
-        adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=128)
-        result = await adapter.acreate_structured_output(
-            text_input="Grace Hopper, 45", system_prompt="Extract.", response_model=_Person
-        )
-    finally:
-        reset_sampling_session(token)
+    _bind(monkeypatch, session)
+
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=128)
+    result = await adapter.acreate_structured_output(
+        text_input="Grace Hopper, 45", system_prompt="Extract.", response_model=_Person
+    )
 
     assert result.name == "Grace" and result.age == 45
 
 
 @pytest.mark.asyncio
-async def test_invalid_reply_triggers_repair_retry():
+async def test_invalid_reply_triggers_repair_retry(monkeypatch):
     session = _mock_session("not json at all", '{"name": "Alan", "age": 41}')
-    token = set_sampling_session(session)
-    try:
-        adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=128)
-        result = await adapter.acreate_structured_output(
-            text_input="Alan Turing, 41", system_prompt="Extract.", response_model=_Person
-        )
-    finally:
-        reset_sampling_session(token)
+    _bind(monkeypatch, session)
+
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=128)
+    result = await adapter.acreate_structured_output(
+        text_input="Alan Turing, 41", system_prompt="Extract.", response_model=_Person
+    )
 
     assert result.name == "Alan" and result.age == 41
     assert session.create_message.await_count == 2
 
 
 @pytest.mark.asyncio
-async def test_str_response_model_passes_text_through():
+async def test_str_response_model_passes_text_through(monkeypatch):
     session = _mock_session("just some prose")
-    token = set_sampling_session(session)
-    try:
-        adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=64)
-        result = await adapter.acreate_structured_output(
-            text_input="say something", system_prompt="You are terse.", response_model=str
-        )
-    finally:
-        reset_sampling_session(token)
+    _bind(monkeypatch, session)
+
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=64)
+    result = await adapter.acreate_structured_output(
+        text_input="say something", system_prompt="You are terse.", response_model=str
+    )
 
     assert result == "just some prose"
 
 
 @pytest.mark.asyncio
-async def test_gives_up_after_retries_exhausted():
+async def test_extra_kwargs_are_accepted(monkeypatch):
+    # Interface parity: callers (e.g. the /v1/llm routes) forward extra params.
+    session = _mock_session('{"name": "Edsger", "age": 72}')
+    _bind(monkeypatch, session)
+
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=64)
+    result = await adapter.acreate_structured_output(
+        text_input="Edsger Dijkstra, 72",
+        system_prompt="Extract.",
+        response_model=_Person,
+        temperature=0.2,
+        top_p=0.9,
+    )
+
+    assert result.name == "Edsger" and result.age == 72
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_retries_exhausted(monkeypatch):
     session = _mock_session("nope", "still nope")
-    token = set_sampling_session(session)
-    try:
-        adapter = McpSamplingAdapter(
-            model="host-default", max_completion_tokens=64, structured_output_retries=2
+    _bind(monkeypatch, session)
+
+    adapter = MCPSamplingAdapter(
+        model="host-default", max_completion_tokens=64, structured_output_retries=2
+    )
+    with pytest.raises(ValueError, match="could not produce structured output"):
+        await adapter.acreate_structured_output(
+            text_input="x", system_prompt="Extract.", response_model=_Person
         )
-        with pytest.raises(ValueError, match="could not produce structured output"):
-            await adapter.acreate_structured_output(
-                text_input="x", system_prompt="Extract.", response_model=_Person
-            )
-    finally:
-        reset_sampling_session(token)
 
     assert session.create_message.await_count == 2
 
 
 @pytest.mark.asyncio
-async def test_raises_when_no_session_available():
-    # No session bound and not running inside an MCP server.
-    adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=64)
+async def test_unsupported_response_model_raises_type_error(monkeypatch):
+    session = _mock_session("{}")
+    _bind(monkeypatch, session)
+
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=64)
+    with pytest.raises(TypeError):
+        await adapter.acreate_structured_output(
+            text_input="x", system_prompt="Extract.", response_model=dict
+        )
+    session.create_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raises_when_no_session_available(monkeypatch):
+    _bind(monkeypatch, None)
+
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=64)
     with pytest.raises(MCPSamplingUnavailableError):
         await adapter.acreate_structured_output(
             text_input="x", system_prompt="Extract.", response_model=_Person
@@ -141,12 +178,141 @@ async def test_raises_when_no_session_available():
 
 @pytest.mark.asyncio
 async def test_create_transcript_returns_none():
-    adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=64)
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=64)
     assert await adapter.create_transcript("audio.wav") is None
 
 
 @pytest.mark.asyncio
 async def test_transcribe_image_not_supported():
-    adapter = McpSamplingAdapter(model="host-default", max_completion_tokens=64)
+    adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=64)
     with pytest.raises(NotImplementedError):
         await adapter.transcribe_image("image.png")
+
+
+def test_factory_builds_mcp_sampling_adapter_without_api_key():
+    # The headline promise of #3644: this provider needs no LLM_API_KEY.
+    from cognee.context_global_variables import llm_config as llm_config_ctx
+    from cognee.infrastructure.llm.config import LLMConfig
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.get_llm_client import (
+        _API_KEY_REQUIRED_PROVIDERS,
+        LLMProvider,
+        _build_llm_client_cache_key,
+        _get_llm_client_cached,
+        _raise_for_missing_api_key,
+    )
+
+    assert LLMProvider("mcp-sampling") is LLMProvider.MCP_SAMPLING
+    assert LLMProvider.MCP_SAMPLING not in _API_KEY_REQUIRED_PROVIDERS
+    # Must not raise even with no key.
+    _raise_for_missing_api_key(LLMProvider.MCP_SAMPLING, None, raise_api_key_error=True)
+
+    config = LLMConfig(
+        llm_provider="mcp-sampling", llm_model="host-default", llm_api_key=None, llm_endpoint=""
+    )
+    token = llm_config_ctx.set(config)
+    try:
+        client = _get_llm_client_cached(_build_llm_client_cache_key(config, 256))
+    finally:
+        llm_config_ctx.reset(token)
+
+    assert isinstance(client, MCPSamplingAdapter)
+    assert client.model == "host-default"
+    assert client.max_completion_tokens == 256
+
+
+def _request_ctx_token(session):
+    """Bind ``session`` on the MCP SDK's per-request context; returns a reset token."""
+    from mcp.server.lowlevel.server import request_ctx
+    from mcp.shared.context import RequestContext
+
+    return request_ctx.set(
+        RequestContext(request_id="test", meta=None, session=session, lifespan_context=None)
+    )
+
+
+class _CapabilitySession:
+    """Stand-in host session that grants or denies sampling like a real one."""
+
+    def __init__(self, granted: bool, reply: str = '{"name": "Ada", "age": 36}') -> None:
+        self._granted = granted
+        self._reply = reply
+        self.create_message_calls = 0
+
+    def check_client_capability(self, capability) -> bool:
+        return self._granted
+
+    async def create_message(self, **kwargs):
+        from mcp.types import CreateMessageResult, TextContent
+
+        self.create_message_calls += 1
+        return CreateMessageResult(
+            role="assistant",
+            content=TextContent(type="text", text=self._reply),
+            model="host",
+        )
+
+
+def test_auto_session_requires_granted_sampling_capability():
+    # A per-request session whose client did NOT grant sampling is treated as
+    # unavailable, so the adapter can raise a clear error rather than let the SDK
+    # emit a raw protocol error.
+    pytest.importorskip("mcp")
+    from mcp.server.lowlevel.server import request_ctx
+
+    token = _request_ctx_token(_CapabilitySession(granted=False))
+    try:
+        assert get_sampling_session() is None
+    finally:
+        request_ctx.reset(token)
+
+
+def test_session_without_capability_method_is_used():
+    # A stand-in session that lacks check_client_capability is assumed usable.
+    pytest.importorskip("mcp")
+    from mcp.server.lowlevel.server import request_ctx
+
+    session = SimpleNamespace()  # no check_client_capability
+    token = _request_ctx_token(session)
+    try:
+        assert get_sampling_session() is session
+    finally:
+        request_ctx.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_ungranted_capability_raises_clear_error():
+    pytest.importorskip("mcp")
+    from mcp.server.lowlevel.server import request_ctx
+
+    session = _CapabilitySession(granted=False)
+    token = _request_ctx_token(session)
+    try:
+        adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=64)
+        with pytest.raises(MCPSamplingUnavailableError):
+            await adapter.acreate_structured_output(
+                text_input="x", system_prompt="Extract.", response_model=_Person
+            )
+    finally:
+        request_ctx.reset(token)
+
+    # The clear error must fire before any sampling/createMessage is issued.
+    assert session.create_message_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_session_used_when_sampling_granted():
+    # Full automatic path against real SDK types: granted capability + a real
+    # CreateMessageResult parsed into the response model.
+    pytest.importorskip("mcp")
+    from mcp.server.lowlevel.server import request_ctx
+
+    token = _request_ctx_token(_CapabilitySession(granted=True))
+    try:
+        adapter = MCPSamplingAdapter(model="host-default", max_completion_tokens=128)
+        result = await adapter.acreate_structured_output(
+            text_input="Ada Lovelace, 36", system_prompt="Extract.", response_model=_Person
+        )
+    finally:
+        request_ctx.reset(token)
+
+    assert result.name == "Ada" and result.age == 36


### PR DESCRIPTION
## Description

`cognee-mcp` runs inside a host (Claude Code, Cursor, …) that already has a working LLM connection, yet today it still needs its own `LLM_API_KEY` — duplicate keys, duplicate billing, extra setup. MCP's `sampling/createMessage` capability exists precisely so a server can borrow the host's model. This adds an optional `LLM_PROVIDER=mcp-sampling` backend that does exactly that.

The design problem worth calling out: the LLM gateway is static and invoked many layers below the MCP request handler, so the host session can't be passed down as an argument. Rather than thread it through every pipeline task, `get_sampling_session()` reads it from the MCP SDK's own per-request context (`request_ctx`), which FastMCP already populates on every tool call. Because `asyncio.create_task` snapshots the context, the background cognify task launched inside a request inherits the session too — so no change to `cognee-mcp/server.py` is required.

MCP sampling returns free text (no native JSON-schema/tool mode), so structured output is produced by embedding the response model's JSON Schema in the prompt and running a bounded validate/repair loop; `str` response models pass through untouched.

Failure is fail-closed and explicit: if cognee is not running as an MCP server, or the client did not grant the `sampling` capability (checked via the SDK's `check_client_capability`), the adapter raises `MCPSamplingUnavailableError` with an actionable message instead of letting a raw protocol error surface.

Scope is deliberately narrow — completions only. Embeddings, audio, and vision have no sampling equivalent and are documented as such (configure an embedding provider for vector search).

Closes #3644. Linear: SDK-139.

## Acceptance Criteria

* `LLM_PROVIDER=mcp-sampling` selects the adapter with no `LLM_API_KEY` required (provider excluded from the API-key-required set).
* Structured output works over free-text sampling (schema-in-prompt + validate/repair).
* No host session, or an ungranted `sampling` capability, yields a clear `MCPSamplingUnavailableError` before any `sampling/createMessage` is issued.
* Non-MCP usage is unchanged; `mcp` remains an optional dependency (imported lazily, no hard dependency in cognee core).
* Tests: 15 unit tests — 11 run without `mcp` installed; 4 capability tests exercise the real MCP SDK and `importorskip("mcp")`. The whole `cognee/tests/unit/infrastructure/llm/` suite passes (36 passed), and `ruff check` / `ruff format --check` are clean.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots

Local run (no network, no `LLM_API_KEY`):

```
$ pytest cognee/tests/unit/infrastructure/llm/test_mcp_sampling_adapter.py -q
15 passed

$ pytest cognee/tests/unit/infrastructure/llm/ -q
36 passed

$ ruff check cognee/infrastructure/llm/ && ruff format --check cognee/infrastructure/llm/
All checks passed!
```

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## Live verification (added 2026-07-11)

Two rounds of empirical verification beyond the unit tests:

**Real-wire-protocol e2e** (genuine `mcp` 1.28.1 `ClientSession` ↔ server as a separate OS process over stdio, real JSON-RPC + capability negotiation): 19/19 assertions pass — granted path with wire-level param checks (message text, JSON Schema in systemPrompt, maxTokens), `str` passthrough, background-task sampling after the tool response returned (the backgrounded-cognify pattern), and the ungranted path (clean typed error, zero sampling requests sent). This test caught a real bug the mocked tests could not: `ServerSession.create_message` validates messages (SEP-1577) **before** pydantic coercion, so the original plain-dict message format crashed on mcp ≥ 1.25. Fixed by constructing typed `SamplingMessage`/`TextContent` (commit `fix(llm): send typed SamplingMessage over MCP sampling`).

**Live host probe against Claude Code 2.1.206** (headless, real MCP handshake, two runs): Claude Code currently negotiates `roots` + `elicitation` but **not** `sampling` (open feature request anthropics/claude-code#1785), so `check_client_capability` correctly reports it ungranted and the adapter raises the clear `MCPSamplingUnavailableError` — the designed graceful path, deterministic across runs, no raw protocol errors. Docs and the error message were made host-agnostic accordingly (`docs(llm): clarify MCP sampling host support`); the happy path is verified against the real protocol and will light up for Claude Code when it ships sampling support.

**Real-pipeline run (added 2026-07-16):** full `add → cognify → search` executed over real-wire MCP sampling with an actual Claude model answering as the host (via `claude -p`) and local fastembed embeddings — zero API keys anywhere. First-try success: 9 sampling calls (incl. the first-run connection test through sampling), knowledge graph exactly as expected (18 nodes / 28 edges), 3/3 strictly-graded factual answers, zero validation retries, zero errors. One observation worth noting: the host model fenced its very first JSON reply despite instructions, and the adapter's fence/prose extraction handled it silently — that path is load-bearing in practice, and it held. Claude Code re-probed at 2.1.211: still no `sampling` grant.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


