### PR TITLE
fix(mcp): first session remember creates its dataset; keep startup migrations off stdio (SDK-192)

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1967,10 +1967,15 @@ async def main():
 
         logger.info("Running database migrations...")
 
-        await setup()
-        # Full startup migrations (relational schema + graph/vector revision
-        # chains) — MCP writes new-scheme data, so it must migrate like the API.
-        await run_migrations()
+        # Database setup and migrations print progress and "table already
+        # exists" notices to stdout. In stdio transport stdout is the JSON-RPC
+        # channel, so route that output to stderr — the same guard every tool
+        # applies around its cognee calls.
+        with redirect_stdout(sys.stderr):
+            await setup()
+            # Full startup migrations (relational schema + graph/vector revision
+            # chains) — MCP writes new-scheme data, so it must migrate like the API.
+            await run_migrations()
 
         logger.info("Database migrations done.")
     elif not is_remote:

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -1059,6 +1059,12 @@ async def _remember_inner(
         if self_improvement:
             from cognee.api.v1.improve import improve
 
+            # Create/authorize the target dataset before launching the
+            # background improve. Otherwise it bridges into a dataset that was
+            # never created, and every bridge stage fails on write/read
+            # authorization. Mirrors the permanent path below.
+            user, _ = await resolve_authorized_user_datasets(dataset_name, user)
+
             async def _session_improve():
                 try:
                     await improve(

--- a/cognee/tests/test_remember_session_dataset_creation.py
+++ b/cognee/tests/test_remember_session_dataset_creation.py
@@ -1,0 +1,88 @@
+"""Regression test for issue #4089.
+
+A session-mode ``remember()`` (``session_id`` set, ``self_improvement=True``)
+launches a background ``improve()`` that bridges the session into the target
+dataset. Before the fix the dataset was never created, so every background
+bridge stage failed on write/read authorization. This test asserts the
+dataset is created/authorized *before* the background improve runs — no LLM
+required (``improve`` is stubbed).
+"""
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.modules.data.methods import get_datasets_by_name
+from cognee.modules.engine.operations.setup import setup as engine_setup
+from cognee.modules.users.methods import get_default_user
+
+
+async def _reset_and_prune() -> None:
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+
+
+@pytest_asyncio.fixture
+async def clean_env(tmp_path):
+    root = Path(tmp_path)
+    cognee.config.data_root_directory(str(root / "data"))
+    cognee.config.system_root_directory(str(root / "system"))
+    await _reset_and_prune()
+    await engine_setup()
+    try:
+        yield
+    finally:
+        await _reset_and_prune()
+
+
+@pytest.mark.asyncio
+async def test_session_remember_creates_dataset_before_background_improve(clean_env, monkeypatch):
+    dataset_name = "agent_scoped_memory"
+
+    # Stub improve so the test needs no LLM, and record whether the target
+    # dataset already exists (is authorized) at the moment improve is invoked.
+    # remember() does `from cognee.api.v1.improve import improve`, so patch the
+    # name on that package module (the dotted path resolves to the re-exported
+    # function, so fetch the package object explicitly).
+    import importlib
+
+    seen = {}
+
+    async def fake_improve(dataset, *, session_ids=None, user=None, **kwargs):
+        resolver = user or await get_default_user()
+        existing = await get_datasets_by_name([str(dataset)], resolver.id)
+        seen["dataset_present_at_improve"] = bool(existing)
+        return {}
+
+    improve_pkg = importlib.import_module("cognee.api.v1.improve")
+    monkeypatch.setattr(improve_pkg, "improve", fake_improve)
+
+    result = await cognee.remember(
+        "The launch codename is Saffron.",
+        dataset_name=dataset_name,
+        session_id="clean-first-session",
+        self_improvement=True,
+    )
+
+    # remember() creates/authorizes the dataset synchronously, before it
+    # returns and before the background improve runs.
+    user = await get_default_user()
+    assert await get_datasets_by_name([dataset_name], user.id), (
+        "session remember must create the target dataset up front"
+    )
+
+    # Drain the background improve and confirm it saw an existing dataset.
+    await result
+    assert seen.get("dataset_present_at_improve") is True


### PR DESCRIPTION
## Summary

Fixes GitHub issue #4089. On a clean direct-mode cognee-mcp session, the first
agent-scoped `remember` (with a `session_id`, no preceding `get_client_info_json`)
produced hidden background write/read authorization failures and contaminated the
stdio JSON-RPC channel. Two independent root causes, both reproduced against the
real MCP server:

### Bug A — first session `remember` never creates its target dataset
`cognee.remember(session_id=..., self_improvement=True)` (the default) stores the
session entry, then launches a **background** `improve(dataset=…, session_ids=[…])`
to bridge the session into the permanent graph — but never creates/authorizes that
dataset first. Every bridge stage then fails on authorization:
`CogneeValidationError: User … does not have write access to dataset: mcp_memory
(422)` on the 4 write stages, plus a `PermissionDeniedError … [read] for any
dataset (403)` on the memify enrichment read. The permanent path a few lines below
already resolves the dataset via `resolve_authorized_user_datasets(...)` (which
creates + authorizes it if missing); the session path did not.

**Fix** (`cognee/api/v1/remember/remember.py`): resolve/authorize the dataset in the
foreground, before launching the background improve — the same call the permanent
path uses.

### Bug B — startup migrations print to the stdio JSON-RPC channel
At MCP startup `main()` runs `await setup()` (create_all) then `await
run_migrations()`. On a fresh DB, create_all builds the schema, then the Alembic
migration replay detects the tables exist and emits three bare `print()` lines to
**stdout** (`principal_configuration/session_records/session_model_usage table
already exists, skipping creation`). In stdio transport stdout is the JSON-RPC
channel, so the official MCP client rejects those three lines as invalid JSON-RPC.

**Fix** (`cognee-mcp/src/server.py`): wrap the startup `setup()` + `run_migrations()`
in `redirect_stdout(sys.stderr)` — the identical guard every MCP tool already
applies around its cognee calls.

## Verification (real MCP server, real LLM)

| | contamination lines | improve write 422s | improve read 403 | recall works |
|---|---|---|---|---|
| before | 3 | ✗ (per write stage) | ✗ | ✓ |
| after | 0 | 0 | 0 | ✓ |

After the fix the bridge runs cleanly (`improve: feedback weights applied from 1
session(s)`) and the immediate session store + recall still succeed.

Added `cognee/tests/test_remember_session_dataset_creation.py`: asserts a session
`remember` creates/authorizes its dataset before the background improve runs
(passes with the fix, fails without). No LLM required (`improve` is stubbed).

`ruff format`/`ruff check` clean; `ty` diagnostics unchanged (42 → 42, all
pre-existing); existing `cognee-mcp` hardening suite (22 tests) green.

Closes SDK-192.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
