### PR TITLE
feat(migration): add LangMemSource adapter for COGX import

### DIFF
--- a/cognee/modules/migration/sources/__init__.py
+++ b/cognee/modules/migration/sources/__init__.py
@@ -1,5 +1,6 @@
 from .base import MemorySource, IMPORT_MODES
 from .cogx_archive import COGXArchiveSource
+from .langmem import LangMemSource
 from .letta import LettaSource
 from .mem0 import Mem0Source
 from .zep import GraphitiSource, ZepSource
@@ -8,6 +9,7 @@ __all__ = [
     "MemorySource",
     "IMPORT_MODES",
     "COGXArchiveSource",
+    "LangMemSource",
     "LettaSource",
     "Mem0Source",
     "GraphitiSource",

--- a/cognee/modules/migration/sources/langmem.py
+++ b/cognee/modules/migration/sources/langmem.py
@@ -1,0 +1,283 @@
+"""LangMem memory source.
+
+Reads a LangMem store dump (JSON export from a LangGraph BaseStore) and yields
+COGX memory records. LangMem stores memories as structured items in namespaces;
+each item has a ``key``, a ``value`` dict with ``{kind, content}``, and optional
+timestamps. The dump is expected to be one of:
+
+- a JSON list of store items (the ``list(store.search(...))`` shape):
+  ``[{"namespace": ["memories", "user123"], "key": "abc", "value": {...}, ...}]``
+- a JSON object of ``{namespace: [{key, value, ...}]}`` (grouped dump)
+- a JSON object of ``{namespace: {key: value}}`` (simplified key-value map)
+- already-parsed Python equivalents (for live-API integration with a
+  LangGraph store client)
+
+Each memory's ``content`` field becomes a :class:`COGXMemory`. If the memory
+value contains ``entities`` or ``facts`` arrays (from structured schemas like
+``PreferenceMemory`` with relationships), those are mapped to
+:class:`COGXEntity` and :class:`COGXFact` respectively.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List, Union
+
+from cognee.modules.migration.cogx import (
+    COGXEntity,
+    COGXFact,
+    COGXMemory,
+    COGXRecord,
+    COGXScope,
+    parse_timestamp,
+)
+from cognee.modules.migration.sources.base import MemorySource
+
+
+def _extract_content(value: Any) -> str:
+    """Pull a textual representation from a LangMem memory value.
+
+    LangMem values can be:
+    - a plain string
+    - ``{"kind": "Memory", "content": {"content": "text"}}`` (default Memory schema)
+    - a Pydantic model dumped as a dict (custom schema)
+    - ``{"kind": "Memory", "content": <string>}`` (simplified)
+
+    For custom structured schemas the whole value dict is serialized
+    as a JSON string so the LLM can reason about it during re-derive.
+    """
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, dict):
+        return str(value) if value is not None else ""
+
+    # Default LangMem Memory shape: {"kind": "Memory", "content": {"content": "..."}}
+    content = value.get("content")
+    if isinstance(content, dict):
+        inner = content.get("content")
+        if isinstance(inner, str) and inner.strip():
+            return inner
+        # Empty or whitespace-only content dict: return empty string to signal skip
+        if isinstance(inner, str) and not inner.strip():
+            return ""
+        # Fallback: serialize the inner dict if it has meaningful keys
+        non_empty = {k: v for k, v in content.items() if v}
+        if non_empty:
+            return json.dumps(non_empty)
+        return ""
+    if isinstance(content, str):
+        return content.strip() or ""
+
+    # For custom schemas, serialize the relevant fields
+    # Look for common content-carrying key names
+    for key in ("content", "text", "preference", "summary", "context", "description"):
+        val = value.get(key)
+        if isinstance(val, str) and val.strip():
+            # If multiple fields carry meaning, include everything
+            if key == "content":
+                return val
+            return json.dumps(value)
+
+    # Fallback: serialize the whole value
+    return json.dumps(value)
+
+
+def _extract_user_id_from_namespace(namespace: Any) -> Union[str, None]:
+    """Heuristic: the first path segment after 'memories' is often the user id.
+
+    LangMem default namespace is ``("memories", "{langgraph_user_id}")``.
+    This extracts the second segment as user_id.
+    """
+    if isinstance(namespace, list) and len(namespace) >= 2:
+        second = namespace[1]
+        if isinstance(second, str) and second.strip() and "{" not in second:
+            return second
+    return None
+
+
+def _extract_entities(value: Any) -> List[Dict[str, Any]]:
+    """Extract entities from a structured LangMem memory value.
+
+    Some custom LangMem schemas embed entity information alongside facts.
+    """
+    if not isinstance(value, dict):
+        return []
+    entities = value.get("entities") or value.get("nodes") or []
+    if isinstance(entities, dict):
+        entities = [entities]
+    if isinstance(entities, list):
+        return [e for e in entities if isinstance(e, dict) and e.get("name")]
+    return []
+
+
+def _extract_facts(value: Any) -> List[Dict[str, Any]]:
+    """Extract facts/relations from a structured LangMem memory value."""
+    if not isinstance(value, dict):
+        return []
+    facts = value.get("facts") or value.get("relations") or value.get("edges") or []
+    if isinstance(facts, dict):
+        facts = [facts]
+    if isinstance(facts, list):
+        return [f for f in facts if isinstance(f, dict)]
+    return []
+
+
+class LangMemSource(MemorySource):
+    """Reads a LangMem store dump and yields COGX memory records.
+
+    LangMem is the long-term memory SDK from LangChain/LangGraph. Memories are
+    stored in a ``BaseStore`` keyed by ``(namespace, key)`` pairs. A dump
+    typically comes from ``list(store.search(...))`` producing a list of
+    ``Item`` objects, each with ``namespace``, ``key``, ``value``,
+    ``created_at``, and ``updated_at``.
+
+    Args:
+        data: Path to a JSON file, a JSON string, or an already-parsed list/dict.
+        mode: Import fidelity mode (``"re-derive"``, ``"preserve"``, ``"hybrid"``).
+
+    Example::
+
+        await cognee.remember(
+            LangMemSource("langmem_dump.json", mode="preserve")
+        )
+    """
+
+    source_system = "langmem"
+
+    def __init__(self, data: Union[str, Path, List[Any], Dict[str, Any]], mode: str = "re-derive"):
+        super().__init__(mode=mode)
+        self._data = data
+
+    def _load_raw(self) -> List[Dict[str, Any]]:
+        """Normalise the dump into a flat list of item dicts."""
+        data = self._data
+        if isinstance(data, (str, Path)):
+            data = json.loads(Path(data).read_text(encoding="utf-8"))
+
+        items: List[Dict[str, Any]] = []
+
+        if isinstance(data, list):
+            items = [item for item in data if isinstance(item, dict)]
+        elif isinstance(data, dict):
+            # Detect if this is a collection wrapper ({"items": [...], "memories": [...]})
+            # vs. a namespace-keyed dump ({"namespace1": [items], "namespace2": {key: value}})
+            is_collection = any(
+                isinstance(data.get(k), list) for k in ("items", "memories", "results")
+            )
+
+            if is_collection:
+                for coll_key in ("items", "memories", "results"):
+                    if isinstance(data.get(coll_key), list):
+                        for item in data[coll_key]:
+                            if isinstance(item, dict):
+                                items.append(item)
+            else:
+                # Namespace-keyed dump: {"namespace_string": [items]} or
+                # {"namespace_string": {user: [items]}} or
+                # {"namespace_string": {key: value}}
+                for key, value in data.items():
+                    if isinstance(value, list):
+                        for item in value:
+                            if isinstance(item, dict):
+                                if "namespace" not in item:
+                                    item = {**item, "namespace": [key]}
+                                items.append(item)
+                    elif isinstance(value, dict):
+                        for inner_key, inner_value in value.items():
+                            if isinstance(inner_value, list):
+                                # {"namespace": {"user": [items]}}
+                                for sub_item in inner_value:
+                                    if isinstance(sub_item, dict):
+                                        if "namespace" not in sub_item:
+                                            sub_item = {**sub_item, "namespace": [key, inner_key]}
+                                        items.append(sub_item)
+                            elif isinstance(inner_value, dict):
+                                # {"namespace": {"key": value}}
+                                items.append(
+                                    {
+                                        "namespace": [key],
+                                        "key": inner_key,
+                                        "value": inner_value,
+                                    }
+                                )
+        return items
+
+    async def records(self) -> AsyncIterator[COGXRecord]:
+        for index, item in enumerate(self._load_raw()):
+            namespace = item.get("namespace") or []
+            key = item.get("key") or f"langmem-{index}"
+            value = item.get("value") or item
+            created_at = parse_timestamp(item.get("created_at"))
+            updated_at = parse_timestamp(item.get("updated_at"))
+
+            user_id: Union[str, None] = (
+                item.get("user_id") or _extract_user_id_from_namespace(namespace)
+            )
+
+            # If value is logically nested (e.g. {"value": {...}}), unwrap once.
+            if isinstance(value, dict) and "value" in value and isinstance(value["value"], dict):
+                value = value["value"]
+
+            scope = COGXScope(
+                user_id=user_id,
+                agent_id=item.get("agent_id"),
+                session_id=item.get("session_id") or item.get("group_id"),
+                run_id=item.get("run_id"),
+            )
+
+            content = _extract_content(value)
+            if content:
+                categories = item.get("categories") or []
+                if isinstance(categories, str):
+                    categories = [categories]
+                yield COGXMemory(
+                    external_system=self.source_system,
+                    external_id=str(key),
+                    content=content,
+                    categories=[str(c) for c in categories],
+                    scope=scope,
+                    created_at=created_at,
+                    updated_at=updated_at,
+                    metadata={
+                        "langmem_namespace": namespace if isinstance(namespace, list) else [str(namespace)],
+                        "langmem_key": str(key),
+                    },
+                )
+
+            # Yield entities if the value carries them (structured schemas)
+            for entity in _extract_entities(value):
+                name = entity.get("name")
+                if not isinstance(name, str) or not name.strip():
+                    continue
+                yield COGXEntity(
+                    external_system=self.source_system,
+                    external_id=str(entity.get("id") or entity.get("external_id") or f"{key}-entity-{name}"),
+                    name=name,
+                    entity_type=entity.get("entity_type") or entity.get("type"),
+                    description=entity.get("description") or entity.get("summary"),
+                    aliases=entity.get("aliases") or [],
+                    attributes=entity.get("attributes") or {},
+                    scope=scope,
+                    created_at=parse_timestamp(entity.get("created_at")),
+                    metadata=entity.get("metadata") or {},
+                )
+
+            # Yield facts if the value carries them
+            for fact in _extract_facts(value):
+                subject = fact.get("subject_ref") or fact.get("subject") or fact.get("source")
+                obj_ref = fact.get("object_ref") or fact.get("object") or fact.get("target")
+                if not subject or not obj_ref:
+                    continue
+                yield COGXFact(
+                    external_system=self.source_system,
+                    external_id=str(fact.get("id") or fact.get("external_id") or f"{key}-fact-{subject}-{obj_ref}"),
+                    subject_ref=str(subject),
+                    predicate=str(fact.get("predicate") or fact.get("relation") or "relates_to"),
+                    object_ref=str(obj_ref),
+                    fact_text=fact.get("fact_text") or fact.get("fact"),
+                    valid_at=parse_timestamp(fact.get("valid_at")),
+                    invalid_at=parse_timestamp(fact.get("invalid_at") or fact.get("expired_at")),
+                    confidence=fact.get("confidence"),
+                    provenance=fact.get("provenance") or [],
+                    scope=scope,
+                    created_at=parse_timestamp(fact.get("created_at")),
+                )

--- a/cognee/tests/unit/migration/test_langmem_source.py
+++ b/cognee/tests/unit/migration/test_langmem_source.py
@@ -1,0 +1,387 @@
+"""Unit tests for LangMemSource adapter.
+
+All tests are pure: no databases, no LLM calls, no network. They verify
+that LangMemSource correctly reads various dump formats and yields the
+expected COGX records.
+"""
+
+import json
+
+import pytest
+
+from cognee.modules.migration.cogx import COGXEntity, COGXFact, COGXMemory
+from cognee.modules.migration.sources.langmem import LangMemSource
+
+
+# -- Sample data fixtures -----------------------------------------------------
+
+def _sample_list_dump():
+    """Standard LangMem dump as returned by ``list(store.search(...))``."""
+    return [
+        {
+            "namespace": ["memories", "user-123"],
+            "key": "550e8400-e29b-41d4-a716-446655440000",
+            "value": {
+                "kind": "Memory",
+                "content": {"content": "User prefers dark mode in all apps"},
+            },
+            "created_at": "2025-06-15T10:00:00Z",
+            "updated_at": "2025-06-15T12:00:00Z",
+        },
+        {
+            "namespace": ["memories", "user-123"],
+            "key": "550e8400-e29b-41d4-a716-446655440001",
+            "value": {
+                "kind": "Memory",
+                "content": {"content": "User's dog is named Fido, a golden retriever"},
+            },
+            "created_at": "2025-06-16T08:30:00Z",
+        },
+    ]
+
+
+def _sample_grouped_dump():
+    """Grouped dump: {namespace: {user: [items]}}."""
+    return {
+        "memories": {
+            "user-123": [
+                {
+                    "key": "mem-1",
+                    "value": {"kind": "Memory", "content": {"content": "User is vegan"}},
+                    "created_at": "2025-05-01T10:00:00Z",
+                }
+            ]
+        }
+    }
+
+
+def _sample_list_with_entities():
+    """Dump where some memories carry embedded entities and facts."""
+    return [
+        {
+            "namespace": ["project", "team_1", "user-456"],
+            "key": "mem-structured-1",
+            "value": {
+                "kind": "Memory",
+                "content": {"content": "User prefers dark mode"},
+                "entities": [
+                    {
+                        "name": "DarkMode",
+                        "entity_type": "Preference",
+                        "description": "UI theme preference",
+                    }
+                ],
+                "facts": [
+                    {
+                        "subject_ref": "DarkMode",
+                        "predicate": "preferred_by",
+                        "object_ref": "user-456",
+                        "fact_text": "User prefers dark mode for all apps",
+                    }
+                ],
+            },
+            "created_at": "2025-07-01T10:00:00Z",
+        }
+    ]
+
+
+def _sample_plain_string_list():
+    """Simple list of string memories (for convenience)."""
+    return [
+        {"namespace": ["memories", "user-1"], "key": "s1", "value": "I like coffee"},
+        {"namespace": ["memories", "user-1"], "key": "s2", "value": "I work remotely"},
+    ]
+
+
+async def _collect(source):
+    return [record async for record in source.records()]
+
+
+# -- Parsing tests ------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestLangMemSourceListFormat:
+    async def test_list_format_yields_memories(self):
+        source = LangMemSource(_sample_list_dump())
+        records = await _collect(source)
+
+        assert len(records) == 2
+        assert all(isinstance(r, COGXMemory) for r in records)
+
+        assert records[0].content == "User prefers dark mode in all apps"
+        assert records[0].external_id == "550e8400-e29b-41d4-a716-446655440000"
+        assert records[0].scope.user_id == "user-123"
+        assert records[0].created_at is not None
+        assert records[0].updated_at is not None
+        assert records[0].external_system == "langmem"
+
+        assert records[1].content == "User's dog is named Fido, a golden retriever"
+        assert records[1].scope.user_id == "user-123"
+        assert records[1].updated_at is None  # no updated_at in sample
+
+    async def test_list_format_preserves_categories(self):
+        dump = [
+            {
+                "namespace": ["memories", "user-1"],
+                "key": "cat-1",
+                "value": {"kind": "Memory", "content": {"content": "Likes hiking"}},
+                "categories": ["recreation", "outdoors"],
+            }
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+
+        assert len(records) == 1
+        assert records[0].categories == ["recreation", "outdoors"]
+
+    async def test_list_format_single_category_string(self):
+        dump = [
+            {
+                "namespace": ["memories", "user-1"],
+                "key": "cat-2",
+                "value": {"kind": "Memory", "content": {"content": "Works in tech"}},
+                "categories": "career",
+            }
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+
+        assert records[0].categories == ["career"]
+
+
+@pytest.mark.asyncio
+class TestLangMemSourceGroupedFormat:
+    async def test_grouped_kv_map(self):
+        source = LangMemSource(_sample_grouped_dump())
+        records = await _collect(source)
+
+        assert len(records) == 1
+        assert records[0].content == "User is vegan"
+        assert records[0].external_id == "mem-1"
+
+
+@pytest.mark.asyncio
+class TestLangMemSourceValueForms:
+    async def test_plain_string_value(self):
+        source = LangMemSource(_sample_plain_string_list())
+        records = await _collect(source)
+
+        assert len(records) == 2
+        assert records[0].content == "I like coffee"
+        assert records[1].content == "I work remotely"
+
+    async def test_value_dict_with_direct_content(self):
+        dump = [
+            {
+                "namespace": ["memories", "u1"],
+                "key": "k1",
+                "value": {"kind": "Memory", "content": "Just a string"},
+            }
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        assert records[0].content == "Just a string"
+
+    async def test_value_with_custom_schema_fields(self):
+        """Custom Pydantic schema values serialize to meaningful text."""
+        dump = [
+            {
+                "namespace": ["memories", "u1"],
+                "key": "k1",
+                "value": {
+                    "kind": "PreferenceMemory",
+                    "category": "ui",
+                    "preference": "dark_mode",
+                    "context": "User stated preference",
+                },
+            }
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        # Should serialize the structured dict to JSON for re-derive
+        assert "dark_mode" in records[0].content or "preference" in records[0].content
+
+
+@pytest.mark.asyncio
+class TestLangMemSourceEntitiesAndFacts:
+    async def test_yields_entities_from_value(self):
+        source = LangMemSource(_sample_list_with_entities())
+        records = await _collect(source)
+
+        memories = [r for r in records if isinstance(r, COGXMemory)]
+        entities = [r for r in records if isinstance(r, COGXEntity)]
+        facts = [r for r in records if isinstance(r, COGXFact)]
+
+        assert len(memories) == 1
+        assert len(entities) == 1
+        assert len(facts) == 1
+
+        assert entities[0].name == "DarkMode"
+        assert entities[0].entity_type == "Preference"
+
+        assert facts[0].subject_ref == "DarkMode"
+        assert facts[0].predicate == "preferred_by"
+        assert facts[0].object_ref == "user-456"
+
+    async def test_total_record_count_includes_all_kinds(self):
+        source = LangMemSource(_sample_list_with_entities())
+        records = await _collect(source)
+        # 1 memory + 1 entity + 1 fact
+        assert len(records) == 3
+
+
+@pytest.mark.asyncio
+class TestLangMemSourceMetadata:
+    async def test_metadata_includes_namespace_and_key(self):
+        source = LangMemSource(_sample_list_dump())
+        records = await _collect(source)
+
+        meta = records[0].metadata
+        assert meta["langmem_namespace"] == ["memories", "user-123"]
+        assert meta["langmem_key"] == "550e8400-e29b-41d4-a716-446655440000"
+
+
+@pytest.mark.asyncio
+class TestLangMemSourceJSONFile:
+    async def test_from_json_file(self, tmp_path):
+        dump_path = tmp_path / "langmem_dump.json"
+        dump_path.write_text(json.dumps(_sample_list_dump()))
+
+        source = LangMemSource(str(dump_path))
+        records = await _collect(source)
+
+        assert len(records) == 2
+        assert records[0].content == "User prefers dark mode in all apps"
+
+
+@pytest.mark.asyncio
+class TestLangMemSourceEdgeCases:
+    async def test_empty_list(self):
+        source = LangMemSource([])
+        records = await _collect(source)
+        assert records == []
+
+    async def test_skips_non_dict_items_in_list(self):
+        dump = [
+            {"namespace": ["m"], "key": "k1", "value": "valid"},
+            "not a dict",
+            None,
+            {"namespace": ["m"], "key": "k2", "value": "also valid"},
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        assert len(records) == 2
+
+    async def test_missing_key_generates_fallback(self):
+        dump = [{"namespace": ["memories", "u1"], "value": "no key here"}]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        assert records[0].external_id == "langmem-0"
+
+    async def test_missing_value_uses_item_as_fallback(self):
+        """When 'value' key is missing, use the whole item as value."""
+        dump = [{"namespace": ["memories", "u1"], "key": "k1", "content": "inline content"}]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        # Content field inside the item dict will be extracted
+        assert len(records) == 1
+
+    async def test_empty_content_skipped(self):
+        dump = [
+            {
+                "namespace": ["memories", "u1"],
+                "key": "k1",
+                "value": {"kind": "Memory", "content": {"content": ""}},
+            }
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        assert records == []
+
+    async def test_namespace_with_three_parts(self):
+        """Three-part namespace: user_id is still index 1."""
+        dump = [
+            {
+                "namespace": ["project", "team-alpha", "user-7"],
+                "key": "k1",
+                "value": {"kind": "Memory", "content": {"content": "test"}},
+            }
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        assert records[0].scope.user_id == "team-alpha"
+
+    async def test_namespace_with_template_stays_none(self):
+        """Template namespaces like {langgraph_user_id} should not resolve to user_id."""
+        dump = [
+            {
+                "namespace": ["memories", "{langgraph_user_id}"],
+                "key": "k1",
+                "value": {"kind": "Memory", "content": {"content": "test"}},
+            }
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        # The second segment is a template string with braces, not a real user_id
+        assert records[0].scope.user_id is None
+
+    async def test_memories_item_collection_key(self):
+        """Dump with a 'memories' top-level key containing a list."""
+        dump = {
+            "memories": [
+                {
+                    "namespace": ["memories", "u1"],
+                    "key": "k1",
+                    "value": {"kind": "Memory", "content": {"content": "from collection"}},
+                }
+            ]
+        }
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        assert len(records) == 1
+        assert records[0].content == "from collection"
+
+    async def test_user_id_from_item_field(self):
+        """Explicit user_id in item overrides namespace inference."""
+        dump = [
+            {
+                "namespace": ["memories", "other-id"],
+                "key": "k1",
+                "value": "test content",
+                "user_id": "explicit-user",
+            }
+        ]
+        source = LangMemSource(dump)
+        records = await _collect(source)
+        assert records[0].scope.user_id == "explicit-user"
+
+
+class TestLangMemSourceModes:
+    def test_default_mode_is_re_derive(self):
+        source = LangMemSource(_sample_list_dump())
+        assert source.mode == "re-derive"
+
+    def test_explicit_mode_preserve(self):
+        source = LangMemSource(_sample_list_dump(), mode="preserve")
+        assert source.mode == "preserve"
+
+    def test_explicit_mode_hybrid(self):
+        source = LangMemSource(_sample_list_dump(), mode="hybrid")
+        assert source.mode == "hybrid"
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            LangMemSource(_sample_list_dump(), mode="invalid-mode")
+
+
+class TestLangMemSourceImportIntegration:
+    """Test that LangMemSource can be imported via the sources module."""
+
+    def test_import_via_sources_package(self):
+        from cognee.modules.migration.sources import LangMemSource as ImportedSource
+
+        assert ImportedSource is LangMemSource
+
+    def test_source_system_is_langmem(self):
+        source = LangMemSource([])
+        assert source.source_system == "langmem"


### PR DESCRIPTION
## Summary

Adds `LangMemSource`, a `MemorySource` that reads LangMem (LangChain/LangGraph long-term memory SDK) store dumps and yields COGX memory, entity, and fact records.

Closes #3403

## What was done

**New adapter**: `cognee/modules/migration/sources/langmem.py`
- Reads LangMem BaseStore dumps in multiple formats (list, namespace-keyed, collection wrappers)
- Yields `COGXMemory`, `COGXEntity`, and `COGXFact` records
- Infers `user_id` from LangGraph namespaces
- Supports all import modes: re-derive, preserve, hybrid

**Exports**: Added `LangMemSource` to `sources/__init__.py`

**Tests**: `cognee/tests/unit/migration/test_langmem_source.py` — 26 pure unit tests covering parsing, value forms, entities/facts, edge cases, modes, and metadata.

## Testing

All 127 migration unit tests pass:
```
uv run pytest cognee/tests/unit/migration/ -v
```

No LLM calls, no database, no network required — all tests are pure Python.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
