### PR TITLE
[SDK-177] feat: add deterministic adaptive path search core

### DIFF
--- a/cognee/modules/graph/cognee_graph/CogneeGraphElements.py
+++ b/cognee/modules/graph/cognee_graph/CogneeGraphElements.py
@@ -214,6 +214,17 @@ class Edge(BaseModel):
     def get_attribute(self, key: str) -> Optional[Union[str, int, float]]:
         return self.attributes.get(key)
 
+    def stable_id(self) -> str:
+        """Stable identifier for this edge, usable as a deterministic sort/dedup key.
+
+        Prefers the stored ``edge_object_id`` attribute when present; otherwise falls
+        back to a value derived from the endpoint IDs and relationship type.
+        """
+        stored = self.attributes.get("edge_object_id")
+        if stored is not None:
+            return str(stored)
+        return f"{self.node1.id}:{self.attributes.get('relationship_type')}:{self.node2.id}"
+
     def get_source_node(self):
         return self.node1
 

--- a/cognee/modules/retrieval/path_search/__init__.py
+++ b/cognee/modules/retrieval/path_search/__init__.py
@@ -1,0 +1,4 @@
+from .path import Path
+from .adaptive_path_search import AdaptivePathSearch
+
+__all__ = ["AdaptivePathSearch", "Path"]

