### PR TITLE
feat(eval): one-command eval runner + optional eval/DeepEval addon (SDK-174)

### DIFF
--- a/cognee/cli/_cognee.py
+++ b/cognee/cli/_cognee.py
@@ -102,6 +102,7 @@ def _discover_commands() -> List[Type[SupportsCliCommand]]:
         ("cognee.cli.commands.improve_command", "ImproveCommand"),
         ("cognee.cli.commands.forget_command", "ForgetCommand"),
         ("cognee.cli.commands.serve_command", "ServeCommand"),
+        ("cognee.cli.commands.eval_command", "EvalCommand"),
         ("cognee.cli.commands.migrate_command", "UpgradeCommand"),
         ("cognee.cli.commands.migrate_command", "DowngradeCommand"),
         ("cognee.cli.commands.migrate_command", "HistoryCommand"),

--- a/cognee/cli/commands/eval_command.py
+++ b/cognee/cli/commands/eval_command.py
@@ -1,0 +1,76 @@
+import argparse
+import asyncio
+
+from cognee.cli.reference import SupportsCliCommand
+from cognee.cli import DEFAULT_DOCS_URL
+import cognee.cli.echo as fmt
+from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+
+
+class EvalCommand(SupportsCliCommand):
+    command_string = "eval"
+    help_string = "Run a memory-quality benchmark end to end (corpus -> answer -> evaluate)"
+    docs_url = DEFAULT_DOCS_URL
+    description = """
+Run a reproducible memory-quality benchmark in one command.
+
+This chains the evaluation harness pipeline - corpus building, question
+answering, evaluation, and an optional dashboard - for a single deterministic
+config. No Modal or Docker is required for local runs.
+
+Examples:
+  cognee eval --benchmark HotPotQA --engine direct_llm --limit 5
+  cognee eval --benchmark Dummy --no-dashboard --output-dir eval_results
+
+The evaluation harness and the DeepEval engine are an optional addon. Install
+them with:  pip install "cognee[eval]"
+
+Once a LongMemEval adapter is registered in the benchmark registry, run it with:
+  cognee eval --benchmark LongMemEval --engine direct_llm
+    """
+
+    def configure_parser(self, parser: argparse.ArgumentParser) -> None:
+        # Import here to keep CLI startup light and avoid importing the eval
+        # harness (and its optional deps) unless the eval command is used.
+        from cognee.eval_framework.runner import add_eval_arguments
+
+        add_eval_arguments(parser)
+        parser.add_argument(
+            "--verbose", "-v", action="store_true", help="Show detailed run information"
+        )
+
+    def execute(self, args: argparse.Namespace) -> None:
+        try:
+            from cognee.eval_framework.runner import (
+                config_from_namespace,
+                run_eval,
+                summarize_result,
+            )
+
+            config = config_from_namespace(args)
+
+            fmt.echo(
+                f"Running eval: benchmark={config.benchmark}, "
+                f"engine={config.evaluation_engine}, "
+                f"samples={config.number_of_samples_in_corpus}, seed={config.seed}"
+            )
+            if getattr(args, "verbose", False):
+                fmt.note("This runs corpus building, question answering, and evaluation.")
+                fmt.note("Depending on the benchmark and LLM, this may take a while.")
+
+            async def _run():
+                try:
+                    return await run_eval(config)
+                except Exception as e:
+                    raise CliCommandInnerException(f"Failed to run eval: {str(e)}") from e
+
+            result = asyncio.run(_run())
+
+            fmt.success("Evaluation completed successfully!")
+            for line in summarize_result(result):
+                fmt.echo(line)
+
+        except Exception as e:
+            if isinstance(e, CliCommandInnerException):
+                raise CliCommandException(str(e), error_code=1) from e
+            raise CliCommandException(f"Error during evaluation: {str(e)}", error_code=1) from e

--- a/cognee/cli/commands/eval_command.py
+++ b/cognee/cli/commands/eval_command.py
@@ -22,8 +22,9 @@ Examples:
   cognee eval --benchmark HotPotQA --engine direct_llm --limit 5
   cognee eval --benchmark Dummy --no-dashboard --output-dir eval_results
 
-The evaluation harness and the DeepEval engine are an optional addon. Install
-them with:  pip install "cognee[eval]"
+The cognee[eval] extra provides the HTML dashboard (on by default), the DeepEval
+engine, and some benchmark dataset downloads; a --engine direct_llm
+--no-dashboard run works without it. Install it with:  pip install "cognee[eval]"
 
 Once a LongMemEval adapter is registered in the benchmark registry, run it with:
   cognee eval --benchmark LongMemEval --engine direct_llm

--- a/cognee/cli/commands/eval_command.py
+++ b/cognee/cli/commands/eval_command.py
@@ -35,9 +35,6 @@ Once a LongMemEval adapter is registered in the benchmark registry, run it with:
         from cognee.eval_framework.runner import add_eval_arguments
 
         add_eval_arguments(parser)
-        parser.add_argument(
-            "--verbose", "-v", action="store_true", help="Show detailed run information"
-        )
 
     def execute(self, args: argparse.Namespace) -> None:
         try:
@@ -54,9 +51,6 @@ Once a LongMemEval adapter is registered in the benchmark registry, run it with:
                 f"engine={config.evaluation_engine}, "
                 f"samples={config.number_of_samples_in_corpus}, seed={config.seed}"
             )
-            if getattr(args, "verbose", False):
-                fmt.note("This runs corpus building, question answering, and evaluation.")
-                fmt.note("Depending on the benchmark and LLM, this may take a while.")
 
             async def _run():
                 try:

