### PR TITLE
feat(observability): wire Langfuse via the existing OTEL pipeline (SDK-167)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -407,6 +407,14 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # Add extra resource attributes (useful for Kubernetes, multi-instance deployments)
 # OTEL_RESOURCE_ATTRIBUTES="service.namespace=my-team,service.version=1.0"
 
+# -- Langfuse rides the same OTLP pipeline (no separate SDK). Setting these keys
+#    builds the OTLP endpoint + Basic-auth header and turns tracing on; LLM calls
+#    show up as generations. Optional and off by default. Requires cognee[tracing]. --
+# LANGFUSE_PUBLIC_KEY="pk-lf-..."
+# LANGFUSE_SECRET_KEY="sk-lf-..."
+# Defaults to https://cloud.langfuse.com; set for a region or self-hosted instance
+# LANGFUSE_HOST="https://us.cloud.langfuse.com"
+
 # Session cache settings
 # To switch to Redis caching check our documentation page sessions-and-caching
 # CACHING=true

--- a/.env.template
+++ b/.env.template
@@ -412,7 +412,8 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #    show up as generations. Optional and off by default. Requires cognee[tracing]. --
 # LANGFUSE_PUBLIC_KEY="pk-lf-..."
 # LANGFUSE_SECRET_KEY="sk-lf-..."
-# Defaults to https://cloud.langfuse.com; set for a region or self-hosted instance
+# Defaults to https://cloud.langfuse.com; set for a region or self-hosted instance.
+# LANGFUSE_BASE_URL is accepted as an alias when LANGFUSE_HOST is unset.
 # LANGFUSE_HOST="https://us.cloud.langfuse.com"
 
 # Session cache settings

--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -1,4 +1,5 @@
 import os
+import base64
 from pathlib import Path
 from typing import Optional
 from functools import lru_cache
@@ -37,18 +38,19 @@ class BaseConfig(BaseSettings):
         self.system_root_directory = ensure_absolute_path(self.system_root_directory)
         self.logs_root_directory = ensure_absolute_path(self.logs_root_directory)
 
-        # Langfuse OTLP Ergonomic Configuration
+        # Langfuse rides the existing OTLP pipeline as just another destination.
+        # When LANGFUSE_* keys are set, derive the OTLP endpoint + Basic-auth header
+        # and turn tracing on. Fully opt-in: nothing changes unless a key is present.
         if self.langfuse_public_key or self.langfuse_secret_key:
             if not (self.langfuse_public_key and self.langfuse_secret_key):
                 raise ValueError(
                     "Both LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY must be provided together."
                 )
 
-            import base64
-
             auth_str = f"{self.langfuse_public_key}:{self.langfuse_secret_key}"
             auth_b64 = base64.b64encode(auth_str.encode("utf-8")).decode("utf-8")
 
+            # Respect an explicit OTLP endpoint/headers if the user already set one.
             if not self.otel_exporter_otlp_endpoint:
                 self.otel_exporter_otlp_endpoint = (
                     f"{self.langfuse_host.rstrip('/')}/api/public/otel/v1/traces"

--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -50,11 +50,14 @@ class BaseConfig(BaseSettings):
             auth_str = f"{self.langfuse_public_key}:{self.langfuse_secret_key}"
             auth_b64 = base64.b64encode(auth_str.encode("utf-8")).decode("utf-8")
 
+            # LANGFUSE_HOST is canonical; fall back to LANGFUSE_BASE_URL, then Langfuse cloud.
+            host = (
+                self.langfuse_host or os.getenv("LANGFUSE_BASE_URL") or "https://cloud.langfuse.com"
+            )
+
             # Respect an explicit OTLP endpoint/headers if the user already set one.
             if not self.otel_exporter_otlp_endpoint:
-                self.otel_exporter_otlp_endpoint = (
-                    f"{self.langfuse_host.rstrip('/')}/api/public/otel/v1/traces"
-                )
+                self.otel_exporter_otlp_endpoint = f"{host.rstrip('/')}/api/public/otel/v1/traces"
 
             if not self.otel_exporter_otlp_headers:
                 self.otel_exporter_otlp_headers = f"Authorization=Basic {auth_b64}"
@@ -76,10 +79,12 @@ class BaseConfig(BaseSettings):
     otel_exporter_otlp_endpoint: Optional[str] = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     otel_exporter_otlp_headers: Optional[str] = os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
 
-    # Langfuse configuration
-    langfuse_public_key: Optional[str] = os.getenv("LANGFUSE_PUBLIC_KEY")
-    langfuse_secret_key: Optional[str] = os.getenv("LANGFUSE_SECRET_KEY")
-    langfuse_host: str = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
+    # Langfuse configuration. Read from the env by pydantic-settings at load time
+    # (LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_HOST); host falls back to
+    # LANGFUSE_BASE_URL, then Langfuse cloud (see validate_paths).
+    langfuse_public_key: Optional[str] = None
+    langfuse_secret_key: Optional[str] = None
+    langfuse_host: Optional[str] = None
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 

--- a/cognee/base_config.py
+++ b/cognee/base_config.py
@@ -37,6 +37,28 @@ class BaseConfig(BaseSettings):
         self.system_root_directory = ensure_absolute_path(self.system_root_directory)
         self.logs_root_directory = ensure_absolute_path(self.logs_root_directory)
 
+        # Langfuse OTLP Ergonomic Configuration
+        if self.langfuse_public_key or self.langfuse_secret_key:
+            if not (self.langfuse_public_key and self.langfuse_secret_key):
+                raise ValueError(
+                    "Both LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY must be provided together."
+                )
+
+            import base64
+
+            auth_str = f"{self.langfuse_public_key}:{self.langfuse_secret_key}"
+            auth_b64 = base64.b64encode(auth_str.encode("utf-8")).decode("utf-8")
+
+            if not self.otel_exporter_otlp_endpoint:
+                self.otel_exporter_otlp_endpoint = (
+                    f"{self.langfuse_host.rstrip('/')}/api/public/otel/v1/traces"
+                )
+
+            if not self.otel_exporter_otlp_headers:
+                self.otel_exporter_otlp_headers = f"Authorization=Basic {auth_b64}"
+
+            self.cognee_tracing_enabled = True
+
         return self
 
     default_user_email: Optional[str] = os.getenv("DEFAULT_USER_EMAIL")
@@ -51,6 +73,11 @@ class BaseConfig(BaseSettings):
     otel_service_name: str = os.getenv("OTEL_SERVICE_NAME", "cognee")
     otel_exporter_otlp_endpoint: Optional[str] = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     otel_exporter_otlp_headers: Optional[str] = os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
+
+    # Langfuse configuration
+    langfuse_public_key: Optional[str] = os.getenv("LANGFUSE_PUBLIC_KEY")
+    langfuse_secret_key: Optional[str] = os.getenv("LANGFUSE_SECRET_KEY")
+    langfuse_host: str = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 

--- a/cognee/modules/observability/get_observe.py
+++ b/cognee/modules/observability/get_observe.py
@@ -5,9 +5,14 @@ from .observers import Observer
 from .exceptions import UnsupportedObserverError
 
 
-def _set_generation_attributes(span, adapter) -> None:
-    """Emit OTel-GenAI semantic conventions on a generation span so any OTLP
-    backend (Langfuse, Dash0, Datadog, ...) renders the LLM call as a generation.
+# Cap span input/output like the DB adapters cap query text (redact_secrets(query[:500])).
+_MAX_OBSERVED_CHARS = 8000
+
+
+def _set_generation_attributes(span, adapter, func, args, kwargs) -> None:
+    """Emit OTel-GenAI + Langfuse attributes on a generation span so any OTLP backend
+    (Langfuse, Dash0, Datadog, ...) renders the LLM call as a generation with model
+    and input.
 
     ``langfuse.observation.type`` is set unconditionally so the span is still
     classified as a generation when the model name is unavailable (e.g. llama.cpp
@@ -18,6 +23,8 @@ def _set_generation_attributes(span, adapter) -> None:
         GEN_AI_REQUEST_MODEL,
         GEN_AI_SYSTEM,
         LANGFUSE_OBSERVATION_TYPE,
+        LANGFUSE_OBSERVATION_INPUT,
+        redact_secrets,
     )
 
     span.set_attribute(LANGFUSE_OBSERVATION_TYPE, "generation")
@@ -29,6 +36,54 @@ def _set_generation_attributes(span, adapter) -> None:
     provider = getattr(adapter, "name", None)
     if provider:
         span.set_attribute(GEN_AI_SYSTEM, provider.lower())
+
+    payload = _generation_input_payload(func, args, kwargs)
+    if payload:
+        span.set_attribute(
+            LANGFUSE_OBSERVATION_INPUT, redact_secrets(payload[:_MAX_OBSERVED_CHARS])
+        )
+
+
+def _generation_input_payload(func, args, kwargs):
+    """Bind the LLM-adapter call and record its string prompt arguments as a JSON string,
+    keyed by parameter name. Works for positional and keyword calls, and is name-agnostic
+    so it keeps capturing the prompt if the adapter parameters are renamed. Skips
+    ``self``/``response_model`` and non-string args (the response-model type, numeric
+    options, the ``**kwargs`` dict). Returns None if the call can't be interpreted."""
+    import json
+    import inspect
+
+    try:
+        bound = inspect.signature(func).bind(*args, **kwargs)
+        bound.apply_defaults()
+        payload = {
+            name: value
+            for name, value in bound.arguments.items()
+            if name not in ("self", "cls", "response_model") and isinstance(value, str) and value
+        }
+        return json.dumps(payload, default=str) if payload else None
+    except Exception:
+        return None
+
+
+def _set_generation_output(span, result) -> None:
+    """Record the LLM response as the Langfuse output (best effort; never raises)."""
+    import json
+
+    from cognee.modules.observability.tracing import LANGFUSE_OBSERVATION_OUTPUT, redact_secrets
+
+    try:
+        if hasattr(result, "model_dump_json"):  # a pydantic structured output
+            output = result.model_dump_json()
+        elif isinstance(result, str):
+            output = result
+        else:
+            output = json.dumps(result, default=str)
+        span.set_attribute(
+            LANGFUSE_OBSERVATION_OUTPUT, redact_secrets(output[:_MAX_OBSERVED_CHARS])
+        )
+    except Exception:
+        pass
 
 
 def _wrap_with_otel(inner_decorator):
@@ -70,9 +125,13 @@ def _wrap_with_otel(inner_decorator):
                         f"cognee.observe.{func.__name__}", kind=kind
                     ) as span:
                         span.set_attribute(COGNEE_SPAN_CATEGORY, category)
