### PR TITLE
[SDK-144] feat(ingestion): Gmail connector (DLT-based, incremental + forget-on-delete)

### DIFF
--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -259,8 +259,9 @@ def _get_message(service: Any, message_id: str) -> Optional[dict]:
     try:
         return service.users().messages().get(userId="me", id=message_id, format="full").execute()
     except Exception as exc:
-        status = getattr(getattr(exc, "resp", None), "status", None)
-        if status in (404, 410) or "404" in str(exc) or "410" in str(exc):
+        # Trust only the structured HTTP status: str(exc) embeds the request
+        # URL, and a hex message id can spuriously contain "404"/"410".
+        if getattr(getattr(exc, "resp", None), "status", None) in (404, 410):
             return None
         raise
 

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -58,6 +58,7 @@ token file (``token.json``) private, and prefer a dedicated dataset so you can
 from __future__ import annotations
 
 import base64
+import os
 from typing import Any, Dict, Iterator, List, Optional
 
 from cognee.shared.logging_utils import get_logger
@@ -97,8 +98,6 @@ def build_gmail_service(
             '    pip install "cognee[gmail]"\n'
             "(provides google-api-python-client, google-auth, google-auth-oauthlib)."
         ) from exc
-
-    import os
 
     scopes = [GMAIL_READONLY_SCOPE]
     creds = None
@@ -273,7 +272,7 @@ def _mailbox_history_id(service: Any) -> Optional[str]:
         history_id = profile.get("historyId")
         return str(history_id) if history_id is not None else None
     except Exception as exc:  # pragma: no cover - network dependent
-        logger.warning("Gmail: failed to read profile historyId: %s", exc)
+        logger.warning("Failed to read profile historyId: %s", exc)
         return None
 
 
