### PR TITLE
feat(deploy): add Islo SDK sandbox deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Use [Cognee Cloud](https://www.cognee.ai) for a fully managed experience, or sel
 | **Fly.io** | Edge deployment, persistent volumes | `bash distributed/deploy/fly-deploy.sh` |
 | **Render** | Simple PaaS with managed Postgres | Deploy to Render button |
 | **Daytona** | Cloud sandboxes (SDK or CLI) | See `distributed/deploy/daytona_sandbox.py` |
+| **Islo** | Isolated cloud sandboxes (SDK) | See `distributed/deploy/islo_sandbox.py` |
 
 See the [`distributed/`](distributed/) folder for deploy scripts, worker configurations, and additional details.
 

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Use [Cognee Cloud](https://www.cognee.ai) for a fully managed experience, or sel
 | **Fly.io** | Edge deployment, persistent volumes | `bash distributed/deploy/fly-deploy.sh` |
 | **Render** | Simple PaaS with managed Postgres | Deploy to Render button |
 | **Daytona** | Cloud sandboxes (SDK or CLI) | See `distributed/deploy/daytona_sandbox.py` |
-| **Islo** | Isolated cloud sandboxes (SDK) | See `distributed/deploy/islo_sandbox.py` |
+| **Islo** | Isolated cloud sandboxes (CLI) | See `distributed/deploy/islo_sandbox.py` |
 
 See the [`distributed/`](distributed/) folder for deploy scripts, worker configurations, and additional details.
 

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Use [Cognee Cloud](https://www.cognee.ai) for a fully managed experience, or sel
 | **Fly.io** | Edge deployment, persistent volumes | `bash distributed/deploy/fly-deploy.sh` |
 | **Render** | Simple PaaS with managed Postgres | Deploy to Render button |
 | **Daytona** | Cloud sandboxes (SDK or CLI) | See `distributed/deploy/daytona_sandbox.py` |
-| **Islo** | Isolated cloud sandboxes (CLI) | See `distributed/deploy/islo_sandbox.py` |
+| **Islo** | Isolated cloud sandboxes (SDK) | See `distributed/deploy/islo_sandbox.py` |
 
 See the [`distributed/`](distributed/) folder for deploy scripts, worker configurations, and additional details.
 

--- a/cognee/tests/unit/distributed/test_islo_sandbox.py
+++ b/cognee/tests/unit/distributed/test_islo_sandbox.py
@@ -1,0 +1,287 @@
+"""Offline unit tests for distributed/deploy/islo_sandbox.py.
+
+The ``islo`` SDK is a documented script prerequisite (like ``daytona`` for
+daytona_sandbox.py), not a project dependency, so these tests inject fake
+``islo`` / ``islo.types`` modules before importing the deploy script. No
+network access and no API key are required.
+"""
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _import_module(monkeypatch):
+    """Import distributed.deploy.islo_sandbox with fake islo modules installed."""
+    fake_islo = types.ModuleType("islo")
+    fake_islo.Islo = MagicMock(name="Islo")
+
+    fake_islo_types = types.ModuleType("islo.types")
+
+    class LifecyclePolicy:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    fake_islo_types.LifecyclePolicy = LifecyclePolicy
+    fake_islo.types = fake_islo_types
+
+    fake_islo_errors = types.ModuleType("islo.errors")
+
+    class ConflictError(Exception):
+        pass
+
+    fake_islo_errors.ConflictError = ConflictError
+    fake_islo.errors = fake_islo_errors
+
+    monkeypatch.setitem(sys.modules, "islo", fake_islo)
+    monkeypatch.setitem(sys.modules, "islo.types", fake_islo_types)
+    monkeypatch.setitem(sys.modules, "islo.errors", fake_islo_errors)
+    sys.modules.pop("distributed.deploy.islo_sandbox", None)
+    return importlib.import_module("distributed.deploy.islo_sandbox")
+
+
+def _exec_result(status, stdout="", stderr="", exit_code=None):
+    return SimpleNamespace(
+        exec_id="e1",
+        status=status,
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=exit_code,
+        truncated=False,
+    )
+
+
+class FakeSandboxes:
+    def __init__(self, exec_results=None, sandbox_statuses=None):
+        self.exec_results = list(exec_results or [])
+        self.sandbox_statuses = list(sandbox_statuses or [])
+        self.create_calls = []
+        self.exec_calls = []
+        self.get_result_calls = 0
+
+    def create_sandbox(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return SimpleNamespace(id="sb-1", name=kwargs.get("name"), status="starting")
+
+    def get_sandbox(self, sandbox_name):
+        return SimpleNamespace(id="sb-1", name=sandbox_name, status=self.sandbox_statuses.pop(0))
+
+    def exec_in_sandbox(self, sandbox_name, *, command, env=None, timeout_secs=None, workdir=None):
+        self.exec_calls.append(
+            {
+                "sandbox_name": sandbox_name,
+                "command": list(command),
+                "env": env,
+                "workdir": workdir,
+                "timeout_secs": timeout_secs,
+            }
+        )
+        return SimpleNamespace(exec_id="e1", sandbox_id="sb-1", status="running")
+
+    def get_exec_result(self, sandbox_name, exec_id):
+        self.get_result_calls += 1
+        return self.exec_results.pop(0)
+
+
+class FakeShares:
+    def __init__(self):
+        self.calls = []
+
+    def create_share(self, sandbox_name, *, port, ttl_seconds=None):
+        self.calls.append((sandbox_name, port, ttl_seconds))
+        return SimpleNamespace(
+            url="https://share.example",
+            port=port,
+            share_id="sh1",
+            expires_at=None,
+            created_at="2026-01-01T00:00:00Z",
+        )
+
+
+class FakeClient:
+    def __init__(self, sandboxes, shares=None):
+        self.sandboxes = sandboxes
+        self.shares = shares or FakeShares()
+
+
+def test_run_command_polls_until_completed(monkeypatch):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(
+        exec_results=[
+            _exec_result("running"),
+            _exec_result("running"),
+            _exec_result("completed", stdout="hi", exit_code=0),
+        ]
+    )
+    client = FakeClient(fake)
+
+    result = module.run_command(client, "cognee-api", ["echo", "hi"], poll_interval=0)
+
+    assert result.status == "completed"
+    assert result.stdout == "hi"
+    assert result.exit_code == 0
+    assert fake.get_result_calls == 3
+    assert len(fake.exec_calls) == 1
+    assert fake.exec_calls[0]["sandbox_name"] == "cognee-api"
+    assert fake.exec_calls[0]["command"] == ["echo", "hi"]
+
+
+@pytest.mark.parametrize("terminal_status", ["failed", "timeout"])
+def test_run_command_returns_on_failed_and_timeout_statuses(monkeypatch, terminal_status):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(
+        exec_results=[
+            _exec_result("running"),
+            _exec_result(terminal_status, stderr="boom", exit_code=1),
+        ]
+    )
+    client = FakeClient(fake)
+
+    result = module.run_command(client, "cognee-api", ["false"], poll_interval=0)
+
+    assert result.status == terminal_status
+    assert fake.get_result_calls == 2
+
+
+def test_run_command_raises_when_exec_never_terminal(monkeypatch):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(exec_results=[_exec_result("running"), _exec_result("running")])
+    client = FakeClient(fake)
+
+    with pytest.raises(RuntimeError, match="terminal status"):
+        module.run_command(client, "cognee-api", ["sleep", "inf"], poll_interval=0, max_wait=0)
+
+    # The deadline stops polling instead of hanging forever.
+    assert fake.get_result_calls == 1
+
+
+def test_wait_for_sandbox_running_success(monkeypatch):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(sandbox_statuses=["starting", "running"])
+    client = FakeClient(fake)
+
+    sandbox = module.wait_for_sandbox_running(client, "cognee-api", poll_interval=0)
+
+    assert sandbox.status == "running"
+    assert fake.sandbox_statuses == []
+
+
+def test_wait_for_sandbox_running_raises_on_failed(monkeypatch):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(sandbox_statuses=["failed"])
+    client = FakeClient(fake)
+
+    with pytest.raises(RuntimeError, match="failed"):
+        module.wait_for_sandbox_running(client, "cognee-api", poll_interval=0)
+
+
+def test_deploy_requires_env_vars(monkeypatch):
+    module = _import_module(monkeypatch)
+
+    monkeypatch.delenv("ISLO_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="ISLO_API_KEY"):
+        module.deploy_cognee()
+
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+    with pytest.raises(ValueError, match="LLM_API_KEY"):
+        module.deploy_cognee()
+
+
+def _deploy_with_fakes(monkeypatch):
+    """Run deploy_cognee() against fully scripted fakes; returns (module, client)."""
+    module = _import_module(monkeypatch)
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+
+    fake_sandboxes = FakeSandboxes(
+        sandbox_statuses=["running"],
+        exec_results=[
+            _exec_result("completed", stdout="installed", exit_code=0),  # pip install
+            _exec_result("completed", stdout="started", exit_code=0),  # server start
+            _exec_result("completed", stdout="OK", exit_code=0),  # health check
+        ],
+    )
+    client = FakeClient(fake_sandboxes)
+    monkeypatch.setattr(module, "Islo", lambda: client)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    sandbox = module.deploy_cognee()
+    return module, client, sandbox
+
+
+def test_deploy_happy_path(monkeypatch):
+    module, client, sandbox = _deploy_with_fakes(monkeypatch)
+
+    assert sandbox.id == "sb-1"
+
+    create_call = client.sandboxes.create_calls[0]
+    assert create_call["name"] == module.SANDBOX_NAME
+    assert create_call["image"] == module.DEFAULT_IMAGE
+    assert create_call["env"]["LLM_API_KEY"] == "test-llm-key"
+    assert create_call["env"]["HOST"] == "0.0.0.0"
+
+    # install, server start, and health check all executed
+    commands = [call["command"] for call in client.sandboxes.exec_calls]
+    assert any("pip install 'cognee[api]'" in " ".join(command) for command in commands)
+    assert any("uvicorn" in " ".join(command) for command in commands)
+
+    assert client.shares.calls == [(module.SANDBOX_NAME, module.API_PORT, 86400)]
+
+
+def test_deploy_share_url_printed(monkeypatch, capsys):
+    _deploy_with_fakes(monkeypatch)
+
+    output = capsys.readouterr().out
+    assert "https://share.example" in output
+    assert "https://share.example/health" in output
+    assert "https://share.example/docs" in output
+
+
+@pytest.mark.parametrize(
+    ("install_status", "install_exit_code"),
+    [("failed", None), ("timeout", None), ("completed", 1)],
+)
+def test_deploy_aborts_when_install_fails(monkeypatch, install_status, install_exit_code):
+    module = _import_module(monkeypatch)
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+
+    fake_sandboxes = FakeSandboxes(
+        sandbox_statuses=["running"],
+        exec_results=[
+            _exec_result(install_status, stderr="pip boom", exit_code=install_exit_code),
+        ],
+    )
+    client = FakeClient(fake_sandboxes)
+    monkeypatch.setattr(module, "Islo", lambda: client)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError, match="Failed to install cognee"):
+        module.deploy_cognee()
+
+    # No server start and no share URL for a broken install.
+    assert len(fake_sandboxes.exec_calls) == 1
+    assert client.shares.calls == []
+
+
+def test_deploy_reports_existing_sandbox_conflict(monkeypatch):
+    module = _import_module(monkeypatch)
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+
+    class ConflictingSandboxes(FakeSandboxes):
+        def create_sandbox(self, **kwargs):
+            raise module.ConflictError("sandbox name already exists")
+
+    client = FakeClient(ConflictingSandboxes())
+    monkeypatch.setattr(module, "Islo", lambda: client)
+
+    with pytest.raises(RuntimeError, match="already exists") as excinfo:
+        module.deploy_cognee()
+
+    assert "delete_sandbox('cognee-api')" in str(excinfo.value)

--- a/cognee/tests/unit/distributed/test_islo_sandbox.py
+++ b/cognee/tests/unit/distributed/test_islo_sandbox.py
@@ -1,243 +1,328 @@
-"""Offline unit tests for the Islo CLI deployment script."""
+"""Offline unit tests for distributed/deploy/islo_sandbox.py.
+
+The ``islo`` SDK is a documented script prerequisite (like ``daytona`` for
+daytona_sandbox.py), not a project dependency, so these tests inject fake
+``islo`` modules before importing the deploy script. No network access and no
+API key are required.
+"""
 
 import importlib
-import json
-import os
-import subprocess
-from pathlib import Path
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 
-def _import_module():
+def _import_module(monkeypatch):
+    """Import distributed.deploy.islo_sandbox with fake islo modules installed."""
+    fake_islo = types.ModuleType("islo")
+    setattr(fake_islo, "Islo", MagicMock(name="Islo"))
+
+    fake_islo_types = types.ModuleType("islo.types")
+
+    class LifecyclePolicy:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    setattr(fake_islo_types, "LifecyclePolicy", LifecyclePolicy)
+    setattr(fake_islo, "types", fake_islo_types)
+
+    fake_islo_errors = types.ModuleType("islo.errors")
+
+    class ConflictError(Exception):
+        pass
+
+    setattr(fake_islo_errors, "ConflictError", ConflictError)
+    setattr(fake_islo, "errors", fake_islo_errors)
+
+    monkeypatch.setitem(sys.modules, "islo", fake_islo)
+    monkeypatch.setitem(sys.modules, "islo.types", fake_islo_types)
+    monkeypatch.setitem(sys.modules, "islo.errors", fake_islo_errors)
+    sys.modules.pop("distributed.deploy.islo_sandbox", None)
     return importlib.import_module("distributed.deploy.islo_sandbox")
 
 
-def _completed(args, returncode=0, stdout="", stderr=""):
-    return subprocess.CompletedProcess(
-        args=args, returncode=returncode, stdout=stdout, stderr=stderr
+def _exec_result(status, stdout="", stderr="", exit_code=None):
+    return SimpleNamespace(
+        exec_id="e1",
+        status=status,
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=exit_code,
+        truncated=False,
     )
 
 
-class FakeIslo:
-    def __init__(self, *, existing=False, deploy_returncode=0, health_returncode=0):
-        self.existing = existing
-        self.created = False
-        self.deploy_returncode = deploy_returncode
-        self.health_returncode = health_returncode
+class FakeSandboxes:
+    def __init__(self, exec_results=None, sandbox_statuses=None):
+        self.exec_results = list(exec_results or [])
+        self.sandbox_statuses = list(sandbox_statuses or [])
+        self.create_calls = []
+        self.exec_calls = []
+        self.get_result_calls = 0
+
+    def create_sandbox(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return SimpleNamespace(id="sb-1", name=kwargs.get("name"), status="starting")
+
+    def get_sandbox(self, sandbox_name):
+        return SimpleNamespace(id="sb-1", name=sandbox_name, status=self.sandbox_statuses.pop(0))
+
+    def exec_in_sandbox(self, sandbox_name, *, command, env=None, timeout_secs=None, workdir=None):
+        self.exec_calls.append(
+            {
+                "sandbox_name": sandbox_name,
+                "command": list(command),
+                "env": env,
+                "workdir": workdir,
+                "timeout_secs": timeout_secs,
+            }
+        )
+        return SimpleNamespace(exec_id="e1", sandbox_id="sb-1", status="running")
+
+    def get_exec_result(self, sandbox_name, exec_id):
+        self.get_result_calls += 1
+        return self.exec_results.pop(0)
+
+
+class FakeShares:
+    def __init__(self):
         self.calls = []
-        self.env_file_contents = None
-        self.env_file_mode = None
 
-    def __call__(self, command, **kwargs):
-        self.calls.append((list(command), kwargs))
-        args = command[1:]
-
-        if args[:3] == ["status", "--output", "json"]:
-            return _completed(command, stdout=json.dumps({"auth": {"authenticated": True}}))
-
-        if args[:2] == ["status", "cognee-api"]:
-            if self.existing or self.created:
-                return _completed(
-                    command,
-                    stdout=json.dumps({"id": "sb-1", "name": "cognee-api", "status": "running"}),
-                )
-            return _completed(command, returncode=1, stderr="sandbox not found")
-
-        if args and args[0] == "use" and _is_health_command(args):
-            if self.health_returncode == 0:
-                return _completed(command, stdout="OK\n")
-            return _completed(command, returncode=self.health_returncode, stderr="not ready")
-
-        if args and args[0] == "use" and _is_log_command(args):
-            return _completed(command, stdout="server log\n")
-
-        if args and args[0] == "use":
-            env_path = Path(args[args.index("--env-file") + 1])
-            self.env_file_contents = env_path.read_text()
-            self.env_file_mode = os.stat(env_path).st_mode & 0o777
-            if self.deploy_returncode != 0:
-                return _completed(
-                    command, returncode=self.deploy_returncode, stderr="deploy failed"
-                )
-            self.created = True
-            return _completed(command, stdout="started\n")
-
-        if args and args[0] == "share":
-            return _completed(
-                command,
-                stdout=json.dumps(
-                    {
-                        "url": "https://share.example",
-                        "expires_at": "2026-07-17T00:00:00Z",
-                    }
-                ),
-            )
-
-        raise AssertionError(f"Unexpected Islo command: {command!r}")
+    def create_share(self, sandbox_name, *, port, ttl_seconds=None):
+        self.calls.append((sandbox_name, port, ttl_seconds))
+        return SimpleNamespace(
+            url="https://share.example",
+            port=port,
+            share_id="sh1",
+            expires_at=None,
+            created_at="2026-01-01T00:00:00Z",
+        )
 
 
-def _is_health_command(args):
-    return "python3" in args and "urllib.request" in args[-1]
+class FakeClient:
+    def __init__(self, sandboxes, shares=None):
+        self.sandboxes = sandboxes
+        self.shares = shares or FakeShares()
 
 
-def _is_log_command(args):
-    return "tail -n 30 /tmp/cognee-server.log" in args
-
-
-def _configure(monkeypatch, fake):
-    module = _import_module()
-    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
-    monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/local/bin/islo")
-    monkeypatch.setattr(module.subprocess, "run", fake)
-    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
-    return module
-
-
-def test_run_islo_returns_completed_process(monkeypatch):
-    module = _import_module()
-    expected = _completed(["islo", "status"], stdout="ok")
-    monkeypatch.setattr(module.subprocess, "run", lambda *_args, **_kwargs: expected)
-
-    result = module.run_islo(["status"], echo=False)
-
-    assert result is expected
-
-
-def test_run_islo_raises_on_nonzero_exit(monkeypatch):
-    module = _import_module()
-    monkeypatch.setattr(
-        module.subprocess,
-        "run",
-        lambda *_args, **_kwargs: _completed([], returncode=2, stderr="boom"),
+def test_run_command_polls_until_completed(monkeypatch):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(
+        exec_results=[
+            _exec_result("running"),
+            _exec_result("running"),
+            _exec_result("completed", stdout="hi", exit_code=0),
+        ]
     )
+    client = FakeClient(fake)
 
-    with pytest.raises(RuntimeError, match="boom"):
-        module.run_islo(["use", "broken"], echo=False)
+    result = module.run_command(client, "cognee-api", ["echo", "hi"], poll_interval=0)
 
-
-def test_run_islo_raises_on_timeout(monkeypatch):
-    module = _import_module()
-
-    def timeout(*_args, **_kwargs):
-        raise subprocess.TimeoutExpired(cmd="islo", timeout=3)
-
-    monkeypatch.setattr(module.subprocess, "run", timeout)
-
-    with pytest.raises(RuntimeError, match="timed out"):
-        module.run_islo(["use", "slow"], timeout=3)
+    assert result.status == "completed"
+    assert result.stdout == "hi"
+    assert result.exit_code == 0
+    assert fake.get_result_calls == 3
+    assert len(fake.exec_calls) == 1
+    assert fake.exec_calls[0]["sandbox_name"] == "cognee-api"
+    assert fake.exec_calls[0]["command"] == ["echo", "hi"]
 
 
-def test_deploy_requires_cli(monkeypatch):
-    module = _import_module()
-    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
-    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+@pytest.mark.parametrize("terminal_status", ["failed", "timeout"])
+def test_run_command_returns_on_failed_and_timeout_statuses(monkeypatch, terminal_status):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(
+        exec_results=[
+            _exec_result("running"),
+            _exec_result(terminal_status, stderr="boom", exit_code=1),
+        ]
+    )
+    client = FakeClient(fake)
 
-    with pytest.raises(RuntimeError, match="Islo CLI is required"):
+    result = module.run_command(client, "cognee-api", ["false"], poll_interval=0)
+
+    assert result.status == terminal_status
+    assert fake.get_result_calls == 2
+
+
+def test_run_command_raises_when_exec_never_terminal(monkeypatch):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(exec_results=[_exec_result("running"), _exec_result("running")])
+    client = FakeClient(fake)
+
+    with pytest.raises(RuntimeError, match="terminal status"):
+        module.run_command(client, "cognee-api", ["sleep", "inf"], poll_interval=0, max_wait=0)
+
+    assert fake.get_result_calls == 1
+
+
+def test_wait_for_sandbox_running_success(monkeypatch):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(sandbox_statuses=["starting", "running"])
+    client = FakeClient(fake)
+
+    sandbox = module.wait_for_sandbox_running(client, "cognee-api", poll_interval=0)
+
+    assert sandbox.status == "running"
+    assert fake.sandbox_statuses == []
+
+
+def test_wait_for_sandbox_running_raises_on_failed(monkeypatch):
+    module = _import_module(monkeypatch)
+    fake = FakeSandboxes(sandbox_statuses=["failed"])
+    client = FakeClient(fake)
+
+    with pytest.raises(RuntimeError, match="failed"):
+        module.wait_for_sandbox_running(client, "cognee-api", poll_interval=0)
+
+
+def test_deploy_requires_env_vars(monkeypatch):
+    module = _import_module(monkeypatch)
+
+    monkeypatch.delenv("ISLO_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="ISLO_API_KEY"):
         module.deploy_cognee()
 
-
-def test_deploy_requires_llm_api_key(monkeypatch):
-    module = _import_module()
-    monkeypatch.delenv("LLM_API_KEY", raising=False)
-    monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/local/bin/islo")
-
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
     with pytest.raises(ValueError, match="LLM_API_KEY"):
         module.deploy_cognee()
 
 
-def test_deploy_requires_authentication(monkeypatch):
-    module = _import_module()
+def _deploy_with_fakes(monkeypatch):
+    """Run deploy_cognee() against fully scripted fakes; returns (module, client)."""
+    module = _import_module(monkeypatch)
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
     monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
-    monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/local/bin/islo")
-    monkeypatch.setattr(
-        module.subprocess,
-        "run",
-        lambda command, **_kwargs: _completed(
-            command, stdout=json.dumps({"auth": {"authenticated": False}})
-        ),
+
+    fake_sandboxes = FakeSandboxes(
+        sandbox_statuses=["running"],
+        exec_results=[
+            _exec_result("completed", stdout="installed", exit_code=0),
+            _exec_result("completed", stdout="started", exit_code=0),
+            _exec_result("completed", stdout="OK", exit_code=0),
+        ],
     )
-
-    with pytest.raises(RuntimeError, match="not authenticated"):
-        module.deploy_cognee()
-
-
-def test_deploy_happy_path_uses_cli_and_protects_credentials(monkeypatch):
-    fake = FakeIslo()
-    module = _configure(monkeypatch, fake)
+    client = FakeClient(fake_sandboxes)
+    monkeypatch.setattr(module, "Islo", lambda: client)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
 
     sandbox = module.deploy_cognee()
-
-    assert sandbox["id"] == "sb-1"
-    commands = [call[0] for call in fake.calls]
-    deploy_command = next(command for command in commands if "--env-file" in command)
-    assert deploy_command[:3] == ["islo", "use", module.SANDBOX_NAME]
-    assert "--cpu" in deploy_command
-    assert "--memory" in deploy_command
-    assert "--disk" in deploy_command
-    assert "--run-as-user" in deploy_command
-    assert "test-llm-key" not in deploy_command
-    assert fake.env_file_contents is not None
-    assert 'LLM_API_KEY="test-llm-key"' in fake.env_file_contents
-    assert fake.env_file_mode == 0o600
-    assert any(command[1] == "share" for command in commands)
+    return module, client, sandbox
 
 
-def test_deploy_removes_temporary_env_file(monkeypatch):
-    fake = FakeIslo()
-    module = _configure(monkeypatch, fake)
+def test_deploy_happy_path(monkeypatch):
+    module, client, sandbox = _deploy_with_fakes(monkeypatch)
 
-    module.deploy_cognee()
+    assert sandbox.id == "sb-1"
 
-    deploy_call = next(call[0] for call in fake.calls if "--env-file" in call[0])
-    env_path = Path(deploy_call[deploy_call.index("--env-file") + 1])
-    assert not env_path.exists()
+    create_call = client.sandboxes.create_calls[0]
+    assert create_call["name"] == module.SANDBOX_NAME
+    assert create_call["image"] == module.DEFAULT_IMAGE
+    assert create_call["env"]["LLM_API_KEY"] == "test-llm-key"
+    assert create_call["env"]["HOST"] == "0.0.0.0"
+
+    commands = [call["command"] for call in client.sandboxes.exec_calls]
+    assert any("pip install 'cognee[api]'" in " ".join(command) for command in commands)
+    assert any("uvicorn" in " ".join(command) for command in commands)
+
+    assert client.shares.calls == [(module.SANDBOX_NAME, module.API_PORT, 86400)]
 
 
-def test_deploy_prints_share_and_cli_cleanup_commands(monkeypatch, capsys):
-    module = _configure(monkeypatch, FakeIslo())
-
-    module.deploy_cognee()
+def test_deploy_share_url_printed(monkeypatch, capsys):
+    _deploy_with_fakes(monkeypatch)
 
     output = capsys.readouterr().out
+    assert "https://share.example" in output
     assert "https://share.example/health" in output
     assert "https://share.example/docs" in output
-    assert "islo stop cognee-api" in output
-    assert "islo rm cognee-api --force" in output
 
 
-def test_deploy_reports_existing_sandbox(monkeypatch):
-    module = _configure(monkeypatch, FakeIslo(existing=True))
+@pytest.mark.parametrize(
+    ("install_status", "install_exit_code"),
+    [("failed", None), ("timeout", None), ("completed", 1)],
+)
+def test_deploy_aborts_when_install_fails(monkeypatch, install_status, install_exit_code):
+    module = _import_module(monkeypatch)
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
 
-    with pytest.raises(RuntimeError, match="islo rm cognee-api --force"):
+    fake_sandboxes = FakeSandboxes(
+        sandbox_statuses=["running"],
+        exec_results=[
+            _exec_result(install_status, stderr="pip boom", exit_code=install_exit_code),
+        ],
+    )
+    client = FakeClient(fake_sandboxes)
+    monkeypatch.setattr(module, "Islo", lambda: client)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError, match="Failed to install cognee"):
         module.deploy_cognee()
 
+    assert len(fake_sandboxes.exec_calls) == 1
+    assert client.shares.calls == []
 
-def test_deploy_aborts_when_cli_deploy_fails(monkeypatch):
-    fake = FakeIslo(deploy_returncode=1)
-    module = _configure(monkeypatch, fake)
 
-    with pytest.raises(RuntimeError, match="deploy failed"):
+def test_deploy_aborts_when_server_start_fails(monkeypatch):
+    module = _import_module(monkeypatch)
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+
+    fake_sandboxes = FakeSandboxes(
+        sandbox_statuses=["running"],
+        exec_results=[
+            _exec_result("completed", stdout="installed", exit_code=0),
+            _exec_result("failed", stderr="uvicorn boom", exit_code=1),
+        ],
+    )
+    client = FakeClient(fake_sandboxes)
+    monkeypatch.setattr(module, "Islo", lambda: client)
+
+    with pytest.raises(RuntimeError, match="Failed to start cognee API server"):
         module.deploy_cognee()
 
-    assert not any(call[0][1] == "share" for call in fake.calls)
+    assert len(fake_sandboxes.exec_calls) == 2
+    assert client.shares.calls == []
 
 
 def test_deploy_aborts_when_server_never_becomes_healthy(monkeypatch):
-    fake = FakeIslo(health_returncode=1)
-    module = _configure(monkeypatch, fake)
+    module = _import_module(monkeypatch)
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+
+    fake_sandboxes = FakeSandboxes(
+        sandbox_statuses=["running"],
+        exec_results=[
+            _exec_result("completed", stdout="installed", exit_code=0),
+            _exec_result("completed", stdout="started", exit_code=0),
+        ],
+    )
+    client = FakeClient(fake_sandboxes)
+    monkeypatch.setattr(module, "Islo", lambda: client)
     monkeypatch.setattr(module, "wait_for_server_health", lambda *_args: False)
 
     with pytest.raises(RuntimeError, match="did not become healthy"):
         module.deploy_cognee()
 
-    assert not any(call[0][1] == "share" for call in fake.calls)
+    assert client.shares.calls == []
 
 
-def test_wait_for_server_health_retries(monkeypatch):
-    fake = FakeIslo(health_returncode=1)
-    module = _configure(monkeypatch, fake)
+def test_deploy_reports_existing_sandbox_conflict(monkeypatch):
+    module = _import_module(monkeypatch)
+    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
 
-    assert module.wait_for_server_health(retries=2, delay=0) is False
-    health_calls = [call for call in fake.calls if _is_health_command(call[0][1:])]
-    assert len(health_calls) == 2
+    class ConflictingSandboxes(FakeSandboxes):
+        def create_sandbox(self, **kwargs):
+            raise module.ConflictError("sandbox name already exists")
+
+    client = FakeClient(ConflictingSandboxes())
+    monkeypatch.setattr(module, "Islo", lambda: client)
+
+    with pytest.raises(RuntimeError, match="already exists") as excinfo:
+        module.deploy_cognee()
+
+    assert "delete_sandbox('cognee-api')" in str(excinfo.value)

--- a/cognee/tests/unit/distributed/test_islo_sandbox.py
+++ b/cognee/tests/unit/distributed/test_islo_sandbox.py
@@ -1,287 +1,243 @@
-"""Offline unit tests for distributed/deploy/islo_sandbox.py.
-
-The ``islo`` SDK is a documented script prerequisite (like ``daytona`` for
-daytona_sandbox.py), not a project dependency, so these tests inject fake
-``islo`` / ``islo.types`` modules before importing the deploy script. No
-network access and no API key are required.
-"""
+"""Offline unit tests for the Islo CLI deployment script."""
 
 import importlib
-import sys
-import types
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+import json
+import os
+import subprocess
+from pathlib import Path
 
 import pytest
 
 
-def _import_module(monkeypatch):
-    """Import distributed.deploy.islo_sandbox with fake islo modules installed."""
-    fake_islo = types.ModuleType("islo")
-    fake_islo.Islo = MagicMock(name="Islo")
-
-    fake_islo_types = types.ModuleType("islo.types")
-
-    class LifecyclePolicy:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    fake_islo_types.LifecyclePolicy = LifecyclePolicy
-    fake_islo.types = fake_islo_types
-
-    fake_islo_errors = types.ModuleType("islo.errors")
-
-    class ConflictError(Exception):
-        pass
-
-    fake_islo_errors.ConflictError = ConflictError
-    fake_islo.errors = fake_islo_errors
-
-    monkeypatch.setitem(sys.modules, "islo", fake_islo)
-    monkeypatch.setitem(sys.modules, "islo.types", fake_islo_types)
-    monkeypatch.setitem(sys.modules, "islo.errors", fake_islo_errors)
-    sys.modules.pop("distributed.deploy.islo_sandbox", None)
+def _import_module():
     return importlib.import_module("distributed.deploy.islo_sandbox")
 
 
-def _exec_result(status, stdout="", stderr="", exit_code=None):
-    return SimpleNamespace(
-        exec_id="e1",
-        status=status,
-        stdout=stdout,
-        stderr=stderr,
-        exit_code=exit_code,
-        truncated=False,
+def _completed(args, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=args, returncode=returncode, stdout=stdout, stderr=stderr
     )
 
 
-class FakeSandboxes:
-    def __init__(self, exec_results=None, sandbox_statuses=None):
-        self.exec_results = list(exec_results or [])
-        self.sandbox_statuses = list(sandbox_statuses or [])
-        self.create_calls = []
-        self.exec_calls = []
-        self.get_result_calls = 0
-
-    def create_sandbox(self, **kwargs):
-        self.create_calls.append(kwargs)
-        return SimpleNamespace(id="sb-1", name=kwargs.get("name"), status="starting")
-
-    def get_sandbox(self, sandbox_name):
-        return SimpleNamespace(id="sb-1", name=sandbox_name, status=self.sandbox_statuses.pop(0))
-
-    def exec_in_sandbox(self, sandbox_name, *, command, env=None, timeout_secs=None, workdir=None):
-        self.exec_calls.append(
-            {
-                "sandbox_name": sandbox_name,
-                "command": list(command),
-                "env": env,
-                "workdir": workdir,
-                "timeout_secs": timeout_secs,
-            }
-        )
-        return SimpleNamespace(exec_id="e1", sandbox_id="sb-1", status="running")
-
-    def get_exec_result(self, sandbox_name, exec_id):
-        self.get_result_calls += 1
-        return self.exec_results.pop(0)
-
-
-class FakeShares:
-    def __init__(self):
+class FakeIslo:
+    def __init__(self, *, existing=False, deploy_returncode=0, health_returncode=0):
+        self.existing = existing
+        self.created = False
+        self.deploy_returncode = deploy_returncode
+        self.health_returncode = health_returncode
         self.calls = []
+        self.env_file_contents = None
+        self.env_file_mode = None
 
-    def create_share(self, sandbox_name, *, port, ttl_seconds=None):
-        self.calls.append((sandbox_name, port, ttl_seconds))
-        return SimpleNamespace(
-            url="https://share.example",
-            port=port,
-            share_id="sh1",
-            expires_at=None,
-            created_at="2026-01-01T00:00:00Z",
-        )
+    def __call__(self, command, **kwargs):
+        self.calls.append((list(command), kwargs))
+        args = command[1:]
+
+        if args[:3] == ["status", "--output", "json"]:
+            return _completed(command, stdout=json.dumps({"auth": {"authenticated": True}}))
+
+        if args[:2] == ["status", "cognee-api"]:
+            if self.existing or self.created:
+                return _completed(
+                    command,
+                    stdout=json.dumps({"id": "sb-1", "name": "cognee-api", "status": "running"}),
+                )
+            return _completed(command, returncode=1, stderr="sandbox not found")
+
+        if args and args[0] == "use" and _is_health_command(args):
+            if self.health_returncode == 0:
+                return _completed(command, stdout="OK\n")
+            return _completed(command, returncode=self.health_returncode, stderr="not ready")
+
+        if args and args[0] == "use" and _is_log_command(args):
+            return _completed(command, stdout="server log\n")
+
+        if args and args[0] == "use":
+            env_path = Path(args[args.index("--env-file") + 1])
+            self.env_file_contents = env_path.read_text()
+            self.env_file_mode = os.stat(env_path).st_mode & 0o777
+            if self.deploy_returncode != 0:
+                return _completed(
+                    command, returncode=self.deploy_returncode, stderr="deploy failed"
+                )
+            self.created = True
+            return _completed(command, stdout="started\n")
+
+        if args and args[0] == "share":
+            return _completed(
+                command,
+                stdout=json.dumps(
+                    {
+                        "url": "https://share.example",
+                        "expires_at": "2026-07-17T00:00:00Z",
+                    }
+                ),
+            )
+
+        raise AssertionError(f"Unexpected Islo command: {command!r}")
 
 
-class FakeClient:
-    def __init__(self, sandboxes, shares=None):
-        self.sandboxes = sandboxes
-        self.shares = shares or FakeShares()
+def _is_health_command(args):
+    return "python3" in args and "urllib.request" in args[-1]
 
 
-def test_run_command_polls_until_completed(monkeypatch):
-    module = _import_module(monkeypatch)
-    fake = FakeSandboxes(
-        exec_results=[
-            _exec_result("running"),
-            _exec_result("running"),
-            _exec_result("completed", stdout="hi", exit_code=0),
-        ]
+def _is_log_command(args):
+    return "tail -n 30 /tmp/cognee-server.log" in args
+
+
+def _configure(monkeypatch, fake):
+    module = _import_module()
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+    monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/local/bin/islo")
+    monkeypatch.setattr(module.subprocess, "run", fake)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+    return module
+
+
+def test_run_islo_returns_completed_process(monkeypatch):
+    module = _import_module()
+    expected = _completed(["islo", "status"], stdout="ok")
+    monkeypatch.setattr(module.subprocess, "run", lambda *_args, **_kwargs: expected)
+
+    result = module.run_islo(["status"], echo=False)
+
+    assert result is expected
+
+
+def test_run_islo_raises_on_nonzero_exit(monkeypatch):
+    module = _import_module()
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: _completed([], returncode=2, stderr="boom"),
     )
-    client = FakeClient(fake)
 
-    result = module.run_command(client, "cognee-api", ["echo", "hi"], poll_interval=0)
-
-    assert result.status == "completed"
-    assert result.stdout == "hi"
-    assert result.exit_code == 0
-    assert fake.get_result_calls == 3
-    assert len(fake.exec_calls) == 1
-    assert fake.exec_calls[0]["sandbox_name"] == "cognee-api"
-    assert fake.exec_calls[0]["command"] == ["echo", "hi"]
+    with pytest.raises(RuntimeError, match="boom"):
+        module.run_islo(["use", "broken"], echo=False)
 
 
-@pytest.mark.parametrize("terminal_status", ["failed", "timeout"])
-def test_run_command_returns_on_failed_and_timeout_statuses(monkeypatch, terminal_status):
-    module = _import_module(monkeypatch)
-    fake = FakeSandboxes(
-        exec_results=[
-            _exec_result("running"),
-            _exec_result(terminal_status, stderr="boom", exit_code=1),
-        ]
-    )
-    client = FakeClient(fake)
+def test_run_islo_raises_on_timeout(monkeypatch):
+    module = _import_module()
 
-    result = module.run_command(client, "cognee-api", ["false"], poll_interval=0)
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="islo", timeout=3)
 
-    assert result.status == terminal_status
-    assert fake.get_result_calls == 2
+    monkeypatch.setattr(module.subprocess, "run", timeout)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        module.run_islo(["use", "slow"], timeout=3)
 
 
-def test_run_command_raises_when_exec_never_terminal(monkeypatch):
-    module = _import_module(monkeypatch)
-    fake = FakeSandboxes(exec_results=[_exec_result("running"), _exec_result("running")])
-    client = FakeClient(fake)
+def test_deploy_requires_cli(monkeypatch):
+    module = _import_module()
+    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
 
-    with pytest.raises(RuntimeError, match="terminal status"):
-        module.run_command(client, "cognee-api", ["sleep", "inf"], poll_interval=0, max_wait=0)
-
-    # The deadline stops polling instead of hanging forever.
-    assert fake.get_result_calls == 1
-
-
-def test_wait_for_sandbox_running_success(monkeypatch):
-    module = _import_module(monkeypatch)
-    fake = FakeSandboxes(sandbox_statuses=["starting", "running"])
-    client = FakeClient(fake)
-
-    sandbox = module.wait_for_sandbox_running(client, "cognee-api", poll_interval=0)
-
-    assert sandbox.status == "running"
-    assert fake.sandbox_statuses == []
-
-
-def test_wait_for_sandbox_running_raises_on_failed(monkeypatch):
-    module = _import_module(monkeypatch)
-    fake = FakeSandboxes(sandbox_statuses=["failed"])
-    client = FakeClient(fake)
-
-    with pytest.raises(RuntimeError, match="failed"):
-        module.wait_for_sandbox_running(client, "cognee-api", poll_interval=0)
-
-
-def test_deploy_requires_env_vars(monkeypatch):
-    module = _import_module(monkeypatch)
-
-    monkeypatch.delenv("ISLO_API_KEY", raising=False)
-    monkeypatch.delenv("LLM_API_KEY", raising=False)
-    with pytest.raises(ValueError, match="ISLO_API_KEY"):
+    with pytest.raises(RuntimeError, match="Islo CLI is required"):
         module.deploy_cognee()
 
-    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+
+def test_deploy_requires_llm_api_key(monkeypatch):
+    module = _import_module()
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/local/bin/islo")
+
     with pytest.raises(ValueError, match="LLM_API_KEY"):
         module.deploy_cognee()
 
 
-def _deploy_with_fakes(monkeypatch):
-    """Run deploy_cognee() against fully scripted fakes; returns (module, client)."""
-    module = _import_module(monkeypatch)
-    monkeypatch.setenv("ISLO_API_KEY", "test-key")
+def test_deploy_requires_authentication(monkeypatch):
+    module = _import_module()
     monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
-
-    fake_sandboxes = FakeSandboxes(
-        sandbox_statuses=["running"],
-        exec_results=[
-            _exec_result("completed", stdout="installed", exit_code=0),  # pip install
-            _exec_result("completed", stdout="started", exit_code=0),  # server start
-            _exec_result("completed", stdout="OK", exit_code=0),  # health check
-        ],
+    monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/local/bin/islo")
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda command, **_kwargs: _completed(
+            command, stdout=json.dumps({"auth": {"authenticated": False}})
+        ),
     )
-    client = FakeClient(fake_sandboxes)
-    monkeypatch.setattr(module, "Islo", lambda: client)
-    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError, match="not authenticated"):
+        module.deploy_cognee()
+
+
+def test_deploy_happy_path_uses_cli_and_protects_credentials(monkeypatch):
+    fake = FakeIslo()
+    module = _configure(monkeypatch, fake)
 
     sandbox = module.deploy_cognee()
-    return module, client, sandbox
+
+    assert sandbox["id"] == "sb-1"
+    commands = [call[0] for call in fake.calls]
+    deploy_command = next(command for command in commands if "--env-file" in command)
+    assert deploy_command[:3] == ["islo", "use", module.SANDBOX_NAME]
+    assert "--cpu" in deploy_command
+    assert "--memory" in deploy_command
+    assert "--disk" in deploy_command
+    assert "--run-as-user" in deploy_command
+    assert "test-llm-key" not in deploy_command
+    assert fake.env_file_contents is not None
+    assert 'LLM_API_KEY="test-llm-key"' in fake.env_file_contents
+    assert fake.env_file_mode == 0o600
+    assert any(command[1] == "share" for command in commands)
 
 
-def test_deploy_happy_path(monkeypatch):
-    module, client, sandbox = _deploy_with_fakes(monkeypatch)
+def test_deploy_removes_temporary_env_file(monkeypatch):
+    fake = FakeIslo()
+    module = _configure(monkeypatch, fake)
 
-    assert sandbox.id == "sb-1"
+    module.deploy_cognee()
 
-    create_call = client.sandboxes.create_calls[0]
-    assert create_call["name"] == module.SANDBOX_NAME
-    assert create_call["image"] == module.DEFAULT_IMAGE
-    assert create_call["env"]["LLM_API_KEY"] == "test-llm-key"
-    assert create_call["env"]["HOST"] == "0.0.0.0"
-
-    # install, server start, and health check all executed
-    commands = [call["command"] for call in client.sandboxes.exec_calls]
-    assert any("pip install 'cognee[api]'" in " ".join(command) for command in commands)
-    assert any("uvicorn" in " ".join(command) for command in commands)
-
-    assert client.shares.calls == [(module.SANDBOX_NAME, module.API_PORT, 86400)]
+    deploy_call = next(call[0] for call in fake.calls if "--env-file" in call[0])
+    env_path = Path(deploy_call[deploy_call.index("--env-file") + 1])
+    assert not env_path.exists()
 
 
-def test_deploy_share_url_printed(monkeypatch, capsys):
-    _deploy_with_fakes(monkeypatch)
+def test_deploy_prints_share_and_cli_cleanup_commands(monkeypatch, capsys):
+    module = _configure(monkeypatch, FakeIslo())
+
+    module.deploy_cognee()
 
     output = capsys.readouterr().out
-    assert "https://share.example" in output
     assert "https://share.example/health" in output
     assert "https://share.example/docs" in output
+    assert "islo stop cognee-api" in output
+    assert "islo rm cognee-api --force" in output
 
 
-@pytest.mark.parametrize(
-    ("install_status", "install_exit_code"),
-    [("failed", None), ("timeout", None), ("completed", 1)],
-)
-def test_deploy_aborts_when_install_fails(monkeypatch, install_status, install_exit_code):
-    module = _import_module(monkeypatch)
-    monkeypatch.setenv("ISLO_API_KEY", "test-key")
-    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
+def test_deploy_reports_existing_sandbox(monkeypatch):
+    module = _configure(monkeypatch, FakeIslo(existing=True))
 
-    fake_sandboxes = FakeSandboxes(
-        sandbox_statuses=["running"],
-        exec_results=[
-            _exec_result(install_status, stderr="pip boom", exit_code=install_exit_code),
-        ],
-    )
-    client = FakeClient(fake_sandboxes)
-    monkeypatch.setattr(module, "Islo", lambda: client)
-    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
-
-    with pytest.raises(RuntimeError, match="Failed to install cognee"):
+    with pytest.raises(RuntimeError, match="islo rm cognee-api --force"):
         module.deploy_cognee()
 
-    # No server start and no share URL for a broken install.
-    assert len(fake_sandboxes.exec_calls) == 1
-    assert client.shares.calls == []
 
+def test_deploy_aborts_when_cli_deploy_fails(monkeypatch):
+    fake = FakeIslo(deploy_returncode=1)
+    module = _configure(monkeypatch, fake)
 
-def test_deploy_reports_existing_sandbox_conflict(monkeypatch):
-    module = _import_module(monkeypatch)
-    monkeypatch.setenv("ISLO_API_KEY", "test-key")
-    monkeypatch.setenv("LLM_API_KEY", "test-llm-key")
-
-    class ConflictingSandboxes(FakeSandboxes):
-        def create_sandbox(self, **kwargs):
-            raise module.ConflictError("sandbox name already exists")
-
-    client = FakeClient(ConflictingSandboxes())
-    monkeypatch.setattr(module, "Islo", lambda: client)
-
-    with pytest.raises(RuntimeError, match="already exists") as excinfo:
+    with pytest.raises(RuntimeError, match="deploy failed"):
         module.deploy_cognee()
 
-    assert "delete_sandbox('cognee-api')" in str(excinfo.value)
+    assert not any(call[0][1] == "share" for call in fake.calls)
+
+
+def test_deploy_aborts_when_server_never_becomes_healthy(monkeypatch):
+    fake = FakeIslo(health_returncode=1)
+    module = _configure(monkeypatch, fake)
+    monkeypatch.setattr(module, "wait_for_server_health", lambda *_args: False)
+
+    with pytest.raises(RuntimeError, match="did not become healthy"):
+        module.deploy_cognee()
+
+    assert not any(call[0][1] == "share" for call in fake.calls)
+
+
+def test_wait_for_server_health_retries(monkeypatch):
+    fake = FakeIslo(health_returncode=1)
+    module = _configure(monkeypatch, fake)
+
+    assert module.wait_for_server_health(retries=2, delay=0) is False
+    health_calls = [call for call in fake.calls if _is_health_command(call[0][1:])]
+    assert len(health_calls) == 2

--- a/distributed/deploy/README.md
+++ b/distributed/deploy/README.md
@@ -11,7 +11,7 @@
 | **Fly.io** | Edge deployment, persistent volumes | `bash distributed/deploy/fly-deploy.sh` |
 | **Render** | Simple PaaS with managed Postgres | Deploy to Render button |
 | **Daytona** | Cloud sandboxes (SDK or CLI) | `python distributed/deploy/daytona_sandbox.py` |
-| **Islo** | Isolated cloud sandboxes for agents (SDK) | `python distributed/deploy/islo_sandbox.py` |
+| **Islo** | Isolated cloud sandboxes for agents (CLI) | `python distributed/deploy/islo_sandbox.py` |
 
 All platforms require setting `LLM_API_KEY` as a minimum.
 
@@ -138,21 +138,21 @@ python -m uvicorn cognee.api.client:app --host 0.0.0.0 --port 8000
 Islo provides isolated cloud sandbox VMs for autonomous agents, built by the Incredibuild team. Cognee runs inside a sandbox and is exposed through a temporary public share URL. Docs: https://docs.islo.dev
 
 ```bash
-pip install islo
+curl -fsSL https://islo.dev/install.sh | bash
+islo login  # interactive use
 
-export ISLO_API_KEY=your-key   # from https://app.islo.dev/api-keys
+# CI alternative: create the key with the CLI, store it securely, and set ISLO_API_KEY
+islo api-key create cognee-ci --expires 90 --output-file /secure/path/islo-api-key
+
 export LLM_API_KEY=sk-xxx
 python distributed/deploy/islo_sandbox.py
 ```
 
-The script creates a sandbox, installs `cognee[api]`, starts the API server, and prints a temporary public share URL (24-hour TTL). Stop or delete the sandbox via the SDK:
+The script drives the official Islo CLI: `islo use` creates the sandbox and runs the setup, while `islo share` exposes the API with a 24-hour URL. Credentials are loaded from a mode-0600 temporary env file that is removed immediately after setup. Stop or delete the sandbox with the CLI:
 
-```python
-from islo import Islo
-
-client = Islo()  # reads ISLO_API_KEY from the environment
-client.sandboxes.stop_sandbox("cognee-api")
-client.sandboxes.delete_sandbox("cognee-api")
+```bash
+islo stop cognee-api
+islo rm cognee-api --force
 ```
 
 The sandbox name is fixed (`cognee-api`), so re-running the script while a previous deployment still exists fails with a name conflict — delete the old sandbox first (see above), then re-run.

--- a/distributed/deploy/README.md
+++ b/distributed/deploy/README.md
@@ -11,7 +11,7 @@
 | **Fly.io** | Edge deployment, persistent volumes | `bash distributed/deploy/fly-deploy.sh` |
 | **Render** | Simple PaaS with managed Postgres | Deploy to Render button |
 | **Daytona** | Cloud sandboxes (SDK or CLI) | `python distributed/deploy/daytona_sandbox.py` |
-| **Islo** | Isolated cloud sandboxes for agents (CLI) | `python distributed/deploy/islo_sandbox.py` |
+| **Islo** | Isolated cloud sandboxes for agents (SDK) | `python distributed/deploy/islo_sandbox.py` |
 
 All platforms require setting `LLM_API_KEY` as a minimum.
 
@@ -139,20 +139,23 @@ Islo provides isolated cloud sandbox VMs for autonomous agents, built by the Inc
 
 ```bash
 curl -fsSL https://islo.dev/install.sh | bash
-islo login  # interactive use
+islo login
+islo api-key create cognee-deploy --expires 90 --show
 
-# CI alternative: create the key with the CLI, store it securely, and set ISLO_API_KEY
-islo api-key create cognee-ci --expires 90 --output-file /secure/path/islo-api-key
-
+pip install islo
+export ISLO_API_KEY=your-cli-created-key
 export LLM_API_KEY=sk-xxx
 python distributed/deploy/islo_sandbox.py
 ```
 
-The script drives the official Islo CLI: `islo use` creates the sandbox and runs the setup, while `islo share` exposes the API with a 24-hour URL. Credentials are loaded from a mode-0600 temporary env file that is removed immediately after setup. Stop or delete the sandbox with the CLI:
+The CLI is used only to create the access key. The deployment itself uses the official Python SDK to create the sandbox, install `cognee[api]`, start the API server, verify `/health`, and create a 24-hour share URL. Stop or delete the sandbox via the SDK:
 
-```bash
-islo stop cognee-api
-islo rm cognee-api --force
+```python
+from islo import Islo
+
+client = Islo()  # reads ISLO_API_KEY from the environment
+client.sandboxes.stop_sandbox("cognee-api")
+client.sandboxes.delete_sandbox("cognee-api")
 ```
 
 The sandbox name is fixed (`cognee-api`), so re-running the script while a previous deployment still exists fails with a name conflict — delete the old sandbox first (see above), then re-run.

--- a/distributed/deploy/README.md
+++ b/distributed/deploy/README.md
@@ -11,6 +11,7 @@
 | **Fly.io** | Edge deployment, persistent volumes | `bash distributed/deploy/fly-deploy.sh` |
 | **Render** | Simple PaaS with managed Postgres | Deploy to Render button |
 | **Daytona** | Cloud sandboxes (SDK or CLI) | `python distributed/deploy/daytona_sandbox.py` |
+| **Islo** | Isolated cloud sandboxes for agents (SDK) | `python distributed/deploy/islo_sandbox.py` |
 
 All platforms require setting `LLM_API_KEY` as a minimum.
 
@@ -129,6 +130,32 @@ daytona create
 pip install 'cognee[api]'
 python -m uvicorn cognee.api.client:app --host 0.0.0.0 --port 8000
 ```
+
+---
+
+## Islo (Cloud Sandbox)
+
+Islo provides isolated cloud sandbox VMs for autonomous agents, built by the Incredibuild team. Cognee runs inside a sandbox and is exposed through a temporary public share URL. Docs: https://docs.islo.dev
+
+```bash
+pip install islo
+
+export ISLO_API_KEY=your-key   # from https://app.islo.dev/api-keys
+export LLM_API_KEY=sk-xxx
+python distributed/deploy/islo_sandbox.py
+```
+
+The script creates a sandbox, installs `cognee[api]`, starts the API server, and prints a temporary public share URL (24-hour TTL). Stop or delete the sandbox via the SDK:
+
+```python
+from islo import Islo
+
+client = Islo()  # reads ISLO_API_KEY from the environment
+client.sandboxes.stop_sandbox("cognee-api")
+client.sandboxes.delete_sandbox("cognee-api")
+```
+
+The sandbox name is fixed (`cognee-api`), so re-running the script while a previous deployment still exists fails with a name conflict — delete the old sandbox first (see above), then re-run.
 
 ---
 

--- a/distributed/deploy/islo_sandbox.py
+++ b/distributed/deploy/islo_sandbox.py
@@ -1,0 +1,258 @@
+"""
+Cognee on Islo — deploy Cognee API inside an Islo cloud sandbox.
+
+Islo (https://islo.dev) provides isolated cloud sandbox VMs for autonomous
+agents, built by the Incredibuild team. This script creates a sandbox,
+installs Cognee, starts the API server, and prints a temporary public
+share URL for the API.
+
+Prerequisites:
+    pip install islo
+
+    Set environment variables:
+        ISLO_API_KEY  — your Islo API key (from https://app.islo.dev/api-keys)
+        LLM_API_KEY   — your LLM provider API key
+
+Usage:
+    python distributed/deploy/islo_sandbox.py
+
+Note:
+    The sandbox name is fixed ("cognee-api"). Re-running the script while a
+    previous deployment still exists fails with a name conflict — delete the
+    old sandbox first:
+        python -c "from islo import Islo; Islo().sandboxes.delete_sandbox('cognee-api')"
+"""
+
+import os
+import sys
+import time
+
+from islo import Islo
+from islo.errors import ConflictError
+from islo.types import LifecyclePolicy
+
+DEFAULT_IMAGE = "ghcr.io/islo-labs/islo-runner:latest"
+SANDBOX_NAME = "cognee-api"
+API_PORT = 8000
+TERMINAL_EXEC_STATUSES = {"completed", "failed", "timeout"}
+
+_HEALTHCHECK_SNIPPET = (
+    "import urllib.request\n"
+    "try:\n"
+    "    urllib.request.urlopen('http://localhost:8000/health', timeout=5)\n"
+    "    print('OK')\n"
+    "except Exception:\n"
+    "    print('WAITING')\n"
+)
+
+
+def run_command(
+    client,
+    sandbox_name: str,
+    command: list,
+    *,
+    env: dict = None,
+    workdir: str = None,
+    timeout_secs: int = None,
+    poll_interval: float = 2.0,
+    max_wait: float = None,
+    label: str = "",
+):
+    """Run a command in the sandbox and poll until it reaches a terminal status.
+
+    Islo exec is asynchronous: ``exec_in_sandbox`` starts the command and returns
+    an exec ID, then ``get_exec_result`` is polled until the status is one of
+    ``completed``, ``failed``, or ``timeout``. Returns the final ExecResultResponse.
+
+    ``timeout_secs`` is only a server-side hint, so polling is also bounded by a
+    client-side deadline: ``max_wait`` seconds if given, otherwise derived from
+    ``timeout_secs`` plus a margin (10 minutes when neither is set). Raises
+    RuntimeError if the exec never reaches a terminal status in time.
+    """
+    started = client.sandboxes.exec_in_sandbox(
+        sandbox_name,
+        command=command,
+        env=env,
+        workdir=workdir,
+        timeout_secs=timeout_secs,
+    )
+
+    if max_wait is None:
+        max_wait = timeout_secs + 60.0 if timeout_secs else 600.0
+    deadline = time.monotonic() + max_wait
+
+    while True:
+        result = client.sandboxes.get_exec_result(sandbox_name, started.exec_id)
+        if result.status in TERMINAL_EXEC_STATUSES:
+            break
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"Command {command!r} did not reach a terminal status within {max_wait:.0f}s "
+                f"(last status: '{result.status}')"
+            )
+        time.sleep(poll_interval)
+
+    prefix = f"[{label}] " if label else ""
+    if result.stdout:
+        for line in result.stdout.splitlines():
+            print(f"{prefix}{line}", flush=True)
+    if result.stderr:
+        for line in result.stderr.splitlines():
+            print(f"{prefix}{line}", file=sys.stderr, flush=True)
+    if result.truncated:
+        print(f"{prefix}(output truncated)", flush=True)
+
+    return result
+
+
+def wait_for_sandbox_running(
+    client,
+    sandbox_name: str,
+    timeout: float = 300,
+    poll_interval: float = 3.0,
+):
+    """Poll the sandbox until it is running. Returns the SandboxResponse."""
+    deadline = time.monotonic() + timeout
+    while True:
+        sandbox = client.sandboxes.get_sandbox(sandbox_name)
+        if sandbox.status == "running":
+            return sandbox
+        if sandbox.status in {"failed", "stopped", "deleted"}:
+            raise RuntimeError(f"Sandbox '{sandbox_name}' entered state '{sandbox.status}'")
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"Sandbox '{sandbox_name}' not running after {timeout}s")
+        print(f"  Sandbox status: {sandbox.status}", flush=True)
+        time.sleep(poll_interval)
+
+
+def wait_for_server_health(
+    client,
+    sandbox_name: str,
+    retries: int = 30,
+    delay: float = 3.0,
+) -> bool:
+    """Poll the Cognee API /health endpoint inside the sandbox until it responds."""
+    for attempt in range(retries):
+        result = run_command(
+            client,
+            sandbox_name,
+            ["python3", "-c", _HEALTHCHECK_SNIPPET],
+            timeout_secs=30,
+            poll_interval=1.0,
+            label="health",
+        )
+        if "OK" in result.stdout:
+            print("Server is ready!")
+            return True
+        print(f"  ({attempt + 1}) waiting for server...", flush=True)
+        time.sleep(delay)
+
+    # Print server log for debugging
+    run_command(
+        client,
+        sandbox_name,
+        ["bash", "-lc", "tail -n 30 /tmp/cognee-server.log"],
+        timeout_secs=30,
+        label="server-log",
+    )
+    print("WARNING: Server may not be ready yet.")
+    return False
+
+
+def deploy_cognee():
+    """Create an Islo sandbox, start the Cognee API server, and print a share URL."""
+    if not os.environ.get("ISLO_API_KEY"):
+        raise ValueError("ISLO_API_KEY environment variable is required")
+    llm_api_key = os.environ.get("LLM_API_KEY")
+    if not llm_api_key:
+        raise ValueError("LLM_API_KEY environment variable is required")
+
+    # The client picks up ISLO_API_KEY from the environment automatically.
+    client = Islo()
+
+    print("Creating Islo sandbox for Cognee...")
+    try:
+        sandbox = client.sandboxes.create_sandbox(
+            name=SANDBOX_NAME,
+            image=DEFAULT_IMAGE,
+            vcpus=2,
+            memory_mb=4096,
+            disk_gb=10,
+            env={
+                "LLM_API_KEY": llm_api_key,
+                "LLM_MODEL": os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
+                "LLM_PROVIDER": os.environ.get("LLM_PROVIDER", "openai"),
+                "HOST": "0.0.0.0",
+            },
+            lifecycle=LifecyclePolicy(pause_after_idle=3600, auto_resume="on_activity"),
+        )
+    except ConflictError as error:
+        raise RuntimeError(
+            f"A sandbox named '{SANDBOX_NAME}' already exists (likely from a previous run). "
+            "Delete it first, then re-run this script:\n"
+            f'  python -c "from islo import Islo; '
+            f"Islo().sandboxes.delete_sandbox('{SANDBOX_NAME}')\""
+        ) from error
+    print(f"Sandbox created: {sandbox.id}\n")
+
+    print("Waiting for sandbox to start...")
+    wait_for_sandbox_running(client, SANDBOX_NAME)
+
+    # Step 1: Install Cognee
+    print("=== Installing Cognee ===")
+    install = run_command(
+        client,
+        SANDBOX_NAME,
+        ["bash", "-lc", "pip install 'cognee[api]'"],
+        timeout_secs=1800,
+        label="install",
+    )
+    if install.status != "completed" or install.exit_code not in (0, None):
+        raise RuntimeError(
+            f"Failed to install cognee (status '{install.status}', exit {install.exit_code}): "
+            f"{install.stderr}"
+        )
+    print()
+
+    # Step 2: Start the server as a background daemon
+    print("=== Starting Cognee API server ===")
+    run_command(
+        client,
+        SANDBOX_NAME,
+        [
+            "bash",
+            "-lc",
+            f"nohup python3 -m uvicorn cognee.api.client:app --host 0.0.0.0 --port {API_PORT} "
+            "> /tmp/cognee-server.log 2>&1 & echo started",
+        ],
+        timeout_secs=30,
+        label="server",
+    )
+
+    print("Waiting for server to start...", flush=True)
+    wait_for_server_health(client, SANDBOX_NAME)
+
+    # Step 3: Create a temporary public share for the API port
+    share = client.shares.create_share(SANDBOX_NAME, port=API_PORT, ttl_seconds=86400)
+
+    print("\nCognee is running!")
+    print(f"  Sandbox: {SANDBOX_NAME} ({sandbox.id})")
+    print(f"\n  API URL: {share.url}")
+    print(f"  Health:  {share.url}/health")
+    print(f"  Docs:    {share.url}/docs")
+    if share.expires_at:
+        print(f"  (share URL expires at {share.expires_at})")
+    else:
+        print("  (share URL expires in 24 hours)")
+    print("\nTo stop the sandbox:")
+    print(f"  python -c \"from islo import Islo; Islo().sandboxes.stop_sandbox('{SANDBOX_NAME}')\"")
+    print("To delete it:")
+    print(
+        f"  python -c \"from islo import Islo; Islo().sandboxes.delete_sandbox('{SANDBOX_NAME}')\""
+    )
+
+    return sandbox
+
+
+if __name__ == "__main__":
+    deploy_cognee()

--- a/distributed/deploy/islo_sandbox.py
+++ b/distributed/deploy/islo_sandbox.py
@@ -1,20 +1,20 @@
 """
-Cognee on Islo — deploy Cognee API with the Islo CLI.
+Cognee on Islo — deploy Cognee API inside an Islo cloud sandbox.
 
 Islo (https://islo.dev) provides isolated cloud sandbox VMs for autonomous
-agents, built by the Incredibuild team. This script uses the official Islo CLI
-to create a sandbox, install Cognee, start the API server, and print a temporary
-public share URL.
+agents, built by the Incredibuild team. This script uses the official Islo
+Python SDK to create a sandbox, install Cognee, start the API server, and print
+a temporary public share URL.
 
 Prerequisites:
-    Install the Islo CLI:
-        curl -fsSL https://islo.dev/install.sh | bash
+    pip install islo
 
-    Authenticate once with ``islo login``. For CI, create a key with
-    ``islo api-key create cognee-ci --expires 90`` and set ``ISLO_API_KEY``.
+    Create an Islo key with the CLI:
+        islo api-key create cognee-deploy --expires 90 --show
 
-    Set your LLM provider API key:
-        export LLM_API_KEY=your-key
+    Set environment variables:
+        ISLO_API_KEY  — the key created by the Islo CLI
+        LLM_API_KEY   — your LLM provider API key
 
 Usage:
     python distributed/deploy/islo_sandbox.py
@@ -23,28 +23,28 @@ Note:
     The sandbox name is fixed ("cognee-api"). Re-running the script while a
     previous deployment still exists fails with a name conflict — delete the
     old sandbox first:
-        islo rm cognee-api --force
+        python -c "from islo import Islo; Islo().sandboxes.delete_sandbox('cognee-api')"
 """
 
-import json
 import os
-import shutil
-import subprocess
 import sys
-import tempfile
 import time
-from typing import Any
+
+from islo import Islo
+from islo.errors import ConflictError
+from islo.types import LifecyclePolicy
 
 DEFAULT_IMAGE = "ghcr.io/islo-labs/islo-runner:latest"
 SANDBOX_NAME = "cognee-api"
 API_PORT = 8000
+TERMINAL_EXEC_STATUSES = {"completed", "failed", "timeout"}
 
 # The islo-runner image ships Python without pip/ensurepip and marks the system
 # environment as PEP 668 "externally managed", so Cognee is installed into a
 # dedicated virtualenv (bootstrapped via apt) rather than the system interpreter.
 VENV_PATH = "/opt/cognee-venv"
 VENV_PYTHON = f"{VENV_PATH}/bin/python"
-_DEPLOY_SCRIPT = (
+_INSTALL_SCRIPT = (
     "set -e\n"
     "export DEBIAN_FRONTEND=noninteractive\n"
     "apt-get update -qq\n"
@@ -52,253 +52,230 @@ _DEPLOY_SCRIPT = (
     f"python3 -m venv {VENV_PATH}\n"
     f"{VENV_PATH}/bin/pip install --upgrade pip\n"
     f"{VENV_PATH}/bin/pip install 'cognee[api]'\n"
-    f"nohup {VENV_PYTHON} -m uvicorn cognee.api.client:app "
-    f"--host 0.0.0.0 --port {API_PORT} > /tmp/cognee-server.log 2>&1 &\n"
-    "echo started\n"
 )
 
 _HEALTHCHECK_SNIPPET = (
-    "import sys, urllib.request\n"
+    "import urllib.request\n"
     "try:\n"
     f"    urllib.request.urlopen('http://localhost:{API_PORT}/health', timeout=5)\n"
+    "    print('OK')\n"
     "except Exception:\n"
-    "    sys.exit(1)\n"
-    "print('OK')\n"
+    "    print('WAITING')\n"
 )
 
 
-def run_islo(
-    args: list[str],
+def run_command(
+    client,
+    sandbox_name: str,
+    command: list,
     *,
-    check: bool = True,
-    timeout: float | None = None,
-    echo: bool = True,
-) -> subprocess.CompletedProcess[str]:
-    """Run an Islo CLI command and return its completed process."""
-    command = ["islo", *args]
-    try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as error:
-        raise RuntimeError(f"Islo command timed out after {timeout:.0f}s: {args!r}") from error
+    timeout_secs: int | None = None,
+    poll_interval: float = 2.0,
+    max_wait: float | None = None,
+    label: str = "",
+):
+    """Run a command in the sandbox and poll until it reaches a terminal status.
 
-    if echo:
-        if result.stdout:
-            print(result.stdout, end="" if result.stdout.endswith("\n") else "\n", flush=True)
-        if result.stderr:
-            print(
-                result.stderr,
-                end="" if result.stderr.endswith("\n") else "\n",
-                file=sys.stderr,
-                flush=True,
+    Islo exec is asynchronous: ``exec_in_sandbox`` starts the command and returns
+    an exec ID, then ``get_exec_result`` is polled until the status is one of
+    ``completed``, ``failed``, or ``timeout``. Returns the final ExecResultResponse.
+
+    ``timeout_secs`` is only a server-side hint, so polling is also bounded by a
+    client-side deadline: ``max_wait`` seconds if given, otherwise derived from
+    ``timeout_secs`` plus a margin (10 minutes when neither is set). Raises
+    RuntimeError if the exec never reaches a terminal status in time.
+    """
+    started = client.sandboxes.exec_in_sandbox(
+        sandbox_name,
+        command=command,
+        timeout_secs=timeout_secs,
+    )
+
+    if max_wait is None:
+        max_wait = timeout_secs + 60.0 if timeout_secs else 600.0
+    deadline = time.monotonic() + max_wait
+
+    while True:
+        result = client.sandboxes.get_exec_result(sandbox_name, started.exec_id)
+        if result.status in TERMINAL_EXEC_STATUSES:
+            break
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"Command {command!r} did not reach a terminal status within {max_wait:.0f}s "
+                f"(last status: '{result.status}')"
             )
+        time.sleep(poll_interval)
 
-    if check and result.returncode != 0:
-        detail = (result.stderr or result.stdout).strip()
-        suffix = f": {detail}" if detail else ""
-        raise RuntimeError(f"Islo command failed (exit {result.returncode}){suffix}")
+    prefix = f"[{label}] " if label else ""
+    if result.stdout:
+        for line in result.stdout.splitlines():
+            print(f"{prefix}{line}", flush=True)
+    if result.stderr:
+        for line in result.stderr.splitlines():
+            print(f"{prefix}{line}", file=sys.stderr, flush=True)
+    if result.truncated:
+        print(f"{prefix}(output truncated)", flush=True)
 
     return result
 
 
-def _parse_json(result: subprocess.CompletedProcess[str], description: str) -> dict[str, Any]:
-    """Parse a JSON object returned by the CLI with an actionable error."""
-    try:
-        value = json.loads(result.stdout)
-    except (json.JSONDecodeError, TypeError) as error:
-        raise RuntimeError(f"Islo returned invalid JSON while reading {description}") from error
-    if not isinstance(value, dict):
-        raise RuntimeError(f"Islo returned an unexpected response while reading {description}")
-    return value
+def wait_for_sandbox_running(
+    client,
+    sandbox_name: str,
+    timeout: float = 300,
+    poll_interval: float = 3.0,
+):
+    """Poll the sandbox until it is running. Returns the SandboxResponse."""
+    deadline = time.monotonic() + timeout
+    while True:
+        sandbox = client.sandboxes.get_sandbox(sandbox_name)
+        if sandbox.status == "running":
+            return sandbox
+        if sandbox.status in {"failed", "stopped", "deleted"}:
+            raise RuntimeError(f"Sandbox '{sandbox_name}' entered state '{sandbox.status}'")
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"Sandbox '{sandbox_name}' not running after {timeout}s")
+        print(f"  Sandbox status: {sandbox.status}", flush=True)
+        time.sleep(poll_interval)
 
 
-def _write_env_file(values: dict[str, str]) -> str:
-    """Write sandbox variables to a mode-0600 temporary dotenv file."""
-    descriptor, path = tempfile.mkstemp(prefix="cognee-islo-", suffix=".env", text=True)
-    try:
-        with os.fdopen(descriptor, "w") as env_file:
-            for key, value in values.items():
-                env_file.write(f"{key}={json.dumps(value)}\n")
-        os.chmod(path, 0o600)
-    except Exception:
-        os.unlink(path)
-        raise
-    return path
-
-
-def _check_prerequisites() -> str:
-    """Validate the local CLI, authentication, and required provider key."""
-    if shutil.which("islo") is None:
-        raise RuntimeError(
-            "Islo CLI is required. Install it with: curl -fsSL https://islo.dev/install.sh | bash"
-        )
-
-    llm_api_key = os.environ.get("LLM_API_KEY")
-    if not llm_api_key:
-        raise ValueError("LLM_API_KEY environment variable is required")
-
-    status_result = run_islo(["status", "--output", "json"], check=False, echo=False)
-    if status_result.returncode != 0:
-        raise RuntimeError(
-            "Islo authentication failed. Run 'islo login' or create a CI key with "
-            "'islo api-key create cognee-ci --expires 90', then set ISLO_API_KEY."
-        )
-    status = _parse_json(status_result, "authentication status")
-    if not status.get("auth", {}).get("authenticated"):
-        raise RuntimeError(
-            "Islo is not authenticated. Run 'islo login' or create a CI key with "
-            "'islo api-key create cognee-ci --expires 90', then set ISLO_API_KEY."
-        )
-
-    return llm_api_key
-
-
-def _sandbox_exists() -> bool:
-    """Return whether the fixed deployment sandbox already exists."""
-    result = run_islo(
-        ["status", SANDBOX_NAME, "--output", "json"],
-        check=False,
-        echo=False,
-    )
-    return result.returncode == 0
-
-
-def wait_for_server_health(retries: int = 30, delay: float = 3.0) -> bool:
-    """Poll the Cognee API /health endpoint inside the sandbox."""
+def wait_for_server_health(
+    client,
+    sandbox_name: str,
+    retries: int = 30,
+    delay: float = 3.0,
+) -> bool:
+    """Poll the Cognee API /health endpoint inside the sandbox until it responds."""
     for attempt in range(retries):
-        result = run_islo(
-            [
-                "use",
-                SANDBOX_NAME,
-                "--no-config",
-                "--output",
-                "plain",
-                "--",
-                "python3",
-                "-c",
-                _HEALTHCHECK_SNIPPET,
-            ],
-            check=False,
-            timeout=30,
-            echo=False,
+        result = run_command(
+            client,
+            sandbox_name,
+            ["python3", "-c", _HEALTHCHECK_SNIPPET],
+            timeout_secs=30,
+            poll_interval=1.0,
+            label="health",
         )
-        if result.returncode == 0 and result.stdout.strip().splitlines()[-1:] == ["OK"]:
+        if (
+            result.status == "completed"
+            and result.exit_code in (0, None)
+            and result.stdout
+            and result.stdout.strip() == "OK"
+        ):
             print("Server is ready!")
             return True
         print(f"  ({attempt + 1}) waiting for server...", flush=True)
         time.sleep(delay)
 
-    run_islo(
-        [
-            "use",
-            SANDBOX_NAME,
-            "--no-config",
-            "--output",
-            "plain",
-            "--",
-            "bash",
-            "-lc",
-            "tail -n 30 /tmp/cognee-server.log",
-        ],
-        check=False,
-        timeout=30,
+    run_command(
+        client,
+        sandbox_name,
+        ["bash", "-lc", "tail -n 30 /tmp/cognee-server.log"],
+        timeout_secs=30,
+        label="server-log",
     )
     print("ERROR: Server did not become healthy.", file=sys.stderr)
     return False
 
 
-def deploy_cognee() -> dict[str, Any]:
-    """Create an Islo sandbox, start the Cognee API, and print a share URL."""
-    llm_api_key = _check_prerequisites()
+def deploy_cognee():
+    """Create an Islo sandbox, start the Cognee API server, and print a share URL."""
+    if not os.environ.get("ISLO_API_KEY"):
+        raise ValueError(
+            "ISLO_API_KEY is required. Create one with "
+            "'islo api-key create cognee-deploy --expires 90 --show'."
+        )
+    llm_api_key = os.environ.get("LLM_API_KEY")
+    if not llm_api_key:
+        raise ValueError("LLM_API_KEY environment variable is required")
 
-    if _sandbox_exists():
+    # The SDK picks up ISLO_API_KEY from the environment automatically.
+    client = Islo()
+
+    print("Creating Islo sandbox for Cognee...")
+    try:
+        sandbox = client.sandboxes.create_sandbox(
+            name=SANDBOX_NAME,
+            image=DEFAULT_IMAGE,
+            vcpus=2,
+            memory_mb=4096,
+            disk_gb=10,
+            env={
+                "LLM_API_KEY": llm_api_key,
+                "LLM_MODEL": os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
+                "LLM_PROVIDER": os.environ.get("LLM_PROVIDER", "openai"),
+                "HOST": "0.0.0.0",
+            },
+            lifecycle=LifecyclePolicy(pause_after_idle=3600, auto_resume="on_activity"),
+        )
+    except ConflictError as error:
         raise RuntimeError(
             f"A sandbox named '{SANDBOX_NAME}' already exists (likely from a previous run). "
-            f"Delete it with 'islo rm {SANDBOX_NAME} --force', then re-run this script."
-        )
+            "Delete it first, then re-run this script:\n"
+            f'  python -c "from islo import Islo; '
+            f"Islo().sandboxes.delete_sandbox('{SANDBOX_NAME}')\""
+        ) from error
+    print(f"Sandbox created: {sandbox.id}\n")
 
-    env_path = _write_env_file(
-        {
-            "LLM_API_KEY": llm_api_key,
-            "LLM_MODEL": os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
-            "LLM_PROVIDER": os.environ.get("LLM_PROVIDER", "openai"),
-            "HOST": "0.0.0.0",
-        }
+    print("Waiting for sandbox to start...")
+    wait_for_sandbox_running(client, SANDBOX_NAME)
+
+    print("=== Installing Cognee ===")
+    install = run_command(
+        client,
+        SANDBOX_NAME,
+        ["bash", "-lc", _INSTALL_SCRIPT],
+        timeout_secs=1800,
+        label="install",
     )
-    print("Creating Islo sandbox and installing Cognee...")
-    try:
-        run_islo(
-            [
-                "use",
-                SANDBOX_NAME,
-                "--no-config",
-                "--image",
-                DEFAULT_IMAGE,
-                "--cpu",
-                "2",
-                "--memory",
-                "4096",
-                "--disk",
-                "10",
-                "--pause-after-idle",
-                "3600",
-                "--auto-resume",
-                "on_activity",
-                "--run-as-user",
-                "root",
-                "--env-file",
-                env_path,
-                "--output",
-                "plain",
-                "--",
-                "bash",
-                "-lc",
-                _DEPLOY_SCRIPT,
-            ],
-            timeout=1860,
+    if install.status != "completed" or install.exit_code not in (0, None):
+        raise RuntimeError(
+            f"Failed to install cognee (status '{install.status}', exit {install.exit_code}): "
+            f"{install.stderr}"
         )
-    finally:
-        os.unlink(env_path)
+    print()
+
+    print("=== Starting Cognee API server ===")
+    server_start = run_command(
+        client,
+        SANDBOX_NAME,
+        [
+            "bash",
+            "-lc",
+            f"nohup {VENV_PYTHON} -m uvicorn cognee.api.client:app --host 0.0.0.0 --port {API_PORT} "
+            "> /tmp/cognee-server.log 2>&1 & echo started",
+        ],
+        timeout_secs=30,
+        label="server",
+    )
+    if server_start.status != "completed" or server_start.exit_code not in (0, None):
+        raise RuntimeError(
+            f"Failed to start cognee API server (status '{server_start.status}', "
+            f"exit {server_start.exit_code}): {server_start.stderr}"
+        )
 
     print("Waiting for server to start...", flush=True)
-    if not wait_for_server_health():
+    if not wait_for_server_health(client, SANDBOX_NAME):
         raise RuntimeError(
             "Cognee API server did not become healthy; see the server log printed above"
         )
 
-    share_result = run_islo(
-        ["share", SANDBOX_NAME, str(API_PORT), "--ttl", "24h", "--output", "json"],
-        echo=False,
-    )
-    share = _parse_json(share_result, "share URL")
-    share_url = share.get("url")
-    if not isinstance(share_url, str) or not share_url:
-        raise RuntimeError("Islo did not return a share URL")
-
-    sandbox_result = run_islo(
-        ["status", SANDBOX_NAME, "--output", "json"],
-        echo=False,
-    )
-    sandbox = _parse_json(sandbox_result, "sandbox status")
+    share = client.shares.create_share(SANDBOX_NAME, port=API_PORT, ttl_seconds=86400)
 
     print("\nCognee is running!")
-    print(f"  Sandbox: {SANDBOX_NAME}")
-    print(f"\n  API URL: {share_url}")
-    print(f"  Health:  {share_url}/health")
-    print(f"  Docs:    {share_url}/docs")
-    if share.get("expires_at"):
-        print(f"  (share URL expires at {share['expires_at']})")
+    print(f"  Sandbox: {SANDBOX_NAME} ({sandbox.id})")
+    print(f"\n  API URL: {share.url}")
+    print(f"  Health:  {share.url}/health")
+    print(f"  Docs:    {share.url}/docs")
+    if share.expires_at:
+        print(f"  (share URL expires at {share.expires_at})")
     else:
         print("  (share URL expires in 24 hours)")
     print("\nTo stop the sandbox:")
-    print(f"  islo stop {SANDBOX_NAME}")
+    print(f"  python -c \"from islo import Islo; Islo().sandboxes.stop_sandbox('{SANDBOX_NAME}')\"")
     print("To delete it:")
-    print(f"  islo rm {SANDBOX_NAME} --force")
+    print(
+        f"  python -c \"from islo import Islo; Islo().sandboxes.delete_sandbox('{SANDBOX_NAME}')\""
+    )
 
     return sandbox
 

--- a/distributed/deploy/islo_sandbox.py
+++ b/distributed/deploy/islo_sandbox.py
@@ -1,17 +1,20 @@
 """
-Cognee on Islo — deploy Cognee API inside an Islo cloud sandbox.
+Cognee on Islo — deploy Cognee API with the Islo CLI.
 
 Islo (https://islo.dev) provides isolated cloud sandbox VMs for autonomous
-agents, built by the Incredibuild team. This script creates a sandbox,
-installs Cognee, starts the API server, and prints a temporary public
-share URL for the API.
+agents, built by the Incredibuild team. This script uses the official Islo CLI
+to create a sandbox, install Cognee, start the API server, and print a temporary
+public share URL.
 
 Prerequisites:
-    pip install islo
+    Install the Islo CLI:
+        curl -fsSL https://islo.dev/install.sh | bash
 
-    Set environment variables:
-        ISLO_API_KEY  — your Islo API key (from https://app.islo.dev/api-keys)
-        LLM_API_KEY   — your LLM provider API key
+    Authenticate once with ``islo login``. For CI, create a key with
+    ``islo api-key create cognee-ci --expires 90`` and set ``ISLO_API_KEY``.
+
+    Set your LLM provider API key:
+        export LLM_API_KEY=your-key
 
 Usage:
     python distributed/deploy/islo_sandbox.py
@@ -20,28 +23,28 @@ Note:
     The sandbox name is fixed ("cognee-api"). Re-running the script while a
     previous deployment still exists fails with a name conflict — delete the
     old sandbox first:
-        python -c "from islo import Islo; Islo().sandboxes.delete_sandbox('cognee-api')"
+        islo rm cognee-api --force
 """
 
+import json
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import time
-
-from islo import Islo
-from islo.errors import ConflictError
-from islo.types import LifecyclePolicy
+from typing import Any
 
 DEFAULT_IMAGE = "ghcr.io/islo-labs/islo-runner:latest"
 SANDBOX_NAME = "cognee-api"
 API_PORT = 8000
-TERMINAL_EXEC_STATUSES = {"completed", "failed", "timeout"}
 
 # The islo-runner image ships Python without pip/ensurepip and marks the system
 # environment as PEP 668 "externally managed", so Cognee is installed into a
 # dedicated virtualenv (bootstrapped via apt) rather than the system interpreter.
 VENV_PATH = "/opt/cognee-venv"
 VENV_PYTHON = f"{VENV_PATH}/bin/python"
-_INSTALL_SCRIPT = (
+_DEPLOY_SCRIPT = (
     "set -e\n"
     "export DEBIAN_FRONTEND=noninteractive\n"
     "apt-get update -qq\n"
@@ -49,218 +52,253 @@ _INSTALL_SCRIPT = (
     f"python3 -m venv {VENV_PATH}\n"
     f"{VENV_PATH}/bin/pip install --upgrade pip\n"
     f"{VENV_PATH}/bin/pip install 'cognee[api]'\n"
+    f"nohup {VENV_PYTHON} -m uvicorn cognee.api.client:app "
+    f"--host 0.0.0.0 --port {API_PORT} > /tmp/cognee-server.log 2>&1 &\n"
+    "echo started\n"
 )
 
 _HEALTHCHECK_SNIPPET = (
-    "import urllib.request\n"
+    "import sys, urllib.request\n"
     "try:\n"
-    "    urllib.request.urlopen('http://localhost:8000/health', timeout=5)\n"
-    "    print('OK')\n"
+    f"    urllib.request.urlopen('http://localhost:{API_PORT}/health', timeout=5)\n"
     "except Exception:\n"
-    "    print('WAITING')\n"
+    "    sys.exit(1)\n"
+    "print('OK')\n"
 )
 
 
-def run_command(
-    client,
-    sandbox_name: str,
-    command: list,
+def run_islo(
+    args: list[str],
     *,
-    timeout_secs: int = None,
-    poll_interval: float = 2.0,
-    max_wait: float = None,
-    label: str = "",
-):
-    """Run a command in the sandbox and poll until it reaches a terminal status.
+    check: bool = True,
+    timeout: float | None = None,
+    echo: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run an Islo CLI command and return its completed process."""
+    command = ["islo", *args]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(f"Islo command timed out after {timeout:.0f}s: {args!r}") from error
 
-    Islo exec is asynchronous: ``exec_in_sandbox`` starts the command and returns
-    an exec ID, then ``get_exec_result`` is polled until the status is one of
-    ``completed``, ``failed``, or ``timeout``. Returns the final ExecResultResponse.
-
-    ``timeout_secs`` is only a server-side hint, so polling is also bounded by a
-    client-side deadline: ``max_wait`` seconds if given, otherwise derived from
-    ``timeout_secs`` plus a margin (10 minutes when neither is set). Raises
-    RuntimeError if the exec never reaches a terminal status in time.
-    """
-    started = client.sandboxes.exec_in_sandbox(
-        sandbox_name,
-        command=command,
-        timeout_secs=timeout_secs,
-    )
-
-    if max_wait is None:
-        max_wait = timeout_secs + 60.0 if timeout_secs else 600.0
-    deadline = time.monotonic() + max_wait
-
-    while True:
-        result = client.sandboxes.get_exec_result(sandbox_name, started.exec_id)
-        if result.status in TERMINAL_EXEC_STATUSES:
-            break
-        if time.monotonic() >= deadline:
-            raise RuntimeError(
-                f"Command {command!r} did not reach a terminal status within {max_wait:.0f}s "
-                f"(last status: '{result.status}')"
+    if echo:
+        if result.stdout:
+            print(result.stdout, end="" if result.stdout.endswith("\n") else "\n", flush=True)
+        if result.stderr:
+            print(
+                result.stderr,
+                end="" if result.stderr.endswith("\n") else "\n",
+                file=sys.stderr,
+                flush=True,
             )
-        time.sleep(poll_interval)
 
-    prefix = f"[{label}] " if label else ""
-    if result.stdout:
-        for line in result.stdout.splitlines():
-            print(f"{prefix}{line}", flush=True)
-    if result.stderr:
-        for line in result.stderr.splitlines():
-            print(f"{prefix}{line}", file=sys.stderr, flush=True)
-    if result.truncated:
-        print(f"{prefix}(output truncated)", flush=True)
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"Islo command failed (exit {result.returncode}){suffix}")
 
     return result
 
 
-def wait_for_sandbox_running(
-    client,
-    sandbox_name: str,
-    timeout: float = 300,
-    poll_interval: float = 3.0,
-):
-    """Poll the sandbox until it is running. Returns the SandboxResponse."""
-    deadline = time.monotonic() + timeout
-    while True:
-        sandbox = client.sandboxes.get_sandbox(sandbox_name)
-        if sandbox.status == "running":
-            return sandbox
-        if sandbox.status in {"failed", "stopped", "deleted"}:
-            raise RuntimeError(f"Sandbox '{sandbox_name}' entered state '{sandbox.status}'")
-        if time.monotonic() >= deadline:
-            raise RuntimeError(f"Sandbox '{sandbox_name}' not running after {timeout}s")
-        print(f"  Sandbox status: {sandbox.status}", flush=True)
-        time.sleep(poll_interval)
+def _parse_json(result: subprocess.CompletedProcess[str], description: str) -> dict[str, Any]:
+    """Parse a JSON object returned by the CLI with an actionable error."""
+    try:
+        value = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError) as error:
+        raise RuntimeError(f"Islo returned invalid JSON while reading {description}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError(f"Islo returned an unexpected response while reading {description}")
+    return value
 
 
-def wait_for_server_health(
-    client,
-    sandbox_name: str,
-    retries: int = 30,
-    delay: float = 3.0,
-) -> bool:
-    """Poll the Cognee API /health endpoint inside the sandbox until it responds."""
-    for attempt in range(retries):
-        result = run_command(
-            client,
-            sandbox_name,
-            ["python3", "-c", _HEALTHCHECK_SNIPPET],
-            timeout_secs=30,
-            poll_interval=1.0,
-            label="health",
+def _write_env_file(values: dict[str, str]) -> str:
+    """Write sandbox variables to a mode-0600 temporary dotenv file."""
+    descriptor, path = tempfile.mkstemp(prefix="cognee-islo-", suffix=".env", text=True)
+    try:
+        with os.fdopen(descriptor, "w") as env_file:
+            for key, value in values.items():
+                env_file.write(f"{key}={json.dumps(value)}\n")
+        os.chmod(path, 0o600)
+    except Exception:
+        os.unlink(path)
+        raise
+    return path
+
+
+def _check_prerequisites() -> str:
+    """Validate the local CLI, authentication, and required provider key."""
+    if shutil.which("islo") is None:
+        raise RuntimeError(
+            "Islo CLI is required. Install it with: curl -fsSL https://islo.dev/install.sh | bash"
         )
-        if "OK" in result.stdout:
+
+    llm_api_key = os.environ.get("LLM_API_KEY")
+    if not llm_api_key:
+        raise ValueError("LLM_API_KEY environment variable is required")
+
+    status_result = run_islo(["status", "--output", "json"], check=False, echo=False)
+    if status_result.returncode != 0:
+        raise RuntimeError(
+            "Islo authentication failed. Run 'islo login' or create a CI key with "
+            "'islo api-key create cognee-ci --expires 90', then set ISLO_API_KEY."
+        )
+    status = _parse_json(status_result, "authentication status")
+    if not status.get("auth", {}).get("authenticated"):
+        raise RuntimeError(
+            "Islo is not authenticated. Run 'islo login' or create a CI key with "
+            "'islo api-key create cognee-ci --expires 90', then set ISLO_API_KEY."
+        )
+
+    return llm_api_key
+
+
+def _sandbox_exists() -> bool:
+    """Return whether the fixed deployment sandbox already exists."""
+    result = run_islo(
+        ["status", SANDBOX_NAME, "--output", "json"],
+        check=False,
+        echo=False,
+    )
+    return result.returncode == 0
+
+
+def wait_for_server_health(retries: int = 30, delay: float = 3.0) -> bool:
+    """Poll the Cognee API /health endpoint inside the sandbox."""
+    for attempt in range(retries):
+        result = run_islo(
+            [
+                "use",
+                SANDBOX_NAME,
+                "--no-config",
+                "--output",
+                "plain",
+                "--",
+                "python3",
+                "-c",
+                _HEALTHCHECK_SNIPPET,
+            ],
+            check=False,
+            timeout=30,
+            echo=False,
+        )
+        if result.returncode == 0 and result.stdout.strip().splitlines()[-1:] == ["OK"]:
             print("Server is ready!")
             return True
         print(f"  ({attempt + 1}) waiting for server...", flush=True)
         time.sleep(delay)
 
-    # Print server log for debugging
-    run_command(
-        client,
-        sandbox_name,
-        ["bash", "-lc", "tail -n 30 /tmp/cognee-server.log"],
-        timeout_secs=30,
-        label="server-log",
+    run_islo(
+        [
+            "use",
+            SANDBOX_NAME,
+            "--no-config",
+            "--output",
+            "plain",
+            "--",
+            "bash",
+            "-lc",
+            "tail -n 30 /tmp/cognee-server.log",
+        ],
+        check=False,
+        timeout=30,
     )
-    print("WARNING: Server may not be ready yet.")
+    print("ERROR: Server did not become healthy.", file=sys.stderr)
     return False
 
 
-def deploy_cognee():
-    """Create an Islo sandbox, start the Cognee API server, and print a share URL."""
-    if not os.environ.get("ISLO_API_KEY"):
-        raise ValueError("ISLO_API_KEY environment variable is required")
-    llm_api_key = os.environ.get("LLM_API_KEY")
-    if not llm_api_key:
-        raise ValueError("LLM_API_KEY environment variable is required")
+def deploy_cognee() -> dict[str, Any]:
+    """Create an Islo sandbox, start the Cognee API, and print a share URL."""
+    llm_api_key = _check_prerequisites()
 
-    # The client picks up ISLO_API_KEY from the environment automatically.
-    client = Islo()
-
-    print("Creating Islo sandbox for Cognee...")
-    try:
-        sandbox = client.sandboxes.create_sandbox(
-            name=SANDBOX_NAME,
-            image=DEFAULT_IMAGE,
-            vcpus=2,
-            memory_mb=4096,
-            disk_gb=10,
-            env={
-                "LLM_API_KEY": llm_api_key,
-                "LLM_MODEL": os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
-                "LLM_PROVIDER": os.environ.get("LLM_PROVIDER", "openai"),
-                "HOST": "0.0.0.0",
-            },
-            lifecycle=LifecyclePolicy(pause_after_idle=3600, auto_resume="on_activity"),
-        )
-    except ConflictError as error:
+    if _sandbox_exists():
         raise RuntimeError(
             f"A sandbox named '{SANDBOX_NAME}' already exists (likely from a previous run). "
-            "Delete it first, then re-run this script:\n"
-            f'  python -c "from islo import Islo; '
-            f"Islo().sandboxes.delete_sandbox('{SANDBOX_NAME}')\""
-        ) from error
-    print(f"Sandbox created: {sandbox.id}\n")
-
-    print("Waiting for sandbox to start...")
-    wait_for_sandbox_running(client, SANDBOX_NAME)
-
-    # Step 1: Install Cognee
-    print("=== Installing Cognee ===")
-    install = run_command(
-        client,
-        SANDBOX_NAME,
-        ["bash", "-lc", _INSTALL_SCRIPT],
-        timeout_secs=1800,
-        label="install",
-    )
-    if install.status != "completed" or install.exit_code not in (0, None):
-        raise RuntimeError(
-            f"Failed to install cognee (status '{install.status}', exit {install.exit_code}): "
-            f"{install.stderr}"
+            f"Delete it with 'islo rm {SANDBOX_NAME} --force', then re-run this script."
         )
-    print()
 
-    # Step 2: Start the server as a background daemon
-    print("=== Starting Cognee API server ===")
-    run_command(
-        client,
-        SANDBOX_NAME,
-        [
-            "bash",
-            "-lc",
-            f"nohup {VENV_PYTHON} -m uvicorn cognee.api.client:app --host 0.0.0.0 --port {API_PORT} "
-            "> /tmp/cognee-server.log 2>&1 & echo started",
-        ],
-        timeout_secs=30,
-        label="server",
+    env_path = _write_env_file(
+        {
+            "LLM_API_KEY": llm_api_key,
+            "LLM_MODEL": os.environ.get("LLM_MODEL", "openai/gpt-4o-mini"),
+            "LLM_PROVIDER": os.environ.get("LLM_PROVIDER", "openai"),
+            "HOST": "0.0.0.0",
+        }
     )
+    print("Creating Islo sandbox and installing Cognee...")
+    try:
+        run_islo(
+            [
+                "use",
+                SANDBOX_NAME,
+                "--no-config",
+                "--image",
+                DEFAULT_IMAGE,
+                "--cpu",
+                "2",
+                "--memory",
+                "4096",
+                "--disk",
+                "10",
+                "--pause-after-idle",
+                "3600",
+                "--auto-resume",
+                "on_activity",
+                "--run-as-user",
+                "root",
+                "--env-file",
+                env_path,
+                "--output",
+                "plain",
+                "--",
+                "bash",
+                "-lc",
+                _DEPLOY_SCRIPT,
+            ],
+            timeout=1860,
+        )
+    finally:
+        os.unlink(env_path)
 
     print("Waiting for server to start...", flush=True)
-    wait_for_server_health(client, SANDBOX_NAME)
+    if not wait_for_server_health():
+        raise RuntimeError(
+            "Cognee API server did not become healthy; see the server log printed above"
+        )
 
-    # Step 3: Create a temporary public share for the API port
-    share = client.shares.create_share(SANDBOX_NAME, port=API_PORT, ttl_seconds=86400)
+    share_result = run_islo(
+        ["share", SANDBOX_NAME, str(API_PORT), "--ttl", "24h", "--output", "json"],
+        echo=False,
+    )
+    share = _parse_json(share_result, "share URL")
+    share_url = share.get("url")
+    if not isinstance(share_url, str) or not share_url:
+        raise RuntimeError("Islo did not return a share URL")
+
+    sandbox_result = run_islo(
+        ["status", SANDBOX_NAME, "--output", "json"],
+        echo=False,
+    )
+    sandbox = _parse_json(sandbox_result, "sandbox status")
 
     print("\nCognee is running!")
-    print(f"  Sandbox: {SANDBOX_NAME} ({sandbox.id})")
-    print(f"\n  API URL: {share.url}")
-    print(f"  Health:  {share.url}/health")
-    print(f"  Docs:    {share.url}/docs")
-    if share.expires_at:
-        print(f"  (share URL expires at {share.expires_at})")
+    print(f"  Sandbox: {SANDBOX_NAME}")
+    print(f"\n  API URL: {share_url}")
+    print(f"  Health:  {share_url}/health")
+    print(f"  Docs:    {share_url}/docs")
+    if share.get("expires_at"):
+        print(f"  (share URL expires at {share['expires_at']})")
     else:
         print("  (share URL expires in 24 hours)")
     print("\nTo stop the sandbox:")
-    print(f"  python -c \"from islo import Islo; Islo().sandboxes.stop_sandbox('{SANDBOX_NAME}')\"")
+    print(f"  islo stop {SANDBOX_NAME}")
     print("To delete it:")
-    print(
-        f"  python -c \"from islo import Islo; Islo().sandboxes.delete_sandbox('{SANDBOX_NAME}')\""
-    )
+    print(f"  islo rm {SANDBOX_NAME} --force")
 
     return sandbox
 

--- a/distributed/deploy/islo_sandbox.py
+++ b/distributed/deploy/islo_sandbox.py
@@ -36,6 +36,21 @@ SANDBOX_NAME = "cognee-api"
 API_PORT = 8000
 TERMINAL_EXEC_STATUSES = {"completed", "failed", "timeout"}
 
+# The islo-runner image ships Python without pip/ensurepip and marks the system
+# environment as PEP 668 "externally managed", so Cognee is installed into a
+# dedicated virtualenv (bootstrapped via apt) rather than the system interpreter.
+VENV_PATH = "/opt/cognee-venv"
+VENV_PYTHON = f"{VENV_PATH}/bin/python"
+_INSTALL_SCRIPT = (
+    "set -e\n"
+    "export DEBIAN_FRONTEND=noninteractive\n"
+    "apt-get update -qq\n"
+    "apt-get install -y -qq python3-venv\n"
+    f"python3 -m venv {VENV_PATH}\n"
+    f"{VENV_PATH}/bin/pip install --upgrade pip\n"
+    f"{VENV_PATH}/bin/pip install 'cognee[api]'\n"
+)
+
 _HEALTHCHECK_SNIPPET = (
     "import urllib.request\n"
     "try:\n"
@@ -203,7 +218,7 @@ def deploy_cognee():
     install = run_command(
         client,
         SANDBOX_NAME,
-        ["bash", "-lc", "pip install 'cognee[api]'"],
+        ["bash", "-lc", _INSTALL_SCRIPT],
         timeout_secs=1800,
         label="install",
     )
@@ -222,7 +237,7 @@ def deploy_cognee():
         [
             "bash",
             "-lc",
-            f"nohup python3 -m uvicorn cognee.api.client:app --host 0.0.0.0 --port {API_PORT} "
+            f"nohup {VENV_PYTHON} -m uvicorn cognee.api.client:app --host 0.0.0.0 --port {API_PORT} "
             "> /tmp/cognee-server.log 2>&1 & echo started",
         ],
         timeout_secs=30,

--- a/distributed/deploy/islo_sandbox.py
+++ b/distributed/deploy/islo_sandbox.py
@@ -66,8 +66,6 @@ def run_command(
     sandbox_name: str,
     command: list,
     *,
-    env: dict = None,
-    workdir: str = None,
     timeout_secs: int = None,
     poll_interval: float = 2.0,
     max_wait: float = None,
@@ -87,8 +85,6 @@ def run_command(
     started = client.sandboxes.exec_in_sandbox(
         sandbox_name,
         command=command,
-        env=env,
-        workdir=workdir,
         timeout_secs=timeout_secs,
     )
 


### PR DESCRIPTION
## Description

This PR adds an Islo deployment script for [Cognee](https://github.com/topoteretes/cognee). [Islo](https://islo.dev) ([docs](https://docs.islo.dev)) provides isolated cloud sandbox VMs for coding agents and is built by the Incredibuild team.

**Disclosure:** I work on the Islo team. The initial contribution was prepared with assistance from Claude Code and finalized with Codex; flagging that context up front for review.

## What changed

- `distributed/deploy/islo_sandbox.py` uses the official Islo Python SDK to create a 2 vCPU / 4 GB RAM / 10 GB sandbox with idle pause and auto-resume lifecycle settings.
- The script bootstraps a virtual environment, installs `cognee[api]`, starts uvicorn on port 8000, polls the internal `/health` endpoint, and creates a 24-hour public share only after the server is healthy.
- SDK executions are polled to a terminal state with client-side deadlines. Sandbox startup, package installation, server startup, and health failures stop with actionable errors before sharing.
- The Islo CLI is used only to log in and mint the API key: `islo api-key create cognee-deploy --expires 90 --show`. Sandbox lifecycle and command execution stay SDK-native.
- `README.md` and `distributed/deploy/README.md` document setup, deployment, and SDK cleanup.
- Offline unit tests inject a fake `islo` package, so they require no account, credential, or network access.

The SDK remains a documented deployment-script prerequisite (`pip install islo`), not a Cognee runtime dependency.

## Acceptance criteria

- With `ISLO_API_KEY` and `LLM_API_KEY` set, `python distributed/deploy/islo_sandbox.py` deploys the Cognee API and prints a public share URL.
- Missing prerequisites and deployment failures stop with actionable errors.
- A share is created only after the internal health check passes.
- Offline tests cover command polling, sandbox state transitions, successful deployment, and installation/server/health failure gates.

## Validation

### Live SDK E2E

- Minted a temporary access key with the Islo CLI, then used that key exclusively through the Python SDK.
- In Islo's France region, the script created a fresh sandbox, installed `cognee[api]`, started uvicorn, and passed the internal health gate.
- The issued public share returned HTTP 200 from `/health`.
- The share and sandbox were removed; both France and Canada regions were checked for leftover test sandboxes.
- The temporary API key was revoked and verified absent.

### Local verification at current HEAD

- `uv run pytest cognee/tests/unit/distributed/test_islo_sandbox.py -q` → **15 passed**
- `uv run pytest cognee/tests/unit/distributed/ -q` → **26 passed**
- `uv run ruff check .` → passed
- `uv run ruff format --check .` → **1826 files already formatted**
- `uv run ty check .` → passed
- `uv lock --check` → passed
- `uv run pre-commit run --files README.md distributed/deploy/README.md distributed/deploy/islo_sandbox.py cognee/tests/unit/distributed/test_islo_sandbox.py` → passed
- `git diff --check` → passed

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code refactoring
- [ ] Other

## Pre-submission checklist

- [x] Live SDK deployment and cleanup verified
- [x] Minimal integration-specific changes
- [x] Project lint, formatting, typing, lock, and pre-commit checks pass
- [x] Offline success and failure tests included
- [x] Documentation included
- [x] Commits include DCO sign-off

## DCO affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