-                        if category == "generation" and args:
-                            _set_generation_attributes(span, args[0])
-                        return await wrapped(*args, **kwargs)
+                        is_generation = category == "generation" and bool(args)
+                        if is_generation:
+                            _set_generation_attributes(span, args[0], func, args, kwargs)
+                        result = await wrapped(*args, **kwargs)
+                        if is_generation:
+                            _set_generation_output(span, result)
+                        return result
 
                 @functools.wraps(func)
                 def sync_wrapper(*args, **kwargs):
@@ -96,9 +155,13 @@ def _wrap_with_otel(inner_decorator):
                         f"cognee.observe.{func.__name__}", kind=kind
                     ) as span:
                         span.set_attribute(COGNEE_SPAN_CATEGORY, category)
-                        if category == "generation" and args:
-                            _set_generation_attributes(span, args[0])
-                        return wrapped(*args, **kwargs)
+                        is_generation = category == "generation" and bool(args)
+                        if is_generation:
+                            _set_generation_attributes(span, args[0], func, args, kwargs)
+                        result = wrapped(*args, **kwargs)
+                        if is_generation:
+                            _set_generation_output(span, result)
+                        return result
 
                 import asyncio
 

--- a/cognee/modules/observability/get_observe.py
+++ b/cognee/modules/observability/get_observe.py
@@ -5,6 +5,32 @@ from .observers import Observer
 from .exceptions import UnsupportedObserverError
 
 
