### PR TITLE
feat(graph): add Turso (libSQL) graph database backend (SDK-176)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -180,6 +180,13 @@ GRAPH_DATASET_DATABASE_HANDLER="kuzu"
 #GRAPH_DATABASE_USERNAME=neo4j
 #GRAPH_DATABASE_PASSWORD=pleaseletmein
 
+# Turso / libSQL (local, graph-as-tables over a single libSQL file — no extra
+# dependency; a libSQL file is a SQLite file, read through the aiosqlite driver).
+# GRAPH_DATABASE_URL is optional: set it to an absolute libSQL file path to
+# override the default location under the system databases directory.
+#GRAPH_DATABASE_PROVIDER="turso"
+#GRAPH_DATABASE_URL=/absolute/path/to/graph.db
+
 ################################################################################
 #  Vector Database — Advanced
 #  Provider-specific connection details.

--- a/cognee/infrastructure/databases/dataset_database_handler/supported_dataset_database_handlers.py
+++ b/cognee/infrastructure/databases/dataset_database_handler/supported_dataset_database_handlers.py
@@ -19,6 +19,9 @@ from cognee.infrastructure.databases.vector.turso.TursoVectorDatasetDatabaseHand
 from cognee.infrastructure.databases.graph.postgres.PostgresGraphDatasetDatabaseHandler import (
     PostgresGraphDatasetDatabaseHandler,
 )
