### PR TITLE
feat(cognee-mcp): per-request cognee-API token in API mode (multi-user)

### DIFF
--- a/cognee-mcp/src/auth_context.py
+++ b/cognee-mcp/src/auth_context.py
@@ -1,0 +1,60 @@
+"""Per-request cognee-API token resolution.
+
+In API mode one MCP process can serve many users: each outgoing cognee-API
+call must carry the *caller's* token, not only the static ``--api-token``
+given at startup. The caller's token is resolved per request:
+
+1. An explicit override set via :func:`set_request_token` (contextvar).
+   Used by auth layers that exchange the transport credential for a
+   cognee-API token, and by tests.
+2. The ``Authorization: Bearer`` header of the HTTP request that delivered
+   the current MCP message. The SDK's streamable-HTTP and SSE transports
+   attach the starlette ``Request`` to the per-message ``request_ctx``, so
+   this works inside tool handlers even though they run outside the ASGI
+   request task.
+3. ``None`` — callers fall back to the static token (single-user behaviour
+   is unchanged; stdio transport always lands here).
+"""
+
+from contextvars import ContextVar, Token
+from typing import Optional
+
+from mcp.server.lowlevel.server import request_ctx
+
+_request_token: ContextVar[Optional[str]] = ContextVar("cognee_request_token", default=None)
+
+
+def set_request_token(token: Optional[str]) -> Token:
+    """Explicitly set the caller's token; returns a Token for reset."""
+    return _request_token.set(token)
+
+
+def reset_request_token(token: Token) -> None:
+    """Undo a previous :func:`set_request_token`."""
+    _request_token.reset(token)
+
+
+def _token_from_request_ctx() -> Optional[str]:
+    """Extract a Bearer token from the HTTP request behind the current MCP message."""
+    try:
+        ctx = request_ctx.get()
+    except LookupError:
+        return None
+    headers = getattr(getattr(ctx, "request", None), "headers", None)
+    if headers is None:
+        return None
+    authorization = headers.get("authorization")
+    if not authorization:
+        return None
+    scheme, _, value = authorization.partition(" ")
+    if scheme.lower() != "bearer":
+        return None
+    return value.strip() or None
+
+
+def get_request_token() -> Optional[str]:
+    """Return the current caller's API token, or None if not in a request."""
+    token = _request_token.get()
+    if token is not None:
+        return token
+    return _token_from_request_ctx()

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -16,6 +16,11 @@ from cognee.shared.logging_utils import get_logger
 import json
 
 try:
+    from .auth_context import get_request_token
+except ImportError:
+    from auth_context import get_request_token
+
+try:
     from .server_utils import normalize_delete_mode
 except ImportError:
     from server_utils import normalize_delete_mode
@@ -72,16 +77,21 @@ class CogneeClient:
 
         Uses X-Api-Key + X-Tenant-Id for tenant APIs (cloud),
         falls back to Bearer token for local/self-hosted backends.