--- a/cognee/modules/retrieval/path_search/adaptive_path_search.py
+++ b/cognee/modules/retrieval/path_search/adaptive_path_search.py
@@ -1,0 +1,191 @@
+import random
+from typing import Any, List, Optional, Tuple
+
+from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+from cognee.modules.retrieval.utils.brute_force_triplet_search import get_memory_fragment
+from cognee.modules.retrieval.utils.node_edge_vector_search import NodeEdgeVectorSearch
+from cognee.shared.logging_utils import get_logger
+
+from .path import Path
+
+logger = get_logger("AdaptivePathSearch")
+
+DEFAULT_COLLECTIONS = [
+    "Entity_name",
+    "TextSummary_text",
+    "EntityType_name",
+    "DocumentChunk_text",
+    "EdgeType_relationship_name",
+]
+
+
+class AdaptivePathSearch:
+    """
+    Standalone path-search core: samples reproducible walks over the in-memory graph,
+    scores them against the query, and returns the best connected paths.
+
+    Seeds are the vector-closest nodes, selected deterministically. From each seed,
+    ``walks_per_seed`` random walks are sampled with a seeded RNG (uniform choice among
+    unvisited neighbors, sorted by ``Edge.stable_id()`` before sampling), so a fixed
+    ``random_seed`` reproduces the same paths. All scored, deduplicated candidates are
+    retained in ``scored_candidates``; ``run()`` returns the ``top_k`` best.
+    """
+
+    def __init__(
+        self,
+        num_seeds: int = 5,
+        walks_per_seed: int = 10,
+        max_depth: int = 4,
+        top_k: int = 5,
+        random_seed: int = 0,
+        memory_fragment: Optional[CogneeGraph] = None,
+        vector_search: Optional[NodeEdgeVectorSearch] = None,
+        collections: Optional[List[str]] = None,
+        wide_search_top_k: int = 100,
+    ):
+        for name, value in (
+            ("num_seeds", num_seeds),
+            ("walks_per_seed", walks_per_seed),
+            ("max_depth", max_depth),
+            ("top_k", top_k),
+            ("wide_search_top_k", wide_search_top_k),
+        ):
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer, got {value!r}")
+
+        self.num_seeds = num_seeds
+        self.walks_per_seed = walks_per_seed
+        self.max_depth = max_depth
+        self.top_k = top_k
+        self.random_seed = random_seed
+        self.memory_fragment = memory_fragment
+        self.vector_search = vector_search
+        self.collections = list(collections) if collections else list(DEFAULT_COLLECTIONS)
+        self.wide_search_top_k = wide_search_top_k
+        self.scored_candidates: List[Path] = []
+
+    async def run(self, query: str) -> List[Path]:
+        """Sample, score, and return the best paths for the query, ordered best to worst."""
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("query must be a non-empty string")
+
+        self.scored_candidates = []
+
+        vector_search = self.vector_search or NodeEdgeVectorSearch()
+        await vector_search.embed_and_retrieve_distances(
+            query=query,
+            collections=self.collections,
+            wide_search_limit=self.wide_search_top_k,
+        )
+        if not vector_search.has_results():
+            return []
+
+        memory_fragment = self.memory_fragment
+        if memory_fragment is None:
+            memory_fragment = await get_memory_fragment(
+                relevant_ids_to_filter=vector_search.extract_relevant_node_ids(),
+            )
+        if not memory_fragment.nodes or not memory_fragment.edges:
+            return []
+
+        await memory_fragment.map_vector_distances_to_graph_nodes(
+            node_distances=vector_search.node_distances
+        )
+        await memory_fragment.map_vector_distances_to_graph_edges(
+            edge_distances=vector_search.edge_distances
+        )
+
+        penalty = memory_fragment.triplet_distance_penalty
+        seeds = self._select_seeds(memory_fragment, penalty)
+        if not seeds:
+            return []
+
+        # Fresh RNG per run so repeated run() calls with the same seed reproduce paths.
+        rng = random.Random(self.random_seed)
+        sampled_paths: List[Path] = []
+        for seed in seeds:
+            for _ in range(self.walks_per_seed):
+                path = self._sample_walk(seed, rng)
+                if path is not None:
+                    sampled_paths.append(path)
+
+        unique_paths = self._deduplicate(sampled_paths)
+        for path in unique_paths:
+            path.score = self._score_path(path, penalty)
+        unique_paths.sort(key=lambda path: (path.score, path.dedup_key))
+
+        self.scored_candidates = unique_paths
+        return unique_paths[: self.top_k]
+
+    def _select_seeds(self, memory_fragment: CogneeGraph, penalty: float) -> List[Node]:
+        """Deterministically pick the vector-closest nodes as walk starting points."""
+        candidates: List[Tuple[float, str, Node]] = []
+        for node in memory_fragment.nodes.values():
+            distance = self._element_distance(node)
+            if distance is None or distance >= penalty:
+                continue
+            candidates.append((distance, node.id, node))
+        candidates.sort(key=lambda candidate: (candidate[0], candidate[1]))
+        return [node for _, _, node in candidates[: self.num_seeds]]
+
+    def _sample_walk(self, seed: Node, rng: random.Random) -> Optional[Path]:
+        """Sample one walk from the seed, up to max_depth steps, never revisiting nodes."""
+        nodes = [seed]
+        edges: List[Edge] = []
+        visited = {seed.id}
+        current = seed
+        for _ in range(self.max_depth):
+            step = self._step(current, visited, rng)
+            if step is None:
+                break
+            edge, neighbor = step
+            edges.append(edge)
+            nodes.append(neighbor)
+            visited.add(neighbor.id)
+            current = neighbor
+        if not edges:
+            return None
+        return Path(nodes=nodes, edges=edges)
+
+    def _step(self, current: Node, visited: set, rng: random.Random) -> Optional[Tuple[Edge, Node]]:
+        """Pick the next edge uniformly among unvisited neighbors, in stable order."""
+        candidates: List[Tuple[Edge, Node]] = []
+        for edge in current.skeleton_edges:
+            neighbor = edge.node2 if edge.node1 == current else edge.node1
+            if neighbor.id in visited:
+                continue
+            candidates.append((edge, neighbor))
+        if not candidates:
+            return None
+        # Sorting before sampling makes the seeded RNG's picks independent of the
+        # (projection-order-dependent) skeleton_edges order.
+        candidates.sort(key=lambda candidate: candidate[0].stable_id())
+        return rng.choice(candidates)
+
+    @staticmethod
+    def _deduplicate(paths: List[Path]) -> List[Path]:
+        unique: dict = {}
+        for path in paths:
+            unique.setdefault(path.dedup_key, path)
+        return list(unique.values())
+
+    def _score_path(self, path: Path, penalty: float) -> float:
+        """First score: mean vector distance over the path's nodes and edges (lower is better)."""
+        elements: List[Any] = [*path.nodes, *path.edges]
+        total = 0.0
+        for element in elements:
+            distance = self._element_distance(element)
+            total += penalty if distance is None else distance
+        return total / len(elements)
+
+    @staticmethod
+    def _element_distance(element: Any) -> Optional[float]:
+        """Read an element's mapped vector distance; supports list (per-query) or scalar."""
+        distance = element.attributes.get("vector_distance")
+        if isinstance(distance, list):
+            distance = distance[0] if distance else None
+        try:
+            return float(distance)
+        except (TypeError, ValueError):
+            return None

