### PR TITLE
feat(telegram): Telegram bot powered by cognee memory (SDK-147)

### DIFF
--- a/cognee-telegram/.env.template
+++ b/cognee-telegram/.env.template
@@ -1,0 +1,15 @@
+# --- Required ---
+# Token from @BotFather (https://t.me/BotFather → /newbot)
+TELEGRAM_BOT_TOKEN="123456:ABC-DEF..."
+
+# cognee needs an LLM to build and query memory. OpenAI is the default.
+LLM_API_KEY="your_openai_api_key"
+# LLM_MODEL="openai/gpt-5-mini"   # optional; this is the default
+
+# --- Optional ---
+# Split group memory per sender so each person can hard-delete their own data.
+# COGNEE_TG_PER_USER="false"
+# Buffer N messages before one cognee write (1 = ingest each message immediately).
+# COGNEE_TG_BATCH_SIZE="1"
+# Capture messages by default until a chat runs /optout.
+# COGNEE_TG_INGEST_DEFAULT="true"

--- a/cognee-telegram/.env.template
+++ b/cognee-telegram/.env.template
@@ -5,9 +5,3 @@ TELEGRAM_BOT_TOKEN="123456:ABC-DEF..."
 # cognee needs an LLM to build and query memory. OpenAI is the default.
 LLM_API_KEY="your_openai_api_key"
 # LLM_MODEL="openai/gpt-5-mini"   # optional; this is the default
-
-# --- Optional ---
-# Split group memory per sender so each person can hard-delete their own data.
-# COGNEE_TG_PER_USER="false"
-# Capture messages by default until a chat runs /optout.
-# COGNEE_TG_INGEST_DEFAULT="true"

--- a/cognee-telegram/.env.template
+++ b/cognee-telegram/.env.template
@@ -9,7 +9,5 @@ LLM_API_KEY="your_openai_api_key"
 # --- Optional ---
 # Split group memory per sender so each person can hard-delete their own data.
 # COGNEE_TG_PER_USER="false"
-# Buffer N messages before one cognee write (1 = ingest each message immediately).
-# COGNEE_TG_BATCH_SIZE="1"
 # Capture messages by default until a chat runs /optout.
 # COGNEE_TG_INGEST_DEFAULT="true"

