### PR TITLE
feat(cli): calm, honest first run for #3605

### DIFF
--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -3,8 +3,29 @@ import os
 import argparse
 import signal
 import subprocess
+import warnings
 from typing import Any, Sequence, Dict, Type, cast, List
 import click
+
+
+# aiohttp closes its ClientSession asynchronously via __del__ during
+# interpreter shutdown; when the CLI exits between the last await and the
+# event-loop teardown the finalizer emits a "Unclosed client session"
+# ResourceWarning that panics first-time users into thinking the run
+# failed. The message is not actionable in the CLI context, so suppress it
+# at the process boundary. Debug mode leaves warnings alone so contributors
+# still see the trace when they need it.
+if not any(a in ("-x", "--debug") for a in sys.argv[1:]):
+    warnings.filterwarnings(
+        "ignore",
+        message="Unclosed client session",
+        category=ResourceWarning,
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message="Unclosed connector",
+        category=ResourceWarning,
+    )
 
 try:
     import rich_argparse
@@ -19,6 +40,7 @@ from cognee.cli.config import CLI_DESCRIPTION
 from cognee.cli import debug
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException
+from cognee.cli.remediation import find_remediation
 
 
 ACTION_EXECUTED = False
@@ -380,6 +402,13 @@ def main() -> int:
 
             # Print exception
             fmt.error(str(ex))
+
+            # Surface a prescriptive next step for known first-run failure
+            # modes between the error line and the generic docs pointer, so
+            # the actionable fix sits directly under the error it addresses.
+            hint = find_remediation(str(ex))
+            if hint:
+                fmt.note(hint)
 
             fmt.note(f"Please refer to our docs at '{docs_url}' for further assistance.")
 

--- a/cognee/cli/commands/cognify_command.py
+++ b/cognee/cli/commands/cognify_command.py
@@ -8,6 +8,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import CHUNKER_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.hints import add_quiet_flag, cognify_hint
 
 
 class CognifyCommand(SupportsCliCommand):
@@ -70,6 +71,7 @@ After successful cognify processing, use `cognee search` to query the knowledge 
             type=int,
             help="Number of chunks to process per task batch (try 50 for large single documents).",
         )
+        add_quiet_flag(parser)
 
     def execute(self, args: argparse.Namespace) -> None:
         try:
@@ -170,6 +172,11 @@ After successful cognify processing, use `cognee search` to query the knowledge 
                 fmt.success("Cognification completed successfully!")
                 if args.verbose and result:
                     fmt.echo(f"Processing results: {result}")
+
+            # The hint uses the first dataset supplied or a placeholder so it
+            # copy-pastes cleanly when the user targeted all data.
+            hint_dataset = args.datasets[0] if args.datasets else "<dataset-name>"
+            cognify_hint(args, hint_dataset)
 
         except Exception as e:
             if isinstance(e, CliCommandInnerException):

--- a/cognee/cli/commands/forget_command.py
+++ b/cognee/cli/commands/forget_command.py
@@ -6,6 +6,7 @@ from cognee.cli.reference import SupportsCliCommand
 from cognee.cli import DEFAULT_DOCS_URL
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.hints import add_quiet_flag, forget_hint
 
 
 class ForgetCommand(SupportsCliCommand):
@@ -36,6 +37,7 @@ to delete a dataset, or dataset + --data-id to delete a single item.
             default=False,
             help="Delete all datasets and data",
         )
+        add_quiet_flag(parser)
 
     def execute(self, args: argparse.Namespace) -> None:
         try:
@@ -68,6 +70,12 @@ to delete a dataset, or dataset + --data-id to delete a single item.
 
             result = asyncio.run(run_forget())
             fmt.success(f"Done: {result}")
+
+            # After a successful forget the natural next step is to seed the
+            # graph again with remember; a placeholder is used when the user
+            # wiped everything so no specific dataset name is meaningful.
+            hint_dataset = dataset or "<dataset-name>"
+            forget_hint(args, hint_dataset)
 
         except Exception as e:
             if isinstance(e, CliCommandInnerException):

--- a/cognee/cli/commands/recall_command.py
+++ b/cognee/cli/commands/recall_command.py
@@ -7,6 +7,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import SEARCH_TYPE_CHOICES, OUTPUT_FORMAT_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.hints import add_quiet_flag, recall_hint
 
 
 class RecallCommand(SupportsCliCommand):
@@ -64,6 +65,7 @@ Otherwise, this is a memory-oriented alias for `cognee search`.
             default="pretty",
             help="Output format (default: pretty)",
         )
+        add_quiet_flag(parser)
 
     def execute(self, args: argparse.Namespace) -> None:
         try:
@@ -129,6 +131,12 @@ Otherwise, this is a memory-oriented alias for `cognee search`.
             else:
                 if not results:
                     fmt.warning("No results found for your query.")
+                    # Hint scoped to the pretty output path: json/simple are
+                    # for scripting so an extra line would corrupt the sink.
+                    hint_dataset = (
+                        args.datasets[0] if getattr(args, "datasets", None) else "<dataset-name>"
+                    )
+                    recall_hint(args, hint_dataset, had_results=False)
                     return
 
                 # Detect session results by _source tag

--- a/cognee/cli/commands/remember_command.py
+++ b/cognee/cli/commands/remember_command.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+from importlib import resources
 
 from cognee.cli.reference import SupportsCliCommand
 from cognee.cli import DEFAULT_DOCS_URL
@@ -7,6 +8,20 @@ from cognee.cli.config import CHUNKER_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
 from cognee.cli.hints import add_quiet_flag, remember_hint
+
+
+_SAMPLE_FIXTURE = "quickstart.txt"
+
+
+def _resolve_sample_path() -> str:
+    """Return the absolute path of the bundled quickstart fixture.
+
+    ``importlib.resources.files`` gives a path that survives both editable
+    and wheel installs. The fixture is copied into the package on install,
+    so no environment variable or ``DATA_ROOT_DIRECTORY`` override is
+    required to run the demo.
+    """
+    return str(resources.files("cognee.cli.samples").joinpath(_SAMPLE_FIXTURE))
 
 
 class RememberCommand(SupportsCliCommand):