--- a/cognee/cli/config.py
+++ b/cognee/cli/config.py
@@ -23,6 +23,7 @@ COMMAND_DESCRIPTIONS = {
     "improve": "Enrich an existing knowledge graph with additional context and rules",
     "forget": "Remove data from the knowledge graph",
     "serve": "Connect to a Cognee instance (cloud or local)",
+    "eval": "Run a memory-quality benchmark end to end (corpus, answer, evaluate)",
     "upgrade": "Apply pending relational + data migrations (alembic-style; head or a revision)",
     "downgrade": "Revert data migrations to a revision ('base' or a slug); rewrites data",
     "stamp": "Set the stored migration revision WITHOUT running migrations (bookkeeping repair)",

--- a/cognee/eval_framework/README.md
+++ b/cognee/eval_framework/README.md
@@ -14,8 +14,10 @@ pip install "cognee[eval]"
 ```
 
 This one extra installs the analysis/dashboard dependencies plus the DeepEval
-engine. If you only use the `direct_llm` engine you can run without `deepeval`
-installed — it is imported lazily and only when the DeepEval engine is selected.
+engine — everything needed to run a benchmark end to end. Core cognee never
+imports the harness, so a plain `pip install cognee` is unaffected. Within the
+harness `deepeval` is imported lazily and only when the DeepEval engine is
+selected, so the `direct_llm` engine never pulls it in.
 
 ## Run a benchmark in one command
 
@@ -39,6 +41,7 @@ Key flags:
 | `--engine, -e` | `direct_llm` (uses the LLM from your `.env`) or `deepeval` (requires the `eval` extra). |
 | `--limit, -n` | Number of samples in the corpus. |
 | `--seed` | Seed for deterministic corpus sampling (default: `42`). |
+| `--qa-engine` | Retriever used to answer questions (default: `cognee_graph_completion`). |
 | `--output-dir, -o` | Directory for run artifacts, namespaced by benchmark/engine so runs stay comparable. |
 | `--dashboard / --no-dashboard` | Toggle HTML dashboard generation. |
 

--- a/cognee/eval_framework/README.md
+++ b/cognee/eval_framework/README.md
@@ -15,9 +15,12 @@ pip install "cognee[eval]"
 
 This one extra installs the analysis/dashboard dependencies plus the DeepEval
 engine — everything needed to run a benchmark end to end. Core cognee never
-imports the harness, so a plain `pip install cognee` is unaffected. Within the
-harness `deepeval` is imported lazily and only when the DeepEval engine is
-selected, so the `direct_llm` engine never pulls it in.
+imports the harness, so a plain `pip install cognee` is unaffected. The extra
+itself is only needed for the HTML dashboard (plotly), the DeepEval engine
+(deepeval), and downloading some benchmark datasets (e.g. Musique via gdown):
+a `--engine direct_llm --no-dashboard` run works without it. When the dashboard
+is enabled but its dependencies are missing, the runner fails fast before any
+pipeline work with an actionable error.
 
 ## Run a benchmark in one command
 

--- a/cognee/eval_framework/README.md
+++ b/cognee/eval_framework/README.md
@@ -1,0 +1,87 @@
+# Cognee Evaluation Harness
+
+Reproducible, one-command **memory-quality benchmarking** for cognee. The harness
+chains four steps — **corpus building → question answering → evaluation →
+dashboard** — for a single deterministic config.
+
+The harness and the DeepEval engine are an **optional addon**. Core cognee never
+imports them; they are pulled in only when you actually run an eval.
+
+## Install
+
+```bash
+pip install "cognee[eval]"
+```
+
+This one extra installs the analysis/dashboard dependencies plus the DeepEval
+engine. If you only use the `direct_llm` engine you can run without `deepeval`
+installed — it is imported lazily and only when the DeepEval engine is selected.
+
+## Run a benchmark in one command
+
+CLI:
+
+```bash
+cognee eval --benchmark HotPotQA --engine direct_llm --limit 5
+```
+
+Or as a module:
+
+```bash
+python -m cognee.eval_framework --benchmark HotPotQA --engine direct_llm --limit 5
+```
+
+Key flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `--benchmark, -b` | Benchmark dataset (`HotPotQA`, `Musique`, `TwoWikiMultiHop`, `Dummy`, …). Once registered, `LongMemEval` works here too. |
+| `--engine, -e` | `direct_llm` (uses the LLM from your `.env`) or `deepeval` (requires the `eval` extra). |
+| `--limit, -n` | Number of samples in the corpus. |
+| `--seed` | Seed for deterministic corpus sampling (default: `42`). |
+| `--output-dir, -o` | Directory for run artifacts, namespaced by benchmark/engine so runs stay comparable. |
+| `--dashboard / --no-dashboard` | Toggle HTML dashboard generation. |
+
+## Programmatic use
+
+```python
+import asyncio
+from cognee.eval_framework.eval_config import EvalConfig
+from cognee.eval_framework.runner import run_eval
+
+config = EvalConfig(
+    benchmark="HotPotQA",
+    evaluation_engine="DirectLLM",
+    number_of_samples_in_corpus=5,
+    seed=42,
+    results_dir="eval_results",
+)
+
+result = asyncio.run(run_eval(config))
+print(result.aggregate_metrics)     # {'correctness': {'mean': ..., 'ci_lower': ..., ...}}
+print(result.metrics_path)          # per-answer metrics artifact
+print(result.config_path)           # resolved config, saved for reproducibility
+```
+
+`run_eval` returns an `EvalResult` with the produced artifact paths and the
+aggregate metrics, so it is callable and assertable from tests and other code
+instead of relying on side-effect files.
+
+## Reproducibility
+
+- `--seed` is threaded through the corpus builder into the benchmark adapters so
+  sampling is deterministic across runs.
+- When `--output-dir` is set, artifacts (questions, answers, metrics, dashboard,
+  and the resolved `eval_config.json`) are written under
+  `<output-dir>/<benchmark>_<engine>/`, so successive runs are comparable instead
+  of overwriting each other.
+
+## Adding a benchmark
+
+Subclass `BaseBenchmarkAdapter` (see `benchmark_adapters/hotpot_qa_adapter.py`)
+and register it in `benchmark_adapters/benchmark_adapters.py`. It then works with
+the runner and CLI with no further wiring:
+
+```bash
+cognee eval --benchmark <YourBenchmark> --engine direct_llm
+```

--- a/cognee/eval_framework/README.md
+++ b/cognee/eval_framework/README.md
@@ -4,8 +4,9 @@ Reproducible, one-command **memory-quality benchmarking** for cognee. The harnes
 chains four steps — **corpus building → question answering → evaluation →
 dashboard** — for a single deterministic config.
 
-The harness and the DeepEval engine are an **optional addon**. Core cognee never
-imports them; they are pulled in only when you actually run an eval.
+The harness ships with cognee, but its heavier dependencies — the HTML dashboard,
+the DeepEval engine, and some dataset downloads — live in the **optional `eval`
+extra**. Core cognee never imports the harness.
 
 ## Install
 
@@ -46,7 +47,7 @@ Key flags:
 | `--seed` | Seed for deterministic corpus sampling (default: `42`). |
 | `--qa-engine` | Retriever used to answer questions (default: `cognee_graph_completion`). |
 | `--output-dir, -o` | Directory for run artifacts, namespaced by benchmark/engine so runs stay comparable. |
-| `--dashboard / --no-dashboard` | Toggle HTML dashboard generation. |
+| `--dashboard / --no-dashboard` | Toggle HTML dashboard generation (on by default; requires the `eval` extra). |
 
 ## Programmatic use
 

--- a/cognee/eval_framework/__main__.py
+++ b/cognee/eval_framework/__main__.py
@@ -1,0 +1,35 @@
+"""Module entry point: ``python -m cognee.eval_framework [options]``.
+
+Thin wrapper around :func:`cognee.eval_framework.runner.run_eval` that shares its
+argument surface with the ``cognee eval`` CLI command.
+"""
+
+import argparse
+import asyncio
+
+from cognee.eval_framework.runner import (
+    add_eval_arguments,
+    config_from_namespace,
+    run_eval,
+    summarize_result,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m cognee.eval_framework",
+        description="Run a cognee memory-quality benchmark end to end in one command.",
+    )
+    add_eval_arguments(parser)
+    args = parser.parse_args()
+
+    config = config_from_namespace(args)
+    result = asyncio.run(run_eval(config))
+
+    print("\nEvaluation complete.")
+    for line in summarize_result(result):
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/cognee/eval_framework/benchmark_adapters/hotpot_qa_adapter.py
+++ b/cognee/eval_framework/benchmark_adapters/hotpot_qa_adapter.py
@@ -1,4 +1,3 @@
-import requests
 import os
 import json
 import random
@@ -45,6 +44,11 @@ class HotpotQAAdapter(BaseBenchmarkAdapter):
             with open(filename, "r", encoding="utf-8") as f:
                 raw_corpus = json.load(f)
         else:
+            # Imported lazily: requests is not a declared cognee dependency
+            # (present transitively today), so keep the benchmark registry
+            # importable regardless.
+            import requests
+
             response = requests.get(self.dataset_info["url"])
             response.raise_for_status()
             raw_corpus = response.json()

--- a/cognee/eval_framework/benchmark_adapters/musique_adapter.py
+++ b/cognee/eval_framework/benchmark_adapters/musique_adapter.py
@@ -4,8 +4,6 @@ import random
 from typing import Optional, Any, List, Union, Tuple
 import zipfile
 
-import gdown
-
 from cognee.eval_framework.benchmark_adapters.base_benchmark_adapter import BaseBenchmarkAdapter
 
 
@@ -108,6 +106,16 @@ class MusiqueQAAdapter(BaseBenchmarkAdapter):
 
     def _musique_download_file(self) -> None:
         """Downloads and unzips the Musique dataset if not present locally."""
+        # Imported lazily so the benchmark registry (and the eval runner) can be
+        # imported without the optional eval extra installed.
+        try:
+            import gdown
+        except ImportError as error:
+            raise ImportError(
+                "Downloading the Musique dataset requires optional dependencies. "
+                'Install them with: pip install "cognee[eval]"'
+            ) from error
+
         url = self.dataset_info["download_url"]
         zip_filename = self.dataset_info["zip_filename"]
         target_filename = self.dataset_info["filename"]

--- a/cognee/eval_framework/corpus_builder/corpus_builder_executor.py
+++ b/cognee/eval_framework/corpus_builder/corpus_builder_executor.py
@@ -34,9 +34,13 @@ class CorpusBuilderExecutor:
         limit: Optional[int] = None,
         load_golden_context: bool = False,
         instance_filter: Optional[Union[str, List[str], List[int]]] = None,
+        seed: int = 42,
     ) -> Tuple[List[Dict], List[str]]:
         self.raw_corpus, self.questions = self.adapter.load_corpus(
-            limit=limit, load_golden_context=load_golden_context, instance_filter=instance_filter
+            limit=limit,
+            seed=seed,
+            load_golden_context=load_golden_context,
+            instance_filter=instance_filter,
         )
         return self.raw_corpus, self.questions
 
@@ -47,10 +51,14 @@ class CorpusBuilderExecutor:
         chunker=TextChunker,
         load_golden_context: bool = False,
         instance_filter: Optional[Union[str, List[str], List[int]]] = None,
+        seed: int = 42,
     ) -> List[str]:
         await self.adapter.prepare_corpus()
         self.load_corpus(
-            limit=limit, load_golden_context=load_golden_context, instance_filter=instance_filter
+            limit=limit,
+            load_golden_context=load_golden_context,
+            instance_filter=instance_filter,
+            seed=seed,
         )
         await self.run_cognee(chunk_size=chunk_size, chunker=chunker)
         return self.questions

--- a/cognee/eval_framework/corpus_builder/run_corpus_builder.py
+++ b/cognee/eval_framework/corpus_builder/run_corpus_builder.py
@@ -65,6 +65,7 @@ async def run_corpus_builder(
             chunk_size=chunk_size,
             load_golden_context=params.get("evaluating_contexts"),
             instance_filter=instance_filter,
+            seed=params.get("seed", 42),
         )
         with open(params["questions_path"], "w", encoding="utf-8") as f:
             json.dump(questions, f, ensure_ascii=False, indent=4)

--- a/cognee/eval_framework/eval_config.py
+++ b/cognee/eval_framework/eval_config.py
@@ -36,6 +36,15 @@ class EvalConfig(BaseSettings):
     # Visualization
     dashboard: bool = True
 
+    # Reproducibility
+    seed: int = 42  # Seed for deterministic corpus sampling across runs
+
+    # Optional directory for run artifacts. When set, the runner namespaces
+    # artifacts under "<results_dir>/<benchmark>_<engine>/" so successive runs
+    # are comparable instead of overwriting each other. When unset, artifacts are
+    # written to the current working directory (legacy behavior).
+    results_dir: Optional[str] = None
+
     # file paths
     questions_path: str = "questions_output.json"
     answers_path: str = "answers_output.json"
@@ -61,6 +70,8 @@ class EvalConfig(BaseSettings):
             "evaluation_metrics": self.evaluation_metrics,
             "calculate_metrics": self.calculate_metrics,
             "dashboard": self.dashboard,
+            "seed": self.seed,
+            "results_dir": self.results_dir,
             "questions_path": self.questions_path,
             "answers_path": self.answers_path,
             "metrics_path": self.metrics_path,

--- a/cognee/eval_framework/evaluation/evaluator_adapters.py
+++ b/cognee/eval_framework/evaluation/evaluator_adapters.py
@@ -1,31 +1,64 @@
-import importlib
 from enum import Enum
+from importlib import import_module
+from typing import Optional, Type
 
 
 class EvaluatorAdapter(Enum):
-    """Adapter class is resolved lazily on first ``.adapter_class`` access, not at module
-    import time — so selecting one adapter (e.g. ``BeamEval``) never forces every other
-    adapter's dependencies (e.g. ``deepeval``) to be installed.
+    """Registry of evaluation engines.
+
+    The adapter class is resolved lazily through an import path instead of being
+    imported at module load time. This keeps optional dependencies (e.g.
+    ``deepeval``) out of the import graph unless the engine that needs them is
+    actually selected, so importing this registry - or running the DirectLLM
+    engine - never requires the ``eval`` extra to be installed.
     """
 
-    DEEPEVAL = ("DeepEval", "cognee.eval_framework.evaluation.deep_eval_adapter", "DeepEvalAdapter")
-    BEAM = ("BeamEval", "cognee.eval_framework.beam.eval.beam_eval_adapter", "BeamEvalAdapter")
+    #  (engine name, module path, class name, optional extra that provides it)
+    DEEPEVAL = (
+        "DeepEval",
+        "cognee.eval_framework.evaluation.deep_eval_adapter",
+        "DeepEvalAdapter",
+        "eval",
+    )
+    BEAM = (
+        "BeamEval",
+        "cognee.eval_framework.beam.eval.beam_eval_adapter",
+        "BeamEvalAdapter",
+        None,
+    )
     DIRECT_LLM = (
         "DirectLLM",
         "cognee.eval_framework.evaluation.direct_llm_eval_adapter",
         "DirectLLMEvalAdapter",
+        None,
     )
 
-    def __new__(cls, adapter_name: str, module_path: str, class_name: str):
+    def __new__(cls, adapter_name: str, module_path: str, class_name: str, extra: Optional[str]):
         obj = object.__new__(cls)
         obj._value_ = adapter_name
         obj._module_path = module_path
         obj._class_name = class_name
+        obj._extra = extra
         return obj
 
+    def load_adapter_class(self) -> Type:
+        """Import and return the adapter class, raising an actionable error if the
+        optional dependency backing this engine is not installed."""
+        try:
+            module = import_module(self._module_path)
+        except ImportError as error:
+            if self._extra:
+                raise ImportError(
+                    f"The '{self.value}' evaluation engine requires optional dependencies. "
+                    f'Install them with: pip install "cognee[{self._extra}]"'
+                ) from error
+            raise
+        return getattr(module, self._class_name)
+
     @property
-    def adapter_class(self):
-        return getattr(importlib.import_module(self._module_path), self._class_name)
+    def adapter_class(self) -> Type:
+        """Backwards-compatible accessor that resolves the adapter class lazily."""
+        return self.load_adapter_class()
 
     def __str__(self):
         return self.value

--- a/cognee/eval_framework/evaluation/run_evaluation_module.py
+++ b/cognee/eval_framework/evaluation/run_evaluation_module.py
@@ -3,7 +3,6 @@ import json
 from typing import List
 from cognee.eval_framework.evaluation.evaluation_executor import EvaluationExecutor
 from cognee.eval_framework.analysis.metrics_calculator import calculate_metrics_statistics
-from cognee.eval_framework.analysis.dashboard_generator import create_dashboard
 from cognee.infrastructure.files.storage import get_file_storage
 from cognee.infrastructure.databases.relational.get_relational_engine import (
     get_relational_engine,

--- a/cognee/eval_framework/run_eval.py
+++ b/cognee/eval_framework/run_eval.py
@@ -1,44 +1,27 @@
-from cognee.shared.logging_utils import get_logger
+"""Legacy script entry point for the eval harness.
+
+Kept for backward compatibility. New code should prefer the one-command runner:
+
+    from cognee.eval_framework.runner import run_eval
+    result = await run_eval(EvalConfig())
+
+or the CLI:  ``cognee eval ...`` / ``python -m cognee.eval_framework``.
+"""
+
 import asyncio
+
+from cognee.shared.logging_utils import get_logger
 from cognee.eval_framework.eval_config import EvalConfig
+from cognee.eval_framework.runner import run_eval, summarize_result
 
-from cognee.eval_framework.corpus_builder.run_corpus_builder import run_corpus_builder
-from cognee.eval_framework.answer_generation.run_question_answering_module import (
-    run_question_answering,
-)
-from cognee.eval_framework.evaluation.run_evaluation_module import run_evaluation
-from cognee.eval_framework.metrics_dashboard import create_dashboard
-
-# Configure logging(logging.INFO)
 logger = get_logger()
-
-# Define parameters and file paths.
-eval_params = EvalConfig().to_dict()
-
-questions_file = "questions_output.json"
-answers_file = "answers_output.json"
-metrics_file = "metrics_output.json"
-dashboard_path = "dashboard.html"
 
 
 async def main():
-    # Corpus builder
-    await run_corpus_builder(eval_params)
-
-    # Question answering
-    await run_question_answering(eval_params)
-
-    # Metrics calculation + dashboard
-    await run_evaluation(eval_params)
-
-    if eval_params.get("dashboard"):
-        logger.info("Generating dashboard...")
-        create_dashboard(
-            metrics_path=eval_params["metrics_path"],
-            aggregate_metrics_path=eval_params["aggregate_metrics_path"],
-            output_file=eval_params["dashboard_path"],
-            benchmark=eval_params["benchmark"],
-        )
+    result = await run_eval(EvalConfig())
+    for line in summarize_result(result):
+        logger.info(line)
+    return result
 
 
 if __name__ == "__main__":

--- a/cognee/eval_framework/runner.py
+++ b/cognee/eval_framework/runner.py
@@ -274,9 +274,8 @@ def config_from_namespace(args: argparse.Namespace) -> EvalConfig:
 
     config = EvalConfig(**overrides)
 
-    # DirectLLM only scores 'correctness'; default to it when the engine is
-    # selected and the user hasn't overridden the metrics list.
-    if config.evaluation_engine == "DirectLLM" and "evaluation_metrics" not in overrides:
+    # DirectLLM only scores 'correctness', so pin the metrics list to it.
+    if config.evaluation_engine == "DirectLLM":
         config.evaluation_metrics = ["correctness"]
 
     return config

--- a/cognee/eval_framework/runner.py
+++ b/cognee/eval_framework/runner.py
@@ -1,0 +1,302 @@
+"""One-command runner for the cognee evaluation harness.
+
+This module puts a thin, testable surface in front of the existing eval pipeline
+(corpus -> answers -> evaluation -> dashboard). It exposes:
+
+- ``run_eval(config) -> EvalResult``: a programmatic entry point that runs the
+  full pipeline for a single deterministic config and returns the produced
+  artifact paths plus aggregate metrics (instead of relying on side-effect files).
+- ``add_eval_arguments`` / ``config_from_namespace``: argparse helpers shared by
+  the ``cognee eval`` CLI command and ``python -m cognee.eval_framework`` so both
+  map the same flags onto :class:`EvalConfig`.
+
+No Modal/Docker is required on this path; ``modal_run_eval.py`` remains a separate
+opt-in for distributed runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from cognee.shared.logging_utils import get_logger
+from cognee.eval_framework.eval_config import EvalConfig
+
+logger = get_logger()
+
+# Artifact path keys that get namespaced by run when ``results_dir`` is set.
+ARTIFACT_KEYS = (
+    "questions_path",
+    "answers_path",
+    "metrics_path",
+    "aggregate_metrics_path",
+    "dashboard_path",
+)
+
+# Engines available on the CLI, mapped to the EvalConfig engine names.
+ENGINE_CHOICES = {
+    "deepeval": "DeepEval",
+    "direct_llm": "DirectLLM",
+}
+
+
+@dataclass
+class EvalResult:
+    """Structured result of a single evaluation run.
+
+    Returning this from :func:`run_eval` makes the harness callable and assertable
+    from tests and other code, rather than depending on files left in the cwd.
+    """
+
+    benchmark: str
+    engine: str
+    config: Dict[str, Any]
+    config_path: str
+    questions_path: str
+    answers_path: str
+    metrics_path: str
+    aggregate_metrics_path: str
+    dashboard_path: Optional[str] = None
+    aggregate_metrics: Dict[str, Any] = field(default_factory=dict)
+
+
+def _slugify(value: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in str(value)).strip("_") or "run"
+
+
+def resolve_run_paths(config: EvalConfig) -> Dict[str, str]:
+    """Resolve artifact paths for a run.
+
+    When ``results_dir`` is set, artifacts are namespaced under
+    ``<results_dir>/<benchmark>_<engine>/`` so runs with different benchmarks or
+    engines are comparable instead of clobbering each other. When it is unset the
+    legacy flat filenames (relative to the cwd) are preserved for backward
+    compatibility with existing scripts.
+    """
+    params = config.to_dict()
+    if not config.results_dir:
+        return {key: params[key] for key in ARTIFACT_KEYS}
+
+    run_id = f"{_slugify(config.benchmark)}_{_slugify(config.evaluation_engine)}"
+    run_dir = os.path.join(config.results_dir, run_id)
+    return {key: os.path.join(run_dir, params[key]) for key in ARTIFACT_KEYS}
+
+
+def _load_json(path: str) -> Dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+# Thin lazy wrappers around the pipeline steps. Importing them here (rather than
+# at module top) keeps ``import cognee.eval_framework.runner`` - and therefore
+# ``cognee eval --help`` - free of the optional ``eval`` extra. They are also the
+# seams the tests patch to exercise orchestration without an LLM or database.
+async def _corpus_step(params: Dict[str, Any]) -> Any:
+    from cognee.eval_framework.corpus_builder.run_corpus_builder import run_corpus_builder
+
+    return await run_corpus_builder(params)
+
+
+async def _answer_step(params: Dict[str, Any]) -> Any:
+    from cognee.eval_framework.answer_generation.run_question_answering_module import (
+        run_question_answering,
+    )
+
+    return await run_question_answering(params)
+
+
+async def _evaluation_step(params: Dict[str, Any]) -> Any:
+    from cognee.eval_framework.evaluation.run_evaluation_module import run_evaluation
+
+    return await run_evaluation(params)
+
+
+def _create_dashboard(params: Dict[str, Any]) -> str:
+    """Generate the HTML dashboard, importing plotly lazily so core runs (and the
+    ``--no-dashboard`` path) never require the ``eval`` extra."""
+    try:
+        from cognee.eval_framework.metrics_dashboard import create_dashboard
+    except ImportError as error:
+        raise ImportError(
+            "Dashboard generation requires optional dependencies. Install them with: "
+            'pip install "cognee[eval]" (or pass --no-dashboard to skip it).'
+        ) from error
+
+    create_dashboard(
+        metrics_path=params["metrics_path"],
+        aggregate_metrics_path=params["aggregate_metrics_path"],
+        output_file=params["dashboard_path"],
+        benchmark=params["benchmark"],
+    )
+    return params["dashboard_path"]
+
+
+async def run_eval(config: Optional[EvalConfig] = None) -> EvalResult:
+    """Run the full eval pipeline for a single config and return an EvalResult.
+
+    Chains corpus -> answers -> evaluation -> (optional) dashboard, writing the
+    resolved config next to the artifacts for reproducibility.
+    """
+    config = config or EvalConfig()
+    params = config.to_dict()
+
+    resolved = resolve_run_paths(config)
+    params.update(resolved)
+
+    run_dir = os.path.dirname(resolved["metrics_path"])
+    if run_dir:
+        os.makedirs(run_dir, exist_ok=True)
+
+    logger.info(
+        "Running eval: benchmark=%s engine=%s samples=%s seed=%s",
+        config.benchmark,
+        config.evaluation_engine,
+        config.number_of_samples_in_corpus,
+        config.seed,
+    )
+
+    await _corpus_step(params)
+    await _answer_step(params)
+    await _evaluation_step(params)
+
+    dashboard_path = None
+    if params.get("dashboard"):
+        logger.info("Generating dashboard...")
+        dashboard_path = _create_dashboard(params)
+
+    aggregate_metrics = _load_json(resolved["aggregate_metrics_path"])
+
+    config_path = os.path.join(run_dir, "eval_config.json") if run_dir else "eval_config.json"
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(params, f, ensure_ascii=False, indent=4)
+
+    return EvalResult(
+        benchmark=config.benchmark,
+        engine=config.evaluation_engine,
+        config=params,
+        config_path=config_path,
+        questions_path=resolved["questions_path"],
+        answers_path=resolved["answers_path"],
+        metrics_path=resolved["metrics_path"],
+        aggregate_metrics_path=resolved["aggregate_metrics_path"],
+        dashboard_path=dashboard_path,
+        aggregate_metrics=aggregate_metrics,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Shared argparse surface (used by the CLI command and ``python -m``)
+# --------------------------------------------------------------------------- #
+
+
+def add_eval_arguments(parser: argparse.ArgumentParser) -> None:
+    """Attach the shared ``cognee eval`` flags onto a parser."""
+    parser.add_argument(
+        "--benchmark",
+        "-b",
+        default=None,
+        help="Benchmark dataset to evaluate (e.g. HotPotQA, Musique, Dummy, and - once "
+        "registered - LongMemEval). Defaults to the configured EvalConfig value.",
+    )
+    parser.add_argument(
+        "--engine",
+        "-e",
+        choices=sorted(ENGINE_CHOICES.keys()),
+        default=None,
+        help="Evaluation engine. 'deepeval' requires the eval extra; 'direct_llm' uses the "
+        "default LLM from your .env.",
+    )
+    parser.add_argument(
+        "--limit",
+        "-n",
+        type=int,
+        default=None,
+        help="Number of samples to include in the corpus.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for deterministic corpus sampling (default: 42).",
+    )
+    parser.add_argument(
+        "--qa-engine",
+        default=None,
+        help="Retriever used to answer questions (e.g. cognee_graph_completion).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        "-o",
+        default=None,
+        help="Directory for run artifacts. Artifacts are namespaced by benchmark/engine so "
+        "runs stay comparable.",
+    )
+    dashboard_group = parser.add_mutually_exclusive_group()
+    dashboard_group.add_argument(
+        "--dashboard",
+        dest="dashboard",
+        action="store_true",
+        default=None,
+        help="Generate an HTML dashboard (requires the eval extra).",
+    )
+    dashboard_group.add_argument(
+        "--no-dashboard",
+        dest="dashboard",
+        action="store_false",
+        help="Skip dashboard generation.",
+    )
+
+
+def config_from_namespace(args: argparse.Namespace) -> EvalConfig:
+    """Build an EvalConfig from parsed CLI args, applying only provided overrides."""
+    overrides: Dict[str, Any] = {}
+
+    if getattr(args, "benchmark", None) is not None:
+        overrides["benchmark"] = args.benchmark
+    if getattr(args, "engine", None) is not None:
+        overrides["evaluation_engine"] = ENGINE_CHOICES[args.engine]
+    if getattr(args, "limit", None) is not None:
+        overrides["number_of_samples_in_corpus"] = args.limit
+    if getattr(args, "seed", None) is not None:
+        overrides["seed"] = args.seed
+    if getattr(args, "qa_engine", None) is not None:
+        overrides["qa_engine"] = args.qa_engine
+    if getattr(args, "output_dir", None) is not None:
+        overrides["results_dir"] = args.output_dir
+    if getattr(args, "dashboard", None) is not None:
+        overrides["dashboard"] = args.dashboard
+
+    config = EvalConfig(**overrides)
+
+    # DirectLLM only scores 'correctness'; default to it when the engine is
+    # selected and the user hasn't overridden the metrics list.
+    if config.evaluation_engine == "DirectLLM" and "evaluation_metrics" not in overrides:
+        config.evaluation_metrics = ["correctness"]
+
+    return config
+
+
+def summarize_result(result: EvalResult) -> List[str]:
+    """Human-readable summary lines for a completed run."""
+    lines = [
+        f"Benchmark: {result.benchmark}",
+        f"Engine:    {result.engine}",
+        f"Metrics:   {result.metrics_path}",
+        f"Config:    {result.config_path}",
+    ]
+    if result.dashboard_path:
+        lines.append(f"Dashboard: {result.dashboard_path}")
+    if result.aggregate_metrics:
+        lines.append("Aggregate metrics:")
+        for metric, stats in result.aggregate_metrics.items():
+            if isinstance(stats, dict) and "mean" in stats:
+                lines.append(f"  - {metric}: mean={stats['mean']:.4f}")
+            else:
+                lines.append(f"  - {metric}: {stats}")
+    return lines

--- a/cognee/eval_framework/runner.py
+++ b/cognee/eval_framework/runner.py
@@ -82,7 +82,16 @@ def resolve_run_paths(config: EvalConfig) -> Dict[str, str]:
 
     run_id = f"{_slugify(config.benchmark)}_{_slugify(config.evaluation_engine)}"
     run_dir = os.path.join(config.results_dir, run_id)
-    return {key: os.path.join(run_dir, params[key]) for key in ARTIFACT_KEYS}
+    resolved = {}
+    for key in ARTIFACT_KEYS:
+        if os.path.isabs(params[key]):
+            # os.path.join discards run_dir for absolute paths; make the escape
+            # from the namespaced run directory visible instead of silent.
+            logger.warning(
+                "Absolute %s overrides the run directory %s: %s", key, run_dir, params[key]
+            )
+        resolved[key] = os.path.join(run_dir, params[key])
+    return resolved
 
 
 def _load_json(path: str) -> Dict[str, Any]:

--- a/cognee/eval_framework/runner.py
+++ b/cognee/eval_framework/runner.py
@@ -117,9 +117,10 @@ async def _evaluation_step(params: Dict[str, Any]) -> Any:
     return await run_evaluation(params)
 
 
-def _create_dashboard(params: Dict[str, Any]) -> str:
-    """Generate the HTML dashboard, importing plotly lazily so core runs (and the
-    ``--no-dashboard`` path) never require the ``eval`` extra."""
+def _import_dashboard():
+    """Import the dashboard generator lazily (it pulls in plotly), raising an
+    actionable error when the optional deps are missing. Called before the
+    pipeline runs so a costly LLM run is never wasted on a missing extra."""
     try:
         from cognee.eval_framework.metrics_dashboard import create_dashboard
     except ImportError as error:
@@ -127,7 +128,12 @@ def _create_dashboard(params: Dict[str, Any]) -> str:
             "Dashboard generation requires optional dependencies. Install them with: "
             'pip install "cognee[eval]" (or pass --no-dashboard to skip it).'
         ) from error
+    return create_dashboard
 
+
+def _create_dashboard(params: Dict[str, Any]) -> str:
+    """Generate the HTML dashboard."""
+    create_dashboard = _import_dashboard()
     create_dashboard(
         metrics_path=params["metrics_path"],
         aggregate_metrics_path=params["aggregate_metrics_path"],
@@ -148,6 +154,10 @@ async def run_eval(config: Optional[EvalConfig] = None) -> EvalResult:
 
     resolved = resolve_run_paths(config)
     params.update(resolved)
+
+    if params.get("dashboard"):
+        # Fail fast if the dashboard deps are missing, before any pipeline work.
+        _import_dashboard()
 
     run_dir = os.path.dirname(resolved["metrics_path"])
     if run_dir:

--- a/cognee/eval_framework/runner.py
+++ b/cognee/eval_framework/runner.py
@@ -20,7 +20,7 @@ import argparse
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from cognee.shared.logging_utils import get_logger
 from cognee.eval_framework.eval_config import EvalConfig
@@ -84,13 +84,17 @@ def resolve_run_paths(config: EvalConfig) -> Dict[str, str]:
     run_dir = os.path.join(config.results_dir, run_id)
     resolved = {}
     for key in ARTIFACT_KEYS:
-        if os.path.isabs(params[key]):
-            # os.path.join discards run_dir for absolute paths; make the escape
-            # from the namespaced run directory visible instead of silent.
-            logger.warning(
-                "Absolute %s overrides the run directory %s: %s", key, run_dir, params[key]
-            )
-        resolved[key] = os.path.join(run_dir, params[key])
+        joined = os.path.join(run_dir, params[key])
+        # Absolute overrides discard run_dir entirely and ".." components walk
+        # out of it; make the escape from the run directory visible, not silent.
+        try:
+            abs_run_dir = os.path.abspath(run_dir)
+            escapes = os.path.commonpath([abs_run_dir, os.path.abspath(joined)]) != abs_run_dir
+        except ValueError:  # e.g. different drives on Windows — an escape as well
+            escapes = True
+        if escapes:
+            logger.warning("%s escapes the run directory %s: %s", key, run_dir, joined)
+        resolved[key] = joined
     return resolved
 
 
@@ -126,7 +130,7 @@ async def _evaluation_step(params: Dict[str, Any]) -> Any:
     return await run_evaluation(params)
 
 
-def _import_dashboard():
+def _import_dashboard() -> Callable[..., str]:
     """Import the dashboard generator lazily (it pulls in plotly), raising an
     actionable error when the optional deps are missing. Called before the
     pipeline runs so a costly LLM run is never wasted on a missing extra."""
@@ -262,7 +266,7 @@ def add_eval_arguments(parser: argparse.ArgumentParser) -> None:
         dest="dashboard",
         action="store_true",
         default=None,
-        help="Generate an HTML dashboard (requires the eval extra).",
+        help="Generate an HTML dashboard (default: on; requires the eval extra).",
     )
     dashboard_group.add_argument(
         "--no-dashboard",

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
@@ -153,7 +153,7 @@ class MCPSamplingAdapter(LLMInterface):
             f"Last error: {last_error}"
         )
 
-    async def create_transcript(self, input: str) -> TranscriptionReturnType | None:
+    async def create_transcript(self, input: str, **kwargs: Any) -> TranscriptionReturnType | None:
         """Audio transcription has no MCP sampling equivalent — graceful no-audio."""
         logger.debug("create_transcript is not supported over MCP sampling; returning None")
         return None

--- a/cognee/tests/unit/eval_framework/test_eval_runner.py
+++ b/cognee/tests/unit/eval_framework/test_eval_runner.py
@@ -132,6 +132,22 @@ def test_resolve_run_paths_namespaces_by_benchmark_and_engine(tmp_path):
         assert "HotPotQA_DirectLLM" in paths[key]
 
 
+def test_resolve_run_paths_absolute_override_escapes_namespace(tmp_path):
+    """Documented limitation: an absolute artifact-path override wins over the
+    namespaced run directory (os.path.join drops the prefix). resolve_run_paths
+    warns about it but preserves the override."""
+    escape = str(tmp_path / "escape" / "metrics.json")
+    config = EvalConfig(
+        benchmark="Dummy",
+        evaluation_engine="DirectLLM",
+        results_dir=str(tmp_path / "results"),
+        metrics_path=escape,
+    )
+    paths = resolve_run_paths(config)
+    assert paths["metrics_path"] == escape
+    assert "results" not in paths["metrics_path"]
+
+
 # --------------------------------------------------------------------------- #
 # CLI surface: flag -> EvalConfig mapping
 # --------------------------------------------------------------------------- #

--- a/cognee/tests/unit/eval_framework/test_eval_runner.py
+++ b/cognee/tests/unit/eval_framework/test_eval_runner.py
@@ -240,8 +240,10 @@ async def test_run_eval_orchestrates_pipeline_and_returns_result(tmp_path, monke
 
 @pytest.mark.asyncio
 async def test_run_eval_runs_dashboard_step_when_enabled(tmp_path, monkeypatch):
-    """With the dashboard enabled, run_eval invokes the dashboard step and
-    surfaces its path on the result and in the summary."""
+    """With the dashboard enabled, run_eval preflights the dashboard deps, invokes
+    the dashboard step, and surfaces its path on the result and in the summary.
+    Patching _import_dashboard covers both the fail-fast call and the real
+    _create_dashboard plumbing without needing plotly installed."""
 
     async def fake_noop(params):
         return []
@@ -251,15 +253,16 @@ async def test_run_eval_runs_dashboard_step_when_enabled(tmp_path, monkeypatch):
             json.dump({"correctness": {"mean": 1.0}}, f)
         return []
 
-    def fake_dashboard(params):
-        with open(params["dashboard_path"], "w", encoding="utf-8") as f:
+    def fake_create_dashboard(metrics_path, aggregate_metrics_path, output_file, benchmark):
+        with open(output_file, "w", encoding="utf-8") as f:
             f.write("<html></html>")
-        return params["dashboard_path"]
 
     monkeypatch.setattr("cognee.eval_framework.runner._corpus_step", fake_noop)
     monkeypatch.setattr("cognee.eval_framework.runner._answer_step", fake_noop)
     monkeypatch.setattr("cognee.eval_framework.runner._evaluation_step", fake_evaluation)
-    monkeypatch.setattr("cognee.eval_framework.runner._create_dashboard", fake_dashboard)
+    monkeypatch.setattr(
+        "cognee.eval_framework.runner._import_dashboard", lambda: fake_create_dashboard
+    )
 
     config = EvalConfig(
         benchmark="Dummy",
@@ -271,7 +274,38 @@ async def test_run_eval_runs_dashboard_step_when_enabled(tmp_path, monkeypatch):
 
     assert result.dashboard_path is not None
     assert "Dummy_DirectLLM" in result.dashboard_path
+    # The real _create_dashboard plumbing routed output_file to the resolved path.
+    with open(result.dashboard_path, "r", encoding="utf-8") as f:
+        assert f.read() == "<html></html>"
     assert any("Dashboard" in line for line in summarize_result(result))
+
+
+@pytest.mark.asyncio
+async def test_run_eval_fails_fast_when_dashboard_deps_missing(tmp_path, monkeypatch):
+    """When the dashboard is enabled but its deps are missing, run_eval raises
+    before any pipeline step runs, so no LLM time or money is wasted."""
+    calls = []
+
+    async def spy_step(params):
+        calls.append("step")
+        return []
+
+    monkeypatch.setattr("cognee.eval_framework.runner._corpus_step", spy_step)
+    monkeypatch.setattr("cognee.eval_framework.runner._answer_step", spy_step)
+    monkeypatch.setattr("cognee.eval_framework.runner._evaluation_step", spy_step)
+    monkeypatch.setitem(sys.modules, "cognee.eval_framework.metrics_dashboard", None)
+
+    config = EvalConfig(
+        benchmark="Dummy",
+        evaluation_engine="DirectLLM",
+        results_dir=str(tmp_path),
+        dashboard=True,
+    )
+    with pytest.raises(ImportError) as excinfo:
+        await run_eval(config)
+
+    assert calls == []
+    assert "--no-dashboard" in str(excinfo.value)
 
 
 def test_create_dashboard_missing_deps_is_actionable(monkeypatch):

--- a/cognee/tests/unit/eval_framework/test_eval_runner.py
+++ b/cognee/tests/unit/eval_framework/test_eval_runner.py
@@ -1,0 +1,197 @@
+"""Deterministic, keyless tests for the productized eval runner and the
+optional-addon decoupling (issue #3623).
+
+These cover the two chunks that productize the harness:
+- the eval/DeepEval optional addon (lazy engine imports + actionable errors), and
+- the one-command runner / CLI surface (path resolution, flag mapping, orchestration).
+
+They run under CI with no real API keys and without requiring the ``eval`` extra.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from cognee.eval_framework.eval_config import EvalConfig
+from cognee.eval_framework.evaluation.evaluator_adapters import EvaluatorAdapter
+from cognee.eval_framework.runner import (
+    EvalResult,
+    add_eval_arguments,
+    config_from_namespace,
+    resolve_run_paths,
+    run_eval,
+    summarize_result,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Optional addon: lazy engine imports
+# --------------------------------------------------------------------------- #
+
+
+def test_importing_evaluator_registry_does_not_import_deepeval():
+    """Importing the evaluator registry (or the executor) must not pull in the
+    optional ``deepeval`` dependency. Verified in a clean subprocess so it is not
+    affected by other tests importing deepeval."""
+    code = (
+        "import sys;"
+        "import cognee.eval_framework.evaluation.evaluator_adapters;"
+        "import cognee.eval_framework.evaluation.evaluation_executor;"
+        "assert 'deepeval' not in sys.modules, 'deepeval was imported eagerly';"
+        "print('ok')"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_direct_llm_engine_loads_without_extra():
+    """The DirectLLM engine resolves without needing the eval extra."""
+    adapter_cls = EvaluatorAdapter("DirectLLM").load_adapter_class()
+    assert adapter_cls.__name__ == "DirectLLMEvalAdapter"
+
+
+def test_missing_deepeval_raises_actionable_error():
+    """Selecting DeepEval without the extra installed raises an actionable error
+    pointing at ``cognee[eval]`` rather than a bare ImportError."""
+    with patch(
+        "cognee.eval_framework.evaluation.evaluator_adapters.import_module",
+        side_effect=ImportError("No module named 'deepeval'"),
+    ):
+        with pytest.raises(ImportError) as excinfo:
+            EvaluatorAdapter.DEEPEVAL.load_adapter_class()
+
+    assert "cognee[eval]" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- #
+# Runner: path resolution & reproducibility
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_run_paths_legacy_flat_when_no_results_dir():
+    config = EvalConfig(benchmark="HotPotQA", results_dir=None)
+    paths = resolve_run_paths(config)
+    assert paths["metrics_path"] == "metrics_output.json"
+
+
+def test_resolve_run_paths_namespaces_by_benchmark_and_engine(tmp_path):
+    config = EvalConfig(
+        benchmark="HotPotQA",
+        evaluation_engine="DirectLLM",
+        results_dir=str(tmp_path),
+    )
+    paths = resolve_run_paths(config)
+    for key in ("questions_path", "answers_path", "metrics_path"):
+        assert str(tmp_path) in paths[key]
+        assert "HotPotQA_DirectLLM" in paths[key]
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface: flag -> EvalConfig mapping
+# --------------------------------------------------------------------------- #
+
+
+def _parse(argv):
+    parser = argparse.ArgumentParser()
+    add_eval_arguments(parser)
+    return parser.parse_args(argv)
+
+
+def test_config_from_namespace_maps_flags(tmp_path):
+    args = _parse(
+        [
+            "--benchmark",
+            "HotPotQA",
+            "--engine",
+            "direct_llm",
+            "--limit",
+            "7",
+            "--seed",
+            "123",
+            "--output-dir",
+            str(tmp_path),
+            "--no-dashboard",
+        ]
+    )
+    config = config_from_namespace(args)
+
+    assert config.benchmark == "HotPotQA"
+    assert config.evaluation_engine == "DirectLLM"
+    assert config.number_of_samples_in_corpus == 7
+    assert config.seed == 123
+    assert config.results_dir == str(tmp_path)
+    assert config.dashboard is False
+    # DirectLLM defaults to correctness-only scoring.
+    assert config.evaluation_metrics == ["correctness"]
+
+
+def test_config_from_namespace_defaults_untouched():
+    args = _parse([])
+    config = config_from_namespace(args)
+    default = EvalConfig()
+    assert config.benchmark == default.benchmark
+    assert config.evaluation_engine == default.evaluation_engine
+
+
+# --------------------------------------------------------------------------- #
+# Runner orchestration (mocked steps, no LLM/DB)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_run_eval_orchestrates_pipeline_and_returns_result(tmp_path, monkeypatch):
+    """run_eval chains the steps, feeds them namespaced paths, writes a resolved
+    config, and returns an EvalResult carrying the aggregate metrics."""
+    captured = {}
+
+    async def fake_corpus(params):
+        captured["params"] = params
+        with open(params["questions_path"], "w", encoding="utf-8") as f:
+            json.dump([{"question": "q", "answer": "a"}], f)
+        return []
+
+    async def fake_answers(params):
+        with open(params["answers_path"], "w", encoding="utf-8") as f:
+            json.dump([{"question": "q", "answer": "a", "golden_answer": "a"}], f)
+        return []
+
+    async def fake_evaluation(params):
+        # Emulate the real step producing the aggregate metrics artifact.
+        with open(params["aggregate_metrics_path"], "w", encoding="utf-8") as f:
+            json.dump({"correctness": {"mean": 1.0, "ci_lower": 1.0, "ci_upper": 1.0}}, f)
+        return []
+
+    monkeypatch.setattr("cognee.eval_framework.runner._corpus_step", fake_corpus)
+    monkeypatch.setattr("cognee.eval_framework.runner._answer_step", fake_answers)
+    monkeypatch.setattr("cognee.eval_framework.runner._evaluation_step", fake_evaluation)
+
+    config = EvalConfig(
+        benchmark="Dummy",
+        evaluation_engine="DirectLLM",
+        results_dir=str(tmp_path),
+        dashboard=False,
+    )
+    result = await run_eval(config)
+
+    assert isinstance(result, EvalResult)
+    assert result.benchmark == "Dummy"
+    assert result.engine == "DirectLLM"
+    assert result.aggregate_metrics["correctness"]["mean"] == 1.0
+
+    # Steps received namespaced paths and the seed.
+    assert "Dummy_DirectLLM" in captured["params"]["metrics_path"]
+    assert captured["params"]["seed"] == config.seed
+
+    # Resolved config artifact is written for reproducibility.
+    with open(result.config_path, "r", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved["benchmark"] == "Dummy"
+    assert saved["seed"] == config.seed
+
+    # Summary is renderable.
+    assert any("Dummy" in line for line in summarize_result(result))

--- a/cognee/tests/unit/eval_framework/test_eval_runner.py
+++ b/cognee/tests/unit/eval_framework/test_eval_runner.py
@@ -10,6 +10,8 @@ They run under CI with no real API keys and without requiring the ``eval`` extra
 
 import argparse
 import json
+import logging
+import os
 import subprocess
 import sys
 from unittest.mock import patch
@@ -132,10 +134,10 @@ def test_resolve_run_paths_namespaces_by_benchmark_and_engine(tmp_path):
         assert "HotPotQA_DirectLLM" in paths[key]
 
 
-def test_resolve_run_paths_absolute_override_escapes_namespace(tmp_path):
+def test_resolve_run_paths_absolute_override_escapes_namespace(tmp_path, caplog):
     """Documented limitation: an absolute artifact-path override wins over the
     namespaced run directory (os.path.join drops the prefix). resolve_run_paths
-    warns about it but preserves the override."""
+    warns about the escape but preserves the override."""
     escape = str(tmp_path / "escape" / "metrics.json")
     config = EvalConfig(
         benchmark="Dummy",
@@ -143,9 +145,29 @@ def test_resolve_run_paths_absolute_override_escapes_namespace(tmp_path):
         results_dir=str(tmp_path / "results"),
         metrics_path=escape,
     )
-    paths = resolve_run_paths(config)
+    with caplog.at_level(logging.WARNING):
+        paths = resolve_run_paths(config)
     assert paths["metrics_path"] == escape
-    assert "results" not in paths["metrics_path"]
+    assert not paths["metrics_path"].startswith(str(tmp_path / "results"))
+    assert "metrics_path" in caplog.text
+    assert "escapes the run directory" in caplog.text
+
+
+def test_resolve_run_paths_warns_on_relative_escape(tmp_path, caplog):
+    """A relative override with parent components also leaves the run directory
+    and is warned about, while the joined value is preserved unchanged."""
+    config = EvalConfig(
+        benchmark="Dummy",
+        evaluation_engine="DirectLLM",
+        results_dir=str(tmp_path / "results"),
+        metrics_path="../shared/metrics.json",
+    )
+    with caplog.at_level(logging.WARNING):
+        paths = resolve_run_paths(config)
+    expected = os.path.join(str(tmp_path / "results"), "Dummy_DirectLLM", "../shared/metrics.json")
+    assert paths["metrics_path"] == expected
+    assert "metrics_path" in caplog.text
+    assert "escapes the run directory" in caplog.text
 
 
 # --------------------------------------------------------------------------- #

--- a/cognee/tests/unit/eval_framework/test_eval_runner.py
+++ b/cognee/tests/unit/eval_framework/test_eval_runner.py
@@ -67,6 +67,26 @@ def test_importing_runner_surface_does_not_import_optional_extras():
     assert "ok" in result.stdout
 
 
+def test_importing_pipeline_steps_does_not_import_optional_extras():
+    """Importing the pipeline step modules the runner chains must not pull in
+    any optional eval-extra dependency, so a direct_llm run works without the
+    extra. Guards against eager plotly/gdown/deepeval imports sneaking back in
+    (e.g. the dead dashboard import run_evaluation_module used to carry)."""
+    code = (
+        "import sys;"
+        "import cognee.eval_framework.corpus_builder.run_corpus_builder;"
+        "import cognee.eval_framework.answer_generation.run_question_answering_module;"
+        "import cognee.eval_framework.evaluation.run_evaluation_module;"
+        "assert 'plotly' not in sys.modules, 'plotly was imported eagerly';"
+        "assert 'gdown' not in sys.modules, 'gdown was imported eagerly';"
+        "assert 'deepeval' not in sys.modules, 'deepeval was imported eagerly';"
+        "print('ok')"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
 def test_direct_llm_engine_loads_without_extra():
     """The DirectLLM engine resolves without needing the eval extra."""
     adapter_cls = EvaluatorAdapter("DirectLLM").load_adapter_class()

--- a/cognee/tests/unit/eval_framework/test_eval_runner.py
+++ b/cognee/tests/unit/eval_framework/test_eval_runner.py
@@ -20,6 +20,7 @@ from cognee.eval_framework.eval_config import EvalConfig
 from cognee.eval_framework.evaluation.evaluator_adapters import EvaluatorAdapter
 from cognee.eval_framework.runner import (
     EvalResult,
+    _create_dashboard,
     add_eval_arguments,
     config_from_namespace,
     resolve_run_paths,
@@ -49,6 +50,23 @@ def test_importing_evaluator_registry_does_not_import_deepeval():
     assert "ok" in result.stdout
 
 
+def test_importing_runner_surface_does_not_import_optional_extras():
+    """Importing the one-command runner surface must keep both the optional
+    ``plotly`` (dashboard) and ``deepeval`` deps out of the import graph. Checked
+    in a clean subprocess so it holds even in CI where those extras ARE installed
+    — a bare ``--help`` returncode check would not catch a future eager hoist."""
+    code = (
+        "import sys;"
+        "import cognee.eval_framework.runner;"
+        "assert 'plotly' not in sys.modules, 'plotly was imported eagerly';"
+        "assert 'deepeval' not in sys.modules, 'deepeval was imported eagerly';"
+        "print('ok')"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
 def test_direct_llm_engine_loads_without_extra():
     """The DirectLLM engine resolves without needing the eval extra."""
     adapter_cls = EvaluatorAdapter("DirectLLM").load_adapter_class()
@@ -65,7 +83,10 @@ def test_missing_deepeval_raises_actionable_error():
         with pytest.raises(ImportError) as excinfo:
             EvaluatorAdapter.DEEPEVAL.load_adapter_class()
 
+    # The message names the engine and the extra, and chains the original error.
     assert "cognee[eval]" in str(excinfo.value)
+    assert "'DeepEval'" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, ImportError)
 
 
 # --------------------------------------------------------------------------- #
@@ -195,3 +216,58 @@ async def test_run_eval_orchestrates_pipeline_and_returns_result(tmp_path, monke
 
     # Summary is renderable.
     assert any("Dummy" in line for line in summarize_result(result))
+
+
+@pytest.mark.asyncio
+async def test_run_eval_runs_dashboard_step_when_enabled(tmp_path, monkeypatch):
+    """With the dashboard enabled, run_eval invokes the dashboard step and
+    surfaces its path on the result and in the summary."""
+
+    async def fake_noop(params):
+        return []
+
+    async def fake_evaluation(params):
+        with open(params["aggregate_metrics_path"], "w", encoding="utf-8") as f:
+            json.dump({"correctness": {"mean": 1.0}}, f)
+        return []
+
+    def fake_dashboard(params):
+        with open(params["dashboard_path"], "w", encoding="utf-8") as f:
+            f.write("<html></html>")
+        return params["dashboard_path"]
+
+    monkeypatch.setattr("cognee.eval_framework.runner._corpus_step", fake_noop)
+    monkeypatch.setattr("cognee.eval_framework.runner._answer_step", fake_noop)
+    monkeypatch.setattr("cognee.eval_framework.runner._evaluation_step", fake_evaluation)
+    monkeypatch.setattr("cognee.eval_framework.runner._create_dashboard", fake_dashboard)
+
+    config = EvalConfig(
+        benchmark="Dummy",
+        evaluation_engine="DirectLLM",
+        results_dir=str(tmp_path),
+        dashboard=True,
+    )
+    result = await run_eval(config)
+
+    assert result.dashboard_path is not None
+    assert "Dummy_DirectLLM" in result.dashboard_path
+    assert any("Dashboard" in line for line in summarize_result(result))
+
+
+def test_create_dashboard_missing_deps_is_actionable(monkeypatch):
+    """When the dashboard deps (plotly) are absent, _create_dashboard raises an
+    error pointing at both the eval extra and the --no-dashboard escape hatch."""
+    # Setting the module to None makes the in-function import raise ImportError,
+    # emulating a missing plotly even when the eval extra is installed in CI.
+    monkeypatch.setitem(sys.modules, "cognee.eval_framework.metrics_dashboard", None)
+    with pytest.raises(ImportError) as excinfo:
+        _create_dashboard(
+            {
+                "metrics_path": "m.json",
+                "aggregate_metrics_path": "a.json",
+                "dashboard_path": "d.html",
+                "benchmark": "Dummy",
+            }
+        )
+    assert "cognee[eval]" in str(excinfo.value)
+    assert "--no-dashboard" in str(excinfo.value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,14 @@ evals = [
     "locust>=2.0.0,<3",
 ]
 
+# Umbrella extra for the evaluation harness: pulls in the analysis/dashboard
+# dependencies (evals) plus the DeepEval engine. Core cognee never imports these;
+# they are lazily loaded only when the harness or DeepEval engine is used.
+# One-liner install:  pip install "cognee[eval]"
+eval = [
+    "cognee[evals,deepeval]",
+]
+
 graphiti = ["graphiti-core>=0.28.0"]
 # Note: New s3fs and boto3 versions don't work well together
 # Always use comaptible fixed versions of these two dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -1319,6 +1319,17 @@ docs = [
     { name = "unstructured", version = "0.18.32", source = { registry = "https://pypi.org/simple" }, extra = ["csv", "doc", "docx", "epub", "md", "odt", "org", "pdf", "ppt", "pptx", "rst", "rtf", "tsv", "xlsx"], marker = "python_full_version < '3.13'" },
     { name = "unstructured", version = "0.21.5", source = { registry = "https://pypi.org/simple" }, extra = ["csv", "doc", "docx", "epub", "md", "odt", "org", "pdf", "ppt", "pptx", "rst", "rtf", "tsv", "xlsx"], marker = "python_full_version >= '3.13'" },
 ]
+eval = [
+    { name = "deepeval" },
+    { name = "gdown" },
+    { name = "locust" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas" },
+    { name = "plotly" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
 evals = [
     { name = "gdown" },
     { name = "locust" },
@@ -1432,6 +1443,7 @@ requires-dist = [
     { name = "baml-py", marker = "extra == 'baml'", specifier = "==0.206.0" },
     { name = "beautifulsoup4", marker = "extra == 'scraping'", specifier = ">=4.13.1" },
     { name = "cbor2", specifier = ">=5.8.0" },
+    { name = "cognee", extras = ["evals", "deepeval"], marker = "extra == 'eval'" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.3.2,<8" },
     { name = "datamodel-code-generator", specifier = ">=0.54.0" },
     { name = "debugpy", marker = "extra == 'debug'", specifier = ">=1.8.9,<2.0.0" },
@@ -1542,7 +1554,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.34.0,<1.0.0" },
     { name = "websockets", specifier = ">=15.0.1,<16.0.0" },
 ]
-provides-extras = ["api", "distributed", "scraping", "fastembed", "neo4j", "neptune", "postgres", "postgres-binary", "turso", "notebook", "langchain", "llama-index", "huggingface", "ollama", "mistral", "anthropic", "azure", "deepeval", "posthog", "groq", "llama-cpp", "docs", "codegraph", "evals", "graphiti", "aws", "dlt", "baml", "dev", "debug", "redis", "tracing", "docling"]
+provides-extras = ["api", "distributed", "scraping", "fastembed", "neo4j", "neptune", "postgres", "postgres-binary", "turso", "notebook", "langchain", "llama-index", "huggingface", "ollama", "mistral", "anthropic", "azure", "deepeval", "posthog", "groq", "llama-cpp", "docs", "codegraph", "evals", "eval", "graphiti", "aws", "dlt", "baml", "dev", "debug", "redis", "tracing", "docling"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What this does

Productizes the cognee evaluation harness — the two chunks of GitHub hackathon issue #3623 the original author took on:

1. **One-command runner + CLI.** `run_eval(config) -> EvalResult` chains corpus → answer → evaluate → dashboard for a single deterministic config and returns the produced artifact paths plus aggregate metrics (instead of leaving side-effect files). It is exposed as `cognee eval …` and `python -m cognee.eval_framework …`, both mapping the same flags onto `EvalConfig`. No Modal or Docker on the local path.

```bash
cognee eval --benchmark HotPotQA --engine direct_llm --limit 5
python -m cognee.eval_framework --benchmark Dummy --no-dashboard
```

2. **Eval + DeepEval as a clean optional addon.** The evaluator registry now resolves each engine lazily by import path, so importing the registry or the executor — or running the DirectLLM engine — no longer pulls in `deepeval`. Selecting DeepEval without the extra raises an actionable error pointing at `pip install "cognee[eval]"`. A single umbrella `eval` extra installs the whole harness.

Plus reproducibility: a `seed` threaded through the corpus builder into the benchmark adapters (they already accepted it but it was never passed down), and artifacts namespaced under `<output-dir>/<benchmark>_<engine>/` with the resolved config saved alongside, so runs stay comparable.

Closes SDK-174. This reworks and hardens hackathon PR #3817 by @Taimoo-r for gh #3623; the original author's commit is preserved and the rework lands as separate commits on top. The **LongMemEval adapter** and the **DeepEval adapter pin/metrics upgrade** are intentionally out of scope for this chunk (separate follow-ups), mirroring the issue's own chunking — the runner already picks up `cognee eval --benchmark LongMemEval` with no extra wiring once that adapter is registered.

## Review of #3817 (sound approach, merge-worthy with rework)

The design is right and matches the issue. The real fix underneath everything is decoupling: the registry used to import `DeepEvalAdapter` (and therefore `deepeval`) at module load, so merely importing the registry or the `EvaluationExecutor` pulled in the extra even on a DirectLLM-only run. Verified locally in two virtualenvs — one with the `eval` extra and one deliberately without:

- 8 of 8 original runner tests pass; the full `cognee/tests/unit/eval_framework/` suite is 62 passed with the extra installed.
- In an extra-free venv (both `deepeval` and `plotly` genuinely absent): the module `--help` renders, the runner tests pass, selecting DeepEval raises the real (unmocked) install-the-extra error while DirectLLM loads, and dashboard generation raises the same actionable error.
- `cognee eval` registers and its `--help` renders; the top-level command list includes it.

## What I changed on top (5 separate commits)

1. **`fix(deps)`: regenerate `uv.lock` for the new `eval` extra.** The author added the extra to `pyproject.toml` but not to the lockfile, so the required `uv lock --check` gate failed. Added only the `eval` extra (self-referential `cognee[evals,deepeval]`), leaving every other resolved entry byte-identical to `dev` to avoid resolver marker churn.
2. **`refactor(eval)`: drop `--verbose` and simplify the DirectLLM metrics guard.** `--verbose` was registered only on `cognee eval`, not the shared surface, so `python -m … -v` errored — the opposite of the one-shared-surface goal; its only effect was two static notes. The DirectLLM guard's second clause (`"evaluation_metrics" not in overrides`) was dead (there is no `--metrics` flag). Both changes are behavior-preserving.
3. **`test(eval)`: guard the runner import graph and cover the dashboard branch.** A clean-subprocess test asserts importing `cognee.eval_framework.runner` keeps both `plotly` and `deepeval` out of `sys.modules` (catches a future eager hoist even in CI where the extras are installed); the dashboard branch of `run_eval` is now covered (path surfaced, and the missing-deps error names both `cognee[eval]` and `--no-dashboard`); the missing-deepeval test now also asserts the engine name and the chained cause.
4. **`docs(eval)`: document `--qa-engine` and clarify addon optionality.** Added the real `--qa-engine` flag to the README flag table and reworded the optionality note so it is accurate (the extra installs everything needed to run a benchmark; core cognee never imports the harness; `deepeval` is lazy and specific to the DeepEval engine).
5. **`fix(cli)`: register the `eval` command in `COMMAND_DESCRIPTIONS`.** The new subcommand had no `COMMAND_DESCRIPTIONS` entry, so the required `test_command_descriptions_complete` CLI unit test failed. Added the missing entry.

## Second hardening pass

A follow-up pass made the optional-addon promise hold for *executing* the harness, not just importing it, and closed the review's remaining findings:

6. **`fix(eval)`: keep optional deps out of the harness execution path.** Running (not just importing) a direct_llm eval without the extra crashed on imports: `run_evaluation_module` carried a **dead** `create_dashboard` import (pulling plotly even with `--no-dashboard`, which also defeated the runner's lazy-dashboard guard), and `musique_adapter` imported `gdown` at module top (blocking the whole benchmark registry). Removed the dead import and made gdown lazy with the same actionable `cognee[eval]` error. A clean-subprocess regression test locks the step modules' import graph.
7. **`fix(eval)`: fail fast when dashboard deps are missing.** With the default `dashboard=True` on an extra-less install, the runner previously executed the entire paid LLM pipeline and only then died at the dashboard step. `run_eval` now preflights the dashboard import before any pipeline work; a test locks the contract (no step runs when deps are absent).
8. **`fix(eval)` ×2: escape warning for artifact overrides.** An absolute (or `../`-relative) artifact-path env override silently escapes the namespaced run directory (`os.path.join` drops the prefix). The override still wins (deliberate user setting), but `resolve_run_paths` now warns — gated on the resolved path actually escaping (commonpath check, Windows cross-drive treated as escape) — with caplog-verified tests for both cases.
9. **`refactor(eval)`: lazy `requests` in the HotPotQA adapter.** `requests` is not a declared cognee dependency (it is present transitively via `instructor`); its sole use is the dataset download, so import it there, mirroring the Musique/gdown pattern.
10. **`docs(eval)` ×2: precise optionality wording everywhere.** CLI description, README intro/install/flag-table now consistently say: the harness ships with cognee; the `eval` extra provides the dashboard (on by default), the DeepEval engine, and some dataset downloads; `--engine direct_llm --no-dashboard` runs without it.

**End-to-end proof (extra-free venv, invalid LLM key):** `python -m cognee.eval_framework --benchmark Dummy --engine direct_llm --no-dashboard` traverses the full chain and fails only at the LLM authentication call (zero import errors, namespaced run dir created); with the dashboard left on, it fails **instantly** with the actionable `cognee[eval]` / `--no-dashboard` message before any pipeline work.

An adversarial verification workflow over the second pass confirmed **zero regressions** (re-export consumers, mock patch targets, and import-order dependencies all checked).

## Testing

- Full eval_framework unit suite: **66 passed** (with the `eval` extra). Runner tests: **15 passed with and without** the extra — keyless, no API keys. CLI unit tests: **120 passed**.
- `ruff check .`, `ruff format --check .`, `ty check .`, `uv lock --check`, and `pre-commit` are all clean.

## Notes for reviewers

- `cognee/eval_framework/analysis/dashboard_generator.py` is now fully orphaned (its only remaining importer is its own unit test) and duplicates `metrics_dashboard.py`. Recommend deleting it plus `dashboard_test.py` in a follow-up rather than widening this PR's diff.
- The artifact-override escape (absolute or `../` paths combined with `--output-dir`) is kept as override-wins behavior, now with a warning; rejecting it would break deliberate configurations.

---

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
