### PR TITLE
feat(catalog): introduce the Integrations Hub and Use-Case Gallery catalog (SDK-151)

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -29,7 +29,8 @@ jobs:
         uses: ./.github/actions/cognee_setup
         with:
           python-version: "3.11.x"
-          extra-dependencies: "catalog"
+          # pyyaml + jsonschema (the only catalog tooling deps) are already
+          # present transitively in a standard cognee install; no extra needed.
 
       - name: Load and validate catalog entries
         run: uv run python -m catalog.loader

--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -1,0 +1,40 @@
+name: Catalog
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "catalog/**"
+      - ".github/workflows/catalog.yml"
+      - "docs/contributing/add-catalog-entry.md"
+  push:
+    branches: [dev, main]
+    paths:
+      - "catalog/**"
+      - ".github/workflows/catalog.yml"
+      - "docs/contributing/add-catalog-entry.md"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate catalog entries
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: "3.11.x"
+          extra-dependencies: "catalog"
+
+      - name: Load and validate catalog entries
+        run: uv run python -m catalog.loader
+
+      - name: Check drift against cognee-integrations/inventory.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run python -m catalog.inventory_sync

--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Load and validate catalog entries
         run: uv run python -m catalog.loader
 
+      - name: Run catalog loader tests
+        run: uv run python -m pytest catalog/tests -q
+
       # Advisory only: this hits the GitHub API and depends on another repo's
       # inventory.yml, so a transient failure or an upstream reshape must not
       # fail an unrelated catalog PR. Stale references still surface in the log.

--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -35,7 +35,11 @@ jobs:
       - name: Load and validate catalog entries
         run: uv run python -m catalog.loader
 
+      # Advisory only: this hits the GitHub API and depends on another repo's
+      # inventory.yml, so a transient failure or an upstream reshape must not
+      # fail an unrelated catalog PR. Stale references still surface in the log.
       - name: Check drift against cognee-integrations/inventory.yml
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run python -m catalog.inventory_sync

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ You can contribute to **cognee** in many ways:
 - 🔍 Reviewing pull requests
 - 🛠️ Contributing code or tests
 - 🌐 Helping other users
+- 📇 Adding an entry to the [Integrations Hub or Use-Case Gallery](docs/contributing/add-catalog-entry.md)
 
 ## 📫 Get in Touch
 

--- a/catalog/__init__.py
+++ b/catalog/__init__.py
@@ -1,0 +1,9 @@
+"""Cognee Integrations Hub and Use-Case Gallery catalog.
+
+Callers import the loader API directly:
+
+    from catalog.loader import CatalogEntry, CatalogError, load_catalog
+
+See ``catalog/schema.json`` for the entry contract and
+``docs/contributing/add-catalog-entry.md`` for the authoring guide.
+"""

--- a/catalog/entries/integrations/claude-code.yaml
+++ b/catalog/entries/integrations/claude-code.yaml
@@ -10,11 +10,10 @@ tags:
 summary: Persist Claude Code sessions to cognee and surface relevant prior context automatically on prompt.
 what_youll_build: A Claude Code setup where each session's history is captured to a knowledge graph and past decisions surface as context on future prompts.
 quickstart: |
-  # inside your Claude Code plugin directory
-  git clone https://github.com/topoteretes/cognee-integrations.git
-  cd cognee-integrations/integrations/claude-code
-  cp .env.example .env  # fill in LLM_API_KEY and cognee endpoint
-  # register the plugin in Claude Code, then run any coding session
+  claude plugin marketplace add topoteretes/cognee-integrations
+  claude plugin install cognee-memory@cognee
+  export LLM_API_KEY=your_openai_key  # local mode; the plugin bootstraps a local cognee API
+  claude  # first launch runs the SessionStart hook and connects memory
 expected_output: |
   A confirmation from the plugin that turns are being stored, plus a recall
   invoked from a follow-up session that returns prior context about the same

--- a/catalog/entries/integrations/claude-code.yaml
+++ b/catalog/entries/integrations/claude-code.yaml
@@ -1,0 +1,26 @@
+id: claude-code
+title: Cognee plugin for Claude Code
+kind: integration
+stack: agent-runtime
+tags:
+  - claude-code
+  - python
+  - session-storage
+  - context-lookup
+summary: Persist Claude Code sessions to cognee and surface relevant prior context automatically on prompt.
+what_youll_build: A Claude Code setup where each session's history is captured to a knowledge graph and past decisions surface as context on future prompts.
+quickstart: |
+  # inside your Claude Code plugin directory
+  git clone https://github.com/topoteretes/cognee-integrations.git
+  cd cognee-integrations/integrations/claude-code
+  cp .env.example .env  # fill in LLM_API_KEY and cognee endpoint
+  # register the plugin in Claude Code, then run any coding session
+expected_output: |
+  A confirmation from the plugin that turns are being stored, plus a recall
+  invoked from a follow-up session that returns prior context about the same
+  project.
+difficulty: medium
+repo: topoteretes/cognee-integrations
+path: integrations/claude-code
+inventory_slug: claude-code
+docs_url: https://docs.cognee.ai/integrations/claude-code

--- a/catalog/entries/integrations/codex.yaml
+++ b/catalog/entries/integrations/codex.yaml
@@ -1,0 +1,25 @@
+id: codex
+title: Cognee plugin for Codex
+kind: integration
+stack: agent-runtime
+tags:
+  - codex
+  - openai
+  - cli
+  - marketplace-plugin
+summary: Distribute cognee-cli skills to Codex users through the Codex plugin marketplace.
+what_youll_build: A Codex environment where a user can trigger cognee setup, ingest a codebase, and launch the UI without leaving the assistant.
+quickstart: |
+  # from the Codex marketplace, install the cognee plugin
+  # then in a Codex session:
+  cognee-cli add "./my-project"
+  cognee-cli cognify
+  cognee-cli search "How does authentication work?"
+expected_output: |
+  A search response referencing files in the ingested codebase, with cognee
+  running locally against SQLite + LanceDB + Ladybug.
+difficulty: easy
+repo: topoteretes/cognee-integrations
+path: integrations/codex
+inventory_slug: codex
+docs_url: https://docs.cognee.ai/integrations/codex

--- a/catalog/entries/integrations/langgraph.yaml
+++ b/catalog/entries/integrations/langgraph.yaml
@@ -1,0 +1,25 @@
+id: langgraph
+title: Cognee memory node for LangGraph
+kind: integration
+stack: framework
+tags:
+  - langgraph
+  - langchain
+  - python
+  - graph-workflow
+summary: Drop cognee remember and recall as first-class nodes into a LangGraph workflow.
+what_youll_build: A LangGraph agent that stores every meaningful state transition to cognee and can recall past runs when planning the next step.
+quickstart: |
+  pip install "cognee-integration-langgraph"
+  export LLM_API_KEY=your_openai_key
+  # in your LangGraph app:
+  from cognee_langgraph import CogneeRememberNode, CogneeRecallNode
+  # wire them into your StateGraph like any other node
+expected_output: |
+  A workflow run where the graph transitions include cognee remember calls
+  and a recall step returns prior runs relevant to the new input.
+difficulty: medium
+repo: topoteretes/cognee-integrations
+path: integrations/langgraph
+inventory_slug: langgraph
+docs_url: https://docs.cognee.ai/integrations/langgraph

--- a/catalog/entries/integrations/langgraph.yaml
+++ b/catalog/entries/integrations/langgraph.yaml
@@ -7,17 +7,18 @@ tags:
   - langchain
   - python
   - graph-workflow
-summary: Drop cognee remember and recall as first-class nodes into a LangGraph workflow.
-what_youll_build: A LangGraph agent that stores every meaningful state transition to cognee and can recall past runs when planning the next step.
+summary: Add cognee memory to a LangGraph agent as tools it can call to store and search context.
+what_youll_build: A LangGraph agent wired with cognee add and search tools, so it can persist context during a run and pull back relevant prior context on later steps.
 quickstart: |
-  pip install "cognee-integration-langgraph"
+  pip install cognee-integration-langgraph
   export LLM_API_KEY=your_openai_key
-  # in your LangGraph app:
-  from cognee_langgraph import CogneeRememberNode, CogneeRecallNode
-  # wire them into your StateGraph like any other node
+  # in your async agent code:
+  from cognee_integration_langgraph import get_sessionized_cognee_tools
+  add_tool, search_tool = get_sessionized_cognee_tools("user-123")
+  # pass [add_tool, search_tool] into your LangGraph agent, then await agent.ainvoke(...)
 expected_output: |