@@ -25,8 +40,16 @@ After completion, use `cognee recall` (or `cognee search`) to query the graph.
     def configure_parser(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "data",
-            nargs="+",
+            nargs="*",
             help="Data to add: text content, file paths, file URLs, or S3 paths",
+        )
+        parser.add_argument(
+            "--sample-data",
+            action="store_true",
+            help=(
+                "Ingest the bundled quickstart fixture instead of user data. "
+                "Handy for a first-run smoke test; still requires LLM_API_KEY."
+            ),
         )
         parser.add_argument(
             "--dataset-name",
@@ -61,6 +84,19 @@ After completion, use `cognee recall` (or `cognee search`) to query the graph.
     def execute(self, args: argparse.Namespace) -> None:
         try:
             import cognee
+
+            if args.sample_data:
+                if args.data:
+                    raise CliCommandInnerException(
+                        "--sample-data cannot be combined with explicit data arguments."
+                    )
+                sample_path = _resolve_sample_path()
+                fmt.note(f"Using bundled sample fixture: {sample_path}")
+                args.data = [sample_path]
+            elif not args.data:
+                raise CliCommandInnerException(
+                    "No data supplied. Pass file paths, text, or --sample-data."
+                )
 
             fmt.echo(f"Remembering {len(args.data)} item(s) in dataset '{args.dataset_name}'...")
 

--- a/cognee/cli/commands/remember_command.py
+++ b/cognee/cli/commands/remember_command.py
@@ -6,6 +6,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import CHUNKER_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.cli.hints import add_quiet_flag, remember_hint
 
 
 class RememberCommand(SupportsCliCommand):
@@ -55,6 +56,7 @@ After completion, use `cognee recall` (or `cognee search`) to query the graph.
             type=int,
             help="Number of chunks to process per task batch",
         )
+        add_quiet_flag(parser)
 
     def execute(self, args: argparse.Namespace) -> None:
         try:
@@ -112,6 +114,8 @@ After completion, use `cognee recall` (or `cognee search`) to query the graph.
                     fmt.echo(f"  Content hash: {result.content_hash}")
                 if result.elapsed_seconds is not None:
                     fmt.echo(f"  Elapsed: {result.elapsed_seconds:.1f}s")
+
+            remember_hint(args, args.dataset_name)
 
         except Exception as e:
             if isinstance(e, CliCommandInnerException):

--- a/cognee/cli/hints.py
+++ b/cognee/cli/hints.py
@@ -1,0 +1,100 @@
+"""Next-step hints for the primary CLI commands.
+
+Every primary command (``remember``, ``recall``, ``cognify``, ``forget``)
+ends with a single line that names the next natural command the user
+will typically want to run, formatted as copy-paste. Users driving the
+CLI in a script or pipeline can suppress the hint with ``--quiet``.
+
+The hints live in one module so the copy stays consistent across
+commands and a follow-up docs pass can be made in one place instead of
+grepping four command modules. Every hint is a plain string with no
+ANSI colour so it composes cleanly with piped output.
+"""
+
+from __future__ import annotations
+
+import cognee.cli.echo as fmt
+
+_NEXT_LABEL = "Next"
+
+
+def _hint(text: str) -> None:
+    """Emit a single next-step line prefixed with ``Next:``.
+
+    Kept tiny so callers just line up their argument with the copy in
+    this module. ``fmt.echo`` is used so the sink honours the same
+    stream configuration as the surrounding success block.
+    """
+    fmt.echo(f"{_NEXT_LABEL}: {text}")
+
+
+def _quiet(args) -> bool:
+    """Return True when the caller passed ``--quiet``.
+
+    Silent-fail on missing attribute so a command that has not yet
+    declared the flag on its parser does not raise; the hint just
+    prints. All four primary commands declare it via
+    ``add_quiet_flag(parser)``.
+    """
+    return bool(getattr(args, "quiet", False))
+
+
+def add_quiet_flag(parser) -> None:
+    """Attach the ``--quiet`` flag to a command's argparse parser.
+
+    Kept as a helper so the option string and help text stay consistent
+    across the four primary commands and a follow-up rename touches
+    one place.
+    """
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the next-step hint line (useful when piping or scripting).",
+    )
+
+
+def remember_hint(args, dataset_name: str) -> None:
+    """Print the "recall next" hint after a successful ``remember``.
+
+    Uses the user's actual dataset name so the copy is directly
+    executable, not a placeholder.
+    """
+    if _quiet(args):
+        return
+    _hint(f'cognee-cli recall "your question" -d {dataset_name}')
+
+
+def cognify_hint(args, dataset_name: str) -> None:
+    """Print the "recall next" hint after a successful ``cognify``.
+
+    Same target as :func:`remember_hint` because from the user's
+    perspective both commands leave the same next step waiting.
+    """
+    if _quiet(args):
+        return
+    _hint(f'cognee-cli recall "your question" -d {dataset_name}')
+
+
+def recall_hint(args, dataset_name: str, had_results: bool) -> None:
+    """Print a "remember more" hint after ``recall``.
+
+    Only fires when the recall returned no results, so a user who got a
+    useful answer is not nudged toward a follow-up they did not ask
+    for. When results were found the command already gives the user
+    plenty to look at.
+    """
+    if _quiet(args):
+        return
+    if had_results:
+        return
+    _hint(
+        f'no matches in "{dataset_name}". Try "cognee-cli remember <path-or-text> '
+        f'-d {dataset_name}" to seed it, then rerun this recall.'
+    )
+
+
+def forget_hint(args, dataset_name: str) -> None:
+    """Print the "remember to start fresh" hint after a successful ``forget``."""
+    if _quiet(args):
+        return
+    _hint(f"cognee-cli remember <path-or-text> -d {dataset_name} to start a new session.")

