### PR TITLE
fix(ingestion): run deferred DLT orphan_cleanup on foreground add() (SDK-171)

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -272,6 +272,12 @@ async def add(
         data_cache=data_cache,
     )
 
+    # Foreground runs: the fresh rows are committed by pipeline_executor_func
+    # above, so it's now safe to clean up orphans. (Background runs already
+    # ran this up front and set orphan_cleanup to None.)
+    if orphan_cleanup is not None:
+        await orphan_cleanup()
+
     # run_pipeline_blocking returns {dataset_id: PipelineRunInfo} but callers
     # expect a single PipelineRunInfo (add always processes one dataset).
     if isinstance(result, dict) and len(result) == 1:

--- a/cognee/tests/integration/tasks/test_add_foreground_orphan_cleanup.py
+++ b/cognee/tests/integration/tasks/test_add_foreground_orphan_cleanup.py
@@ -1,0 +1,116 @@
+"""Regression: a foreground ``add()`` must run the deferred DLT orphan_cleanup.
+
+``resolve_dlt_sources`` returns a deferred ``orphan_cleanup`` that forgets rows
+deleted upstream. ``add()`` used to await it only for ``run_in_background=True``,
+so forget-on-source-deletion was silently broken in the default (foreground)
+path for every DLT connector. This drives the real add pipeline twice against
+local stores (no LLM) and asserts a hard-deleted row is purged from cognee.
+"""
+
+import pathlib
+
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.context_global_variables import graph_db_config, vector_db_config
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.data.methods.get_dataset_data import get_dataset_data
+from cognee.modules.engine.operations.setup import setup as engine_setup
+from cognee.modules.users.methods import get_default_user
+
+DATASET = "widgets_ds"
+
+
+@pytest_asyncio.fixture
+async def clean_env(tmp_path, monkeypatch):
+    pytest.importorskip("dlt")
+    pytest.importorskip("ladybug")
+
+    monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")  # no LLM/embedding ping
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    root = pathlib.Path(tmp_path)
+    monkeypatch.setenv("DLT_DATA_DIR", str(root / "dlt"))  # isolate dlt pipeline state
+
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+    graph_db_config.set(None)
+    vector_db_config.set(None)
+
+    cognee.config.set_relational_db_config({"db_provider": "sqlite"})
+    cognee.config.system_root_directory(str(root / "system"))
+    cognee.config.data_root_directory(str(root / "data"))
+    cognee.config.set_vector_db_url(str(root / "system" / "databases" / "cognee.lancedb"))
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await engine_setup()
+
+    yield
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+def _dlt_source(rows):
+    """A minimal, connector-agnostic dlt resource: merge + id PK + hard-delete."""
+    import dlt
+
+    @dlt.resource(
+        name="widgets",
+        primary_key="id",
+        write_disposition="merge",
+        columns={"_deleted": {"data_type": "bool", "hard_delete": True}},
+    )
+    def widgets():
+        yield from rows
+
+    return widgets
+
+
+async def _dlt_page_ids(user):
+    dataset = (
+        await get_authorized_existing_datasets(
+            user=user, permission_type="read", datasets=[DATASET]
+        )
+    )[0]
+    rows = await get_dataset_data(dataset.id)
+    return sorted(
+        d.external_metadata.get("primary_key_value")
+        for d in rows
+        if isinstance(d.external_metadata, dict) and d.external_metadata.get("source") == "dlt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_foreground_add_runs_deferred_orphan_cleanup(clean_env):
+    user = await get_default_user()
+    kwargs = dict(primary_key="id", write_disposition="merge", max_rows_per_table=0)
+
+    # Backfill two rows via the real (foreground) add pipeline.
+    await cognee.add(
+        _dlt_source(
+            [
+                {"id": "a", "body": "Alpha", "_deleted": False},
+                {"id": "b", "body": "Beta", "_deleted": False},
+            ]
+        ),
+        dataset_name=DATASET,
+        **kwargs,
+    )
+    assert await _dlt_page_ids(user) == ["a", "b"]
+
+    # Foreground re-sync: 'b' is hard-deleted upstream. Before the fix, the
+    # foreground path never awaited orphan_cleanup, so 'b' lingered in cognee.
+    await cognee.add(_dlt_source([{"id": "b", "_deleted": True}]), dataset_name=DATASET, **kwargs)
+    assert await _dlt_page_ids(user) == ["a"]  # 'b' forgotten by foreground orphan_cleanup


### PR DESCRIPTION
## Description

Standalone fix for a data-loss bug found while verifying the Confluence connector (#4058, SDK-168).

`resolve_dlt_sources` returns a **deferred** `orphan_cleanup` that forgets rows deleted upstream. `add()` awaited it only for `run_in_background=True` (up front). The **foreground** path — the default for `cognee.add()` / `cognee.remember()` — never awaited it, so **forget-on-source-deletion was silently broken by default for every DLT connector** (Gmail, Slack, Google Drive, Confluence): a row deleted upstream was hard-deleted from the dlt destination but its cognee graph / vector / relational records were never purged.

## Fix

Run the deferred `orphan_cleanup` **after** the foreground pipeline commits the fresh rows — post-commit, preserving the exact data-loss-window safety that made it deferred in the first place (a mid-ingest failure must not leave orphans deleted with their replacements uncommitted). Background runs are unchanged: they still run it up front because they commit on a detached pipeline that can't be awaited from here.

```python
    result = await pipeline_executor_func(...)

    # Foreground runs: the fresh rows are committed by pipeline_executor_func
    # above, so it's now safe to clean up orphans. (Background runs already
    # ran this up front and set orphan_cleanup to None.)
    if orphan_cleanup is not None:
        await orphan_cleanup()
```

## Testing

Adds an integration regression test that drives the real (foreground) `add()` pipeline twice against local stores (SQLite + LanceDB + Ladybug, no LLM) with a minimal connector-agnostic dlt resource: it ingests two rows, then re-syncs with one hard-deleted upstream, and asserts that row is forgotten. **Confirmed the test fails without this fix** (`['a', 'b'] == ['a']`) and passes with it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Relationship to #4054

The same six-line `add.py` change is currently bundled inside the Google Drive connector PR #4054 (SDK-166). This PR extracts it so the all-connectors data-loss fix can land independently of that larger connector review. Whichever merges first, the other should drop the duplicate `add.py` hunk (this PR additionally adds the standalone regression test).

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