--- a/cognee-telegram/README.md
+++ b/cognee-telegram/README.md
@@ -1,0 +1,101 @@
+# cognee-telegram
+
+A Telegram bot where **each chat is a memory**. Forward it articles, drop notes,
+chat normally — then `/ask` and get answers **with citations back to the original
+messages**. No OAuth, no public URL: it runs from your laptop with long polling.
+
+Built on cognee's `remember` / `recall` / `forget` ([#3610](https://github.com/topoteretes/cognee/issues/3610)).
+
+---
+
+## Run your own in 5 minutes
+
+**Prerequisites**
+- Python 3.10–3.14
+- A Telegram bot token — message [@BotFather](https://t.me/BotFather), send `/newbot`, copy the token (free, ~1 min, no phone number shared with anyone).
+- An LLM key for cognee to build/query memory — an OpenAI key works out of the box. (Costs a few cents while you test; cognee defaults to `openai/gpt-5-mini`.)
+
+**1. Install**
+```bash
+cd cognee-telegram
+uv venv && source .venv/bin/activate
+uv pip install -e .
+```
+
+**2. Configure** — copy the template and fill in two values:
+```bash
+cp .env.template .env
+# edit .env:
+#   TELEGRAM_BOT_TOKEN="123456:ABC-DEF..."
+#   LLM_API_KEY="sk-..."
+```
+
+**3. Run**
+```bash
+set -a && source .env && set +a   # export the .env vars
+python -m cognee_telegram
+```
+
+**4. Use it** — open Telegram, find your bot, and:
+```
+You:  The Q3 review is on Friday at 2pm in room 4.
+You:  /ask when is the Q3 review?
+Bot:  The Q3 review is on Friday at 2pm in room 4.
+      Sources:
+      • "The Q3 review is on Friday at 2pm in room 4."
+      (from graph memory)
+```
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| *(any message)* | Captured into this chat's memory |
+| `/ask <question>` | Answer from this chat's memory, with sources |
+| `/forget` | Wipe this chat's memory (graph + vectors) |
+| `/optout` / `/optin` | Pause / resume capturing in this chat |
+| `/start` · `/help` | Show the intro |
+
+## How it works
+
+- **One chat → one cognee dataset** — a DM is `telegram_dm_<user_id>`, a group is
+  `telegram_group_<chat_id>` (forum topics add the thread). The dataset is the memory
+  boundary `/forget` clears.
+- **Durable graph memory** — messages are ingested with `remember(dataset_name=...)`, which
+  runs `add` + `cognify` to build a queryable knowledge graph for the chat. `/ask` then runs
+  `recall` over that graph. (Buffer with `COGNEE_TG_BATCH_SIZE` so a busy group triggers one
+  graph build per batch instead of per message.)
+- **Citations** — the bot keeps a `message → (chat_id, message_id)` ledger; when `recall`
+  grounds an answer, the bot maps it back to the originating message and renders a
+  `t.me/c/...` deep link (supergroups) or quotes the snippet (DMs / basic groups).
+- **`/forget`** — `forget(dataset=...)` clears the chat's graph + vectors completely, and the
+  bot drops its local ledger for that chat. Asking before any capture (or after `/forget`)
+  returns "nothing here yet" rather than erroring.
+
+The memory logic lives in `CogneeMemoryAdapter` (transport-agnostic), so the same core can
+back a Slack/Discord bot later — the Telegram layer is just I/O.
+
+## Configuration
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | — | **Required.** @BotFather token. |
+| `LLM_API_KEY` | — | **Required** (by cognee) to build/query memory. |
+| `COGNEE_TG_PER_USER` | `false` | Split group memory per sender (hard per-user delete). |
+| `COGNEE_TG_BATCH_SIZE` | `1` | Buffer N messages before one cognee write (raise it for busy groups). |
+| `COGNEE_TG_INGEST_DEFAULT` | `true` | Capture by default until a chat runs `/optout`. |
+
+## Tests
+
+Deterministic, **no real keys** — Telegram is mocked with `unittest.mock` and cognee's
+memory API is patched at the boundary:
+```bash
+uv pip install -e ".[dev]"   # or: uv pip install pytest pytest-asyncio
+pytest -q
+```
+
+## Scope
+
+**v1 (this):** passive capture, `/ask` with citations, `/forget`, `/optout`, tests, this guide.
+**Later:** link/media extraction, `/forgetme` + per-user scoping, message edit/delete sync,
+and consuming structured citations + abstention from [#3604](https://github.com/topoteretes/cognee/issues/3604) as they land.

--- a/cognee-telegram/README.md
+++ b/cognee-telegram/README.md
@@ -45,6 +45,11 @@ Bot:  The Q3 review is on Friday at 2pm in room 4.
       • "The Q3 review is on Friday at 2pm in room 4."
 ```
 
+> **Using it in a group?** Telegram bots have *privacy mode* on by default, so a bot only
+> sees commands and @-mentions there. To let it passively capture every message, either
+> disable privacy mode via [@BotFather](https://t.me/BotFather) (`/setprivacy` → *Disable*)
+> or make the bot a group admin. DMs work either way.
+
 ## Commands
 
 | Command | What it does |

--- a/cognee-telegram/README.md
+++ b/cognee-telegram/README.md
@@ -43,7 +43,6 @@ You:  /ask when is the Q3 review?
 Bot:  The Q3 review is on Friday at 2pm in room 4.
       Sources:
       • "The Q3 review is on Friday at 2pm in room 4."
-      (from graph memory)
 ```
 
 ## Commands

--- a/cognee-telegram/README.md
+++ b/cognee-telegram/README.md
@@ -63,8 +63,7 @@ Bot:  The Q3 review is on Friday at 2pm in room 4.
   boundary `/forget` clears.
 - **Durable graph memory** — messages are ingested with `remember(dataset_name=...)`, which
   runs `add` + `cognify` to build a queryable knowledge graph for the chat. `/ask` then runs
-  `recall` over that graph. (Buffer with `COGNEE_TG_BATCH_SIZE` so a busy group triggers one
-  graph build per batch instead of per message.)
+  `recall` over that graph.
 - **Citations** — the bot keeps a `message → (chat_id, message_id)` ledger; when `recall`
   grounds an answer, the bot maps it back to the originating message and renders a
   `t.me/c/...` deep link (supergroups) or quotes the snippet (DMs / basic groups).
@@ -82,7 +81,6 @@ back a Slack/Discord bot later — the Telegram layer is just I/O.
 | `TELEGRAM_BOT_TOKEN` | — | **Required.** @BotFather token. |
 | `LLM_API_KEY` | — | **Required** (by cognee) to build/query memory. |
 | `COGNEE_TG_PER_USER` | `false` | Split group memory per sender (hard per-user delete). |
-| `COGNEE_TG_BATCH_SIZE` | `1` | Buffer N messages before one cognee write (raise it for busy groups). |
 | `COGNEE_TG_INGEST_DEFAULT` | `true` | Capture by default until a chat runs `/optout`. |
 
 ## Tests

--- a/cognee-telegram/README.md
+++ b/cognee-telegram/README.md
@@ -80,8 +80,6 @@ back a Slack/Discord bot later — the Telegram layer is just I/O.
 |---|---|---|
 | `TELEGRAM_BOT_TOKEN` | — | **Required.** @BotFather token. |
 | `LLM_API_KEY` | — | **Required** (by cognee) to build/query memory. |
-| `COGNEE_TG_PER_USER` | `false` | Split group memory per sender (hard per-user delete). |
-| `COGNEE_TG_INGEST_DEFAULT` | `true` | Capture by default until a chat runs `/optout`. |
 
 ## Tests
 

--- a/cognee-telegram/pyproject.toml
+++ b/cognee-telegram/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "cognee-telegram"
+version = "0.1.0"
+description = "Telegram bot powered by cognee memory — each chat is a session you can remember, recall, and forget."
+readme = "README.md"
+requires-python = ">=3.10"
+
+dependencies = [
+    "cognee>=1.1.0,<2.0.0",
+    "python-telegram-bot>=21.0,<22.0",
+]
+
+[project.scripts]
+cognee-telegram = "cognee_telegram.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cognee_telegram"]
+
+[dependency-groups]
+dev = [
+    "pytest>=7.4.0,<9",
+    "pytest-asyncio>=0.23.0,<2",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/cognee-telegram/pyproject.toml
+++ b/cognee-telegram/pyproject.toml
@@ -6,7 +6,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 dependencies = [
-    "cognee>=1.1.0,<2.0.0",
+    # recall(..., include_references=True), which the citation resolver relies on,
+    # first shipped in cognee 1.2.0.
+    "cognee>=1.2.0,<2.0.0",
     "python-telegram-bot>=21.0,<22.0",
 ]
 

--- a/cognee-telegram/pyproject.toml
+++ b/cognee-telegram/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/cognee_telegram"]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "pytest>=7.4.0,<9",
     "pytest-asyncio>=0.23.0,<2",

--- a/cognee-telegram/src/cognee_telegram/__init__.py
+++ b/cognee-telegram/src/cognee_telegram/__init__.py
@@ -1,0 +1,35 @@
+"""cognee-telegram — a Telegram bot where each chat is a cognee memory.
+
+Public API::
+
+    from cognee_telegram import CogneeMemoryAdapter, Settings, build_application
+"""
+
+from .adapter import Answer, CogneeMemoryAdapter
+from .citations import CitationLedger, MessageRef
+from .config import Settings
+from .scoping import Scope, resolve_scope
+
+__all__ = [
+    "Answer",
+    "CogneeMemoryAdapter",
+    "CitationLedger",
+    "MessageRef",
+    "Settings",
+    "Scope",
+    "resolve_scope",
+    "build_application",
+]
+
+__version__ = "0.1.0"
+
+
+def build_application(settings, adapter=None):
+    """Lazily import the PTB-backed application builder.
+
+    Kept lazy so importing the adapter/scoping/citations modules (and running
+    their tests) does not require ``python-telegram-bot`` to be installed.
+    """
+    from .bot import build_application as _build
+
+    return _build(settings, adapter)

--- a/cognee-telegram/src/cognee_telegram/__main__.py
+++ b/cognee-telegram/src/cognee_telegram/__main__.py
@@ -15,6 +15,9 @@ def main() -> None:
     logging.basicConfig(
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s", level=logging.INFO
     )
+    # python-telegram-bot talks to the API over httpx, which logs each request line
+    # at INFO — and the request URL embeds the bot token. Keep it out of the logs.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     settings = Settings.from_env()
 
     # Imported here so a missing python-telegram-bot fails with a clear message

--- a/cognee-telegram/src/cognee_telegram/__main__.py
+++ b/cognee-telegram/src/cognee_telegram/__main__.py
@@ -1,0 +1,30 @@
+"""Run the bot with long polling: ``python -m cognee_telegram``.
+
+No public URL or webhook needed — long polling works from a laptop. Requires
+``TELEGRAM_BOT_TOKEN`` and a working cognee LLM config (e.g. ``LLM_API_KEY``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .config import Settings
+
+
+def main() -> None:
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s", level=logging.INFO
+    )
+    settings = Settings.from_env()
+
+    # Imported here so a missing python-telegram-bot fails with a clear message
+    # only when actually running the bot, not on package import.
+    from .bot import build_application
+
+    app = build_application(settings)
+    logging.getLogger("cognee_telegram").info("Bot starting (long polling). Press Ctrl-C to stop.")
+    app.run_polling(allowed_updates=["message", "my_chat_member"])
+
+
+if __name__ == "__main__":
+    main()

--- a/cognee-telegram/src/cognee_telegram/adapter.py
+++ b/cognee-telegram/src/cognee_telegram/adapter.py
@@ -98,12 +98,13 @@ class CogneeMemoryAdapter:
             return Answer(text="")
         texts = [text for text in (_answer_text(item) for item in results or []) if text]
         full_text = "\n\n".join(texts).strip()
-        # include_references appends a raw "Evidence:" block (doc/chunk ids) to the
-        # answer — use it to resolve citations, but show only the answer itself; the
-        # bot renders its own clean, tappable Sources from the ledger.
-        display_text = full_text.split("\n\nEvidence:")[0].strip()
-        citations = self.ledger.resolve(scope.dataset_name, full_text) if full_text else []
-        return Answer(text=display_text, citations=citations)
+        # include_references appends a grounded "Evidence:" block (the retrieved
+        # source chunks) to the answer. Show only the answer, but resolve citations
+        # from the Evidence block alone: it quotes what was actually retrieved, so a
+        # "no information" answer — which carries no Evidence — is never cited.
+        display_text, _, evidence = full_text.partition("\n\nEvidence:")
+        citations = self.ledger.resolve(scope.dataset_name, evidence) if evidence.strip() else []
+        return Answer(text=display_text.strip(), citations=citations)
 
     # -- forget ----------------------------------------------------------
     async def forget(self, scope: Scope) -> None:

--- a/cognee-telegram/src/cognee_telegram/adapter.py
+++ b/cognee-telegram/src/cognee_telegram/adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import cognee
-from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
+from cognee.exceptions import CogneeValidationError
 
 from .citations import CitationLedger, MessageRef
 from .scoping import Scope, resolve_scope
@@ -87,14 +87,16 @@ class CogneeMemoryAdapter:
     async def answer(self, scope: Scope, query: str) -> Answer:
         """Recall an answer for ``query`` and resolve its Telegram citations.
 
-        Returns an empty ``Answer`` when this chat has no memory yet (no dataset)
-        instead of raising, so the bot can say "nothing here yet".
+        Returns an empty ``Answer`` when this chat has no memory yet — either the
+        dataset is missing (``DatasetNotFoundError``) or, on a brand-new install,
+        no database exists so recall raises a precondition error. Both are
+        ``CogneeValidationError`` subclasses and mean "nothing here yet".
         """
         try:
             results = await cognee.recall(
                 query, datasets=[scope.dataset_name], include_references=True
             )
-        except DatasetNotFoundError:
+        except CogneeValidationError:
             return Answer(text="")
         texts = [text for text in (_answer_text(item) for item in results or []) if text]
         full_text = "\n\n".join(texts).strip()
@@ -108,6 +110,15 @@ class CogneeMemoryAdapter:
 
     # -- forget ----------------------------------------------------------
     async def forget(self, scope: Scope) -> None:
-        """Clear a chat's durable dataset (graph + vectors) and drop the ledger."""
-        await cognee.forget(dataset=scope.dataset_name)
+        """Clear a chat's durable dataset (graph + vectors) and drop the ledger.
+
+        Idempotent: clearing a chat that never captured anything is a no-op, not
+        an error. Resolving a missing dataset name inside cognee raises either a
+        ``CogneeValidationError`` or an ``AttributeError`` (the name resolves to
+        ``None``); treat both as "already clear".
+        """
+        try:
+            await cognee.forget(dataset=scope.dataset_name)
+        except (CogneeValidationError, AttributeError):
+            pass
         self.ledger.drop(scope.dataset_name)

--- a/cognee-telegram/src/cognee_telegram/adapter.py
+++ b/cognee-telegram/src/cognee_telegram/adapter.py
@@ -1,0 +1,181 @@
+"""Thin memory adapter: maps chat events onto cognee, nothing more.
+
+The bot carries no memory logic of its own — it calls three primitives here,
+which wrap cognee's ``remember`` / ``recall`` / ``forget``. Keeping this layer
+transport-agnostic means the same core can back a Slack/Discord bot later.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import cognee
+from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
+
+from .citations import CitationLedger, MessageRef
+from .scoping import Scope, resolve_scope
+
+# recall() returns a list of RecallResponse models discriminated by a ``source``
+# field; the renderable text lives in a type-specific field: ``text`` for graph
+# hits (SearchResultItem), ``content`` for graph/session context, ``answer`` for
+# session QA entries. We read whichever is present.
+_TEXT_KEYS = ("answer", "text", "content", "search_result", "result")
+_SOURCE_KEYS = ("source", "_source")
+
+
+def _extract(item: object) -> tuple[str, str | None]:
+    """Pull (text, source) out of one recall result item.
+
+    Handles the real cognee shape (Pydantic ``RecallResponse`` objects with a
+    ``source`` discriminator) and the dict/MCP shape, so the bot is robust to
+    either.
+    """
+    if isinstance(item, str):
+        return item, None
+    get = item.get if isinstance(item, dict) else (lambda key: getattr(item, key, None))
+    source = next((s for s in (get(k) for k in _SOURCE_KEYS) if s), None)
+    for key in _TEXT_KEYS:
+        value = get(key)
+        if value not in (None, ""):
+            return str(value), source
+    return str(item), source
+
+
+def _summarize_sources(sources: list[str]) -> str | None:
+    present = {s for s in sources if s}
+    if not present:
+        return None
+    if len(present) == 1:
+        return next(iter(present))
+    return "mixed"
+
+
+@dataclass
+class Answer:
+    """A recall answer plus its resolved Telegram citations."""
+
+    text: str
+    source_tag: str | None = None
+    citations: list[MessageRef] = field(default_factory=list)
+
+
+class CogneeMemoryAdapter:
+    """Maps Telegram conversations onto cognee memory.
+
+    Args:
+        per_user_in_group: Split group memory per sender (hard per-user delete).
+        batch_size: Buffer this many messages before one ``remember`` call;
+            ``1`` ingests immediately. A query always flushes first.
+        ingest_enabled_default: Whether a fresh chat captures messages until
+            it runs ``/optout``.
+    """
+
+    def __init__(
+        self,
+        *,
+        per_user_in_group: bool = False,
+        batch_size: int = 1,
+        ingest_enabled_default: bool = True,
+    ) -> None:
+        self.per_user_in_group = per_user_in_group
+        self.batch_size = max(1, batch_size)
+        self.ingest_enabled_default = ingest_enabled_default
+        self.ledger = CitationLedger()
+        self._buffers: dict[str, list[MessageRef]] = {}
+        # chat_id -> capturing? Absent means "use ingest_enabled_default".
+        self._capture: dict[int, bool] = {}
+
+    # -- scoping ---------------------------------------------------------
+    def scope_for(
+        self, *, chat_type: str, chat_id: int, user_id: int, thread_id: int | None = None
+    ) -> Scope:
+        return resolve_scope(
+            chat_type=chat_type,
+            chat_id=chat_id,
+            user_id=user_id,
+            thread_id=thread_id,
+            per_user_in_group=self.per_user_in_group,
+        )
+
+    # -- opt-out ---------------------------------------------------------
+    def is_opted_out(self, chat_id: int) -> bool:
+        return not self._capture.get(chat_id, self.ingest_enabled_default)
+
+    def opt_out(self, chat_id: int) -> None:
+        self._capture[chat_id] = False
+
+    def opt_in(self, chat_id: int) -> None:
+        self._capture[chat_id] = True
+
+    # -- ingest ----------------------------------------------------------
+    async def ingest(self, scope: Scope, ref: MessageRef) -> bool:
+        """Capture one message. Returns True if it was flushed to cognee now.
+
+        No-op when the chat has opted out. Records the message in the citation
+        ledger immediately so a later ``/ask`` can cite it.
+        """
+        if self.is_opted_out(scope.chat_id):
+            return False
+        self.ledger.record(scope.dataset_name, ref)
+        buffer = self._buffers.setdefault(scope.dataset_name, [])
+        buffer.append(ref)
+        if len(buffer) >= self.batch_size:
+            await self.flush(scope)
+            return True
+        return False
+
+    async def flush(self, scope: Scope) -> None:
+        """Ingest any buffered messages into the chat's durable graph.
+
+        Uses ``remember(dataset_name=...)`` (add + cognify), which creates the
+        per-chat dataset and builds a queryable knowledge graph. We deliberately
+        do **not** pass ``session_id`` here: a session-only write never creates
+        the dataset, so the background graph bridge can't populate it.
+        """
+        buffer = self._buffers.pop(scope.dataset_name, [])
+        if not buffer:
+            return
+        texts = [ref.attributed_text() for ref in buffer]
+        await cognee.remember(texts, dataset_name=scope.dataset_name)
+
+    # -- answer ----------------------------------------------------------
+    async def answer(self, scope: Scope, query: str) -> Answer:
+        """Recall an answer for ``query`` and resolve its Telegram citations.
+
+        Flushes pending messages first so the query sees everything just sent.
+        Returns an empty ``Answer`` when this chat has no memory yet (no dataset)
+        instead of raising, so the bot can say "nothing here yet".
+        """
+        await self.flush(scope)
+        try:
+            results = await cognee.recall(
+                query, datasets=[scope.dataset_name], include_references=True
+            )
+        except DatasetNotFoundError:
+            return Answer(text="")
+        texts: list[str] = []
+        sources: list[str] = []
+        for item in results or []:
+            text, source = _extract(item)
+            if text:
+                texts.append(text)
+            if source:
+                sources.append(source)
+        full_text = "\n\n".join(texts).strip()
+        # include_references appends a raw "Evidence:" block (doc/chunk ids) to the
+        # answer — use it to resolve citations, but show only the answer itself; the
+        # bot renders its own clean, tappable Sources from the ledger.
+        display_text = full_text.split("\n\nEvidence:")[0].strip()
+        citations = self.ledger.resolve(scope.dataset_name, full_text) if full_text else []
+        return Answer(
+            text=display_text,
+            source_tag=_summarize_sources(sources),
+            citations=citations,
+        )
+
+    # -- forget ----------------------------------------------------------
+    async def forget(self, scope: Scope) -> None:
+        """Clear a chat's durable dataset (graph + vectors) and drop the ledger."""
+        await cognee.forget(dataset=scope.dataset_name)
+        self.ledger.drop(scope.dataset_name)
+        self._buffers.pop(scope.dataset_name, None)

--- a/cognee-telegram/src/cognee_telegram/adapter.py
+++ b/cognee-telegram/src/cognee_telegram/adapter.py
@@ -15,39 +15,20 @@ from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
 from .citations import CitationLedger, MessageRef
 from .scoping import Scope, resolve_scope
 
-# recall() returns a list of RecallResponse models discriminated by a ``source``
-# field; the renderable text lives in a type-specific field: ``text`` for graph
-# hits (SearchResultItem), ``content`` for graph/session context, ``answer`` for
-# session QA entries. We read whichever is present.
-_TEXT_KEYS = ("answer", "text", "content", "search_result", "result")
-_SOURCE_KEYS = ("source", "_source")
+# recall() returns a discriminated union of RecallResponse models; the
+# renderable text lives in a type-specific field — ``answer`` for QA entries,
+# ``text`` for graph hits (SearchResultItem), ``content`` for context entries.
+# We read whichever is set.
+_TEXT_ATTRS = ("answer", "text", "content")
 
 
-def _extract(item: object) -> tuple[str, str | None]:
-    """Pull (text, source) out of one recall result item.
-
-    Handles the real cognee shape (Pydantic ``RecallResponse`` objects with a
-    ``source`` discriminator) and the dict/MCP shape, so the bot is robust to
-    either.
-    """
-    if isinstance(item, str):
-        return item, None
-    get = item.get if isinstance(item, dict) else (lambda key: getattr(item, key, None))
-    source = next((s for s in (get(k) for k in _SOURCE_KEYS) if s), None)
-    for key in _TEXT_KEYS:
-        value = get(key)
-        if value not in (None, ""):
-            return str(value), source
-    return str(item), source
-
-
-def _summarize_sources(sources: list[str]) -> str | None:
-    present = {s for s in sources if s}
-    if not present:
-        return None
-    if len(present) == 1:
-        return next(iter(present))
-    return "mixed"
+def _answer_text(item: object) -> str:
+    """Pull the renderable text out of one recall result item."""
+    for attr in _TEXT_ATTRS:
+        value = getattr(item, attr, None)
+        if value:
+            return str(value)
+    return ""
 
 
 @dataclass
@@ -55,7 +36,6 @@ class Answer:
     """A recall answer plus its resolved Telegram citations."""
 
     text: str
-    source_tag: str | None = None
     citations: list[MessageRef] = field(default_factory=list)
 
 
@@ -116,25 +96,14 @@ class CogneeMemoryAdapter:
             )
         except DatasetNotFoundError:
             return Answer(text="")
-        texts: list[str] = []
-        sources: list[str] = []
-        for item in results or []:
-            text, source = _extract(item)
-            if text:
-                texts.append(text)
-            if source:
-                sources.append(source)
+        texts = [text for text in (_answer_text(item) for item in results or []) if text]
         full_text = "\n\n".join(texts).strip()
         # include_references appends a raw "Evidence:" block (doc/chunk ids) to the
         # answer — use it to resolve citations, but show only the answer itself; the
         # bot renders its own clean, tappable Sources from the ledger.
         display_text = full_text.split("\n\nEvidence:")[0].strip()
         citations = self.ledger.resolve(scope.dataset_name, full_text) if full_text else []
-        return Answer(
-            text=display_text,
-            source_tag=_summarize_sources(sources),
-            citations=citations,
-        )
+        return Answer(text=display_text, citations=citations)
 
     # -- forget ----------------------------------------------------------
     async def forget(self, scope: Scope) -> None:

--- a/cognee-telegram/src/cognee_telegram/adapter.py
+++ b/cognee-telegram/src/cognee_telegram/adapter.py
@@ -60,24 +60,11 @@ class Answer:
 
 
 class CogneeMemoryAdapter:
-    """Maps Telegram conversations onto cognee memory.
+    """Maps Telegram conversations onto cognee memory."""
 
-    Args:
-        per_user_in_group: Split group memory per sender (hard per-user delete).
-        ingest_enabled_default: Whether a fresh chat captures messages until
-            it runs ``/optout``.
-    """
-
-    def __init__(
-        self,
-        *,
-        per_user_in_group: bool = False,
-        ingest_enabled_default: bool = True,
-    ) -> None:
-        self.per_user_in_group = per_user_in_group
-        self.ingest_enabled_default = ingest_enabled_default
+    def __init__(self) -> None:
         self.ledger = CitationLedger()
-        # chat_id -> capturing? Absent means "use ingest_enabled_default".
+        # chat_id -> capturing? Absent means "capturing" (opt-out model).
         self._capture: dict[int, bool] = {}
 
     # -- scoping ---------------------------------------------------------
@@ -85,16 +72,12 @@ class CogneeMemoryAdapter:
         self, *, chat_type: str, chat_id: int, user_id: int, thread_id: int | None = None
     ) -> Scope:
         return resolve_scope(
-            chat_type=chat_type,
-            chat_id=chat_id,
-            user_id=user_id,
-            thread_id=thread_id,
-            per_user_in_group=self.per_user_in_group,
+            chat_type=chat_type, chat_id=chat_id, user_id=user_id, thread_id=thread_id
         )
 
     # -- opt-out ---------------------------------------------------------
     def is_opted_out(self, chat_id: int) -> bool:
-        return not self._capture.get(chat_id, self.ingest_enabled_default)
+        return not self._capture.get(chat_id, True)
 
     def opt_out(self, chat_id: int) -> None:
         self._capture[chat_id] = False

--- a/cognee-telegram/src/cognee_telegram/adapter.py
+++ b/cognee-telegram/src/cognee_telegram/adapter.py
@@ -64,8 +64,6 @@ class CogneeMemoryAdapter:
 
     Args:
         per_user_in_group: Split group memory per sender (hard per-user delete).
-        batch_size: Buffer this many messages before one ``remember`` call;
-            ``1`` ingests immediately. A query always flushes first.
         ingest_enabled_default: Whether a fresh chat captures messages until
             it runs ``/optout``.
     """
@@ -74,14 +72,11 @@ class CogneeMemoryAdapter:
         self,
         *,
         per_user_in_group: bool = False,
-        batch_size: int = 1,
         ingest_enabled_default: bool = True,
     ) -> None:
         self.per_user_in_group = per_user_in_group
-        self.batch_size = max(1, batch_size)
         self.ingest_enabled_default = ingest_enabled_default
         self.ledger = CitationLedger()
-        self._buffers: dict[str, list[MessageRef]] = {}
         # chat_id -> capturing? Absent means "use ingest_enabled_default".
         self._capture: dict[int, bool] = {}
 
@@ -109,44 +104,29 @@ class CogneeMemoryAdapter:
 
     # -- ingest ----------------------------------------------------------
     async def ingest(self, scope: Scope, ref: MessageRef) -> bool:
-        """Capture one message. Returns True if it was flushed to cognee now.
+        """Capture one message into the chat's durable graph.
 
-        No-op when the chat has opted out. Records the message in the citation
-        ledger immediately so a later ``/ask`` can cite it.
+        No-op when the chat has opted out. Uses ``remember(dataset_name=...)``
+        (add + cognify), which creates the per-chat dataset and builds a
+        queryable knowledge graph. We deliberately do **not** pass a
+        ``session_id``: a session-only write never creates the dataset, so the
+        background graph bridge can't populate it. The message is recorded in
+        the citation ledger only after it is durably stored, so ``/ask`` never
+        cites a message that failed to persist.
         """
         if self.is_opted_out(scope.chat_id):
             return False
+        await cognee.remember([ref.attributed_text()], dataset_name=scope.dataset_name)
         self.ledger.record(scope.dataset_name, ref)
-        buffer = self._buffers.setdefault(scope.dataset_name, [])
-        buffer.append(ref)
-        if len(buffer) >= self.batch_size:
-            await self.flush(scope)
-            return True
-        return False
-
-    async def flush(self, scope: Scope) -> None:
-        """Ingest any buffered messages into the chat's durable graph.
-
-        Uses ``remember(dataset_name=...)`` (add + cognify), which creates the
-        per-chat dataset and builds a queryable knowledge graph. We deliberately
-        do **not** pass ``session_id`` here: a session-only write never creates
-        the dataset, so the background graph bridge can't populate it.
-        """
-        buffer = self._buffers.pop(scope.dataset_name, [])
-        if not buffer:
-            return
-        texts = [ref.attributed_text() for ref in buffer]
-        await cognee.remember(texts, dataset_name=scope.dataset_name)
+        return True
 
     # -- answer ----------------------------------------------------------
     async def answer(self, scope: Scope, query: str) -> Answer:
         """Recall an answer for ``query`` and resolve its Telegram citations.
 
-        Flushes pending messages first so the query sees everything just sent.
         Returns an empty ``Answer`` when this chat has no memory yet (no dataset)
         instead of raising, so the bot can say "nothing here yet".
         """
-        await self.flush(scope)
         try:
             results = await cognee.recall(
                 query, datasets=[scope.dataset_name], include_references=True
@@ -178,4 +158,3 @@ class CogneeMemoryAdapter:
         """Clear a chat's durable dataset (graph + vectors) and drop the ledger."""
         await cognee.forget(dataset=scope.dataset_name)
         self.ledger.drop(scope.dataset_name)
-        self._buffers.pop(scope.dataset_name, None)

--- a/cognee-telegram/src/cognee_telegram/bot.py
+++ b/cognee-telegram/src/cognee_telegram/bot.py
@@ -53,9 +53,15 @@ def _scope(adapter: CogneeMemoryAdapter, update: Update) -> Scope:
     chat = update.effective_chat
     user = update.effective_user
     message = update.effective_message
-    thread_id = getattr(message, "message_thread_id", None) if message else None
+    # message_thread_id is set for any reply thread, but only forum *topics* are a
+    # distinct memory boundary — otherwise ordinary reply chains would fork the dataset.
+    thread_id = message.message_thread_id if getattr(message, "is_topic_message", False) else None
+    # user is absent for channel/anonymous posts; user_id only scopes DMs, so 0 is safe.
     return adapter.scope_for(
-        chat_type=chat.type, chat_id=chat.id, user_id=user.id, thread_id=thread_id
+        chat_type=chat.type,
+        chat_id=chat.id,
+        user_id=user.id if user else 0,
+        thread_id=thread_id,
     )
 
 
@@ -81,7 +87,9 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 async def ingest_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     adapter: CogneeMemoryAdapter = context.bot_data["adapter"]
     message = update.effective_message
-    if message is None or not message.text:
+    # Capture plain text plus the caption on forwarded/media posts (links, articles).
+    text = (message.text or message.caption) if message else None
+    if not text:
         return
     scope = _scope(adapter, update)
     if adapter.is_opted_out(scope.chat_id):
@@ -89,7 +97,7 @@ async def ingest_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     ref = MessageRef(
         chat_id=scope.chat_id,
         message_id=message.message_id,
-        text=message.text,
+        text=text,
         thread_id=scope.thread_id,
         author=_author(update),
     )
@@ -171,7 +179,9 @@ def build_application(
     app.add_handler(CommandHandler("optout", optout_command))
     app.add_handler(CommandHandler("optin", optin_command))
     app.add_handler(ChatMemberHandler(greet_on_join, ChatMemberHandler.MY_CHAT_MEMBER))
-    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, ingest_message))
+    app.add_handler(
+        MessageHandler((filters.TEXT | filters.CAPTION) & ~filters.COMMAND, ingest_message)
+    )
     app.add_error_handler(_on_error)
     return app
 