+from cognee.infrastructure.databases.graph.turso.TursoGraphDatasetDatabaseHandler import (
+    TursoGraphDatasetDatabaseHandler,
+)
 
 supported_dataset_database_handlers = {
     "neo4j_aura_dev": {
@@ -47,4 +50,8 @@ supported_dataset_database_handlers = {
         "handler_provider": "ladybug",
     },
     "kuzu": {"handler_instance": LadybugDatasetDatabaseHandler, "handler_provider": "kuzu"},
+    "turso_graph": {
+        "handler_instance": TursoGraphDatasetDatabaseHandler,
+        "handler_provider": "turso",
+    },
 }

--- a/cognee/infrastructure/databases/graph/config.py
+++ b/cognee/infrastructure/databases/graph/config.py
@@ -80,6 +80,8 @@ class GraphConfig(BaseSettings):
             self.graph_dataset_database_handler = "postgres_graph"
         if provider == "neo4j" and graph_dataset_database_handler in ("ladybug", "neo4j"):
             self.graph_dataset_database_handler = "neo4j"
+        if provider == "turso" and graph_dataset_database_handler in ("ladybug", "turso"):
+            self.graph_dataset_database_handler = "turso_graph"
         base_config = get_base_config()
 
         databases_directory_path = os.path.join(base_config.system_root_directory, "databases")

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -593,6 +593,26 @@ def _create_graph_engine(
         return NeptuneAnalyticsAdapter(
             graph_id=graph_identifier,
         )
+    elif graph_database_provider == "turso":
+        if not graph_database_url:
+            raise EnvironmentError("Missing required Turso database URL.")
+
+        auth_token = graph_database_key if graph_database_key else ""
+
+        if auth_token:
+            raise NotImplementedError(
+                "Remote Turso support is not yet implemented. "
+                "Set GRAPH_DATABASE_KEY to an empty string to use local SQLite mode."
+            )
+        else:
+            # Local mode — graph_database_url must be an absolute path.
+            # sqlite+aioturso:/// + /abs/path => sqlite+aioturso:////abs/path (4 slashes = absolute)
+            # pyturso provides Rust-backed async via turso.aio worker thread (same model as aiosqlite).
+            connection_string: str = f"sqlite+aioturso:///{graph_database_url}"
+
+        from .turso.adapter import TursoAdapter
+
+        return TursoAdapter(connection_string=connection_string)
 
     all_providers = list(supported_databases.keys()) + [
         "neo4j",
@@ -603,6 +623,7 @@ def _create_graph_engine(
         "postgres",
         "neptune",
         "neptune_analytics",
+        "turso",
     ]
     raise EnvironmentError(
         f"Unsupported graph database provider: {graph_database_provider}. "

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -594,25 +594,26 @@ def _create_graph_engine(
             graph_id=graph_identifier,
         )
     elif graph_database_provider == "turso":
-        if not graph_database_url:
-            raise EnvironmentError("Missing required Turso database URL.")
-
-        auth_token = graph_database_key if graph_database_key else ""
-
-        if auth_token:
-            raise NotImplementedError(
-                "Remote Turso support is not yet implemented. "
-                "Set GRAPH_DATABASE_KEY to an empty string to use local SQLite mode."
+        # Local libSQL file. A libSQL file is a SQLite file, so cognee talks to it
+        # through the same aiosqlite driver it uses for SQLite. Prefer an explicit
+        # GRAPH_DATABASE_URL (absolute path); otherwise fall back to the
+        # auto-derived graph_file_path so Turso works out of the box in
+        # single-user mode, like the other file-based backends.
+        if graph_database_key:
+            raise EnvironmentError(
+                "Remote Turso (embedded-replica sync) is not supported yet; "
+                "unset GRAPH_DATABASE_KEY to use the local libSQL backend."
             )
-        else:
-            # Local mode — graph_database_url must be an absolute path.
-            # sqlite+aioturso:/// + /abs/path => sqlite+aioturso:////abs/path (4 slashes = absolute)
-            # pyturso provides Rust-backed async via turso.aio worker thread (same model as aiosqlite).
-            connection_string: str = f"sqlite+aioturso:///{graph_database_url}"
-
+        db_path = graph_database_url or graph_file_path
+        if not db_path:
+            raise EnvironmentError(
+                "Missing Turso database path (set GRAPH_DATABASE_URL to an absolute libSQL "
+                "file path, or rely on the default graph_file_path)."
+            )
+        # sqlite+aiosqlite:/// + /abs/path => sqlite+aiosqlite:////abs/path.
         from .turso.adapter import TursoAdapter
 
-        return TursoAdapter(connection_string=connection_string)
+        return TursoAdapter(connection_string=f"sqlite+aiosqlite:///{db_path}")
 
     all_providers = list(supported_databases.keys()) + [
         "neo4j",

--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -12,11 +12,10 @@ from cognee.modules.users.models import User, DatasetDatabase
 
 
 class TursoGraphDatasetDatabaseHandler:
-    """Handler for per-dataset Turso/SQLite graph databases.
+    """Handler for per-dataset Turso/libSQL graph databases.
 
-    Local mode: each dataset gets its own SQLite file under the system databases directory.
-    Remote Turso: set GRAPH_DATABASE_URL to the remote libSQL URL and GRAPH_DATABASE_KEY
-    to the auth token; each dataset then uses a dataset-scoped URL path.
+    Each dataset gets its own libSQL file under the system databases directory, so
+    the existing multi-user permission system isolates datasets by file.
     """
 
     @classmethod
@@ -58,17 +57,12 @@ class TursoGraphDatasetDatabaseHandler:
     async def resolve_dataset_connection_info(
         cls, dataset_database: DatasetDatabase
     ) -> DatasetDatabase:
-        # No credentials to inject for local SQLite; remote Turso would pull key from config.
-        graph_config = get_graph_config()
-        if graph_config.graph_database_key:
-            dataset_database.graph_database_connection_info["graph_database_key"] = (
-                graph_config.graph_database_key
-            )
+        # A local libSQL file has no connection credentials to resolve.
         return dataset_database
 
     @classmethod
     async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
-        dataset_url = dataset_database.graph_database_url
+        dataset_url = str(dataset_database.graph_database_url or "")
 
         evict_graph_engine(
             graph_database_provider="turso",
@@ -77,7 +71,6 @@ class TursoGraphDatasetDatabaseHandler:
             graph_database_key="",
         )
 
-        # Remove the SQLite file for local mode
-        # For remote Turso, file won't exist locally — that's fine.
-        if dataset_url and dataset_url.startswith("/") and os.path.exists(dataset_url):
+        # Remove the dataset's libSQL file.
+        if dataset_url.startswith("/") and os.path.exists(dataset_url):
             os.remove(dataset_url)

--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -1,0 +1,83 @@
+import os
+from uuid import UUID
+from typing import Optional
+
+from cognee.base_config import get_base_config
+from cognee.infrastructure.databases.graph.config import get_graph_config
+from cognee.infrastructure.databases.graph.get_graph_engine import (
+    create_graph_engine,
+    evict_graph_engine,
+)
+from cognee.modules.users.models import User, DatasetDatabase
+
+
+class TursoGraphDatasetDatabaseHandler:
+    """Handler for per-dataset Turso/SQLite graph databases.
+
+    Local mode: each dataset gets its own SQLite file under the system databases directory.
+    Remote Turso: set GRAPH_DATABASE_URL to the remote libSQL URL and GRAPH_DATABASE_KEY
+    to the auth token; each dataset then uses a dataset-scoped URL path.
+    """
+
+    @classmethod
+    async def create_dataset(cls, dataset_id: Optional[UUID], user: Optional[User]) -> dict:
+        graph_config = get_graph_config()
+
+        if graph_config.graph_database_provider != "turso":
+            raise ValueError(
+                "TursoGraphDatasetDatabaseHandler can only be used "
+                "with the turso graph database provider."
+            )
+
+        base_config = get_base_config()
+        databases_dir = os.path.join(base_config.system_root_directory, "databases")
+        os.makedirs(databases_dir, exist_ok=True)
+
+        db_file = os.path.join(databases_dir, f"graph_{dataset_id}.db")
+        # sqlite+aiosqlite:/// needs three slashes for absolute path
+        dataset_url = f"/{db_file}" if not db_file.startswith("/") else db_file
+
+        engine = create_graph_engine(
+            graph_database_provider="turso",
+            graph_file_path="",
+            graph_database_url=dataset_url,
+            graph_database_key="",
+        )
+        await engine.initialize()
+
+        return {
+            "graph_database_provider": "turso",
+            "graph_database_url": dataset_url,
+            "graph_database_name": str(dataset_id),
+            "graph_database_key": "",
+            "graph_dataset_database_handler": "turso_graph",
+            "graph_database_connection_info": {},
+        }
+
+    @classmethod
+    async def resolve_dataset_connection_info(
+        cls, dataset_database: DatasetDatabase
+    ) -> DatasetDatabase:
+        # No credentials to inject for local SQLite; remote Turso would pull key from config.
+        graph_config = get_graph_config()
+        if graph_config.graph_database_key:
+            dataset_database.graph_database_connection_info["graph_database_key"] = (
+                graph_config.graph_database_key
+            )
+        return dataset_database
+
+    @classmethod
+    async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
+        dataset_url = dataset_database.graph_database_url
+
+        evict_graph_engine(
+            graph_database_provider="turso",
+            graph_file_path="",
+            graph_database_url=dataset_url,
+            graph_database_key="",
+        )
+
+        # Remove the SQLite file for local mode
+        # For remote Turso, file won't exist locally — that's fine.
+        if dataset_url and dataset_url.startswith("/") and os.path.exists(dataset_url):
+            os.remove(dataset_url)

--- a/cognee/infrastructure/databases/graph/turso/__init__.py
+++ b/cognee/infrastructure/databases/graph/turso/__init__.py
@@ -1,0 +1,2 @@
+from .adapter import TursoAdapter
+from .TursoGraphDatasetDatabaseHandler import TursoGraphDatasetDatabaseHandler

--- a/cognee/infrastructure/databases/graph/turso/adapter.py
+++ b/cognee/infrastructure/databases/graph/turso/adapter.py
@@ -1,0 +1,780 @@
+"""Turso/libSQL graph adapter using two tables (graph_node, graph_edge) over SQLAlchemy + aiosqlite."""
+
+import asyncio
+import json
+from uuid import UUID
+from datetime import datetime, timezone
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Dict, Any, List, Union, Optional, Tuple, Type
+
+from sqlalchemy import text, insert
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from cognee.shared.logging_utils import get_logger
+from cognee.infrastructure.engine import DataPoint
+from cognee.infrastructure.databases.graph.graph_db_interface import GraphDBInterface
+from cognee.modules.storage.utils import JSONEncoder
+
+from .tables import _meta, _node_table, _edge_table
+
+logger = get_logger()
+
+_WRITE_CHUNK_SIZE = 500
+
+
+def _in_params(prefix: str, values: List[str]) -> Tuple[str, Dict[str, str]]:
+    """Build named params for SQLite IN clause (SQLite has no ANY(:list) support)."""
+    params = {f"{prefix}_{i}": v for i, v in enumerate(values)}
+    placeholders = ", ".join(f":{prefix}_{i}" for i in range(len(values)))
+    return placeholders, params
+
+
+class TursoAdapter(GraphDBInterface):
+    """Graph-as-tables adapter backed by Turso/libSQL, accessed via SQLAlchemy async sessions."""
+
+    _ALLOWED_FILTER_ATTRS = {"id", "name", "type"}
+
+    def __init__(self, connection_string: str) -> None:
+        """Create engine and sessionmaker from a Turso connection string."""
+        # pyturso 0.6.1 omits has_stop on AsyncAdapt_turso_dbapi.
+        # SQLAlchemy 2.0.51+ reads this flag in SQLiteDialect_aiosqlite.__init__
+        # to decide whether force-close via stop() is available.
+        # Setting False tells SQLAlchemy to skip force-close and use graceful
+        # close only — correct since turso.aio has no stop() method.
+        try:
+            import turso.sqlalchemy.dialect as _turso_dialect
+            if not hasattr(_turso_dialect.AsyncAdapt_turso_dbapi, "has_stop"):
+                _turso_dialect.AsyncAdapt_turso_dbapi.has_stop = False
+        except ImportError:
+            pass
+
+        self.db_uri = connection_string
+        self.engine = create_async_engine(
+            self.db_uri,
+            json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
+        )
+        self.sessionmaker = async_sessionmaker(bind=self.engine, expire_on_commit=False)
+        self._write_lock = asyncio.Lock()
+
+    async def close(self) -> None:
+        """Dispose connection pool. Called by closing_lru_cache on eviction."""
+        await self.engine.dispose(close=True)
+
+    async def initialize(self) -> None:
+        """Create tables and indexes if they do not exist."""
+        async with self.engine.begin() as conn:
+            # SQLite disables FK enforcement by default; cascade deletes need this
+            await conn.execute(text("PRAGMA foreign_keys = ON"))
+            await conn.run_sync(_meta.create_all, checkfirst=True)
+
+    @asynccontextmanager
+    async def _session(self) -> AsyncIterator[Any]:
+        """Yield an async session from the underlying engine."""
+        async with self.sessionmaker() as session:
+            await session.execute(text("PRAGMA foreign_keys = ON"))
+            yield session
+
+    def _serialize_properties(self, props: Dict[str, Any]) -> str:
+        """Serialize a dict to a JSON string, handling datetimes and UUIDs."""
+        return json.dumps(props, cls=JSONEncoder)
+
+    def _parse_node_row(self, row) -> Dict[str, Any]:
+        """Convert a (id, name, type, properties) row to a merged dict."""
+        data = {"id": row.id, "name": row.name, "type": row.type}
+        if row.properties is not None:
+            props = (
+                row.properties if isinstance(row.properties, dict) else json.loads(row.properties)
+            )
+            data.update(props)
+        return data
+
+    async def query(self, query_str: str, params: Optional[dict] = None) -> List[Any]:
+        """Not supported. Use typed adapter methods or a graph-native backend.
+
+        Raises:
+        -------
+            NotImplementedError
+        """
+        raise NotImplementedError(
+            "The Turso graph backend does not support raw Cypher queries. "
+            "Use a graph-native backend (Neo4j, Ladybug) for raw query support, "
+            "or use the typed adapter methods (add_nodes, get_neighbors, etc.)."
+        )
+
+    async def is_empty(self) -> bool:
+        """Return True if the graph has no nodes."""
+        await self.initialize()
+        async with self._session() as session:
+            result = await session.execute(text("SELECT EXISTS(SELECT 1 FROM graph_node LIMIT 1)"))
+            return not result.scalar()
+
+    async def add_node(
+        self, node: Union[DataPoint, str], properties: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Add a single node. Delegates to add_nodes."""
+        if isinstance(node, str):
+            props = properties or {}
+            props.setdefault("id", node)
+            await self.add_nodes([(node, props)])
+        else:
+            await self.add_nodes([node])
+
+    async def add_nodes(self, nodes: Union[List[Tuple[str, Dict]], List[DataPoint]]) -> None:
+        """Add multiple nodes via batch upsert."""
+        if not nodes:
+            return
+
+        now = datetime.now(timezone.utc)
+        core_keys = {"id", "name", "type"}
+
+        rows = []
+        for node in nodes:
+            if isinstance(node, tuple):
+                props = {**(node[1] or {}), "id": node[0]}
+            elif hasattr(node, "model_dump"):
+                props = node.model_dump()
+            else:
+                props = vars(node)
+
+            extra = {k: v for k, v in props.items() if k not in core_keys}
+            rows.append(
+                {
+                    "id": str(props.get("id", "")),
+                    "name": str(props.get("name", "")),
+                    "type": str(props.get("type", "")),
+                    "properties": self._serialize_properties(extra),
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+
+        # Deduplicate by id (last wins)
+        rows = list({r["id"]: r for r in rows}.values())
+
+        async with self._write_lock:
+            async with self._session() as session:
+                for i in range(0, len(rows), _WRITE_CHUNK_SIZE):
+                    chunk = rows[i : i + _WRITE_CHUNK_SIZE]
+                    for row in chunk:
+                        # prefix_with("OR REPLACE") → INSERT OR REPLACE INTO ...
+                        stmt = insert(_node_table).prefix_with("OR REPLACE").values(row)
+                        await session.execute(stmt)
+                await session.commit()
+
+    async def delete_node(self, node_id: str) -> None:
+        """Delete a single node. Delegates to delete_nodes."""
+        await self.delete_nodes([node_id])
+
+    async def delete_nodes(self, node_ids: List[str]) -> None:
+        """Delete multiple nodes by ID. Cascade-deletes connected edges."""
+        if not node_ids:
+            return
+        placeholders, params = _in_params("did", node_ids)
+        async with self._write_lock:
+            async with self._session() as session:
+                await session.execute(
+                    text(f"DELETE FROM graph_node WHERE id IN ({placeholders})"), params
+                )
+                await session.commit()
+
+    async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a single node by ID."""
+        results = await self.get_nodes([node_id])
+        return results[0] if results else None
+
+    async def get_nodes(self, node_ids: List[str]) -> List[Dict[str, Any]]:
+        """Retrieve multiple nodes by ID."""
+        if not node_ids:
+            return []
+        placeholders, params = _in_params("gid", node_ids)
+        async with self._session() as session:
+            result = await session.execute(
+                text(
+                    f"SELECT id, name, type, properties FROM graph_node WHERE id IN ({placeholders})"
+                ),
+                params,
+            )
+            return [self._parse_node_row(row) for row in result.fetchall()]
+
+    async def add_edge(
+        self,
+        source_id: str,
+        target_id: str,
+        relationship_name: str,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Add a single edge. Delegates to add_edges."""
+        await self.add_edges(
+            [(str(source_id), str(target_id), relationship_name, properties or {})]
+        )
+
+    async def add_edges(
+        self, edges: Union[List[Tuple[str, str, str, Optional[Dict[str, Any]]]], List]
+    ) -> None:
+        """Add multiple edges via batch upsert."""
+        if not edges:
+            return
+
+        now = datetime.now(timezone.utc)
+
+        rows = []
+        for edge in edges:
+            raw_props = edge[3] if len(edge) > 3 and edge[3] else {}
+            rows.append(
+                {
+                    "source_id": str(edge[0]),
+                    "target_id": str(edge[1]),
+                    "relationship_name": edge[2],
+                    "properties": self._serialize_properties(raw_props),
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            )
+
+        # Deduplicate by composite key (last wins)
+        rows = list(
+            {(r["source_id"], r["target_id"], r["relationship_name"]): r for r in rows}.values()
+        )
+
+        async with self._write_lock:
+            async with self._session() as session:
+                for i in range(0, len(rows), _WRITE_CHUNK_SIZE):
+                    chunk = rows[i : i + _WRITE_CHUNK_SIZE]
+                    for row in chunk:
+                        stmt = insert(_edge_table).prefix_with("OR REPLACE").values(row)
+                        await session.execute(stmt)
+                await session.commit()
+
+    async def has_edge(self, source_id: str, target_id: str, relationship_name: str) -> bool:
+        """Check whether a single edge exists."""
+        result = await self.has_edges([(str(source_id), str(target_id), relationship_name)])
+        return len(result) > 0
+
+    async def has_edges(self, edges: List[Tuple[str, str, str]]) -> List[Tuple[str, str, str]]:
+        """Return subset of input edge tuples that exist in the database."""
+        if not edges:
+            return []
+
+        found: List[Tuple[str, str, str]] = []
+        async with self._session() as session:
+            for source_id, target_id, relationship_name in edges:
+                result = await session.execute(
+                    text("""
+                        SELECT source_id, target_id, relationship_name
+                        FROM graph_edge
+                        WHERE source_id = :src
+                          AND target_id = :tgt
+                          AND relationship_name = :rel
+                    """),
+                    {"src": str(source_id), "tgt": str(target_id), "rel": relationship_name},
+                )
+                row = result.fetchone()
+                if row:
+                    found.append((row[0], row[1], row[2]))
+        return found
+
+    async def get_edges(self, node_id: str) -> List[Tuple[Dict[str, Any], str, Dict[str, Any]]]:
+        """Retrieve all edges connected to a node as (source_dict, rel_name, target_dict)."""
+        async with self._session() as session:
+            result = await session.execute(
+                text("""
+                    SELECT
+                        n.id, n.name, n.type, n.properties,
+                        e.relationship_name,
+                        m.id, m.name, m.type, m.properties
+                    FROM graph_edge e
+                    JOIN graph_node n ON n.id = e.source_id
+                    JOIN graph_node m ON m.id = e.target_id
+                    WHERE e.source_id = :nid OR e.target_id = :nid
+                """),
+                {"nid": node_id},
+            )
+            edges = []
+            for row in result.fetchall():
+                src = {"id": row[0], "name": row[1], "type": row[2]}
+                if row[3]:
+                    src.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                tgt = {"id": row[5], "name": row[6], "type": row[7]}
+                if row[8]:
+                    tgt.update(row[8] if isinstance(row[8], dict) else json.loads(row[8]))
+                edges.append((src, row[4], tgt))
+            return edges
+
+    async def get_neighbors(self, node_id: str) -> List[Dict[str, Any]]:
+        """Retrieve all nodes directly connected to a given node."""
+        async with self._session() as session:
+            result = await session.execute(
+                text("""
+                    SELECT DISTINCT m.id, m.name, m.type, m.properties
+                    FROM graph_edge e
+                    JOIN graph_node m ON m.id = CASE
+                        WHEN e.source_id = :nid THEN e.target_id
+                        ELSE e.source_id
+                    END
+                    WHERE e.source_id = :nid OR e.target_id = :nid
+                """),
+                {"nid": node_id},
+            )
+            return [self._parse_node_row(row) for row in result.fetchall()]
+
+    async def get_connections(
+        self, node_id: Union[str, UUID]
+    ) -> List[Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]]:
+        """Retrieve all connections (source, edge, target) for a node."""
+        nid = str(node_id)
+        async with self._session() as session:
+            result = await session.execute(
+                text("""
+                    SELECT
+                        n.id, n.name, n.type, n.properties,
+                        e.relationship_name, e.properties AS edge_props,
+                        m.id, m.name, m.type, m.properties
+                    FROM graph_edge e
+                    JOIN graph_node n ON n.id = e.source_id
+                    JOIN graph_node m ON m.id = e.target_id
+                    WHERE e.source_id = :nid OR e.target_id = :nid
+                """),
+                {"nid": nid},
+            )
+
+            connections = []
+            for row in result.fetchall():
+                src = {"id": row[0], "name": row[1], "type": row[2]}
+                if row[3]:
+                    src.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+
+                edge = {"relationship_name": row[4]}
+                if row[5]:
+                    edge_props = row[5] if isinstance(row[5], dict) else json.loads(row[5])
+                    edge.update(edge_props)
+
+                tgt = {"id": row[6], "name": row[7], "type": row[8]}
+                if row[9]:
+                    tgt.update(row[9] if isinstance(row[9], dict) else json.loads(row[9]))
+
+                connections.append((src, edge, tgt))
+            return connections
+
+    async def get_graph_data(
+        self,
+    ) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[Tuple[str, str, str, Dict[str, Any]]]]:
+        """Retrieve all nodes as (id, props) and edges as (src, tgt, rel, props)."""
+        async with self._session() as session:
+            node_result = await session.execute(
+                text("SELECT id, name, type, properties FROM graph_node")
+            )
+            nodes = []
+            for row in node_result.fetchall():
+                data = {"name": row[1], "type": row[2]}
+                if row[3]:
+                    data.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                nodes.append((row[0], data))
+
+            if not nodes:
+                return [], []
+
+            edge_result = await session.execute(
+                text("SELECT source_id, target_id, relationship_name, properties FROM graph_edge")
+            )
+            edges = []
+            for row in edge_result.fetchall():
+                props = {}
+                if row[3]:
+                    props = row[3] if isinstance(row[3], dict) else json.loads(row[3])
+                edges.append((row[0], row[1], row[2], props))
+
+            return nodes, edges
+
+    async def get_id_filtered_graph_data(
+        self, target_ids: List[str]
+    ) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[Tuple[str, str, str, Dict[str, Any]]]]:
+        """Retrieve subgraph for edges touching target_ids, plus their endpoint nodes."""
+        if not target_ids:
+            return [], []
+        ids = [str(i) for i in target_ids]
+        placeholders, params = _in_params("tid", ids)
+
+        async with self._session() as session:
+            edge_result = await session.execute(
+                text(f"""
+                    SELECT source_id, target_id, relationship_name, properties
+                    FROM graph_edge
+                    WHERE source_id IN ({placeholders}) OR target_id IN ({placeholders})
+                """),
+                params,
+            )
+            edges = []
+            endpoint_ids: set = set()
+            for row in edge_result.fetchall():
+                props = {}
+                if row[3]:
+                    props = row[3] if isinstance(row[3], dict) else json.loads(row[3])
+                endpoint_ids.update((row[0], row[1]))
+                edges.append((row[0], row[1], row[2], props))
+
+            if not endpoint_ids:
+                return [], []
+
+            ep_ph, ep_params = _in_params("ep", list(endpoint_ids))
+            node_result = await session.execute(
+                text(
+                    f"SELECT id, name, type, properties FROM graph_node WHERE id IN ({ep_ph})"
+                ),
+                ep_params,
+            )
+            nodes = []
+            for row in node_result.fetchall():
+                data = {"name": row[1], "type": row[2]}
+                if row[3]:
+                    data.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                nodes.append((row[0], data))
+
+            return nodes, edges
+
+    async def get_filtered_graph_data(
+        self, attribute_filters: List[Dict[str, List[Union[str, int]]]]
+    ) -> Tuple[List[Tuple[str, Dict]], List[Tuple[str, str, str, Dict]]]:
+        """Retrieve nodes matching attribute filters, plus edges between them."""
+        if not attribute_filters:
+            return await self.get_graph_data()
+
+        where_parts = []
+        params: Dict[str, Any] = {}
+        for i, filter_dict in enumerate(attribute_filters):
+            for attr, filter_values in filter_dict.items():
+                if attr not in self._ALLOWED_FILTER_ATTRS:
+                    raise ValueError(f"Invalid filter attribute: {attr!r}")
+                ph, fp = _in_params(f"filt_{i}_{attr}", [str(v) for v in filter_values])
+                where_parts.append(f"n.{attr} IN ({ph})")
+                params.update(fp)
+
+        if not where_parts:
+            return await self.get_graph_data()
+
+        where_clause = " AND ".join(where_parts)
+
+        async with self._session() as session:
+            node_result = await session.execute(
+                text(f"""
+                    SELECT id, name, type, properties
+                    FROM graph_node n
+                    WHERE {where_clause}
+                """),
+                params,
+            )
+            node_rows = node_result.fetchall()
+            if not node_rows:
+                return [], []
+
+            node_ids = [row[0] for row in node_rows]
+            nodes = []
+            for row in node_rows:
+                data = {"name": row[1], "type": row[2]}
+                if row[3]:
+                    data.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+                nodes.append((row[0], data))
+
+            fn_ph, fn_params = _in_params("fn", node_ids)
+            edge_result = await session.execute(
+                text(f"""
+                    SELECT source_id, target_id, relationship_name, properties
+                    FROM graph_edge
+                    WHERE source_id IN ({fn_ph}) AND target_id IN ({fn_ph})
+                """),
+                fn_params,
+            )
+            edges = []
+            for row in edge_result.fetchall():
+                props = {}
+                if row[3]:
+                    props = row[3] if isinstance(row[3], dict) else json.loads(row[3])
+                edges.append((row[0], row[1], row[2], props))
+
+            return nodes, edges
+
+    async def get_nodeset_subgraph(
+        self, node_type: Type[Any], node_name: List[str], node_name_filter_operator: str = "OR"
+    ) -> Tuple[List[Tuple[str, dict]], List[Tuple[str, str, str, dict]]]:
+        """Retrieve subgraph of matching nodes, their neighbors, and interconnecting edges."""
+        label = node_type.__name__
+
+        name_ph, name_params = _in_params("nm", node_name)
+        name_params["label"] = label
+
+        if node_name_filter_operator == "OR":
+            neighbor_cte = """
+                    neighbor_ids AS (
+                        SELECT DISTINCT CASE
+                            WHEN e.source_id IN (SELECT id FROM primary_nodes)
+                            THEN e.target_id ELSE e.source_id
+                        END AS id
+                        FROM graph_edge e
+                        WHERE e.source_id IN (SELECT id FROM primary_nodes)
+                           OR e.target_id IN (SELECT id FROM primary_nodes)
+                    )"""
+        else:
+            neighbor_cte = """
+                    neighbor_ids AS (
+                        SELECT nbr_id AS id FROM (
+                            SELECT CASE
+                                WHEN e.source_id IN (SELECT id FROM primary_nodes)
+                                THEN e.target_id ELSE e.source_id
+                            END AS nbr_id,
+                            CASE
+                                WHEN e.source_id IN (SELECT id FROM primary_nodes)
+                                THEN e.source_id ELSE e.target_id
+                            END AS primary_id
+                            FROM graph_edge e
+                            WHERE e.source_id IN (SELECT id FROM primary_nodes)
+                               OR e.target_id IN (SELECT id FROM primary_nodes)
+                        ) sub
+                        GROUP BY nbr_id
+                        HAVING COUNT(DISTINCT primary_id) = :primary_count
+                    )"""
+
+        query_str = f"""
+                    WITH primary_nodes AS (
+                        SELECT DISTINCT id
+                        FROM graph_node
+                        WHERE type = :label AND name IN ({name_ph})
+                    ),
+                    {neighbor_cte},
+                    all_ids AS (
+                        SELECT id FROM primary_nodes
+                        UNION
+                        SELECT id FROM neighbor_ids
+                    )
+                    SELECT 'node' AS kind,
+                           n.id, n.name, n.type, n.properties,
+                           NULL AS source_id, NULL AS target_id,
+                           NULL AS relationship_name, NULL AS edge_props
+                    FROM graph_node n
+                    WHERE n.id IN (SELECT id FROM all_ids)
+                    UNION ALL
+                    SELECT 'edge', NULL, NULL, NULL, NULL,
+                           e.source_id, e.target_id,
+                           e.relationship_name, e.properties
+                    FROM graph_edge e
+                    WHERE e.source_id IN (SELECT id FROM all_ids)
+                      AND e.target_id IN (SELECT id FROM all_ids)
+                """
+
+        if node_name_filter_operator != "OR":
+            name_params["primary_count"] = len(node_name)
+
+        async with self._session() as session:
+            result = await session.execute(text(query_str), name_params)
+
+            nodes = []
+            edges = []
+            for row in result.fetchall():
+                if row[0] == "node":
+                    data = {"name": row[2], "type": row[3]}
+                    if row[4]:
+                        data.update(row[4] if isinstance(row[4], dict) else json.loads(row[4]))
+                    nodes.append((row[1], data))
+                else:
+                    props = {}
+                    if row[8]:
+                        props = row[8] if isinstance(row[8], dict) else json.loads(row[8])
+                    edges.append((row[5], row[6], row[7], props))
+
+            return nodes, edges
+
+    async def get_graph_metrics(self, include_optional: bool = False) -> Dict[str, Any]:
+        """Compute graph metrics matching the PostgresAdapter output schema."""
+        async with self._session() as session:
+            n_result = await session.execute(text("SELECT count(*) FROM graph_node"))
+            num_nodes = n_result.scalar()
+            e_result = await session.execute(text("SELECT count(*) FROM graph_edge"))
+            num_edges = e_result.scalar()
+
+            mean_degree = (2 * num_edges) / num_nodes if num_nodes else None
+            edge_density = num_edges / (num_nodes * (num_nodes - 1)) if num_nodes > 1 else 0
+
+            # SQLite supports recursive CTEs for connected components
+            comp_result = await session.execute(
+                text("""
+                WITH RECURSIVE component AS (
+                    SELECT id AS node_id, id AS comp_root
+                    FROM graph_node
+                    UNION
+                    SELECT
+                        CASE WHEN e.source_id = c.node_id THEN e.target_id ELSE e.source_id END,
+                        c.comp_root
+                    FROM component c
+                    JOIN graph_edge e ON e.source_id = c.node_id OR e.target_id = c.node_id
+                ),
+                node_comp AS (
+                    SELECT node_id, MIN(comp_root) AS comp_id
+                    FROM component
+                    GROUP BY node_id
+                )
+                SELECT comp_id, count(*) AS sz
+                FROM node_comp
+                GROUP BY comp_id
+                ORDER BY sz DESC
+            """)
+            )
+            comp_rows = comp_result.fetchall()
+            num_components = len(comp_rows)
+            component_sizes = [row[1] for row in comp_rows]
+
+            metrics = {
+                "num_nodes": num_nodes,
+                "num_edges": num_edges,
+                "mean_degree": mean_degree,
+                "edge_density": edge_density,
+                "num_connected_components": num_components,
+                "sizes_of_connected_components": component_sizes,
+            }
+
+            if include_optional:
+                sl_result = await session.execute(
+                    text("SELECT count(*) FROM graph_edge WHERE source_id = target_id")
+                )
+                metrics["num_selfloops"] = sl_result.scalar()
+                metrics["diameter"] = -1
+                metrics["avg_shortest_path_length"] = -1
+                metrics["avg_clustering"] = -1
+            else:
+                metrics["num_selfloops"] = -1
+                metrics["diameter"] = -1
+                metrics["avg_shortest_path_length"] = -1
+                metrics["avg_clustering"] = -1
+
+            return metrics
+
+    async def get_neighborhood(
+        self,
+        node_ids: List[str],
+        depth: int = 1,
+        edge_types: Optional[List[str]] = None,
+    ) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[Tuple[str, str, str, Dict[str, Any]]]]:
+        """Get the k-hop neighborhood subgraph around seed nodes."""
+        if not node_ids:
+            return [], []
+
+        edge_filter = ""
+        et_params: Dict[str, Any] = {}
+        if edge_types:
+            et_ph, et_params = _in_params("et", edge_types)
+            edge_filter = f"AND e.relationship_name IN ({et_ph})"
+
+        # SQLite has no unnest(); build seed rows via UNION ALL with named params
+        seed_selects = " UNION ALL ".join(
+            [f"SELECT :seed_{i} AS id, 0 AS hops" for i in range(len(node_ids))]
+        )
+        seed_params = {f"seed_{i}": nid for i, nid in enumerate(node_ids)}
+
+        query_str = f"""
+            WITH RECURSIVE neighborhood(id, hops) AS (
+                {seed_selects}
+              UNION
+                SELECT CASE WHEN e.source_id = n.id THEN e.target_id
+                            ELSE e.source_id END,
+                       n.hops + 1
+                FROM neighborhood n
+                JOIN graph_edge e ON (e.source_id = n.id OR e.target_id = n.id)
+                    {edge_filter}
+                WHERE n.hops < :depth
+            ),
+            ids AS (SELECT DISTINCT id FROM neighborhood)
+
+            SELECT 'node' AS kind,
+                   gn.id, gn.name, gn.type, gn.properties,
+                   NULL AS source_id, NULL AS target_id,
+                   NULL AS relationship_name, NULL AS edge_properties
+            FROM graph_node gn
+            JOIN ids ON gn.id = ids.id
+
+            UNION ALL
+
+            SELECT 'edge' AS kind,
+                   NULL, NULL, NULL, NULL,
+                   ge.source_id, ge.target_id,
+                   ge.relationship_name, ge.properties
+            FROM graph_edge ge
+            WHERE ge.source_id IN (SELECT id FROM ids)
+              AND ge.target_id IN (SELECT id FROM ids)
+        """
+
+        params: Dict[str, Any] = {"depth": depth, **seed_params, **et_params}
+
+        async with self._session() as session:
+            result = await session.execute(text(query_str), params)
+
+            nodes = []
+            edges = []
+            for row in result.fetchall():
+                if row.kind == "node":
+                    data = self._parse_node_row(row)
+                    data.pop("id", None)
+                    nodes.append((row.id, data))
+                else:
+                    props = {}
+                    if row.edge_properties is not None:
+                        props = (
+                            row.edge_properties
+                            if isinstance(row.edge_properties, dict)
+                            else json.loads(row.edge_properties)
+                        )
+                    edges.append((row.source_id, row.target_id, row.relationship_name, props))
+
+            return nodes, edges
+
+    async def delete_graph(self) -> None:
+        """Delete all nodes and edges from the graph."""
+        await self.initialize()
+        async with self._write_lock:
+            async with self._session() as session:
+                await session.execute(text("DELETE FROM graph_edge"))
+                await session.execute(text("DELETE FROM graph_node"))
+                await session.commit()
+
+    async def get_triplets_batch(self, offset: int, limit: int) -> List[Dict[str, Any]]:
+        """Retrieve a batch of (source, relationship, target) triplets."""
+        if offset < 0:
+            raise ValueError(f"Offset must be non-negative, got {offset}")
+        if limit < 0:
+            raise ValueError(f"Limit must be non-negative, got {limit}")
+
+        async with self._session() as session:
+            result = await session.execute(
+                text("""
+                    SELECT
+                        s.id, s.name, s.type, s.properties,
+                        e.relationship_name, e.properties AS edge_props,
+                        t.id, t.name, t.type, t.properties
+                    FROM graph_edge e
+                    JOIN graph_node s ON s.id = e.source_id
+                    JOIN graph_node t ON t.id = e.target_id
+                    ORDER BY e.source_id, e.target_id, e.relationship_name
+                    LIMIT :lim OFFSET :off
+                """),
+                {"off": offset, "lim": limit},
+            )
+
+            triplets = []
+            for row in result.fetchall():
+                start_node = {"id": row[0], "name": row[1], "type": row[2]}
+                if row[3]:
+                    start_node.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
+
+                rel = {"relationship_name": row[4]}
+                if row[5]:
+                    rel_props = row[5] if isinstance(row[5], dict) else json.loads(row[5])
+                    rel.update(rel_props)
+
+                end_node = {"id": row[6], "name": row[7], "type": row[8]}
+                if row[9]:
+                    end_node.update(row[9] if isinstance(row[9], dict) else json.loads(row[9]))
+
+                triplets.append(
+                    {
+                        "start_node": start_node,
+                        "relationship_properties": rel,
+                        "end_node": end_node,
+                    }
+                )
+            return triplets

--- a/cognee/infrastructure/databases/graph/turso/adapter.py
+++ b/cognee/infrastructure/databases/graph/turso/adapter.py
@@ -10,6 +10,7 @@ from typing import AsyncIterator, Dict, Any, List, Union, Optional, Tuple, Type
 from sqlalchemy import text, event
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy.pool import NullPool
 
 from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.engine import DataPoint
@@ -61,7 +62,14 @@ class TursoAdapter(GraphDBInterface):
         # Properties are serialized to TEXT columns by _serialize_properties, so
         # there is no JSON-typed column for SQLAlchemy to encode — hence no
         # json_serializer, unlike the Postgres adapter with its JSONB columns.
-        self.engine = create_async_engine(self.db_uri)
+        #
+        # NullPool for on-disk files (matching the relational SqlAlchemyAdapter):
+        # per-dataset engines are cached and evicted, and pooling would keep
+        # connections/file handles open to a file that eviction may delete. An
+        # in-memory database must instead keep its single connection alive, or the
+        # schema vanishes between operations, so leave those on the default pool.
+        engine_kwargs = {} if ":memory:" in self.db_uri else {"poolclass": NullPool}
+        self.engine = create_async_engine(self.db_uri, **engine_kwargs)
 
         # These PRAGMAs are connection-scoped and a no-op inside a transaction, so
         # apply them on every new connection via the connect event, mirroring the

--- a/cognee/infrastructure/databases/graph/turso/adapter.py
+++ b/cognee/infrastructure/databases/graph/turso/adapter.py
@@ -7,7 +7,8 @@ from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Dict, Any, List, Union, Optional, Tuple, Type
 
-from sqlalchemy import text, insert
+from sqlalchemy import text, event
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 from cognee.shared.logging_utils import get_logger
@@ -23,10 +24,26 @@ _WRITE_CHUNK_SIZE = 500
 
 
 def _in_params(prefix: str, values: List[str]) -> Tuple[str, Dict[str, str]]:
-    """Build named params for SQLite IN clause (SQLite has no ANY(:list) support)."""
+    """Build named params for a SQLite IN clause of small, bounded lists
+    (edge types, node names, filter values). SQLite has no ANY(:list) support.
+    """
     params = {f"{prefix}_{i}": v for i, v in enumerate(values)}
     placeholders = ", ".join(f":{prefix}_{i}" for i in range(len(values)))
     return placeholders, params
+
+
+def _id_subquery(prefix: str, ids: List[str]) -> Tuple[str, Dict[str, str]]:
+    """Build a ``(SELECT value FROM json_each(:prefix))`` subquery and a single
+    JSON-array param for an id list.
+
+    One bound parameter regardless of list size — mirrors Postgres's
+    ``= ANY(:ids)`` and stays under SQLite's per-statement variable cap, so bulk
+    deletes/reads of large id sets do not raise "too many SQL variables".
+    """
+    return (
+        f"(SELECT value FROM json_each(:{prefix}))",
+        {prefix: json.dumps([str(i) for i in ids])},
+    )
 
 
 class TursoAdapter(GraphDBInterface):
@@ -35,24 +52,35 @@ class TursoAdapter(GraphDBInterface):
     _ALLOWED_FILTER_ATTRS = {"id", "name", "type"}
 
     def __init__(self, connection_string: str) -> None:
-        """Create engine and sessionmaker from a Turso connection string."""
-        # pyturso 0.6.1 omits has_stop on AsyncAdapt_turso_dbapi.
-        # SQLAlchemy 2.0.51+ reads this flag in SQLiteDialect_aiosqlite.__init__
-        # to decide whether force-close via stop() is available.
-        # Setting False tells SQLAlchemy to skip force-close and use graceful
-        # close only — correct since turso.aio has no stop() method.
-        try:
-            import turso.sqlalchemy.dialect as _turso_dialect
-            if not hasattr(_turso_dialect.AsyncAdapt_turso_dbapi, "has_stop"):
-                _turso_dialect.AsyncAdapt_turso_dbapi.has_stop = False
-        except ImportError:
-            pass
+        """Create engine and sessionmaker for a local libSQL file.
 
+        A libSQL file is a SQLite file, so cognee talks to it through the same
+        aiosqlite driver it already uses for SQLite (``sqlite+aiosqlite:///``).
+        """
         self.db_uri = connection_string
-        self.engine = create_async_engine(
-            self.db_uri,
-            json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
-        )
+        # Properties are serialized to TEXT columns by _serialize_properties, so
+        # there is no JSON-typed column for SQLAlchemy to encode — hence no
+        # json_serializer, unlike the Postgres adapter with its JSONB columns.
+        self.engine = create_async_engine(self.db_uri)
+
+        # These PRAGMAs are connection-scoped and a no-op inside a transaction, so
+        # apply them on every new connection via the connect event, mirroring the
+        # relational SqlAlchemyAdapter (issue #2717):
+        #   - foreign_keys: SQLite disables FK enforcement by default; graph_edge's
+        #     ON DELETE CASCADE relies on it.
+        #   - journal_mode=WAL + busy_timeout: concurrent writers wait instead of
+        #     failing with "database is locked".
+        @event.listens_for(self.engine.sync_engine, "connect")
+        def _set_sqlite_pragmas(dbapi_connection, _record):
+            cursor = dbapi_connection.cursor()
+            try:
+                cursor.execute("PRAGMA foreign_keys=ON")
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.execute("PRAGMA synchronous=NORMAL")
+                cursor.execute("PRAGMA busy_timeout=120000")
+            finally:
+                cursor.close()
+
         self.sessionmaker = async_sessionmaker(bind=self.engine, expire_on_commit=False)
         self._write_lock = asyncio.Lock()
 
@@ -63,15 +91,12 @@ class TursoAdapter(GraphDBInterface):
     async def initialize(self) -> None:
         """Create tables and indexes if they do not exist."""
         async with self.engine.begin() as conn:
-            # SQLite disables FK enforcement by default; cascade deletes need this
-            await conn.execute(text("PRAGMA foreign_keys = ON"))
             await conn.run_sync(_meta.create_all, checkfirst=True)
 
     @asynccontextmanager
     async def _session(self) -> AsyncIterator[Any]:
         """Yield an async session from the underlying engine."""
         async with self.sessionmaker() as session:
-            await session.execute(text("PRAGMA foreign_keys = ON"))
             yield session
 
     def _serialize_properties(self, props: Dict[str, Any]) -> str:
@@ -119,8 +144,19 @@ class TursoAdapter(GraphDBInterface):
         else:
             await self.add_nodes([node])
 
-    async def add_nodes(self, nodes: Union[List[Tuple[str, Dict]], List[DataPoint]]) -> None:
-        """Add multiple nodes via batch upsert."""
+    async def add_nodes(
+        self,
+        nodes: Union[List[Tuple[str, Dict]], List[DataPoint]],
+        source_ref_key: Optional[str] = None,
+        pipeline_run_id: Optional[str] = None,
+    ) -> None:
+        """Add multiple nodes via batch upsert.
+
+        ``source_ref_key`` / ``pipeline_run_id`` are the graph-provenance stamp the
+        storage path always passes; Turso does not fold provenance into the graph
+        (it uses the relational-ledger delete path), so they are accepted and
+        ignored — the same contract as any non-graph-provenance backend.
+        """
         if not nodes:
             return
 
@@ -151,14 +187,25 @@ class TursoAdapter(GraphDBInterface):
         # Deduplicate by id (last wins)
         rows = list({r["id"]: r for r in rows}.values())
 
+        # Upsert with ON CONFLICT DO UPDATE (not INSERT OR REPLACE). REPLACE deletes
+        # the conflicting row first, which fires graph_edge's ON DELETE CASCADE and
+        # would wipe a node's edges every time it is re-added; DO UPDATE edits in
+        # place, preserving edges and created_at. Mirrors the Postgres adapter.
         async with self._write_lock:
             async with self._session() as session:
                 for i in range(0, len(rows), _WRITE_CHUNK_SIZE):
                     chunk = rows[i : i + _WRITE_CHUNK_SIZE]
-                    for row in chunk:
-                        # prefix_with("OR REPLACE") → INSERT OR REPLACE INTO ...
-                        stmt = insert(_node_table).prefix_with("OR REPLACE").values(row)
-                        await session.execute(stmt)
+                    stmt = sqlite_insert(_node_table).values(chunk)
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["id"],
+                        set_={
+                            "name": stmt.excluded.name,
+                            "type": stmt.excluded.type,
+                            "properties": stmt.excluded.properties,
+                            "updated_at": stmt.excluded.updated_at,
+                        },
+                    )
+                    await session.execute(stmt)
                 await session.commit()
 
     async def delete_node(self, node_id: str) -> None:
@@ -169,11 +216,11 @@ class TursoAdapter(GraphDBInterface):
         """Delete multiple nodes by ID. Cascade-deletes connected edges."""
         if not node_ids:
             return
-        placeholders, params = _in_params("did", node_ids)
+        subquery, params = _id_subquery("did", node_ids)
         async with self._write_lock:
             async with self._session() as session:
                 await session.execute(
-                    text(f"DELETE FROM graph_node WHERE id IN ({placeholders})"), params
+                    text(f"DELETE FROM graph_node WHERE id IN {subquery}"), params
                 )
                 await session.commit()
 
@@ -186,12 +233,10 @@ class TursoAdapter(GraphDBInterface):
         """Retrieve multiple nodes by ID."""
         if not node_ids:
             return []
-        placeholders, params = _in_params("gid", node_ids)
+        subquery, params = _id_subquery("gid", node_ids)
         async with self._session() as session:
             result = await session.execute(
-                text(
-                    f"SELECT id, name, type, properties FROM graph_node WHERE id IN ({placeholders})"
-                ),
+                text(f"SELECT id, name, type, properties FROM graph_node WHERE id IN {subquery}"),
                 params,
             )
             return [self._parse_node_row(row) for row in result.fetchall()]
@@ -209,9 +254,16 @@ class TursoAdapter(GraphDBInterface):
         )
 
     async def add_edges(
-        self, edges: Union[List[Tuple[str, str, str, Optional[Dict[str, Any]]]], List]
+        self,
+        edges: Union[List[Tuple[str, str, str, Optional[Dict[str, Any]]]], List],
+        source_ref_key: Optional[str] = None,
+        pipeline_run_id: Optional[str] = None,
     ) -> None:
-        """Add multiple edges via batch upsert."""
+        """Add multiple edges via batch upsert.
+
+        ``source_ref_key`` / ``pipeline_run_id`` are accepted and ignored (see
+        ``add_nodes``).
+        """
         if not edges:
             return
 
@@ -236,13 +288,20 @@ class TursoAdapter(GraphDBInterface):
             {(r["source_id"], r["target_id"], r["relationship_name"]): r for r in rows}.values()
         )
 
+        # ON CONFLICT DO UPDATE, not INSERT OR REPLACE (see add_nodes for why).
         async with self._write_lock:
             async with self._session() as session:
                 for i in range(0, len(rows), _WRITE_CHUNK_SIZE):
                     chunk = rows[i : i + _WRITE_CHUNK_SIZE]
-                    for row in chunk:
-                        stmt = insert(_edge_table).prefix_with("OR REPLACE").values(row)
-                        await session.execute(stmt)
+                    stmt = sqlite_insert(_edge_table).values(chunk)
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["source_id", "target_id", "relationship_name"],
+                        set_={
+                            "properties": stmt.excluded.properties,
+                            "updated_at": stmt.excluded.updated_at,
+                        },
+                    )
+                    await session.execute(stmt)
                 await session.commit()
 
     async def has_edge(self, source_id: str, target_id: str, relationship_name: str) -> bool:
@@ -251,27 +310,31 @@ class TursoAdapter(GraphDBInterface):
         return len(result) > 0
 
     async def has_edges(self, edges: List[Tuple[str, str, str]]) -> List[Tuple[str, str, str]]:
-        """Return subset of input edge tuples that exist in the database."""
+        """Return subset of input edge tuples that exist in the database.
+
+        Resolved with a single set-based query (candidates joined against
+        graph_edge via json_each) rather than one SELECT per edge — this runs on
+        the cognify dedup hot path with thousands of candidate edges per batch.
+        """
         if not edges:
             return []
 
-        found: List[Tuple[str, str, str]] = []
+        candidates = json.dumps([[str(s), str(t), str(r)] for s, t, r in edges])
         async with self._session() as session:
-            for source_id, target_id, relationship_name in edges:
-                result = await session.execute(
-                    text("""
-                        SELECT source_id, target_id, relationship_name
-                        FROM graph_edge
-                        WHERE source_id = :src
-                          AND target_id = :tgt
-                          AND relationship_name = :rel
-                    """),
-                    {"src": str(source_id), "tgt": str(target_id), "rel": relationship_name},
-                )
-                row = result.fetchone()
-                if row:
-                    found.append((row[0], row[1], row[2]))
-        return found
+            result = await session.execute(
+                text("""
+                    SELECT j.value ->> 0, j.value ->> 1, j.value ->> 2
+                    FROM json_each(:candidates) j
+                    WHERE EXISTS (
+                        SELECT 1 FROM graph_edge e
+                        WHERE e.source_id = j.value ->> 0
+                          AND e.target_id = j.value ->> 1
+                          AND e.relationship_name = j.value ->> 2
+                    )
+                """),
+                {"candidates": candidates},
+            )
+            return [(row[0], row[1], row[2]) for row in result.fetchall()]
 
     async def get_edges(self, node_id: str) -> List[Tuple[Dict[str, Any], str, Dict[str, Any]]]:
         """Retrieve all edges connected to a node as (source_dict, rel_name, target_dict)."""
@@ -391,15 +454,14 @@ class TursoAdapter(GraphDBInterface):
         """Retrieve subgraph for edges touching target_ids, plus their endpoint nodes."""
         if not target_ids:
             return [], []
-        ids = [str(i) for i in target_ids]
-        placeholders, params = _in_params("tid", ids)
+        subquery, params = _id_subquery("tid", target_ids)
 
         async with self._session() as session:
             edge_result = await session.execute(
                 text(f"""
                     SELECT source_id, target_id, relationship_name, properties
                     FROM graph_edge
-                    WHERE source_id IN ({placeholders}) OR target_id IN ({placeholders})
+                    WHERE source_id IN {subquery} OR target_id IN {subquery}
                 """),
                 params,
             )
@@ -415,10 +477,10 @@ class TursoAdapter(GraphDBInterface):
             if not endpoint_ids:
                 return [], []
 
-            ep_ph, ep_params = _in_params("ep", list(endpoint_ids))
+            ep_subquery, ep_params = _id_subquery("ep", list(endpoint_ids))
             node_result = await session.execute(
                 text(
-                    f"SELECT id, name, type, properties FROM graph_node WHERE id IN ({ep_ph})"
+                    f"SELECT id, name, type, properties FROM graph_node WHERE id IN {ep_subquery}"
                 ),
                 ep_params,
             )
@@ -444,6 +506,11 @@ class TursoAdapter(GraphDBInterface):
             for attr, filter_values in filter_dict.items():
                 if attr not in self._ALLOWED_FILTER_ATTRS:
                     raise ValueError(f"Invalid filter attribute: {attr!r}")
+                if not filter_values:
+                    # Empty value list matches nothing (SQLite has no "IN ()");
+                    # matches Postgres's "= ANY('{}')" semantics.
+                    where_parts.append("0 = 1")
+                    continue
                 ph, fp = _in_params(f"filt_{i}_{attr}", [str(v) for v in filter_values])
                 where_parts.append(f"n.{attr} IN ({ph})")
                 params.update(fp)
@@ -474,12 +541,12 @@ class TursoAdapter(GraphDBInterface):
                     data.update(row[3] if isinstance(row[3], dict) else json.loads(row[3]))
                 nodes.append((row[0], data))
 
-            fn_ph, fn_params = _in_params("fn", node_ids)
+            fn_subquery, fn_params = _id_subquery("fn", node_ids)
             edge_result = await session.execute(
                 text(f"""
                     SELECT source_id, target_id, relationship_name, properties
                     FROM graph_edge
-                    WHERE source_id IN ({fn_ph}) AND target_id IN ({fn_ph})
+                    WHERE source_id IN {fn_subquery} AND target_id IN {fn_subquery}
                 """),
                 fn_params,
             )
@@ -496,10 +563,12 @@ class TursoAdapter(GraphDBInterface):
         self, node_type: Type[Any], node_name: List[str], node_name_filter_operator: str = "OR"
     ) -> Tuple[List[Tuple[str, dict]], List[Tuple[str, str, str, dict]]]:
         """Retrieve subgraph of matching nodes, their neighbors, and interconnecting edges."""
