### PR TITLE
test(mcp): MCP Docker image HTTP e2e suite, direct mode (SDK-153)

### DIFF
--- a/.github/workflows/test_deployment_mcp.yml
+++ b/.github/workflows/test_deployment_mcp.yml
@@ -9,6 +9,9 @@ on:
       - "cognee/tests/deployment/**"
       - ".github/workflows/test_deployment_mcp.yml"
 
+permissions:
+  contents: read
+
 env:
   COGNEE_SKIP_CONNECTION_TEST: "true"
   COGNEE_MCP_IMAGE: "cognee-mcp:local"

--- a/.github/workflows/test_deployment_mcp.yml
+++ b/.github/workflows/test_deployment_mcp.yml
@@ -1,7 +1,6 @@
 name: test | deployment mcp http e2e
 
 on:
-  workflow_call:
   workflow_dispatch:
   pull_request:
     branches: [dev]
@@ -18,6 +17,7 @@ jobs:
   mcp-http-e2e:
     name: MCP Docker HTTP e2e (direct mode)
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/test_deployment_mcp.yml
+++ b/.github/workflows/test_deployment_mcp.yml
@@ -1,0 +1,42 @@
+name: test | deployment mcp http e2e
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    branches: [dev]
+    paths:
+      - "cognee-mcp/**"
+      - "cognee/tests/deployment/**"
+      - ".github/workflows/test_deployment_mcp.yml"
+
+env:
+  COGNEE_SKIP_CONNECTION_TEST: "true"
+  COGNEE_MCP_IMAGE: "cognee-mcp:local"
+
+jobs:
+  mcp-http-e2e:
+    name: MCP Docker HTTP e2e (direct mode)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build cognee-mcp image
+        run: docker build -f cognee-mcp/Dockerfile -t cognee-mcp:local .
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install "pytest>=7.4,<8" "pytest-asyncio>=0.21,<0.22" "httpx" "mcp>=1.12,<2.0"
+
+      - name: Run MCP HTTP e2e (mock LLM, no secrets)
+        run: pytest cognee/tests/deployment/test_mcp_http_direct.py -m deployment -v

--- a/cognee/tests/deployment/conftest.py
+++ b/cognee/tests/deployment/conftest.py
@@ -1,8 +1,9 @@
 """Pytest fixtures and marker registration for deployment end-to-end tests.
 
-Deployment tests build and run Docker images and are therefore opt-in via the
-``deployment`` marker (select with ``pytest -m deployment``). They are skipped
-automatically when no Docker daemon is reachable.
+Deployment tests run a prebuilt ``cognee-mcp`` Docker image and are therefore
+opt-in via the ``deployment`` marker (select with ``pytest -m deployment``).
+They are skipped automatically when Docker is unavailable or the image has not
+been built.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ import pytest
 from mcp_harness import (
     MCPContainer,
     docker_available,
-    ensure_mcp_image,
+    image_exists,
     run_mcp_http_container,
 )
 
@@ -26,24 +27,29 @@ HEALTH_TIMEOUT = float(os.getenv("COGNEE_DEPLOYMENT_HEALTH_TIMEOUT", "120"))
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
-        "deployment: end-to-end tests that build and run Docker images "
+        "deployment: end-to-end tests that run a prebuilt Docker image "
         "(opt-in; excluded from the default unit run).",
     )
 
 
 @pytest.fixture(scope="session")
 def mcp_image() -> str:
-    """Ensure the cognee-mcp image exists locally and return its tag.
+    """Return the tag of a locally available cognee-mcp image.
 
     Skips the whole suite (rather than failing) when Docker is unavailable or
-    the image cannot be built, so the marker stays friendly on dev machines.
+    the image has not been built, so the marker stays friendly on dev machines.
+    The image is built explicitly beforehand (CI does this) rather than from
+    inside a fixture, so a bare ``pytest -m deployment`` never triggers a
+    surprise multi-minute build.
     """
     if not docker_available():
         pytest.skip("Docker daemon is not available; skipping deployment tests.")
-    try:
-        return ensure_mcp_image(DEFAULT_MCP_IMAGE)
-    except Exception as exc:  # noqa: BLE001 - surface as skip with context
-        pytest.skip(f"Could not build/find cognee-mcp image {DEFAULT_MCP_IMAGE!r}: {exc}")
+    if not image_exists(DEFAULT_MCP_IMAGE):
+        pytest.skip(
+            f"cognee-mcp image {DEFAULT_MCP_IMAGE!r} not found; build it first:\n"
+            f"  docker build -f cognee-mcp/Dockerfile -t {DEFAULT_MCP_IMAGE} ."
+        )
+    return DEFAULT_MCP_IMAGE
 
 
 @pytest.fixture(scope="module")