--- a/cognee/modules/retrieval/path_search/path.py
+++ b/cognee/modules/retrieval/path_search/path.py
@@ -1,0 +1,34 @@
+from typing import List, Tuple
+
+from pydantic import BaseModel, ConfigDict
+
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+
+
+class Path(BaseModel):
+    """
+    A connected walk through the graph.
+
+    Attributes:
+        nodes (List[Node]): Ordered nodes visited by the walk (len(edges) + 1 entries).
+        edges (List[Edge]): Ordered edges traversed by the walk; edge i connects
+            nodes[i] and nodes[i + 1].
+        score (float): Query-relevance score for the whole path (lower is better).
+    """
+
+    nodes: List[Node]
+    edges: List[Edge]
+    score: float = 0.0
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @property
+    def dedup_key(self) -> Tuple[str, ...]:
+        """Deterministic identity of the path: the sequence of traversed edge IDs."""
+        return tuple(edge.stable_id() for edge in self.edges)
+
+    def __len__(self) -> int:
+        return len(self.edges)
+
+    def __repr__(self) -> str:
+        node_ids = " -> ".join(node.id for node in self.nodes)
+        return f"Path({node_ids}, score={self.score})"

--- a/cognee/tests/unit/modules/graph/cognee_graph_test.py
+++ b/cognee/tests/unit/modules/graph/cognee_graph_test.py
@@ -70,6 +70,25 @@ def test_add_edge_success(setup_graph):
     assert edge in node2.skeleton_edges
 
 
+def test_edge_stable_id_prefers_stored_edge_object_id():
+    """stable_id returns the stored edge_object_id when present."""
+    node1 = Node("node1")
+    node2 = Node("node2")
+    edge = Edge(node1, node2, attributes={"edge_object_id": "stored-edge-id"})
+    assert edge.stable_id() == "stored-edge-id"
+    # Repeated calls resolve to the same value.
+    assert edge.stable_id() == edge.stable_id()
+
+
+def test_edge_stable_id_falls_back_to_derived_id():
+    """stable_id derives a deterministic value when edge_object_id is missing."""
+    node1 = Node("node1")
+    node2 = Node("node2")
+    edge = Edge(node1, node2, attributes={"relationship_type": "related_to"})
+    assert edge.stable_id() == "node1:related_to:node2"
+    assert edge.stable_id() == edge.stable_id()
+
+
 def test_get_node_success(setup_graph):
     """Test retrieving an existing node."""
     graph = setup_graph