@@ -305,7 +304,7 @@ def full_backfill(
 
     if baseline_history_id is not None:
         state["last_history_id"] = baseline_history_id
-    logger.info("Gmail: full backfill yielded %d message(s).", count)
+    logger.info("Full backfill yielded %d message(s).", count)
 
 
 def incremental_fetch(
@@ -355,7 +354,7 @@ def incremental_fetch(
             status = getattr(getattr(exc, "resp", None), "status", None)
             if status == 404 or "404" in str(exc):
                 logger.warning(
-                    "Gmail: history id %s expired; falling back to full backfill.",
+                    "History id %s expired; falling back to full backfill.",
                     start_history_id,
                 )
                 state.pop("last_history_id", None)
@@ -423,7 +422,7 @@ def incremental_fetch(
 
     state["last_history_id"] = str(newest_history_id)
     logger.info(
-        "Gmail: incremental sync yielded %d added/changed and %d deleted message(s).",
+        "Incremental sync yielded %d added/changed and %d deleted message(s).",
         added_count,
         len(seen_deleted),
     )

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -460,7 +460,9 @@ def gmail_source(
         import dlt
     except ImportError as exc:
         raise ImportError(
-            'The Gmail connector requires the dlt extra: pip install "cognee[dlt]".'
+            "The Gmail connector requires the 'gmail' extra. Install it with:\n"
+            '    pip install "cognee[gmail]"\n'
+            "(the gmail extra bundles dlt)."
         ) from exc
 
     @dlt.resource(

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -387,7 +387,18 @@ def incremental_fetch(
     for msg_id in seen_added:
         message = _get_message(service, msg_id)
         if message is None:
-            # Disappeared between history and fetch — treat as a deletion.
+            # Genuinely gone (404/410) — treat as a deletion.
+            seen_deleted.add(msg_id)
+            continue
+        # A message that was trashed or moved out of the configured label scope
+        # must be forgotten, not re-ingested as live. Trashing INBOX mail fires
+        # labelsRemoved(INBOX) (not messagesDeleted), so without this check the
+        # trashed message would be fetched and upserted. Re-checking the full
+        # label set here also matches full_backfill's AND-of-all-labels scope
+        # (history.list can pre-filter by a single labelId only).
+        labels = set(message.get("labelIds", []) or [])
+        out_of_scope = bool(label_ids) and not set(label_ids).issubset(labels)
+        if "TRASH" in labels or "SPAM" in labels or out_of_scope:
             seen_deleted.add(msg_id)
             continue
         added_count += 1

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -1,6 +1,6 @@
 """Gmail connector for cognee — a ``dlt`` source that turns your inbox into memory.
 
-Pull Gmail messages (optionally label/query-scoped) into cognee, incrementally
+Pull Gmail messages (optionally label-scoped) into cognee, incrementally
 and with forget-on-deletion — "ask my inbox".  This builds entirely on the
 existing DLT ingestion subsystem; the source produced here is meant to be
 handed directly to :func:`cognee.remember`::
@@ -45,7 +45,7 @@ Privacy
 -------
 This connector reads the content of your email.  It is **opt-in**: nothing is
 fetched until you explicitly construct a source and call ``remember``.  Use
-``label_ids`` / ``query`` to scope what leaves your mailbox, keep the OAuth
+``label_ids`` to scope what leaves your mailbox, keep the OAuth
 token file (``token.json``) private, and prefer a dedicated dataset so you can
 ``cognee.forget`` the inbox in one call.
 """
@@ -72,7 +72,6 @@ _HISTORY_TYPES = ["messageAdded", "messageDeleted", "labelAdded", "labelRemoved"
 def build_gmail_service(
     credentials_path: str = "credentials.json",
     token_path: str = "token.json",
-    scopes: Optional[List[str]] = None,
 ) -> Any:
     """Build an authenticated Gmail API client via the OAuth2 installed-app flow.
 
@@ -96,7 +95,7 @@ def build_gmail_service(
 
     import os
 
-    scopes = scopes or [GMAIL_READONLY_SCOPE]
+    scopes = [GMAIL_READONLY_SCOPE]
     creds = None
 
     if os.path.exists(token_path):
@@ -197,7 +196,6 @@ def parse_message(message: dict) -> Dict[str, Any]:
         "snippet": message.get("snippet", ""),
         "body": _extract_plaintext(payload),
         "internal_date": internal_date,
-        "history_id": str(message.get("historyId")) if message.get("historyId") else None,
         # Hard-delete marker (always False for live messages). Deleted/trashed
         # messages are emitted separately with _deleted=True.
         "_deleted": False,
@@ -215,11 +213,9 @@ def _deleted_row(message_id: str) -> Dict[str, Any]:
 def _list_message_ids(
     service: Any,
     label_ids: Optional[List[str]],
-    query: Optional[str],
-    include_spam_trash: bool,
     max_results: Optional[int],
 ) -> Iterator[str]:
-    """Yield message ids matching the given filters, following pagination."""
+    """Yield message ids matching the given labels, following pagination."""
     page_token = None
     fetched = 0
     while True:
@@ -229,8 +225,6 @@ def _list_message_ids(
             .list(
                 userId="me",
                 labelIds=label_ids or None,
-                q=query or None,
-                includeSpamTrash=include_spam_trash,
                 pageToken=page_token,
             )
         )
@@ -273,8 +267,6 @@ def full_backfill(
     state: dict,
     *,
     label_ids: Optional[List[str]] = None,
-    query: Optional[str] = None,
-    include_spam_trash: bool = False,
     max_results: Optional[int] = None,
 ) -> Iterator[Dict[str, Any]]:
     """Yield every matching message and record the incremental baseline.
@@ -286,7 +278,7 @@ def full_backfill(
     baseline_history_id = _mailbox_history_id(service)
 
     count = 0
-    for message_id in _list_message_ids(service, label_ids, query, include_spam_trash, max_results):
+    for message_id in _list_message_ids(service, label_ids, max_results):
         message = _get_message(service, message_id)
         if message is None:
             continue
@@ -411,8 +403,6 @@ def gmail_source(
     credentials_path: str = "credentials.json",
     token_path: str = "token.json",
     label_ids: Optional[List[str]] = None,
-    query: Optional[str] = None,
-    include_spam_trash: bool = False,
     max_results: Optional[int] = None,
     service: Any = None,
 ):
@@ -422,8 +412,6 @@ def gmail_source(
         credentials_path: Path to the OAuth client-secret JSON (Desktop app).
         token_path: Where the cached user token is read/written.
         label_ids: Restrict to these Gmail label ids (e.g. ``["INBOX"]``).
-        query: Gmail search query (e.g. ``"from:boss@x.com newer_than:30d"``).
-        include_spam_trash: Include SPAM/TRASH in the backfill listing.
         max_results: Cap the number of messages pulled in a full backfill
             (handy for demos/tests). ``None`` = no cap.
         service: Pre-built Gmail API client. Mainly an injection point for
@@ -461,8 +449,6 @@ def gmail_source(
                 client,
                 resource_state,
                 label_ids=label_ids,
-                query=query,
-                include_spam_trash=include_spam_trash,
                 max_results=max_results,
             )
 

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -356,7 +356,9 @@ def incremental_fetch(
 
         for record in response.get("history", []) or []:
             record_history_id = record.get("id")
-            if record_history_id and str(record_history_id) > str(newest_history_id):
+            # historyIds are monotonically increasing integers — compare
+            # numerically, not lexicographically ("1000" < "999" as strings).
+            if record_history_id and int(record_history_id) > int(newest_history_id):
                 newest_history_id = str(record_history_id)
 
             for deleted in record.get("messagesDeleted", []) or []:
@@ -372,10 +374,8 @@ def incremental_fetch(
                         seen_added.add(msg_id)
 
         page_token = response.get("nextPageToken")
-        if response.get("historyId"):
-            candidate = str(response["historyId"])
-            if candidate > str(newest_history_id):
-                newest_history_id = candidate
+        if response.get("historyId") and int(response["historyId"]) > int(newest_history_id):
+            newest_history_id = str(response["historyId"])
         if not page_token:
             break
 

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -12,9 +12,14 @@ handed directly to :func:`cognee.remember`::
         gmail_source(label_ids=["INBOX"]),
         dataset_name="my_inbox",
         primary_key="id",
-        write_disposition="merge",   # incremental upsert by message id
-        max_rows_per_table=0,        # 0 = no row cap (see note below)
+        write_disposition="merge",   # REQUIRED (see .. important:: below)
+        max_rows_per_table=0,        # REQUIRED for a real inbox (see .. note:: below)
     )
+
+.. important::
+   ``write_disposition="merge"`` is **mandatory**.  The add pipeline defaults to
+   ``"replace"`` (drop + reload the table each run); on the second, incremental
+   sync that would wipe the entire synced inbox.  Always pass ``"merge"``.
 
 Design
 ------

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -240,12 +240,21 @@ def _list_message_ids(
 
 
 def _get_message(service: Any, message_id: str) -> Optional[dict]:
-    """Fetch a full message; return None if it has since vanished (404)."""
+    """Fetch a full message; return None only if it is genuinely gone (404/410).
+
+    A transient failure (5xx / rate-limit / network) is re-raised rather than
+    swallowed. On the incremental path a ``None`` result is interpreted as a
+    deletion, so masking a transient error here would hard-delete a live
+    message from memory. Re-raising instead aborts the sync before the cursor
+    advances, so the next run safely retries from the same point.
+    """
     try:
         return service.users().messages().get(userId="me", id=message_id, format="full").execute()
-    except Exception as exc:  # pragma: no cover - network/permission dependent
-        logger.warning("Gmail: failed to fetch message %s: %s", message_id, exc)
-        return None
+    except Exception as exc:
+        status = getattr(getattr(exc, "resp", None), "status", None)
+        if status in (404, 410) or "404" in str(exc) or "410" in str(exc):
+            return None
+        raise
 
 
 def _mailbox_history_id(service: Any) -> Optional[str]:

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -399,15 +399,20 @@ def incremental_fetch(
             # Genuinely gone (404/410) — treat as a deletion.
             seen_deleted.add(msg_id)
             continue
-        # A message that was trashed or moved out of the configured label scope
-        # must be forgotten, not re-ingested as live. Trashing INBOX mail fires
-        # labelsRemoved(INBOX) (not messagesDeleted), so without this check the
-        # trashed message would be fetched and upserted. Re-checking the full
-        # label set here also matches full_backfill's AND-of-all-labels scope
-        # (history.list can pre-filter by a single labelId only).
+        # A message that moved out of scope (e.g. trashed) must be forgotten,
+        # not re-ingested as live: trashing INBOX mail fires labelsRemoved(INBOX)
+        # (not messagesDeleted), so without this check it would be fetched and
+        # upserted. Re-check the message against the SAME scope full_backfill
+        # applies — history.list can only pre-filter by a single labelId, so the
+        # authoritative decision is made here after the full label set is known.
         labels = set(message.get("labelIds", []) or [])
-        out_of_scope = bool(label_ids) and not set(label_ids).issubset(labels)
-        if "TRASH" in labels or "SPAM" in labels or out_of_scope:
+        if label_ids:
+            # full_backfill lists with labelIds=label_ids, which ANDs them.
+            in_scope = set(label_ids).issubset(labels)
+        else:
+            # Unscoped: mirror messages.list, which excludes SPAM/TRASH.
+            in_scope = "TRASH" not in labels and "SPAM" not in labels
+        if not in_scope:
             seen_deleted.add(msg_id)
             continue
         added_count += 1

--- a/cognee/tasks/ingestion/connectors/gmail.py
+++ b/cognee/tasks/ingestion/connectors/gmail.py
@@ -113,8 +113,12 @@ def build_gmail_service(
                 )
             flow = InstalledAppFlow.from_client_secrets_file(credentials_path, scopes)
             creds = flow.run_local_server(port=0)
-        with open(token_path, "w", encoding="utf-8") as token_file:
+        # token.json holds the long-lived OAuth refresh token — keep it private.
+        # Create it 0600 (no group/world read) rather than the default 0644.
+        fd = os.open(token_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as token_file:
             token_file.write(creds.to_json())
+        os.chmod(token_path, 0o600)  # tighten a pre-existing token file too
 
     return build("gmail", "v1", credentials=creds, cache_discovery=False)
 

--- a/cognee/tests/unit/tasks/test_gmail_connector.py
+++ b/cognee/tests/unit/tasks/test_gmail_connector.py
@@ -357,6 +357,25 @@ def test_incremental_fetch_multi_label_keeps_in_scope_and_forgets_out_of_scope()
     assert by_id["drop"] == {"id": "drop", "_deleted": True}
 
 
+def test_incremental_fetch_keeps_explicitly_scoped_spam():
+    # When the caller explicitly scopes to SPAM, backfill ingests spam, so
+    # incremental must keep it too — the SPAM/TRASH exclusion only applies to
+    # the unscoped (label_ids=None) case that mirrors messages.list defaults.
+    spam = _make_message("s", labels=["SPAM"], history_id="1040")
+    svc = FakeGmailService(
+        messages=[spam],
+        history_response={
+            "history": [{"id": "1040", "messagesAdded": [{"message": {"id": "s"}}]}],
+            "historyId": "1040",
+        },
+    )
+    rows = list(incremental_fetch(svc, {"last_history_id": "1000"}, label_ids=["SPAM"]))
+
+    assert len(rows) == 1
+    assert rows[0]["id"] == "s"
+    assert rows[0]["_deleted"] is False
+
+
 # ---------------------------------------------------------------------------
 # gmail_source (dlt wiring) — requires dlt
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/tasks/test_gmail_connector.py
+++ b/cognee/tests/unit/tasks/test_gmail_connector.py
@@ -9,10 +9,12 @@ libraries and no live credentials are required, so these run in CI. Coverage:
   - deleted/trashed messages become hard-delete markers (forget-on-delete)
   - an expired historyId (404) transparently falls back to a full backfill
   - the dlt resource is wired with merge + id PK + the hard_delete column
+  - a dlt-gated e2e run proves a delete marker physically removes the row
 
-The end-to-end "deletion removes from memory" guarantee is provided by the
-existing ``orphan_cleanup`` path (see test_dlt_p0_correctness.py); here we
-prove the connector emits the markers that drive it.
+The e2e test drives gmail_source through a real (offline, LLM-free) dlt merge
+to prove a ``_deleted`` marker removes the row from the destination table.
+cognee's existing ``orphan_cleanup`` path (see test_dlt_p0_correctness.py)
+then turns that into removal from the graph + vector + relational stores.
 """
 
 import base64
@@ -393,3 +395,48 @@ def test_gmail_source_requires_dlt(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     with pytest.raises(ImportError, match="cognee\\[dlt\\]"):
         gmail_source(service=object())
+
+
+def test_e2e_dlt_merge_hard_delete_removes_deleted_message(tmp_path):
+    """End-to-end, offline (no LLM): drive gmail_source through a real dlt
+    merge and prove a ``_deleted`` marker physically removes the row from the
+    destination — which is exactly what cognee's orphan_cleanup reconciles
+    against. Also exercises the gmail_source() closure dispatching from
+    backfill to incremental via persisted dlt resource_state.
+    """
+    dlt = pytest.importorskip("dlt")
+
+    pipelines_dir = str(tmp_path / "dlt_pipelines")
+    db_path = tmp_path / "gmail.db"
+
+    def sync(service):
+        # Same pipeline name + dir on both runs so resource_state (the
+        # historyId cursor) persists and run 2 takes the incremental branch.
+        pipeline = dlt.pipeline(
+            pipeline_name="gmail_e2e_test",
+            destination=dlt.destinations.sqlalchemy(f"sqlite:///{db_path}"),
+            dataset_name="gmail_e2e",
+            pipelines_dir=pipelines_dir,
+        )
+        pipeline.run(gmail_source(service=service))
+        with pipeline.sql_client() as client:
+            rows = client.execute_sql("SELECT id FROM gmail_messages ORDER BY id")
+        return [row[0] for row in rows]
+
+    # Run 1 — backfill loads both messages and records the historyId baseline.
+    backfill_svc = FakeGmailService(
+        messages=[_make_message("a"), _make_message("b")],
+        profile_history_id="500",
+    )
+    assert sync(backfill_svc) == ["a", "b"]
+
+    # Run 2 — incremental reports 'a' deleted; the hard-delete marker must
+    # physically remove it from the destination, leaving only 'b'.
+    incremental_svc = FakeGmailService(
+        messages=[_make_message("b")],
+        history_response={
+            "history": [{"id": "600", "messagesDeleted": [{"message": {"id": "a"}}]}],
+            "historyId": "600",
+        },
+    )
+    assert sync(incremental_svc) == ["b"]

--- a/cognee/tests/unit/tasks/test_gmail_connector.py
+++ b/cognee/tests/unit/tasks/test_gmail_connector.py
@@ -412,7 +412,7 @@ def test_gmail_source_requires_dlt(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    with pytest.raises(ImportError, match="cognee\\[dlt\\]"):
+    with pytest.raises(ImportError, match="cognee\\[gmail\\]"):
         gmail_source(service=object())
 
 

--- a/cognee/tests/unit/tasks/test_gmail_connector.py
+++ b/cognee/tests/unit/tasks/test_gmail_connector.py
@@ -315,6 +315,46 @@ def test_incremental_fetch_advances_cursor_across_digit_boundary():
     assert state["last_history_id"] == "1000"  # advanced past the boundary
 
 
+def test_incremental_fetch_trashed_message_is_forgotten():
+    # Trashing INBOX mail fires labelsRemoved(INBOX), not messagesDeleted; the
+    # message is still fetchable but now labelled TRASH. It must be forgotten.
+    trashed = _make_message("t1", subject="Old", labels=["TRASH"], history_id="1020")
+    svc = FakeGmailService(
+        messages=[trashed],
+        history_response={
+            "history": [{"id": "1020", "labelsRemoved": [{"message": {"id": "t1"}}]}],
+            "historyId": "1020",
+        },
+    )
+    rows = list(incremental_fetch(svc, {"last_history_id": "1000"}, label_ids=["INBOX"]))
+    assert rows == [{"id": "t1", "_deleted": True}]
+
+
+def test_incremental_fetch_multi_label_keeps_in_scope_and_forgets_out_of_scope():
+    # full_backfill scopes by ALL label_ids (AND); incremental must match that:
+    # a message still carrying every label is kept, one that lost a label is
+    # forgotten (not re-ingested as live).
+    keep = _make_message("keep", labels=["INBOX", "IMPORTANT"], history_id="1030")
+    drop = _make_message("drop", labels=["INBOX"], history_id="1031")  # lost IMPORTANT
+    svc = FakeGmailService(
+        messages=[keep, drop],
+        history_response={
+            "history": [
+                {"id": "1030", "messagesAdded": [{"message": {"id": "keep"}}]},
+                {"id": "1031", "labelsRemoved": [{"message": {"id": "drop"}}]},
+            ],
+            "historyId": "1031",
+        },
+    )
+    rows = list(
+        incremental_fetch(svc, {"last_history_id": "1000"}, label_ids=["INBOX", "IMPORTANT"])
+    )
+    by_id = {r["id"]: r for r in rows}
+
+    assert by_id["keep"]["_deleted"] is False
+    assert by_id["drop"] == {"id": "drop", "_deleted": True}
+
+
 # ---------------------------------------------------------------------------
 # gmail_source (dlt wiring) — requires dlt
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/tasks/test_gmail_connector.py
+++ b/cognee/tests/unit/tasks/test_gmail_connector.py
@@ -298,6 +298,23 @@ def test_incremental_fetch_transient_error_does_not_delete_live_message():
     assert state["last_history_id"] == "1000"  # cursor NOT advanced
 
 
+def test_incremental_fetch_advances_cursor_across_digit_boundary():
+    # historyIds are integers; a lexicographic compare treats "1000" < "999"
+    # and would freeze the cursor forever. It must advance numerically.
+    svc = FakeGmailService(
+        messages=[_make_message("n", subject="New", history_id="1000")],
+        history_response={
+            "history": [{"id": "1000", "messagesAdded": [{"message": {"id": "n"}}]}],
+            "historyId": "1000",
+        },
+    )
+    state = {"last_history_id": "999"}
+    rows = list(incremental_fetch(svc, state))
+
+    assert [r["id"] for r in rows] == ["n"]
+    assert state["last_history_id"] == "1000"  # advanced past the boundary
+
+
 # ---------------------------------------------------------------------------
 # gmail_source (dlt wiring) — requires dlt
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/tasks/test_gmail_connector.py
+++ b/cognee/tests/unit/tasks/test_gmail_connector.py
@@ -13,8 +13,8 @@ libraries and no live credentials are required, so these run in CI. Coverage:
 
 The e2e test drives gmail_source through a real (offline, LLM-free) dlt merge
 to prove a ``_deleted`` marker removes the row from the destination table.
-cognee's existing ``orphan_cleanup`` path (see test_dlt_p0_correctness.py)
-then turns that into removal from the graph + vector + relational stores.
+cognee's existing ``orphan_cleanup`` path then turns that into removal from
+the graph + vector + relational stores.
 """
 
 import base64

--- a/cognee/tests/unit/tasks/test_gmail_connector.py
+++ b/cognee/tests/unit/tasks/test_gmail_connector.py
@@ -80,6 +80,8 @@ class _Messages:
         return _Request({"messages": [{"id": mid} for mid in self._svc.message_ids]})
 
     def get(self, *, userId, id, format):  # noqa: A002 - mirror Gmail API kwarg name
+        if id in self._svc.get_errors:
+            return _Request(_HttpError(self._svc.get_errors[id]))
         if id not in self._svc.messages:
             return _Request(_HttpError(404))
         return _Request(self._svc.messages[id])
@@ -112,11 +114,16 @@ class _Users:
 class FakeGmailService:
     """Minimal stand-in for the googleapiclient Gmail service."""
 
-    def __init__(self, messages=None, profile_history_id="500", history_response=None):
+    def __init__(
+        self, messages=None, profile_history_id="500", history_response=None, get_errors=None
+    ):
         self.messages = {m["id"]: m for m in (messages or [])}
         self.message_ids = list(self.messages.keys())
         self.profile_history_id = profile_history_id
         self.history_response = history_response or {"history": [], "historyId": profile_history_id}
+        # Map of message id -> HTTP status to raise from messages().get(), used
+        # to simulate transient (non-404) fetch failures.
+        self.get_errors = get_errors or {}
 
     def users(self):
         return _Users(self)
@@ -271,6 +278,24 @@ def test_incremental_fetch_missing_message_on_fetch_is_treated_as_deleted():
     )
     rows = list(incremental_fetch(svc, {"last_history_id": "1000"}))
     assert rows == [{"id": "ghost", "_deleted": True}]
+
+
+def test_incremental_fetch_transient_error_does_not_delete_live_message():
+    # History reports a change, but get() hits a transient 500 (NOT a 404).
+    # The message is still live — it must not be turned into a hard-delete,
+    # and the cursor must not advance so the next run retries the same window.
+    svc = FakeGmailService(
+        messages=[_make_message("m")],
+        history_response={
+            "history": [{"id": "1010", "messagesAdded": [{"message": {"id": "m"}}]}],
+            "historyId": "1010",
+        },
+        get_errors={"m": 500},
+    )
+    state = {"last_history_id": "1000"}
+    with pytest.raises(_HttpError):
+        list(incremental_fetch(svc, state))
+    assert state["last_history_id"] == "1000"  # cursor NOT advanced
 
 
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/tasks/test_gmail_connector.py
+++ b/cognee/tests/unit/tasks/test_gmail_connector.py
@@ -10,11 +10,6 @@ libraries and no live credentials are required, so these run in CI. Coverage:
   - an expired historyId (404) transparently falls back to a full backfill
   - the dlt resource is wired with merge + id PK + the hard_delete column
   - a dlt-gated e2e run proves a delete marker physically removes the row
-
-The e2e test drives gmail_source through a real (offline, LLM-free) dlt merge
-to prove a ``_deleted`` marker removes the row from the destination table.
-cognee's existing ``orphan_cleanup`` path then turns that into removal from
-the graph + vector + relational stores.
 """
 
 import base64
@@ -317,63 +312,39 @@ def test_incremental_fetch_advances_cursor_across_digit_boundary():
     assert state["last_history_id"] == "1000"  # advanced past the boundary
 
 
-def test_incremental_fetch_trashed_message_is_forgotten():
-    # Trashing INBOX mail fires labelsRemoved(INBOX), not messagesDeleted; the
-    # message is still fetchable but now labelled TRASH. It must be forgotten.
-    trashed = _make_message("t1", subject="Old", labels=["TRASH"], history_id="1020")
+@pytest.mark.parametrize(
+    ("label_ids", "msg_labels", "kept"),
+    [
+        # Trashing INBOX mail fires labelsRemoved(INBOX), not messagesDeleted;
+        # the message is still fetchable but now out of scope -> forgotten.
+        pytest.param(["INBOX"], ["TRASH"], False, id="trashed-inbox-forgotten"),
+        # full_backfill scopes by ALL label_ids (AND); incremental must match:
+        pytest.param(["INBOX", "IMPORTANT"], ["INBOX", "IMPORTANT"], True, id="all-labels-kept"),
+        pytest.param(["INBOX", "IMPORTANT"], ["INBOX"], False, id="lost-one-label-forgotten"),
+        # Explicit SPAM scope means spam IS the corpus -> kept; the SPAM/TRASH
+        # exclusion only applies unscoped, mirroring messages.list defaults.
+        pytest.param(["SPAM"], ["SPAM"], True, id="explicitly-scoped-spam-kept"),
+        pytest.param(None, ["TRASH"], False, id="unscoped-trash-forgotten"),
+    ],
+)
+def test_incremental_fetch_scope_recheck(label_ids, msg_labels, kept):
+    # A changed message must be re-checked against the SAME scope full_backfill
+    # uses: still in scope -> upserted live; out of scope -> forgotten.
+    msg = _make_message("m", labels=msg_labels, history_id="1020")
     svc = FakeGmailService(
-        messages=[trashed],
+        messages=[msg],
         history_response={
-            "history": [{"id": "1020", "labelsRemoved": [{"message": {"id": "t1"}}]}],
+            "history": [{"id": "1020", "labelsRemoved": [{"message": {"id": "m"}}]}],
             "historyId": "1020",
         },
     )
-    rows = list(incremental_fetch(svc, {"last_history_id": "1000"}, label_ids=["INBOX"]))
-    assert rows == [{"id": "t1", "_deleted": True}]
+    rows = list(incremental_fetch(svc, {"last_history_id": "1000"}, label_ids=label_ids))
 
-
-def test_incremental_fetch_multi_label_keeps_in_scope_and_forgets_out_of_scope():
-    # full_backfill scopes by ALL label_ids (AND); incremental must match that:
-    # a message still carrying every label is kept, one that lost a label is
-    # forgotten (not re-ingested as live).
-    keep = _make_message("keep", labels=["INBOX", "IMPORTANT"], history_id="1030")
-    drop = _make_message("drop", labels=["INBOX"], history_id="1031")  # lost IMPORTANT
-    svc = FakeGmailService(
-        messages=[keep, drop],
-        history_response={
-            "history": [
-                {"id": "1030", "messagesAdded": [{"message": {"id": "keep"}}]},
-                {"id": "1031", "labelsRemoved": [{"message": {"id": "drop"}}]},
-            ],
-            "historyId": "1031",
-        },
-    )
-    rows = list(
-        incremental_fetch(svc, {"last_history_id": "1000"}, label_ids=["INBOX", "IMPORTANT"])
-    )
-    by_id = {r["id"]: r for r in rows}
-
-    assert by_id["keep"]["_deleted"] is False
-    assert by_id["drop"] == {"id": "drop", "_deleted": True}
-
-
-def test_incremental_fetch_keeps_explicitly_scoped_spam():
-    # When the caller explicitly scopes to SPAM, backfill ingests spam, so
-    # incremental must keep it too — the SPAM/TRASH exclusion only applies to
-    # the unscoped (label_ids=None) case that mirrors messages.list defaults.
-    spam = _make_message("s", labels=["SPAM"], history_id="1040")
-    svc = FakeGmailService(
-        messages=[spam],
-        history_response={
-            "history": [{"id": "1040", "messagesAdded": [{"message": {"id": "s"}}]}],
-            "historyId": "1040",
-        },
-    )
-    rows = list(incremental_fetch(svc, {"last_history_id": "1000"}, label_ids=["SPAM"]))
-
-    assert len(rows) == 1
-    assert rows[0]["id"] == "s"
-    assert rows[0]["_deleted"] is False
+    if kept:
+        assert [r["id"] for r in rows] == ["m"]
+        assert rows[0]["_deleted"] is False
+    else:
+        assert rows == [{"id": "m", "_deleted": True}]
 
 
 # ---------------------------------------------------------------------------
@@ -420,8 +391,7 @@ def test_e2e_dlt_merge_hard_delete_removes_deleted_message(tmp_path):
     """End-to-end, offline (no LLM): drive gmail_source through a real dlt
     merge and prove a ``_deleted`` marker physically removes the row from the
     destination — which is exactly what cognee's orphan_cleanup reconciles
-    against. Also exercises the gmail_source() closure dispatching from
-    backfill to incremental via persisted dlt resource_state.
+    against.
     """
     dlt = pytest.importorskip("dlt")
 

--- a/examples/demos/gmail_connector_example.py
+++ b/examples/demos/gmail_connector_example.py
@@ -12,8 +12,8 @@ Gmail are forgotten from memory on the next sync.
 Privacy / opt-in
 ────────────────────────────────────────────────────────────────────────────
 This reads the *content* of your email. It is strictly opt-in — nothing is
-fetched until you run this script. Scope what you ingest with ``label_ids`` /
-``query``, keep ``token.json`` private, and use a dedicated dataset so you can
+fetched until you run this script. Scope what you ingest with ``label_ids``,
+keep ``token.json`` private, and use a dedicated dataset so you can
 wipe it with a single ``cognee.forget``.
 
 ────────────────────────────────────────────────────────────────────────────

--- a/examples/demos/gmail_connector_example.py
+++ b/examples/demos/gmail_connector_example.py
@@ -47,9 +47,12 @@ from cognee.tasks.ingestion.connectors import gmail_source
 # Keep the inbox in its own dataset so it is easy to inspect and forget.
 DATASET_NAME = "gmail_inbox"
 
-# Routing kwargs shared by every remember() call below. ``max_rows_per_table=0``
-# disables cognee's per-table read cap so orphan-cleanup (forget-on-delete)
-# compares against the *entire* synced corpus, not a 50-row window.
+# Routing kwargs shared by every remember() call below.
+#   write_disposition="merge" is REQUIRED: the add pipeline defaults to
+#     "replace", which would wipe the whole synced inbox on the second sync.
+#   max_rows_per_table=0 disables cognee's per-table read cap so orphan-cleanup
+#     (forget-on-delete) compares against the *entire* synced corpus, not a
+#     50-row window.
 GMAIL_REMEMBER_KWARGS = {
     "primary_key": "id",
     "write_disposition": "merge",

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -32,8 +32,8 @@ await cognee.remember(
     gmail_source(label_ids=["INBOX"], credentials_path="credentials.json"),
     dataset_name="gmail_inbox",
     primary_key="id",
-    write_disposition="merge",
-    max_rows_per_table=0,   # 0 = no read cap, so forget-on-delete sees the whole inbox
+    write_disposition="merge",  # REQUIRED — any other disposition wipes the corpus on re-sync
+    max_rows_per_table=0,       # REQUIRED for a real inbox — forget-on-delete must see every row
 )
 
 answer = await cognee.search(
@@ -44,12 +44,3 @@ answer = await cognee.search(
 
 See the [example](../demos/gmail_connector_example.py) for OAuth setup,
 incremental re-sync, and the privacy / opt-in notes.
-
-## Adding a new connector
-
-1. Create `cognee/tasks/ingestion/connectors/<source>.py` exposing a factory
-   that returns a `dlt` resource/source (`primary_key`, `write_disposition="merge"`,
-   and a `hard_delete` marker column for deletions). Keep the SDK import lazy.
-2. Add a matching optional-dependency extra in `pyproject.toml`.
-3. Add a runnable example under `examples/demos/` and a row to the table above.
-4. Add mocked-SaaS + mocked-LLM tests (no live credentials in CI).

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -16,7 +16,7 @@ all share the same guarantees instead of each reinventing ingestion:
 
 | Source | Extra | Factory | Example | Notes |
 |---|---|---|---|---|
-| **Gmail** | `cognee[gmail]` | `cognee.tasks.ingestion.connectors.gmail_source` | [`demos/gmail_connector_example.py`](../demos/gmail_connector_example.py) | Messages/threads, label & query scoped. Incremental via `historyId`; trashed/deleted mail forgotten on next sync. OAuth2 (read-only). |
+| **Gmail** | `cognee[gmail]` | `cognee.tasks.ingestion.connectors.gmail_source` | [`demos/gmail_connector_example.py`](../demos/gmail_connector_example.py) | Messages/threads, label scoped. Incremental via `historyId`; trashed/deleted mail forgotten on next sync. OAuth2 (read-only). |
 
 ## Gmail quickstart
 


### PR DESCRIPTION
## Summary

"Ask my inbox" — pull Gmail messages into cognee memory, incrementally and with forget-on-deletion, built entirely on the existing DLT ingestion subsystem (`resolve_dlt_sources` → `ingest_dlt_source` → `orphan_cleanup`). `gmail_source(...)` returns a dlt resource you hand straight to `cognee.remember(...)`.

- OAuth2 installed-app flow, read-only Gmail scope; token cached at `token.json` (written `0600`).
- Primary key = message `id`, `write_disposition="merge"` for idempotent upserts.
- Incremental sync via Gmail `historyId`, persisted in dlt resource state.
- Deleted/trashed messages emitted with the `_deleted` hard-delete marker → cognee's existing `orphan_cleanup` purges them from the graph + vector + relational stores.
- `cognee[gmail]` extra (lazy imports), runnable demo under `examples/demos/`, Integrations Hub entry.

Fixes #3620.

## Relation to #3752

This builds on @junaiddshaukat's original connector (#3752): the first commit is that work verbatim, with author attribution preserved. Every commit on top is review-driven hardening and simplification.

## What the rework adds (on top of the original commit)

**Correctness / data-loss**
- Don't forget live mail on a transient fetch error — `_get_message` returns `None` only on a genuine 404/410 and re-raises transient (5xx / 429 / network) errors, so the incremental path never misreads a blip as a deletion (it previously did, and advanced the cursor past the "deleted" message).
- Compare `historyId` numerically — a lexicographic string compare froze the cursor whenever the id crossed a digit-count boundary (`"1000" < "999"`).
- Forget trashed / out-of-scope mail on incremental — trashing INBOX mail fires `labelsRemoved(INBOX)`, not `messagesDeleted`, so the message was re-ingested as live. A post-fetch scope re-check (mirroring backfill's AND-of-all-labels) now demotes it to a hard-delete. This also aligns multi-label scoping between backfill and incremental.

**Security**
- Write `token.json` (holds the long-lived OAuth refresh token) with `0600` permissions.

**Scope reduction — kept to issue #3620's contract**
- Dropped out-of-scope params (`query`, `include_spam_trash`, `scopes`) and a dead per-row `history_id` field. Label filtering is the sole, consistent scoping mechanism on both the list and history paths.

**Tests & docs**
- Added an offline (no-LLM, ~0.2s) end-to-end test that drives `gmail_source` through a real dlt merge and proves the `_deleted` marker physically removes the row from the destination; plus regression tests for the three fixes above. 18 unit tests, all mocked (no live creds in CI).
- Documented `write_disposition="merge"` as **mandatory** and aligned the connector with cognee conventions (module-top imports, log style, `ImportError` idiom).

## Known follow-ups (shared DLT subsystem — out of this connector's scope)

- `resolve_dlt_sources` hard-defaults `write_disposition` to `"replace"`, which overrides a resource's declared `merge`; calling `remember(gmail_source(...))` *without* `write_disposition="merge"` would wipe the synced corpus on the second run. Mitigated here by documenting `merge` as mandatory; the real cure is to honor the resource's declared disposition when the caller omits it.
- `ingest_dlt_source` uses a constant dlt `pipeline_name`, so the `historyId` cursor state is shared across datasets (affects multi-inbox use, not the single-inbox scope of #3620).

## Test plan

- [x] `uv run pytest cognee/tests/unit/tasks/test_gmail_connector.py` — 18 passed (mocked Gmail API, no live creds)
- [x] `ruff check .` && `ruff format --check .` on the touched files — clean
- [x] Offline e2e dlt merge / hard-delete round-trip

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