--- a/cognee/tests/deployment/conftest.py
+++ b/cognee/tests/deployment/conftest.py
@@ -1,0 +1,53 @@
+"""Pytest fixtures and marker registration for deployment end-to-end tests.
+
+Deployment tests build and run Docker images and are therefore opt-in via the
+``deployment`` marker (select with ``pytest -m deployment``). They are skipped
+automatically when no Docker daemon is reachable.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+
+from mcp_harness import (
+    MCPContainer,
+    docker_available,
+    ensure_mcp_image,
+    run_mcp_http_container,
+)
+
+DEFAULT_MCP_IMAGE = os.getenv("COGNEE_MCP_IMAGE", "cognee-mcp:local")
+HEALTH_TIMEOUT = float(os.getenv("COGNEE_DEPLOYMENT_HEALTH_TIMEOUT", "120"))
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "deployment: end-to-end tests that build and run Docker images "
+        "(opt-in; excluded from the default unit run).",
+    )
+
+
+@pytest.fixture(scope="session")
+def mcp_image() -> str:
+    """Ensure the cognee-mcp image exists locally and return its tag.
+
+    Skips the whole suite (rather than failing) when Docker is unavailable or
+    the image cannot be built, so the marker stays friendly on dev machines.
+    """
+    if not docker_available():
+        pytest.skip("Docker daemon is not available; skipping deployment tests.")
+    try:
+        return ensure_mcp_image(DEFAULT_MCP_IMAGE)
+    except Exception as exc:  # noqa: BLE001 - surface as skip with context
+        pytest.skip(f"Could not build/find cognee-mcp image {DEFAULT_MCP_IMAGE!r}: {exc}")
+
+
+@pytest.fixture(scope="module")
+def mcp_http_container(mcp_image: str) -> Iterator[MCPContainer]:
+    """A module-scoped cognee-mcp container in HTTP transport (direct) mode."""
+    with run_mcp_http_container(mcp_image, health_timeout=HEALTH_TIMEOUT) as container:
+        yield container

--- a/cognee/tests/deployment/conftest.py
+++ b/cognee/tests/deployment/conftest.py
@@ -21,7 +21,6 @@ from mcp_harness import (
 )
 
 DEFAULT_MCP_IMAGE = os.getenv("COGNEE_MCP_IMAGE", "cognee-mcp:local")
-HEALTH_TIMEOUT = float(os.getenv("COGNEE_DEPLOYMENT_HEALTH_TIMEOUT", "120"))
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -55,5 +54,5 @@ def mcp_image() -> str:
 @pytest.fixture(scope="module")
 def mcp_http_container(mcp_image: str) -> Iterator[MCPContainer]:
     """A module-scoped cognee-mcp container in HTTP transport (direct) mode."""
-    with run_mcp_http_container(mcp_image, health_timeout=HEALTH_TIMEOUT) as container:
+    with run_mcp_http_container(mcp_image) as container:
         yield container

--- a/cognee/tests/deployment/mcp_harness.py
+++ b/cognee/tests/deployment/mcp_harness.py
@@ -1,8 +1,8 @@
 """Helpers for the MCP Docker HTTP e2e suite (T3 / #3361).
 
 Drive the built ``cognee-mcp`` image over HTTP (Docker CLI + httpx + mcp): image
-availability/build, a free-port picker, a health poller, a container context
-manager with guaranteed teardown, and an MCP streamable-HTTP client session.
+availability, a free-port picker, a health poller, a container context manager
+with guaranteed teardown, and an MCP streamable-HTTP client session.
 """
 
 from __future__ import annotations
@@ -12,11 +12,7 @@ import shutil
 import socket
 import subprocess
 import time
-from pathlib import Path
 from typing import AsyncIterator, Iterator, Optional
-
-# mcp_harness.py -> deployment -> tests -> cognee -> repo root
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 # Port the MCP server listens on inside the container (entrypoint default).
 CONTAINER_HTTP_PORT = 8000
@@ -47,27 +43,6 @@ def image_exists(tag: str) -> bool:
         ).returncode
         == 0
     )
-
-
-def ensure_mcp_image(tag: str) -> str:
-    """Return ``tag`` if present locally, otherwise build it from cognee-mcp/Dockerfile."""
-    if image_exists(tag):
-        return tag
-
-    dockerfile = REPO_ROOT / "cognee-mcp" / "Dockerfile"
-    subprocess.run(
-        [
-            "docker",
-            "build",
-            "-f",
-            str(dockerfile),
-            "-t",
-            tag,
-            str(REPO_ROOT),
-        ],
-        check=True,
-    )
-    return tag
 
 
 def free_port() -> int:

--- a/cognee/tests/deployment/mcp_harness.py
+++ b/cognee/tests/deployment/mcp_harness.py
@@ -105,16 +105,17 @@ def run_mcp_http_container(
     image: str,
     *,
     extra_env: Optional[dict] = None,
-    name_suffix: str = "",
     health_timeout: float = 120.0,
 ) -> Iterator[MCPContainer]:
     """Start cognee-mcp with ``TRANSPORT_MODE=http``, yield it, always tear down.
 
-    ``LLM_API_KEY`` is a dummy: the session-cache remember/recall path never calls
-    a model, so the run is deterministic and key-free.
+    ``LLM_API_KEY`` is a dummy: the exercised session-cache recall matches stored
+    text by keyword and needs no model, so the assertions stay deterministic and
+    key-free. (A background session-distillation step may log a benign embedding
+    error under the dummy key; it does not affect the round-trip.)
     """
     port = free_port()
-    name = f"cognee-mcp-t3-{port}{name_suffix}"
+    name = f"cognee-mcp-t3-{port}"
 
     env = {
         "TRANSPORT_MODE": "http",

--- a/cognee/tests/deployment/mcp_harness.py
+++ b/cognee/tests/deployment/mcp_harness.py
@@ -1,0 +1,198 @@
+"""Helpers for the MCP Docker HTTP e2e suite (T3 / #3361).
+
+Drive the built ``cognee-mcp`` image over HTTP (Docker CLI + httpx + mcp): image
+availability/build, a free-port picker, a health poller, a container context
+manager with guaranteed teardown, and an MCP streamable-HTTP client session.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import AsyncIterator, Iterator, Optional
+
+# mcp_harness.py -> deployment -> tests -> cognee -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Port the MCP server listens on inside the container (entrypoint default).
+CONTAINER_HTTP_PORT = 8000
+
+
+def docker_available() -> bool:
+    """Return True when a usable Docker daemon is reachable."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return False
+    return True
+
+
+def image_exists(tag: str) -> bool:
+    """Return True when ``tag`` is present in the local image store."""
+    return (
+        subprocess.run(
+            ["docker", "image", "inspect", tag],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def ensure_mcp_image(tag: str) -> str:
+    """Return ``tag`` if present locally, otherwise build it from cognee-mcp/Dockerfile."""
+    if image_exists(tag):
+        return tag
+
+    dockerfile = REPO_ROOT / "cognee-mcp" / "Dockerfile"
+    subprocess.run(
+        [
+            "docker",
+            "build",
+            "-f",
+            str(dockerfile),
+            "-t",
+            tag,
+            str(REPO_ROOT),
+        ],
+        check=True,
+    )
+    return tag
+
+
+def free_port() -> int:
+    """Reserve and return a free TCP port on the loopback interface."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def wait_for_health(url: str, timeout: float = 120.0) -> None:
+    """Poll an HTTP health endpoint until it returns 200 or raise ``TimeoutError``."""
+    import httpx
+
+    deadline = time.monotonic() + timeout
+    last_error: Optional[Exception] = None
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(url, timeout=5)
+            if response.status_code == 200:
+                return
+        except Exception as exc:  # noqa: BLE001 - poller intentionally tolerant
+            last_error = exc
+        time.sleep(1.0)
+    raise TimeoutError(
+        f"Health check {url!r} did not pass within {timeout:.0f}s; last error: {last_error}"
+    )
+
+
+class MCPContainer:
+    """A running ``cognee-mcp`` container in HTTP transport (direct) mode."""
+
+    def __init__(self, name: str, host_port: int):
+        self.name = name
+        self.host_port = host_port
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.host_port}"
+
+    @property
+    def health_url(self) -> str:
+        return f"{self.base_url}/health"
+
+    @property
+    def mcp_url(self) -> str:
+        return f"{self.base_url}/mcp"
+
+    def logs(self) -> str:
+        """Return combined stdout+stderr from ``docker logs`` (for debugging)."""
+        result = subprocess.run(
+            ["docker", "logs", self.name],
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout + result.stderr
+
+
+@contextlib.contextmanager
+def run_mcp_http_container(
+    image: str,
+    *,
+    extra_env: Optional[dict] = None,
+    name_suffix: str = "",
+    health_timeout: float = 120.0,
+) -> Iterator[MCPContainer]:
+    """Start cognee-mcp with ``TRANSPORT_MODE=http``, yield it, always tear down.
+
+    ``LLM_API_KEY`` is a dummy: the session-cache remember/recall path never calls
+    a model, so the run is deterministic and key-free.
+    """
+    port = free_port()
+    name = f"cognee-mcp-t3-{port}{name_suffix}"
+
+    env = {
+        "TRANSPORT_MODE": "http",
+        "LLM_API_KEY": "mock-key",
+        "ENV": "local",
+    }
+    if extra_env:
+        env.update(extra_env)
+
+    env_args: list[str] = []
+    for key, value in env.items():
+        env_args += ["-e", f"{key}={value}"]
+
+    subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            name,
+            "-p",
+            f"{port}:{CONTAINER_HTTP_PORT}",
+            *env_args,
+            image,
+        ],
+        check=True,
+    )
+
+    container = MCPContainer(name=name, host_port=port)
+    try:
+        try:
+            wait_for_health(container.health_url, timeout=health_timeout)
+        except Exception:
+            print(
+                f"\n----- docker logs {name} -----\n"
+                f"{container.logs()}\n"
+                f"------------------------------"
+            )
+            raise
+        yield container
+    finally:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+
+
+@contextlib.asynccontextmanager
+async def mcp_client_session(mcp_url: str) -> AsyncIterator[object]:
+    """Open an initialized MCP client session over streamable HTTP at ``/mcp``."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async with streamablehttp_client(mcp_url) as (read_stream, write_stream, _get_session_id):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            yield session

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -1,0 +1,218 @@
+"""T3 (#3361): MCP Docker image e2e over streamable HTTP (direct mode).
+
+Drives the built ``cognee/cognee-mcp`` image through a real MCP session: boots it
+with ``TRANSPORT_MODE=http``, connects an MCP client at ``/mcp``, asserts the tool
+surface, exercises a ``remember`` -> ``recall`` round-trip, and validates
+``MCP_ALLOWED_HOSTS`` / DNS-rebinding behaviour on the ``0.0.0.0`` bind.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from mcp_harness import mcp_client_session, run_mcp_http_container
+
+pytestmark = pytest.mark.deployment
+
+# Mirrors EXPECTED_TOOLS in cognee-mcp/tests/test_mcp_server_hardening.py and
+# cognee-mcp/src/test_client.py.
+EXPECTED_TOOLS = {
+    "remember",
+    "recall",
+    "forget",
+    "visualize_graph_ui",
+    "upload_file_ui",
+    "open_cognee_workspace",
+    "cognify_file",
+    "list_datasets_json",
+    "list_dataset_data_json",
+    "create_dataset_json",
+    "get_client_info_json",
+}
+
+# Host-validation rejection statuses, tolerant across MCP SDK versions.
+HOST_REJECTION_CODES = {400, 403, 421}
+
+_MCP_POST_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+}
+
+
+def _initialize_body(client_name: str) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": client_name, "version": "0.0.0"},
+        },
+    }
+
+
+def _text_of(result) -> str:
+    """Flatten an MCP tool-call result into plain text."""
+    blocks = getattr(result, "content", None) or []
+    return "\n".join(getattr(block, "text", str(block)) for block in blocks)
+
+
+def _post_initialize_status(client: httpx.Client, url: str, host: str):
+    """POST an initialize to ``/mcp`` with a given Host header.
+
+    Returns the HTTP status code, or ``None`` when the request times out while
+    reading the body. A timeout means the request passed Host validation and the
+    server began streaming a response (a rejected Host is answered immediately
+    with a small error body), so ``None`` is treated as "accepted".
+    """
+    try:
+        response = client.post(
+            url,
+            headers={**_MCP_POST_HEADERS, "Host": host},
+            json=_initialize_body("t3-host-probe"),
+        )
+    except httpx.TimeoutException:
+        return None
+    return response.status_code
+
+
+def test_health_endpoint(mcp_http_container):
+    """The container boots in HTTP mode and serves ``/health``."""
+    response = httpx.get(mcp_http_container.health_url, timeout=10)
+    assert response.status_code == 200
+    assert response.json().get("status") == "ok"
+
+
+@pytest.mark.asyncio
+async def test_list_tools_over_http(mcp_http_container):
+    """A real MCP client at ``/mcp`` lists exactly the expected tool surface."""
+    async with mcp_client_session(mcp_http_container.mcp_url) as session:
+        tools = await session.list_tools()
+
+    names = {tool.name for tool in tools.tools}
+    assert names == EXPECTED_TOOLS, (
+        f"Tool surface mismatch. "
+        f"Missing: {sorted(EXPECTED_TOOLS - names)}. "
+        f"Unexpected: {sorted(names - EXPECTED_TOOLS)}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_remember_recall_roundtrip(mcp_http_container):
+    """``remember`` then ``recall`` returns the stored content.
+
+    Uses session mode (keyword session cache) so the assertion targets stable,
+    stored text rather than model-generated output.
+    """
+    session_id = f"t3-{uuid.uuid4().hex}"
+    unique_token = f"T3_TOKEN_{uuid.uuid4().hex}"
+    memory_text = f"Cognee T3 end-to-end memory {unique_token}"
+
+    async with mcp_client_session(mcp_http_container.mcp_url) as session:
+        remember_result = await session.call_tool(
+            "remember",
+            arguments={"data": memory_text, "session_id": session_id},
+        )
+        recall_result = await session.call_tool(
+            "recall",
+            arguments={"query": unique_token, "session_id": session_id, "top_k": 5},
+        )
+
+    remember_text = _text_of(remember_result)
+    recall_text = _text_of(recall_result)
+
+    assert "Stored in session cache" in remember_text, remember_text
+    assert unique_token in recall_text, (
+        f"Stored token {unique_token!r} not retrievable via recall. "
+        f"recall returned: {recall_text!r}"
+    )
+
+
+@pytest.mark.skip(reason="Needs the T0 mock-LLM sidecar (#3358) for deterministic cognify.")
+@pytest.mark.asyncio
+async def test_remember_cognify_recall_graph_path(mcp_http_container):
+    """Permanent-memory round-trip through the knowledge graph.
+
+    Drives ``remember`` (no ``session_id``) -> cognify -> ``recall`` over the
+    graph. The recall assertion also guards against the Kuzu JSON-extension gotcha
+    (a missing extension surfaces as an error string rather than empty results).
+    """
+    unique_token = f"T3_GRAPH_{uuid.uuid4().hex}"
+    memory_text = f"Cognee graph memory anchor {unique_token} relates to deployment tests."
+
+    async with mcp_client_session(mcp_http_container.mcp_url) as session:
+        remember_result = await session.call_tool(
+            "remember",
+            arguments={"data": memory_text, "dataset_name": "t3_graph"},
+        )
+        recall_result = await session.call_tool(
+            "recall",
+            arguments={"query": unique_token, "datasets": "t3_graph", "top_k": 5},
+        )
+
+    remember_text = _text_of(remember_result)
+    recall_text = _text_of(recall_result)
+
+    assert "Stored permanently in knowledge graph" in remember_text, remember_text
+    assert "has not been installed" not in recall_text, (
+        f"Kuzu JSON extension missing — recall errored instead of returning data: {recall_text!r}"
+    )
+    assert unique_token in recall_text, (
+        f"Stored token {unique_token!r} not retrievable via graph recall. "
+        f"recall returned: {recall_text!r}"
+    )
+
+
+def test_dns_rebinding_rejects_spoofed_host(mcp_http_container):
+    """With the server bound to ``0.0.0.0`` a spoofed Host header is rejected.
+
+    Only the Host header differs between the two requests, so loopback-accepted
+    vs spoofed-rejected isolates the DNS-rebinding guard as the cause.
+    """
+    mcp_url = mcp_http_container.mcp_url
+
+    with httpx.Client(timeout=10) as client:
+        spoofed_status = _post_initialize_status(client, mcp_url, "evil.example.com")
+        control_status = _post_initialize_status(
+            client, mcp_url, f"127.0.0.1:{mcp_http_container.host_port}"
+        )
+
+    assert spoofed_status in HOST_REJECTION_CODES, (
+        f"Spoofed Host was not rejected (status {spoofed_status})"
+    )
+    assert control_status not in HOST_REJECTION_CODES, (
+        f"Loopback Host was rejected like a spoofed one (status {control_status})"
+    )
+
+
+def test_allowed_hosts_env_permits_configured_host(mcp_image):
+    """``MCP_ALLOWED_HOSTS`` lets an otherwise-untrusted Host through.
+
+    Boots a dedicated container with ``MCP_ALLOWED_HOSTS`` set and asserts the
+    configured host is accepted while a still-unlisted host is rejected.
+    """
+    allowed_host = "cognee-mcp.test"
+
+    with run_mcp_http_container(
+        mcp_image,
+        extra_env={"MCP_ALLOWED_HOSTS": f"{allowed_host}:*"},
+        name_suffix="-allowedhosts",
+    ) as container:
+        with httpx.Client(timeout=10) as client:
+            allowed_status = _post_initialize_status(
+                client, container.mcp_url, f"{allowed_host}:{container.host_port}"
+            )
+            rejected_status = _post_initialize_status(
+                client, container.mcp_url, "still-not-allowed.example.com"
+            )
+
+    assert rejected_status in HOST_REJECTION_CODES, (
+        f"Unlisted Host was not rejected (status {rejected_status})"
+    )
+    assert allowed_status not in HOST_REJECTION_CODES, (
+        f"MCP_ALLOWED_HOSTS host was rejected (status {allowed_status})"
+    )

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -33,8 +33,10 @@ EXPECTED_TOOLS = {
     "get_client_info_json",
 }
 
-# Host-validation rejection statuses, tolerant across MCP SDK versions.
-HOST_REJECTION_CODES = {400, 403, 421}
+# The MCP SDK's transport-security middleware rejects a bad Host with 421 (and a
+# bad Origin with 403); 400 is its Content-Type/JSON-parse status, so it is left
+# out here to avoid misreading a valid-Host protocol error as a Host rejection.
+HOST_REJECTION_CODES = {403, 421}
 
 _MCP_POST_HEADERS = {
     "Accept": "application/json, text/event-stream",

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -132,41 +132,6 @@ async def test_remember_recall_roundtrip(mcp_http_container):
     )
 
 
-@pytest.mark.skip(reason="Needs the T0 mock-LLM sidecar (#3358) for deterministic cognify.")
-@pytest.mark.asyncio
-async def test_remember_cognify_recall_graph_path(mcp_http_container):
-    """Permanent-memory round-trip through the knowledge graph.
-
-    Drives ``remember`` (no ``session_id``) -> cognify -> ``recall`` over the
-    graph. The recall assertion also guards against the Kuzu JSON-extension gotcha
-    (a missing extension surfaces as an error string rather than empty results).
-    """
-    unique_token = f"T3_GRAPH_{uuid.uuid4().hex}"
-    memory_text = f"Cognee graph memory anchor {unique_token} relates to deployment tests."
-
-    async with mcp_client_session(mcp_http_container.mcp_url) as session:
-        remember_result = await session.call_tool(
-            "remember",
-            arguments={"data": memory_text, "dataset_name": "t3_graph"},
-        )
-        recall_result = await session.call_tool(
-            "recall",
-            arguments={"query": unique_token, "datasets": "t3_graph", "top_k": 5},
-        )
-
-    remember_text = _text_of(remember_result)
-    recall_text = _text_of(recall_result)
-
-    assert "Stored permanently in knowledge graph" in remember_text, remember_text
-    assert "has not been installed" not in recall_text, (
-        f"Kuzu JSON extension missing — recall errored instead of returning data: {recall_text!r}"
-    )
-    assert unique_token in recall_text, (
-        f"Stored token {unique_token!r} not retrievable via graph recall. "
-        f"recall returned: {recall_text!r}"
-    )
-
-
 def test_dns_rebinding_rejects_spoofed_host(mcp_http_container):
     """With the server bound to ``0.0.0.0`` a spoofed Host header is rejected.
 

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -165,7 +165,6 @@ def test_allowed_hosts_env_permits_configured_host(mcp_image):
     with run_mcp_http_container(
         mcp_image,
         extra_env={"MCP_ALLOWED_HOSTS": f"{allowed_host}:*"},
-        name_suffix="-allowedhosts",
     ) as container:
         with httpx.Client(timeout=10) as client:
             allowed_status = _post_initialize_status(


### PR DESCRIPTION
## Summary

Reworked and hardened continuation of community PR #3656 (by @KumarNirupam1) for hackathon issue #3361 (T3) — drive the built `cognee-mcp` image through a real MCP session over streamable HTTP, validating the image as an actual MCP server rather than only that the container boots and `/health` answers.

The original author's commit is preserved as the base; every change below is layered on top as a separate, self-contained commit.

Linear: SDK-153. Closes #3361.

## What the suite does

A new opt-in deployment suite under `cognee/tests/deployment/` boots the image with `TRANSPORT_MODE=http` and, over a real MCP client at `/mcp`:

| Acceptance criterion (#3361) | Test |
| --- | --- |
| Run image with `TRANSPORT_MODE=http` + `/health` | `test_health_endpoint` |
| Connect a real MCP client over `/mcp` + assert tools | `test_list_tools_over_http` (exact 11-tool surface) |
| `remember` → `recall` round-trip | `test_remember_recall_roundtrip` (keyless session cache) |
| DNS-rebinding / `MCP_ALLOWED_HOSTS` on the `0.0.0.0` bind | `test_dns_rebinding_rejects_spoofed_host`, `test_allowed_hosts_env_permits_configured_host` |
| PR-blocking CI, mock LLM, no secrets | `.github/workflows/test_deployment_mcp.yml` |

The suite skips cleanly when Docker is unavailable, so it stays friendly on dev machines.

## Changes on top of the original commit

1. **Drop the permanently-skipped graph-path test.** It depended on the unmerged T0 mock-LLM sidecar (#3358), so it never executed and provided no live coverage — including no live coverage of the Kuzu JSON-extension guard written inside it. The round-trip criterion is already met by the keyless session test. Deferred to the #3358 follow-up, where it can actually run.
2. **Trim the CI workflow.** Drop an unreachable `workflow_call` trigger (nothing `uses:` this file) and add `timeout-minutes: 20` so a hung container/MCP session fails the blocking gate fast. The editable `cognee` install is intentionally kept: pytest imports the ancestor `cognee/tests/conftest.py`, and because `cognee/tests` is a package that pulls in the `cognee` package (and its deps, e.g. `structlog`), the runner needs cognee installed even though no deployment test imports it directly.
3. **Require a prebuilt image instead of building inside a fixture.** A bare `pytest -m deployment` no longer risks a surprise multi-minute `docker build`; it skips with the exact build command. CI builds the image explicitly beforehand (unchanged there).
4. **Remove speculative config surface** (an unused tunable-timeout env knob, a redundant container-name suffix) and correct a harness note about the mock key.
5. **Tighten `HOST_REJECTION_CODES` to `{403, 421}`** — 421 is the status the MCP SDK actually returns for a bad Host; 400 is its Content-Type/parse status and was dropped to avoid misreading a valid-Host protocol error as a rejection.

Net effect: ~56 fewer lines and less runtime surface, with no loss of any acceptance-criterion coverage.

## Verification

Docker was not available in the review environment, so the Docker-independent behavior was verified locally:

- The suite collects and skips cleanly (imports, marker registration, and the require-and-skip fixture all work): `5 skipped`.
- The keyless session `remember` → `recall` mechanism was exercised in-process against the real cognee code — the stored token is returned tagged as a session result under a dummy key (a background distillation step logs a benign embedding error but does not affect the result).
- The harness container lifecycle was unit-tested with a mocked Docker CLI: exact `docker run` argv/env wiring, URL properties, unique naming, `image_exists`, and guaranteed teardown including the health-failure path.
- `ruff format --check` and `ruff check` pass on the changed files.

The full suite then ran green on real Docker in this PR's CI (`test | deployment mcp http e2e`): the image built, the container booted in HTTP mode, and all 5 tests passed — `5 passed in 167.92s`.

## Notes for maintainers

- This workflow self-triggers on `pull_request` with a `paths:` filter (like `community_tests.yml` / `weighted_edges_tests.yml`) so the heavy image build only runs when `cognee-mcp` or the deployment tests change. If you would rather have it in the standard gate, it can instead be made `workflow_call`-only and dispatched from `test_suites.yml` (as `test_mcp.yml` / `backend_docker_build_test.yml` are) — a deliberate always-on-vs-path-scoped choice left to you.
- Graph-path round-trip and the Kuzu-extension guard are intentionally deferred to #3358.

## Out of scope
- API mode / two-container topology (T4).
- Any change to `cognee-mcp` server code.

---

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