+        if not node_name:
+            return [], []
         label = node_type.__name__
 
         name_ph, name_params = _in_params("nm", node_name)
-        name_params["label"] = label
+        params: Dict[str, Any] = {**name_params, "label": label}
 
         if node_name_filter_operator == "OR":
             neighbor_cte = """
@@ -560,10 +629,10 @@ class TursoAdapter(GraphDBInterface):
                 """
 
         if node_name_filter_operator != "OR":
-            name_params["primary_count"] = len(node_name)
+            params["primary_count"] = len(node_name)
 
         async with self._session() as session:
-            result = await session.execute(text(query_str), name_params)
+            result = await session.execute(text(query_str), params)
 
             nodes = []
             edges = []
@@ -661,15 +730,13 @@ class TursoAdapter(GraphDBInterface):
             et_ph, et_params = _in_params("et", edge_types)
             edge_filter = f"AND e.relationship_name IN ({et_ph})"
 
-        # SQLite has no unnest(); build seed rows via UNION ALL with named params
-        seed_selects = " UNION ALL ".join(
-            [f"SELECT :seed_{i} AS id, 0 AS hops" for i in range(len(node_ids))]
-        )
-        seed_params = {f"seed_{i}": nid for i, nid in enumerate(node_ids)}
+        # SQLite has no unnest(); seed the recursion from a JSON array (one bound
+        # param, no per-seed variable cap).
+        seed_subquery, seed_params = _id_subquery("seeds", node_ids)
 
         query_str = f"""
             WITH RECURSIVE neighborhood(id, hops) AS (
-                {seed_selects}
+                SELECT value AS id, 0 AS hops FROM json_each(:seeds)
               UNION
                 SELECT CASE WHEN e.source_id = n.id THEN e.target_id
                             ELSE e.source_id END,
@@ -778,3 +845,55 @@ class TursoAdapter(GraphDBInterface):
                     }
                 )
             return triplets
+
+    async def remove_belongs_to_set_tags(
+        self,
+        tags: List[str],
+        node_ids: Optional[List[str]] = None,
+    ) -> None:
+        """Strip ``tags`` from each node's ``belongs_to_set`` property array.
+
+        Keeps the denormalized membership list consistent with the additive
+        belongs_to_set edges after a NodeSet (or its dataset) is deleted.
+        ``belongs_to_set`` lives inside the JSON ``properties`` TEXT blob, so this
+        is a read-filter-write over that array. Mirrors the Postgres adapter.
+        """
+        if not tags:
+            return None
+        if node_ids is not None and not node_ids:
+            return None
+
+        tag_set = set(tags)
+        async with self._session() as session:
+            if node_ids is not None:
+                subquery, params = _id_subquery("bts", node_ids)
+                result = await session.execute(
+                    text(f"SELECT id, properties FROM graph_node WHERE id IN {subquery}"), params
+                )
+            else:
+                result = await session.execute(text("SELECT id, properties FROM graph_node"))
+            rows = result.fetchall()
+
+        updates = []
+        for row in rows:
+            properties = json.loads(row[1]) if row[1] else {}
+            current = properties.get("belongs_to_set")
+            if not isinstance(current, list) or not any(tag in tag_set for tag in current):
+                continue
+            properties["belongs_to_set"] = [tag for tag in current if tag not in tag_set]
+            updates.append({"id": row[0], "properties": self._serialize_properties(properties)})
+
+        if updates:
+            now = datetime.now(timezone.utc)
+            async with self._write_lock:
+                async with self._session() as session:
+                    for update in updates:
+                        await session.execute(
+                            text(
+                                "UPDATE graph_node SET properties = :p, updated_at = :now "
+                                "WHERE id = :id"
+                            ),
+                            {"id": update["id"], "p": update["properties"], "now": now},
+                        )
+                    await session.commit()
+        return None

--- a/cognee/infrastructure/databases/graph/turso/tables.py
+++ b/cognee/infrastructure/databases/graph/turso/tables.py
@@ -1,0 +1,44 @@
+"""Schema definitions for the Turso graph adapter (graph_node, graph_edge)."""  
+  
+from sqlalchemy import Table, Column, MetaData, String, DateTime, Index, ForeignKey, func  
+  
+_meta = MetaData()  
+  
+_node_table = Table(  
+    "graph_node",  
+    _meta,  
+    Column("id", String, primary_key=True),  
+    Column("name", String),  
+    Column("type", String),  
+    Column("properties", String),  # JSON stored as TEXT in SQLite  
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),  
+    Column("updated_at", DateTime(timezone=True), server_default=func.now()),  
+)  
+  
+_edge_table = Table(  
+    "graph_edge",  
+    _meta,  
+    Column(  
+        "source_id",  
+        String,  
+        ForeignKey("graph_node.id", ondelete="CASCADE"),  
+        primary_key=True,  
+        nullable=False,  
+    ),  
+    Column(  
+        "target_id",  
+        String,  
+        ForeignKey("graph_node.id", ondelete="CASCADE"),  
+        primary_key=True,  
+        nullable=False,  
+    ),  
+    Column("relationship_name", String, primary_key=True, nullable=False),  
+    Column("properties", String),  # JSON stored as TEXT in SQLite  
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),  
+    Column("updated_at", DateTime(timezone=True), server_default=func.now()),  
+)  
+  
+# Standard indexes for performance  
+Index("idx_edge_source", _edge_table.c.source_id)  
+Index("idx_edge_target", _edge_table.c.target_id)  
+Index("idx_node_type", _node_table.c.type)

--- a/cognee/infrastructure/databases/graph/turso/tables.py
+++ b/cognee/infrastructure/databases/graph/turso/tables.py
@@ -1,44 +1,44 @@
-"""Schema definitions for the Turso graph adapter (graph_node, graph_edge)."""  
-  
-from sqlalchemy import Table, Column, MetaData, String, DateTime, Index, ForeignKey, func  
-  
-_meta = MetaData()  
-  
-_node_table = Table(  
-    "graph_node",  
-    _meta,  
-    Column("id", String, primary_key=True),  
-    Column("name", String),  
-    Column("type", String),  
-    Column("properties", String),  # JSON stored as TEXT in SQLite  
-    Column("created_at", DateTime(timezone=True), server_default=func.now()),  
-    Column("updated_at", DateTime(timezone=True), server_default=func.now()),  
-)  
-  
-_edge_table = Table(  
-    "graph_edge",  
-    _meta,  
-    Column(  
-        "source_id",  
-        String,  
-        ForeignKey("graph_node.id", ondelete="CASCADE"),  
-        primary_key=True,  
-        nullable=False,  
-    ),  
-    Column(  
-        "target_id",  
-        String,  
-        ForeignKey("graph_node.id", ondelete="CASCADE"),  
-        primary_key=True,  
-        nullable=False,  
-    ),  
-    Column("relationship_name", String, primary_key=True, nullable=False),  
-    Column("properties", String),  # JSON stored as TEXT in SQLite  
-    Column("created_at", DateTime(timezone=True), server_default=func.now()),  
-    Column("updated_at", DateTime(timezone=True), server_default=func.now()),  
-)  
-  
-# Standard indexes for performance  
-Index("idx_edge_source", _edge_table.c.source_id)  
-Index("idx_edge_target", _edge_table.c.target_id)  
+"""Schema definitions for the Turso graph adapter (graph_node, graph_edge)."""
+
+from sqlalchemy import Table, Column, MetaData, String, DateTime, Index, ForeignKey, func
+
+_meta = MetaData()
+
+_node_table = Table(
+    "graph_node",
+    _meta,
+    Column("id", String, primary_key=True),
+    Column("name", String),
+    Column("type", String),
+    Column("properties", String),  # JSON stored as TEXT in SQLite
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),
+    Column("updated_at", DateTime(timezone=True), server_default=func.now()),
+)
+
+_edge_table = Table(
+    "graph_edge",
+    _meta,
+    Column(
+        "source_id",
+        String,
+        ForeignKey("graph_node.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    ),
+    Column(
+        "target_id",
+        String,
+        ForeignKey("graph_node.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    ),
+    Column("relationship_name", String, primary_key=True, nullable=False),
+    Column("properties", String),  # JSON stored as TEXT in SQLite
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),
+    Column("updated_at", DateTime(timezone=True), server_default=func.now()),
+)
+
+# Standard indexes for performance
+Index("idx_edge_source", _edge_table.c.source_id)
+Index("idx_edge_target", _edge_table.c.target_id)
 Index("idx_node_type", _node_table.c.type)

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/mcp_sampling/adapter.py
@@ -153,7 +153,7 @@ class MCPSamplingAdapter(LLMInterface):
             f"Last error: {last_error}"
         )
 
-    async def create_transcript(self, input: str) -> TranscriptionReturnType | None:
+    async def create_transcript(self, input: str, **kwargs: Any) -> TranscriptionReturnType | None:
         """Audio transcription has no MCP sampling equivalent — graceful no-audio."""
         logger.debug("create_transcript is not supported over MCP sampling; returning None")
         return None

--- a/cognee/modules/retrieval/natural_language_retriever.py
+++ b/cognee/modules/retrieval/natural_language_retriever.py
@@ -107,11 +107,12 @@ class NaturalLanguageRetriever(BaseRetriever):
     async def get_retrieved_objects(self, query: str) -> Any:
         graph_engine = await get_graph_engine()
 
-        # Postgres backends do not support Cypher generation/execution
+        # Postgres and Turso backends do not support Cypher generation/execution
         from cognee.infrastructure.databases.graph.postgres.adapter import PostgresAdapter
         from cognee.infrastructure.databases.hybrid.postgres.adapter import PostgresHybridAdapter
+        from cognee.infrastructure.databases.graph.turso.adapter import TursoAdapter
 
-        if isinstance(graph_engine, (PostgresAdapter, PostgresHybridAdapter)):
+        if isinstance(graph_engine, (PostgresAdapter, PostgresHybridAdapter, TursoAdapter)):
             raise SearchTypeNotSupported(
                 "Natural language search is not supported with the Postgres graph backend. "
                 "This retriever generates and executes Cypher queries, which require a "

--- a/cognee/modules/retrieval/natural_language_retriever.py
+++ b/cognee/modules/retrieval/natural_language_retriever.py
@@ -114,7 +114,7 @@ class NaturalLanguageRetriever(BaseRetriever):
 
         if isinstance(graph_engine, (PostgresAdapter, PostgresHybridAdapter, TursoAdapter)):
             raise SearchTypeNotSupported(
-                "Natural language search is not supported with the Postgres graph backend. "
+                "Natural language search is not supported with the Postgres or Turso graph backends. "
                 "This retriever generates and executes Cypher queries, which require a "
                 "Cypher-capable graph backend (Neo4j, Ladybug)."
             )

--- a/cognee/tests/e2e/turso/test_graphdb_turso.py
+++ b/cognee/tests/e2e/turso/test_graphdb_turso.py
@@ -1,0 +1,21 @@
+"""End-to-end graph database test using the Turso (libSQL) backend.
+
+Exercises the full add -> cognify -> search pipeline against a local libSQL file.
+Requires:
+  - LLM_API_KEY set for cognify
+  - A working vector database (default LanceDB is fine)
+
+Turso is local and needs no server or extra dependency (a libSQL file is a SQLite
+file, read through the aiosqlite driver), so no connection setup is required.
+"""
+
+import asyncio
+from cognee.tests.e2e.postgres.test_graphdb_shared import run_graph_db_test
+
+
+async def main():
+    await run_graph_db_test("turso")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cognee/tests/e2e/turso/test_turso_adapter.py
+++ b/cognee/tests/e2e/turso/test_turso_adapter.py
@@ -1,0 +1,210 @@
+"""Unit tests for TursoAdapter using an in-memory SQLite database."""
+
+import json
+import pytest
+import pytest_asyncio
+
+from cognee.infrastructure.databases.graph.turso.adapter import TursoAdapter
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    """In-memory SQLite adapter — fast, no disk I/O, isolated per test."""
+    a = TursoAdapter(connection_string="sqlite+aiosqlite:///:memory:")
+    await a.initialize()
+    yield a
+    await a.delete_graph()
+    await a.close()
+
+
+@pytest.mark.asyncio
+async def test_is_empty_on_fresh_db(adapter):
+    assert await adapter.is_empty()
+
+
+@pytest.mark.asyncio
+async def test_add_and_get_node(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    node = await adapter.get_node("n1")
+    assert node is not None
+    assert node["name"] == "Alice"
+    assert node["type"] == "Person"
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_bulk(adapter):
+    nodes = [
+        ("n1", {"name": "Alice", "type": "Person"}),
+        ("n2", {"name": "Bob", "type": "Person"}),
+        ("n3", {"name": "Carol", "type": "Person"}),
+    ]
+    await adapter.add_nodes(nodes)
+    results = await adapter.get_nodes(["n1", "n2", "n3"])
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_upsert_node(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n1", {"name": "Alice Updated", "type": "Person"})
+    node = await adapter.get_node("n1")
+    assert node["name"] == "Alice Updated"
+
+
+@pytest.mark.asyncio
+async def test_delete_node(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.delete_node("n1")
+    assert await adapter.get_node("n1") is None
+
+
+@pytest.mark.asyncio
+async def test_add_and_has_edge(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    assert await adapter.has_edge("n1", "n2", "KNOWS")
+    assert not await adapter.has_edge("n2", "n1", "KNOWS")
+
+
+@pytest.mark.asyncio
+async def test_has_edges_returns_found_tuples(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    found = await adapter.has_edges([
+        ("n1", "n2", "KNOWS"),
+        ("n2", "n1", "KNOWS"),   # does not exist
+    ])
+    assert len(found) == 1
+    assert found[0] == ("n1", "n2", "KNOWS")
+
+
+@pytest.mark.asyncio
+async def test_get_edges_returns_src_rel_tgt_tuples(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    edges = await adapter.get_edges("n1")
+    assert len(edges) == 1
+    src, rel, tgt = edges[0]
+    assert isinstance(src, dict) and src["id"] == "n1"
+    assert rel == "KNOWS"
+    assert isinstance(tgt, dict) and tgt["id"] == "n2"
+
+
+@pytest.mark.asyncio
+async def test_get_neighbors(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_node("n3", {"name": "Carol", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    await adapter.add_edge("n1", "n3", "KNOWS")
+
+    neighbors = await adapter.get_neighbors("n1")
+    ids = {n["id"] for n in neighbors}
+    assert ids == {"n2", "n3"}
+
+
+@pytest.mark.asyncio
+async def test_get_connections(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS", {"since": 2020})
+
+    conns = await adapter.get_connections("n1")
+    assert len(conns) == 1
+    src, edge, tgt = conns[0]
+    assert src["id"] == "n1"
+    assert edge["relationship_name"] == "KNOWS"
+    assert tgt["id"] == "n2"
+
+
+@pytest.mark.asyncio
+async def test_get_graph_data_format(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    nodes, edges = await adapter.get_graph_data()
+
+    # nodes must be (id, props_dict) tuples
+    assert all(isinstance(n, tuple) and len(n) == 2 for n in nodes)
+    node_ids = {n[0] for n in nodes}
+    assert node_ids == {"n1", "n2"}
+
+    # edges must be (src, tgt, rel, props) tuples
+    assert all(isinstance(e, tuple) and len(e) == 4 for e in edges)
+    assert edges[0][:3] == ("n1", "n2", "KNOWS")
+
+
+@pytest.mark.asyncio
+async def test_get_graph_metrics(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    metrics = await adapter.get_graph_metrics()
+    assert metrics["num_nodes"] == 2
+    assert metrics["num_edges"] == 1
+    assert "mean_degree" in metrics
+    assert "edge_density" in metrics
+    assert "num_connected_components" in metrics
+
+
+@pytest.mark.asyncio
+async def test_delete_graph(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    await adapter.delete_graph()
+    assert await adapter.is_empty()
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_node("n3", {"name": "Carol", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    await adapter.add_edge("n2", "n3", "KNOWS")
+
+    nodes, edges = await adapter.get_neighborhood(["n1"], depth=1)
+    node_ids = {n[0] for n in nodes}
+    # depth=1: n1 and its direct neighbor n2
+    assert "n1" in node_ids
+    assert "n2" in node_ids
+    assert "n3" not in node_ids
+
+
+@pytest.mark.asyncio
+async def test_get_triplets_batch(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    triplets = await adapter.get_triplets_batch(offset=0, limit=10)
+    assert len(triplets) == 1
+    assert triplets[0]["start_node"]["id"] == "n1"
+    assert triplets[0]["relationship_properties"]["relationship_name"] == "KNOWS"
+    assert triplets[0]["end_node"]["id"] == "n2"
+
+
+@pytest.mark.asyncio
+async def test_cascade_delete_edges_on_node_delete(adapter):
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    await adapter.delete_node("n1")
+    # Edge should be cascade-deleted
+    edges = await adapter.get_edges("n2")
+    assert len(edges) == 0
+
+
+@pytest.mark.asyncio
+async def test_query_raises_not_implemented(adapter):
+    with pytest.raises(NotImplementedError):
+        await adapter.query("MATCH (n) RETURN n")

--- a/cognee/tests/e2e/turso/test_turso_adapter.py
+++ b/cognee/tests/e2e/turso/test_turso_adapter.py
@@ -73,10 +73,12 @@ async def test_has_edges_returns_found_tuples(adapter):
     await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
     await adapter.add_edge("n1", "n2", "KNOWS")
 
-    found = await adapter.has_edges([
-        ("n1", "n2", "KNOWS"),
-        ("n2", "n1", "KNOWS"),   # does not exist
-    ])
+    found = await adapter.has_edges(
+        [
+            ("n1", "n2", "KNOWS"),
+            ("n2", "n1", "KNOWS"),  # does not exist
+        ]
+    )
     assert len(found) == 1
     assert found[0] == ("n1", "n2", "KNOWS")
 
@@ -208,3 +210,126 @@ async def test_cascade_delete_edges_on_node_delete(adapter):
 async def test_query_raises_not_implemented(adapter):
     with pytest.raises(NotImplementedError):
         await adapter.query("MATCH (n) RETURN n")
+
+
+# --- Regression tests for the maintainer rework (SDK-176) -----------------------
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_and_edges_accept_provenance_kwargs(adapter):
+    """The storage path always passes source_ref_key/pipeline_run_id; the adapter
+    must accept (and ignore) them instead of raising TypeError at cognify time."""
+    await adapter.add_nodes(
+        [("n1", {"name": "Alice", "type": "Person"})],
+        source_ref_key="ref",
+        pipeline_run_id="run",
+    )
+    await adapter.add_edges(
+        [("n1", "n1", "SELF", {})],
+        source_ref_key="ref",
+        pipeline_run_id="run",
+    )
+    assert await adapter.get_node("n1") is not None
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_preserves_edges(adapter):
+    """Re-adding an existing node (upsert) must NOT delete its edges. Regression
+    for INSERT OR REPLACE, which cascade-deleted edges via ON DELETE CASCADE."""
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+
+    # Re-add n1 with changed properties (happens on every re-cognify / shared entity).
+    await adapter.add_node("n1", {"name": "Alice Updated", "type": "Person"})
+
+    assert (await adapter.get_node("n1"))["name"] == "Alice Updated"
+    assert len(await adapter.get_edges("n1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_remove_belongs_to_set_tags(adapter):
+    await adapter.add_node(
+        "n1", {"name": "Alice", "type": "Person", "belongs_to_set": ["set_a", "set_b"]}
+    )
+    await adapter.add_node("n2", {"name": "Bob", "type": "Person", "belongs_to_set": ["set_c"]})
+
+    await adapter.remove_belongs_to_set_tags(["set_a"])
+
+    assert (await adapter.get_node("n1"))["belongs_to_set"] == ["set_b"]
+    assert (await adapter.get_node("n2"))["belongs_to_set"] == ["set_c"]
+
+
+@pytest.mark.asyncio
+async def test_get_filtered_graph_data_empty_values_matches_nothing(adapter):
+    """An empty filter value list matches nothing without an "IN ()" syntax error."""
+    await adapter.add_node("n1", {"name": "Alice", "type": "Person"})
+    nodes, edges = await adapter.get_filtered_graph_data([{"type": []}])
+    assert nodes == [] and edges == []
+
+
+@pytest.mark.asyncio
+async def test_get_nodeset_subgraph_empty_names(adapter):
+    class Person:
+        pass
+
+    nodes, edges = await adapter.get_nodeset_subgraph(Person, [])
+    assert nodes == [] and edges == []
+
+
+@pytest.mark.asyncio
+async def test_bulk_add_delete_large_id_set(adapter):
+    """Bulk add/get/delete over a large id set must not raise "too many SQL
+    variables" — id lists are bound as a single JSON array via json_each."""
+    ids = [f"n{i}" for i in range(2000)]
+    await adapter.add_nodes([(i, {"name": i, "type": "Person"}) for i in ids])
+    assert len(await adapter.get_nodes(ids)) == 2000
+    await adapter.delete_nodes(ids)
+    assert await adapter.is_empty()
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_depth_and_edge_types(adapter):
+    for n in ("n1", "n2", "n3", "n4"):
+        await adapter.add_node(n, {"name": n, "type": "Person"})
+    await adapter.add_edge("n1", "n2", "KNOWS")
+    await adapter.add_edge("n2", "n3", "KNOWS")
+    await adapter.add_edge("n3", "n4", "LIKES")
+
+    nodes, _ = await adapter.get_neighborhood(["n1"], depth=2)
+    assert {n[0] for n in nodes} == {"n1", "n2", "n3"}
+
+    # edge_types restricts traversal to KNOWS edges only.
+    nodes, _ = await adapter.get_neighborhood(["n1"], depth=3, edge_types=["KNOWS"])
+    assert "n4" not in {n[0] for n in nodes}
+
+
+@pytest.mark.asyncio
+async def test_factory_returns_turso_adapter_and_rejects_remote(tmp_path):
+    from cognee.infrastructure.databases.graph.get_graph_engine import (
+        create_graph_engine,
+        evict_graph_engine,
+    )
+
+    db_path = str(tmp_path / "graph.db")
+    kwargs = dict(
+        graph_database_provider="turso",
+        graph_file_path="",
+        graph_database_url=db_path,
+        graph_database_key="",
+    )
+    engine = create_graph_engine(**kwargs)
+    try:
+        assert isinstance(engine, TursoAdapter)
+        assert engine.db_uri == f"sqlite+aiosqlite:///{db_path}"
+    finally:
+        evict_graph_engine(**kwargs)
+
+    # A set auth token (remote) is rejected: remote sync is not supported yet.
+    with pytest.raises(EnvironmentError):
+        create_graph_engine(
+            graph_database_provider="turso",
+            graph_file_path="",
+            graph_database_url=db_path,
+            graph_database_key="token",
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ fastembed = [
 ]
 
 neo4j = ["neo4j>=5.28.0,<6"]
+turso = ["pyturso>=0.6.1"]
 neptune = ["langchain_aws>=0.2.22"]
 postgres = [
     "psycopg2>=2.9.10,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ fastembed = [
 ]
 
 neo4j = ["neo4j>=5.28.0,<6"]
-turso = ["pyturso>=0.6.1"]
 neptune = ["langchain_aws>=0.2.22"]
 postgres = [
     "psycopg2>=2.9.10,<3",


### PR DESCRIPTION
## Description

Maintainer continuation of #3862 (by @chinu0609) for hackathon issue #3584 — adds Turso / libSQL as a selectable graph backend (`GRAPH_DATABASE_PROVIDER=turso`).

`TursoAdapter(GraphDBInterface)` stores the knowledge graph as two relational tables (`graph_node` / `graph_edge`) and answers every graph operation with parameterized SQL — JOINs for neighbors/connections/triplets, `WITH RECURSIVE` CTEs for k-hop neighborhood, connected components, and nodeset subgraphs — directly mirroring the Postgres graph adapter (`PostgresAdapter`). A per-dataset dataset-database handler gives each user+dataset its own libSQL file so the existing multi-user permission system works unchanged. Cypher and natural-language search are rejected explicitly, matching Postgres.

**Scope: local / embedded libSQL only**, which is the whole of the issue's stated design (adapter + schema + factory branch + config mapping + one dataset handler). The original PR's remote embedded-replica sync (commit 3) was **not** carried forward — it is not in issue #3584, and shipped with known limitations (all datasets sharing one remote DB/token, throttled-pull staleness). Remote sync is a documented follow-up.

The author's local-mode commits are preserved as authored by them; every change I made lands as a separate commit on top.

## Why the original PR was reworked

The adapter passed its own unit tests but broke on the real product path, because those tests exercised it in isolation (positional calls, in-memory `aiosqlite`) rather than through cognify/search on the configured driver:

- **cognify crashed on the first graph write.** `add_data_points` always calls `add_nodes(..., source_ref_key=…, pipeline_run_id=…)`, but the adapter's overrides did not accept those kwargs → `TypeError`. Now accepted and no-op-ignored (the correct contract for a backend that does not fold graph-provenance; it uses the relational-ledger delete path).
- **Node upserts silently destroyed edges.** Writes used `INSERT OR REPLACE`, which deletes the conflicting row before re-inserting; with `ON DELETE CASCADE` on, re-adding an existing node (every re-cognify, every shared entity) cascade-deleted all of its edges. Switched to `INSERT … ON CONFLICT DO UPDATE` (in-place, preserves `created_at`), matching Postgres.
- **Recursive-CTE traversals crashed on the real driver.** The factory built the engine on `sqlite+aioturso` (the pyturso Rust engine), which cannot parse `WITH RECURSIVE` — `get_neighborhood` and `get_graph_metrics` raised `Parse error: Recursive CTEs are not yet supported`. Switched the query path to the core `aiosqlite` driver (a libSQL file is a SQLite file), which runs them natively. This matches the Turso relational sibling's driver choice and means **no extra dependency** is required for the local backend — so the unused `pyturso` / `cognee[turso]` extra was removed.
- **Foreign-key enforcement was fragile.** `PRAGMA foreign_keys = ON` was set inside a transaction (a no-op in SQLite). Moved to a `connect`-event listener alongside `journal_mode=WAL` / `busy_timeout` (mirroring the relational `SqlAlchemyAdapter`, issue #2717).
- **Scale / hot-path fixes.** Large id lists now bind as one JSON array via `json_each` instead of one parameter per id (bulk deletes no longer risk "too many SQL variables"); `has_edges` resolves in a single set-based query instead of one SELECT per edge (cognify dedup hot path).
- **Delete parity.** Implemented `remove_belongs_to_set_tags` so NodeSet/dataset deletion reconciles the denormalized `belongs_to_set` arrays, like Postgres/Ladybug.
- **Usability.** In single-user mode Turso now falls back to the auto-derived `graph_file_path` when `GRAPH_DATABASE_URL` is unset, so it works out of the box like the other file-based backends.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- Adapter unit/behaviour tests (in-memory + file libSQL): node/edge CRUD, upsert-preserves-edges, cascade delete, neighbors/connections/triplets, k-hop neighborhood + edge-type filtering, nodeset subgraph (AND/OR), metrics, `belongs_to_set` reconciliation, empty-filter guards, bulk add/delete over a large id set, and the factory branch (returns `TursoAdapter` on `aiosqlite`, rejects remote).
- Full adapter surface verified running on the production `aiosqlite` path; recursive-CTE methods confirmed failing on `aioturso` and passing on `aiosqlite`.
- Single-user `get_graph_engine()` + provenance-marker integration and the per-dataset handler (create → write → delete) verified end-to-end offline.
- `cognee/tests/e2e/turso/test_graphdb_turso.py` runs the shared full add → cognify → search pipeline against Turso (requires an LLM key).
- `ruff` clean; `ty` adds no new diagnostics (the adapter's remaining override diagnostics are identical to the Postgres template).

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