-  A workflow run where the graph transitions include cognee remember calls
-  and a recall step returns prior runs relevant to the new input.
+  An agent run where the model calls the cognee add tool to store context and
+  the search tool to retrieve relevant prior context for its next step.
 difficulty: medium
 repo: topoteretes/cognee-integrations
 path: integrations/langgraph

--- a/catalog/entries/integrations/openclaw.yaml
+++ b/catalog/entries/integrations/openclaw.yaml
@@ -1,0 +1,25 @@
+id: openclaw
+title: Cognee memory for OpenClaw
+kind: integration
+stack: agent-runtime
+tags:
+  - openclaw
+  - typescript
+  - auto-recall
+  - session-memory
+summary: Give OpenClaw sessions persistent, recall-able memory through the cognee HTTP API.
+what_youll_build: An OpenClaw session that transparently remembers what happened before and can be queried by tool call.
+quickstart: |
+  npm install @cognee/cognee-openclaw
+  export COGNEE_API_URL=https://cognee.example.com
+  export COGNEE_API_TOKEN=your_token
+  # register the plugin in your OpenClaw config, then run a session
+expected_output: |
+  A running OpenClaw session that pushes turns to cognee via `remember` and
+  can recall past context on request. Confirm by triggering a recall and
+  seeing prior turn content in the response.
+difficulty: easy
+repo: topoteretes/cognee-integrations
+path: integrations/openclaw
+inventory_slug: openclaw
+docs_url: https://docs.cognee.ai/integrations/openclaw

--- a/catalog/entries/integrations/openclaw.yaml
+++ b/catalog/entries/integrations/openclaw.yaml
@@ -10,10 +10,10 @@ tags:
 summary: Give OpenClaw sessions persistent, recall-able memory through the cognee HTTP API.
 what_youll_build: An OpenClaw session that transparently remembers what happened before and can be queried by tool call.
 quickstart: |
-  npm install @cognee/cognee-openclaw
-  export COGNEE_API_URL=https://cognee.example.com
-  export COGNEE_API_TOKEN=your_token
-  # register the plugin in your OpenClaw config, then run a session
+  openclaw plugins install @cognee/cognee-openclaw
+  export COGNEE_BASE_URL=https://your-instance.cognee.ai
+  export COGNEE_API_KEY=ck_your_key
+  # add "@cognee/cognee-openclaw" to plugins.allow in ~/.openclaw/openclaw.json, then run a session
 expected_output: |
   A running OpenClaw session that pushes turns to cognee via `remember` and
   can recall past context on request. Confirm by triggering a recall and

--- a/catalog/entries/packages/qdrant.yaml
+++ b/catalog/entries/packages/qdrant.yaml
@@ -10,12 +10,13 @@ tags:
 summary: Use Qdrant as cognee's vector store, backing recall and similarity search with a production-grade vector database.
 what_youll_build: A cognee deployment where all embeddings live in Qdrant, cognify and search go through the community-maintained adapter, and the built-in LanceDB is bypassed.
 quickstart: |
-  # start Qdrant locally
+  # start Qdrant locally (the example defaults to http://localhost:6333)
   docker run -p 6333:6333 qdrant/qdrant
+  git clone https://github.com/topoteretes/cognee-community.git
+  cd cognee-community/packages/vector/qdrant
   pip install cognee-community-vector-adapter-qdrant
-  export VECTOR_DB_PROVIDER=qdrant
-  export VECTOR_DB_URL=http://localhost:6333
-  python -m cognee-community/packages/vector/qdrant/example.py
+  export LLM_API_KEY=your_openai_key
+  python example.py
 expected_output: |
   Confirmation that embeddings are being written to Qdrant collections, and
   a search response drawn from Qdrant instead of LanceDB.

--- a/catalog/entries/packages/qdrant.yaml
+++ b/catalog/entries/packages/qdrant.yaml
@@ -1,0 +1,25 @@
+id: qdrant
+title: Qdrant vector store adapter
+kind: package
+stack: vector-store
+tags:
+  - qdrant
+  - vector-store
+  - python
+  - community-package
+summary: Use Qdrant as cognee's vector store, backing recall and similarity search with a production-grade vector database.
+what_youll_build: A cognee deployment where all embeddings live in Qdrant, cognify and search go through the community-maintained adapter, and the built-in LanceDB is bypassed.
+quickstart: |
+  # start Qdrant locally
+  docker run -p 6333:6333 qdrant/qdrant
+  pip install cognee-community-vector-adapter-qdrant
+  export VECTOR_DB_PROVIDER=qdrant
+  export VECTOR_DB_URL=http://localhost:6333
+  python -m cognee-community/packages/vector/qdrant/example.py
+expected_output: |
+  Confirmation that embeddings are being written to Qdrant collections, and
+  a search response drawn from Qdrant instead of LanceDB.
+difficulty: medium
+repo: topoteretes/cognee-community
+path: packages/vector/qdrant
+docs_url: https://docs.cognee.ai/packages/vector/qdrant

--- a/catalog/entries/packages/weaviate.yaml
+++ b/catalog/entries/packages/weaviate.yaml
@@ -10,12 +10,12 @@ tags:
 summary: Route cognee's vector operations through Weaviate, using its hybrid semantic + keyword search behind the standard cognee interface.
 what_youll_build: A cognee deployment where cognify writes chunks and embeddings into Weaviate classes, and recall benefits from Weaviate's hybrid search out of the box.
 quickstart: |
-  # start Weaviate locally with the default docker-compose
+  # start Weaviate locally
+  docker run -p 8080:8080 -p 50051:50051 cr.weaviate.io/semitechnologies/weaviate:1.32.4
   git clone https://github.com/topoteretes/cognee-community.git
   cd cognee-community/packages/vector/weaviate
-  docker compose up -d
   pip install cognee-community-vector-adapter-weaviate
-  export VECTOR_DB_PROVIDER=weaviate
+  export LLM_API_KEY=your_openai_key
   export VECTOR_DB_URL=http://localhost:8080
   python example.py
 expected_output: |

--- a/catalog/entries/packages/weaviate.yaml
+++ b/catalog/entries/packages/weaviate.yaml
@@ -1,0 +1,27 @@
+id: weaviate
+title: Weaviate vector store adapter
+kind: package
+stack: vector-store
+tags:
+  - weaviate
+  - vector-store
+  - python
+  - community-package
+summary: Route cognee's vector operations through Weaviate, using its hybrid semantic + keyword search behind the standard cognee interface.
+what_youll_build: A cognee deployment where cognify writes chunks and embeddings into Weaviate classes, and recall benefits from Weaviate's hybrid search out of the box.
+quickstart: |
+  # start Weaviate locally with the default docker-compose
+  git clone https://github.com/topoteretes/cognee-community.git
+  cd cognee-community/packages/vector/weaviate
+  docker compose up -d
+  pip install cognee-community-vector-adapter-weaviate
+  export VECTOR_DB_PROVIDER=weaviate
+  export VECTOR_DB_URL=http://localhost:8080
+  python example.py
+expected_output: |
+  Weaviate classes populated by cognify, plus a recall response that matches
+  the cognee search contract while running against Weaviate under the hood.
+difficulty: medium
+repo: topoteretes/cognee-community
+path: packages/vector/weaviate
+docs_url: https://docs.cognee.ai/packages/vector/weaviate

--- a/catalog/entries/use-cases/agent-memory.yaml
+++ b/catalog/entries/use-cases/agent-memory.yaml
@@ -1,0 +1,20 @@
+id: agent-memory
+title: Give an agent persistent memory in three calls
+kind: use-case
+stack: use-case
+tags:
+  - agent-memory
+  - remember
+  - recall
+  - quickstart
+summary: The minimum-viable path from a fresh cognee install to an agent that can remember and recall.
+what_youll_build: A Python script that ingests a few facts, cognifies them into a knowledge graph, and answers a natural-language question about them.
+quickstart: |
+  uv pip install cognee
+  export LLM_API_KEY=your_openai_key
+  python examples/guides/agent_memory_quickstart.py
+expected_output: |
+  Console output showing the graph was built, followed by a natural-language
+  answer to the sample question that cites the ingested facts.
+difficulty: easy
+example_path: examples/guides/agent_memory_quickstart.py