--- a/cognee/cli/remediation.py
+++ b/cognee/cli/remediation.py
@@ -1,0 +1,116 @@
+"""First-run error remediation table.
+
+The four failure modes that show up most often on a clean install are:
+
+1. **Missing / empty API key** — user has not set ``LLM_API_KEY``.
+2. **Invalid API key** — key is set but rejected upstream (401 / 403).
+3. **Unreachable custom endpoint** — user pointed ``EMBEDDING_ENDPOINT`` or
+   ``LLM_ENDPOINT`` at a URL that resolves but does not respond.
+4. **Wrong ontology path** — ``--ontology-file`` argument does not exist.
+
+Each of these triggers a raw stack trace from deep in the pipeline today.
+This module lifts a short, prescriptive hint to the top of the terminal
+so the user knows the exact env var or flag to fix without reading the
+trace.
+
+The dispatcher is deliberately pattern-based on the exception ``repr``
+rather than exception-type checks: many of these failures surface via
+``CliCommandException`` with a stringified inner error, so ``isinstance``
+would miss the real class. Keeping the match on substrings also lets a
+new failure mode land as one dict entry with no import graph work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+@dataclass(frozen=True)
+class Remediation:
+    """A pattern + hint pair.
+
+    ``needles`` is any/all: the hint fires when *any* needle is a
+    case-insensitive substring of the error message. Keep needles short
+    and stable — full sentence fragments are more brittle across
+    ``litellm`` versions than one or two anchor words.
+    """
+
+    needles: tuple[str, ...]
+    hint: str
+
+
+# Ordering matters: the first match wins, so put narrower patterns
+# ahead of broader ones. Auth failures beat generic BadRequest.
+_TABLE: tuple[Remediation, ...] = (
+    Remediation(
+        needles=("authenticationerror", "invalid api key", "incorrect api key"),
+        hint=(
+            "The LLM provider rejected the API key. Fix: set LLM_API_KEY in "
+            "your .env to a valid key for the LLM_PROVIDER you configured "
+            "(default provider: openai)."
+        ),
+    ),
+    Remediation(
+        needles=("permissiondeniederror", "insufficient_quota", "billing"),
+        hint=(
+            "The LLM provider accepted the key but denied the request. Fix: "
+            "confirm the account has active billing and quota, or switch "
+            "LLM_PROVIDER/LLM_MODEL to one your account can use."
+        ),
+    ),
+    Remediation(
+        needles=(
+            "llm_api_key",
+            "no api key",
+        ),
+        hint=(
+            "LLM_API_KEY is not set. Fix: copy .env.template to .env and "
+            "populate LLM_API_KEY. Cognee defaults to the OpenAI provider "
+            "so an OpenAI key is the simplest starting point."
+        ),
+    ),
+    Remediation(
+        needles=(
+            "embedding_endpoint",
+            "cannot connect to embedding",
+            "embedding endpoint timed out",
+        ),
+        hint=(
+            "The configured EMBEDDING_ENDPOINT is not reachable. Fix: verify "
+            "the URL, that the host is running, and that the port is open. "
+            "Unset EMBEDDING_ENDPOINT to fall back to the provider default."
+        ),
+    ),
+    Remediation(
+        needles=("ontology file not found",),
+        hint=(
+            "The --ontology-file path does not exist. Fix: pass an absolute "
+            "path to an .owl / .ttl file, or drop the flag to use the built-in "
+            "resolver."
+        ),
+    ),
+)
+
+
+def find_remediation(message: str) -> Optional[str]:
+    """Return the hint for the first matching pattern, or ``None``.
+
+    Deliberately tolerant of a ``None`` or empty message so callers can
+    hand off whatever they got from ``str(ex)`` without pre-validation.
+    """
+    if not message:
+        return None
+    haystack = message.lower()
+    for row in _TABLE:
+        if _matches(haystack, row.needles):
+            return row.hint
+    return None
+
+
+def _matches(haystack: str, needles: Iterable[str]) -> bool:
+    """Return True when any needle is a substring of ``haystack``.
+
+    Case handling is caller-owned: pass in an already-lowered haystack.
+    """
+    return any(needle in haystack for needle in needles)

--- a/cognee/cli/samples/__init__.py
+++ b/cognee/cli/samples/__init__.py
@@ -1,0 +1,5 @@
+"""Bundled sample fixtures for calm first-run demos.
+
+Kept as a package so ``importlib.resources`` can resolve the file path
+without depending on the source-tree layout.
+"""

--- a/cognee/cli/samples/quickstart.txt
+++ b/cognee/cli/samples/quickstart.txt
@@ -1,0 +1,19 @@
+Cognee is an open-source AI memory platform. It transforms raw text,
+files, and URLs into a persistent knowledge graph that agents can query.
+
+The core workflow has three verbs: remember (ingest data), recall (query
+the graph), and forget (evict data). Behind the scenes, remember runs an
+extract-cognify-load pipeline: it chunks the input, extracts entities and
+relationships with an LLM, embeds the chunks, and stores the results in
+a graph database plus a vector store.
+
+For example, Alice works at Anthropic in San Francisco. She contributes
+to the Cognee project. The Cognee project depends on litellm for LLM
+routing and on Ladybug as its default graph backend. Ladybug is a
+lightweight, in-process graph store designed for local development.
+
+Recall queries can traverse this graph: "who works at Anthropic" returns
+Alice, "what does Cognee depend on" returns litellm and Ladybug, and
+"where does Alice live" returns San Francisco. Recall combines a vector
+similarity step with graph traversal so the answers stay grounded in the
+original chunks rather than being invented by the language model.

--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -113,8 +113,19 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
     @retry(
         stop=stop_after_delay(128),
         wait=wait_exponential_jitter(2, 128),
+        # Skip the retry chain for terminal error classes. Authentication /
+        # authorization / not-found / payment-required errors will never succeed
+        # on a retry, so the previous behaviour of running the full backoff
+        # ladder wasted ~2 minutes of user wall clock on a mis-typed API key.
+        # Matches the exclusion set already used by the LLM adapters
+        # (see cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/openai/adapter.py).
         retry=retry_if_not_exception_type(
-            (litellm.exceptions.NotFoundError, asyncio.CancelledError)
+            (
+                litellm.exceptions.NotFoundError,
+                litellm.exceptions.AuthenticationError,
+                litellm.exceptions.PermissionDeniedError,
+                asyncio.CancelledError,
+            )
         ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
@@ -232,6 +243,17 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
             raise EmbeddingException(
                 "Cannot connect to embedding endpoint. Check EMBEDDING_ENDPOINT."
             ) from e
+
+        except (
+            litellm.exceptions.AuthenticationError,
+            litellm.exceptions.PermissionDeniedError,
+            asyncio.CancelledError,
+        ):
+            # Terminal failures must reach tenacity unwrapped so
+            # ``retry_if_not_exception_type`` can short-circuit the
+            # backoff ladder. Wrapping in EmbeddingException here would
+            # hide the class and force the full ~2-minute retry cycle.
+            raise
 
         except (
             litellm.exceptions.BadRequestError,

--- a/cognee/tests/cli_tests/cli_unit_tests/test_hints.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_hints.py
@@ -1,0 +1,66 @@
+"""Unit tests for CLI next-step hint helpers.
+
+The hints module renders the "Next: ..." line after each primary
+command. These tests pin behaviour that scripting users depend on:
+``--quiet`` fully silences the hint, and the recall hint is only fired
+when the search returned zero results.
+"""
+
+from argparse import Namespace
+
+import pytest
+
+from cognee.cli import hints
+
+
+@pytest.fixture(autouse=True)
+def _capture_echo(monkeypatch):
+    lines: list[str] = []
+    monkeypatch.setattr(hints.fmt, "echo", lambda msg: lines.append(msg))
+    return lines
+
+
+def _args(**kwargs) -> Namespace:
+    kwargs.setdefault("quiet", False)
+    return Namespace(**kwargs)
+
+
+def test_remember_hint_prints_dataset(_capture_echo):
+    hints.remember_hint(_args(), "docs")
+    assert _capture_echo == ['Next: cognee-cli recall "your question" -d docs']
+
+
+def test_cognify_hint_mirrors_remember(_capture_echo):
+    hints.cognify_hint(_args(), "docs")
+    assert _capture_echo == ['Next: cognee-cli recall "your question" -d docs']
+
+
+def test_recall_hint_skipped_on_hit(_capture_echo):
+    hints.recall_hint(_args(), "docs", had_results=True)
+    assert _capture_echo == []
+
+
+def test_recall_hint_fires_on_miss(_capture_echo):
+    hints.recall_hint(_args(), "docs", had_results=False)
+    assert len(_capture_echo) == 1
+    assert 'no matches in "docs"' in _capture_echo[0]
+
+
+def test_forget_hint_prints_restart_line(_capture_echo):
+    hints.forget_hint(_args(), "docs")
+    assert len(_capture_echo) == 1
+    assert "cognee-cli remember" in _capture_echo[0]
+
+
+@pytest.mark.parametrize(
+    "fn,extra",
+    [
+        (hints.remember_hint, {}),
+        (hints.cognify_hint, {}),
+        (hints.recall_hint, {"had_results": False}),
+        (hints.forget_hint, {}),
+    ],
+)
+def test_quiet_flag_suppresses_all_hints(fn, extra, _capture_echo):
+    fn(_args(quiet=True), "docs", **extra)
+    assert _capture_echo == []

--- a/cognee/tests/cli_tests/cli_unit_tests/test_remediation.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_remediation.py
@@ -1,0 +1,63 @@
+"""Unit tests for the CLI first-run remediation table.
+
+Behaviour under test: for each documented failure mode, the substring
+match resolves to the correct actionable hint. Regressions here would
+silently downgrade the first-run experience back to a bare stack trace.
+"""
+
+import pytest
+
+from cognee.cli.remediation import find_remediation
+
+
+@pytest.mark.parametrize(
+    "message,anchor",
+    [
+        (
+            "litellm.exceptions.AuthenticationError: invalid api key",
+            "LLM_API_KEY",
+        ),
+        (
+            "PermissionDeniedError: insufficient_quota for tier",
+            "billing and quota",
+        ),
+        (
+            "ValueError: LLM_API_KEY missing from environment",
+            ".env.template",
+        ),
+        (
+            "Cannot connect to embedding endpoint. Check EMBEDDING_ENDPOINT.",
+            "EMBEDDING_ENDPOINT",
+        ),
+        (
+            "Embedding endpoint timed out. EMBEDDING_ENDPOINT='http://x'",
+            "EMBEDDING_ENDPOINT",
+        ),
+        (
+            "Ontology file not found: /tmp/does-not-exist.owl",
+            "--ontology-file",
+        ),
+    ],
+)
+def test_match_returns_expected_hint(message: str, anchor: str) -> None:
+    hint = find_remediation(message)
+    assert hint is not None
+    assert anchor in hint
+
+
+def test_no_match_returns_none() -> None:
+    assert find_remediation("some unrelated error") is None
+
+
+def test_empty_message_returns_none() -> None:
+    assert find_remediation("") is None
+    assert find_remediation(None) is None  # type: ignore[arg-type]
+
+
+def test_auth_wins_over_generic_llm_key_pattern() -> None:
+    """Order matters. AuthenticationError should not fall through to the
+    "no api key" hint just because both patterns overlap the same error.
+    """
+    hint = find_remediation("AuthenticationError: LLM_API_KEY rejected")
+    assert hint is not None
+    assert "rejected the API key" in hint

--- a/cognee/tests/unit/test_litellm_embedding_auth_fastfail.py
+++ b/cognee/tests/unit/test_litellm_embedding_auth_fastfail.py
@@ -1,0 +1,99 @@
+"""Regression test: the embedding engine must NOT retry on auth failures.
+
+Rationale: prior to the fix, the tenacity ``retry`` decorator only
+skipped ``NotFoundError`` and ``CancelledError``. On an invalid
+``LLM_API_KEY`` litellm raised ``AuthenticationError`` and the engine
+walked the full 8s -> 128s exponential backoff ladder, hanging the CLI
+for two full minutes before surfacing the failure. This test pins the
+retry set so the fast-fail behaviour cannot silently regress.
+"""
+
+import asyncio
+
+import httpx
+import litellm
+import pytest
+
+from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+    LiteLLMEmbeddingEngine,
+)
+
+
+def _fake_response(status_code: int) -> httpx.Response:
+    """Build a minimal ``httpx.Response`` for litellm exception constructors.
+
+    litellm.PermissionDeniedError requires a real Response object, so a
+    plain string is not enough. Only the status code is meaningful here.
+    """
+    return httpx.Response(
+        status_code=status_code,
+        request=httpx.Request("POST", "https://example.invalid"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_error_bypasses_retry(monkeypatch):
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_auth(**kwargs):
+        calls["count"] += 1
+        raise litellm.exceptions.AuthenticationError(
+            message="invalid api key",
+            llm_provider="openai",
+            model="text-embedding-3-large",
+        )
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_auth)
+
+    with pytest.raises(litellm.exceptions.AuthenticationError):
+        await engine.embed_text(["hello world"])
+
+    # The critical assertion: exactly one attempt, no backoff ladder.
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_permission_denied_bypasses_retry(monkeypatch):
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_perm(**kwargs):
+        calls["count"] += 1
+        raise litellm.exceptions.PermissionDeniedError(
+            message="quota exhausted",
+            llm_provider="openai",
+            model="text-embedding-3-large",
+            response=_fake_response(403),
+        )
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_perm)
+
+    with pytest.raises(litellm.exceptions.PermissionDeniedError):
+        await engine.embed_text(["hello world"])
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_bypasses_retry(monkeypatch):
+    """Existing behaviour, kept as a guard rail."""
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+    engine = LiteLLMEmbeddingEngine(dimensions=4)
+
+    calls = {"count": 0}
+
+    async def _raise_cancelled(**kwargs):
+        calls["count"] += 1
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(litellm, "aembedding", _raise_cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        await engine.embed_text(["hello world"])
+
+    assert calls["count"] == 1

--- a/docs/onboarding-audit-2026-Q3.md
+++ b/docs/onboarding-audit-2026-Q3.md
@@ -1,0 +1,204 @@
+# Onboarding audit, 2026-Q3
+
+Written for issue [#3605](https://github.com/topoteretes/cognee/issues/3605). Part 1 of that ticket: walk the real first-run paths as a new user, capture the friction verbatim, and rank it. The proposal (Part 2) and quick-win implementation (Part 3) build on this document and land in the same PR series.
+
+## Setup
+
+- Auditor: Labi-Joy
+- Date: 2026-07-09
+- Baseline: Ubuntu 22.04, Python 3.10.12 via `uv`, no prior cognee config on disk, no `LLM_API_KEY` in the environment at `t = 0`
+- Cognee version: `1.2.2-local` on `dev` at `89eaa725b`
+- Entry points walked: Python SDK, `cognee-cli`, `cognee-cli -ui`, `docker compose up`
+
+## Executive summary
+
+Six findings ranked by user-time-cost times frequency. Two more (F7, F8) are called out for cross-reference to sibling issues.
+
+| Rank | Finding | Impact |
+| ---- | ------- | ------ |
+| F1 | Invalid `LLM_API_KEY` retries with exponential backoff for ~2 minutes before erroring | **Critical**. Every new user with a typo, quota-exhausted key, or wrong provider hits this. Two minutes of ambiguous log spam before a 401 is finally surfaced. |
+| F2 | Errors leak upstream implementation details (`Status code: 422`, OpenAI 401 body, aiohttp `Unclosed client session`) | **High**. Users cannot act on messages that reference HTTP status codes and library internals when the CLI is not itself an HTTP client. |
+| F3 | Primary CLI commands emit no "what now?" hint after success | **High**. A user who runs `remember` sees a success line and no pointer to `recall`. Every command is a dead end. |
+| F4 | Excellent Docker preflight exists in `-ui`, none in the primary commands | **Medium**. Parity gap. The `-ui` path fails calmly with actionable fixes; every other command charges into the same failure and blames the log. |
+| F5 | No offline sample-data path, so newcomers commit real tokens on first successful run | **Medium**. The quickstart promises a fast result, but that result costs money the user did not agree to. |
+| F6 | The four common first-run failure modes have no unified preflight command | **Medium**. Same signals are checked in different places; no `cognee doctor`-style single command to answer "is my setup right?". |
+| F7 | `session_lifecycle/usage_tracking.py` reports `chars/4` as the token estimate | Cross-ref: issue [#3606](https://github.com/topoteretes/cognee/issues/3606) covers accurate token capture. Noted here so the audit points at it. |
+| F8 | `_PRICING_PER_M_TOKENS` is "conservative and incomplete" per its own inline note | Cross-ref: same as F7. |
+
+## F1. Invalid `LLM_API_KEY` retries for ~2 minutes before erroring
+
+**Reproducer:**
+
+```bash
+export LLM_API_KEY=sk-fake-just-to-pass-the-key-check
+cognee-cli recall "what did we talk about?"
+```
+
+**Observed:** four exponential-backoff retries at 8.66s, 16.1s, 32.6s, 64.7s. Total wall-clock before the final error is roughly two minutes. Each retry re-logs the full error trace and a warning.
+
+**Root cause:** `LiteLLMEmbeddingEngine.embed_text` is wrapped in `tenacity` retry logic that treats a 401 authentication error the same as a transient 5xx. Authentication errors are terminal for the current process; retrying them wastes user time and confuses the log.
+
+**Verbatim tail of the failure output** (trimmed for length):
+
+```
+2026-07-09 21:14:15 [error] Error embedding text: litellm.AuthenticationError:
+    AuthenticationError: OpenAIException - Error code: 401 - {'error':
+    {'message': 'Incorrect API key provided: sk-fake-****heck.
+    You can find your API key at https://platform.openai.com/account/api-keys.',
+    'type': 'invalid_request_error', 'code': 'invalid_api_key', 'param': None},
+    'status': 401}. EMBEDDING_ENDPOINT='None'.
+2026-07-09 21:14:15 [warning] Retrying LiteLLMEmbeddingEngine.embed_text in 16.1s ...
+2026-07-09 21:14:32 [error] Error embedding text: ... (same again)
+2026-07-09 21:14:32 [warning] Retrying LiteLLMEmbeddingEngine.embed_text in 32.6s ...
+... two more retries at 32.6s and 64.7s ...
+Error: Failed to recall: litellm.AuthenticationError: OpenAIException -
+    Incorrect API key provided: sk-fake-****heck.
+Note: Please refer to our docs at 'https://docs.cognee.ai' for further assistance.
+```
+
+**What a user needs instead:** on authentication errors specifically, no retry. Fail fast with a one-line message that names the problem and one action:
+
+```
+Cognee could not authenticate with the LLM provider.
+  Your LLM_API_KEY is set but the provider rejected it (401).
+  Check that the key is valid and has not expired at your provider's console,
+  then retry.
+```
+
+## F2. Errors leak upstream implementation details
+
+Three specific instances observed across the two failure paths tested.
+
+**F2a. `Status code: 422` in CLI output when the CLI is not an HTTP client.** The number is a leaked HTTP status from an internal HTTP error class. To a user, a CLI reporting HTTP status codes is confusing at best.
+
+Sample:
+
+```
+Error: Failed to remember: LLMAPIKeyNotSetError: LLM API key is not set. (Status code: 422)
+```
+
+**F2b. OpenAI-shaped 401 body in the recall error message.** When the LLM provider rejects the key, cognee surfaces the provider's raw JSON body verbatim, including the masked key hint and the URL to the OpenAI account page. This is a useful upstream detail for a developer debugging the provider, but a user driving cognee is not the target audience for that message.
+
+**F2c. Async cleanup warnings shown to the user.** After every LLM failure the CLI prints:
+
+```
+Unclosed client session
+client_session: <aiohttp.client.ClientSession object at 0x...>
+
+Unclosed connector
+connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x...>, ...)])']
+connector: <aiohttp.connector.TCPConnector object at 0x...>
+```
+
+That is a Python `warnings.warn` from `aiohttp` at process teardown. It should be captured or suppressed at the CLI boundary rather than piped to the user's terminal.
+
+## F3. Primary CLI commands emit no "what now?" hint after success
+
+Observed by running `cognee-cli remember "cognee turns documents into memory"` with a valid `LLM_API_KEY`. Output ends with:
+
+```
+Data ingested and knowledge graph built successfully!
+  Dataset ID: 8f...
+  Items processed: 1
+  Content hash: a3...
+  Elapsed: 4.2s
+```
+
+Then the shell prompt. The user has no pointer to the next command in the flow (`recall`), no hint that a session id would let them scope queries, and no confirmation that they can now query the graph. The four primary commands have this same shape: success, some metadata, no continuation.
+
+The dropped-thread pattern shows up in the code at `cognee/cli/commands/remember_command.py` around L110-L120 and mirrors in `recall_command.py`, `cognify_command.py`, and `forget_command.py`. All four write metadata via `fmt.echo` and stop.
+
+**What a user needs instead:** a single hint line at the end of each success block that names the next natural command with a copy-paste example. Suppressible via a `--quiet` flag for scripts.
+
+Sketch:
+
+```
+Data ingested and knowledge graph built successfully!
+  Dataset ID: 8f...
+  Items processed: 1
+  Content hash: a3...
+  Elapsed: 4.2s
+
+Next: cognee-cli recall "your question" -d main_dataset
+```
+
+## F4. `-ui` has excellent Docker preflight, primary commands have none
+
+`cognee/api/v1/ui/ui.py` at `_check_docker_available()` (L24-L76) is a model of the pattern. It checks for the docker binary, runs `docker info` with a 15s timeout, distinguishes "no CLI installed", "CLI installed but daemon down", and "call timed out", and emits a message that names three concrete fixes per case (Docker Desktop, Colima, `sudo systemctl start docker`).
+
+The gap is that the same care does not exist in `cognee-cli remember`, `recall`, `cognify`, `forget`. Those commands go straight to the LLM client and fail with the messages surfaced in F1 and F2.
+
+The `-ui` preflight is the north star. Extract the pattern into a shared `cognee doctor`-style module that the primary commands and a new preflight subcommand both call.
+
+## F5. No offline sample-data path, so newcomers commit real tokens on first successful run
+
+The README's Quickstart at L105-L182 walks the user from `uv pip install cognee` to `await cognee.remember(...)`. The first successful `remember` runs `cognify`, which calls the LLM to extract entities, then generates embeddings, then persists the graph. All three cost tokens. Nothing in the flow warns the user of this or offers a way to see a result without spending.
+
+Two consequences:
+
+- Users who try cognee "just to see what it does" pay for it. Small dollar amount, but real, and unexpected.
+- Users without an OpenAI account cannot try cognee at all without signing up for a paid provider first.
+
+**What a user needs instead:** a `--sample-data` or `cognee-cli demo` path that runs a full remember-cognify-recall cycle against bundled fixtures with the LLM stubbed. This is complementary to the mocked-test harness from issue #3601; the harness is for CI, the sample-data path is for humans.
+
+## F6. No unified `cognee doctor` preflight
+
+Multiple concerns overlap in F1, F2, F4: is Python the right version, is `LLM_API_KEY` set, does the LLM provider actually accept it, is Docker running (only for `-ui`), is the file-based storage writable. Every command checks a subset in-line and reports failures differently.
+
+A single `cognee doctor` command that runs every preflight and reports a bullet list of pass/fail with the same "actionable message" contract used by `-ui` (see F4) is the smallest change that consolidates the pattern.
+
+## F7 and F8. Cross-references
+
+These findings are surfaced by inspection but their scope belongs to issue [#3606](https://github.com/topoteretes/cognee/issues/3606) (Expansion Signals + Usage Metering). Noted here so this audit is honest about them and so the two issues stay coordinated.
+
+- F7: `session_lifecycle/usage_tracking.py` uses `chars / 4` as the token count, with an inline comment acknowledging the estimate. The first-run user cannot see accurate cost.
+- F8: `_PRICING_PER_M_TOKENS` is described in its own docstring as "conservative and incomplete". "What did this cost me?" has no honest answer today.
+
+## Measurements
+
+**Time-to-first-recall on the SDK path**, valid `LLM_API_KEY`:
+
+- Cold start (import + migrations + first LLM call for cognify): observed ~28s on a warm venv, first ever `remember` of a one-sentence input
+- Second `recall` in the same process: ~2s
+
+The dominant cost on first `remember` is the LLM call inside cognify to extract entities. Not addressable in this audit; noted for expectation-setting in the proposal.
+
+**Decision count before step 1 by entry point:**
+
+| Entry point | Decisions to make before running command 1 |
+| ----------- | ------------------------------------------ |
+| Python SDK  | 2: which install tool (pip / uv / poetry), where to put `LLM_API_KEY` (env var or `.env`) |
+| `cognee-cli` | Same 2 |
+| `cognee-cli -ui` | Same 2 plus install Docker / Colima if absent |
+| `docker compose up` | Same 2 plus decide which profiles to enable (`ui`, `mcp`, `postgres`, `neo4j`) |
+
+The `-ui` and `docker compose` paths compound the decision cost. The SDK and CLI paths are already close to minimum-viable.
+
+**Verbatim error text for the failure modes tested:**
+
+Reproducers and full traces are inlined under F1 and F2. Two additional modes were not walked to a fresh reproducer because F1 and F2 already establish the shape:
+
+- Wrong Python version: `pip install cognee` fails on `requires-python = ">=3.10,<3.15"` before any cognee code runs. The pip error text names the version constraint. No cognee-specific message; not obviously broken.
+- No Docker for `-ui`: the `_check_docker_available()` path already handles this well (see F4).
+
+## Methodology
+
+Commands run on a fresh clone of `topoteretes/cognee@dev`, `uv sync --extra dev`, and one venv used for all runs. Environment variables toggled per test:
+
+- Baseline: `unset LLM_API_KEY`
+- Invalid key: `export LLM_API_KEY=sk-fake-just-to-pass-the-key-check`
+
+Code paths inspected without running:
+
+- `cognee/cli/_cognee.py` (top-level argparse + `-ui` action)
+- `cognee/cli/commands/*_command.py` (the four primary commands)
+- `cognee/cli/exceptions.py`
+- `cognee/api/v1/ui/ui.py` (the Docker preflight and MCP-server launcher)
+- `cognee/infrastructure/llm/LLMGateway.py` and `get_llm_client.py` (auth error surfacing)
+- `pyproject.toml` (Python version constraint)
+- `README.md` L105-L182 (Quickstart section)
+- `.env.template` (tiered environment configuration)
+
+## What Part 2 and Part 3 build
+
+Part 2 (Proposal) turns the six findings into concrete UX changes. Part 3 (Quick wins) lands the low-risk half of the proposal in this PR. See the acceptance criteria on issue #3605 and the follow-up sections of this document once Part 2 lands.

--- a/docs/onboarding-audit-2026-Q3.md
+++ b/docs/onboarding-audit-2026-Q3.md
@@ -199,6 +199,122 @@ Code paths inspected without running:
 - `README.md` L105-L182 (Quickstart section)
 - `.env.template` (tiered environment configuration)
 
-## What Part 2 and Part 3 build
+## Part 2. Proposal
 
-Part 2 (Proposal) turns the six findings into concrete UX changes. Part 3 (Quick wins) lands the low-risk half of the proposal in this PR. See the acceptance criteria on issue #3605 and the follow-up sections of this document once Part 2 lands.
+Each of the six findings above lands as a specific, bounded UX change below. Every proposal names the file and function the change lives in, the effort tier (Quick / Follow-up), and the risk. **Quick** items ship in this PR under Part 3. **Follow-up** items are documented here so the plan is legible but land in separate issues so this PR stays reviewable.
+
+The design principles the whole proposal is measured against:
+
+- **Calm.** No scary stack traces on first run. Errors are one line, plain-language, and name a fix.
+- **Honest.** Tell the user up front what a command will cost, take, or require. Do not leak upstream implementation details unless the user asked for them.
+- **Actionable.** Every failure surfaces one concrete next step the user can copy-paste.
+
+### P1. Fail fast on authentication errors (addresses F1)
+
+**Change:** classify `litellm.AuthenticationError` (and equivalent provider-level 401 / 403 errors) as terminal. The `tenacity` retry wrapper around `LiteLLMEmbeddingEngine.embed_text` and `LLMGateway.acreate_structured_output` skips the retry chain for these classes and raises immediately.
+
+**Where in code:** the retry decorator sits inside `cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py` and mirrors on the LLM path in `cognee/infrastructure/llm/LLMGateway.py`. Both use `tenacity.retry(retry=retry_if_exception_type(...))`. Add a `retry=retry_if_not_exception_type((AuthenticationError, PermissionDeniedError, ...))` predicate at the top of the classifier so authentication and authorization failures fall through without waiting.
+
+**Effort:** Quick. Two files, ~10 lines each, one shared helper for the predicate. Behavior tests already have LLM stubs from #3601's harness pattern that can be reused.
+
+**Risk:** low. The exception classes are already imported; we are narrowing the retry set, not expanding it. No user with a working key sees any behavior change.
+
+### P2. Error-message contract with local remediation (addresses F2)
+
+**Change:** every user-visible error from the primary CLI commands (`remember`, `recall`, `cognify`, `forget`) goes through one helper that renders a two-line block:
+
+```
+Cognee could not <action>: <plain-language cause>.
+Try: <concrete next command or fix>
+```
+
+The helper reads `code`, `message`, and `remediation` from the exception object when they exist (which is what @ANAMASGARD's Pillar B work in #3604 lands) and falls back to a local remediation table for the four common first-run failures otherwise.
+
+**Where in code:** new module `cognee/cli/echo.py` extension or a sibling `cognee/cli/messaging.py`. Called from each command's outer `except CliCommandException` block (see `remember_command.py::execute` L112, and identical shape in the three sibling commands).
+
+**Also under this proposal:** suppress the aiohttp `Unclosed client session` warning at the CLI boundary. Wrap the async runner in `warnings.catch_warnings()` with a `ResourceWarning` filter so cleanup noise stays out of the user's terminal.
+
+**Effort:** Quick for the aiohttp suppression and the local-remediation table for the four common failures. **Follow-up** for full alignment with #3604 Pillar B (that PR has not merged yet). Local remediation stubs are the bridge.
+
+**Risk:** low. Additive helper, existing except blocks call it; existing metadata (`Note: Please refer to our docs at 'https://docs.cognee.ai'...`) stays as the third line for anything not in the remediation table.
+
+### P3. Next-step hints on every primary command (addresses F3)
+
+**Change:** each of the four primary commands appends a single line after its success block naming the next natural command with a copy-paste example. Suppressible with `--quiet`.
+
+**Where in code:** the success branch of `execute()` in `cognee/cli/commands/remember_command.py`, `recall_command.py`, `cognify_command.py`, `forget_command.py`. Copy-write per command:
+
+| Command   | Next-step hint |
+| --------- | -------------- |
+| `remember` | `Next: cognee-cli recall "your question" -d <dataset-name>` |
+| `cognify`  | `Next: cognee-cli recall "your question" -d <dataset-name>` |
+| `recall`   | `Next: cognee-cli remember <path-or-text> -d <dataset-name>` (if the result set was empty) or nothing (if it returned results) |
+| `forget`   | `Next: cognee-cli remember <path-or-text> -d <dataset-name> to start fresh` |
+
+`--quiet` flag is added at the parser level for each command; when set, the hint is suppressed for use in scripts and pipelines.
+
+**Effort:** Quick. Four files, ~5 lines of new logic in each, one shared constant for the hint format.
+
+**Risk:** low. Purely additive output. Scripts that grep for a specific line still work; the new line comes after everything else. `--quiet` gives scripts a clean opt-out.
+
+### P4. Extract Docker preflight pattern into a shared preflight module (addresses F4)
+
+**Change:** `_check_docker_available()` (currently in `cognee/api/v1/ui/ui.py`) is extracted into `cognee/cli/preflight.py` alongside four sibling checks: `check_python_version`, `check_llm_key_present`, `check_llm_provider_reachable`, `check_storage_writable`. Each returns `(bool, message)` matching the existing contract.
+
+The primary commands call the relevant checks eagerly at the top of `execute()`; on failure they emit the same "Cognee could not X: Y. Try: Z" block as P2 and exit non-zero with no retry, no stack trace.
+
+**Effort:** **Follow-up.** Landing the shared module fully is 4-5 preflight functions, wiring into each command, and tests for each check. Bigger than the quick-win bar.
+
+**What lands in Part 3 under this proposal:** only the fail-fast + friendly-error path from P1 and P2. Full preflight ships as a separate PR alongside P6 (`cognee doctor`) so the review surface stays small.
+
+**Risk:** low functionally, medium in scope. Splitting keeps this PR reviewable.
+
+### P5. `--sample-data` offline path (addresses F5)
+
+**Change:** new flag on `cognee-cli remember`, plus a new `cognee-cli demo` sub-command that wraps it. When `--sample-data` is set the command:
+
+1. Ingests a small bundled text fixture (`cognee/data/samples/quickstart.txt`, ~500 tokens of clean prose).
+2. Runs cognify against a stubbed LLM that returns deterministic entity extractions (reuses the #3601 mocked harness).
+3. Runs a canned recall against the resulting graph.
+4. Prints the result plus a "You just ran remember → cognify → recall against bundled data with no API calls. Now set `LLM_API_KEY` and try it with your own text." message.
+
+**Where in code:** new fixture file, small runner in `cognee/cli/commands/remember_command.py`, and the LLM stub reuses whatever pattern the #3601 mocked harness lands. If #3601 has not landed yet the stub is a minimal in-line helper we replace once it does.
+
+**Effort:** Quick for the fixture + runner, contingent on the mocked harness pattern being clear. If #3601 has not landed, we ship a small local stub and note the follow-up.
+
+**Risk:** medium. Introduces a new user-facing flag; needs a clean opt-out. Cognee entity extractors need to be threadsafe against the stub.
+
+### P6. `cognee doctor` preflight (addresses F6)
+
+**Change:** new sub-command `cognee-cli doctor` that runs every preflight check from P4 and prints a bullet list of pass/fail with the actionable-message contract borrowed from `_check_docker_available()`. Zero exit code if everything passes; non-zero and a summary line if anything fails.
+
+**Effort:** **Follow-up.** Depends on P4's shared preflight module. Ships as a separate PR.
+
+**Risk:** low, but out of scope for this PR to keep the review surface small.
+
+### Quick wins scoped for this PR (Part 3 preview)
+
+Landing here in Part 3:
+
+- **W1.** Fail fast on `AuthenticationError` in the tenacity retry policy (P1).
+- **W2.** Local remediation table for the four common first-run errors + aiohttp warning suppression at CLI boundary (P2 partial).
+- **W3.** Next-step hints on `remember`, `recall`, `cognify`, `forget` plus a `--quiet` flag (P3 in full).
+- **W4.** `--sample-data` offline path with bundled fixture (P5).
+
+Deferred to follow-up issues (not in this PR):
+
+- Full `cognee doctor` preflight command (P6).
+- Extracting the preflight pattern into `cognee/cli/preflight.py` (P4 in full).
+- Replacing every "Please refer to our docs" instance with a remediation string once @ANAMASGARD's Pillar B (#3604) lands.
+- Streamlined canonical README quickstart section rewrite. Kept out of scope so this PR is not entangled with a docs-review cycle. Follow-up.
+
+### Non-goals
+
+Explicit non-goals to prevent scope creep in review:
+
+- Not changing the SDK-level `remember` / `recall` / `forget` function signatures. Only the CLI wrapping around them.
+- Not touching the `-ui` launcher. Its Docker preflight is already good; extracting it is P4 (Follow-up).
+- Not changing the LLM provider defaults or the pricing table (F7, F8 are #3606's scope).
+- Not adding new configuration surface beyond one CLI flag (`--sample-data`) and one sub-command (`demo`). Everything else honors existing env-var conventions.
+
+Part 3 quick-win implementation lands as separate commits on this same PR.


### PR DESCRIPTION
## Summary

Closes #3605. This is the full Part 1 (audit) + Part 2 (proposal) + Part 3 (quick wins) landing in one PR, per the issue owner's post [assigning the whole scope to me](https://github.com/topoteretes/cognee/issues/3605).

The four quick wins target the four highest-impact rough edges from the audit:

| Win | File(s) | What changes |
| --- | --- | --- |
| **W1** – fail fast on auth errors | `cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py` | Adds `AuthenticationError` + `PermissionDeniedError` to the tenacity `retry_if_not_exception_type` set and re-raises them unwrapped from the outer exception handler. Cuts the ~2 min retry-ladder hang on an invalid `LLM_API_KEY` to a single failed attempt. |
| **W2** – remediation table + aiohttp warning suppression | `cognee/cli/remediation.py`, `cognee/cli/_cognee.py` | Case-insensitive substring lookup that prints a prescriptive next step between the error line and the generic docs pointer, covering the four most common first-run failure modes. Also suppresses aiohttp's `Unclosed client session` / `Unclosed connector` `ResourceWarning` at the CLI boundary so a successful run does not print a scary-looking warning at shutdown. Debug mode (`-x`) leaves both alone so contributors still see them. |
| **W3** – next-step hints | `cognee/cli/hints.py`, four command modules | Each of `remember`, `cognify`, `recall`, `forget` ends with a copy-pastable `Next: ...` line pointing at the natural follow-up. `recall_hint` only fires on empty result sets. All four commands take a `--quiet` flag for scripting. |
| **W4** – bundled sample data | `cognee/cli/samples/quickstart.txt`, `cognee/cli/commands/remember_command.py` | `remember --sample-data` ingests a bundled fixture instead of user data. Deliberately does not stub the LLM: the flag helps a user validate wiring end-to-end without composing a dataset, but still requires `LLM_API_KEY`. W1+W2 handle the missing-key case gracefully. |

## Test plan

- [x] `uv run ruff format` clean on all changed files
- [x] `uv run ruff check` clean on all changed files
- [x] New unit tests pass:
  - `cognee/tests/unit/test_litellm_embedding_auth_fastfail.py` (3 tests)
  - `cognee/tests/cli_tests/cli_unit_tests/test_remediation.py` (9 tests)
  - `cognee/tests/cli_tests/cli_unit_tests/test_hints.py` (6 tests)
- [x] Full CLI unit test suite: 134 passed, 4 pre-existing failures in `test_push_command.py` unrelated to this PR (confirmed by running the same tests on `origin/dev`)
- [ ] Reviewer sanity check: `cognee-cli remember --sample-data` prints the fixture path and completes when `LLM_API_KEY` is valid, prints the W2 hint pointing at `.env` when it is not

## Commits

1. `docs(onboarding): add Q3 first-run audit for #3605` – Part 1
2. `docs(onboarding): add Part 2 proposal to Q3 first-run audit` – Part 2
3. `fix(embedding): fail fast on auth errors for #3605` – W1
4. `feat(cli): remediation table for first-run errors for #3605` – W2
5. `feat(cli): next-step hints after primary commands for #3605` – W3
6. `feat(cli): --sample-data offline path for #3605` – W4