### PR TITLE
fix(session): drop session-cache answers grounded in deleted graph nodes (#4030)

### DIFF
--- a/cognee/infrastructure/session/session_manager.py
+++ b/cognee/infrastructure/session/session_manager.py
@@ -443,6 +443,74 @@ class SessionManager:
             lines.append(f"ANSWER: {entry.get('answer', '')}\n\n")
         return "".join(lines)
 
+    @staticmethod
+    def _entry_grounding_node_ids(entry: Any) -> list[str]:
+        """Return the graph node ids a QA entry's answer was grounded in (may be empty).
+
+        Accepts either a ``SessionQAEntry`` or a raw dict, since adapters may hand back
+        either shape.
+        """
+        if isinstance(entry, dict):
+            graph_elements = entry.get("used_graph_element_ids")
+        else:
+            graph_elements = getattr(entry, "used_graph_element_ids", None)
+        if not isinstance(graph_elements, dict):
+            return []
+        node_ids = graph_elements.get("node_ids") or []
+        return [str(node_id) for node_id in node_ids if node_id]
+
+    async def _drop_entries_grounded_in_deleted_nodes(
+        self, entries: list[SessionQAEntry]
+    ) -> list[SessionQAEntry]:
+        """Drop QA entries whose grounding graph nodes no longer exist.
+
+        Session-cache answers persist independently of the knowledge graph, so an
+        answer grounded in a document survives that document being hard-deleted
+        (``forget`` / ``delete(mode="hard")``). Replaying such an entry — either as
+        conversation history injected into the completion prompt or as an exact-question
+        cache hit — makes completions assert facts from deleted data (issue #4030).
+
+        We treat an entry as stale when any node it was grounded in is now missing from
+        the graph: its answer cited evidence that no longer exists, so it must not feed a
+        new completion. Entries without graph grounding (e.g. feedback-only turns) are
+        always kept. Fail-open: any error (or an unavailable graph engine) returns the
+        entries unchanged so a graph hiccup never drops live conversation history.
+        """
+        referenced_node_ids: set[str] = set()
+        for entry in entries:
+            referenced_node_ids.update(self._entry_grounding_node_ids(entry))
+
+        # No grounded entries → nothing the graph could have invalidated; skip the query.
+        if not referenced_node_ids:
+            return entries
+
+        try:
+            from cognee.infrastructure.databases.graph.get_graph_engine import (
+                get_graph_engine,
+            )
+
+            graph_engine = await get_graph_engine()
+            existing_nodes = await graph_engine.get_nodes(list(referenced_node_ids))
+            existing_node_ids = {
+                str(node.get("id"))
+                for node in existing_nodes
+                if isinstance(node, dict) and node.get("id") is not None
+            }
+        except Exception as error:
+            logger.warning(
+                "SessionManager: staleness check failed open, keeping session entries: %s",
+                error,
+            )
+            return entries
+
+        fresh_entries: list[SessionQAEntry] = []
+        for entry in entries:
+            grounding_ids = self._entry_grounding_node_ids(entry)
+            if grounding_ids and any(node_id not in existing_node_ids for node_id in grounding_ids):
+                continue
+            fresh_entries.append(entry)
+        return fresh_entries
+
     async def get_session(
         self,
         *,
@@ -488,10 +556,11 @@ class SessionManager:
 
         if entries is None:
             return "" if formatted else []
-        entries_list = list(entries)
+        entries_list = await self._drop_entries_grounded_in_deleted_nodes(list(entries))
         return (
             self.format_entries(
-                [entry.model_dump() for entry in entries_list], include_context=include_context
+                [entry.model_dump() for entry in entries_list],
+                include_context=include_context,
             )
             if formatted
             else entries_list
@@ -512,7 +581,8 @@ class SessionManager:
         if not self.is_available or not qa_ids:
             return []
 
-        return await self._cache.get_qa_entries_by_ids(user_id, session_id, qa_ids)
+        entries = await self._cache.get_qa_entries_by_ids(user_id, session_id, qa_ids)
+        return await self._drop_entries_grounded_in_deleted_nodes(list(entries or []))
 
     async def get_agent_trace_session(
         self,

--- a/cognee/tests/unit/infrastructure/session/test_session_manager.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_manager.py
@@ -1190,3 +1190,142 @@ class TestSessionManager:
         qa_kw = mock_cache.create_qa_entry.call_args.kwargs
         assert qa_kw["feedback_text"] is None
         assert qa_kw["feedback_score"] is None
+
+
+class TestStaleSessionEntryFiltering:
+    """Session cache must not replay QA entries grounded in deleted graph nodes (#4030).
+
+    A session answer persists independently of the knowledge graph, so after a
+    document is hard-deleted (``forget`` / ``delete(mode="hard")``) its cached answers
+    would otherwise resurface — either as conversation history injected into the
+    completion prompt or as an exact-question cache hit — and make completions assert
+    facts from data that no longer exists. ``get_session`` /
+    ``get_session_entries_by_ids`` drop any entry whose grounding nodes are gone.
+    """
+
+    @staticmethod
+    def _patch_graph_engine(monkeypatch, factory):
+        """Patch get_graph_engine on its defining module.
+
+        The ``graph`` package re-exports the ``get_graph_engine`` function, so the
+        dotted string path is ambiguous; patch the module object directly instead.
+        """
+        import importlib
+
+        gge_module = importlib.import_module(
+            "cognee.infrastructure.databases.graph.get_graph_engine"
+        )
+        monkeypatch.setattr(gge_module, "get_graph_engine", factory)
+
+    @staticmethod
+    def _entry(qa_id: str, answer: str, node_ids=None) -> SessionQAEntry:
+        return SessionQAEntry(
+            time="2031-01-01T00:00:00",
+            question=f"q-{qa_id}",
+            context="",
+            answer=answer,
+            qa_id=qa_id,
+            used_graph_element_ids={"node_ids": node_ids} if node_ids else None,
+        )
+
+    def _graph_engine_returning(self, surviving_node_ids):
+        """Mock graph engine whose get_nodes echoes back only the surviving node ids."""
+        surviving = set(surviving_node_ids)
+
+        async def get_nodes(node_ids):
+            return [{"id": nid} for nid in node_ids if nid in surviving]
+
+        engine = MagicMock()
+        engine.get_nodes = AsyncMock(side_effect=get_nodes)
+        return engine
+
+    def _sm(self, entries):
+        cache = MagicMock()
+        cache.get_latest_qa_entries = AsyncMock(return_value=list(entries))
+        cache.get_all_qa_entries = AsyncMock(return_value=list(entries))
+        cache.get_qa_entries_by_ids = AsyncMock(return_value=list(entries))
+        return SessionManager(cache_engine=cache)
+
+    @pytest.mark.asyncio
+    async def test_get_session_drops_entries_grounded_in_deleted_nodes(self, monkeypatch):
+        """An entry citing a now-missing node is dropped; a live-grounded entry survives."""
+        alive = self._entry("qa-alive", "kept", node_ids=["n-alive"])
+        stale = self._entry("qa-stale", "leaked deleted fact", node_ids=["n-deleted"])
+        sm = self._sm([alive, stale])
+        self._patch_graph_engine(
+            monkeypatch,
+            AsyncMock(return_value=self._graph_engine_returning({"n-alive"})),
+        )
+
+        result = await sm.get_session(user_id="u1", last_n=10)
+
+        assert [e.qa_id for e in result] == ["qa-alive"]
+
+    @pytest.mark.asyncio
+    async def test_get_session_empty_graph_drops_all_grounded_entries(self, monkeypatch):
+        """The #4030 scenario: graph scrubbed to zero nodes → every grounded answer dropped."""
+        entries = [
+            self._entry("qa-1", "deleted fact one", node_ids=["n1"]),
+            self._entry("qa-2", "deleted fact two", node_ids=["n2", "n3"]),
+        ]
+        sm = self._sm(entries)
+        self._patch_graph_engine(
+            monkeypatch, AsyncMock(return_value=self._graph_engine_returning(set()))
+        )
+
+        result = await sm.get_session(user_id="u1", last_n=10)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_partial_grounding_loss_drops_entry(self, monkeypatch):
+        """If any grounding node is gone the answer is stale, even if others survive."""
+        entry = self._entry("qa-mixed", "half deleted", node_ids=["n-alive", "n-deleted"])
+        sm = self._sm([entry])
+        self._patch_graph_engine(
+            monkeypatch,
+            AsyncMock(return_value=self._graph_engine_returning({"n-alive"})),
+        )
+
+        result = await sm.get_session(user_id="u1", last_n=10)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_ungrounded_entries_kept_without_graph_call(self, monkeypatch):
+        """Feedback-only turns carry no graph grounding, so keep them and skip the graph query."""
+        entry = self._entry("qa-feedback", "thanks for your feedback", node_ids=None)
+        sm = self._sm([entry])
+        graph_engine_factory = AsyncMock()
+        self._patch_graph_engine(monkeypatch, graph_engine_factory)
+
+        result = await sm.get_session(user_id="u1", last_n=10)
+
+        assert [e.qa_id for e in result] == ["qa-feedback"]
+        graph_engine_factory.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_staleness_check_fails_open_on_graph_error(self, monkeypatch):
+        """A graph hiccup must never drop live history — return entries unchanged."""
+        entry = self._entry("qa-1", "answer", node_ids=["n1"])
+        sm = self._sm([entry])
+        self._patch_graph_engine(monkeypatch, AsyncMock(side_effect=RuntimeError("graph down")))
+
+        result = await sm.get_session(user_id="u1", last_n=10)
+
+        assert [e.qa_id for e in result] == ["qa-1"]
+
+    @pytest.mark.asyncio
+    async def test_get_session_entries_by_ids_filters_stale(self, monkeypatch):
+        """The vector-hit read path (exact-question replay) is filtered too."""
+        alive = self._entry("qa-alive", "kept", node_ids=["n-alive"])
+        stale = self._entry("qa-stale", "leaked deleted fact", node_ids=["n-deleted"])
+        sm = self._sm([alive, stale])
+        self._patch_graph_engine(
+            monkeypatch,
+            AsyncMock(return_value=self._graph_engine_returning({"n-alive"})),
+        )
+
+        result = await sm.get_session_entries_by_ids(user_id="u1", qa_ids=["qa-alive", "qa-stale"])
+
+        assert [e.qa_id for e in result] == ["qa-alive"]


### PR DESCRIPTION
## Description

Fixes #4030.

With the session cache on (the default), a `GRAPH_COMPLETION` search keeps asserting facts from a document after that document has been hard-deleted — in the reporter's repro the graph is at 0 nodes / 0 edges when the stale answers are produced. The reason is that session-cache QA answers live independently of the knowledge graph, so nothing invalidates them when the underlying data is removed via `forget()` / `delete(mode="hard")`.

I traced the two mechanisms from the issue back to a single shared source. Both the exact-question replay and the session-context contamination pull prior turns through `SessionManager.get_session` / `get_session_entries_by_ids` (see the readers in `session_turn.py` and the retrievers). So rather than plumb invalidation through every deletion path and cache backend (the tracker notes in `forget.py` already flag per-dataset cache cleanup as a future enhancement because sessions aren't tagged by dataset), I filter at the read side, which is adapter-agnostic and covers every reader at once.

Each stored QA entry already records `used_graph_element_ids.node_ids` — the graph nodes its answer was grounded in. On read, I collect those ids, do one batched `graph_engine.get_nodes()` existence check, and drop any entry that was grounded in a node the graph no longer has. An entry is considered stale if **any** of its grounding nodes is gone, because a partially-deleted answer still recites removed facts.

Design choices worth calling out:
- **Ungrounded entries are always kept** (e.g. feedback-only turns), and the graph isn't queried at all when no returned entry has grounding — so feedback-only sessions pay nothing.
- **Fail-open**: if the graph engine is unavailable or the check raises, the entries are returned unchanged. A transient graph hiccup must never silently drop live conversation history. This matches the fail-open convention already used across the session layer.
- I deliberately did **not** touch the deletion path or the cache adapters, to keep this the minimal change that fixes the correctness issue. Happy to move to eager delete-time invalidation instead if maintainers prefer that direction — this read-side filter is the smaller, backend-independent option.

## Acceptance Criteria

- After a document is hard-deleted, cached answers grounded in it are no longer replayed into completions (both exact-question replay and session-context injection).
- With the graph scrubbed to zero nodes, every grounded cached answer is dropped (the exact repro scenario).
- Entries without graph grounding, and behavior when the graph check fails, are unchanged.

Proof — new regression tests, all passing locally:

```
test_get_session_drops_entries_grounded_in_deleted_nodes  PASSED
test_get_session_empty_graph_drops_all_grounded_entries   PASSED
test_partial_grounding_loss_drops_entry                   PASSED
test_ungrounded_entries_kept_without_graph_call           PASSED
test_staleness_check_fails_open_on_graph_error            PASSED
test_get_session_entries_by_ids_filters_stale             PASSED

67 passed  (full test_session_manager.py suite)
306 passed, 2 skipped  (unit/infrastructure/session + databases/cache)
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines (ruff format + ruff check pass)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