--- a/cognee/tests/unit/modules/retrieval/adaptive_path_search_test.py
+++ b/cognee/tests/unit/modules/retrieval/adaptive_path_search_test.py
@@ -1,0 +1,226 @@
+import pytest
+
+from cognee.modules.graph.cognee_graph.CogneeGraph import CogneeGraph
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+from cognee.modules.retrieval.path_search import AdaptivePathSearch, Path
+from cognee.modules.retrieval.path_search import adaptive_path_search as aps_module
+
+
+class MockScoredResult:
+    """Mock class for vector search results."""
+
+    def __init__(self, id, score, payload=None):
+        self.id = id
+        self.score = score
+        self.payload = payload or {}
+
+
+class StubVectorSearch:
+    """Duck-typed stand-in for NodeEdgeVectorSearch with pre-baked results."""
+
+    def __init__(self, node_results=None, edge_results=None):
+        self.node_distances = {"Entity_name": node_results or []}
+        self.edge_distances = edge_results or []
+        self.query_list_length = None
+        self.calls = []
+
+    async def embed_and_retrieve_distances(self, **kwargs):
+        self.calls.append(kwargs)
+
+    def has_results(self):
+        return any(bool(results) for results in self.node_distances.values()) or bool(
+            self.edge_distances
+        )
+
+    def extract_relevant_node_ids(self):
+        return [str(result.id) for results in self.node_distances.values() for result in results]
+
+
+def make_graph(edge_specs):
+    """Build a CogneeGraph from (source_id, target_id, relationship_type) tuples."""
+    graph = CogneeGraph()
+    for source_id, target_id, relationship_type in edge_specs:
+        for node_id in (source_id, target_id):
+            if graph.get_node(node_id) is None:
+                graph.add_node(Node(node_id))
+        edge = Edge(
+            graph.get_node(source_id),
+            graph.get_node(target_id),
+            attributes={"relationship_type": relationship_type},
+        )
+        graph.add_edge(edge)
+    return graph
+
+
+def make_search(graph, node_scores, **overrides):
+    """AdaptivePathSearch wired to an injected graph and stubbed vector results."""
+    stub = StubVectorSearch(
+        node_results=[MockScoredResult(node_id, score) for node_id, score in node_scores]
+    )
+    config = dict(
+        num_seeds=3,
+        walks_per_seed=5,
+        max_depth=4,
+        top_k=5,
+        random_seed=42,
+        memory_fragment=graph,
+        vector_search=stub,
+    )
+    config.update(overrides)
+    return AdaptivePathSearch(**config)
+
+
+def path_keys(paths):
+    return [path.dedup_key for path in paths]
+
+
+@pytest.mark.parametrize(
+    "field", ["num_seeds", "walks_per_seed", "max_depth", "top_k", "wide_search_top_k"]
+)
+@pytest.mark.parametrize("value", [0, -1])
+def test_invalid_config_raises(field, value):
+    """Non-positive configuration values raise ValueError."""
+    with pytest.raises(ValueError, match=field):
+        AdaptivePathSearch(**{field: value})
+
+
+@pytest.mark.asyncio
+async def test_empty_query_raises():
+    search = make_search(make_graph([("a", "b", "rel")]), [("a", 0.1)])
+    with pytest.raises(ValueError, match="query"):
+        await search.run("   ")
+
+
+@pytest.mark.asyncio
+async def test_no_vector_hits_returns_empty():
+    """A vector search with no hits returns [] without touching the graph."""
+    search = make_search(make_graph([("a", "b", "rel")]), node_scores=[])
+    assert await search.run("anything") == []
+    assert search.scored_candidates == []
+
+
+@pytest.mark.asyncio
+async def test_empty_graph_returns_empty():
+    search = make_search(CogneeGraph(), [("a", 0.1)])
+    assert await search.run("anything") == []
+
+
+@pytest.mark.asyncio
+async def test_injected_graph_is_reused(monkeypatch):
+    """An injected memory fragment is used directly; no projection from the DB happens."""
+
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("get_memory_fragment must not be called with an injected graph")
+
+    monkeypatch.setattr(aps_module, "get_memory_fragment", fail_if_called)
+
+    graph = make_graph([("a", "b", "rel"), ("b", "c", "rel")])
+    search = make_search(graph, [("a", 0.1)])
+    results = await search.run("anything")
+
+    assert results
+    assert all(isinstance(path, Path) for path in results)
+
+
+@pytest.mark.asyncio
+async def test_fixed_seed_reproduces_paths():
+    """The same random_seed yields identical paths across instances and repeated runs."""
+    edge_specs = [
+        ("hub", "a", "rel"),
+        ("hub", "b", "rel"),
+        ("hub", "c", "rel"),
+        ("a", "d", "rel"),
+        ("b", "e", "rel"),
+        ("c", "f", "rel"),
+        ("d", "e", "rel"),
+    ]
+    node_scores = [("hub", 0.1), ("a", 0.3), ("b", 0.5)]
+
+    first_search = make_search(make_graph(edge_specs), node_scores)
+    first = await first_search.run("anything")
+    first_repeat = await first_search.run("anything")
+
+    second_search = make_search(make_graph(edge_specs), node_scores)
+    second = await second_search.run("anything")
+
+    assert path_keys(first) == path_keys(first_repeat) == path_keys(second)
+    assert [path.score for path in first] == [path.score for path in second]
+
+
+@pytest.mark.asyncio
+async def test_paths_never_revisit_nodes():
+    """Walks on a cyclic graph never visit the same node twice."""
+    graph = make_graph([("a", "b", "rel"), ("b", "c", "rel"), ("c", "a", "rel")])
+    search = make_search(graph, [("a", 0.1), ("b", 0.2), ("c", 0.3)], max_depth=10)
+    await search.run("anything")
+
+    assert search.scored_candidates
+    for path in search.scored_candidates:
+        node_ids = [node.id for node in path.nodes]
+        assert len(node_ids) == len(set(node_ids))
+
+
+@pytest.mark.asyncio
+async def test_dead_end_truncates_walk():
+    """Walks hitting a dead end terminate cleanly instead of crashing or looping."""
+    graph = make_graph([("a", "b", "rel")])
+    search = make_search(graph, [("a", 0.1)], num_seeds=1, max_depth=10)
+    results = await search.run("anything")
+
+    assert len(results) == 1
+    assert [node.id for node in results[0].nodes] == ["a", "b"]
+    assert len(results[0].edges) == 1
+
+
+@pytest.mark.asyncio
+async def test_results_ordered_best_to_worst():
+    """Returned paths are sorted by ascending score (lower distance = better)."""
+    graph = make_graph(
+        [
+            ("hub", "close", "rel"),
+            ("hub", "far", "rel"),
+            ("close", "leaf1", "rel"),
+            ("far", "leaf2", "rel"),
+        ]
+    )
+    search = make_search(graph, [("hub", 0.1), ("close", 0.2), ("far", 1.9)], walks_per_seed=10)
+    results = await search.run("anything")
+
+    assert len(results) > 1
+    scores = [path.score for path in results]
+    assert scores == sorted(scores)
+    assert search.scored_candidates == sorted(
+        search.scored_candidates, key=lambda path: (path.score, path.dedup_key)
+    )
+
+
+@pytest.mark.asyncio
+async def test_scored_candidates_retained_separately_from_selection():
+    """All deduplicated scored paths are kept; run() returns only the top_k best."""
+    graph = make_graph(
+        [
+            ("hub", "a", "rel"),
+            ("hub", "b", "rel"),
+            ("hub", "c", "rel"),
+            ("a", "d", "rel"),
+            ("b", "d", "rel"),
+        ]
+    )
+    search = make_search(graph, [("hub", 0.1), ("a", 0.2), ("b", 0.3)], top_k=2, walks_per_seed=10)
+    results = await search.run("anything")
+
+    assert len(results) == 2
+    assert len(search.scored_candidates) > 2
+    assert results == search.scored_candidates[:2]
+    assert len(set(path_keys(search.scored_candidates))) == len(search.scored_candidates)
+
+
+@pytest.mark.asyncio
+async def test_seeds_require_real_vector_hits():
+    """Nodes without a vector hit (left at the penalty distance) are never seeds."""
+    graph = make_graph([("a", "b", "rel"), ("c", "d", "rel")])
+    search = make_search(graph, [("a", 0.1)], walks_per_seed=10)
+    await search.run("anything")
+
+    for path in search.scored_candidates:
+        assert path.nodes[0].id == "a"