--- a/cognee-telegram/src/cognee_telegram/bot.py
+++ b/cognee-telegram/src/cognee_telegram/bot.py
@@ -162,7 +162,6 @@ def build_application(
     """Wire the adapter and handlers into a python-telegram-bot Application."""
     adapter = adapter or CogneeMemoryAdapter(
         per_user_in_group=settings.per_user_in_group,
-        batch_size=settings.batch_size,
         ingest_enabled_default=settings.ingest_enabled_default,
     )
     # concurrent_updates keeps the bot responsive: a slow ingest (cognify) on one

--- a/cognee-telegram/src/cognee_telegram/bot.py
+++ b/cognee-telegram/src/cognee_telegram/bot.py
@@ -160,10 +160,7 @@ def build_application(
     settings: Settings, adapter: CogneeMemoryAdapter | None = None
 ) -> Application:
     """Wire the adapter and handlers into a python-telegram-bot Application."""
-    adapter = adapter or CogneeMemoryAdapter(
-        per_user_in_group=settings.per_user_in_group,
-        ingest_enabled_default=settings.ingest_enabled_default,
-    )
+    adapter = adapter or CogneeMemoryAdapter()
     # concurrent_updates keeps the bot responsive: a slow ingest (cognify) on one
     # message won't block /ask or other commands.
     app = Application.builder().token(settings.bot_token).concurrent_updates(True).build()

--- a/cognee-telegram/src/cognee_telegram/bot.py
+++ b/cognee-telegram/src/cognee_telegram/bot.py
@@ -1,0 +1,187 @@
+"""python-telegram-bot handlers — Telegram I/O only; memory lives in the adapter."""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.ext import (
+    Application,
+    ChatMemberHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+from .adapter import Answer, CogneeMemoryAdapter
+from .citations import MessageRef
+from .config import Settings
+from .scoping import Scope
+
+logger = logging.getLogger(__name__)
+
+_BACKEND_DOWN = (
+    "⚠️ I couldn't reach the memory backend just now — it may be rate-limited, "
+    "starting up, or missing an LLM key. Please try again in a moment."
+)
+
+INTRO = (
+    "👋 I'm a cognee memory bot. I quietly remember what's shared here so you can ask "
+    "about it later.\n\n"
+    "• Just chat — I capture messages into this chat's private memory.\n"
+    "• /ask <question> — I answer from this chat's memory, with sources.\n"
+    "• /forget — wipe this chat's memory.\n"
+    "• /optout — stop capturing here (/optin to resume).\n\n"
+    "Nothing leaves this chat's own memory. An LLM is used to build and query it."
+)
+
+_EMPTY = (
+    "I don't have anything in memory for this chat yet. Send a few messages or forward "
+    "something, then try /ask again."
+)
+
+
+def _author(update: Update) -> str | None:
+    user = update.effective_user
+    if user is None:
+        return None
+    return user.full_name or user.username or str(user.id)
+
+
+def _scope(adapter: CogneeMemoryAdapter, update: Update) -> Scope:
+    chat = update.effective_chat
+    user = update.effective_user
+    message = update.effective_message
+    thread_id = getattr(message, "message_thread_id", None) if message else None
+    return adapter.scope_for(
+        chat_type=chat.type, chat_id=chat.id, user_id=user.id, thread_id=thread_id
+    )
+
+
+def render_answer(answer: Answer) -> str:
+    """Format a recall answer with tappable sources and an honest freshness tag."""
+    if not answer.text:
+        return _EMPTY
+    lines = [answer.text]
+    if answer.citations:
+        lines += ["", "Sources:"]
+        for ref in answer.citations:
+            label = ref.text if len(ref.text) <= 60 else ref.text[:59] + "…"
+            link = ref.deep_link()
+            lines.append(f"• {label} — {link}" if link else f'• "{label}"')
+    if answer.source_tag:
+        lines += ["", f"(from {answer.source_tag} memory)"]
+    return "\n".join(lines)
+
+
+# -- handlers ------------------------------------------------------------
+async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.effective_message.reply_text(INTRO)
+
+
+async def ingest_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    adapter: CogneeMemoryAdapter = context.bot_data["adapter"]
+    message = update.effective_message
+    if message is None or not message.text:
+        return
+    scope = _scope(adapter, update)
+    if adapter.is_opted_out(scope.chat_id):
+        return
+    ref = MessageRef(
+        chat_id=scope.chat_id,
+        message_id=message.message_id,
+        text=message.text,
+        thread_id=scope.thread_id,
+        author=_author(update),
+    )
+    try:
+        await adapter.ingest(scope, ref)
+    except Exception:
+        # Capture is passive — log and move on rather than nagging the chat.
+        logger.exception("ingest failed for chat %s", scope.chat_id)
+
+
+async def ask_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    adapter: CogneeMemoryAdapter = context.bot_data["adapter"]
+    query = " ".join(context.args).strip() if context.args else ""
+    if not query:
+        await update.effective_message.reply_text("Usage: /ask <your question>")
+        return
+    scope = _scope(adapter, update)
+    try:
+        answer = await adapter.answer(scope, query)
+    except Exception:
+        logger.exception("ask failed for chat %s", scope.chat_id)
+        await update.effective_message.reply_text(_BACKEND_DOWN)
+        return
+    await update.effective_message.reply_text(render_answer(answer), disable_web_page_preview=True)
+
+
+async def forget_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    adapter: CogneeMemoryAdapter = context.bot_data["adapter"]
+    scope = _scope(adapter, update)
+    try:
+        await adapter.forget(scope)
+    except Exception:
+        logger.exception("forget failed for chat %s", scope.chat_id)
+        await update.effective_message.reply_text(_BACKEND_DOWN)
+        return
+    await update.effective_message.reply_text("🧹 Cleared this chat's memory (graph + vectors).")
+
+
+async def optout_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    adapter: CogneeMemoryAdapter = context.bot_data["adapter"]
+    adapter.opt_out(update.effective_chat.id)
+    await update.effective_message.reply_text(
+        "🔕 Paused capturing in this chat. Existing memory is kept — use /forget to clear it, "
+        "or /optin to resume."
+    )
+
+
+async def optin_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    adapter: CogneeMemoryAdapter = context.bot_data["adapter"]
+    adapter.opt_in(update.effective_chat.id)
+    await update.effective_message.reply_text("🔔 Resumed capturing in this chat.")
+
+
+async def greet_on_join(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Post the calm intro once, when the bot is added to a group."""
+    member = update.my_chat_member
+    if member is None:
+        return
+    was_in = member.old_chat_member.status in {"member", "administrator"}
+    now_in = member.new_chat_member.status in {"member", "administrator"}
+    if not was_in and now_in:
+        await context.bot.send_message(chat_id=member.chat.id, text=INTRO)
+
+
+def build_application(
+    settings: Settings, adapter: CogneeMemoryAdapter | None = None
+) -> Application:
+    """Wire the adapter and handlers into a python-telegram-bot Application."""
+    adapter = adapter or CogneeMemoryAdapter(
+        per_user_in_group=settings.per_user_in_group,
+        batch_size=settings.batch_size,
+        ingest_enabled_default=settings.ingest_enabled_default,
+    )
+    # concurrent_updates keeps the bot responsive: a slow ingest (cognify) on one
+    # message won't block /ask or other commands.
+    app = Application.builder().token(settings.bot_token).concurrent_updates(True).build()
+    app.bot_data["adapter"] = adapter
+
+    app.add_handler(CommandHandler("start", start_command))
+    app.add_handler(CommandHandler("help", start_command))
+    app.add_handler(CommandHandler("ask", ask_command))
+    app.add_handler(CommandHandler("forget", forget_command))
+    app.add_handler(CommandHandler("optout", optout_command))
+    app.add_handler(CommandHandler("optin", optin_command))
+    app.add_handler(ChatMemberHandler(greet_on_join, ChatMemberHandler.MY_CHAT_MEMBER))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, ingest_message))
+    app.add_error_handler(_on_error)
+    return app
+
+
+async def _on_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Last-resort handler so no exception goes completely unnoticed."""
+    logger.exception("Unhandled handler error", exc_info=context.error)

--- a/cognee-telegram/src/cognee_telegram/bot.py
+++ b/cognee-telegram/src/cognee_telegram/bot.py
@@ -60,7 +60,7 @@ def _scope(adapter: CogneeMemoryAdapter, update: Update) -> Scope:
 
 
 def render_answer(answer: Answer) -> str:
-    """Format a recall answer with tappable sources and an honest freshness tag."""
+    """Format a recall answer with tappable sources back to the original messages."""
     if not answer.text:
         return _EMPTY
     lines = [answer.text]
@@ -70,8 +70,6 @@ def render_answer(answer: Answer) -> str:
             label = ref.text if len(ref.text) <= 60 else ref.text[:59] + "…"
             link = ref.deep_link()
             lines.append(f"• {label} — {link}" if link else f'• "{label}"')
-    if answer.source_tag:
-        lines += ["", f"(from {answer.source_tag} memory)"]
     return "\n".join(lines)
 
 

--- a/cognee-telegram/src/cognee_telegram/citations.py
+++ b/cognee-telegram/src/cognee_telegram/citations.py
@@ -1,0 +1,137 @@
+"""Bridge cognee's source references back to tappable Telegram links.
+
+``recall(..., include_references=True)`` grounds an answer in source chunks,
+but those references point at cognee documents, not Telegram messages. So the
+bot keeps its own ledger: every ingested message is recorded with its
+``chat_id`` / ``message_id`` / ``thread_id``, and after a recall we match the
+answer's evidence back to the originating message to render a deep link.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+_WORD = re.compile(r"[a-z0-9]+")
+_MIN_TERM_LEN = 3
+
+# Common words that shouldn't, on their own, link an answer back to a message.
+_STOPWORDS = frozenset(
+    {
+        "the",
+        "and",
+        "for",
+        "are",
+        "was",
+        "with",
+        "you",
+        "this",
+        "that",
+        "but",
+        "not",
+        "from",
+        "what",
+        "when",
+        "who",
+        "why",
+        "how",
+        "where",
+        "your",
+        "our",
+        "their",
+        "has",
+        "have",
+        "had",
+        "will",
+        "would",
+        "can",
+        "could",
+        "should",
+        "did",
+        "does",
+        "about",
+        "into",
+        "out",
+        "they",
+        "them",
+        "its",
+        "his",
+        "her",
+        "she",
+        "him",
+        "any",
+        "all",
+        "some",
+    }
+)
+
+
+def _terms(text: str) -> set[str]:
+    return {
+        t for t in _WORD.findall(text.lower()) if len(t) >= _MIN_TERM_LEN and t not in _STOPWORDS
+    }
+
+
+@dataclass(frozen=True)
+class MessageRef:
+    """A Telegram message the bot ingested, kept for citation resolution."""
+
+    chat_id: int
+    message_id: int
+    text: str
+    thread_id: int | None = None
+    author: str | None = None
+
+    def attributed_text(self) -> str:
+        """The text as stored in memory, prefixed with author attribution."""
+        return f"{self.author}: {self.text}" if self.author else self.text
+
+    def deep_link(self) -> str | None:
+        """A ``t.me/c/...`` link, or None when Telegram exposes no public link.
+
+        Only supergroups/channels (chat ids prefixed ``-100``) have public
+        message deep links. DMs and basic groups return None — the caller
+        falls back to quoting the source snippet.
+        """
+        raw = str(self.chat_id)
+        if not raw.startswith("-100"):
+            return None
+        internal = raw[4:]
+        if self.thread_id is not None:
+            return f"https://t.me/c/{internal}/{self.thread_id}/{self.message_id}"
+        return f"https://t.me/c/{internal}/{self.message_id}"
+
+
+@dataclass
+class CitationLedger:
+    """Per-dataset record of ingested messages, used to resolve citations."""
+
+    _by_dataset: dict[str, list[MessageRef]] = field(default_factory=dict)
+
+    def record(self, dataset_name: str, ref: MessageRef) -> None:
+        self._by_dataset.setdefault(dataset_name, []).append(ref)
+
+    def drop(self, dataset_name: str) -> None:
+        """Forget a dataset's ledger (called on ``/forget``)."""
+        self._by_dataset.pop(dataset_name, None)
+
+    def refs(self, dataset_name: str) -> list[MessageRef]:
+        return list(self._by_dataset.get(dataset_name, []))
+
+    def resolve(self, dataset_name: str, evidence: str, *, limit: int = 3) -> list[MessageRef]:
+        """Match recall evidence text back to ingested messages.
+
+        Ranks this dataset's ledger entries by term overlap with the answer /
+        evidence text and returns the strongest matches. Returns ``[]`` when
+        nothing overlaps (so the bot abstains from citing rather than guess).
+        """
+        wanted = _terms(evidence)
+        if not wanted:
+            return []
+        scored: list[tuple[int, MessageRef]] = []
+        for ref in self._by_dataset.get(dataset_name, []):
+            overlap = len(_terms(ref.text) & wanted)
+            if overlap:
+                scored.append((overlap, ref))
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return [ref for _, ref in scored[:limit]]

--- a/cognee-telegram/src/cognee_telegram/citations.py
+++ b/cognee-telegram/src/cognee_telegram/citations.py
@@ -10,10 +10,15 @@ answer's evidence back to the originating message to render a deep link.
 from __future__ import annotations
 
 import re
+from collections import deque
 from dataclasses import dataclass, field
 
 _WORD = re.compile(r"[a-z0-9]+")
 _MIN_TERM_LEN = 3
+
+# Cap the per-chat ledger so a long-lived bot's memory stays bounded. Recall only
+# ranks the newest messages anyway (recency), so we keep the most recent N.
+_MAX_REFS_PER_DATASET = 1000
 
 # Common words that shouldn't, on their own, link an answer back to a message.
 _STOPWORDS = frozenset(
@@ -104,12 +109,19 @@ class MessageRef:
 
 @dataclass
 class CitationLedger:
-    """Per-dataset record of ingested messages, used to resolve citations."""
+    """Per-dataset record of ingested messages, used to resolve citations.
 
-    _by_dataset: dict[str, list[MessageRef]] = field(default_factory=dict)
+    Each dataset keeps at most ``_MAX_REFS_PER_DATASET`` most-recent messages so
+    a long-running bot's memory footprint stays bounded.
+    """
+
+    _by_dataset: dict[str, deque[MessageRef]] = field(default_factory=dict)
 
     def record(self, dataset_name: str, ref: MessageRef) -> None:
-        self._by_dataset.setdefault(dataset_name, []).append(ref)
+        refs = self._by_dataset.get(dataset_name)
+        if refs is None:
+            refs = self._by_dataset[dataset_name] = deque(maxlen=_MAX_REFS_PER_DATASET)
+        refs.append(ref)
 
     def drop(self, dataset_name: str) -> None:
         """Forget a dataset's ledger (called on ``/forget``)."""

--- a/cognee-telegram/src/cognee_telegram/citations.py
+++ b/cognee-telegram/src/cognee_telegram/citations.py
@@ -16,8 +16,9 @@ from dataclasses import dataclass, field
 _WORD = re.compile(r"[a-z0-9]+")
 _MIN_TERM_LEN = 3
 
-# Cap the per-chat ledger so a long-lived bot's memory stays bounded. Recall only
-# ranks the newest messages anyway (recency), so we keep the most recent N.
+# Cap the per-chat ledger so a long-lived bot's memory stays bounded. We keep the
+# most recent N messages; if recall ever grounds an answer in an older, evicted
+# message, the bot omits that citation rather than mis-attributing it.
 _MAX_REFS_PER_DATASET = 1000
 
 # Common words that shouldn't, on their own, link an answer back to a message.

--- a/cognee-telegram/src/cognee_telegram/config.py
+++ b/cognee-telegram/src/cognee_telegram/config.py
@@ -6,12 +6,6 @@ import os
 from dataclasses import dataclass
 
 
-def _as_bool(value: str | None, default: bool) -> bool:
-    if value is None:
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
 @dataclass(frozen=True)
 class Settings:
     """Bot configuration.
@@ -22,8 +16,6 @@ class Settings:
     """
 
     bot_token: str
-    per_user_in_group: bool = False
-    ingest_enabled_default: bool = True
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -33,8 +25,4 @@ class Settings:
                 "TELEGRAM_BOT_TOKEN is not set. Create a bot with @BotFather, then "
                 "export TELEGRAM_BOT_TOKEN=<token>. See the README for the 5-minute setup."
             )
-        return cls(
-            bot_token=token,
-            per_user_in_group=_as_bool(os.environ.get("COGNEE_TG_PER_USER"), False),
-            ingest_enabled_default=_as_bool(os.environ.get("COGNEE_TG_INGEST_DEFAULT"), True),
-        )
+        return cls(bot_token=token)

--- a/cognee-telegram/src/cognee_telegram/config.py
+++ b/cognee-telegram/src/cognee_telegram/config.py
@@ -1,0 +1,47 @@
+"""Runtime settings for the Telegram bot, read from the environment."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _as_bool(value: str | None, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Bot configuration.
+
+    ``bot_token`` is the only required value. ``LLM_API_KEY`` (or an
+    equivalent cognee LLM config) must also be set in the environment for
+    cognee to build and query memory — the bot does not read it directly.
+    """
+
+    bot_token: str
+    per_user_in_group: bool = False
+    batch_size: int = 1
+    ingest_enabled_default: bool = True
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+        if not token:
+            raise RuntimeError(
+                "TELEGRAM_BOT_TOKEN is not set. Create a bot with @BotFather, then "
+                "export TELEGRAM_BOT_TOKEN=<token>. See the README for the 5-minute setup."
+            )
+        batch_raw = os.environ.get("COGNEE_TG_BATCH_SIZE", "1").strip() or "1"
+        try:
+            batch_size = max(1, int(batch_raw))
+        except ValueError:
+            batch_size = 1
+        return cls(
+            bot_token=token,
+            per_user_in_group=_as_bool(os.environ.get("COGNEE_TG_PER_USER"), False),
+            batch_size=batch_size,
+            ingest_enabled_default=_as_bool(os.environ.get("COGNEE_TG_INGEST_DEFAULT"), True),
+        )

--- a/cognee-telegram/src/cognee_telegram/config.py
+++ b/cognee-telegram/src/cognee_telegram/config.py
@@ -23,7 +23,6 @@ class Settings:
 
     bot_token: str
     per_user_in_group: bool = False
-    batch_size: int = 1
     ingest_enabled_default: bool = True
 
     @classmethod
@@ -34,14 +33,8 @@ class Settings:
                 "TELEGRAM_BOT_TOKEN is not set. Create a bot with @BotFather, then "
                 "export TELEGRAM_BOT_TOKEN=<token>. See the README for the 5-minute setup."
             )
-        batch_raw = os.environ.get("COGNEE_TG_BATCH_SIZE", "1").strip() or "1"
-        try:
-            batch_size = max(1, int(batch_raw))
-        except ValueError:
-            batch_size = 1
         return cls(
             bot_token=token,
             per_user_in_group=_as_bool(os.environ.get("COGNEE_TG_PER_USER"), False),
-            batch_size=batch_size,
             ingest_enabled_default=_as_bool(os.environ.get("COGNEE_TG_INGEST_DEFAULT"), True),
         )

--- a/cognee-telegram/src/cognee_telegram/scoping.py
+++ b/cognee-telegram/src/cognee_telegram/scoping.py
@@ -1,0 +1,98 @@
+"""Map a Telegram conversation to a cognee dataset + session.
+
+Each Telegram chat is one memory boundary. The **dataset** is the durable
+store and the unit ``/forget`` clears; the **session_id** is an optional
+freshness cache so a just-sent message is answerable before the background
+graph sync finishes.
+
+Convention (per-chat by default)::
+
+    DM (private)   dataset telegram_dm_<user_id>             session telegram:dm:<user_id>
+    group / super  dataset telegram_group_<chat_id>          session telegram:group:<chat_id>
+    forum topic    dataset telegram_group_<chat_id>_<thread> session telegram:group:<chat_id>:<thread>
+
+With ``per_user_in_group=True`` a group is split per sender
+(``telegram_group_<chat_id>_user_<user_id>``) so hard per-user deletion works.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+PRIVATE = "private"
+GROUP = "group"
+SUPERGROUP = "supergroup"
+
+_SANITIZE = re.compile(r"[^0-9a-zA-Z]+")
+
+
+def _sanitize(value: object) -> str:
+    """Make a Telegram id safe for a cognee dataset name.
+
+    Telegram group ids are negative (e.g. ``-1001234567890``); the leading
+    ``-`` is encoded as ``n`` so positive and negative ids never collide and
+    the name stays alphanumeric + underscore.
+    """
+    text = str(value)
+    text = text.replace("-", "n")
+    return _SANITIZE.sub("_", text)
+
+
+@dataclass(frozen=True)
+class Scope:
+    """The resolved memory boundary for one Telegram conversation."""
+
+    dataset_name: str
+    session_id: str
+    chat_id: int
+    thread_id: int | None = None
+    is_private: bool = False
+
+
+def resolve_scope(
+    *,
+    chat_type: str,
+    chat_id: int,
+    user_id: int,
+    thread_id: int | None = None,
+    per_user_in_group: bool = False,
+) -> Scope:
+    """Resolve a Telegram chat into its ``Scope`` (dataset + session).
+
+    Args:
+        chat_type: Telegram ``chat.type`` (``private`` / ``group`` / ``supergroup``).
+        chat_id: Telegram ``chat.id``.
+        user_id: Sender ``user.id`` (used for DMs and per-user group scoping).
+        thread_id: Forum-topic ``message_thread_id`` when present.
+        per_user_in_group: Split group memory per sender when True.
+
+    Returns:
+        The ``Scope`` describing this conversation's dataset and session id.
+    """
+    is_private = chat_type == PRIVATE
+    if is_private:
+        return Scope(
+            dataset_name=f"telegram_dm_{_sanitize(user_id)}",
+            session_id=f"telegram:dm:{user_id}",
+            chat_id=chat_id,
+            thread_id=None,
+            is_private=True,
+        )
+
+    base_ds = f"telegram_group_{_sanitize(chat_id)}"
+    base_sid = f"telegram:group:{chat_id}"
+    if thread_id is not None:
+        base_ds += f"_{_sanitize(thread_id)}"
+        base_sid += f":{thread_id}"
+    if per_user_in_group:
+        base_ds += f"_user_{_sanitize(user_id)}"
+        base_sid += f":user:{user_id}"
+
+    return Scope(
+        dataset_name=base_ds,
+        session_id=base_sid,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        is_private=False,
+    )

--- a/cognee-telegram/src/cognee_telegram/scoping.py
+++ b/cognee-telegram/src/cognee_telegram/scoping.py
@@ -1,15 +1,13 @@
-"""Map a Telegram conversation to a cognee dataset + session.
+"""Map a Telegram conversation to a cognee dataset.
 
-Each Telegram chat is one memory boundary. The **dataset** is the durable
-store and the unit ``/forget`` clears; the **session_id** is an optional
-freshness cache so a just-sent message is answerable before the background
-graph sync finishes.
+Each Telegram chat is one memory boundary: the **dataset** is the durable
+store and the unit ``/forget`` clears.
 
 Convention (per-chat by default)::
 
-    DM (private)   dataset telegram_dm_<user_id>             session telegram:dm:<user_id>
-    group / super  dataset telegram_group_<chat_id>          session telegram:group:<chat_id>
-    forum topic    dataset telegram_group_<chat_id>_<thread> session telegram:group:<chat_id>:<thread>
+    DM (private)   dataset telegram_dm_<user_id>
+    group / super  dataset telegram_group_<chat_id>
+    forum topic    dataset telegram_group_<chat_id>_<thread>
 
 With ``per_user_in_group=True`` a group is split per sender
 (``telegram_group_<chat_id>_user_<user_id>``) so hard per-user deletion works.
@@ -44,10 +42,8 @@ class Scope:
     """The resolved memory boundary for one Telegram conversation."""
 
     dataset_name: str
-    session_id: str
     chat_id: int
     thread_id: int | None = None
-    is_private: bool = False
 
 
 def resolve_scope(
@@ -58,7 +54,7 @@ def resolve_scope(
     thread_id: int | None = None,
     per_user_in_group: bool = False,
 ) -> Scope:
-    """Resolve a Telegram chat into its ``Scope`` (dataset + session).
+    """Resolve a Telegram chat into its ``Scope`` (dataset).
 
     Args:
         chat_type: Telegram ``chat.type`` (``private`` / ``group`` / ``supergroup``).
@@ -68,31 +64,19 @@ def resolve_scope(
         per_user_in_group: Split group memory per sender when True.
 
     Returns:
-        The ``Scope`` describing this conversation's dataset and session id.
+        The ``Scope`` describing this conversation's dataset.
     """
-    is_private = chat_type == PRIVATE
-    if is_private:
+    if chat_type == PRIVATE:
         return Scope(
             dataset_name=f"telegram_dm_{_sanitize(user_id)}",
-            session_id=f"telegram:dm:{user_id}",
             chat_id=chat_id,
             thread_id=None,
-            is_private=True,
         )
 
-    base_ds = f"telegram_group_{_sanitize(chat_id)}"
-    base_sid = f"telegram:group:{chat_id}"
+    dataset_name = f"telegram_group_{_sanitize(chat_id)}"
     if thread_id is not None:
-        base_ds += f"_{_sanitize(thread_id)}"
-        base_sid += f":{thread_id}"
+        dataset_name += f"_{_sanitize(thread_id)}"
     if per_user_in_group:
-        base_ds += f"_user_{_sanitize(user_id)}"
-        base_sid += f":user:{user_id}"
+        dataset_name += f"_user_{_sanitize(user_id)}"
 
-    return Scope(
-        dataset_name=base_ds,
-        session_id=base_sid,
-        chat_id=chat_id,
-        thread_id=thread_id,
-        is_private=False,
-    )
+    return Scope(dataset_name=dataset_name, chat_id=chat_id, thread_id=thread_id)

--- a/cognee-telegram/src/cognee_telegram/scoping.py
+++ b/cognee-telegram/src/cognee_telegram/scoping.py
@@ -3,14 +3,11 @@
 Each Telegram chat is one memory boundary: the **dataset** is the durable
 store and the unit ``/forget`` clears.
 
-Convention (per-chat by default)::
+Convention::
 
     DM (private)   dataset telegram_dm_<user_id>
     group / super  dataset telegram_group_<chat_id>
     forum topic    dataset telegram_group_<chat_id>_<thread>
-
-With ``per_user_in_group=True`` a group is split per sender
-(``telegram_group_<chat_id>_user_<user_id>``) so hard per-user deletion works.
 """
 
 from __future__ import annotations
@@ -52,16 +49,14 @@ def resolve_scope(
     chat_id: int,
     user_id: int,
     thread_id: int | None = None,
-    per_user_in_group: bool = False,
 ) -> Scope:
     """Resolve a Telegram chat into its ``Scope`` (dataset).
 
     Args:
         chat_type: Telegram ``chat.type`` (``private`` / ``group`` / ``supergroup``).
         chat_id: Telegram ``chat.id``.
-        user_id: Sender ``user.id`` (used for DMs and per-user group scoping).
+        user_id: Sender ``user.id`` (used to scope DMs to the user).
         thread_id: Forum-topic ``message_thread_id`` when present.
-        per_user_in_group: Split group memory per sender when True.
 
     Returns:
         The ``Scope`` describing this conversation's dataset.
@@ -76,7 +71,5 @@ def resolve_scope(
     dataset_name = f"telegram_group_{_sanitize(chat_id)}"
     if thread_id is not None:
         dataset_name += f"_{_sanitize(thread_id)}"
-    if per_user_in_group:
-        dataset_name += f"_user_{_sanitize(user_id)}"
 
     return Scope(dataset_name=dataset_name, chat_id=chat_id, thread_id=thread_id)

--- a/cognee-telegram/tests/conftest.py
+++ b/cognee-telegram/tests/conftest.py
@@ -1,0 +1,56 @@
+"""Shared fixtures. Patches cognee's memory API so tests are deterministic and
+need no real LLM/API keys (the #3601 spirit, applied at the cognee boundary)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_cognee(monkeypatch):
+    """Replace cognee.remember/recall/forget with AsyncMocks.
+
+    The adapter calls ``cognee.<fn>`` at call time, so patching the module
+    attributes is enough — no real ingestion, no keys.
+    """
+    import cognee
+
+    remember = AsyncMock(return_value={"status": "session_stored"})
+    recall = AsyncMock(return_value=[])
+    forget = AsyncMock(return_value={"datasets_removed": 1})
+    monkeypatch.setattr(cognee, "remember", remember)
+    monkeypatch.setattr(cognee, "recall", recall)
+    monkeypatch.setattr(cognee, "forget", forget)
+    return SimpleNamespace(remember=remember, recall=recall, forget=forget)
+
+
+@pytest.fixture
+def graph_result():
+    """Build a real ``ResponseGraphEntry`` (the shape recall actually returns)."""
+    from cognee.modules.recall.types.RecallResponse import ResponseGraphEntry
+    from cognee.modules.recall.types.SearchResultItem import SearchResultKind
+    from cognee.modules.search.types.SearchType import SearchType
+
+    def _make(text: str, source: str = "graph"):
+        return ResponseGraphEntry(
+            kind=SearchResultKind.GRAPH_COMPLETION,
+            search_type=SearchType.GRAPH_COMPLETION,
+            text=text,
+            source=source,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def session_result():
+    """Build a real ``ResponseQAEntry`` (a session-cache hit)."""
+    from cognee.modules.recall.types.RecallResponse import ResponseQAEntry
+
+    def _make(answer: str):
+        return ResponseQAEntry(
+            time="2026-01-01T00:00:00", question="", context="", answer=answer, source="session"
+        )
+
+    return _make

--- a/cognee-telegram/tests/test_adapter.py
+++ b/cognee-telegram/tests/test_adapter.py
@@ -42,7 +42,13 @@ async def test_extract_reads_real_recall_shapes(graph_result, session_result):
 
 
 async def test_answer_recalls_with_references_and_resolves_citations(mock_cognee, graph_result):
-    mock_cognee.recall.return_value = [graph_result("The revenue report is due Friday.")]
+    # include_references appends an Evidence block quoting the retrieved source;
+    # citations resolve from that grounded block back to the original message.
+    grounded = (
+        "The revenue report is due Friday.\n\nEvidence:\n"
+        '- chunk 1 of document text_x (data_id: a): "the revenue report is due friday"'
+    )
+    mock_cognee.recall.return_value = [graph_result(grounded)]
     adapter = CogneeMemoryAdapter()
     scope = _dm(adapter)
     await adapter.ingest(
@@ -58,6 +64,22 @@ async def test_answer_recalls_with_references_and_resolves_citations(mock_cognee
     assert answer.text == "The revenue report is due Friday."
     assert len(answer.citations) == 1
     assert answer.citations[0].message_id == 11
+
+
+async def test_refusal_answer_is_never_cited(mock_cognee, graph_result):
+    # A "no information" answer carries no Evidence block; even though it shares
+    # "revenue"/"report" with a stored message, the bot must not cite it — matching
+    # an answer's own words against the ledger would fabricate a source.
+    mock_cognee.recall.return_value = [
+        graph_result("I don't have any information about the revenue report.")
+    ]
+    adapter = CogneeMemoryAdapter()
+    scope = _dm(adapter)
+    await adapter.ingest(
+        scope, MessageRef(chat_id=7, message_id=11, text="the revenue report is due friday")
+    )
+    answer = await adapter.answer(scope, "when is the revenue report due?")
+    assert answer.citations == []
 
 
 async def test_forget_clears_dataset_and_drops_ledger(mock_cognee):

--- a/cognee-telegram/tests/test_adapter.py
+++ b/cognee-telegram/tests/test_adapter.py
@@ -1,0 +1,164 @@
+"""Adapter behavior against a mocked cognee — the deterministic, key-free core."""
+
+import pytest
+
+from cognee_telegram.adapter import CogneeMemoryAdapter
+from cognee_telegram.citations import MessageRef
+
+
+def _dm(adapter, user_id=7):
+    return adapter.scope_for(chat_type="private", chat_id=user_id, user_id=user_id)
+
+
+async def test_ingest_immediately_remembers_with_right_scope(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    scope = _dm(adapter)
+    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="hello", author="Ada"))
+
+    mock_cognee.remember.assert_awaited_once()
+    args, kwargs = mock_cognee.remember.call_args
+    assert args[0] == ["Ada: hello"]
+    assert kwargs["dataset_name"] == "telegram_dm_7"
+    # Durable ingest: no session_id (a session-only write never creates the dataset).
+    assert "session_id" not in kwargs
+
+
+async def test_opted_out_chat_is_not_ingested(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    scope = _dm(adapter)
+    adapter.opt_out(scope.chat_id)
+
+    ingested = await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="secret"))
+    assert ingested is False
+    mock_cognee.remember.assert_not_awaited()
+
+
+async def test_batching_flushes_only_at_threshold(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=2)
+    scope = _dm(adapter)
+
+    flushed = await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="one"))
+    assert flushed is False
+    mock_cognee.remember.assert_not_awaited()
+
+    flushed = await adapter.ingest(scope, MessageRef(chat_id=7, message_id=2, text="two"))
+    assert flushed is True
+    mock_cognee.remember.assert_awaited_once()
+    args, _ = mock_cognee.remember.call_args
+    assert args[0] == ["one", "two"]
+
+
+async def test_extract_reads_real_recall_shapes(graph_result, session_result):
+    # Guards against the mock drifting from cognee's real RecallResponse shape.
+    from cognee_telegram.adapter import _extract
+
+    assert _extract(graph_result("durable answer")) == ("durable answer", "graph")
+    assert _extract(session_result("fresh answer")) == ("fresh answer", "session")
+
+
+async def test_answer_tags_mixed_sources(mock_cognee, graph_result, session_result):
+    mock_cognee.recall.return_value = [session_result("fresh note"), graph_result("durable fact")]
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    answer = await adapter.answer(_dm(adapter), "what do you know?")
+    assert answer.source_tag == "mixed"
+    assert "fresh note" in answer.text and "durable fact" in answer.text
+
+
+async def test_answer_recalls_with_references_and_resolves_citations(mock_cognee, graph_result):
+    mock_cognee.recall.return_value = [graph_result("The revenue report is due Friday.")]
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    scope = _dm(adapter)
+    await adapter.ingest(
+        scope, MessageRef(chat_id=7, message_id=11, text="the revenue report is due friday")
+    )
+
+    answer = await adapter.answer(scope, "when is the revenue report due?")
+
+    _, kwargs = mock_cognee.recall.call_args
+    assert kwargs["datasets"] == ["telegram_dm_7"]
+    assert kwargs["include_references"] is True
+
+    assert answer.text == "The revenue report is due Friday."
+    assert answer.source_tag == "graph"
+    assert len(answer.citations) == 1
+    assert answer.citations[0].message_id == 11
+
+
+async def test_answer_flushes_pending_messages_first(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=10)  # nothing auto-flushes
+    scope = _dm(adapter)
+    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="buffered note"))
+    mock_cognee.remember.assert_not_awaited()
+
+    await adapter.answer(scope, "anything?")
+    mock_cognee.remember.assert_awaited_once()  # /ask forced the flush
+
+
+async def test_forget_clears_dataset_and_drops_ledger(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    scope = _dm(adapter)
+    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="remember me"))
+
+    await adapter.forget(scope)
+
+    _, kwargs = mock_cognee.forget.call_args
+    assert kwargs["dataset"] == "telegram_dm_7"
+    assert adapter.ledger.refs("telegram_dm_7") == []
+
+
+async def test_forget_clears_pending_buffer(mock_cognee):
+    # Buffered-but-not-yet-flushed messages must be dropped by /forget too.
+    adapter = CogneeMemoryAdapter(batch_size=10)
+    scope = _dm(adapter)
+    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="buffered"))
+    mock_cognee.remember.assert_not_awaited()  # still in the buffer
+
+    await adapter.forget(scope)
+    await adapter.flush(scope)  # nothing should be left to flush
+    mock_cognee.remember.assert_not_awaited()
+
+
+async def test_answer_returns_empty_when_dataset_missing(mock_cognee):
+    # Before any ingest (or after /forget) the dataset doesn't exist; recall raises
+    # DatasetNotFoundError — the bot must say "nothing here yet", not crash.
+    from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
+
+    mock_cognee.recall.side_effect = DatasetNotFoundError(message="No datasets found.")
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    answer = await adapter.answer(_dm(adapter), "anything?")
+    assert answer.text == ""
+    assert answer.citations == []
+
+
+async def test_answer_strips_raw_evidence_block(mock_cognee, graph_result):
+    # recall appends an "Evidence:" block when include_references=True; the bot must
+    # show only the answer and render its own clean sources instead.
+    raw = 'The Q3 review is Friday.\n\nEvidence:\n- chunk 1 of document text_x (data_id: a): "x"'
+    mock_cognee.recall.return_value = [graph_result(raw)]
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    answer = await adapter.answer(_dm(adapter), "when is the review?")
+    assert answer.text == "The Q3 review is Friday."
+    assert "Evidence:" not in answer.text
+
+
+async def test_empty_recall_yields_no_citations(mock_cognee):
+    mock_cognee.recall.return_value = []
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    scope = _dm(adapter)
+    answer = await adapter.answer(scope, "nothing stored yet")
+    assert answer.text == ""
+    assert answer.citations == []
+    assert answer.source_tag is None
+
+
+async def test_opt_in_mode_captures_only_after_opt_in(mock_cognee):
+    # With ingest_enabled_default=False a chat must opt in before anything is stored.
+    adapter = CogneeMemoryAdapter(batch_size=1, ingest_enabled_default=False)
+    scope = _dm(adapter)
+    assert adapter.is_opted_out(scope.chat_id) is True
+    assert await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="hi")) is False
+    mock_cognee.remember.assert_not_awaited()
+
+    adapter.opt_in(scope.chat_id)
+    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=2, text="now captured"))
+    mock_cognee.remember.assert_awaited_once()

--- a/cognee-telegram/tests/test_adapter.py
+++ b/cognee-telegram/tests/test_adapter.py
@@ -11,7 +11,7 @@ def _dm(adapter, user_id=7):
 
 
 async def test_ingest_immediately_remembers_with_right_scope(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     scope = _dm(adapter)
     await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="hello", author="Ada"))
 
@@ -24,28 +24,13 @@ async def test_ingest_immediately_remembers_with_right_scope(mock_cognee):
 
 
 async def test_opted_out_chat_is_not_ingested(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     scope = _dm(adapter)
     adapter.opt_out(scope.chat_id)
 
     ingested = await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="secret"))
     assert ingested is False
     mock_cognee.remember.assert_not_awaited()
-
-
-async def test_batching_flushes_only_at_threshold(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=2)
-    scope = _dm(adapter)
-
-    flushed = await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="one"))
-    assert flushed is False
-    mock_cognee.remember.assert_not_awaited()
-
-    flushed = await adapter.ingest(scope, MessageRef(chat_id=7, message_id=2, text="two"))
-    assert flushed is True
-    mock_cognee.remember.assert_awaited_once()
-    args, _ = mock_cognee.remember.call_args
-    assert args[0] == ["one", "two"]
 
 
 async def test_extract_reads_real_recall_shapes(graph_result, session_result):
@@ -58,7 +43,7 @@ async def test_extract_reads_real_recall_shapes(graph_result, session_result):
 
 async def test_answer_tags_mixed_sources(mock_cognee, graph_result, session_result):
     mock_cognee.recall.return_value = [session_result("fresh note"), graph_result("durable fact")]
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     answer = await adapter.answer(_dm(adapter), "what do you know?")
     assert answer.source_tag == "mixed"
     assert "fresh note" in answer.text and "durable fact" in answer.text
@@ -66,7 +51,7 @@ async def test_answer_tags_mixed_sources(mock_cognee, graph_result, session_resu
 
 async def test_answer_recalls_with_references_and_resolves_citations(mock_cognee, graph_result):
     mock_cognee.recall.return_value = [graph_result("The revenue report is due Friday.")]
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     scope = _dm(adapter)
     await adapter.ingest(
         scope, MessageRef(chat_id=7, message_id=11, text="the revenue report is due friday")
@@ -84,18 +69,8 @@ async def test_answer_recalls_with_references_and_resolves_citations(mock_cognee
     assert answer.citations[0].message_id == 11
 
 
-async def test_answer_flushes_pending_messages_first(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=10)  # nothing auto-flushes
-    scope = _dm(adapter)
-    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="buffered note"))
-    mock_cognee.remember.assert_not_awaited()
-
-    await adapter.answer(scope, "anything?")
-    mock_cognee.remember.assert_awaited_once()  # /ask forced the flush
-
-
 async def test_forget_clears_dataset_and_drops_ledger(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     scope = _dm(adapter)
     await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="remember me"))
 
@@ -106,25 +81,13 @@ async def test_forget_clears_dataset_and_drops_ledger(mock_cognee):
     assert adapter.ledger.refs("telegram_dm_7") == []
 
 
-async def test_forget_clears_pending_buffer(mock_cognee):
-    # Buffered-but-not-yet-flushed messages must be dropped by /forget too.
-    adapter = CogneeMemoryAdapter(batch_size=10)
-    scope = _dm(adapter)
-    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="buffered"))
-    mock_cognee.remember.assert_not_awaited()  # still in the buffer
-
-    await adapter.forget(scope)
-    await adapter.flush(scope)  # nothing should be left to flush
-    mock_cognee.remember.assert_not_awaited()
-
-
 async def test_answer_returns_empty_when_dataset_missing(mock_cognee):
     # Before any ingest (or after /forget) the dataset doesn't exist; recall raises
     # DatasetNotFoundError — the bot must say "nothing here yet", not crash.
     from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
 
     mock_cognee.recall.side_effect = DatasetNotFoundError(message="No datasets found.")
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     answer = await adapter.answer(_dm(adapter), "anything?")
     assert answer.text == ""
     assert answer.citations == []
@@ -135,7 +98,7 @@ async def test_answer_strips_raw_evidence_block(mock_cognee, graph_result):
     # show only the answer and render its own clean sources instead.
     raw = 'The Q3 review is Friday.\n\nEvidence:\n- chunk 1 of document text_x (data_id: a): "x"'
     mock_cognee.recall.return_value = [graph_result(raw)]
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     answer = await adapter.answer(_dm(adapter), "when is the review?")
     assert answer.text == "The Q3 review is Friday."
     assert "Evidence:" not in answer.text
@@ -143,7 +106,7 @@ async def test_answer_strips_raw_evidence_block(mock_cognee, graph_result):
 
 async def test_empty_recall_yields_no_citations(mock_cognee):
     mock_cognee.recall.return_value = []
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     scope = _dm(adapter)
     answer = await adapter.answer(scope, "nothing stored yet")
     assert answer.text == ""
@@ -153,7 +116,7 @@ async def test_empty_recall_yields_no_citations(mock_cognee):
 
 async def test_opt_in_mode_captures_only_after_opt_in(mock_cognee):
     # With ingest_enabled_default=False a chat must opt in before anything is stored.
-    adapter = CogneeMemoryAdapter(batch_size=1, ingest_enabled_default=False)
+    adapter = CogneeMemoryAdapter(ingest_enabled_default=False)
     scope = _dm(adapter)
     assert adapter.is_opted_out(scope.chat_id) is True
     assert await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="hi")) is False

--- a/cognee-telegram/tests/test_adapter.py
+++ b/cognee-telegram/tests/test_adapter.py
@@ -129,6 +129,15 @@ async def test_forget_is_idempotent_on_missing_dataset(mock_cognee):
     assert adapter.ledger.refs(scope.dataset_name) == []
 
 
+async def test_forget_is_idempotent_on_validation_error(mock_cognee):
+    # The other not-found shape: cognee raises a CogneeValidationError; also a no-op.
+    from cognee.exceptions import CogneeValidationError
+
+    mock_cognee.forget.side_effect = CogneeValidationError(message="No datasets found.")
+    adapter = CogneeMemoryAdapter()
+    await adapter.forget(_dm(adapter))  # must not raise
+
+
 async def test_answer_strips_raw_evidence_block(mock_cognee, graph_result):
     # recall appends an "Evidence:" block when include_references=True; the bot must
     # show only the answer and render its own clean sources instead.

--- a/cognee-telegram/tests/test_adapter.py
+++ b/cognee-telegram/tests/test_adapter.py
@@ -35,18 +35,10 @@ async def test_opted_out_chat_is_not_ingested(mock_cognee):
 
 async def test_extract_reads_real_recall_shapes(graph_result, session_result):
     # Guards against the mock drifting from cognee's real RecallResponse shape.
-    from cognee_telegram.adapter import _extract
+    from cognee_telegram.adapter import _answer_text
 
-    assert _extract(graph_result("durable answer")) == ("durable answer", "graph")
-    assert _extract(session_result("fresh answer")) == ("fresh answer", "session")
-
-
-async def test_answer_tags_mixed_sources(mock_cognee, graph_result, session_result):
-    mock_cognee.recall.return_value = [session_result("fresh note"), graph_result("durable fact")]
-    adapter = CogneeMemoryAdapter()
-    answer = await adapter.answer(_dm(adapter), "what do you know?")
-    assert answer.source_tag == "mixed"
-    assert "fresh note" in answer.text and "durable fact" in answer.text
+    assert _answer_text(graph_result("durable answer")) == "durable answer"
+    assert _answer_text(session_result("fresh answer")) == "fresh answer"
 
 
 async def test_answer_recalls_with_references_and_resolves_citations(mock_cognee, graph_result):
@@ -64,7 +56,6 @@ async def test_answer_recalls_with_references_and_resolves_citations(mock_cognee
     assert kwargs["include_references"] is True
 
     assert answer.text == "The revenue report is due Friday."
-    assert answer.source_tag == "graph"
     assert len(answer.citations) == 1
     assert answer.citations[0].message_id == 11
 
@@ -111,7 +102,6 @@ async def test_empty_recall_yields_no_citations(mock_cognee):
     answer = await adapter.answer(scope, "nothing stored yet")
     assert answer.text == ""
     assert answer.citations == []
-    assert answer.source_tag is None
 
 
 async def test_capture_is_on_by_default_until_opt_out(mock_cognee):

--- a/cognee-telegram/tests/test_adapter.py
+++ b/cognee-telegram/tests/test_adapter.py
@@ -106,6 +106,29 @@ async def test_answer_returns_empty_when_dataset_missing(mock_cognee):
     assert answer.citations == []
 
 
+async def test_answer_returns_empty_on_fresh_install(mock_cognee):
+    # On a brand-new install (no DB yet) recall raises a precondition error, not
+    # DatasetNotFoundError; the bot must still say "nothing here yet", not crash.
+    from cognee.exceptions import CogneeValidationError
+
+    mock_cognee.recall.side_effect = CogneeValidationError(
+        message="Recall prerequisites not met.", name="RecallPreconditionError"
+    )
+    adapter = CogneeMemoryAdapter()
+    answer = await adapter.answer(_dm(adapter), "anything?")
+    assert answer.text == ""
+
+
+async def test_forget_is_idempotent_on_missing_dataset(mock_cognee):
+    # /forget on a chat that never captured anything: cognee raises AttributeError
+    # resolving the unknown dataset name. Treat it as already-clear, not an error.
+    mock_cognee.forget.side_effect = AttributeError("'NoneType' object has no attribute 'id'")
+    adapter = CogneeMemoryAdapter()
+    scope = _dm(adapter)
+    await adapter.forget(scope)  # must not raise
+    assert adapter.ledger.refs(scope.dataset_name) == []
+
+
 async def test_answer_strips_raw_evidence_block(mock_cognee, graph_result):
     # recall appends an "Evidence:" block when include_references=True; the bot must
     # show only the answer and render its own clean sources instead.

--- a/cognee-telegram/tests/test_adapter.py
+++ b/cognee-telegram/tests/test_adapter.py
@@ -114,14 +114,14 @@ async def test_empty_recall_yields_no_citations(mock_cognee):
     assert answer.source_tag is None
 
 
-async def test_opt_in_mode_captures_only_after_opt_in(mock_cognee):
-    # With ingest_enabled_default=False a chat must opt in before anything is stored.
-    adapter = CogneeMemoryAdapter(ingest_enabled_default=False)
+async def test_capture_is_on_by_default_until_opt_out(mock_cognee):
+    # Opt-out model: a fresh chat captures until it runs /optout.
+    adapter = CogneeMemoryAdapter()
     scope = _dm(adapter)
-    assert adapter.is_opted_out(scope.chat_id) is True
-    assert await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="hi")) is False
-    mock_cognee.remember.assert_not_awaited()
-
-    adapter.opt_in(scope.chat_id)
-    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=2, text="now captured"))
+    assert adapter.is_opted_out(scope.chat_id) is False
+    await adapter.ingest(scope, MessageRef(chat_id=7, message_id=1, text="captured"))
     mock_cognee.remember.assert_awaited_once()
+
+    adapter.opt_out(scope.chat_id)
+    assert await adapter.ingest(scope, MessageRef(chat_id=7, message_id=2, text="ignored")) is False
+    mock_cognee.remember.assert_awaited_once()  # unchanged

--- a/cognee-telegram/tests/test_bot.py
+++ b/cognee-telegram/tests/test_bot.py
@@ -1,0 +1,180 @@
+"""Handler wiring with Telegram mocked via unittest.mock (PTB has no test harness)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from cognee_telegram.adapter import Answer, CogneeMemoryAdapter
+from cognee_telegram.bot import (
+    INTRO,
+    ask_command,
+    forget_command,
+    greet_on_join,
+    ingest_message,
+    optin_command,
+    optout_command,
+    render_answer,
+    start_command,
+)
+from cognee_telegram.citations import MessageRef
+
+
+def make_update(
+    *, text=None, chat_id=7, chat_type="private", user_id=7, message_id=1, thread_id=None
+):
+    update = MagicMock()
+    update.effective_chat.id = chat_id
+    update.effective_chat.type = chat_type
+    update.effective_user.id = user_id
+    update.effective_user.full_name = "Ada"
+    update.effective_user.username = "ada"
+    message = MagicMock()
+    message.message_id = message_id
+    message.text = text
+    message.message_thread_id = thread_id
+    message.reply_text = AsyncMock()
+    update.effective_message = message
+    return update
+
+
+def make_context(adapter, args=None):
+    context = MagicMock()
+    context.bot_data = {"adapter": adapter}
+    context.args = args or []
+    context.bot.send_message = AsyncMock()
+    return context
+
+
+# -- render_answer -------------------------------------------------------
+def test_render_answer_empty():
+    assert "don't have anything in memory" in render_answer(Answer(text=""))
+
+
+def test_render_answer_with_deep_link_citation():
+    answer = Answer(
+        text="It's due Friday.",
+        source_tag="graph",
+        citations=[MessageRef(chat_id=-1001234567890, message_id=99, text="report due friday")],
+    )
+    out = render_answer(answer)
+    assert "It's due Friday." in out
+    assert "https://t.me/c/1234567890/99" in out
+    assert "from graph memory" in out
+
+
+def test_render_answer_quotes_when_no_public_link():
+    answer = Answer(
+        text="Lunch is at noon.",
+        citations=[MessageRef(chat_id=7, message_id=1, text="lunch at noon")],
+    )
+    out = render_answer(answer)
+    assert '"lunch at noon"' in out
+
+
+def test_render_answer_forum_topic_deep_link():
+    answer = Answer(
+        text="It's Friday.",
+        citations=[
+            MessageRef(chat_id=-1001234567890, message_id=99, text="q3 friday", thread_id=12)
+        ],
+    )
+    assert "https://t.me/c/1234567890/12/99" in render_answer(answer)
+
+
+# -- handlers ------------------------------------------------------------
+async def test_ingest_message_stores_to_memory(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    update = make_update(text="remember the wifi password is hunter2")
+    await ingest_message(update, make_context(adapter))
+
+    mock_cognee.remember.assert_awaited_once()
+    args, kwargs = mock_cognee.remember.call_args
+    assert args[0] == ["Ada: remember the wifi password is hunter2"]
+    assert kwargs["dataset_name"] == "telegram_dm_7"
+
+
+async def test_ingest_skips_when_opted_out(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter.opt_out(7)
+    update = make_update(text="should not be stored")
+    await ingest_message(update, make_context(adapter))
+    mock_cognee.remember.assert_not_awaited()
+
+
+async def test_ask_command_replies_with_answer_and_sources(mock_cognee, graph_result):
+    mock_cognee.recall.return_value = [graph_result("The wifi password is hunter2.")]
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    # seed the ledger so the citation resolves
+    update_seed = make_update(text="the wifi password is hunter2", message_id=5)
+    await ingest_message(update_seed, make_context(adapter))
+
+    update = make_update(text="/ask")
+    await ask_command(update, make_context(adapter, args=["what's", "the", "wifi", "password?"]))
+
+    update.effective_message.reply_text.assert_awaited_once()
+    reply = update.effective_message.reply_text.call_args.args[0]
+    assert "hunter2" in reply
+
+
+async def test_ask_without_query_shows_usage(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    update = make_update(text="/ask")
+    await ask_command(update, make_context(adapter, args=[]))
+    reply = update.effective_message.reply_text.call_args.args[0]
+    assert "Usage" in reply
+    mock_cognee.recall.assert_not_awaited()
+
+
+async def test_ask_replies_friendly_error_on_backend_failure(mock_cognee):
+    # Live test exposed: a rate-limited/failed backend must not leave /ask silent.
+    mock_cognee.recall.side_effect = RuntimeError("rate limited")
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    update = make_update(text="/ask")
+    await ask_command(update, make_context(adapter, args=["anything"]))
+    reply = update.effective_message.reply_text.call_args.args[0]
+    assert "couldn't reach the memory backend" in reply
+
+
+async def test_forget_command_clears_memory(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    update = make_update(text="/forget")
+    await forget_command(update, make_context(adapter))
+
+    mock_cognee.forget.assert_awaited_once()
+    _, kwargs = mock_cognee.forget.call_args
+    assert kwargs["dataset"] == "telegram_dm_7"
+
+
+async def test_optout_then_optin_toggles_capture(mock_cognee):
+    adapter = CogneeMemoryAdapter(batch_size=1)
+    await optout_command(make_update(text="/optout"), make_context(adapter))
+    assert adapter.is_opted_out(7) is True
+    await optin_command(make_update(text="/optin"), make_context(adapter))
+    assert adapter.is_opted_out(7) is False
+
+
+async def test_start_command_sends_intro(mock_cognee):
+    update = make_update(text="/start")
+    await start_command(update, make_context(CogneeMemoryAdapter()))
+    reply = update.effective_message.reply_text.call_args.args[0]
+    assert "cognee memory bot" in reply
+
+
+async def test_greet_on_join_posts_intro_when_added(mock_cognee):
+    update = MagicMock()
+    update.my_chat_member.old_chat_member.status = "left"
+    update.my_chat_member.new_chat_member.status = "member"
+    update.my_chat_member.chat.id = -1001234567890
+    context = make_context(CogneeMemoryAdapter())
+    await greet_on_join(update, context)
+    context.bot.send_message.assert_awaited_once()
+    _, kwargs = context.bot.send_message.call_args
+    assert kwargs["chat_id"] == -1001234567890
+    assert kwargs["text"] == INTRO
+
+
+async def test_greet_on_join_silent_when_already_member(mock_cognee):
+    update = MagicMock()
+    update.my_chat_member.old_chat_member.status = "member"
+    update.my_chat_member.new_chat_member.status = "administrator"
+    context = make_context(CogneeMemoryAdapter())
+    await greet_on_join(update, context)
+    context.bot.send_message.assert_not_awaited()

--- a/cognee-telegram/tests/test_bot.py
+++ b/cognee-telegram/tests/test_bot.py
@@ -154,8 +154,9 @@ async def test_ingest_channel_post_without_sender(mock_cognee):
     )
     await ingest_message(update, make_context(adapter))
     mock_cognee.remember.assert_awaited_once()
-    _, kwargs = mock_cognee.remember.call_args
+    args, kwargs = mock_cognee.remember.call_args
     assert kwargs["dataset_name"] == "telegram_group_n1001234567890"
+    assert args[0] == ["auto-forwarded post"]  # no sender, so no author prefix
 
 
 async def test_ingest_skips_when_opted_out(mock_cognee):

--- a/cognee-telegram/tests/test_bot.py
+++ b/cognee-telegram/tests/test_bot.py
@@ -81,7 +81,7 @@ def test_render_answer_forum_topic_deep_link():
 
 # -- handlers ------------------------------------------------------------
 async def test_ingest_message_stores_to_memory(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     update = make_update(text="remember the wifi password is hunter2")
     await ingest_message(update, make_context(adapter))
 
@@ -92,7 +92,7 @@ async def test_ingest_message_stores_to_memory(mock_cognee):
 
 
 async def test_ingest_skips_when_opted_out(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     adapter.opt_out(7)
     update = make_update(text="should not be stored")
     await ingest_message(update, make_context(adapter))
@@ -101,7 +101,7 @@ async def test_ingest_skips_when_opted_out(mock_cognee):
 
 async def test_ask_command_replies_with_answer_and_sources(mock_cognee, graph_result):
     mock_cognee.recall.return_value = [graph_result("The wifi password is hunter2.")]
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     # seed the ledger so the citation resolves
     update_seed = make_update(text="the wifi password is hunter2", message_id=5)
     await ingest_message(update_seed, make_context(adapter))
@@ -115,7 +115,7 @@ async def test_ask_command_replies_with_answer_and_sources(mock_cognee, graph_re
 
 
 async def test_ask_without_query_shows_usage(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     update = make_update(text="/ask")
     await ask_command(update, make_context(adapter, args=[]))
     reply = update.effective_message.reply_text.call_args.args[0]
@@ -126,7 +126,7 @@ async def test_ask_without_query_shows_usage(mock_cognee):
 async def test_ask_replies_friendly_error_on_backend_failure(mock_cognee):
     # Live test exposed: a rate-limited/failed backend must not leave /ask silent.
     mock_cognee.recall.side_effect = RuntimeError("rate limited")
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     update = make_update(text="/ask")
     await ask_command(update, make_context(adapter, args=["anything"]))
     reply = update.effective_message.reply_text.call_args.args[0]
@@ -134,7 +134,7 @@ async def test_ask_replies_friendly_error_on_backend_failure(mock_cognee):
 
 
 async def test_forget_command_clears_memory(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     update = make_update(text="/forget")
     await forget_command(update, make_context(adapter))
 
@@ -144,7 +144,7 @@ async def test_forget_command_clears_memory(mock_cognee):
 
 
 async def test_optout_then_optin_toggles_capture(mock_cognee):
-    adapter = CogneeMemoryAdapter(batch_size=1)
+    adapter = CogneeMemoryAdapter()
     await optout_command(make_update(text="/optout"), make_context(adapter))
     assert adapter.is_opted_out(7) is True
     await optin_command(make_update(text="/optin"), make_context(adapter))

--- a/cognee-telegram/tests/test_bot.py
+++ b/cognee-telegram/tests/test_bot.py
@@ -18,18 +18,32 @@ from cognee_telegram.citations import MessageRef
 
 
 def make_update(
-    *, text=None, chat_id=7, chat_type="private", user_id=7, message_id=1, thread_id=None
+    *,
+    text=None,
+    caption=None,
+    chat_id=7,
+    chat_type="private",
+    user_id=7,
+    message_id=1,
+    thread_id=None,
+    is_topic_message=False,
+    has_user=True,
 ):
     update = MagicMock()
     update.effective_chat.id = chat_id
     update.effective_chat.type = chat_type
-    update.effective_user.id = user_id
-    update.effective_user.full_name = "Ada"
-    update.effective_user.username = "ada"
+    if has_user:
+        update.effective_user.id = user_id
+        update.effective_user.full_name = "Ada"
+        update.effective_user.username = "ada"
+    else:
+        update.effective_user = None
     message = MagicMock()
     message.message_id = message_id
     message.text = text
+    message.caption = caption
     message.message_thread_id = thread_id
+    message.is_topic_message = is_topic_message
     message.reply_text = AsyncMock()
     update.effective_message = message
     return update
@@ -87,6 +101,61 @@ async def test_ingest_message_stores_to_memory(mock_cognee):
     args, kwargs = mock_cognee.remember.call_args
     assert args[0] == ["Ada: remember the wifi password is hunter2"]
     assert kwargs["dataset_name"] == "telegram_dm_7"
+
+
+async def test_ingest_captures_media_caption(mock_cognee):
+    # A forwarded article/photo arrives as media with a caption, not message.text.
+    adapter = CogneeMemoryAdapter()
+    update = make_update(text=None, caption="great read https://example.com/article")
+    await ingest_message(update, make_context(adapter))
+    mock_cognee.remember.assert_awaited_once()
+    args, _ = mock_cognee.remember.call_args
+    assert "article" in args[0][0]
+
+
+async def test_forum_topic_scopes_to_its_thread(mock_cognee):
+    adapter = CogneeMemoryAdapter()
+    update = make_update(
+        text="topic note",
+        chat_type="supergroup",
+        chat_id=-1001234567890,
+        thread_id=42,
+        is_topic_message=True,
+    )
+    await ingest_message(update, make_context(adapter))
+    _, kwargs = mock_cognee.remember.call_args
+    assert kwargs["dataset_name"] == "telegram_group_n1001234567890_42"
+
+
+async def test_reply_thread_does_not_fork_dataset(mock_cognee):
+    # message_thread_id is populated for ordinary reply chains too; only real forum
+    # topics (is_topic_message) should get their own dataset.
+    adapter = CogneeMemoryAdapter()
+    update = make_update(
+        text="just a reply",
+        chat_type="supergroup",
+        chat_id=-1001234567890,
+        thread_id=42,
+        is_topic_message=False,
+    )
+    await ingest_message(update, make_context(adapter))
+    _, kwargs = mock_cognee.remember.call_args
+    assert kwargs["dataset_name"] == "telegram_group_n1001234567890"
+
+
+async def test_ingest_channel_post_without_sender(mock_cognee):
+    # Auto-forwarded channel posts / anonymous admins have no effective_user.
+    adapter = CogneeMemoryAdapter()
+    update = make_update(
+        text="auto-forwarded post",
+        chat_type="supergroup",
+        chat_id=-1001234567890,
+        has_user=False,
+    )
+    await ingest_message(update, make_context(adapter))
+    mock_cognee.remember.assert_awaited_once()
+    _, kwargs = mock_cognee.remember.call_args
+    assert kwargs["dataset_name"] == "telegram_group_n1001234567890"
 
 
 async def test_ingest_skips_when_opted_out(mock_cognee):

--- a/cognee-telegram/tests/test_bot.py
+++ b/cognee-telegram/tests/test_bot.py
@@ -51,13 +51,11 @@ def test_render_answer_empty():
 def test_render_answer_with_deep_link_citation():
     answer = Answer(
         text="It's due Friday.",
-        source_tag="graph",
         citations=[MessageRef(chat_id=-1001234567890, message_id=99, text="report due friday")],
     )
     out = render_answer(answer)
     assert "It's due Friday." in out
     assert "https://t.me/c/1234567890/99" in out
-    assert "from graph memory" in out
 
 
 def test_render_answer_quotes_when_no_public_link():

--- a/cognee-telegram/tests/test_citations.py
+++ b/cognee-telegram/tests/test_citations.py
@@ -51,3 +51,18 @@ def test_ledger_drop_clears_dataset():
     ledger.record(ds, MessageRef(chat_id=7, message_id=1, text="something to remember"))
     ledger.drop(ds)
     assert ledger.refs(ds) == []
+
+
+def test_ledger_caps_entries_per_dataset():
+    # A long-running bot must not grow the ledger without bound; only the most
+    # recent N messages per chat are kept.
+    from cognee_telegram.citations import _MAX_REFS_PER_DATASET
+
+    ledger = CitationLedger()
+    ds = "telegram_dm_7"
+    for i in range(_MAX_REFS_PER_DATASET + 50):
+        ledger.record(ds, MessageRef(chat_id=7, message_id=i, text=f"note {i}"))
+    kept = ledger.refs(ds)
+    assert len(kept) == _MAX_REFS_PER_DATASET
+    assert kept[0].message_id == 50  # the 50 oldest were evicted
+    assert kept[-1].message_id == _MAX_REFS_PER_DATASET + 49

--- a/cognee-telegram/tests/test_citations.py
+++ b/cognee-telegram/tests/test_citations.py
@@ -1,0 +1,53 @@
+"""Citation ledger + t.me deep-link rendering (pure logic, no keys)."""
+
+from cognee_telegram.citations import CitationLedger, MessageRef
+
+
+def test_supergroup_deep_link_strips_100_prefix():
+    ref = MessageRef(chat_id=-1001234567890, message_id=99, text="hi")
+    assert ref.deep_link() == "https://t.me/c/1234567890/99"
+
+
+def test_forum_topic_deep_link_includes_thread():
+    ref = MessageRef(chat_id=-1001234567890, message_id=99, text="hi", thread_id=12)
+    assert ref.deep_link() == "https://t.me/c/1234567890/12/99"
+
+
+def test_dm_and_basic_group_have_no_public_link():
+    assert MessageRef(chat_id=42, message_id=1, text="hi").deep_link() is None
+    assert MessageRef(chat_id=-500, message_id=1, text="hi").deep_link() is None
+
+
+def test_attributed_text_prefixes_author():
+    assert (
+        MessageRef(chat_id=1, message_id=1, text="hi", author="Ada").attributed_text() == "Ada: hi"
+    )
+    assert MessageRef(chat_id=1, message_id=1, text="hi").attributed_text() == "hi"
+
+
+def test_ledger_records_and_resolves_by_overlap():
+    ledger = CitationLedger()
+    ds = "telegram_dm_7"
+    ledger.record(
+        ds, MessageRef(chat_id=7, message_id=1, text="the quarterly revenue report is due friday")
+    )
+    ledger.record(ds, MessageRef(chat_id=7, message_id=2, text="lunch plans for the weekend"))
+
+    hits = ledger.resolve(ds, "when is the revenue report due")
+    assert len(hits) == 1
+    assert hits[0].message_id == 1
+
+
+def test_ledger_abstains_when_nothing_overlaps():
+    ledger = CitationLedger()
+    ds = "telegram_dm_7"
+    ledger.record(ds, MessageRef(chat_id=7, message_id=1, text="completely unrelated content"))
+    assert ledger.resolve(ds, "xylophone zeppelin") == []
+
+
+def test_ledger_drop_clears_dataset():
+    ledger = CitationLedger()
+    ds = "telegram_dm_7"
+    ledger.record(ds, MessageRef(chat_id=7, message_id=1, text="something to remember"))
+    ledger.drop(ds)
+    assert ledger.refs(ds) == []

--- a/cognee-telegram/tests/test_config.py
+++ b/cognee-telegram/tests/test_config.py
@@ -1,0 +1,23 @@
+"""Settings parsing — onboarding-critical, so the required-token error is tested."""
+
+import pytest
+
+from cognee_telegram.config import Settings
+
+
+def test_from_env_reads_and_strips_token(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "  123456:ABC-DEF  ")
+    settings = Settings.from_env()
+    assert settings.bot_token == "123456:ABC-DEF"
+
+
+def test_from_env_missing_token_raises(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    with pytest.raises(RuntimeError, match="TELEGRAM_BOT_TOKEN"):
+        Settings.from_env()
+
+
+def test_from_env_blank_token_raises(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "   ")
+    with pytest.raises(RuntimeError, match="TELEGRAM_BOT_TOKEN"):
+        Settings.from_env()

--- a/cognee-telegram/tests/test_scoping.py
+++ b/cognee-telegram/tests/test_scoping.py
@@ -20,14 +20,6 @@ def test_forum_topic_extends_chat():
     assert scope.thread_id == 55
 
 
-def test_per_user_in_group_splits_by_sender():
-    a = resolve_scope(chat_type="group", chat_id=-100, user_id=1, per_user_in_group=True)
-    b = resolve_scope(chat_type="group", chat_id=-100, user_id=2, per_user_in_group=True)
-    assert a.dataset_name != b.dataset_name
-    assert a.dataset_name.endswith("_user_1")
-    assert b.dataset_name.endswith("_user_2")
-
-
 def test_dataset_names_are_identifier_safe():
     # Negative ids must not leak a '-' into the dataset name, and positive vs
     # negative ids of the same magnitude must not collide.

--- a/cognee-telegram/tests/test_scoping.py
+++ b/cognee-telegram/tests/test_scoping.py
@@ -1,0 +1,42 @@
+"""Scoping: chat → dataset + session mapping (pure logic, no cognee, no keys)."""
+
+from cognee_telegram.scoping import resolve_scope
+
+
+def test_dm_is_per_user():
+    scope = resolve_scope(chat_type="private", chat_id=7, user_id=7)
+    assert scope.dataset_name == "telegram_dm_7"
+    assert scope.session_id == "telegram:dm:7"
+    assert scope.is_private is True
+    assert scope.thread_id is None
+
+
+def test_group_is_per_chat():
+    scope = resolve_scope(chat_type="supergroup", chat_id=-1001234567890, user_id=7)
+    assert scope.dataset_name == "telegram_group_n1001234567890"
+    assert scope.session_id == "telegram:group:-1001234567890"
+    assert scope.is_private is False
+
+
+def test_forum_topic_extends_chat():
+    scope = resolve_scope(chat_type="supergroup", chat_id=-1001234567890, user_id=7, thread_id=55)
+    assert scope.dataset_name == "telegram_group_n1001234567890_55"
+    assert scope.session_id == "telegram:group:-1001234567890:55"
+    assert scope.thread_id == 55
+
+
+def test_per_user_in_group_splits_by_sender():
+    a = resolve_scope(chat_type="group", chat_id=-100, user_id=1, per_user_in_group=True)
+    b = resolve_scope(chat_type="group", chat_id=-100, user_id=2, per_user_in_group=True)
+    assert a.dataset_name != b.dataset_name
+    assert a.dataset_name.endswith("_user_1")
+    assert b.dataset_name.endswith("_user_2")
+
+
+def test_dataset_names_are_identifier_safe():
+    # Negative ids must not leak a '-' into the dataset name, and positive vs
+    # negative ids of the same magnitude must not collide.
+    neg = resolve_scope(chat_type="group", chat_id=-100, user_id=1).dataset_name
+    pos = resolve_scope(chat_type="group", chat_id=100, user_id=1).dataset_name
+    assert "-" not in neg
+    assert neg != pos

--- a/cognee-telegram/tests/test_scoping.py
+++ b/cognee-telegram/tests/test_scoping.py
@@ -6,22 +6,17 @@ from cognee_telegram.scoping import resolve_scope
 def test_dm_is_per_user():
     scope = resolve_scope(chat_type="private", chat_id=7, user_id=7)
     assert scope.dataset_name == "telegram_dm_7"
-    assert scope.session_id == "telegram:dm:7"
-    assert scope.is_private is True
     assert scope.thread_id is None
 
 
 def test_group_is_per_chat():
     scope = resolve_scope(chat_type="supergroup", chat_id=-1001234567890, user_id=7)
     assert scope.dataset_name == "telegram_group_n1001234567890"
-    assert scope.session_id == "telegram:group:-1001234567890"
-    assert scope.is_private is False
 
 
 def test_forum_topic_extends_chat():
     scope = resolve_scope(chat_type="supergroup", chat_id=-1001234567890, user_id=7, thread_id=55)
     assert scope.dataset_name == "telegram_group_n1001234567890_55"
-    assert scope.session_id == "telegram:group:-1001234567890:55"
     assert scope.thread_id == 55
 
 

--- a/cognee-telegram/tests/test_scoping.py
+++ b/cognee-telegram/tests/test_scoping.py
@@ -1,4 +1,4 @@
-"""Scoping: chat → dataset + session mapping (pure logic, no cognee, no keys)."""
+"""Scoping: chat → dataset mapping (pure logic, no cognee, no keys)."""
 
 from cognee_telegram.scoping import resolve_scope
 


### PR DESCRIPTION
## Summary

Maintainer rework of community PR #3725 (by @vinayaksonthalia) for hackathon issue #3610 — a self-contained `cognee-telegram/` package (mirrors `cognee-mcp/`) where **each Telegram chat is a cognee memory**: it passively captures what's shared, answers `/ask` from that chat's memory **with citations back to the source message**, and supports `/forget` + per-chat `/optout`. No OAuth, no public URL — it runs from a laptop with long polling. The memory logic lives in a transport-agnostic `CogneeMemoryAdapter` over cognee's `remember` / `recall` / `forget`, so the same core can back a Slack/Discord bot later.

Closes #3610. Linear: SDK-147.

## Attribution

The original contributor's commit is preserved verbatim as the base of this branch (authorship intact, DCO-signed). Every commit after it is a single-concern maintainer change on top.

## What the rework changes

The design was verified sound against cognee `dev` before any change — `remember` / `recall` / `forget` signatures, the `include_references` Evidence-block format, `RecallResponse` types, and exception paths all match. On top of that:

**Simplification / scope (removes code and three env knobs not required by #3610):**
- ingest each message directly, dropping the batching subsystem — this also fixes a drop-on-failure bug where a failed `remember` silently lost the buffered batch;
- drop dead `Scope.session_id` / `Scope.is_private`;
- drop out-of-scope config knobs (`per_user_in_group`, `ingest_enabled_default`);
- simplify recall extraction; drop the always-"graph" provenance tag.

**Correctness / production fixes:**
- **cite only from the grounded Evidence block** — a "no information" answer that merely shares a word with a stored message is no longer cited (regression test added);
- scope real forum topics only (`is_topic_message`), capture media captions / forwarded content, and tolerate channel/anonymous posts with no sender;
- friendly "nothing here yet" replies on a fresh install and on `/forget` for a never-used chat (both previously surfaced a misleading backend error);
- stop leaking the bot token via httpx request logs;
- bound the in-memory citation ledger;
- require `cognee>=1.2.0`, the floor that actually ships `include_references`.

## Verification

- **45 key-free tests** pass (Telegram mocked with `unittest.mock`; cognee patched at the boundary; recall results built from the real `RecallResponse` types); `ruff check` + `ruff format` clean.
- Offline end-to-end (no LLM key): the real `python-telegram-bot` Application builds and wires all handlers; ingest → grounded cited recall → refusal-not-cited → idempotent `/forget` all pass.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
