### PR TITLE
SDK-183 fix(ingestion): pass UUID node ids in DLT FK/schema edge tuples

### DIFF
--- a/cognee/tasks/ingestion/extract_dlt_fk_edges.py
+++ b/cognee/tasks/ingestion/extract_dlt_fk_edges.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, List, Optional
-from uuid import uuid5, NAMESPACE_OID
+from uuid import UUID, uuid5, NAMESPACE_OID
 
 from cognee.infrastructure.engine.models.DataPoint import DataPoint
 from cognee.infrastructure.databases.provenance import graph_provenance_write_kwargs
@@ -157,11 +157,14 @@ async def extract_dlt_fk_edges(
             source_table_id = table_node_ids.get(table_name)
             target_table_id = table_node_ids.get(ref_table)
 
+            # Edge tuples carry UUID node ids (slots 0/1), matching the
+            # get_graph_from_model contract that upsert_edges relies on;
+            # the JSON attributes keep string copies.
             if source_table_id:
                 schema_edges.append(
                     (
-                        str(source_table_id),
-                        str(relationship.id),
+                        source_table_id,
+                        relationship.id,
                         "has_foreign_key",
                         {
                             "source_node_id": str(source_table_id),
@@ -173,8 +176,8 @@ async def extract_dlt_fk_edges(
             if target_table_id:
                 schema_edges.append(
                     (
-                        str(relationship.id),
-                        str(target_table_id),
+                        relationship.id,
+                        target_table_id,
                         "references_table",
                         {
                             "source_node_id": str(relationship.id),
@@ -196,8 +199,8 @@ async def extract_dlt_fk_edges(
         if table_node_id:
             schema_edges.append(
                 (
-                    doc_id,
-                    str(table_node_id),
+                    UUID(doc_id),
+                    table_node_id,
                     "is_row_of",
                     {
                         "source_node_id": doc_id,
@@ -221,8 +224,8 @@ async def extract_dlt_fk_edges(
 
             fk_row_edges.append(
                 (
-                    doc_id,
-                    target_data_id,
+                    UUID(doc_id),
+                    UUID(target_data_id),
                     relationship_name,
                     {
                         "source_node_id": doc_id,

--- a/cognee/tests/unit/tasks/ingestion/test_extract_dlt_fk_edges_uuid_ids.py
+++ b/cognee/tests/unit/tasks/ingestion/test_extract_dlt_fk_edges_uuid_ids.py
@@ -1,0 +1,71 @@
+"""Regression: DLT FK/schema edge tuples must carry UUID node ids.
+
+``upsert_edges`` declares ``List[Tuple[UUID, UUID, str, Dict]]`` and inserts
+slots 0/1 straight into UUID-typed relational columns, so stringified ids
+crash the rollback ledger with "'str' object has no attribute 'hex'" — for
+every DLT source, since the ``is_row_of`` edge fires per row even without FKs.
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+import cognee.modules.graph.methods as graph_methods
+import cognee.tasks.ingestion.extract_dlt_fk_edges as dlt_module
+from cognee.modules.pipelines.models import PipelineContext
+
+graph_engine_module = importlib.import_module(
+    "cognee.infrastructure.databases.graph.get_graph_engine"
+)
+
+
+@pytest.mark.asyncio
+async def test_extract_dlt_fk_edges_passes_uuid_node_ids(monkeypatch):
+    ext_metadata = {
+        "source": "dlt",
+        "table_name": "orders",
+        "schema_info": [{"name": "id", "data_type": "bigint"}],
+        "foreign_keys": [{"column": "customer_id", "ref_table": "customers", "ref_column": "id"}],
+        "dlt_db_name": "shop",
+        "fk_references": [
+            {
+                "target_data_id": str(uuid4()),
+                "relationship_name": "references_customers",
+                "target_table": "customers",
+                "column": "customer_id",
+            }
+        ],
+    }
+    graph = SimpleNamespace(add_nodes=AsyncMock(), add_edges=AsyncMock())
+    monkeypatch.setattr(dlt_module, "_is_dlt_data_point", lambda dp: True)
+    monkeypatch.setattr(dlt_module, "parse_external_metadata", lambda doc: ext_metadata)
+    monkeypatch.setattr(dlt_module, "index_data_points", AsyncMock())
+    monkeypatch.setattr(
+        dlt_module,
+        "graph_provenance_write_kwargs",
+        AsyncMock(return_value={"source_ref_key": None, "pipeline_run_id": None}),
+    )
+    monkeypatch.setattr(graph_engine_module, "get_graph_engine", AsyncMock(return_value=graph))
+    upsert_edges = AsyncMock()
+    monkeypatch.setattr(graph_methods, "upsert_nodes", AsyncMock())
+    monkeypatch.setattr(graph_methods, "upsert_edges", upsert_edges)
+    ctx = PipelineContext(
+        user=SimpleNamespace(id=uuid4(), tenant_id=uuid4()),
+        dataset=SimpleNamespace(id=uuid4()),
+        data_item=SimpleNamespace(id=uuid4()),
+        pipeline_run_id=uuid4(),
+    )
+
+    await dlt_module.extract_dlt_fk_edges(
+        [SimpleNamespace(is_part_of=SimpleNamespace(id=uuid4()))], ctx=ctx
+    )
+
+    graph_edges = graph.add_edges.await_args.args[0]
+    ledger_edges = upsert_edges.await_args.args[0]
+    assert graph_edges and ledger_edges
+    for source_id, target_id, _name, _attrs in [*graph_edges, *ledger_edges]:
+        assert isinstance(source_id, UUID), f"str source id would crash the ledger: {source_id!r}"
+        assert isinstance(target_id, UUID), f"str target id would crash the ledger: {target_id!r}"


### PR DESCRIPTION
## Summary

Running **any** DLT source (CSV, SQL connection string, Gmail, Slack export) through the default `remember()` / `add()`+`cognify()` flow crashes on a ledger graph:

```
sqlalchemy.exc.StatementError: (builtins.AttributeError) 'str' object has no attribute 'hex'
[SQL: INSERT INTO edges (id, slug, user_id, data_id, dataset_id, ...)]
```

`extract_dlt_fk_edges` builds edge tuples with **stringified** uuid5 ids (`str(source_table_id)`, `str(doc.id)`, …). The graph engine tolerates that, but the rollback-ledger registration inserts the same tuples into the relational `edges` table, whose `source_node_id`/`destination_node_id` columns are `UUID(as_uuid=True)`. The `is_row_of` (row → SchemaTable) edge fires for **every** dlt row even without FKs, so every dlt cognify hits it.

`upsert_edges` declares `List[Tuple[UUID, UUID, str, Dict]]`, and the standard cognify path (`get_graph_from_model`) passes UUID objects — the dlt task was the one violator.

## Fix

Keep UUID objects in edge-tuple slots 0/1; the JSON `attributes` payload keeps the string copies. This matches the standard path for both sinks (graph + ledger). The graph-native provenance mode skips the ledger, but ledger graphs are the default and still crashed.

## Testing

- New regression test asserts every tuple handed to `graph.add_edges` **and** `upsert_edges` carries UUID ids — verified it **fails without the fix** (`AssertionError: str source id would crash the ledger`) and passes with it.
- Existing `test_extract_dlt_fk_edges_provenance.py` and `test_dlt_p0_correctness.py` stay green.
- Verified end-to-end: with this fix (plus #4062), a realistic Slack-export `remember → cognify → recall` run completes and both incremental re-sync and forget-on-delete work (see SDK-183 for the full trace).

Found by running the Slack-export connector (SDK-143 / #3993) end-to-end — no CI test cognifies a dlt source, so this never surfaced. Complements #4062 (SDK-171), the other all-connectors blocker that the E2E exposed.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
