### PR TITLE
fix(estimator): account for reasoning-model output tokens in dry-run (SDK-185)

### DIFF
--- a/cognee/modules/cognify/estimator.py
+++ b/cognee/modules/cognify/estimator.py
@@ -13,6 +13,8 @@ Known approximations:
   transcription of audio/image items) and embedding costs are not included.
 - Input tokens use the real tokenizer, prompt templates, and response-model
   JSON schema; output tokens use fixed heuristics.
+- Reasoning models (gpt-5 / o-series) bill hidden reasoning tokens as output;
+  their output/cost is scaled by a rough allowance and flagged approximate.
 """
 
 import inspect
@@ -56,6 +58,22 @@ from cognee.tasks.ingestion.data_item import DataItem
 SUMMARY_OUTPUT_TOKENS_PER_CHUNK = 150
 GRAPH_OUTPUT_TOKEN_RATIO = 0.5
 MIN_GRAPH_OUTPUT_TOKENS_PER_CHUNK = 256
+
+# Reasoning models (gpt-5 / o-series and future reasoning families) emit hidden
+# reasoning tokens that are billed as output. On a real gpt-5-mini run the actual
+# completion tokens were ~20x the visible-output heuristics above (graph ~28x,
+# summary ~14x the base). Since the amount varies with reasoning effort and task,
+# we apply a single rough multiplier (calibrated to that run, biased slightly low
+# so it is a plausible central figure, not a hard bound) and flag the estimate as
+# approximate for these models rather than pretend to predict it precisely.
+REASONING_OUTPUT_MULTIPLIER = 20
+_REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def _is_reasoning_model(model: str) -> bool:
+    key = model.split("/")[-1].lower()
+    return any(key.startswith(prefix) for prefix in _REASONING_MODEL_PREFIXES)
+
 
 # Formats whose bytes are not directly tokenizable text: images and audio would
 # need LLM transcription, PDF/Office formats a loader pass over stored files.
@@ -230,13 +248,17 @@ def estimate_chunks(
         read_query_prompt("summarize_content.txt") or "", tokenizer
     ) + _schema_tokens(summarization_model, tokenizer)
 
+    # Reasoning models spend most output on hidden reasoning tokens; scale the
+    # visible-output heuristics by a rough allowance for them (see constant).
+    output_multiplier = REASONING_OUTPUT_MULTIPLIER if _is_reasoning_model(model) else 1
+
     graph_input = sum(tokens + graph_overhead for tokens in chunk_token_counts)
-    graph_output = sum(
+    graph_output = output_multiplier * sum(
         max(MIN_GRAPH_OUTPUT_TOKENS_PER_CHUNK, int(tokens * GRAPH_OUTPUT_TOKEN_RATIO))
         for tokens in chunk_token_counts
     )
     summary_input = sum(tokens + summary_overhead for tokens in chunk_token_counts)
-    summary_output = len(llm_chunks) * SUMMARY_OUTPUT_TOKENS_PER_CHUNK
+    summary_output = output_multiplier * len(llm_chunks) * SUMMARY_OUTPUT_TOKENS_PER_CHUNK
 
     stages = [
         DryRunStageEstimate(
@@ -265,6 +287,12 @@ def estimate_chunks(
         warnings.append(
             f"Skipped {skipped_dlt_chunks} DLT row chunk(s) because they do not use "
             "LLM extraction or summarization."
+        )
+    if output_multiplier != 1:
+        warnings.append(
+            f"{model} is a reasoning model: output tokens and cost include a rough "
+            "reasoning-token allowance and can vary several-fold with reasoning effort — "
+            "treat the output/cost figures as approximate."
         )
     total_tokens = sum(stage.total_tokens for stage in stages)
     if total_tokens and not sum(stage.cost_usd for stage in stages):

--- a/cognee/tests/unit/modules/cognify/test_estimator.py
+++ b/cognee/tests/unit/modules/cognify/test_estimator.py
@@ -105,6 +105,47 @@ def test_estimate_chunks_warns_when_model_has_no_pricing(offline_estimator, monk
     assert any("no pricing entry" in warning for warning in estimate.warnings)
 
 
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("openai/gpt-5-mini", True),
+        ("gpt-5", True),
+        ("gpt-5-nano", True),
+        ("gpt-5.4", True),
+        ("o1", True),
+        ("o3-mini", True),
+        ("openai/o4-mini", True),
+        ("gpt-4o", False),
+        ("gpt-4o-mini", False),
+        ("gpt-4.1", False),
+        ("anthropic/claude-opus-4-5", False),
+        ("gemini-2.5-pro", False),
+    ],
+)
+def test_is_reasoning_model(model, expected):
+    assert estimator._is_reasoning_model(model) is expected
+
+
+def test_reasoning_model_scales_output_and_warns(offline_estimator, monkeypatch):
+    # gpt-5/o-series bill hidden reasoning tokens as output; the estimator scales
+    # the visible-output heuristics by REASONING_OUTPUT_MULTIPLIER and warns.
+    chunks = [SimpleNamespace(text="alpha beta gamma delta")]
+
+    baseline = estimator.estimate_chunks(chunks, operation="cognify", graph_model=_TinyGraph)
+
+    monkeypatch.setattr(
+        estimator,
+        "get_llm_config",
+        lambda: SimpleNamespace(llm_model="openai/gpt-5-mini", graph_prompt_path="unused.txt"),
+    )
+    reasoning = estimator.estimate_chunks(chunks, operation="cognify", graph_model=_TinyGraph)
+
+    assert reasoning.input_tokens == baseline.input_tokens
+    assert reasoning.output_tokens == baseline.output_tokens * estimator.REASONING_OUTPUT_MULTIPLIER
+    assert any("reasoning model" in w for w in reasoning.warnings)
+    assert not any("reasoning model" in w for w in baseline.warnings)
+
+
 def test_estimate_chunks_skips_dlt_chunks(offline_estimator):
     dlt_document = estimator.DltRowDocument(
         name="table-row",


### PR DESCRIPTION
## Description

Closes SDK-185. Follow-up to **#3974** (SDK-136, dry-run estimator + quota guard).

> **Stacked PR:** the estimator (`cognee/modules/cognify/estimator.py`) exists only on #3974's branch, not on `dev` yet, so this PR is based on the #3974 branch and shows only the fix diff. Retarget to `dev` (or merge after) once #3974 lands.

## Problem — found on a real paid run

A **real** `cognify` run on the default model (`openai/gpt-5-mini`) showed the dry-run cost estimate was off by **~16×**. Reasoning models (gpt-5 / o-series) emit hidden reasoning tokens billed as `completion_tokens`, and output is priced ~8× input, so the fixed output heuristics (which predate reasoning models) badly under-predict cost.

Real-run evidence (1 chunk, 130-word corpus, `gpt-5-mini`; captured via a litellm usage callback):

| Metric | Estimate (before) | Actual | Error |
|---|---|---|---|
| LLM chat calls | 2 | 2 | 0% ✅ |
| input tokens | 1,538 | 1,445 | +6.4% ✅ |
| **output tokens** | **406** | **9,360** | **−95.7%** ❌ |
| **cost (USD)** | **$0.0012** | **$0.0191** | **−93.7%** ❌ |

Per call: graph extraction `completion=7233` (heuristic 256 → 28× under); summarization `completion=2127` (heuristic 150 → 14× under).

## Fix

- Detect reasoning models (`gpt-5*`, `o1/o3/o4*`, future reasoning families) and scale the per-call **output** estimate by `REASONING_OUTPUT_MULTIPLIER` (=20, calibrated to the observed run — blended ~23×, biased slightly low as a plausible central figure rather than a hard bound).
- Emit a **warning** on the estimate for reasoning models that output/cost is approximate and can vary several-fold with reasoning effort.
- **Non-reasoning models unchanged** (gpt-4o, claude, gemini keep the existing accurate heuristics).
- Only the output estimate changes — input-token and call-count models were already accurate on the real run and are untouched.

Effect on the run above: estimated output `406 → 8,120` (from ~23× under to ~1.15× under); cost tracks proportionally. Input/call-count unchanged.

## Scope
This targets the MAJOR inconsistency (reasoning output/cost). Not modeling embedding calls remains a documented known approximation (note-level), tracked separately if desired.

## Testing
- New unit tests: `test_is_reasoning_model` (12 cases) and `test_reasoning_model_scales_output_and_warns` (output ×multiplier, input unchanged, warning present). Full `test_estimator.py`: 32 passed.
- ruff check + format clean.
- Offline sanity: `cognify(dry_run=True)` on `gpt-5-mini` now scales output and shows the reasoning warning; makes zero LLM calls.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)