--- a/examples/demos/adaptive_path_search_example.py
+++ b/examples/demos/adaptive_path_search_example.py
@@ -1,0 +1,87 @@
+import asyncio
+
+import cognee
+from cognee.modules.retrieval.path_search import AdaptivePathSearch, Path
+from cognee.shared.logging_utils import ERROR, setup_logging
+
+# Prerequisites:
+# 1. Copy `.env.template` and rename it to `.env`.
+# 2. Add your OpenAI API key to the `.env` file in the `LLM_API_KEY` field:
+#    LLM_API_KEY = "your_key_here"
+#
+# WARNING: this demo starts by wiping local cognee memory (cognee.forget).
+
+
+def node_label(node) -> str:
+    """Human-readable node label: name when available, else type (e.g. DocumentChunk), else ID."""
+    return node.attributes.get("name") or node.attributes.get("type") or node.id
+
+
+def format_path(path: Path) -> str:
+    """Render a path as: A -[rel]-> B <-[rel]- C (arrows follow edge direction)."""
+    parts = [node_label(path.nodes[0])]
+    current = path.nodes[0]
+    for edge, node in zip(path.edges, path.nodes[1:]):
+        relationship = edge.attributes.get("relationship_type") or "related_to"
+        if edge.node1.id == current.id:
+            parts.append(f"-[{relationship}]-> {node_label(node)}")
+        else:
+            parts.append(f"<-[{relationship}]- {node_label(node)}")
+        current = node
+    return " ".join(parts)
+
+
+async def main():
+    # Start clean, then remember several separate stories. Entities repeat across
+    # the texts (Alice, Acme Corp, Atlas, Nimbus, Berlin/Munich), so the knowledge
+    # graph connects facts from different documents — exactly the multi-hop
+    # structure that path search is built to surface.
+    await cognee.forget(everything=True)
+    texts = [
+        """
+        Alice is a senior engineer at Acme Corp, where she leads the Atlas project.
+        Bob collaborates with Alice on the Atlas project and reports to Carol.
+        Carol is the head of engineering at Acme Corp.
+        """,
+        """
+        Acme Corp is a logistics company headquartered in Berlin.
+        Acme Corp acquired Nimbus Analytics in 2023.
+        Nimbus Analytics keeps its main office in Munich.
+        """,
+        """
+        Berlin is the capital of Germany. Munich is a city in Germany.
+        Alice moved from Munich to Berlin when she joined Acme Corp.
+        """,
+        """
+        The Atlas project is a route optimization engine written in Rust.
+        Nimbus Analytics contributes demand forecasting models to the Atlas project.
+        Carol approved the Rust rewrite of the Atlas project.
+        """,
+    ]
+    for text in texts:
+        await cognee.remember(text, self_improvement=False)
+
+    query = "How is Alice connected to Munich?"
+    print(f"Searching for paths with query: '{query}'\n")
+
+    path_search = AdaptivePathSearch(
+        num_seeds=4,
+        walks_per_seed=10,
+        max_depth=5,
+        top_k=5,
+        random_seed=42,
+    )
+    paths = await path_search.run(query)
+
+    if not paths:
+        print("No paths found.")
+        return
+
+    print(f"Top {len(paths)} paths (of {len(path_search.scored_candidates)} scored candidates):\n")
+    for rank, path in enumerate(paths, start=1):
+        print(f"{rank}. score={path.score:.3f}  {format_path(path)}")
+
+
+if __name__ == "__main__":
+    logger = setup_logging(log_level=ERROR)
+    asyncio.run(main())


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Adds a standalone path-search core that samples and scores reproducible graph walks over the in-memory `CogneeGraph`. Today, retrieval ranks triplets independently (`brute_force_triplet_search`), so top-k results can be disconnected facts — nothing in the pipeline asks whether they connect. `AdaptivePathSearch` fills that gap: it returns *connected multi-hop paths* relevant to the query.

This is the engine only — public search APIs are deliberately untouched (no `SearchType`, no retriever wiring, no hybrid context). The future commits will build up on this to create a full working retriever.

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