--- a/catalog/entries/use-cases/agent-memory.yaml
+++ b/catalog/entries/use-cases/agent-memory.yaml
@@ -10,6 +10,8 @@ tags:
 summary: The minimum-viable path from a fresh cognee install to an agent that can remember and recall.
 what_youll_build: A Python script that ingests a few facts, cognifies them into a knowledge graph, and answers a natural-language question about them.
 quickstart: |
+  git clone https://github.com/topoteretes/cognee.git
+  cd cognee
   uv pip install cognee
   export LLM_API_KEY=your_openai_key
   python examples/guides/agent_memory_quickstart.py

--- a/catalog/entries/use-cases/custom-ontology.yaml
+++ b/catalog/entries/use-cases/custom-ontology.yaml
@@ -10,6 +10,8 @@ tags:
 summary: Constrain cognee's entity extraction to a domain ontology (OWL or similar) so the graph reflects your vocabulary, not the LLM's guesses.
 what_youll_build: A cognify run configured with a custom ontology file where entity types and relationships come from the ontology, and recall answers respect the domain's terminology.
 quickstart: |
+  git clone https://github.com/topoteretes/cognee.git
+  cd cognee
   uv pip install cognee
   export LLM_API_KEY=your_openai_key
   export ONTOLOGY_FILE_PATH=/path/to/your/domain.owl

--- a/catalog/entries/use-cases/custom-ontology.yaml
+++ b/catalog/entries/use-cases/custom-ontology.yaml
@@ -1,0 +1,23 @@
+id: custom-ontology
+title: Ground the knowledge graph in a custom ontology
+kind: use-case
+stack: use-case
+tags:
+  - ontology
+  - owl
+  - domain-vocabulary
+  - entity-extraction
+summary: Constrain cognee's entity extraction to a domain ontology (OWL or similar) so the graph reflects your vocabulary, not the LLM's guesses.
+what_youll_build: A cognify run configured with a custom ontology file where entity types and relationships come from the ontology, and recall answers respect the domain's terminology.
+quickstart: |
+  uv pip install cognee
+  export LLM_API_KEY=your_openai_key
+  export ONTOLOGY_FILE_PATH=/path/to/your/domain.owl
+  export MATCHING_STRATEGY=fuzzy
+  python examples/guides/ontology_quickstart.py
+expected_output: |
+  A graph where node types and edge labels come from the ontology, plus a
+  recall answer that uses the ontology's terms instead of ad-hoc LLM
+  paraphrases.
+difficulty: advanced
+example_path: examples/guides/ontology_quickstart.py

--- a/catalog/entries/use-cases/document-qa.yaml
+++ b/catalog/entries/use-cases/document-qa.yaml
@@ -10,6 +10,8 @@ tags:
 summary: Answer questions grounded in a set of documents using cognee's graph-completion retrieval instead of plain RAG.
 what_youll_build: A recall pipeline that ingests documents, extracts entities and relationships into a graph, and answers questions with citations back to source chunks.
 quickstart: |
+  git clone https://github.com/topoteretes/cognee.git
+  cd cognee
   uv pip install cognee
   export LLM_API_KEY=your_openai_key
   python examples/guides/recall_core.py

--- a/catalog/entries/use-cases/document-qa.yaml
+++ b/catalog/entries/use-cases/document-qa.yaml
@@ -1,0 +1,21 @@
+id: document-qa
+title: Document Q&A backed by a knowledge graph
+kind: use-case
+stack: use-case
+tags:
+  - document-qa
+  - graph-rag
+  - recall
+  - reading-comprehension
+summary: Answer questions grounded in a set of documents using cognee's graph-completion retrieval instead of plain RAG.
+what_youll_build: A recall pipeline that ingests documents, extracts entities and relationships into a graph, and answers questions with citations back to source chunks.
+quickstart: |
+  uv pip install cognee
+  export LLM_API_KEY=your_openai_key
+  python examples/guides/recall_core.py
+expected_output: |
+  A ranked list of retrieved passages plus a synthesized natural-language
+  answer citing the original documents. Compare against a plain RAG baseline
+  to see graph-completion's contribution.
+difficulty: easy
+example_path: examples/guides/recall_core.py

--- a/catalog/entries/use-cases/temporal-reasoning.yaml
+++ b/catalog/entries/use-cases/temporal-reasoning.yaml
@@ -1,0 +1,21 @@
+id: temporal-reasoning
+title: Temporal reasoning over time-stamped events
+kind: use-case
+stack: use-case
+tags:
+  - temporal
+  - events
+  - time-aware
+  - graph-completion
+summary: Recall against a knowledge graph where every node knows when it was true, so questions about ordering and duration return coherent answers.
+what_youll_build: A recall pipeline that ingests time-stamped events, builds a temporal knowledge graph, and answers questions like "what happened first" or "what was true on date X".
+quickstart: |
+  uv pip install cognee
+  export LLM_API_KEY=your_openai_key
+  python examples/guides/temporal_recall.py
+expected_output: |
+  Answers to time-relative questions grounded in the ingested events, with
+  recall order matching the true event ordering rather than embedding-similarity
+  order alone.
+difficulty: medium
+example_path: examples/guides/temporal_recall.py

--- a/catalog/entries/use-cases/temporal-reasoning.yaml
+++ b/catalog/entries/use-cases/temporal-reasoning.yaml
@@ -10,6 +10,8 @@ tags:
 summary: Recall against a knowledge graph where every node knows when it was true, so questions about ordering and duration return coherent answers.
 what_youll_build: A recall pipeline that ingests time-stamped events, builds a temporal knowledge graph, and answers questions like "what happened first" or "what was true on date X".
 quickstart: |
+  git clone https://github.com/topoteretes/cognee.git
+  cd cognee
   uv pip install cognee
   export LLM_API_KEY=your_openai_key
   python examples/guides/temporal_recall.py

