### PR TITLE
feat(ingestion): implement SaaS connector pattern and reference Notion integration

### DIFF
--- a/cognee/tasks/ingestion/connectors/__init__.py
+++ b/cognee/tasks/ingestion/connectors/__init__.py
@@ -1,0 +1,1 @@
+from .notion import notion

--- a/cognee/tasks/ingestion/connectors/notion.py
+++ b/cognee/tasks/ingestion/connectors/notion.py
@@ -1,0 +1,100 @@
+import os
+from typing import Optional
+import httpx
+
+try:
+    import dlt
+except ImportError:
+    dlt = None
+
+def notion(
+    api_key: Optional[str] = None,
+    database_id: Optional[str] = None,
+):
+    """Notion SaaS source connector built on Cognee DLT ingestion.
+    
+    Pulls pages from the Notion workspace, supporting incremental loading
+    based on page last_edited_time, and primary key mapping for merge deduplication.
+    """
+    if dlt is None:
+        raise ImportError(
+            "The 'dlt' package is required to use SaaS source connectors. "
+            "Please install it using 'pip install dlt'."
+        )
+    
+    api_key = api_key or os.getenv("NOTION_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "Notion API Key is required. Pass api_key or set the NOTION_API_KEY environment variable."
+        )
+
+    @dlt.source(name="notion")
+    def notion_source():
+        @dlt.resource(
+            name="pages",
+            write_disposition="merge",
+            primary_key="id",
+        )
+        def fetch_pages(
+            last_edited_time = dlt.sources.incremental(
+                "last_edited_time",
+                initial_value="1970-01-01T00:00:00.000Z"
+            )
+        ):
+            headers = {
+                "Authorization": f"Bearer {api_key}",
+                "Notion-Version": "2022-06-28",
+                "Content-Type": "application/json",
+            }
+            
+            url = "https://api.notion.com/v1/search"
+            payload = {
+                "filter": {
+                    "value": "page",
+                    "property": "object"
+                },
+                "sort": {
+                    "direction": "ascending",
+                    "timestamp": "last_edited_time"
+                }
+            }
+            
+            start_cursor = None
+            
+            while True:
+                if start_cursor:
+                    payload["start_cursor"] = start_cursor
+                
+                response = httpx.post(url, headers=headers, json=payload)
+                response.raise_for_status()
+                data = response.json()
+                
+                for result in data.get("results", []):
+                    # Extract the text content from the page properties for indexing
+                    title = ""
+                    properties = result.get("properties", {})
+                    for prop_name, prop_val in properties.items():
+                        if prop_val.get("type") == "title":
+                            title_parts = prop_val.get("title", [])
+                            title = "".join(part.get("plain_text", "") for part in title_parts)
+                            break
+                    
+                    page_id = result.get("id")
+                    last_edited = result.get("last_edited_time")
+                    
+                    # Yield structured dictionary
+                    yield {
+                        "id": page_id,
+                        "title": title,
+                        "last_edited_time": last_edited,
+                        "url": result.get("url"),
+                        "raw_properties": properties,
+                    }
+                    
+                if not data.get("has_more"):
+                    break
+                start_cursor = data.get("next_cursor")
+                
+        return fetch_pages
+        
+    return notion_source()

--- a/cognee/tasks/ingestion/dlt_row_data.py
+++ b/cognee/tasks/ingestion/dlt_row_data.py
@@ -15,3 +15,4 @@ class DltRowData:
     foreign_keys: list
     dlt_db_name: str
     dataset_name: str
+    dlt_source_name: str = "dlt_source"

