### PR TITLE
fix(api): require update file

### DIFF
--- a/cognee/api/v1/update/routers/get_update_router.py
+++ b/cognee/api/v1/update/routers/get_update_router.py
@@ -50,7 +50,7 @@ def get_update_router() -> APIRouter:
             examples=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
         ),
         data: List[UploadFile] = File(
-            default=None,
+            ...,
             description=(
                 "New version of the document that replaces the existing one. The existing "
                 "document is deleted before the replacement is ingested, so always provide "

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -370,6 +370,20 @@ class TestMemifyEndpoint:
 
 
 class TestUpdateEndpoint:
+    def test_update_missing_file_returns_422_without_calling_update(self, client, monkeypatch):
+        import cognee.api.v1.update as update_pkg
+
+        update = AsyncMock()
+        monkeypatch.setattr(update_pkg, "update", update)
+
+        resp = client.patch(
+            "/update",
+            params={"data_id": str(uuid4()), "dataset_id": str(uuid4())},
+        )
+
+        assert resp.status_code == 422
+        update.assert_not_awaited()
+
     def test_update_pipeline_errored_returns_500(self, client):
         import cognee.api.v1.update as update_pkg
 


### PR DESCRIPTION
## Description

Require a replacement upload at the update API boundary. Previously, an omitted `data` field reached `update()`, which deletes the existing record before the replacement ingestion fails. The router now rejects that invalid request with FastAPI validation.

## Acceptance Criteria

- A PATCH request without multipart `data` fails with 422 before `update()` can run.
- The regression test exercises that boundary with TestClient and asserts the update operation is not awaited.
- Valid replacement uploads keep the existing path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Pre-submission Checklist

- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