+
+        The token is resolved per request: the current caller's token (see
+        auth_context) takes precedence over the static api_token, so one
+        client instance can serve many users.
         """
         headers: Dict[str, str] = {}
         if include_content_type:
             headers["Content-Type"] = "application/json"
-        if self.api_token:
+        api_token = get_request_token() or self.api_token
+        if api_token:
             if self.tenant_id:
-                headers["X-Api-Key"] = self.api_token
+                headers["X-Api-Key"] = api_token
                 headers["X-Tenant-Id"] = self.tenant_id
             else:
-                headers["Authorization"] = f"Bearer {self.api_token}"
+                headers["Authorization"] = f"Bearer {api_token}"
         return headers
 
     @staticmethod

--- a/cognee-mcp/tests/test_per_request_token.py
+++ b/cognee-mcp/tests/test_per_request_token.py
@@ -1,0 +1,239 @@
+"""Per-request API token resolution (multi-tenant API mode).
+
+One MCP instance must serve N users: every outgoing cognee-API call has to
+carry the *caller's* token, not the static --api-token the process was
+started with. The caller's token is resolved per request, in priority order:
+
+1. an explicit override set via ``set_request_token()`` (contextvar),
+2. the ``Authorization: Bearer`` header of the HTTP request that carried the
+   current MCP message (``request_ctx`` from the MCP SDK),
+3. the static ``--api-token`` fallback (single-user behaviour, unchanged).
+"""
+
+import asyncio
+import contextlib
+import importlib
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import uvicorn
+from starlette.requests import Request
+
+from mcp.server.lowlevel.server import request_ctx
+from mcp.shared.context import RequestContext
+
+MCP_ROOT = Path(__file__).resolve().parents[1]  # cognee-mcp/
+if str(MCP_ROOT) not in sys.path:
+    sys.path.insert(0, str(MCP_ROOT))
+
+auth_context = importlib.import_module("src.auth_context")
+CogneeClient = importlib.import_module("src.cognee_client").CogneeClient
+
+
+def _http_request(headers: dict[str, str] | None = None) -> Request:
+    """Build a starlette Request like the SDK attaches to request_ctx."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": raw_headers,
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+def _request_context(request: Request | None) -> RequestContext:
+    """Minimal RequestContext as the lowlevel server sets it per message."""
+    return RequestContext(
+        request_id=1,
+        meta=None,
+        session=None,
+        lifespan_context=None,
+        request=request,
+    )
+
+
+# --- token resolution -------------------------------------------------------
+
+
+def test_get_request_token_returns_none_outside_any_request():
+    assert auth_context.get_request_token() is None
+
+
+def test_get_request_token_reads_bearer_from_request_ctx():
+    ctx_token = request_ctx.set(
+        _request_context(_http_request({"Authorization": "Bearer caller-jwt"}))
+    )
+    try:
+        assert auth_context.get_request_token() == "caller-jwt"
+    finally:
+        request_ctx.reset(ctx_token)
+
+
+def test_get_request_token_ignores_non_bearer_authorization():
+    ctx_token = request_ctx.set(
+        _request_context(_http_request({"Authorization": "Basic dXNlcjpwdw=="}))
+    )
+    try:
+        assert auth_context.get_request_token() is None
+    finally:
+        request_ctx.reset(ctx_token)
+
+
+def test_get_request_token_handles_request_ctx_without_http_request():
+    # stdio transport: request_ctx is set but carries no HTTP request
+    ctx_token = request_ctx.set(_request_context(None))
+    try:
+        assert auth_context.get_request_token() is None
+    finally:
+        request_ctx.reset(ctx_token)
+
+
+def test_explicit_override_wins_over_request_ctx():
+    ctx_token = request_ctx.set(
+        _request_context(_http_request({"Authorization": "Bearer from-header"}))
+    )
+    override = auth_context.set_request_token("explicit-token")
+    try:
+        assert auth_context.get_request_token() == "explicit-token"
+    finally:
+        auth_context.reset_request_token(override)
+        request_ctx.reset(ctx_token)
+    # after reset the header token is visible again
+    try:
+        assert auth_context.get_request_token() is None
+    finally:
+        pass
+
+
+# --- CogneeClient header integration ----------------------------------------
+
+
+def test_get_headers_prefers_request_token_over_static():
+    client = CogneeClient(api_url="http://cognee.local", api_token="static-token")
+    override = auth_context.set_request_token("per-request-jwt")
+    try:
+        headers = client._get_headers()
+    finally:
+        auth_context.reset_request_token(override)
+
+    assert headers["Authorization"] == "Bearer per-request-jwt"
+
+
+def test_get_headers_falls_back_to_static_token():
+    client = CogneeClient(api_url="http://cognee.local", api_token="static-token")
+
+    assert client._get_headers()["Authorization"] == "Bearer static-token"
+
+
+def test_get_headers_without_any_token_has_no_authorization():
+    client = CogneeClient(api_url="http://cognee.local")
+
+    assert "Authorization" not in client._get_headers()
+
+
+@pytest.mark.asyncio
+async def test_api_calls_send_per_request_token_per_caller():
+    """Acceptance shape: one client instance, two callers, two identities."""
+    seen: list[str | None] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("authorization"))
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = CogneeClient(api_url="http://cognee.local", api_token="static-token")
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    try:
+        for jwt in ("user-a-jwt", "user-b-jwt"):
+            ctx_token = request_ctx.set(
+                _request_context(_http_request({"Authorization": f"Bearer {jwt}"}))
+            )
+            try:
+                await client.add("memory", dataset_name="ds")
+            finally:
+                request_ctx.reset(ctx_token)
+        # no caller context -> static fallback
+        await client.add("memory", dataset_name="ds")
+    finally:
+        await client.close()
+
+    assert seen == ["Bearer user-a-jwt", "Bearer user-b-jwt", "Bearer static-token"]
+
+
+@pytest.mark.asyncio
+async def test_request_tokens_are_isolated_across_concurrent_tasks():
+    client = CogneeClient(api_url="http://cognee.local", api_token="static-token")
+    results: dict[str, str] = {}
+
+    async def caller(name: str, jwt: str, delay: float) -> None:
+        ctx_token = request_ctx.set(
+            _request_context(_http_request({"Authorization": f"Bearer {jwt}"}))
+        )
+        try:
+            await asyncio.sleep(delay)  # force interleaving
+            results[name] = client._get_headers()["Authorization"]
+        finally:
+            request_ctx.reset(ctx_token)
+
+    await asyncio.gather(caller("a", "token-a", 0.02), caller("b", "token-b", 0))
+
+    assert results == {"a": "Bearer token-a", "b": "Bearer token-b"}
+
+
+# --- full-stack integration ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_stack_forwards_caller_token(monkeypatch):
+    """The risky link: tool handlers run in the MCP session task, not in the
+    ASGI request task. Prove the Authorization header of the HTTP call reaches
+    the outgoing cognee-API request through the real streamable-HTTP stack."""
+    import src.server as server
+    from mcp.client.session import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    upstream_auth: list[str | None] = []
+
+    async def cognee_api(request: httpx.Request) -> httpx.Response:
+        upstream_auth.append(request.headers.get("authorization"))
+        return httpx.Response(200, json=[])
+
+    api_client = CogneeClient(api_url="http://cognee.local", api_token="static-token")
+    await api_client.client.aclose()
+    api_client.client = httpx.AsyncClient(transport=httpx.MockTransport(cognee_api))
+    monkeypatch.setattr(server, "cognee_client", api_client)
+
+    app = server.mcp.streamable_http_app()
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error")
+    http_server = uvicorn.Server(config)
+    serve_task = asyncio.create_task(http_server.serve())
+    try:
+        while not http_server.started:
+            await asyncio.sleep(0.02)
+        port = http_server.servers[0].sockets[0].getsockname()[1]
+        url = f"http://127.0.0.1:{port}/mcp"
+
+        async def call_as(jwt: str) -> None:
+            async with contextlib.AsyncExitStack() as stack:
+                http_client = httpx.AsyncClient(headers={"Authorization": f"Bearer {jwt}"})
+                read, write, _ = await stack.enter_async_context(
+                    streamable_http_client(url, http_client=http_client)
+                )
+                session = await stack.enter_async_context(ClientSession(read, write))
+                await session.initialize()
+                result = await session.call_tool("list_datasets_json", {})
+                assert not result.isError
+
+        await call_as("user-a-jwt")
+        await call_as("user-b-jwt")
+    finally:
+        http_server.should_exit = True
+        await serve_task
+        await api_client.close()
+
+    assert upstream_auth == ["Bearer user-a-jwt", "Bearer user-b-jwt"]