--- a/cognee/tasks/ingestion/ingest_dlt_source.py
+++ b/cognee/tasks/ingestion/ingest_dlt_source.py
@@ -142,6 +142,7 @@ async def ingest_dlt_source(
     default_max_rows = get_ingestion_config().dlt_max_rows_per_table
     effective_max_rows = max_rows_per_table if max_rows_per_table is not None else default_max_rows
     try:
+        dlt_source_name = getattr(dlt_source, "name", "dlt_source")
         row_data_list = await _read_rows_from_tables(
             dlt_db_name=dlt_db_name,
             dataset_name=dataset_name,
@@ -149,6 +150,7 @@ async def ingest_dlt_source(
             primary_key=primary_key,
             relational_config=relational_config,
             max_rows_per_table=effective_max_rows,
+            dlt_source_name=dlt_source_name,
         )
     except Exception as e:
         raise DLTIngestionError(
@@ -227,6 +229,7 @@ async def _read_rows_from_tables(
     primary_key: Optional[str],
     relational_config,
     max_rows_per_table: int = 50,
+    dlt_source_name: str = "dlt_source",
 ) -> List[DltRowData]:
     """Read rows from the dlt database tables and return DltRowData objects."""
     if relational_config.db_provider == "sqlite":
@@ -260,6 +263,7 @@ async def _read_rows_from_tables(
                         dlt_db_name=dlt_db_name,
                         relational_config=relational_config,
                         max_rows=max_rows_per_table,
+                        dlt_source_name=dlt_source_name,
                     )
                     row_data_list.extend(table_rows)
                 except Exception as e:
@@ -285,6 +289,7 @@ async def _read_single_table(
     dlt_db_name: str,
     relational_config,
     max_rows: int = 50,
+    dlt_source_name: str = "dlt_source",
 ) -> List[DltRowData]:
     """Read rows from a single table and return DltRowData objects.
 
@@ -367,6 +372,7 @@ async def _read_single_table(
                 foreign_keys=foreign_keys,
                 dlt_db_name=dlt_db_name,
                 dataset_name=dataset_name,
+                dlt_source_name=dlt_source_name,
             )
         )
 

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -159,6 +159,7 @@ async def resolve_dlt_sources(
             "fk_references": fk_references,
             "dlt_db_name": table_meta["dlt_db_name"],
             "content_hash": row.content_hash,
+            "dlt_source_name": row.dlt_source_name,
         }
 
         item = DataItem(
@@ -196,9 +197,10 @@ async def resolve_dlt_sources(
     orphan_cleanup: Optional[Callable[[], Any]] = None
     if write_disposition != "append":
         fresh_data_ids: Set[UUID] = set(row_id_lookup.values())
+        active_dlt_source_names = {getattr(item, "name", "dlt_source") for item in dlt_items}
 
         async def _cleanup() -> None:
-            await _delete_dlt_orphans(dataset_name, user, fresh_data_ids)
+            await _delete_dlt_orphans(dataset_name, user, fresh_data_ids, active_dlt_source_names)
 
         orphan_cleanup = _cleanup
 
@@ -316,6 +318,7 @@ async def _delete_dlt_orphans(
     dataset_name: str,
     user: User,
     fresh_data_ids: Set[UUID],
+    active_dlt_source_names: Set[str] = None,
 ) -> None:
     """Delete dlt-sourced Data records (and their graph/vector artifacts) that
     are no longer present in the freshly-ingested dlt source.
@@ -348,6 +351,9 @@ async def _delete_dlt_orphans(
         ext = data_item.external_metadata
         if not isinstance(ext, dict) or ext.get("source") != "dlt":
             continue
+        if active_dlt_source_names is not None:
+            if ext.get("dlt_source_name") not in active_dlt_source_names:
+                continue
         if data_item.id not in fresh_data_ids:
             orphans.append(data_item)
 

--- a/cognee/tests/unit/tasks/test_saas_connectors.py
+++ b/cognee/tests/unit/tasks/test_saas_connectors.py
@@ -1,0 +1,148 @@
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+from uuid import uuid4, UUID
+from types import SimpleNamespace
+
+import dlt
+from cognee.tasks.ingestion.connectors.notion import notion
+from cognee.tasks.ingestion.resolve_dlt_sources import resolve_dlt_sources, _delete_dlt_orphans
+from cognee.tasks.ingestion.dlt_row_data import DltRowData
+from cognee.modules.users.models import User
+
+@pytest.mark.asyncio
+async def test_notion_connector_fetching():
+    """Test that the notion connector successfully invokes search and parses results."""
+    mock_response_data = {
+        "results": [
+            {
+                "id": "page-1",
+                "object": "page",
+                "last_edited_time": "2026-07-09T10:00:00.000Z",
+                "url": "https://notion.so/page-1",
+                "properties": {
+                    "Name": {
+                        "type": "title",
+                        "title": [{"plain_text": "Notion Test Page"}]
+                    }
+                }
+            }
+        ],
+        "has_more": False,
+        "next_cursor": None
+    }
+    
+    # Mock httpx.post inside connectors.notion
+    with patch("httpx.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_response_data
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+        
+        # Instantiate notion source
+        source = notion(api_key="fake_key")
+        # Extract the page resource function
+        fetch_pages_resource = source.resources["pages"]
+        
+        # Collect yielded pages by calling the underlying wrapped function directly
+        pages = list(fetch_pages_resource.__wrapped__())
+        
+        assert len(pages) == 1
+        assert pages[0]["id"] == "page-1"
+        assert pages[0]["title"] == "Notion Test Page"
+        assert pages[0]["last_edited_time"] == "2026-07-09T10:00:00.000Z"
+        assert pages[0]["url"] == "https://notion.so/page-1"
+        
+        # Verify httpx.post was called with correct headers & url
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://api.notion.com/v1/search"
+        assert kwargs["headers"]["Authorization"] == "Bearer fake_key"
+
+@pytest.mark.asyncio
+async def test_resolve_dlt_sources_enrichment():
+    """Test that resolve_dlt_sources correctly injects the dlt_source_name into external_metadata."""
+    # Create mock rows returned by DLT ingestion
+    mock_row = DltRowData(
+        table_name="pages",
+        primary_key_column="id",
+        primary_key_value="p-100",
+        row_data={"title": "Test Row"},
+        content_hash="hash123",
+        schema_info=[],
+        schema_hash="shash",
+        foreign_keys=[],
+        dlt_db_name="dlt_db",
+        dataset_name="test_ds",
+        dlt_source_name="notion" # Custom field populated by ingestion
+    )
+    
+    # We mock ingest_dlt_source and get_unique_data_id to bypass actual database connection and return mock_row
+    with patch("cognee.tasks.ingestion.resolve_dlt_sources.ingest_dlt_source", new_callable=AsyncMock) as mock_ingest, \
+         patch("cognee.tasks.ingestion.resolve_dlt_sources.get_unique_data_id", new_callable=AsyncMock) as mock_get_id:
+        mock_ingest.return_value = [mock_row]
+        mock_get_id.return_value = uuid4()
+        
+        @dlt.source(name="notion")
+        def mock_source():
+            @dlt.resource(name="pages")
+            def get_pages():
+                yield {"id": "p-100", "title": "Test Row"}
+            return get_pages
+            
+        mock_user = User(id=uuid4(), email="test@example.com")
+        
+        # Run resolve_dlt_sources
+        result, cleanup_hook = await resolve_dlt_sources(
+            data=mock_source(),
+            dataset_name="test_ds",
+            user=mock_user,
+            write_disposition="merge"
+        )
+        
+        assert len(result) == 1
+        data_item = result[0]
+        assert data_item.external_metadata["dlt_source_name"] == "notion"
+        assert data_item.external_metadata["source"] == "dlt"
+
+@pytest.mark.asyncio
+async def test_orphan_cleanup_source_isolation():
+    """Test that orphan cleanup of one DLT source does not delete rows from another source."""
+    mock_user = User(id=uuid4(), email="test@example.com")
+    
+    # Mock datasets matching dataset_name
+    mock_dataset = SimpleNamespace(id=uuid4())
+    
+    # Mock data items in the dataset
+    notion_item = SimpleNamespace(
+        id=uuid4(),
+        external_metadata={"source": "dlt", "dlt_source_name": "notion"}
+    )
+    drive_item = SimpleNamespace(
+        id=uuid4(),
+        external_metadata={"source": "dlt", "dlt_source_name": "google_drive"}
+    )
+    
+    with patch("cognee.modules.data.methods.get_authorized_existing_datasets", new_callable=AsyncMock) as mock_get_ds, \
+         patch("cognee.modules.data.methods.get_dataset_data.get_dataset_data", new_callable=AsyncMock) as mock_get_data, \
+         patch("cognee.modules.data.methods.delete_data.delete_data", new_callable=AsyncMock) as mock_delete, \
+         patch("cognee.modules.graph.methods.has_data_related_nodes.has_data_related_nodes", new_callable=AsyncMock) as mock_has_nodes:
+         
+        mock_get_ds.return_value = [mock_dataset]
+        mock_get_data.return_value = [notion_item, drive_item]
+        mock_has_nodes.return_value = False
+        
+        # Simulate Notion sync run: fresh_data_ids doesn't contain notion_item (meaning it is orphaned),
+        # but the active source set is {"notion"}.
+        active_sources = {"notion"}
+        fresh_ids = {drive_item.id} # drive_item is "fresh", notion_item is missing
+        
+        await _delete_dlt_orphans(
+            dataset_name="test_ds",
+            user=mock_user,
+            fresh_data_ids=fresh_ids,
+            active_dlt_source_names=active_sources
+        )
+        
+        # delete_data should be called for notion_item (since it belongs to the active source "notion" and is missing)
+        # but NOT for drive_item (which belongs to a different source and wasn't in active_dlt_source_names)
+        mock_delete.assert_called_once_with(notion_item, mock_dataset.id)

--- a/examples/demos/notion_connector_example.py
+++ b/examples/demos/notion_connector_example.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+import cognee
+from cognee.tasks.ingestion.connectors import notion
+
+async def main():
+    # 1. Reset cognee state to start clean
+    print("Resetting cognee data...")
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    print("Reset complete.\n")
+
+    # 2. Retrieve Notion API Key from environment
+    api_key = os.getenv("NOTION_API_KEY")
+    if not api_key:
+        print("=" * 60)
+        print("Warning: NOTION_API_KEY environment variable is not set.")
+        print("To run this example with a live Notion account, please set it:")
+        print("export NOTION_API_KEY='your-notion-integration-token'")
+        print("=" * 60)
+        print("Exiting example gracefully.")
+        return
+
+    print("Initializing Notion connector and ingesting workspace pages...")
+    
+    # 3. Trigger Cognee ingestion using the Notion connector
+    # Behind the scenes, resolve_dlt_sources will detect the Notion DLT source,
+    # run the ingestion pipeline, and map pages to DataItems.
+    try:
+        remember_result = await cognee.remember(
+            notion(api_key=api_key),
+            dataset_name="notion_workspace_dataset"
+        )
+        print("\nIngestion completed successfully!")
+        print(remember_result)
+    except Exception as e:
+        print(f"Error during Notion ingestion: {e}")
+        return
+
+    # 4. Search within the ingested memory
+    query = "What projects or tasks are mentioned in the Notion pages?"
+    print(f"\nRecalling memory with query: '{query}'")
+    
+    search_results = await cognee.recall(query)
+    print("\nSearch results:")
+    for idx, result in enumerate(search_results):
+        print(f"{idx + 1}. {result}")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
# feat(ingestion): implement SaaS connector pattern and reference Notion integration

Closes #3616

##  Summary of Changes
This PR implements the core SaaS connector pattern by extending Cognee's native DLT (Data Load Tool) pipeline, providing a clean framework that all future connectors (Confluence, Google Drive, Gmail, Slack export) can inherit.

### Core Architecture Updates:
1. **Isolated Orphan Deletion & Namespace Protection**:
   * Updated `DltRowData` dataclass and the ingestion pipeline under `ingest_dlt_source.py` to capture the active `dlt_source_name` during run.
   * Modified `resolve_dlt_sources.py` to store `"dlt_source_name"` inside the resolved data points' `external_metadata`.
   * Refined `_delete_dlt_orphans` so that orphan deletion is scoped **only** to the active source names synced in the current run. This guarantees that running a Notion sync does not delete records previously synced from Google Drive or other DLT sources.
2. **Reference Notion Connector**:
   * Created a new package under `cognee/tasks/ingestion/connectors/notion.py` that queries pages via the Notion `/v1/search` endpoint.
   * Configured it to support DLT's native incremental loading (via the `last_edited_time` cursor) and merge disposition (with `id` as the primary key).
   * Ensures that `dlt` remains a lazy and optional dependency—throwing a clean `ImportError` only if a user attempts to call a connector without DLT installed.
3. **Verification & Tests**:
   * Created a comprehensive mocked test suite under `cognee/tests/unit/tasks/test_saas_connectors.py` verifying initial fetch structure, DLT source name resolution, and isolated orphan cleanup.
   * Created a runnable example under `examples/demos/notion_connector_example.py`.

---

## Requirement Compliance Checklist

| Required Feature | Status | Implementation Details |
| :--- | :---: | :--- |
| **Extend existing DLT pipeline** | ✅ | Reuses the existing `resolve_dlt_sources.py` and `ingest_dlt_source.py` pathways directly without creating parallel pipelines. |
| **Keep DLT optional/lazy** | ✅ | Imports `dlt` dynamically inside `connectors/notion.py` and raises a clean, descriptive `ImportError` if it is not installed, preventing import errors on standard startup. |
| **Incremental loading** | ✅ | Uses DLT's native `incremental` parameter on `last_edited_time` with `write_disposition="merge"` inside the Notion connector. |
| **Forget-on-deletion (forget)** | ✅ | Integrated into the `_delete_dlt_orphans` callback. Added source name namespace checking to ensure one connector's sync run doesn't wipe out records from other connectors. |
| **Easy Cognee UX** | ✅ | Ingestion can be triggered in a single call by passing the connector output straight to `cognee.remember(notion(api_key="..."))`. |
| **Example code under `examples/`** | ✅ | Created [notion_connector_example.py](file:///Users/naitikrishu/Desktop/cognee/examples/demos/notion_connector_example.py) showing full setup, authentication warnings, remember execution, and query retrieval. |
| **Unit Test Coverage** | ✅ | Added [test_saas_connectors.py](file:///Users/naitikrishu/Desktop/cognee/cognee/tests/unit/tasks/test_saas_connectors.py) testing API mocking, metadata enrichment, and source isolation for cleanup. |

---

## Verification Screenshots

### Notion Ingestion Example Execution
*Demonstrates running the script which gracefully prompts users to export `NOTION_API_KEY` when credentials are not configured.*
<img width="1470" height="629" alt="Screenshot 2026-07-09 at 4 38 23 PM" src="https://github.com/user-attachments/assets/387a3043-99f8-48ee-812c-b586c84a54da" />

### SaaS Connector Test Results
*Demonstrates all unit and integration tests passing successfully in a clean virtual environment.*
<img width="1470" height="479" alt="Screenshot 2026-07-09 at 4 39 12 PM" src="https://github.com/user-attachments/assets/c2a84bdd-d2d0-4f86-9638-a1fcb1f06d43" />

### Directory Structure via Find
*Shows the standard file organization of the connectors package.*
<img width="1094" height="124" alt="Screenshot 2026-07-09 at 4 39 56 PM" src="https://github.com/user-attachments/assets/1a5202eb-8b9c-49fd-9d29-75b558ac5aa9" />