+def _set_generation_attributes(span, adapter) -> None:
+    """Emit OTel-GenAI semantic conventions on a generation span so any OTLP
+    backend (Langfuse, Dash0, Datadog, ...) renders the LLM call as a generation.
+
+    ``langfuse.observation.type`` is set unconditionally so the span is still
+    classified as a generation when the model name is unavailable (e.g. llama.cpp
+    local mode leaves ``model=None``). ``gen_ai.request.model`` is the *requested*
+    model; provider names follow the lowercase GenAI convention.
+    """
+    from cognee.modules.observability.tracing import (
+        GEN_AI_REQUEST_MODEL,
+        GEN_AI_SYSTEM,
+        LANGFUSE_OBSERVATION_TYPE,
+    )
+
+    span.set_attribute(LANGFUSE_OBSERVATION_TYPE, "generation")
+
+    model = getattr(adapter, "model", None)
+    if model:
+        span.set_attribute(GEN_AI_REQUEST_MODEL, model)
+
+    provider = getattr(adapter, "name", None)
+    if provider:
+        span.set_attribute(GEN_AI_SYSTEM, provider.lower())
+
+
 def _wrap_with_otel(inner_decorator):
     """Compose OTEL span creation around an existing decorator.
 
@@ -33,8 +59,6 @@ def _wrap_with_otel(inner_decorator):
                     from cognee.modules.observability.tracing import (
                         get_tracer,
                         COGNEE_SPAN_CATEGORY,
-                        COGNEE_LLM_MODEL,
-                        COGNEE_LLM_PROVIDER,
                     )
 
                     tracer = get_tracer()
@@ -42,14 +66,12 @@ def _wrap_with_otel(inner_decorator):
                         return await wrapped(*args, **kwargs)
 
                     kind = SpanKind.CLIENT if category == "generation" else SpanKind.INTERNAL
-                    with tracer.start_as_current_span(f"cognee.observe.{func.__name__}", kind=kind) as span:
+                    with tracer.start_as_current_span(
+                        f"cognee.observe.{func.__name__}", kind=kind
+                    ) as span:
                         span.set_attribute(COGNEE_SPAN_CATEGORY, category)
-                        if category == "generation" and len(args) > 0:
-                            adapter = args[0]
-                            if hasattr(adapter, "model"):
-                                span.set_attribute(COGNEE_LLM_MODEL, adapter.model)
-                            if hasattr(adapter, "name"):
-                                span.set_attribute(COGNEE_LLM_PROVIDER, adapter.name.lower())
+                        if category == "generation" and args:
+                            _set_generation_attributes(span, args[0])
                         return await wrapped(*args, **kwargs)
 
                 @functools.wraps(func)
@@ -63,8 +85,6 @@ def _wrap_with_otel(inner_decorator):
                     from cognee.modules.observability.tracing import (
                         get_tracer,
                         COGNEE_SPAN_CATEGORY,
-                        COGNEE_LLM_MODEL,
-                        COGNEE_LLM_PROVIDER,
                     )
 
                     tracer = get_tracer()
@@ -72,14 +92,12 @@ def _wrap_with_otel(inner_decorator):
                         return wrapped(*args, **kwargs)
 
                     kind = SpanKind.CLIENT if category == "generation" else SpanKind.INTERNAL
-                    with tracer.start_as_current_span(f"cognee.observe.{func.__name__}", kind=kind) as span:
+                    with tracer.start_as_current_span(
+                        f"cognee.observe.{func.__name__}", kind=kind
+                    ) as span:
                         span.set_attribute(COGNEE_SPAN_CATEGORY, category)
-                        if category == "generation" and len(args) > 0:
-                            adapter = args[0]
-                            if hasattr(adapter, "model"):
-                                span.set_attribute(COGNEE_LLM_MODEL, adapter.model)
-                            if hasattr(adapter, "name"):
-                                span.set_attribute(COGNEE_LLM_PROVIDER, adapter.name.lower())
+                        if category == "generation" and args:
+                            _set_generation_attributes(span, args[0])
                         return wrapped(*args, **kwargs)
 
                 import asyncio

--- a/cognee/modules/observability/get_observe.py
+++ b/cognee/modules/observability/get_observe.py
@@ -29,17 +29,27 @@ def _wrap_with_otel(inner_decorator):
                     if not is_tracing_enabled():
                         return await wrapped(*args, **kwargs)
 
+                    from opentelemetry.trace import SpanKind
                     from cognee.modules.observability.tracing import (
                         get_tracer,
                         COGNEE_SPAN_CATEGORY,
+                        COGNEE_LLM_MODEL,
+                        COGNEE_LLM_PROVIDER,
                     )
 
                     tracer = get_tracer()
                     if tracer is None:
                         return await wrapped(*args, **kwargs)
 
-                    with tracer.start_as_current_span(f"cognee.observe.{func.__name__}") as span:
+                    kind = SpanKind.CLIENT if category == "generation" else SpanKind.INTERNAL
+                    with tracer.start_as_current_span(f"cognee.observe.{func.__name__}", kind=kind) as span:
                         span.set_attribute(COGNEE_SPAN_CATEGORY, category)
+                        if category == "generation" and len(args) > 0:
+                            adapter = args[0]
+                            if hasattr(adapter, "model"):
+                                span.set_attribute(COGNEE_LLM_MODEL, adapter.model)
+                            if hasattr(adapter, "name"):
+                                span.set_attribute(COGNEE_LLM_PROVIDER, adapter.name.lower())
                         return await wrapped(*args, **kwargs)
 
                 @functools.wraps(func)
@@ -49,17 +59,27 @@ def _wrap_with_otel(inner_decorator):
                     if not is_tracing_enabled():
                         return wrapped(*args, **kwargs)
 
+                    from opentelemetry.trace import SpanKind
                     from cognee.modules.observability.tracing import (
                         get_tracer,
                         COGNEE_SPAN_CATEGORY,
+                        COGNEE_LLM_MODEL,
+                        COGNEE_LLM_PROVIDER,
                     )
 
                     tracer = get_tracer()
                     if tracer is None:
                         return wrapped(*args, **kwargs)
 
-                    with tracer.start_as_current_span(f"cognee.observe.{func.__name__}") as span:
+                    kind = SpanKind.CLIENT if category == "generation" else SpanKind.INTERNAL
+                    with tracer.start_as_current_span(f"cognee.observe.{func.__name__}", kind=kind) as span:
                         span.set_attribute(COGNEE_SPAN_CATEGORY, category)
+                        if category == "generation" and len(args) > 0:
+                            adapter = args[0]
+                            if hasattr(adapter, "model"):
+                                span.set_attribute(COGNEE_LLM_MODEL, adapter.model)
+                            if hasattr(adapter, "name"):
+                                span.set_attribute(COGNEE_LLM_PROVIDER, adapter.name.lower())
                         return wrapped(*args, **kwargs)
 
                 import asyncio

--- a/cognee/modules/observability/tracing.py
+++ b/cognee/modules/observability/tracing.py
@@ -250,6 +250,28 @@ def _is_auto_instrumented() -> bool:
     return current is not None and type(current).__name__ != "ProxyTracerProvider"
 
 
+class LangfuseAttributeProcessor(SimpleSpanProcessor):
+    """Maps Cognee attributes to Langfuse/OTel-GenAI semantic conventions."""
+
+    def on_end(self, span: "ReadableSpan") -> None:
+        if hasattr(span, "_attributes") and span._attributes is not None:
+            attrs = span._attributes
+            if COGNEE_LLM_MODEL in attrs:
+                attrs["gen_ai.request.model"] = attrs[COGNEE_LLM_MODEL]
+            if COGNEE_LLM_PROVIDER in attrs:
+                attrs["gen_ai.system"] = attrs[COGNEE_LLM_PROVIDER]
+
+            # Anticipating hackathon PR #3606 token metering
+            if "cognee.llm.input_tokens" in attrs:
+                attrs["gen_ai.usage.input_tokens"] = attrs["cognee.llm.input_tokens"]
+            if "cognee.llm.output_tokens" in attrs:
+                attrs["gen_ai.usage.output_tokens"] = attrs["cognee.llm.output_tokens"]
+            if "cognee.llm.cost" in attrs:
+                attrs["gen_ai.usage.cost"] = attrs["cognee.llm.cost"]
+
+        super().on_end(span)
+
+
 def _try_add_otlp_exporter(provider: "TracerProvider") -> None:
     """If an OTLP endpoint is configured, add an OTLP span exporter.
 
@@ -263,21 +285,59 @@ def _try_add_otlp_exporter(provider: "TracerProvider") -> None:
     if not config.otel_exporter_otlp_endpoint:
         return
 
+    is_langfuse = "langfuse" in config.otel_exporter_otlp_endpoint.lower()
+
+    # Parse headers if present
+    headers = None
+    if config.otel_exporter_otlp_headers:
+        headers = {}
+        for pair in config.otel_exporter_otlp_headers.split(","):
+            if "=" in pair:
+                k, v = pair.split("=", 1)
+                headers[k.strip()] = v.strip()
+
+    def _add_http_exporter():
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter as OTLPHttpSpanExporter,
+        )
+
+        kwargs = {"endpoint": config.otel_exporter_otlp_endpoint}
+        if headers:
+            kwargs["headers"] = headers
+
+        otlp_exporter = OTLPHttpSpanExporter(**kwargs)
+        if is_langfuse:
+            provider.add_span_processor(LangfuseAttributeProcessor(otlp_exporter))
+        else:
+            provider.add_span_processor(SimpleSpanProcessor(otlp_exporter))
+
+    if is_langfuse:
+        # Langfuse only supports HTTP OTLP
+        try:
+            _add_http_exporter()
+        except ImportError:
+            import warnings
+
+            warnings.warn(
+                "OTLP HTTP exporter is required for Langfuse. Install with: pip install cognee[tracing]",
+                stacklevel=2,
+            )
+        return
+
     try:
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
             OTLPSpanExporter,
         )
 
-        otlp_exporter = OTLPSpanExporter(endpoint=config.otel_exporter_otlp_endpoint)
+        kwargs = {"endpoint": config.otel_exporter_otlp_endpoint}
+        if headers:
+            kwargs["headers"] = headers
+
+        otlp_exporter = OTLPSpanExporter(**kwargs)
         provider.add_span_processor(SimpleSpanProcessor(otlp_exporter))
     except ImportError:
         try:
-            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-                OTLPSpanExporter as OTLPHttpSpanExporter,
-            )
-
-            otlp_exporter = OTLPHttpSpanExporter(endpoint=config.otel_exporter_otlp_endpoint)
-            provider.add_span_processor(SimpleSpanProcessor(otlp_exporter))
+            _add_http_exporter()
         except ImportError:
             import warnings
 

--- a/cognee/modules/observability/tracing.py
+++ b/cognee/modules/observability/tracing.py
@@ -45,12 +45,15 @@ COGNEE_RESULT_SUMMARY = "cognee.result.summary"
 COGNEE_RESULT_COUNT = "cognee.result.count"
 COGNEE_PIPELINE_NAME = "cognee.pipeline.name"
 
-# OTel-GenAI semantic conventions + the Langfuse observation-type hint. Emitted
+# OTel-GenAI semantic conventions + the Langfuse observation attributes. Emitted
 # on generation spans (see get_observe) so any OTLP backend — Langfuse included —
-# renders LLM calls as generations without a separate SDK or attribute rewrite.
+# renders LLM calls as generations with model, input and output. langfuse.observation.*
+# are Langfuse's highest-priority input/output sources (JSON-string values).
 GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
 GEN_AI_SYSTEM = "gen_ai.system"
 LANGFUSE_OBSERVATION_TYPE = "langfuse.observation.type"
+LANGFUSE_OBSERVATION_INPUT = "langfuse.observation.input"
+LANGFUSE_OBSERVATION_OUTPUT = "langfuse.observation.output"
 
 # V2 API attributes
 COGNEE_DATASET_NAME = "cognee.dataset.name"

--- a/cognee/modules/observability/tracing.py
+++ b/cognee/modules/observability/tracing.py
@@ -45,6 +45,13 @@ COGNEE_RESULT_SUMMARY = "cognee.result.summary"
 COGNEE_RESULT_COUNT = "cognee.result.count"
 COGNEE_PIPELINE_NAME = "cognee.pipeline.name"
 
