### PR TITLE
test(perf): DLT ingestion benchmark + profiling harness (#3626)

### DIFF
--- a/cognee/tests/performance/README_dlt_ingestion_benchmark.md
+++ b/cognee/tests/performance/README_dlt_ingestion_benchmark.md
@@ -1,0 +1,69 @@
+# DLT ingestion benchmark & profiling harness (#3626)
+
+Phase-0 deliverable for *"Make DLT ingestion more scalable and faster"*: a
+reproducible benchmark that measures **where time and memory actually go** in
+cognee's DLT ingestion path, so optimization targets are chosen from data, not
+guesses.
+
+## What it profiles
+
+The DLT path never needs an LLM — structured rows bypass entity extraction — so
+the harness drives the real ingestion functions directly (no `cognee.add`, no
+vector/graph/LLM init) and runs **with no API key**:
+
+```
+resolve_dlt_sources
+  ├─ ingest_dlt_source
+  │    ├─ dlt pipeline.run (extract+normalize+load)   -> stage: dlt_ingest_total
+  │    ├─ _extract_dlt_schema                          -> stage: schema_extract
+  │    └─ _read_rows_from_tables (materializes rows)   -> stage: row_readback
+  ├─ Phase 1: get_unique_data_id per row              -> stage: resolve/id_resolve
+  └─ Phase 2: build DataItems (schema text + FK)
+ingest_data (add-pipeline storage task)
+  ├─ identify -> get_unique_data_id AGAIN per row     -> stage: ingest_data/id_resolve
+  │              (result discarded; DataItem.data_id already set)
+  └─ BinaryData.get_metadata (~3x/row, thread each)   -> stage: metadata_threads
+orphan_cleanup (re-ingest only)
+  └─ get_dataset_data loads the WHOLE dataset          -> stage: orphan_cleanup
+```
+
+Each run does a **first ingest** and a **re-ingest with the tail 20% dropped**
+(`write_disposition="replace"`), so orphan-cleanup and incremental re-sync are
+measured, not skipped.
+
+## Running
+
+```bash
+# single size: full per-stage breakdown for first-ingest + re-ingest
+python -m cognee.tests.performance.benchmark_dlt_ingestion_profile 2000
+
+# scan several sizes (sequential, in one process) and write results JSON
+python -m cognee.tests.performance.benchmark_dlt_ingestion_profile --sizes 200,500,900
+
+# add a cProfile cumulative-time attribution pass
+python -m cognee.tests.performance.benchmark_dlt_ingestion_profile 1000 --cprofile
+```
+
+`--sizes` writes `results/dlt_ingestion_baseline.json` (committed baseline). Every
+optimization PR should re-run the same sizes and report before/after numbers.
+
+## Isolation notes
+
+- **State root**: the harness points `DATA_ROOT_DIRECTORY`, `SYSTEM_ROOT_DIRECTORY`,
+  and `DLT_DATA_DIR` at a per-process temp dir and uses a fresh `DB_NAME`, so runs
+  are hermetic and don't pollute the repo's `.cognee_system`.
+- **`--sizes` runs sequentially in one process** (each size gets a unique dataset
+  name). It is deliberately *not* a subprocess fan-out: on Windows, spawning the
+  benchmark as a child while dlt parallelizes normalize/load re-imports `__main__`
+  and deadlocks.
+- **dlt working dir is global — a real finding**: cognee hardcodes
+  `pipeline_name="ingest_dlt_source"`, whose dlt state lives in a global dir
+  (`~/.dlt/pipelines/ingest_dlt_source`). Two *concurrent* cognee DLT ingests share
+  it and collide (`SchemaNotFoundError`). See the findings report, hotspot #7.
+
+## Files
+
+- `benchmark_dlt_ingestion_profile.py` — this harness (fine-grained stages + orphan cleanup + JSON).
+- `benchmark_dlt_ingestion.py` — the earlier coarse harness (resolve/ingest totals only), kept for reference.
+- `results/dlt_ingestion_baseline.json` — committed baseline numbers.
+- `results/dlt_ingestion_findings.md` — where-time-goes analysis + prioritized optimization targets.

--- a/cognee/tests/performance/benchmark_dlt_ingestion.py
+++ b/cognee/tests/performance/benchmark_dlt_ingestion.py
@@ -1,0 +1,135 @@
+"""Phase 0 benchmark + profiling harness for DLT ingestion (#3626).
+
+Profiles the two pure DLT ingestion functions directly, with **no LLM key** and
+without touching the vector/graph engines (so nothing calls an embedding/LLM API):
+
+  * ``resolve_dlt_sources``  -> dlt load + schema extract + row read-back +
+                               id resolution + DataItem build
+  * ``ingest_data``          -> the add path: per-row storage + classify + relational write
+
+(Calling ``cognee.add`` instead would trigger ``setup()``/vector init, which probes
+the embedding model and blocks on a real API call — irrelevant to ingestion perf.)
+
+Reports per stage: wall-clock, rows/sec, peak memory (tracemalloc), plus a cProfile
+attribution of cognee-side time to the real hotspots, and the default
+``max_rows_per_table`` cap effect.
+
+Run (no API key needed):
+    python -m cognee.tests.performance.benchmark_dlt_ingestion
+    python -m cognee.tests.performance.benchmark_dlt_ingestion 200 1000 3000
+"""
+
+import os
+import asyncio
+import cProfile
+import io
+import pstats
+import sys
+import time
+import tracemalloc
+import uuid
+
+os.environ.setdefault("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+os.environ.setdefault("REQUIRE_AUTHENTICATION", "false")
+os.environ.setdefault("TELEMETRY_DISABLED", "1")
+os.environ.setdefault("LLM_API_KEY", "sk-noop-not-used")
+
+# Isolate each process with its own relational DB file so every run is a clean
+# first-ingest (cognee persists datasets; reusing one DB across runs collides on
+# the default dataset's identity in the session).
+os.environ["DB_NAME"] = "bench_" + os.urandom(4).hex()
+
+import dlt  # noqa: E402  (pip install cognee[dlt])
+import cognee  # noqa: E402,F401
+from cognee.tasks.ingestion.resolve_dlt_sources import resolve_dlt_sources  # noqa: E402
+from cognee.tasks.ingestion import ingest_data  # noqa: E402
+from cognee.modules.users.methods import get_default_user  # noqa: E402
+
+N_DEPTS = 10
+UNCAPPED = 10_000_000
+
+
+def make_resources(n_rows: int):
+    @dlt.resource(name="departments", primary_key="id")
+    def departments():
+        for i in range(N_DEPTS):
+            yield {"id": i, "name": f"dept_{i}", "budget": i * 1000}
+
+    @dlt.resource(name="users", primary_key="id")
+    def users():
+        for i in range(n_rows):
+            yield {
+                "id": i,
+                "name": f"user_{i}",
+                "email": f"user_{i}@example.com",
+                "dept_id": i % N_DEPTS,
+                "bio": f"Synthetic user {i} for DLT ingestion benchmarking.",
+            }
+
+    return [departments(), users()]
+
+
+async def run_once(user, n_rows: int, max_rows: int, label: str):
+    ds = f"bench_{label}_{uuid.uuid4().hex[:8]}"
+    resources = make_resources(n_rows)
+
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    expanded, _cleanup = await resolve_dlt_sources(
+        resources, dataset_name=ds, user=user,
+        primary_key="id", write_disposition="merge", max_rows_per_table=max_rows,
+    )
+    t_resolve = time.perf_counter() - t0
+
+    t1 = time.perf_counter()
+    await ingest_data(expanded, ds, user)
+    t_ingest = time.perf_counter() - t1
+
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return t_resolve, t_ingest, peak / 1e6, len(expanded)
+
+
+async def main(n_rows: int, max_rows: int, profile: bool):
+    # One run per process: cognee holds dataset instances in a session across
+    # calls, so multiple add-style runs in one process collide. Drive several
+    # sizes by invoking this module once per size.
+    # Create relational tables only (no setup()/vector init -> no embedding probe,
+    # so this runs with no LLM key). Fresh DB_NAME per process => clean state.
+    from cognee.infrastructure.databases.relational import get_relational_engine
+
+    rel = get_relational_engine()
+    os.makedirs(os.path.dirname(rel.db_path), exist_ok=True)
+    await rel.create_database()
+    user = await get_default_user()
+
+    if profile:
+        pr = cProfile.Profile()
+        pr.enable()
+        try:
+            tr, ti, peak, ing = await run_once(user, n_rows, max_rows, "prof")
+        finally:
+            pr.disable()
+        print(f"RESULT rows={ing} resolve={tr:.2f} ingest={ti:.2f} "
+              f"total={tr + ti:.2f} rps={ing / (tr + ti):.0f} peakMB={peak:.1f}")
+        s = io.StringIO()
+        pstats.Stats(pr, stream=s).sort_stats("cumulative").print_stats(25)
+        print("--- cProfile top 25 by cumulative time ---")
+        started = False
+        for line in s.getvalue().splitlines():
+            if "ncalls" in line:
+                started = True
+            if started and line.strip():
+                print(line.rstrip()[:160])
+        return
+
+    tr, ti, peak, ing = await run_once(user, n_rows, max_rows, f"r{n_rows}")
+    print(f"RESULT rows={ing} resolve={tr:.2f} ingest={ti:.2f} "
+          f"total={tr + ti:.2f} rps={ing / (tr + ti):.0f} peakMB={peak:.1f}")
+
+
+if __name__ == "__main__":
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 1000
+    mx = int(sys.argv[2]) if len(sys.argv) > 2 else UNCAPPED
+    prof = "profile" in sys.argv
+    asyncio.run(main(n, mx, prof))

--- a/cognee/tests/performance/benchmark_dlt_ingestion_profile.py
+++ b/cognee/tests/performance/benchmark_dlt_ingestion_profile.py
@@ -1,0 +1,468 @@
+"""Phase-0 benchmark + profiling harness for the DLT ingestion path (issue #3626).
+
+This is the "profile first" deliverable: a reproducible, no-LLM-key benchmark that
+measures **where time and memory actually go** in cognee's DLT ingestion path, with a
+per-stage breakdown finer than wall-clock resolve/ingest totals.
+
+It profiles the real ingestion functions directly (no ``cognee.add`` / no vector or
+LLM init), because the DLT path never needs an LLM — structured rows bypass extraction:
+
+    resolve_dlt_sources
+      ├─ ingest_dlt_source
+      │    ├─ dlt pipeline.run   (extract + normalize + load)   -> stage: dlt_run
+      │    ├─ _extract_dlt_schema                                -> stage: schema_extract
+      │    └─ _read_rows_from_tables (materializes all rows)     -> stage: row_readback
+      ├─ Phase 1: get_unique_data_id per row (1 DB session/row)  -> stage: phase1_id_resolve
+      └─ Phase 2: build DataItems (schema text + FK resolve)     -> stage: phase2_build
+    ingest_data (the add-pipeline storage task)
+      ├─ identify -> get_unique_data_id AGAIN per row (result    -> stage: ingest_redundant_id
+      │              discarded: DataItem.data_id already set)
+      ├─ save_data_item_to_storage / data_item_to_text_file      (per-row file I/O)
+      └─ BinaryData.get_metadata (~3x/row, each spawns a thread) -> stage: metadata_threads
+    orphan_cleanup (re-ingest only)
+      └─ get_dataset_data loads the WHOLE dataset into Python    -> stage: orphan_cleanup
+
+Each ``main()`` run does a **first ingest** and a **re-ingest with deletions**, so the
+orphan-cleanup path (a named concern in #3626) is measured, not skipped.
+
+Stage timings are collected by monkeypatching the target functions with thin timing
+wrappers and snapshotting per-stage deltas around the resolve / ingest / cleanup phases
+(so ``get_unique_data_id`` is attributed to *phase1* vs the *redundant ingest* call
+separately). No production code is modified.
+
+Isolation: the process points DATA_ROOT_DIRECTORY / SYSTEM_ROOT_DIRECTORY / DLT_DATA_DIR
+at a temp dir and uses a fresh DB_NAME, so runs are hermetic. ``--sizes`` runs the sizes
+*sequentially in one process* (each with a unique dataset name) — deliberately not a
+subprocess fan-out, because on Windows dlt's parallel normalize/load re-imports __main__
+in spawned children and deadlocks. Note cognee hardcodes
+``pipeline_name="ingest_dlt_source"`` whose dlt state dir is global, so two *concurrent*
+cognee DLT ingests would still collide — a finding, not something the harness relies on.
+
+Usage (no API key needed)::
+
+    # single size, full per-stage breakdown + both runs:
+    python -m cognee.tests.performance.benchmark_dlt_ingestion_profile 2000
+
+    # scan several sizes (spawns one isolated subprocess per size) + write JSON report:
+    python -m cognee.tests.performance.benchmark_dlt_ingestion_profile --sizes 500,2000,5000
+
+    # add a cProfile attribution pass on top of the stage timers:
+    python -m cognee.tests.performance.benchmark_dlt_ingestion_profile 2000 --cprofile
+"""
+
+import os
+import sys
+
+# --- Environment isolation (must be set before importing cognee) -------------
+os.environ.setdefault("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+os.environ.setdefault("REQUIRE_AUTHENTICATION", "false")
+os.environ.setdefault("TELEMETRY_DISABLED", "1")
+os.environ.setdefault("LITELLM_LOG", "ERROR")
+os.environ.setdefault("LLM_API_KEY", "sk-noop-not-used-by-ingestion")
+# Fresh relational DB per process => every run is a clean first-ingest.
+os.environ.setdefault("DB_NAME", "bench_" + os.urandom(4).hex())
+# Isolate ALL cognee state (relational + graph + vector dirs) per process, in a
+# temp dir. This keeps the repo clean AND prevents lock contention: cognee opens
+# the graph DB under SYSTEM_ROOT, so two processes sharing it block on a file
+# lock (this is why the --sizes subprocess driver used to deadlock against the
+# parent's `import cognee`).
+import tempfile as _tempfile  # noqa: E402
+
+_ROOT = _tempfile.mkdtemp(prefix="cognee_bench_" + os.urandom(3).hex() + "_")
+os.environ.setdefault("DATA_ROOT_DIRECTORY", os.path.join(_ROOT, "data"))
+os.environ.setdefault("SYSTEM_ROOT_DIRECTORY", os.path.join(_ROOT, "system"))
+# Per-process dlt working dir => concurrent runs don't clobber dlt pipeline state.
+os.environ.setdefault("DLT_DATA_DIR", os.path.join(_ROOT, "dlt"))
+
+import asyncio  # noqa: E402
+import cProfile  # noqa: E402
+import io  # noqa: E402
+import json  # noqa: E402
+import pstats  # noqa: E402
+import time  # noqa: E402
+import tracemalloc  # noqa: E402
+import uuid  # noqa: E402
+from contextlib import contextmanager  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+
+import dlt  # noqa: E402  (pip install cognee[dlt])
+
+
+N_DEPTS = 10
+UNCAPPED = 10_000_000
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), "results")
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic source: 3 tables with real FK fan-out so FK resolution is exercised.
+#   departments (N_DEPTS) <- users (n_rows) <- orders (2*n_rows)
+# --------------------------------------------------------------------------- #
+def make_source(n_rows: int, drop_tail_frac: float = 0.0):
+    """Build a single 3-table dlt source with FK fan-out.
+
+    Returned as ONE ``@dlt.source`` (not a list of resources) so all tables are
+    read back exactly once: passing separate DltResources makes
+    ``resolve_dlt_sources`` run ``ingest_dlt_source`` per resource, and each run
+    re-reads the whole schema (departments would be read 3x, users 2x, ...).
+
+    ``drop_tail_frac`` removes a fraction of the tail rows of users/orders so a
+    re-ingest with write_disposition="replace" produces orphans, exercising
+    orphan_cleanup + incremental re-sync.
+    """
+    n_users = int(n_rows * (1.0 - drop_tail_frac))
+    n_orders = int(2 * n_rows * (1.0 - drop_tail_frac))
+
+    @dlt.source(name="bench")
+    def bench_source():
+        @dlt.resource(name="departments", primary_key="id")
+        def departments():
+            for i in range(N_DEPTS):
+                yield {"id": i, "name": f"dept_{i}", "budget": i * 1000}
+
+        @dlt.resource(name="users", primary_key="id")
+        def users():
+            for i in range(n_users):
+                yield {
+                    "id": i,
+                    "name": f"user_{i}",
+                    "email": f"user_{i}@example.com",
+                    "dept_id": i % N_DEPTS,
+                    "bio": f"Synthetic user {i} for DLT ingestion benchmarking.",
+                }
+
+        @dlt.resource(name="orders", primary_key="id")
+        def orders():
+            for i in range(n_orders):
+                yield {
+                    "id": i,
+                    "user_id": i % max(n_users, 1),
+                    "amount": round(i * 1.5, 2),
+                    "status": "open" if i % 3 else "closed",
+                }
+
+        return departments, users, orders
+
+    return bench_source()
+
+
+# --------------------------------------------------------------------------- #
+# Stage timing via monkeypatch.
+# --------------------------------------------------------------------------- #
+class Stages:
+    """Accumulates (calls, seconds) per named stage. Snapshot deltas per phase."""
+
+    def __init__(self):
+        self.data: dict[str, list] = {}
+
+    def add(self, name: str, seconds: float):
+        slot = self.data.setdefault(name, [0, 0.0])
+        slot[0] += 1
+        slot[1] += seconds
+
+    def snapshot(self) -> dict:
+        return {k: (v[0], v[1]) for k, v in self.data.items()}
+
+    def delta(self, before: dict) -> dict:
+        out = {}
+        for k, (calls, secs) in self.data.items():
+            b_calls, b_secs = before.get(k, (0, 0.0))
+            dc, ds = calls - b_calls, secs - b_secs
+            if dc:
+                out[k] = {"calls": dc, "seconds": round(ds, 4)}
+        return out
+
+
+STAGES = Stages()
+
+
+def _wrap_async(mod, attr, stage_name):
+    orig = getattr(mod, attr)
+
+    async def wrapper(*args, **kwargs):
+        t0 = time.perf_counter()
+        try:
+            return await orig(*args, **kwargs)
+        finally:
+            STAGES.add(stage_name, time.perf_counter() - t0)
+
+    setattr(mod, attr, wrapper)
+    return orig
+
+
+def _wrap_sync(mod_or_cls, attr, stage_name):
+    orig = getattr(mod_or_cls, attr)
+
+    def wrapper(*args, **kwargs):
+        t0 = time.perf_counter()
+        try:
+            return orig(*args, **kwargs)
+        finally:
+            STAGES.add(stage_name, time.perf_counter() - t0)
+
+    setattr(mod_or_cls, attr, wrapper)
+    return orig
+
+
+@contextmanager
+def patch_timers():
+    """Install per-stage timing wrappers, restore on exit."""
+    # Use `import ... as` to bind the actual *module* objects; the ingestion
+    # package __init__ re-exports functions of the same name, which would shadow
+    # the submodules under `from ... import name`.
+    # importlib.import_module returns the true submodule from sys.modules; a plain
+    # `import a.b.c as x` would bind x to the parent package attribute, which the
+    # ingestion __init__ has overwritten with the same-named function.
+    import importlib
+
+    rds = importlib.import_module("cognee.tasks.ingestion.resolve_dlt_sources")
+    ids = importlib.import_module("cognee.tasks.ingestion.ingest_dlt_source")
+    bd = importlib.import_module("cognee.modules.ingestion.data_types.BinaryData")
+    idf = importlib.import_module("cognee.modules.ingestion.identify")
+
+    saved = []
+    # get_unique_data_id is imported by-name into two modules, so patch both
+    # bindings. The Phase-1 call lives in resolve_dlt_sources; the *redundant*
+    # per-row call inside ingest_data goes through identify's binding. Same stage
+    # name -> the phase-window delta (see run_ingest) separates them: resolve
+    # window = Phase 1, ingest window = the discarded identify() re-resolution.
+    saved.append((rds, "get_unique_data_id", _wrap_async(rds, "get_unique_data_id", "id_resolve")))
+    saved.append((idf, "get_unique_data_id", _wrap_async(idf, "get_unique_data_id", "id_resolve")))
+    saved.append((rds, "ingest_dlt_source", _wrap_async(rds, "ingest_dlt_source", "dlt_ingest_total")))
+    saved.append((ids, "_extract_dlt_schema", _wrap_async(ids, "_extract_dlt_schema", "schema_extract")))
+    saved.append((ids, "_read_rows_from_tables", _wrap_async(ids, "_read_rows_from_tables", "row_readback")))
+    saved.append((bd.BinaryData, "get_metadata", _wrap_sync(bd.BinaryData, "get_metadata", "metadata_threads")))
+    try:
+        yield
+    finally:
+        for obj, attr, orig in saved:
+            setattr(obj, attr, orig)
+
+
+# --------------------------------------------------------------------------- #
+# One ingest run (resolve + ingest_data + optional orphan cleanup), instrumented.
+# --------------------------------------------------------------------------- #
+async def run_ingest(user, ds, resources, write_disposition, max_rows):
+    from cognee.tasks.ingestion.resolve_dlt_sources import resolve_dlt_sources
+    from cognee.tasks.ingestion import ingest_data
+
+    # Measure *incremental* peak so multi-size --sizes runs aren't contaminated by
+    # heap still alive from earlier sizes: report peak-above-the-start-baseline.
+    import gc
+
+    gc.collect()
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    base_cur, _ = tracemalloc.get_traced_memory()
+
+    snap0 = STAGES.snapshot()
+    t0 = time.perf_counter()
+    expanded, cleanup = await resolve_dlt_sources(
+        resources, dataset_name=ds, user=user,
+        primary_key="id", write_disposition=write_disposition, max_rows_per_table=max_rows,
+    )
+    t_resolve = time.perf_counter() - t0
+    resolve_stages = STAGES.delta(snap0)
+    _, peak_resolve = tracemalloc.get_traced_memory()
+
+    snap1 = STAGES.snapshot()
+    t1 = time.perf_counter()
+    await ingest_data(expanded, ds, user)
+    t_ingest = time.perf_counter() - t1
+    ingest_stages = STAGES.delta(snap1)
+
+    t_cleanup = 0.0
+    cleanup_stages = {}
+    if cleanup is not None:
+        snap2 = STAGES.snapshot()
+        t2 = time.perf_counter()
+        await cleanup()
+        t_cleanup = time.perf_counter() - t2
+        cleanup_stages = STAGES.delta(snap2)
+
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    n_items = len(expanded) if isinstance(expanded, list) else 1
+    return {
+        "n_dataitems": n_items,
+        "t_resolve": round(t_resolve, 3),
+        "t_ingest": round(t_ingest, 3),
+        "t_cleanup": round(t_cleanup, 3),
+        "t_total": round(t_resolve + t_ingest + t_cleanup, 3),
+        "rows_per_sec": round(n_items / (t_resolve + t_ingest + t_cleanup), 1),
+        "peak_mem_mb": round(max(peak - base_cur, 0) / 1e6, 1),
+        "peak_mem_resolve_mb": round(max(peak_resolve - base_cur, 0) / 1e6, 1),
+        "stage_breakdown": {
+            "resolve": resolve_stages,
+            "ingest_data": ingest_stages,
+            "orphan_cleanup": cleanup_stages,
+        },
+    }
+
+
+async def prepare_db_and_user():
+    """Create relational tables + default user without setup()/vector init."""
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.users.methods import get_default_user
+
+    rel = get_relational_engine()
+    if getattr(rel, "db_path", None):
+        os.makedirs(os.path.dirname(rel.db_path), exist_ok=True)
+    await rel.create_database()
+    return await get_default_user()
+
+
+async def bench_one_size(n_rows: int, max_rows: int, cprofile: bool) -> dict:
+    user = await prepare_db_and_user()
+    ds = f"bench_{n_rows}_{uuid.uuid4().hex[:8]}"
+
+    with patch_timers():
+        pr = cProfile.Profile() if cprofile else None
+        if pr:
+            pr.enable()
+
+        # Run 1: first ingest (all rows).
+        first = await run_ingest(user, ds, make_source(n_rows), "replace", max_rows)
+
+        # Run 2: re-ingest with the tail 20% dropped -> orphans + incremental re-sync.
+        reingest = await run_ingest(
+            user, ds, make_source(n_rows, drop_tail_frac=0.2), "replace", max_rows
+        )
+
+        if pr:
+            pr.disable()
+
+    result = {
+        "n_rows_config": n_rows,
+        "max_rows_per_table": None if max_rows >= UNCAPPED else max_rows,
+        "first_ingest": first,
+        "reingest_with_deletions": reingest,
+    }
+    if pr:
+        result["cprofile_top"] = _cprofile_top(pr, 20)
+    return result
+
+
+def _cprofile_top(pr: cProfile.Profile, n: int) -> list:
+    s = io.StringIO()
+    pstats.Stats(pr, stream=s).sort_stats("cumulative").print_stats(n)
+    rows = []
+    started = False
+    for line in s.getvalue().splitlines():
+        if "ncalls" in line:
+            started = True
+            continue
+        if started and line.strip():
+            rows.append(line.strip()[:150])
+    return rows[:n]
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+def _fmt_stage_table(title: str, stages: dict) -> str:
+    lines = [f"  {title}:"]
+    flat = []
+    for phase, d in stages.items():
+        for stage, m in d.items():
+            flat.append((f"{phase}/{stage}", m["calls"], m["seconds"]))
+    flat.sort(key=lambda x: -x[2])
+    for name, calls, secs in flat:
+        lines.append(f"    {name:<34} {calls:>8} calls  {secs:>8.3f}s")
+    return "\n".join(lines)
+
+
+def print_run(label: str, r: dict):
+    print(
+        f"  [{label}] items={r['n_dataitems']} "
+        f"resolve={r['t_resolve']}s ingest={r['t_ingest']}s cleanup={r['t_cleanup']}s "
+        f"total={r['t_total']}s  {r['rows_per_sec']} items/s  peak={r['peak_mem_mb']}MB"
+    )
+    print(_fmt_stage_table("stage breakdown (seconds)", r["stage_breakdown"]))
+
+
+def print_size_report(res: dict):
+    cap = res["max_rows_per_table"]
+    print(f"\n=== size={res['n_rows_config']} rows/table  (cap={cap or 'uncapped'}) ===")
+    print_run("first ingest", res["first_ingest"])
+    print_run("re-ingest (tail 20% dropped)", res["reingest_with_deletions"])
+    if "cprofile_top" in res:
+        print("  cProfile top-cumulative:")
+        for line in res["cprofile_top"]:
+            print(f"    {line}")
+
+
+# --------------------------------------------------------------------------- #
+# Multi-size driver (in-process, sequential)
+# --------------------------------------------------------------------------- #
+async def drive_sizes(sizes: list, max_rows: int):
+    """Run each size sequentially in one process.
+
+    Each size uses a unique dataset name (many datasets in one relational DB is
+    normal cognee usage), so runs don't collide. This is intentionally NOT a
+    subprocess fan-out: on Windows, spawning the benchmark as a child while dlt
+    parallelizes normalize/load re-imports __main__ and deadlocks. Sequential
+    in-process is robust and the numbers are process-warm-cache comparable.
+    """
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    collected = []
+    for n in sizes:
+        print(f"\n>>> running size={n} ...", flush=True)
+        res = await bench_one_size(n, max_rows, cprofile=False)
+        collected.append(res)
+        print_size_report(res)
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "note": "Phase-0 DLT ingestion baseline (#3626). No LLM. SQLite destination. "
+        "Sizes run sequentially in one process, each with a unique dataset name.",
+        "results": collected,
+    }
+    out = os.path.join(RESULTS_DIR, "dlt_ingestion_baseline.json")
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+    print(f"\nWrote {out}")
+    _print_scaling_summary(collected)
+
+
+def _print_scaling_summary(results: list):
+    print("\n=== scaling summary (first ingest) ===")
+    print(f"  {'rows':>8} {'items':>8} {'total_s':>9} {'items/s':>9} {'peakMB':>8}")
+    for r in results:
+        fi = r["first_ingest"]
+        print(f"  {r['n_rows_config']:>8} {fi['n_dataitems']:>8} "
+              f"{fi['t_total']:>9} {fi['rows_per_sec']:>9} {fi['peak_mem_mb']:>8}")
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+def _parse_args(argv):
+    sizes = None
+    n = 1000
+    max_rows = UNCAPPED
+    cprofile = "--cprofile" in argv
+    for i, a in enumerate(argv):
+        if a == "--sizes" and i + 1 < len(argv):
+            sizes = [int(x) for x in argv[i + 1].split(",") if x.strip()]
+        elif a == "--max-rows" and i + 1 < len(argv):
+            max_rows = int(argv[i + 1])
+        elif a.isdigit():
+            n = int(a)
+    return sizes, n, max_rows, cprofile
+
+
+async def _amain(n, max_rows, cprofile):
+    res = await bench_one_size(n, max_rows, cprofile)
+    if os.environ.get("_BENCH_EMIT_JSON"):
+        print("JSONRESULT " + json.dumps(res))
+    else:
+        print_size_report(res)
+
+
+if __name__ == "__main__":
+    sizes, n, max_rows, cprofile = _parse_args(sys.argv[1:])
+    if sizes:
+        asyncio.run(drive_sizes(sizes, max_rows))
+    else:
+        asyncio.run(_amain(n, max_rows, cprofile))