--- a/catalog/inventory_sync.py
+++ b/catalog/inventory_sync.py
@@ -1,0 +1,184 @@
+"""Cross-repo drift check between the catalog and cognee-integrations/inventory.yml.
+
+Fetches ``inventory.yml`` from ``topoteretes/cognee-integrations`` via the
+GitHub REST API and cross-checks the ``slug`` values against every
+``inventory_slug`` field in the local catalog.
+
+Two directions of drift are reported:
+
+* **Coverage gaps**: slugs present in ``inventory.yml`` that no catalog entry
+  claims. These are integrations the community has surfaced without a catalog
+  card, so users won't find them in the Hub.
+* **Stale references**: ``inventory_slug`` values in catalog entries that no
+  longer exist in ``inventory.yml``. These usually mean an integration was
+  renamed or removed upstream and the catalog didn't catch up.
+
+Kept separate from :mod:`catalog.loader` so ``python -m catalog.loader``
+stays offline. This module is invoked by CI (which has network) and can be
+run locally by anyone wanting to check drift before opening a PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+import yaml
+
+from catalog.loader import CatalogError, ENTRIES_ROOT, load_catalog
+
+INVENTORY_REPO = "topoteretes/cognee-integrations"
+INVENTORY_PATH = "integrations/inventory.yml"
+GITHUB_API = "https://api.github.com"
+USER_AGENT = "cognee-catalog-drift-check"
+
+
+class InventoryFetchError(RuntimeError):
+    """Raised when the upstream ``inventory.yml`` cannot be fetched."""
+
+
+def _github_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_inventory() -> dict[str, Any]:
+    """Fetch and parse the upstream ``inventory.yml``.
+
+    Uses ``GITHUB_TOKEN`` when set (avoids anonymous rate limits in CI).
+    """
+
+    url = f"{GITHUB_API}/repos/{INVENTORY_REPO}/contents/{INVENTORY_PATH}"
+    request = urllib.request.Request(url, headers=_github_headers())
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            payload = json.load(response)
+    except urllib.error.URLError as cause:
+        raise InventoryFetchError(f"could not fetch inventory.yml from GitHub: {cause}") from cause
+
+    content = payload.get("content")
+    encoding = payload.get("encoding")
+    if not content or encoding != "base64":
+        raise InventoryFetchError("inventory.yml payload was not base64-encoded content")
+
+    decoded = base64.b64decode(content).decode("utf-8")
+    parsed = yaml.safe_load(decoded)
+    if not isinstance(parsed, dict):
+        raise InventoryFetchError("inventory.yml top-level was not a mapping")
+    return parsed
+
+
+def collect_inventory_slugs(inventory: dict[str, Any]) -> set[str]:
+    entries = inventory.get("integrations")
+    if not isinstance(entries, list):
+        raise InventoryFetchError("inventory.yml: expected `integrations` list")
+
+    slugs: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("slug")
+        if isinstance(slug, str) and slug:
+            slugs.add(slug)
+    return slugs
+
+
+def collect_catalog_inventory_slugs() -> dict[str, str]:
+    """Map ``inventory_slug`` values to their catalog entry ids."""
+
+    catalog = load_catalog()
+    mapped: dict[str, str] = {}
+    for entry in catalog:
+        if entry.inventory_slug is not None:
+            mapped[entry.inventory_slug] = entry.id
+    return mapped
+
+
+def report_drift(inventory_slugs: set[str], catalog_slugs: dict[str, str]) -> list[str]:
+    """Return a list of drift descriptions. Empty list means no drift."""
+
+    problems: list[str] = []
+
+    uncovered = sorted(inventory_slugs - set(catalog_slugs))
+    for slug in uncovered:
+        problems.append(
+            f"coverage gap: inventory.yml slug '{slug}' has no catalog entry "
+            "(add catalog/entries/integrations/{slug}.yaml with inventory_slug: {slug})".format(
+                slug=slug
+            )
+        )
+
+    stale = sorted(set(catalog_slugs) - inventory_slugs)
+    for slug in stale:
+        problems.append(
+            f"stale reference: catalog entry '{catalog_slugs[slug]}' claims "
+            f"inventory_slug '{slug}', which is not in inventory.yml"
+        )
+
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cross-repo drift check for the catalog.")
+    parser.add_argument(
+        "--strict-coverage",
+        action="store_true",
+        help=(
+            "Treat coverage gaps (inventory slugs without a catalog entry) as errors. "
+            "Default is to warn but exit 0 so drift can accumulate for a batch PR."
+        ),
+    )
+    args = parser.parse_args()
+
+    try:
+        inventory = fetch_inventory()
+    except InventoryFetchError as cause:
+        print(f"error: {cause}", file=sys.stderr)
+        return 2
+
+    try:
+        catalog_slugs = collect_catalog_inventory_slugs()
+    except CatalogError as cause:
+        print(str(cause), file=sys.stderr)
+        return 1
+
+    inventory_slugs = collect_inventory_slugs(inventory)
+    problems = report_drift(inventory_slugs, catalog_slugs)
+
+    if not problems:
+        print(
+            f"catalog is in sync with {INVENTORY_REPO}/{INVENTORY_PATH} "
+            f"({len(inventory_slugs)} inventory slugs, {len(catalog_slugs)} catalog references)"
+        )
+        return 0
+
+    print(f"drift detected against {INVENTORY_REPO}/{INVENTORY_PATH}:")
+    stale_seen = False
+    for problem in problems:
+        print(f"  - {problem}")
+        if problem.startswith("stale reference:"):
+            stale_seen = True
+
+    if stale_seen or args.strict_coverage:
+        return 1
+
+    print("(coverage gaps only; run with --strict-coverage to fail on these)")
+    _ = ENTRIES_ROOT  # keep the import used even when we exit early
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/catalog/inventory_sync.py
+++ b/catalog/inventory_sync.py
@@ -20,18 +20,16 @@ run locally by anyone wanting to check drift before opening a PR.
 
 from __future__ import annotations
 
-import argparse
 import base64
 import json
 import os
 import sys
-import urllib.error
 import urllib.request
 from typing import Any
 
 import yaml
 
-from catalog.loader import CatalogError, ENTRIES_ROOT, load_catalog
+from catalog.loader import CatalogError, load_catalog
 
 INVENTORY_REPO = "topoteretes/cognee-integrations"
 INVENTORY_PATH = "integrations/inventory.yml"
@@ -58,7 +56,9 @@ def _github_headers() -> dict[str, str]:
 def fetch_inventory() -> dict[str, Any]:
     """Fetch and parse the upstream ``inventory.yml``.
 
-    Uses ``GITHUB_TOKEN`` when set (avoids anonymous rate limits in CI).
+    Uses ``GITHUB_TOKEN`` when set (avoids anonymous rate limits in CI). Any
+    network, decode, or parse failure is re-raised as :class:`InventoryFetchError`
+    so callers get one clean error type instead of a raw traceback.
     """
 
     url = f"{GITHUB_API}/repos/{INVENTORY_REPO}/contents/{INVENTORY_PATH}"
@@ -66,16 +66,16 @@ def fetch_inventory() -> dict[str, Any]:
     try:
         with urllib.request.urlopen(request, timeout=15) as response:
             payload = json.load(response)
-    except urllib.error.URLError as cause:
-        raise InventoryFetchError(f"could not fetch inventory.yml from GitHub: {cause}") from cause
+        content = payload.get("content")
+        encoding = payload.get("encoding")
+        if not content or encoding != "base64":
+            raise InventoryFetchError("inventory.yml payload was not base64-encoded content")
+        parsed = yaml.safe_load(base64.b64decode(content).decode("utf-8"))
+    except InventoryFetchError:
+        raise
+    except (OSError, ValueError, yaml.YAMLError) as cause:
+        raise InventoryFetchError(f"could not fetch or parse inventory.yml: {cause}") from cause
 
-    content = payload.get("content")
-    encoding = payload.get("encoding")
-    if not content or encoding != "base64":
-        raise InventoryFetchError("inventory.yml payload was not base64-encoded content")
-
-    decoded = base64.b64decode(content).decode("utf-8")
-    parsed = yaml.safe_load(decoded)
     if not isinstance(parsed, dict):
         raise InventoryFetchError("inventory.yml top-level was not a mapping")
     return parsed
@@ -116,9 +116,7 @@ def report_drift(inventory_slugs: set[str], catalog_slugs: dict[str, str]) -> li
     for slug in uncovered:
         problems.append(
             f"coverage gap: inventory.yml slug '{slug}' has no catalog entry "
-            "(add catalog/entries/integrations/{slug}.yaml with inventory_slug: {slug})".format(
-                slug=slug
-            )
+            f"(add catalog/entries/integrations/{slug}.yaml with inventory_slug: {slug})"
         )
 
     stale = sorted(set(catalog_slugs) - inventory_slugs)
@@ -132,19 +130,17 @@ def report_drift(inventory_slugs: set[str], catalog_slugs: dict[str, str]) -> li
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Cross-repo drift check for the catalog.")
-    parser.add_argument(
-        "--strict-coverage",
-        action="store_true",
-        help=(
-            "Treat coverage gaps (inventory slugs without a catalog entry) as errors. "
-            "Default is to warn but exit 0 so drift can accumulate for a batch PR."
-        ),
-    )
-    args = parser.parse_args()
+    """Report catalog/inventory drift.
+
+    Exit codes: 0 when in sync or only coverage gaps remain; 1 on stale
+    references (a catalog entry claims a slug the inventory no longer has);
+    2 when the inventory could not be fetched. The CI step runs non-blocking,
+    so an upstream reshape or a transient fetch failure never fails a PR.
+    """
 
     try:
         inventory = fetch_inventory()
+        inventory_slugs = collect_inventory_slugs(inventory)
     except InventoryFetchError as cause:
         print(f"error: {cause}", file=sys.stderr)
         return 2
@@ -155,7 +151,6 @@ def main() -> int:
         print(str(cause), file=sys.stderr)
         return 1
 
-    inventory_slugs = collect_inventory_slugs(inventory)
     problems = report_drift(inventory_slugs, catalog_slugs)
 
     if not problems:
@@ -172,11 +167,10 @@ def main() -> int:
         if problem.startswith("stale reference:"):
             stale_seen = True
 
-    if stale_seen or args.strict_coverage:
+    if stale_seen:
         return 1
 
-    print("(coverage gaps only; run with --strict-coverage to fail on these)")
-    _ = ENTRIES_ROOT  # keep the import used even when we exit early
+    print("(coverage gaps only; informational, not a failure)")
     return 0
 
 

--- a/catalog/loader.py
+++ b/catalog/loader.py
@@ -13,8 +13,8 @@ Reads every YAML file under ``catalog/entries/`` and returns a validated list of
    which fetches them via the GitHub API.
 
 The loader is intentionally dependency-light: only ``pyyaml`` and
-``jsonschema``. Both live behind the ``cognee[catalog]`` extra so the core
-install path is untouched.
+``jsonschema``, both already present in a standard cognee install, so the
+catalog tooling adds nothing to the shipped package.
 """
 
 from __future__ import annotations