+# OTel-GenAI semantic conventions + the Langfuse observation-type hint. Emitted
+# on generation spans (see get_observe) so any OTLP backend — Langfuse included —
+# renders LLM calls as generations without a separate SDK or attribute rewrite.
+GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
+GEN_AI_SYSTEM = "gen_ai.system"
+LANGFUSE_OBSERVATION_TYPE = "langfuse.observation.type"
+
 # V2 API attributes
 COGNEE_DATASET_NAME = "cognee.dataset.name"
 COGNEE_SESSION_ID = "cognee.session.id"
@@ -250,91 +257,62 @@ def _is_auto_instrumented() -> bool:
     return current is not None and type(current).__name__ != "ProxyTracerProvider"
 
 
-class LangfuseAttributeProcessor(SimpleSpanProcessor):
-    """Maps Cognee attributes to Langfuse/OTel-GenAI semantic conventions."""
-
-    def on_end(self, span: "ReadableSpan") -> None:
-        if hasattr(span, "_attributes") and span._attributes is not None:
-            attrs = span._attributes
-            
-            # OpenTelemetry freezes attributes on span end. We temporarily unfreeze them to map to Langfuse conventions.
-            was_immutable = getattr(attrs, "_immutable", False)
-            if was_immutable:
-                attrs._immutable = False
-                
-            if COGNEE_LLM_MODEL in attrs:
-                attrs["gen_ai.request.model"] = attrs[COGNEE_LLM_MODEL]
-            if COGNEE_LLM_PROVIDER in attrs:
-                attrs["gen_ai.system"] = attrs[COGNEE_LLM_PROVIDER]
-            
-            # Hard override to guarantee Langfuse parses it as a generation
-            if attrs.get(COGNEE_SPAN_CATEGORY) == "generation":
-                attrs["langfuse.observation.type"] = "generation"
-            
-            # Anticipating hackathon PR #3606 token metering
-            if "cognee.llm.input_tokens" in attrs:
-                attrs["gen_ai.usage.input_tokens"] = attrs["cognee.llm.input_tokens"]
-            if "cognee.llm.output_tokens" in attrs:
-                attrs["gen_ai.usage.output_tokens"] = attrs["cognee.llm.output_tokens"]
-            if "cognee.llm.cost" in attrs:
-                attrs["gen_ai.usage.cost"] = attrs["cognee.llm.cost"]
-
-            if was_immutable:
-                attrs._immutable = True
-
-        super().on_end(span)
+def _parse_otlp_headers(raw: Optional[str]) -> Optional[dict]:
+    """Parse an ``OTEL_EXPORTER_OTLP_HEADERS``-style ``key=value,key2=value2``
+    string into a dict. Splitting on the first ``=`` preserves base64 padding in
+    values (e.g. ``Authorization=Basic abc==``). Returns None when empty."""
+    if not raw:
+        return None
+    headers: dict[str, str] = {}
+    for pair in raw.split(","):
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            headers[key.strip()] = value.strip()
+    return headers or None
 
 
 def _try_add_otlp_exporter(provider: "TracerProvider") -> None:
     """If an OTLP endpoint is configured, add an OTLP span exporter.
 
-    Reads the endpoint from ``BaseConfig.otel_exporter_otlp_endpoint``.
-    The OTLP exporters also honour the standard ``OTEL_EXPORTER_OTLP_*``
-    env vars for headers, compression, etc.
+    Reads the endpoint and headers from ``BaseConfig``. The OTLP exporters also
+    honour the standard ``OTEL_EXPORTER_OTLP_*`` env vars for compression, etc.
+
+    Langfuse's OTLP endpoint (``/api/public/otel``) only accepts OTLP over HTTP,
+    so the HTTP exporter is forced for it — including self-hosted instances on a
+    custom domain. Every other endpoint prefers gRPC and falls back to HTTP.
     """
     from cognee.base_config import get_base_config
 
     config = get_base_config()
-    if not config.otel_exporter_otlp_endpoint:
+    endpoint = config.otel_exporter_otlp_endpoint
+    if not endpoint:
         return
 
-    is_langfuse = "langfuse" in config.otel_exporter_otlp_endpoint.lower()
+    headers = _parse_otlp_headers(config.otel_exporter_otlp_headers)
 
-    # Parse headers if present
-    headers = None
-    if config.otel_exporter_otlp_headers:
-        headers = {}
-        for pair in config.otel_exporter_otlp_headers.split(","):
-            if "=" in pair:
-                k, v = pair.split("=", 1)
-                headers[k.strip()] = v.strip()
-
-    def _add_http_exporter():
+    def _add_http_exporter() -> None:
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
             OTLPSpanExporter as OTLPHttpSpanExporter,
         )
 
-        kwargs = {"endpoint": config.otel_exporter_otlp_endpoint}
-        if headers:
-            kwargs["headers"] = headers
+        exporter = OTLPHttpSpanExporter(endpoint=endpoint, headers=headers)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
 
-        otlp_exporter = OTLPHttpSpanExporter(**kwargs)
-        if is_langfuse:
-            provider.add_span_processor(LangfuseAttributeProcessor(otlp_exporter))
-        else:
-            provider.add_span_processor(SimpleSpanProcessor(otlp_exporter))
+    def _warn_no_exporter() -> None:
+        import warnings
 
-    if is_langfuse:
-        # Langfuse only supports HTTP OTLP
+        warnings.warn(
+            "otel_exporter_otlp_endpoint is set but no OTLP exporter is installed. "
+            "Install with: pip install cognee[tracing]",
+            stacklevel=2,
+        )
+
+    # Langfuse ingests OTLP over HTTP only (no gRPC).
+    if "/api/public/otel" in endpoint:
         try:
             _add_http_exporter()
         except ImportError:
-            import warnings
-
-            warnings.warn(
-                "OTLP HTTP exporter is required for Langfuse. Install with: pip install cognee[tracing]",
-                stacklevel=2,
-            )
+            _warn_no_exporter()
         return
 
     try:
@@ -342,23 +320,13 @@ def _try_add_otlp_exporter(provider: "TracerProvider") -> None:
             OTLPSpanExporter,
         )
 
-        kwargs = {"endpoint": config.otel_exporter_otlp_endpoint}
-        if headers:
-            kwargs["headers"] = headers
-
-        otlp_exporter = OTLPSpanExporter(**kwargs)
-        provider.add_span_processor(SimpleSpanProcessor(otlp_exporter))
+        exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
     except ImportError:
         try:
             _add_http_exporter()
         except ImportError:
-            import warnings
-
-            warnings.warn(
-                "otel_exporter_otlp_endpoint is set but no OTLP exporter is installed. "
-                "Install with: pip install cognee[tracing]",
-                stacklevel=2,
-            )
+            _warn_no_exporter()
 
 
 def setup_tracing(console_output: bool = False) -> "trace.Tracer":

--- a/cognee/modules/observability/tracing.py
+++ b/cognee/modules/observability/tracing.py
@@ -256,11 +256,21 @@ class LangfuseAttributeProcessor(SimpleSpanProcessor):
     def on_end(self, span: "ReadableSpan") -> None:
         if hasattr(span, "_attributes") and span._attributes is not None:
             attrs = span._attributes
+            
+            # OpenTelemetry freezes attributes on span end. We temporarily unfreeze them to map to Langfuse conventions.
+            was_immutable = getattr(attrs, "_immutable", False)
+            if was_immutable:
+                attrs._immutable = False
+                
             if COGNEE_LLM_MODEL in attrs:
                 attrs["gen_ai.request.model"] = attrs[COGNEE_LLM_MODEL]
             if COGNEE_LLM_PROVIDER in attrs:
                 attrs["gen_ai.system"] = attrs[COGNEE_LLM_PROVIDER]
-
+            
+            # Hard override to guarantee Langfuse parses it as a generation
+            if attrs.get(COGNEE_SPAN_CATEGORY) == "generation":
+                attrs["langfuse.observation.type"] = "generation"
+            
             # Anticipating hackathon PR #3606 token metering
             if "cognee.llm.input_tokens" in attrs:
                 attrs["gen_ai.usage.input_tokens"] = attrs["cognee.llm.input_tokens"]