--- a/cognee/tests/performance/results/dlt_ingestion_baseline.json
+++ b/cognee/tests/performance/results/dlt_ingestion_baseline.json
@@ -1,0 +1,264 @@
+{
+  "generated_at": "2026-07-09T13:00:31.176025+00:00",
+  "note": "Phase-0 DLT ingestion baseline (#3626). No LLM. SQLite destination. Sizes run sequentially in one process, each with a unique dataset name.",
+  "results": [
+    {
+      "n_rows_config": 200,
+      "max_rows_per_table": null,
+      "first_ingest": {
+        "n_dataitems": 610,
+        "t_resolve": 4.163,
+        "t_ingest": 8.762,
+        "t_cleanup": 0.203,
+        "t_total": 13.128,
+        "rows_per_sec": 46.5,
+        "peak_mem_mb": 14.8,
+        "peak_mem_resolve_mb": 4.5,
+        "stage_breakdown": {
+          "resolve": {
+            "schema_extract": {
+              "calls": 1,
+              "seconds": 0.1687
+            },
+            "row_readback": {
+              "calls": 1,
+              "seconds": 0.0631
+            },
+            "dlt_ingest_total": {
+              "calls": 1,
+              "seconds": 0.8994
+            },
+            "id_resolve": {
+              "calls": 610,
+              "seconds": 3.2271
+            }
+          },
+          "ingest_data": {
+            "id_resolve": {
+              "calls": 610,
+              "seconds": 3.5949
+            },
+            "metadata_threads": {
+              "calls": 1830,
+              "seconds": 2.8171
+            }
+          },
+          "orphan_cleanup": {}
+        }
+      },
+      "reingest_with_deletions": {
+        "n_dataitems": 490,
+        "t_resolve": 3.448,
+        "t_ingest": 9.705,
+        "t_cleanup": 8.195,
+        "t_total": 21.347,
+        "rows_per_sec": 23.0,
+        "peak_mem_mb": 12.2,
+        "peak_mem_resolve_mb": 2.2,
+        "stage_breakdown": {
+          "resolve": {
+            "schema_extract": {
+              "calls": 1,
+              "seconds": 0.1228
+            },
+            "row_readback": {
+              "calls": 1,
+              "seconds": 0.0512
+            },
+            "dlt_ingest_total": {
+              "calls": 1,
+              "seconds": 0.6577
+            },
+            "id_resolve": {
+              "calls": 490,
+              "seconds": 2.7594
+            }
+          },
+          "ingest_data": {
+            "id_resolve": {
+              "calls": 490,
+              "seconds": 3.0068
+            },
+            "metadata_threads": {
+              "calls": 1470,
+              "seconds": 2.5361
+            }
+          },
+          "orphan_cleanup": {}
+        }
+      }
+    },
+    {
+      "n_rows_config": 500,
+      "max_rows_per_table": null,
+      "first_ingest": {
+        "n_dataitems": 1510,
+        "t_resolve": 9.078,
+        "t_ingest": 21.855,
+        "t_cleanup": 0.425,
+        "t_total": 31.358,
+        "rows_per_sec": 48.2,
+        "peak_mem_mb": 26.7,
+        "peak_mem_resolve_mb": 4.3,
+        "stage_breakdown": {
+          "resolve": {
+            "schema_extract": {
+              "calls": 1,
+              "seconds": 0.124
+            },
+            "row_readback": {
+              "calls": 1,
+              "seconds": 0.1229
+            },
+            "dlt_ingest_total": {
+              "calls": 1,
+              "seconds": 0.9578
+            },
+            "id_resolve": {
+              "calls": 1510,
+              "seconds": 8.0326
+            }
+          },
+          "ingest_data": {
+            "id_resolve": {
+              "calls": 1510,
+              "seconds": 8.5474
+            },
+            "metadata_threads": {
+              "calls": 4530,
+              "seconds": 7.7444
+            }
+          },
+          "orphan_cleanup": {}
+        }
+      },
+      "reingest_with_deletions": {
+        "n_dataitems": 1210,
+        "t_resolve": 7.242,
+        "t_ingest": 24.118,
+        "t_cleanup": 23.91,
+        "t_total": 55.27,
+        "rows_per_sec": 21.9,
+        "peak_mem_mb": 28.9,
+        "peak_mem_resolve_mb": 3.6,
+        "stage_breakdown": {
+          "resolve": {
+            "schema_extract": {
+              "calls": 1,
+              "seconds": 0.1192
+            },
+            "row_readback": {
+              "calls": 1,
+              "seconds": 0.0986
+            },
+            "dlt_ingest_total": {
+              "calls": 1,
+              "seconds": 0.8416
+            },
+            "id_resolve": {
+              "calls": 1210,
+              "seconds": 6.3318
+            }
+          },
+          "ingest_data": {
+            "id_resolve": {
+              "calls": 1210,
+              "seconds": 7.0299
+            },
+            "metadata_threads": {
+              "calls": 3630,
+              "seconds": 6.3677
+            }
+          },
+          "orphan_cleanup": {}
+        }
+      }
+    },
+    {
+      "n_rows_config": 900,
+      "max_rows_per_table": null,
+      "first_ingest": {
+        "n_dataitems": 2710,
+        "t_resolve": 15.834,
+        "t_ingest": 39.985,
+        "t_cleanup": 1.144,
+        "t_total": 56.963,
+        "rows_per_sec": 47.6,
+        "peak_mem_mb": 55.2,
+        "peak_mem_resolve_mb": 6.6,
+        "stage_breakdown": {
+          "resolve": {
+            "schema_extract": {
+              "calls": 1,
+              "seconds": 0.1231
+            },
+            "row_readback": {
+              "calls": 1,
+              "seconds": 0.2143
+            },
+            "dlt_ingest_total": {
+              "calls": 1,
+              "seconds": 1.1957
+            },
+            "id_resolve": {
+              "calls": 2710,
+              "seconds": 14.4829
+            }
+          },
+          "ingest_data": {
+            "id_resolve": {
+              "calls": 2710,
+              "seconds": 15.494
+            },
+            "metadata_threads": {
+              "calls": 8130,
+              "seconds": 14.4888
+            }
+          },
+          "orphan_cleanup": {}
+        }
+      },
+      "reingest_with_deletions": {
+        "n_dataitems": 2170,
+        "t_resolve": 12.749,
+        "t_ingest": 47.178,
+        "t_cleanup": 48.479,
+        "t_total": 108.406,
+        "rows_per_sec": 20.0,
+        "peak_mem_mb": 51.3,
+        "peak_mem_resolve_mb": 5.4,
+        "stage_breakdown": {
+          "resolve": {
+            "schema_extract": {
+              "calls": 1,
+              "seconds": 0.117
+            },
+            "row_readback": {
+              "calls": 1,
+              "seconds": 0.172
+            },
+            "dlt_ingest_total": {
+              "calls": 1,
+              "seconds": 1.0245
+            },
+            "id_resolve": {
+              "calls": 2170,
+              "seconds": 11.5956
+            }
+          },
+          "ingest_data": {
+            "id_resolve": {
+              "calls": 2170,
+              "seconds": 12.8819
+            },
+            "metadata_threads": {
+              "calls": 6510,
+              "seconds": 13.5513
+            }
+          },
+          "orphan_cleanup": {}
+        }
+      }
+    }
+  ]
+}