--- a/catalog/loader.py
+++ b/catalog/loader.py
@@ -1,0 +1,238 @@
+"""Catalog loader for the Cognee Integrations Hub and Use-Case Gallery.
+
+Reads every YAML file under ``catalog/entries/`` and returns a validated list of
+:class:`CatalogEntry`. Validation happens in three passes:
+
+1. Structural: entry conforms to ``catalog/schema.json``.
+2. Naming: ``id`` matches the filename stem, and the entry lives under the
+   subdirectory that matches its ``kind``.
+3. Resolution: for entries pointing at ``topoteretes/cognee`` sources, the
+   referenced files must exist in the current checkout. Cross-repo references
+   (``topoteretes/cognee-community``, ``topoteretes/cognee-integrations``) are
+   syntax-checked only; live resolution is deferred to ``inventory_sync.py``
+   which fetches them via the GitHub API.
+
+The loader is intentionally dependency-light: only ``pyyaml`` and
+``jsonschema``. Both live behind the ``cognee[catalog]`` extra so the core
+install path is untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft7Validator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CATALOG_ROOT = Path(__file__).resolve().parent
+ENTRIES_ROOT = CATALOG_ROOT / "entries"
+SCHEMA_PATH = CATALOG_ROOT / "schema.json"
+
+KIND_TO_SUBDIR = {
+    "integration": "integrations",
+    "use-case": "use-cases",
+    "package": "packages",
+}
+
+LOCAL_REPO = "topoteretes/cognee"
+EXTERNAL_REPOS = {"topoteretes/cognee-community", "topoteretes/cognee-integrations"}
+
+
+class CatalogError(Exception):
+    """Raised when the catalog fails validation.
+
+    The ``errors`` attribute carries every discovered problem so a contributor
+    fixes them in one pass instead of one CI cycle per typo.
+    """
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("catalog validation failed:\n  - " + "\n  - ".join(errors))
+
+
+@dataclass
+class CatalogEntry:
+    """A single loaded, validated catalog entry."""
+
+    id: str
+    title: str
+    kind: str
+    stack: str
+    tags: list[str]
+    summary: str
+    what_youll_build: str
+    quickstart: str
+    expected_output: str
+    difficulty: str
+    source_path: Path
+    repo: str | None = None
+    path: str | None = None
+    example_path: str | None = None
+    inventory_slug: str | None = None
+    docs_url: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], source_path: Path) -> CatalogEntry:
+        return cls(
+            id=data["id"],
+            title=data["title"],
+            kind=data["kind"],
+            stack=data["stack"],
+            tags=list(data["tags"]),
+            summary=data["summary"],
+            what_youll_build=data["what_youll_build"],
+            quickstart=data["quickstart"],
+            expected_output=data["expected_output"],
+            difficulty=data["difficulty"],
+            source_path=source_path,
+            repo=data.get("repo"),
+            path=data.get("path"),
+            example_path=data.get("example_path"),
+            inventory_slug=data.get("inventory_slug"),
+            docs_url=data.get("docs_url"),
+            raw=data,
+        )
+
+
+def _load_schema() -> dict[str, Any]:
+    with SCHEMA_PATH.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _load_yaml(source_path: Path) -> dict[str, Any]:
+    with source_path.open("r", encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle)
+    if not isinstance(loaded, dict):
+        raise CatalogError(
+            [f"{source_path}: top-level must be a mapping, got {type(loaded).__name__}"]
+        )
+    return loaded
+
+
+def validate_entry(data: dict[str, Any], source_path: Path) -> list[str]:
+    """Validate a single already-parsed entry.
+
+    Returns a list of human-readable error strings. Empty list means valid.
+    Kept public because both :func:`load_catalog` and the CI drift check use
+    it, and future tooling (an editor plugin, a preview site) may want it too.
+    """
+
+    schema = _load_schema()
+    validator = Draft7Validator(schema)
+    errors: list[str] = []
+
+    for problem in validator.iter_errors(data):
+        path = "/".join(str(segment) for segment in problem.absolute_path) or "<root>"
+        errors.append(f"{source_path}: schema violation at {path}: {problem.message}")
+
+    if not errors:
+        entry_id = data.get("id")
+        stem = source_path.stem
+        if entry_id != stem:
+            errors.append(f"{source_path}: id '{entry_id}' does not match filename stem '{stem}'")
+
+        expected_subdir = KIND_TO_SUBDIR.get(data.get("kind", ""))
+        if expected_subdir and source_path.parent.name != expected_subdir:
+            errors.append(
+                f"{source_path}: kind '{data.get('kind')}' expects the entry under "
+                f"catalog/entries/{expected_subdir}/, found under "
+                f"catalog/entries/{source_path.parent.name}/"
+            )
+
+        repo = data.get("repo")
+        path = data.get("path")
+        if repo == LOCAL_REPO and path:
+            resolved = REPO_ROOT / path
+            if not resolved.exists():
+                errors.append(f"{source_path}: local path does not exist: {path}")
+        elif repo is not None and repo not in EXTERNAL_REPOS and repo != LOCAL_REPO:
+            errors.append(
+                f"{source_path}: repo '{repo}' is not one of the known Cognee repos "
+                f"({LOCAL_REPO}, {', '.join(sorted(EXTERNAL_REPOS))})"
+            )
+
+        example_path = data.get("example_path")
+        if example_path and (repo in (None, LOCAL_REPO)):
+            resolved = REPO_ROOT / example_path
+            if not resolved.exists():
+                errors.append(
+                    f"{source_path}: example_path does not exist in the local checkout: {example_path}"
+                )
+
+    return errors
+
+
+def load_catalog(entries_root: Path | None = None) -> list[CatalogEntry]:
+    """Load every catalog entry, validate, and return a sorted list.
+
+    Raises :class:`CatalogError` with the full list of problems on any
+    validation failure. On success, entries are returned sorted by kind then id
+    so downstream renderers get a stable order.
+    """
+
+    root = entries_root or ENTRIES_ROOT
+    if not root.exists():
+        raise CatalogError([f"catalog entries root does not exist: {root}"])
+
+    all_errors: list[str] = []
+    entries: list[CatalogEntry] = []
+    seen_ids: dict[str, Path] = {}
+
+    for source_path in sorted(root.rglob("*.yaml")):
+        try:
+            data = _load_yaml(source_path)
+        except yaml.YAMLError as cause:
+            all_errors.append(f"{source_path}: could not parse YAML: {cause}")
+            continue
+        except CatalogError as cause:
+            all_errors.extend(cause.errors)
+            continue
+
+        errors = validate_entry(data, source_path)
+        if errors:
+            all_errors.extend(errors)
+            continue
+
+        entry_id = data["id"]
+        prior = seen_ids.get(entry_id)
+        if prior is not None:
+            all_errors.append(f"{source_path}: duplicate id '{entry_id}' also seen at {prior}")
+            continue
+        seen_ids[entry_id] = source_path
+
+        entries.append(CatalogEntry.from_dict(data, source_path))
+
+    if all_errors:
+        raise CatalogError(all_errors)
+
+    return sorted(entries, key=lambda entry: (entry.kind, entry.id))
+
+
+def main() -> int:
+    """CLI entry point: ``python -m catalog.loader``.
+
+    Returns exit code 0 on success, 1 on validation failure. Used by CI.
+    """
+
+    try:
+        entries = load_catalog()
+    except CatalogError as cause:
+        print(str(cause))
+        return 1
+
+    print(f"loaded {len(entries)} catalog entries")
+    by_kind: dict[str, int] = {}
+    for entry in entries:
+        by_kind[entry.kind] = by_kind.get(entry.kind, 0) + 1
+    for kind, count in sorted(by_kind.items()):
+        print(f"  {kind}: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/catalog/loader.py
+++ b/catalog/loader.py
@@ -20,7 +20,7 @@ catalog tooling adds nothing to the shipped package.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -74,7 +74,6 @@ class CatalogEntry:
     example_path: str | None = None
     inventory_slug: str | None = None
     docs_url: str | None = None
-    raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any], source_path: Path) -> CatalogEntry:
@@ -95,7 +94,6 @@ class CatalogEntry:
             example_path=data.get("example_path"),
             inventory_slug=data.get("inventory_slug"),
             docs_url=data.get("docs_url"),
-            raw=data,
         )
 
 
@@ -114,16 +112,14 @@ def _load_yaml(source_path: Path) -> dict[str, Any]:
     return loaded
 
 
-def validate_entry(data: dict[str, Any], source_path: Path) -> list[str]:
-    """Validate a single already-parsed entry.
+def _validate_entry(
+    data: dict[str, Any], source_path: Path, validator: Draft7Validator
+) -> list[str]:
+    """Validate a single already-parsed entry against the schema and naming rules.
 
-    Returns a list of human-readable error strings. Empty list means valid.
-    Kept public because both :func:`load_catalog` and the CI drift check use
-    it, and future tooling (an editor plugin, a preview site) may want it too.
+    Returns a list of human-readable error strings; an empty list means valid.
     """
 