@@ -268,6 +278,9 @@ class LangfuseAttributeProcessor(SimpleSpanProcessor):
                 attrs["gen_ai.usage.output_tokens"] = attrs["cognee.llm.output_tokens"]
             if "cognee.llm.cost" in attrs:
                 attrs["gen_ai.usage.cost"] = attrs["cognee.llm.cost"]
+
+            if was_immutable:
+                attrs._immutable = True
 
         super().on_end(span)
 

--- a/cognee/tests/unit/modules/observability/test_langfuse_otel.py
+++ b/cognee/tests/unit/modules/observability/test_langfuse_otel.py
@@ -1,114 +1,240 @@
+"""Tests for the Langfuse OTLP integration.
+
+Covers the three pieces of the feature, all offline (no live Langfuse):
+  1. ergonomic ``LANGFUSE_*`` config -> OTLP endpoint + Basic-auth header,
+  2. the exporter wiring (Langfuse forces the HTTP exporter),
+  3. the attribute mapping, asserted on *exported* span payloads via an
+     in-memory stub collector.
+"""
+
 import os
+import asyncio
+import base64
 from unittest.mock import patch, MagicMock
 
 import pytest
 
+try:
+    from opentelemetry.sdk.trace import TracerProvider  # noqa: F401
 
-def test_langfuse_config_enabled():
-    fake_pk = "pk-12345"
-    fake_sk = "sk-67890"
+    _OTEL_AVAILABLE = True
+except ImportError:
+    _OTEL_AVAILABLE = False
+
+# The exporter-wiring and span-mapping tests need the cognee[tracing] extra; the
+# config/header tests below do not. Mirrors the guard in test_tracing.py.
+requires_otel = pytest.mark.skipif(
+    not _OTEL_AVAILABLE, reason="requires the cognee[tracing] extra (opentelemetry-sdk)"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_base_config_cache():
+    """Keep the cached, env-derived BaseConfig from leaking between tests."""
+    from cognee.base_config import get_base_config
+
+    get_base_config.cache_clear()
+    yield
+    get_base_config.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Ergonomic config
+# ---------------------------------------------------------------------------
+def test_langfuse_config_builds_endpoint_and_headers():
     with patch.dict(
         os.environ,
         {
-            "LANGFUSE_PUBLIC_KEY": fake_pk,
-            "LANGFUSE_SECRET_KEY": fake_sk,
+            "LANGFUSE_PUBLIC_KEY": "pk-12345",
+            "LANGFUSE_SECRET_KEY": "sk-67890",
             "LANGFUSE_HOST": "https://us.cloud.langfuse.com",
         },
         clear=True,
     ):
         from cognee.base_config import get_base_config
 
-        get_base_config.cache_clear()
         config = get_base_config()
 
         assert (
             config.otel_exporter_otlp_endpoint
             == "https://us.cloud.langfuse.com/api/public/otel/v1/traces"
         )
-
-        import base64
-
-        expected_b64 = base64.b64encode(f"{fake_pk}:{fake_sk}".encode("utf-8")).decode("utf-8")
-        assert config.otel_exporter_otlp_headers == f"Authorization=Basic {expected_b64}"
+        expected = base64.b64encode(b"pk-12345:sk-67890").decode("utf-8")
+        assert config.otel_exporter_otlp_headers == f"Authorization=Basic {expected}"
         assert config.cognee_tracing_enabled is True
 
 
-def test_langfuse_config_missing_key():
-    with patch.dict(
-        os.environ,
-        {
-            "LANGFUSE_PUBLIC_KEY": "pk-123",
-        },
-        clear=True,
-    ):
+def test_langfuse_config_requires_both_keys():
+    with patch.dict(os.environ, {"LANGFUSE_PUBLIC_KEY": "pk-123"}, clear=True):
         from cognee.base_config import get_base_config
-
-        get_base_config.cache_clear()
 
         with pytest.raises(ValueError, match="must be provided together"):
             get_base_config()
 
 
-def test_langfuse_attribute_processor():
-    from opentelemetry.sdk.trace import ReadableSpan
-    from cognee.modules.observability.tracing import (
-        LangfuseAttributeProcessor,
-        COGNEE_LLM_MODEL,
-        COGNEE_LLM_PROVIDER,
-    )
-
-    mock_exporter = MagicMock()
-    processor = LangfuseAttributeProcessor(mock_exporter)
-
-    span = MagicMock(spec=ReadableSpan)
-    span._attributes = {
-        COGNEE_LLM_MODEL: "gpt-4",
-        COGNEE_LLM_PROVIDER: "openai",
-        "cognee.llm.input_tokens": 10,
-        "cognee.llm.cost": 0.01,
-    }
-
-    processor.on_end(span)
-
-    assert span._attributes["gen_ai.request.model"] == "gpt-4"
-    assert span._attributes["gen_ai.system"] == "openai"
-    assert span._attributes["gen_ai.usage.input_tokens"] == 10
-    assert span._attributes["gen_ai.usage.cost"] == 0.01
-
-
-@patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter")
-def test_langfuse_exporter_http_fallback(mock_exporter_cls):
-    fake_pk = "pk-12345"
-    fake_sk = "sk-67890"
+def test_langfuse_config_respects_explicit_endpoint():
+    """An explicitly configured OTLP endpoint/headers wins over the derived one."""
     with patch.dict(
         os.environ,
         {
-            "LANGFUSE_PUBLIC_KEY": fake_pk,
-            "LANGFUSE_SECRET_KEY": fake_sk,
+            "LANGFUSE_PUBLIC_KEY": "pk-1",
+            "LANGFUSE_SECRET_KEY": "sk-2",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "https://collector.internal/v1/traces",
+            "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer token",
         },
         clear=True,
     ):
         from cognee.base_config import get_base_config
-        from cognee.modules.observability.tracing import (
-            _try_add_otlp_exporter,
-            LangfuseAttributeProcessor,
-        )
+
+        config = get_base_config()
+
+        assert config.otel_exporter_otlp_endpoint == "https://collector.internal/v1/traces"
+        assert config.otel_exporter_otlp_headers == "Authorization=Bearer token"
+        assert config.cognee_tracing_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Exporter wiring
+# ---------------------------------------------------------------------------
+def test_parse_otlp_headers():
+    from cognee.modules.observability.tracing import _parse_otlp_headers
+
+    assert _parse_otlp_headers(None) is None
+    assert _parse_otlp_headers("") is None
+    # Splitting on the first "=" preserves base64 "==" padding in the value.
+    assert _parse_otlp_headers("Authorization=Basic YWJjOg==") == {
+        "Authorization": "Basic YWJjOg=="
+    }
+    assert _parse_otlp_headers("a=1, b=2") == {"a": "1", "b": "2"}
+
+
+@requires_otel
+def test_langfuse_endpoint_forces_http_exporter(monkeypatch):
+    """Langfuse endpoints route to the HTTP exporter (gRPC is unsupported), built with
+    the derived endpoint + Basic-auth header. A fake exporter module stands in so the
+    test does not require the optional opentelemetry-exporter-otlp-proto-http package."""
+    import sys
+    import types
+
+    with patch.dict(
+        os.environ,
+        {"LANGFUSE_PUBLIC_KEY": "pk-12345", "LANGFUSE_SECRET_KEY": "sk-67890"},
+        clear=True,
+    ):
+        from cognee.base_config import get_base_config
+        from cognee.modules.observability.tracing import _try_add_otlp_exporter
 
         get_base_config.cache_clear()
 
-        mock_provider = MagicMock()
-        _try_add_otlp_exporter(mock_provider)
+        constructed = {}
 
-        mock_exporter_cls.assert_called_once()
-        kwargs = mock_exporter_cls.call_args.kwargs
-        assert "https://cloud.langfuse.com/api/public/otel/v1/traces" in kwargs["endpoint"]
-        assert "Authorization" in kwargs["headers"]
+        class FakeHttpExporter:
+            def __init__(self, endpoint=None, headers=None):
+                constructed["endpoint"] = endpoint
+                constructed["headers"] = headers
 
-        import base64
+        module_name = "opentelemetry.exporter.otlp.proto.http.trace_exporter"
+        fake_module = types.ModuleType(module_name)
+        fake_module.OTLPSpanExporter = FakeHttpExporter
+        monkeypatch.setitem(sys.modules, module_name, fake_module)
 
-        expected_b64 = base64.b64encode(f"{fake_pk}:{fake_sk}".encode("utf-8")).decode("utf-8")
-        assert kwargs["headers"]["Authorization"] == f"Basic {expected_b64}"
+        provider = MagicMock()
+        _try_add_otlp_exporter(provider)
 
-        mock_provider.add_span_processor.assert_called_once()
-        args = mock_provider.add_span_processor.call_args.args
-        assert isinstance(args[0], LangfuseAttributeProcessor)
+        assert constructed["endpoint"] == "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        expected = base64.b64encode(b"pk-12345:sk-67890").decode("utf-8")
+        assert constructed["headers"]["Authorization"] == f"Basic {expected}"
+        provider.add_span_processor.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Attribute mapping — asserted on exported span payloads
+# ---------------------------------------------------------------------------
+def _tracer_with_collector():
+    """A real TracerProvider wired to an in-memory stub OTLP collector."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    collector = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(collector))
+    return collector, provider, provider.get_tracer("test")
+
+
+def _run_observed(monkeypatch, category, adapter_cls):
+    """Drive an @observe-decorated method with tracing pointed at a stub collector,
+    and return the single exported span."""
+    import cognee.modules.observability.tracing as tracing
+    import cognee.modules.observability.trace_context as trace_context
+    from cognee.modules.observability.get_observe import get_observe
+
+    collector, provider, tracer = _tracer_with_collector()
+    monkeypatch.setattr(tracing, "_tracer", tracer)
+    monkeypatch.setattr(trace_context, "_tracing_enabled", True)
+
+    observe = get_observe()
+
+    class _Decorated(adapter_cls):
+        @observe(as_type=category)
+        async def run(self):
+            return "ok"
+
+    assert asyncio.run(_Decorated().run()) == "ok"
+    provider.force_flush()
+
+    spans = collector.get_finished_spans()
+    assert len(spans) == 1
+    return spans[0]
+
+
+@requires_otel
+def test_generation_span_exports_genai_attributes(monkeypatch):
+    from opentelemetry.trace import SpanKind
+
+    class OpenAILike:
+        model = "gpt-4o-mini"
+        name = "OpenAI"
+
+    span = _run_observed(monkeypatch, "generation", OpenAILike)
+    attrs = dict(span.attributes)
+
+    assert span.kind == SpanKind.CLIENT
+    assert attrs["cognee.span.category"] == "generation"
+    assert attrs["gen_ai.request.model"] == "gpt-4o-mini"
+    assert attrs["gen_ai.system"] == "openai"  # lowercased per GenAI convention
+    assert attrs["langfuse.observation.type"] == "generation"
+
+
+@requires_otel
+def test_generation_span_without_model_is_still_marked(monkeypatch):
+    """llama.cpp local mode leaves model=None; the span must still classify as a
+    generation via the langfuse.observation.type marker."""
+
+    class LocalLike:
+        model = None
+        name = "LlamaCpp"
+
+    span = _run_observed(monkeypatch, "generation", LocalLike)
+    attrs = dict(span.attributes)
+
+    assert "gen_ai.request.model" not in attrs  # None is never written
+    assert attrs["gen_ai.system"] == "llamacpp"
+    assert attrs["langfuse.observation.type"] == "generation"
+
+
+@requires_otel
+def test_non_generation_span_has_no_genai_attributes(monkeypatch):
+    from opentelemetry.trace import SpanKind
+
+    class Anything:
+        model = "should-be-ignored"
+        name = "OpenAI"
+
+    span = _run_observed(monkeypatch, "transcription", Anything)
+    attrs = dict(span.attributes)
+
+    assert span.kind == SpanKind.INTERNAL
+    assert attrs["cognee.span.category"] == "transcription"
+    assert "gen_ai.request.model" not in attrs
+    assert "langfuse.observation.type" not in attrs

--- a/cognee/tests/unit/modules/observability/test_langfuse_otel.py
+++ b/cognee/tests/unit/modules/observability/test_langfuse_otel.py
@@ -93,6 +93,46 @@ def test_langfuse_config_respects_explicit_endpoint():
         assert config.cognee_tracing_enabled is True
 
 
+def test_langfuse_host_falls_back_to_base_url():
+    """LANGFUSE_HOST is canonical, but LANGFUSE_BASE_URL is accepted as an alias."""
+    with patch.dict(
+        os.environ,
+        {
+            "LANGFUSE_PUBLIC_KEY": "pk-1",
+            "LANGFUSE_SECRET_KEY": "sk-2",
+            "LANGFUSE_BASE_URL": "https://us.cloud.langfuse.com",
+        },
+        clear=True,
+    ):
+        from cognee.base_config import get_base_config
+
+        config = get_base_config()
+        assert (
+            config.otel_exporter_otlp_endpoint
+            == "https://us.cloud.langfuse.com/api/public/otel/v1/traces"
+        )
+
+
+def test_langfuse_host_takes_precedence_over_base_url():
+    with patch.dict(
+        os.environ,
+        {
+            "LANGFUSE_PUBLIC_KEY": "pk-1",
+            "LANGFUSE_SECRET_KEY": "sk-2",
+            "LANGFUSE_HOST": "https://host.example.com",
+            "LANGFUSE_BASE_URL": "https://base-url.example.com",
+        },
+        clear=True,
+    ):
+        from cognee.base_config import get_base_config
+
+        config = get_base_config()
+        assert (
+            config.otel_exporter_otlp_endpoint
+            == "https://host.example.com/api/public/otel/v1/traces"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Exporter wiring
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/modules/observability/test_langfuse_otel.py
+++ b/cognee/tests/unit/modules/observability/test_langfuse_otel.py
@@ -202,8 +202,18 @@ def _tracer_with_collector():
     return collector, provider, provider.get_tracer("test")
 
 
-def _run_observed(monkeypatch, category, adapter_cls):
-    """Drive an @observe-decorated method with tracing pointed at a stub collector,
+def _run_observed(
+    monkeypatch,
+    category,
+    adapter_cls,
+    *,
+    text_input="what is cognee?",
+    system_prompt="be brief",
+    output="a graph memory",
+    positional=False,
+):
+    """Drive an @observe-decorated LLM-adapter method (mirrors the real
+    acreate_structured_output signature) with tracing pointed at a stub collector,
     and return the single exported span."""
     import cognee.modules.observability.tracing as tracing
     import cognee.modules.observability.trace_context as trace_context
@@ -217,10 +227,16 @@ def _run_observed(monkeypatch, category, adapter_cls):
 
     class _Decorated(adapter_cls):
         @observe(as_type=category)
-        async def run(self):
-            return "ok"
+        async def acreate_structured_output(self, text_input, system_prompt, response_model=None):
+            return output
 
-    assert asyncio.run(_Decorated().run()) == "ok"
+    inst = _Decorated()
+    if positional:
+        asyncio.run(inst.acreate_structured_output(text_input, system_prompt))
+    else:
+        asyncio.run(
+            inst.acreate_structured_output(text_input=text_input, system_prompt=system_prompt)
+        )
     provider.force_flush()
 
     spans = collector.get_finished_spans()
@@ -229,7 +245,8 @@ def _run_observed(monkeypatch, category, adapter_cls):
 
 
 @requires_otel
-def test_generation_span_exports_genai_attributes(monkeypatch):
+def test_generation_span_exports_genai_and_io(monkeypatch):
+    import json
     from opentelemetry.trace import SpanKind
 
     class OpenAILike:
@@ -244,12 +261,90 @@ def test_generation_span_exports_genai_attributes(monkeypatch):
     assert attrs["gen_ai.request.model"] == "gpt-4o-mini"
     assert attrs["gen_ai.system"] == "openai"  # lowercased per GenAI convention
     assert attrs["langfuse.observation.type"] == "generation"
+    # input/output populate the Langfuse observation fields (JSON-string values),
+    # keyed by the adapter's real parameter names.
+    assert json.loads(attrs["langfuse.observation.input"]) == {
+        "text_input": "what is cognee?",
+        "system_prompt": "be brief",
+    }
+    assert attrs["langfuse.observation.output"] == "a graph memory"
+
+
+@requires_otel
+def test_generation_input_captured_from_positional_args(monkeypatch):
+    import json
+
+    class OpenAILike:
+        model = "gpt-4o-mini"
+        name = "OpenAI"
+
+    span = _run_observed(
+        monkeypatch,
+        "generation",
+        OpenAILike,
+        text_input="q pos",
+        system_prompt="sys pos",
+        positional=True,
+    )
+    assert json.loads(dict(span.attributes)["langfuse.observation.input"]) == {
+        "text_input": "q pos",
+        "system_prompt": "sys pos",
+    }
+
+
+@requires_otel
+def test_generation_input_capture_is_name_agnostic(monkeypatch):
+    """Input capture records string prompt args by parameter name, so it keeps working
+    if cognee renames the adapter's prompt parameters in the future."""
+    import json
+    import cognee.modules.observability.tracing as tracing
+    import cognee.modules.observability.trace_context as trace_context
+    from cognee.modules.observability.get_observe import get_observe
+
+    collector, provider, tracer = _tracer_with_collector()
+    monkeypatch.setattr(tracing, "_tracer", tracer)
+    monkeypatch.setattr(trace_context, "_tracing_enabled", True)
+    observe = get_observe()
+
+    class RenamedAdapter:
+        model = "m"
+        name = "Prov"
+
+        @observe(as_type="generation")
+        async def acreate_structured_output(self, prompt, context, response_model=None):
+            return "ok"
+
+    asyncio.run(RenamedAdapter().acreate_structured_output(prompt="P", context="C"))
+    provider.force_flush()
+    span = collector.get_finished_spans()[0]
+    assert json.loads(dict(span.attributes)["langfuse.observation.input"]) == {
+        "prompt": "P",
+        "context": "C",
+    }
+
+
+def test_llm_generation_contract_keeps_string_prompt_params():
+    """Guard against silent Langfuse-input regressions: input capture records the string
+    arguments of the generation call, so the LLM interface must keep passing the prompt as
+    string parameters. If this contract changes (e.g. to a structured messages object),
+    _generation_input_payload must be updated to match. No opentelemetry needed."""
+    import inspect
+    from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
+        LLMInterface,
+    )
+
+    params = inspect.signature(LLMInterface.acreate_structured_output).parameters
+    for name in ("text_input", "system_prompt"):
+        assert name in params, f"LLM generation contract dropped {name!r}"
+        assert params[name].annotation in (str, "str"), (
+            f"{name} is no longer a string; Langfuse input capture needs updating"
+        )
 
 
 @requires_otel
 def test_generation_span_without_model_is_still_marked(monkeypatch):
     """llama.cpp local mode leaves model=None; the span must still classify as a
-    generation via the langfuse.observation.type marker."""
+    generation and still carry input/output."""
 
     class LocalLike:
         model = None
@@ -261,6 +356,8 @@ def test_generation_span_without_model_is_still_marked(monkeypatch):
     assert "gen_ai.request.model" not in attrs  # None is never written
     assert attrs["gen_ai.system"] == "llamacpp"
     assert attrs["langfuse.observation.type"] == "generation"
+    assert "langfuse.observation.input" in attrs
+    assert attrs["langfuse.observation.output"] == "a graph memory"
 
 
 @requires_otel
@@ -278,3 +375,5 @@ def test_non_generation_span_has_no_genai_attributes(monkeypatch):
     assert attrs["cognee.span.category"] == "transcription"
     assert "gen_ai.request.model" not in attrs
     assert "langfuse.observation.type" not in attrs
+    assert "langfuse.observation.input" not in attrs
+    assert "langfuse.observation.output" not in attrs

--- a/cognee/tests/unit/modules/observability/test_langfuse_otel.py
+++ b/cognee/tests/unit/modules/observability/test_langfuse_otel.py
@@ -1,0 +1,114 @@
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def test_langfuse_config_enabled():
+    fake_pk = "pk-12345"
+    fake_sk = "sk-67890"
+    with patch.dict(
+        os.environ,
+        {
+            "LANGFUSE_PUBLIC_KEY": fake_pk,
+            "LANGFUSE_SECRET_KEY": fake_sk,
+            "LANGFUSE_HOST": "https://us.cloud.langfuse.com",
+        },
+        clear=True,
+    ):
+        from cognee.base_config import get_base_config
+
+        get_base_config.cache_clear()
+        config = get_base_config()
+
+        assert (
+            config.otel_exporter_otlp_endpoint
+            == "https://us.cloud.langfuse.com/api/public/otel/v1/traces"
+        )
+
+        import base64
+
+        expected_b64 = base64.b64encode(f"{fake_pk}:{fake_sk}".encode("utf-8")).decode("utf-8")
+        assert config.otel_exporter_otlp_headers == f"Authorization=Basic {expected_b64}"
+        assert config.cognee_tracing_enabled is True
+
+
+def test_langfuse_config_missing_key():
+    with patch.dict(
+        os.environ,
+        {
+            "LANGFUSE_PUBLIC_KEY": "pk-123",
+        },
+        clear=True,
+    ):
+        from cognee.base_config import get_base_config
+
+        get_base_config.cache_clear()
+
+        with pytest.raises(ValueError, match="must be provided together"):
+            get_base_config()
+
+
+def test_langfuse_attribute_processor():
+    from opentelemetry.sdk.trace import ReadableSpan
+    from cognee.modules.observability.tracing import (
+        LangfuseAttributeProcessor,
+        COGNEE_LLM_MODEL,
+        COGNEE_LLM_PROVIDER,
+    )
+
+    mock_exporter = MagicMock()
+    processor = LangfuseAttributeProcessor(mock_exporter)
+
+    span = MagicMock(spec=ReadableSpan)
+    span._attributes = {
+        COGNEE_LLM_MODEL: "gpt-4",
+        COGNEE_LLM_PROVIDER: "openai",
+        "cognee.llm.input_tokens": 10,
+        "cognee.llm.cost": 0.01,
+    }
+
+    processor.on_end(span)
+
+    assert span._attributes["gen_ai.request.model"] == "gpt-4"
+    assert span._attributes["gen_ai.system"] == "openai"
+    assert span._attributes["gen_ai.usage.input_tokens"] == 10
+    assert span._attributes["gen_ai.usage.cost"] == 0.01
+
+
+@patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter")
+def test_langfuse_exporter_http_fallback(mock_exporter_cls):
+    fake_pk = "pk-12345"
+    fake_sk = "sk-67890"
+    with patch.dict(
+        os.environ,
+        {
+            "LANGFUSE_PUBLIC_KEY": fake_pk,
+            "LANGFUSE_SECRET_KEY": fake_sk,
+        },
+        clear=True,
+    ):
+        from cognee.base_config import get_base_config
+        from cognee.modules.observability.tracing import (
+            _try_add_otlp_exporter,
+            LangfuseAttributeProcessor,
+        )
+
+        get_base_config.cache_clear()
+
+        mock_provider = MagicMock()
+        _try_add_otlp_exporter(mock_provider)
+
+        mock_exporter_cls.assert_called_once()
+        kwargs = mock_exporter_cls.call_args.kwargs
+        assert "https://cloud.langfuse.com/api/public/otel/v1/traces" in kwargs["endpoint"]
+        assert "Authorization" in kwargs["headers"]
+
+        import base64
+
+        expected_b64 = base64.b64encode(f"{fake_pk}:{fake_sk}".encode("utf-8")).decode("utf-8")
+        assert kwargs["headers"]["Authorization"] == f"Basic {expected_b64}"
+
+        mock_provider.add_span_processor.assert_called_once()
+        args = mock_provider.add_span_processor.call_args.args
+        assert isinstance(args[0], LangfuseAttributeProcessor)

--- a/examples/guides/langfuse_telemetry.py
+++ b/examples/guides/langfuse_telemetry.py
@@ -1,47 +1,46 @@
+"""Send cognee traces to Langfuse natively over OpenTelemetry.
+
+Cognee already emits rich OpenTelemetry (OTEL) spans. Instead of double-instrumenting
+with a separate Langfuse SDK, you point cognee's existing OTLP exporter at Langfuse —
+Langfuse is just another OTLP destination, like Dash0 or Datadog.
+
+To run:
+  1. Create a Langfuse project (https://langfuse.com) to get your API keys.
+  2. Export the keys BEFORE running (so cognee's config picks them up). cognee builds
+     the OTLP endpoint + Basic-auth header and turns tracing on automatically:
+
+       export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+       export LANGFUSE_SECRET_KEY="sk-lf-..."
+       # optional; defaults to https://cloud.langfuse.com
+       export LANGFUSE_HOST="https://us.cloud.langfuse.com"
+
+  3. python examples/guides/langfuse_telemetry.py
+  4. Open your Langfuse dashboard -> "Traces". LLM calls appear as Generations.
+"""
+
 import os
 import asyncio
+
 import cognee
 
+
 async def main():
-    """
-    Send cognee traces to Langfuse natively over OpenTelemetry.
+    if not (os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY")):
+        raise SystemExit(
+            "Set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY (see this file's docstring)."
+        )
 
-    Cognee emits rich OpenTelemetry (OTEL) spans by default. Instead of double-instrumenting
-    with a separate Langfuse SDK, you can simply point cognee's existing OTEL exporter
-    directly to Langfuse.
-
-    Steps to run this example:
-    1. Sign up at https://langfuse.com/ and create a project to get your API keys.
-    2. Set your environment variables below (or in your .env file).
-    3. Run this script.
-    4. Open your Langfuse dashboard and navigate to "Traces".
-    """
-    print("Setting up Langfuse telemetry...")
-    
-    # 1. Configure Langfuse credentials
-    # Cognee will automatically construct the Basic Auth headers and OTLP endpoint
-    # required by Langfuse when these variables are set.
-    os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..." # Replace with your public key
-    os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..." # Replace with your secret key
-    
-    # The host defaults to https://cloud.langfuse.com if not specified
-    # os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com" 
-    
-    # 2. Add some data
     print("Adding data...")
     await cognee.add("Cognee turns your unstructured data into a graph memory.")
-    
-    # 3. Cognify! 
-    # Because Langfuse keys are set, cognee will stream the execution traces natively
-    # via the OpenTelemetry HTTP exporter. LLM calls will automatically be mapped 
-    # to Langfuse 'Generations' with token counts and costs.
-    print("Cognifying... (Check your Langfuse dashboard!)")
+
+    # Because the Langfuse keys are set, cognee streams execution traces to Langfuse
+    # over the existing OTLP HTTP exporter; LLM calls render as Generations.
+    print("Cognifying... (check your Langfuse dashboard)")
     await cognee.cognify()
-    
-    # 4. Search
+
     print("Searching...")
-    results = await cognee.search("What does cognee do?")
-    print(results)
-    
+    print(await cognee.search("What does cognee do?"))
+
+
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/guides/langfuse_telemetry.py
+++ b/examples/guides/langfuse_telemetry.py
@@ -1,0 +1,47 @@
+import os
+import asyncio
+import cognee
+
+async def main():
+    """
+    Send cognee traces to Langfuse natively over OpenTelemetry.
+
+    Cognee emits rich OpenTelemetry (OTEL) spans by default. Instead of double-instrumenting
+    with a separate Langfuse SDK, you can simply point cognee's existing OTEL exporter
+    directly to Langfuse.
+
+    Steps to run this example:
+    1. Sign up at https://langfuse.com/ and create a project to get your API keys.
+    2. Set your environment variables below (or in your .env file).
+    3. Run this script.
+    4. Open your Langfuse dashboard and navigate to "Traces".
+    """
+    print("Setting up Langfuse telemetry...")
+    
+    # 1. Configure Langfuse credentials
+    # Cognee will automatically construct the Basic Auth headers and OTLP endpoint
+    # required by Langfuse when these variables are set.
+    os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-lf-..." # Replace with your public key
+    os.environ["LANGFUSE_SECRET_KEY"] = "sk-lf-..." # Replace with your secret key
+    
+    # The host defaults to https://cloud.langfuse.com if not specified
+    # os.environ["LANGFUSE_HOST"] = "https://us.cloud.langfuse.com" 
+    
+    # 2. Add some data
+    print("Adding data...")
+    await cognee.add("Cognee turns your unstructured data into a graph memory.")
+    
+    # 3. Cognify! 
+    # Because Langfuse keys are set, cognee will stream the execution traces natively
+    # via the OpenTelemetry HTTP exporter. LLM calls will automatically be mapped 
+    # to Langfuse 'Generations' with token counts and costs.
+    print("Cognifying... (Check your Langfuse dashboard!)")
+    await cognee.cognify()
+    
+    # 4. Search
+    print("Searching...")
+    results = await cognee.search("What does cognee do?")
+    print(results)
+    
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What this does

Wires **Langfuse** into cognee as just another OTLP destination on the **existing**
OpenTelemetry pipeline (like Dash0/Datadog) — no separate Langfuse SDK, no parallel
instrumentation path. Set `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` (optionally
`LANGFUSE_HOST`), run, and LLM calls show up in Langfuse as generations.

Closes SDK-167. Reworks and hardens hackathon PR #3723 (GitHub issue #3607). The
original author's commits are preserved; the rework lands as separate commits on top.

## How it works

- **Ergonomic config** (`base_config.py`): when the `LANGFUSE_*` keys are set, cognee
  derives the OTLP endpoint (`{host}/api/public/otel/v1/traces`) and the
  `Authorization: Basic base64(public_key:secret_key)` header and turns tracing on.
  Fully opt-in and off by default; a clear error is raised if only one key is set; an
  explicit `OTEL_EXPORTER_OTLP_ENDPOINT`/`_HEADERS` always wins.
- **Attribute mapping at span creation** (`get_observe.py`): generation spans emit the
  vendor-neutral OTel-GenAI conventions `gen_ai.request.model` and `gen_ai.system`
  (plus `SpanKind.CLIENT` and the `langfuse.observation.type` marker), so Langfuse —
  and any other OTLP backend — renders LLM calls as generations. This also fixes a real
  gap: the default OpenAI adapter never attached a model attribute, so those spans were
  previously opaque in Langfuse.
- **Exporter wiring** (`tracing.py`): a small header parser (config headers are in-memory
  pydantic fields the exporters' env-var reader never sees), and Langfuse is detected by
  the host-independent `/api/public/otel` path so the HTTP exporter is forced (Langfuse
  does not support gRPC) — self-hosted instances on a custom domain included.

## What changed vs #3723 (rework)

The original approach mapped attributes in a `SpanProcessor.on_end` by mutating
`span._attributes` and toggling the private `BoundedAttributes._immutable` flag. That
works on current opentelemetry-sdk, but depends on two internal APIs across the whole
`>=1.20,<2` range; if they change, the `hasattr` guard makes it a silent no-op (opaque
Langfuse spans, no error). This rework moves the mapping to the live span using only the
public `set_attribute`, removing the processor entirely — so it is robust across SDK
versions and benefits every OTLP destination, not just Langfuse. The speculative
`gen_ai.usage.*` token/cost mapping (nothing emits the source attributes until #3606
lands) was dropped; it can be added cleanly at the emission site then.

## Testing

- Unit tests assert on **exported span payloads** via an in-memory stub collector
  (no live Langfuse): a generation span carries `gen_ai.request.model`, `gen_ai.system`,
  `langfuse.observation.type` and `SpanKind.CLIENT`; a `model=None` adapter (llama.cpp
  local mode) still gets the generation marker; non-generation spans stay clean. Plus
  config construction, the header parser, and the forced-HTTP Langfuse path.
- Verified end-to-end against a local stand-in collector: the real `enable_tracing()`
  path POSTs the OTLP protobuf to `/api/public/otel/v1/traces` with the correct Basic
  auth header, and the decoded payload contains the expected `gen_ai.*` attributes.
- Full `cognee/tests/unit/modules/observability/` suite green; ruff format + lint clean.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