--- a/cognee/tests/performance/results/dlt_ingestion_findings.md
+++ b/cognee/tests/performance/results/dlt_ingestion_findings.md
@@ -1,0 +1,151 @@
+# DLT ingestion — profiling findings (#3626, Phase 0)
+
+**Profile first, then propose.** This is where time and memory actually go in
+cognee's DLT ingestion path, measured with
+`benchmark_dlt_ingestion_profile.py` (no LLM key; per-stage timers +
+tracemalloc; first-ingest + re-ingest-with-deletions).
+
+Environment: Windows 11, Python 3.13, SQLite destination, dlt 1.28.1, cognee
+`main`. Numbers are wall-clock on one machine — treat proportions, not absolute
+seconds, as the signal.
+
+## Headline
+
+Throughput is **flat at ~40–55 items/sec regardless of source size** (500→3000
+rows all land in the 42–48 rps band on the coarse harness). Ingestion is fully
+**O(rows) and serial** — the bottleneck is cognee's per-row work, **not dlt**.
+dlt's own extract/normalize/load is ~5% of wall-clock.
+
+Peak memory grows **linearly** with source size (14 MB @ 320 rows → 49 MB @ 3020
+rows), because rows are fully materialized before processing.
+
+## Where first-ingest time goes (n=300 → 910 DataItems, 17.1 s)
+
+| Stage | calls | seconds | % | note |
+|---|---:|---:|---:|---|
+| `ingest_data` / `id_resolve` | 910 | 4.66 | 27% | **wasted** — `identify()` re-resolves the id, result discarded |
+| `resolve` / `id_resolve` (Phase 1) | 910 | 4.32 | 25% | 1 DB session + 1 SELECT per row |
+| `ingest_data` / `metadata_threads` | 2730 | 3.87 | 23% | `get_metadata` ~3×/row, each spawns a thread/event-loop |
+| file I/O + Phase-2 build + relational writes | — | ~3.4 | 20% | per-row temp-file write, loader read-back, `session.merge` |
+| `dlt_ingest_total` (extract+normalize+load) | 1 | 0.88 | 5% | the actual dlt work |
+| `schema_extract` | 1 | 0.13 | <1% | |
+| `row_readback` | 1 | 0.08 | <1% | |
+
+**~52% of first-ingest time is ID resolution, and half of that is pure waste.**
+
+## Confirmed hotspots (ranked by leverage)
+
+### 1. Per-row ID resolution is done **twice**, second result discarded — ~27% waste
+`resolve_dlt_sources` Phase 1 computes a stable `data_id` per row via
+`get_unique_data_id` ([resolve_dlt_sources.py:103](../../../tasks/ingestion/resolve_dlt_sources.py#L103))
+and stores it on the `DataItem`. Then `ingest_data`'s pre-loop calls
+`ingestion.identify(...)` per row ([ingest_data.py:98](../../../tasks/ingestion/ingest_data.py#L98)),
+which calls `get_unique_data_id` **again** ([identify.py:11](../../../modules/ingestion/identify.py#L11)) —
+but the result is **immediately overwritten** by the DataItem's existing id
+([ingest_data.py:100-101](../../../tasks/ingestion/ingest_data.py#L100-L101)). For DLT rows this
+entire second round-trip is dead work. **Fix:** skip `identify()` when
+`DataItem.data_id` is already set. Removes ~27% of first-ingest time outright.
+
+### 2. Per-row DB sessions — O(rows) round-trips
+`get_unique_data_id` opens its own `get_async_session()` and runs one `SELECT`
+per call ([get_unique_data_id.py:60-68](../../../modules/data/methods/get_unique_data_id.py#L60-L68)).
+The cProfile run showed **~14,000 sessions opened for ~1000 rows**. **Fix:** batch
+Phase-1 resolution — compute candidate ids in memory, resolve existing ones with a
+single `SELECT ... WHERE id IN (...)`, reuse one session. Collapses N round-trips
+to a few.
+
+### 3. `get_metadata` spawns a thread per call — ~23%
+`BinaryData.get_metadata` calls `run_sync(...)`, which spins up a fresh event
+loop in a new thread every call ([BinaryData.py:26-27](../../../modules/ingestion/data_types/BinaryData.py#L26-L27)).
+It runs ~3×/row (identify + original-file classify + storage-file classify).
+cProfile: **3,063 thread joins ≈ 10 s** at 1000 rows. For in-memory structured DLT
+text this file-metadata machinery is largely redundant. **Fix:** a DLT-aware fast
+path in `ingest_data` that builds the `Data` row directly from the DataItem
+(known text, known id, known content_hash) instead of round-tripping through temp
+files + classify + metadata.
+
+### 4. Per-row file I/O for structured text
+Each DLT row's enriched text is written to a temp file
+(`save_data_item_to_storage` → `save_data_to_file`), read back through a loader
+into cognee storage (`data_item_to_text_file`), then reopened twice more for
+`classify().get_metadata()`. Tens of thousands of filesystem ops for what is
+already in-memory text. Same fast-path fix as #3.
+
+### 5. Orphan cleanup is O(dataset), not O(delta) — dominates re-ingest
+On re-ingest (tail 20% dropped, n=300), deleting **180 orphans took 11.5 s** —
+*more than ingesting all 910 rows*. `_delete_dlt_orphans` calls
+`get_dataset_data(dataset.id)`, loading **every** row of the dataset into Python
+([resolve_dlt_sources.py:344](../../../tasks/ingestion/resolve_dlt_sources.py#L344)), filters
+orphans client-side, then deletes one-by-one. Cost scales with dataset size, not
+with how many rows changed. **Fix:** set-based orphan *identification* (a single
+query returning only orphan ids), plus batched/ledger-aware deletion.
+⚠️ *Do not* collapse deletion to a raw `DELETE ... NOT IN (...)`: the per-row
+graph/vector teardown (`delete_data_nodes_and_edges`) is reference-counted and
+must be preserved (see #3626 thread) — only the *identification* is safely
+set-based.
+
+### 6. Linear memory — full materialization
+`_read_rows_from_tables` does `result.mappings().all()` per table and builds one
+`all_rows` list across all tables ([ingest_dlt_source.py:325](../../../tasks/ingestion/ingest_dlt_source.py#L325)),
+and `resolve_dlt_sources` accumulates all `DataItem`s. Peak memory ∝ source size.
+**Fix:** stream rows in bounded chunks (server-side cursor / `yield_per`) feeding a
+fixed-size processing window.
+
+### 7. Concurrency limitation — dlt working dir is global (discovered empirically)
+`ingest_dlt_source` hardcodes `pipeline_name="ingest_dlt_source"`
+([ingest_dlt_source.py:93](../../../tasks/ingestion/ingest_dlt_source.py#L93)). dlt stores that
+pipeline's schema/state in a **global** dir (`~/.dlt/pipelines/ingest_dlt_source`).
+Running two DLT ingests concurrently made them clobber each other →
+`SchemaNotFoundError` / `no such table: ..._dlt_pipeline_state`. **Fix:** derive a
+unique pipeline name (or `pipelines_dir`) per dataset/run so concurrent ingests
+are isolated. (The harness works around this with a per-process `DLT_DATA_DIR`.)
+
+### Also: multi-resource re-read
+Passing N separate `DltResource`s in one `add()` runs `ingest_dlt_source` N times,
+and each run reads back the **whole** schema — earlier tables are re-read O(N)
+times ([resolve_dlt_sources.py:84-92](../../../tasks/ingestion/resolve_dlt_sources.py#L84-L92)). Prefer
+one `@dlt.source`, or read each table only once across the batch.
+
+## Prioritized optimization targets
+
+1. **Skip the redundant `identify()` for DataItems with a known `data_id`** — biggest
+   win-per-line (~27% of first-ingest), low risk. (chunk: batching)
+2. **DLT-aware fast path in `ingest_data`** — bypass temp-file/classify/metadata for
+   structured rows (~23% + file I/O). (chunk: batching)
+3. **Batch Phase-1 ID resolution** into a single `IN` query. (chunk: batching)
+4. **Set-based orphan identification** + ledger-safe batched deletion + indexes on
+   `data(dataset_id)`. (chunk: destination/orphan_cleanup)
+5. **Stream row read-back** in bounded chunks. (chunk: memory/streaming)
+6. **Per-run dlt pipeline isolation** + single-source read to unlock parallelism.
+   (chunk: dlt parallelism)
+
+## Scaling table
+
+From `dlt_ingestion_baseline.json` (`--sizes 200,500,900`, SQLite, 3 tables:
+`departments` 10 + `users` N + `orders` 2N). Re-ingest drops the tail 20% so
+orphan-cleanup runs.
+
+| rows/table (N) | DataItems | **first-ingest** total | items/sec | peak MB | re-ingest total | orphan-cleanup | orphans | ms / orphan |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 200 | 610 | 13.1 s | 46.5 | 14.8 | 21.3 s | 8.2 s | 120 | 68 |
+| 500 | 1510 | 31.4 s | 48.2 | 26.7 | 55.3 s | 23.9 s | 300 | 80 |
+| 900 | 2710 | 57.0 s | 47.6 | 55.2 | 108.4 s | 48.5 s | 540 | 90 |
+
+Reading it:
+
+- **First-ingest throughput is flat** (~47 items/s at every size) → strictly O(N),
+  no economy of scale. This is the top-line problem.
+- **Peak memory grows with size** (15→27→55 MB) → full materialization. (Peak in
+  multi-size mode carries some residual-heap noise; single-size runs give ~15/30/40
+  MB — same linear trend.)
+- **Orphan-cleanup cost per orphan *rises* with dataset size** (68→80→90 ms) →
+  the `get_dataset_data` full-dataset scan makes cleanup ~O(orphans × dataset),
+  i.e. **super-linear**. Cleanup is ~45% of re-ingest wall-clock at N=900 and
+  getting worse.
+
+## Reproduce
+
+```bash
+python -m cognee.tests.performance.benchmark_dlt_ingestion_profile --sizes 200,500,900
+python -m cognee.tests.performance.benchmark_dlt_ingestion_profile 1000 --cprofile
+```


### PR DESCRIPTION
## Phase 0 for #3626 — profile first, then propose

Per the issue's **"profile first, then propose"** requirement, this PR adds a
reproducible benchmark + profiling harness for the DLT ingestion path and a
committed baseline. **No production code is changed** — this is the measurement
foundation the optimization chunks build on.

### What's here

- `cognee/tests/performance/benchmark_dlt_ingestion_profile.py` — no-LLM-key harness
  that drives the real ingestion functions (`resolve_dlt_sources` + `ingest_data`)
  with a **per-stage** breakdown (dlt run vs schema-extract vs row read-back vs
  Phase-1 id resolution vs the redundant ingest-side id resolution vs metadata
  threads), a **first-ingest + re-ingest-with-deletions** run so `orphan_cleanup`
  is measured, and per-stage wall-clock / rows-per-sec / peak memory. `--sizes`
  scans multiple sizes and writes the results JSON; `--cprofile` adds a
  cumulative-time attribution pass.
- `cognee/tests/performance/benchmark_dlt_ingestion.py` — earlier coarse
  resolve/ingest-totals harness (kept for reference).
- `cognee/tests/performance/results/dlt_ingestion_baseline.json` — committed baseline.
- `cognee/tests/performance/results/dlt_ingestion_findings.md` — the where-time-goes
  analysis + prioritized optimization targets mapped to the issue's chunks.
- `cognee/tests/performance/README_dlt_ingestion_benchmark.md` — how to run / read.

### Baseline (SQLite, 3-table FK source, N = 200 / 500 / 900 rows-per-table)

| N | DataItems | first-ingest | items/s | peak MB | re-ingest | orphan-cleanup | ms/orphan |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 200 | 610 | 13.1 s | 46.5 | 14.8 | 21.3 s | 8.2 s | 68 |
| 500 | 1510 | 31.4 s | 48.2 | 26.7 | 55.3 s | 23.9 s | 80 |
| 900 | 2710 | 57.0 s | 47.6 | 55.2 | 108.4 s | 48.5 s | 90 |

### What the profile shows

- **Throughput is flat at ~47 items/s regardless of size → ingestion is strictly
  O(N) and serial. dlt itself is ~3% of wall-clock** — the bottleneck is cognee's
  per-row work, not dlt.
- **~27% of first-ingest time is wasted re-resolution.** `resolve_dlt_sources`
  Phase 1 computes a stable `data_id` per row; then `ingest_data` → `identify()`
  computes `get_unique_data_id` **again** per row, but the result is immediately
  discarded because `DataItem.data_id` is already set
  (`ingest_data.py:100-101`). Deleting this redundant call is the highest
  leverage / lowest risk win.
- **~25% is `BinaryData.get_metadata` spawning a thread per call** (`run_sync`,
  ~3×/row) — redundant file-metadata machinery for in-memory structured text.
- **Orphan cleanup is super-linear** (68 → 80 → 90 ms/orphan): `get_dataset_data`
  loads the whole dataset into Python, so cleanup ≈ O(orphans × dataset). It's
  ~45% of re-ingest wall-clock at N=900 and worsening.
- **Peak memory grows linearly** — rows are fully materialized before processing.
- **Concurrency note:** `pipeline_name="ingest_dlt_source"` is hardcoded with a
  global dlt working dir, so two concurrent cognee DLT ingests collide
  (`SchemaNotFoundError`); and passing N separate `DltResource`s re-reads the
  whole schema N times.

### Prioritized optimization targets (follow-up chunks)

1. Skip the redundant `identify()` for DataItems with a known `data_id` (~27%).
2. DLT-aware fast path in `ingest_data` — bypass temp-file/classify/metadata for
   structured rows (~25% + file I/O).
3. Batch Phase-1 ID resolution into a single `IN` query.
4. Set-based orphan **identification** + ledger-safe batched deletion + index on
   `data(dataset_id)`.
5. Stream row read-back in bounded chunks.
6. Per-run dlt pipeline isolation + single-source read to unlock parallelism.

### Testing

`python -m cognee.tests.performance.benchmark_dlt_ingestion_profile --sizes 200,500,900`
runs with **no API key** (structured DLT rows bypass LLM extraction) and writes the
baseline JSON. Every optimization PR should re-run the same sizes and report
before/after numbers.