-    schema = _load_schema()
-    validator = Draft7Validator(schema)
     errors: list[str] = []
 
     for problem in validator.iter_errors(data):
@@ -179,6 +175,7 @@ def load_catalog(entries_root: Path | None = None) -> list[CatalogEntry]:
     if not root.exists():
         raise CatalogError([f"catalog entries root does not exist: {root}"])
 
+    validator = Draft7Validator(_load_schema())
     all_errors: list[str] = []
     entries: list[CatalogEntry] = []
     seen_ids: dict[str, Path] = {}
@@ -193,7 +190,7 @@ def load_catalog(entries_root: Path | None = None) -> list[CatalogEntry]:
             all_errors.extend(cause.errors)
             continue
 
-        errors = validate_entry(data, source_path)
+        errors = _validate_entry(data, source_path, validator)
         if errors:
             all_errors.extend(errors)
             continue

--- a/catalog/schema.json
+++ b/catalog/schema.json
@@ -79,11 +79,13 @@
     },
     "quickstart": {
       "type": "string",
-      "description": "Copy-paste block that gets a newcomer running. Include install, env, and a single run command. Multi-line YAML block scalar. No shell prompts, no wrapping backticks."
+      "description": "Copy-paste block that gets a newcomer running. Include install, env, and a single run command. Multi-line YAML block scalar. No shell prompts, no wrapping backticks.",
+      "minLength": 10
     },
     "expected_output": {
       "type": "string",
-      "description": "Concrete output the user should see after the quickstart. Ranges/summaries are fine; exact values are not required."
+      "description": "Concrete output the user should see after the quickstart. Ranges/summaries are fine; exact values are not required.",
+      "minLength": 10
     },
     "difficulty": {
       "type": "string",
@@ -123,15 +125,7 @@
   "allOf": [
     {
       "if": {
-        "properties": {"kind": {"const": "integration"}}
-      },
-      "then": {
-        "required": ["repo", "path"]
-      }
-    },
-    {
-      "if": {
-        "properties": {"kind": {"const": "package"}}
+        "properties": {"kind": {"enum": ["integration", "package"]}}
       },
       "then": {
         "required": ["repo", "path"]

--- a/catalog/schema.json
+++ b/catalog/schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/topoteretes/cognee/catalog/schema.json",
+  "title": "CogneeCatalogEntry",
+  "description": "Schema for a single entry in the Cognee Integrations Hub and Use-Case Gallery. One YAML file under catalog/entries/{integrations,use-cases,packages}/ per entry. See docs/contributing/add-catalog-entry.md.",
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "kind",
+    "stack",
+    "tags",
+    "summary",
+    "what_youll_build",
+    "quickstart",
+    "expected_output",
+    "difficulty"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable machine identifier. Lowercase, dashes, no spaces. Must match the filename stem.",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 2,
+      "maxLength": 64
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable title as it appears in the Hub.",
+      "minLength": 2,
+      "maxLength": 120
+    },
+    "kind": {
+      "type": "string",
+      "description": "Which view an entry belongs to. Integrations and packages appear in the Integrations Hub; use-cases appear in the Use-Case Gallery.",
+      "enum": ["integration", "use-case", "package"]
+    },
+    "stack": {
+      "type": "string",
+      "description": "Primary technology bucket. Drives filtering in the rendered Hub. `use-case` is reserved for entries where the stack is orthogonal to the outcome.",
+      "enum": [
+        "llm-provider",
+        "vector-store",
+        "graph-store",
+        "relational-store",
+        "framework",
+        "agent-runtime",
+        "workflow-tool",
+        "observability",
+        "loader",
+        "use-case"
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "description": "Free-form filter tags. Redundant with stack on purpose so users can search by outcome (`document-qa`) or provider (`openai`) without a taxonomy war.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$",
+        "minLength": 2,
+        "maxLength": 32
+      },
+      "minItems": 1,
+      "maxItems": 12,
+      "uniqueItems": true
+    },
+    "summary": {
+      "type": "string",
+      "description": "One sentence, shown on the Hub card. Answer: does this work with my stack.",
+      "minLength": 10,
+      "maxLength": 240
+    },
+    "what_youll_build": {
+      "type": "string",
+      "description": "One sentence promising a concrete outcome. Answer: what do I get if I follow the quickstart.",
+      "minLength": 10,
+      "maxLength": 240
+    },
+    "quickstart": {
+      "type": "string",
+      "description": "Copy-paste block that gets a newcomer running. Include install, env, and a single run command. Multi-line YAML block scalar. No shell prompts, no wrapping backticks."
+    },
+    "expected_output": {
+      "type": "string",
+      "description": "Concrete output the user should see after the quickstart. Ranges/summaries are fine; exact values are not required."
+    },
+    "difficulty": {
+      "type": "string",
+      "description": "Rough effort estimate for a new user, not a code-complexity rating.",
+      "enum": ["easy", "medium", "advanced"]
+    },
+    "repo": {
+      "type": "string",
+      "description": "Owning repository in `owner/name` form. Required for integrations and packages, optional for use-cases (which typically live in cognee/examples).",
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+    },
+    "path": {
+      "type": "string",
+      "description": "Path within `repo` to the source. Required for integrations and packages. Loader confirms the path resolves.",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "example_path": {
+      "type": "string",
+      "description": "Path to a runnable example. Required for use-cases; optional for integrations and packages. Loader confirms the file exists.",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "inventory_slug": {
+      "type": "string",
+      "description": "Slug in cognee-integrations/integrations/inventory.yml this entry corresponds to. Used by the drift check so an inventory entry without a catalog entry (or vice versa) fails CI.",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 2,
+      "maxLength": 64
+    },
+    "docs_url": {
+      "type": "string",
+      "description": "Optional link to a longer doc page (e.g. docs.cognee.ai/integrations/openai).",
+      "format": "uri"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"kind": {"const": "integration"}}
+      },
+      "then": {
+        "required": ["repo", "path"]
+      }
+    },
+    {
+      "if": {
+        "properties": {"kind": {"const": "package"}}
+      },
+      "then": {
+        "required": ["repo", "path"]
+      }
+    },
+    {
+      "if": {
+        "properties": {"kind": {"const": "use-case"}}
+      },
+      "then": {
+        "required": ["example_path"]
+      }
+    }
+  ]
+}

--- a/catalog/tests/test_loader.py
+++ b/catalog/tests/test_loader.py
@@ -1,0 +1,136 @@
+"""Tests for the catalog loader's validation passes.
+
+Each test writes YAML fixtures into a temporary entries root and asserts the
+loader either returns the expected entries or raises ``CatalogError`` with a
+message pointing at the specific problem. One smoke test loads the real shipped
+catalog so a broken seed entry fails here too.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from catalog.loader import CatalogError, load_catalog
+
+# A minimal entry that passes every validation pass. ``repo`` points at an
+# external repo so ``path`` is syntax-checked only (never resolved on disk).
+VALID_INTEGRATION = {
+    "id": "example-tool",
+    "title": "Example tool integration",
+    "kind": "integration",
+    "stack": "framework",
+    "tags": ["example", "python"],
+    "summary": "A minimal valid integration entry used by the loader tests.",
+    "what_youll_build": "Nothing real; this is a fixture for the loader tests.",
+    "quickstart": "pip install example\npython run.py",
+    "expected_output": "Some expected output text.",
+    "difficulty": "easy",
+    "repo": "topoteretes/cognee-community",
+    "path": "packages/example",
+}
+
+SUBDIR = {"integration": "integrations", "use-case": "use-cases", "package": "packages"}
+
+
+def _use_case(**overrides: object) -> dict:
+    """A valid use-case entry whose example_path resolves against the repo root."""
+    entry = {
+        **VALID_INTEGRATION,
+        "kind": "use-case",
+        "example_path": "pyproject.toml",
+    }
+    entry.pop("repo")
+    entry.pop("path")
+    entry.update(overrides)
+    return entry
+
+
+def _write(root: Path, entry: dict, *, filename: str | None = None) -> Path:
+    subdir = root / SUBDIR[entry["kind"]]
+    subdir.mkdir(parents=True, exist_ok=True)
+    path = subdir / (filename or f"{entry['id']}.yaml")
+    path.write_text(yaml.safe_dump(entry), encoding="utf-8")
+    return path
+
+
+def test_valid_entry_loads(tmp_path: Path) -> None:
+    _write(tmp_path, VALID_INTEGRATION)
+    entries = load_catalog(entries_root=tmp_path)
+    assert [e.id for e in entries] == ["example-tool"]
+    assert entries[0].kind == "integration"
+
+
+def test_entries_sorted_by_kind_then_id(tmp_path: Path) -> None:
+    _write(tmp_path, {**VALID_INTEGRATION, "id": "b-tool"})
+    _write(tmp_path, {**VALID_INTEGRATION, "id": "a-tool"})
+    _write(tmp_path, _use_case(id="a-case"))
+    entries = load_catalog(entries_root=tmp_path)
+    assert [(e.kind, e.id) for e in entries] == [
+        ("integration", "a-tool"),
+        ("integration", "b-tool"),
+        ("use-case", "a-case"),
+    ]
+
+
+def test_missing_required_field_fails(tmp_path: Path) -> None:
+    _write(tmp_path, {k: v for k, v in VALID_INTEGRATION.items() if k != "summary"})
+    with pytest.raises(CatalogError) as exc:
+        load_catalog(entries_root=tmp_path)
+    assert any("summary" in e for e in exc.value.errors)
+
+
+def test_id_must_match_filename_stem(tmp_path: Path) -> None:
+    _write(tmp_path, VALID_INTEGRATION, filename="different-name.yaml")
+    with pytest.raises(CatalogError) as exc:
+        load_catalog(entries_root=tmp_path)
+    assert any("does not match filename stem" in e for e in exc.value.errors)
+
+
+def test_kind_must_match_subdirectory(tmp_path: Path) -> None:
+    subdir = tmp_path / "use-cases"
+    subdir.mkdir(parents=True)
+    (subdir / "example-tool.yaml").write_text(yaml.safe_dump(VALID_INTEGRATION), encoding="utf-8")
+    with pytest.raises(CatalogError) as exc:
+        load_catalog(entries_root=tmp_path)
+    assert any("expects the entry under" in e for e in exc.value.errors)
+
+
+def test_use_case_requires_example_path(tmp_path: Path) -> None:
+    entry = _use_case()
+    entry.pop("example_path")
+    _write(tmp_path, entry)
+    with pytest.raises(CatalogError) as exc:
+        load_catalog(entries_root=tmp_path)
+    assert any("example_path" in e for e in exc.value.errors)
+
+
+def test_local_example_path_must_exist(tmp_path: Path) -> None:
+    _write(tmp_path, _use_case(example_path="does/not/exist.py"))
+    with pytest.raises(CatalogError) as exc:
+        load_catalog(entries_root=tmp_path)
+    assert any("does not exist" in e for e in exc.value.errors)
+
+
+def test_duplicate_id_across_kinds_fails(tmp_path: Path) -> None:
+    _write(tmp_path, VALID_INTEGRATION)
+    _write(tmp_path, _use_case(id="example-tool"))
+    with pytest.raises(CatalogError) as exc:
+        load_catalog(entries_root=tmp_path)
+    assert any("duplicate id" in e for e in exc.value.errors)
+
+
+def test_all_errors_aggregated(tmp_path: Path) -> None:
+    _write(tmp_path, {k: v for k, v in VALID_INTEGRATION.items() if k != "summary"})
+    _write(tmp_path, _use_case(id="broken", example_path="nope.py"))
+    with pytest.raises(CatalogError) as exc:
+        load_catalog(entries_root=tmp_path)
+    assert len(exc.value.errors) >= 2
+
+
+def test_shipped_catalog_is_valid() -> None:
+    entries = load_catalog()
+    assert len(entries) >= 10
+    assert {e.kind for e in entries} == {"integration", "use-case", "package"}

--- a/docs/contributing/add-catalog-entry.md
+++ b/docs/contributing/add-catalog-entry.md
@@ -31,6 +31,8 @@ tags:
 summary: Answer questions grounded in a set of documents using cognee's graph-completion retrieval instead of plain RAG.
 what_youll_build: A recall pipeline that ingests documents, extracts entities and relationships into a graph, and answers questions with citations back to source chunks.
 quickstart: |
+  git clone https://github.com/topoteretes/cognee.git
+  cd cognee
   uv pip install cognee
   export LLM_API_KEY=your_openai_key
   python examples/guides/recall_core.py

--- a/docs/contributing/add-catalog-entry.md
+++ b/docs/contributing/add-catalog-entry.md
@@ -79,7 +79,7 @@ The full schema lives in `catalog/schema.json`. Highlights:
    uv run python -m catalog.loader
    uv run python -m catalog.inventory_sync
    ```
-   The loader must exit 0 for the entry to be considered valid. The drift check tolerates coverage gaps (integrations in the inventory but not yet in the catalog) but fails on stale references.
+   The loader must exit 0 for the entry to be considered valid — that is the blocking gate. The drift check is advisory: it tolerates coverage gaps (integrations in the inventory but not yet in the catalog) and flags stale references, and it runs as a non-blocking CI step so an upstream change never fails your PR.
 7. Open a PR. The `Catalog` workflow will re-run both checks.
 
 ## Coverage gaps

--- a/docs/contributing/add-catalog-entry.md
+++ b/docs/contributing/add-catalog-entry.md
@@ -1,0 +1,91 @@
+# Adding a catalog entry
+
+The Cognee Integrations Hub and Use-Case Gallery are generated from the YAML entries under `catalog/entries/`. Adding a new integration, use-case, or community package is a single-PR change: catalog entry, plus a runnable example the entry points at.
+
+This guide covers the mechanics. The contract itself is `catalog/schema.json`.
+
+## What the catalog is for
+
+Users looking to adopt cognee ask two questions:
+
+- "Does cognee work with my stack?" (answered by the Integrations Hub)
+- "How do I do the thing I need done?" (answered by the Use-Case Gallery)
+
+Every catalog entry is one card in one of those views. It carries just enough context for a user to decide it's the right starting point, plus a runnable example they can copy-paste.
+
+## Anatomy of an entry
+
+Every entry is a YAML file under `catalog/entries/{integrations,use-cases,packages}/`. The filename stem must match the entry's `id`. Example:
+
+```yaml
+# catalog/entries/use-cases/document-qa.yaml
+id: document-qa
+title: Document Q&A backed by a knowledge graph
+kind: use-case
+stack: use-case
+tags:
+  - document-qa
+  - graph-rag
+  - recall
+  - reading-comprehension
+summary: Answer questions grounded in a set of documents using cognee's graph-completion retrieval instead of plain RAG.
+what_youll_build: A recall pipeline that ingests documents, extracts entities and relationships into a graph, and answers questions with citations back to source chunks.
+quickstart: |
+  uv pip install cognee
+  export LLM_API_KEY=your_openai_key
+  python examples/guides/recall_core.py
+expected_output: |
+  A ranked list of retrieved passages plus a synthesized natural-language
+  answer citing the original documents. Compare against a plain RAG baseline
+  to see graph-completion's contribution.
+difficulty: easy
+example_path: examples/guides/recall_core.py
+```
+
+## Fields
+
+The full schema lives in `catalog/schema.json`. Highlights:
+
+- **`id`**: Lowercase, dashes, no spaces. Must match the filename stem. This is the stable machine identifier every downstream tool uses.
+- **`title`**: The human-readable name as it appears on the Hub card.
+- **`kind`**: `integration`, `use-case`, or `package`. Drives which subdirectory the file lives under and which view it appears in.
+- **`stack`**: The primary technology bucket (`llm-provider`, `vector-store`, `graph-store`, `relational-store`, `framework`, `agent-runtime`, `workflow-tool`, `observability`, `loader`, or `use-case`). Drives the Hub filter chips.
+- **`tags`**: Free-form filter labels. Redundant with `stack` on purpose so users can search by outcome or provider without hitting a taxonomy wall.
+- **`summary`**: One sentence, shown on the Hub card. Answers "does this work with my stack".
+- **`what_youll_build`**: One sentence promising a concrete outcome. Answers "what do I get if I follow the quickstart".
+- **`quickstart`**: A copy-paste block that gets a newcomer running. Include install, env, and a single run command. Multi-line YAML block scalar (`quickstart: |`).
+- **`expected_output`**: A concrete description of what the user should see after running the quickstart. Doesn't need to be exact values, but should be specific enough that a user knows if their run worked.
+- **`difficulty`**: `easy`, `medium`, or `advanced`. Measures the effort for a new user, not code complexity.
+- **`repo`, `path`**: Required for integrations and packages. Point at the source in one of `topoteretes/cognee`, `topoteretes/cognee-community`, or `topoteretes/cognee-integrations`.
+- **`example_path`**: Required for use-cases. Path within `topoteretes/cognee` to a runnable script.
+- **`inventory_slug`**: Optional. If your integration already has a slug in `cognee-integrations/integrations/inventory.yml`, set it here so the drift check keeps them aligned.
+- **`docs_url`**: Optional link to a longer doc page (e.g. `docs.cognee.ai/integrations/openai`).
+
+## Adding an entry: the workflow
+
+1. Pick the right subdirectory (`integrations/`, `use-cases/`, or `packages/`).
+2. Copy an existing entry as a starting point:
+   ```bash
+   cp catalog/entries/use-cases/document-qa.yaml catalog/entries/use-cases/your-new-entry.yaml
+   ```
+3. Edit every field. The schema catches typos in field names, so a stray letter turns into a CI error, not a silent bug.
+4. Make sure the `example_path` (for use-cases) or the `path` (for integrations/packages pointing at `topoteretes/cognee`) resolves against the current checkout.
+5. If you're referencing an example that doesn't have a mocked test yet, coordinate with #3601 so the example runs in CI.
+6. Run the validation locally:
+   ```bash
+   uv sync --extra catalog
+   uv run python -m catalog.loader
+   uv run python -m catalog.inventory_sync
+   ```
+   The loader must exit 0 for the entry to be considered valid. The drift check tolerates coverage gaps (integrations in the inventory but not yet in the catalog) but fails on stale references.
+7. Open a PR. The `Catalog` workflow will re-run both checks.
+
+## Coverage gaps
+
+If you add an entry with an `inventory_slug`, the drift check confirms the slug exists upstream. If you don't add one, you're implicitly saying "this is a brand-new integration not in inventory.yml yet." That's fine.
+
+If you want to help close a coverage gap, run the drift check locally to see the outstanding list, then add entries one at a time. Batch PRs of 5-10 entries are welcome; larger batches are harder to review.
+
+## What if I'm adding an integration that lives in a private fork?
+
+Point `repo` at the private fork, or leave `repo` and `path` unset and treat it as a use-case (`kind: use-case`) with a public `example_path`. The catalog is designed for public discovery, so anything a user can't reach shouldn't be an entry.

--- a/docs/contributing/add-catalog-entry.md
+++ b/docs/contributing/add-catalog-entry.md
@@ -71,9 +71,9 @@ The full schema lives in `catalog/schema.json`. Highlights:
 3. Edit every field. The schema catches typos in field names, so a stray letter turns into a CI error, not a silent bug.
 4. Make sure the `example_path` (for use-cases) or the `path` (for integrations/packages pointing at `topoteretes/cognee`) resolves against the current checkout.
 5. If you're referencing an example that doesn't have a mocked test yet, coordinate with #3601 so the example runs in CI.
-6. Run the validation locally:
+6. Run the validation locally (a standard `uv sync` already provides the `pyyaml` and `jsonschema` the tooling needs):
    ```bash
-   uv sync --extra catalog
+   uv sync
    uv run python -m catalog.loader
    uv run python -m catalog.inventory_sync
    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,6 @@ dependencies = [
 [project.optional-dependencies]
 api=[]
 
-catalog = [
-    "pyyaml>=6.0",
-    "jsonschema>=4.17.0",
-]
-
 distributed = [
     "modal>=1.0.5,<2.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,11 @@ dependencies = [
 [project.optional-dependencies]
 api=[]
 
+catalog = [
+    "pyyaml>=6.0",
+    "jsonschema>=4.17.0",
+]
+
 distributed = [
     "modal>=1.0.5,<2.0.0",
 ]


### PR DESCRIPTION
## Description

Maintainer rework of the hackathon PR #3776 (GitHub issue #3603, "Integrations Hub + Use-Case Gallery"), re-submitted from a same-repo branch so CI secrets are available. Tracked as Linear **SDK-151**.

This is **chunk 1** of #3603 — the catalog contract and the pieces everything else builds on. It ships a machine-readable schema, a validating loader with an offline CI gate, ten seed entries across all three kinds (integration / use-case / package), a cross-repo drift check against the `cognee-integrations` inventory, and contributor docs. Hub/Gallery rendering, full cross-repo aggregation, and the mocked example-test harness (#3601) stay deferred to follow-up chunks, as the original PR intended.

The original author's commit is preserved verbatim at the base of the branch for attribution. My changes sit on top as separate, reviewable commits.

**What the original PR got right:** the schema is a clean draft-07 contract, the loader's three-pass validation (schema → naming → local path resolution) with aggregated errors is a good design, and the author verified that every referenced path resolves and the drift check works against real upstream data.

**What I changed (one commit per concern):**

1. **`fix`: drop the redundant `catalog` extra.** It was added to `pyproject.toml` without regenerating `uv.lock`, which failed the required `uv lock --check` gate — the one thing that turned CI red. The extra was also redundant (`pyyaml`/`jsonschema` are already installed transitively) and mis-targeted (the `catalog/` tooling is never shipped in the wheel, so a published extra would install deps for code end users never receive). Removing it restores the locked baseline with **no `uv.lock` churn**.
2. **`fix`: correct the seed quickstarts so they run as written.** Five of the ten did not match the real upstream integrations (invalid `python -m <filepath>`, a `docker compose` file that doesn't exist, a copied `.env.example` that doesn't exist, imports of symbols that don't exist, wrong install commands / env-var names). Each is now verified against the upstream README / example.
3. **`refactor`: simplify the loader.** Drop the never-read `raw` field, build the JSON-schema validator once instead of per entry, and make the internal validation helper private.
4. **`refactor`: tighten the schema.** Add `minLength` to the two free-text required fields (an empty string previously validated), and merge the duplicate `integration`/`package` conditional branches.
5. **`fix`: harden the drift check and make its CI step advisory.** It reaches the GitHub API and depends on another repo's `inventory.yml`, so a transient failure or an upstream reshape must not fail an unrelated catalog PR (`continue-on-error: true`); error handling now re-raises cleanly instead of leaking tracebacks; dropped the speculative `--strict-coverage` flag and dead code.
6. **`test`: add loader validation tests** covering the happy path and every error branch, run by the Catalog workflow.

Net effect excluding the new test file: **86 insertions / 87 deletions** — a small reduction in production code while fixing the blocker and the seed quickstarts.

## Acceptance Criteria

* `uv lock --check` passes with no `uv.lock` change; the `Catalog` workflow is green.
* `python -m catalog.loader` validates all ten seed entries and exits non-zero with a clear message on a broken entry (the blocking gate).
* The drift check degrades gracefully and never blocks a catalog PR on upstream or network issues.
* Every seed quickstart runs as written against the integration it names.
* Loader has unit tests; `ruff check` and `ruff format` pass.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Code refactoring
- [ ] Other (please specify):

## Screenshots

Local verification (no API keys required):

```
uv lock --check                         -> PASS (lockfile in sync)
python -m catalog.loader                -> loaded 10 catalog entries (integration:4, package:2, use-case:4)
python -m pytest catalog/tests          -> 10 passed
python -m catalog.inventory_sync        -> exit 0 (coverage gaps only; advisory)
ruff check catalog/ && ruff format --check catalog/  -> All checks passed / already formatted
```

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

Credit to the original author, @Labi-Joy, whose commit is preserved at the base of this branch. Supersedes #3776. Closes #3603 is intentionally **not** used, since this is only chunk 1 of that issue.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