### PR DESCRIPTION
## Description

In API mode the client pins `--api-token` once at process start, so one MCP instance can be used only by one cognee-API user, even though cognee-API itself is multi-user. This PR resolves the caller's token on every request instead:

1. explicit contextvar override (`src/auth_context.py`) — a hook for auth layers sitting in front of the server;
2. the `Authorization: Bearer` header of the HTTP request that delivered the current MCP message — read via `request_ctx`, NOT via ASGI middleware: tool handlers run in the MCP session task, so a middleware-set contextvar would not propagate in stateful streamable HTTP. Both streamable-HTTP and SSE attach the starlette Request to `request_ctx`;
3. fallback to the static `--api-token` — existing single-user behaviour is unchanged (stdio always lands here).

The only production change besides the new module is `_get_headers()` in `cognee_client.py` preferring the per-request token. Relates to the operator note at server.py:1846 ("enforce auth at the transport layer"): with this change, whatever the transport-layer auth passes through as a Bearer token reaches cognee-API per caller.

## Acceptance Criteria

One API-mode instance serves two JWTs -> two cognee-API users. Proven by the included full-stack test (real uvicorn + MCP client over streamable HTTP, MockTransport at the cognee-API boundary): two sessions with different Bearer tokens produce two different Authorization headers on outgoing cognee-API calls. 11 new tests; existing suite untouched and green.

```
$ uv run pytest tests/ -q
33 passed in 3.83s
```

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (running in my self-hosted deployment)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
