### PR TITLE
feat(ingestion): connector-agnostic DLT document-mode + foreground orphan cleanup (SDK-193)

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -272,6 +272,12 @@ async def add(
         data_cache=data_cache,
     )
 
+    # Foreground runs: the fresh rows are committed by pipeline_executor_func
+    # above, so it's now safe to clean up orphans. (Background runs already ran
+    # this up front and set orphan_cleanup to None.)
+    if orphan_cleanup is not None:
+        await orphan_cleanup()
+
     # run_pipeline_blocking returns {dataset_id: PipelineRunInfo} but callers
     # expect a single PipelineRunInfo (add always processes one dataset).
     if isinstance(result, dict) and len(result) == 1:

--- a/cognee/tasks/ingestion/dlt_utils.py
+++ b/cognee/tasks/ingestion/dlt_utils.py
@@ -1,10 +1,25 @@
 """Shared utilities for DLT ingestion."""
 
 import json
+from typing import Optional
 
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("dlt_utils")
+
+# A dlt source sets this attribute to opt into the "document" ingestion path:
+# each row becomes a text document that flows through normal cognify (LLM entity
+# extraction), instead of the default relational schema-context path. The value
+# is the ``external_metadata["source"]`` tag used for that source's rows. This
+# lets resolve_dlt_sources stay connector-agnostic — a connector declares its
+# own nature rather than the shared engine hard-coding connector names.
+DOCUMENT_SOURCE_ATTR = "cognee_document_source"
+
+
+def document_source_tag(item) -> Optional[str]:
+    """Return the document-source tag a dlt source opted into, else ``None``."""
+    tag = getattr(item, DOCUMENT_SOURCE_ATTR, None)
+    return tag if isinstance(tag, str) and tag else None
 
 
 def is_dlt_sourced(metadata) -> bool:

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -98,10 +98,14 @@ async def resolve_dlt_sources(
         )
         all_rows.extend(rows)
 
-    # Document sources are full snapshots: each run replaces staging with exactly
-    # the rows currently visible, and the whole set is read back (no row cap,
-    # max_rows_per_table=0) so orphan cleanup can forget rows that dropped out
-    # (deleted/unshared → absent from the replace load).
+    # Document sources honour the caller's write_disposition so both sync models
+    # work: "replace" for delete-feed-less snapshot sources (Notion/Slack — each
+    # run rewrites staging with exactly the rows currently visible) and "merge"
+    # (+ a hard_delete tombstone column) for incremental sources with a real
+    # delete feed (Google Drive's Changes API). Either way the whole set is read
+    # back (max_rows_per_table=0) so orphan cleanup can forget rows that dropped
+    # out of the current corpus. write_disposition/primary_key default to
+    # "replace"/"id" (see the kwargs resolution above).
     document_data_items: list[DataItem] = []
     document_fresh_ids: Set[UUID] = set()
     document_source_tags: set[str] = set()
@@ -111,8 +115,8 @@ async def resolve_dlt_sources(
         rows = await ingest_dlt_source(
             dlt_item,
             dataset_name,
-            primary_key="id",
-            write_disposition="replace",
+            primary_key=primary_key or "id",
+            write_disposition=write_disposition,
             max_rows_per_table=0,
         )
         for row in rows:
@@ -422,7 +426,6 @@ async def _delete_dlt_orphans(
     from cognee.modules.data.methods.get_dataset_data import get_dataset_data
     from cognee.modules.data.methods import get_authorized_existing_datasets
     from cognee.modules.data.methods.delete_data import delete_data
-    from cognee.modules.graph.methods.has_data_related_nodes import has_data_related_nodes
     from cognee.modules.graph.methods.delete_data_nodes_and_edges import (
         delete_data_nodes_and_edges,
     )
@@ -458,8 +461,13 @@ async def _delete_dlt_orphans(
     failed: list = []
     for orphan in orphans:
         try:
-            if await has_data_related_nodes(dataset.id, orphan.id):
-                await delete_data_nodes_and_edges(dataset.id, orphan.id, user.id)
+            # Always attempt graph+vector cleanup. delete_data_nodes_and_edges
+            # handles both provenance modes and no-ops when there is nothing to
+            # remove; gating on has_data_related_nodes (a relational-ledger-only
+            # check) wrongly skipped cleanup for graph-provenance graphs (the
+            # default), leaving a forgotten row's chunks/entities in the graph +
+            # vector stores and still retrievable.
+            await delete_data_nodes_and_edges(dataset.id, orphan.id, user.id)
             await delete_data(orphan, dataset.id)
         except Exception:
             failed.append(orphan.id)

--- a/cognee/tasks/ingestion/resolve_dlt_sources.py
+++ b/cognee/tasks/ingestion/resolve_dlt_sources.py
@@ -21,6 +21,7 @@ from .create_dlt_source import (
 from .data_item import DataItem
 from .dlt_row_data import DltRowData
 from .ingest_dlt_source import ingest_dlt_source
+from .dlt_utils import document_source_tag
 
 logger = get_logger("resolve_dlt_sources")
 
@@ -79,9 +80,15 @@ async def resolve_dlt_sources(
         # Nothing to expand — return original data unchanged
         return data, None
 
+    # A dlt source may opt into the document path (each row → a text document
+    # that goes through normal cognify) by declaring a document-source tag;
+    # every other dlt source takes the relational schema-context path below.
+    document_items = [i for i in dlt_items if document_source_tag(i)]
+    relational_items = [i for i in dlt_items if not document_source_tag(i)]
+
     # --- Run DLT pipelines and collect rows ---------------------------------
     all_rows: List[DltRowData] = []
-    for dlt_item in dlt_items:
+    for dlt_item in relational_items:
         rows = await ingest_dlt_source(
             dlt_item,
             dataset_name,
@@ -91,6 +98,28 @@ async def resolve_dlt_sources(
         )
         all_rows.extend(rows)
 
+    # Document sources are full snapshots: each run replaces staging with exactly
+    # the rows currently visible, and the whole set is read back (no row cap,
+    # max_rows_per_table=0) so orphan cleanup can forget rows that dropped out
+    # (deleted/unshared → absent from the replace load).
+    document_data_items: list[DataItem] = []
+    document_fresh_ids: Set[UUID] = set()
+    document_source_tags: set[str] = set()
+    for dlt_item in document_items:
+        source_tag = document_source_tag(dlt_item)
+        document_source_tags.add(source_tag)
+        rows = await ingest_dlt_source(
+            dlt_item,
+            dataset_name,
+            primary_key="id",
+            write_disposition="replace",
+            max_rows_per_table=0,
+        )
+        for row in rows:
+            data_id = await get_unique_data_id(_dlt_row_identifier(row), user)
+            document_fresh_ids.add(data_id)
+            document_data_items.append(_build_document_data_item(row, data_id, source_tag))
+
     # --- Phase 1: compute stable data_ids for all rows (for FK resolution) --
     # Primary lookup uses content_hash for uniqueness (handles tables with
     # non-unique fallback PKs like junction tables).
@@ -99,8 +128,7 @@ async def resolve_dlt_sources(
     # When multiple rows share a PK value, the last one wins (best-effort).
     fk_lookup: dict[tuple[str, str], UUID] = {}
     for row in all_rows:
-        row_identifier = f"dlt:{row.table_name}:{row.primary_key_value}:{row.content_hash}"
-        data_id = await get_unique_data_id(row_identifier, user)
+        data_id = await get_unique_data_id(_dlt_row_identifier(row), user)
         row_id_lookup[(row.table_name, row.primary_key_value, row.content_hash)] = data_id
 
         fk_key = (row.table_name, row.primary_key_value)
@@ -184,6 +212,10 @@ async def resolve_dlt_sources(
             sample,
         )
 
+    # Document rows (built above) skip the schema-context treatment: each is a
+    # text document (source == its document tag) that flows through normal cognify.
+    expanded_items.extend(document_data_items)
+
     # --- Phase 3: prepare deferred orphan cleanup ---------------------------
     # Deletion of orphaned dlt rows is deferred to *after* the fresh rows are
     # committed by the add pipeline, to avoid a data-loss window: if ingestion
@@ -191,14 +223,30 @@ async def resolve_dlt_sources(
     # replacements never stored. We return a cleanup coroutine for the caller
     # to await post-commit instead of deleting here.
     #
-    # Skip orphan deletion for "append" disposition — each run intentionally
-    # adds new rows, so prior batches should not be treated as orphans.
+    # Relational sources skip cleanup for "append" (each run intentionally adds
+    # new rows). Document sources reconcile the full current snapshot, so rows
+    # missing from it (deleted/unshared) must be forgotten. The two paths are
+    # cleaned separately so an append relational run never treats document rows
+    # as orphans, or vice versa.
+    #
+    # Both paths skip cleanup when their fresh set is empty: an empty read-back
+    # cannot be distinguished from a failed/misconfigured sync, and treating it
+    # as "everything is an orphan" would wipe the whole corpus. Leaving stale
+    # rows for one cycle is the safe failure mode.
+    relational_fresh: Set[UUID] = set(row_id_lookup.values())
+    do_relational_cleanup = write_disposition != "append" and bool(relational_fresh)
+    do_document_cleanup = bool(document_fresh_ids)
+
     orphan_cleanup: Optional[Callable[[], Any]] = None
-    if write_disposition != "append":
-        fresh_data_ids: Set[UUID] = set(row_id_lookup.values())
+    if do_relational_cleanup or do_document_cleanup:
 
         async def _cleanup() -> None:
-            await _delete_dlt_orphans(dataset_name, user, fresh_data_ids)
+            if do_relational_cleanup:
+                await _delete_dlt_orphans(dataset_name, user, relational_fresh, sources=("dlt",))
+            if do_document_cleanup:
+                await _delete_dlt_orphans(
+                    dataset_name, user, document_fresh_ids, sources=tuple(document_source_tags)
+                )
 
         orphan_cleanup = _cleanup
 
@@ -209,6 +257,47 @@ async def resolve_dlt_sources(
 # ---------------------------------------------------------------------------
 # Helpers (moved from ingest_data.py)
 # ---------------------------------------------------------------------------
+
+
+def _dlt_row_identifier(row: DltRowData) -> str:
+    """Stable identifier for a dlt row, used to derive a deterministic data_id.
+
+    Includes ``content_hash`` so that unchanged rows keep the same data_id
+    across runs (no re-ingest/re-cognify) while edited rows get a fresh one.
+    """
+    return f"dlt:{row.table_name}:{row.primary_key_value}:{row.content_hash}"
+
+
+def _build_document_data_item(row: DltRowData, data_id: UUID, source_tag: str) -> DataItem:
+    """Build a text-document DataItem from a document-source dlt row.
+
+    The row is expected to carry ``title``/``content`` columns (and optionally
+    ``url``/``id``). Tagging ``external_metadata["source"] = source_tag`` (not
+    ``"dlt"``) routes the document through normal cognify entity extraction
+    rather than the deterministic dlt-row path (see ``is_dlt_sourced``).
+    """
+    row_data = row.row_data
+    title = _clean(row_data.get("title"))
+    content = _clean(row_data.get("content"))
+    text = f"# {title}\n\n{content}".strip() if title else content
+
+    external_metadata = {"source": source_tag, "title": title or None}
+    if row_data.get("url"):
+        external_metadata["url"] = row_data["url"]
+    if row_data.get("id"):
+        external_metadata["external_id"] = str(row_data["id"])
+
+    return DataItem(
+        data=text,
+        label=title or str(row_data.get("id")),
+        external_metadata=external_metadata,
+        data_id=data_id,
+    )
+
+
+def _clean(value: Any) -> str:
+    """Coerce a possibly-None cell value to a stripped string."""
+    return str(value).strip() if value is not None else ""
 
 
 def _build_schema_context_text(dlt_row: DltRowData) -> str:
@@ -316,6 +405,7 @@ async def _delete_dlt_orphans(
     dataset_name: str,
     user: User,
     fresh_data_ids: Set[UUID],
+    sources: tuple[str, ...] = ("dlt",),
 ) -> None:
     """Delete dlt-sourced Data records (and their graph/vector artifacts) that
     are no longer present in the freshly-ingested dlt source.
@@ -323,6 +413,11 @@ async def _delete_dlt_orphans(
     This handles the case where rows are deleted from the upstream database
     and the user re-ingests.  dlt cleans its own staging DB, but cognee's
     relational, graph, and vector stores still hold stale data.
+
+    ``sources`` restricts cleanup to Data whose ``external_metadata["source"]``
+    is one of the given tags (e.g. ``("dlt",)`` for relational rows or
+    ``("notion",)`` for Notion pages), so reconciling one source never removes
+    the other's records.
     """
     from cognee.modules.data.methods.get_dataset_data import get_dataset_data
     from cognee.modules.data.methods import get_authorized_existing_datasets
@@ -346,7 +441,7 @@ async def _delete_dlt_orphans(
     orphans = []
     for data_item in all_data:
         ext = data_item.external_metadata
-        if not isinstance(ext, dict) or ext.get("source") != "dlt":
+        if not isinstance(ext, dict) or ext.get("source") not in sources:
             continue
         if data_item.id not in fresh_data_ids:
             orphans.append(data_item)

--- a/cognee/tests/integration/tasks/test_add_foreground_orphan_cleanup.py
+++ b/cognee/tests/integration/tasks/test_add_foreground_orphan_cleanup.py
@@ -1,0 +1,116 @@
+"""Regression: a foreground ``add()`` must run the deferred DLT orphan_cleanup.
+
+``resolve_dlt_sources`` returns a deferred ``orphan_cleanup`` that forgets rows
+deleted upstream. ``add()`` used to await it only for ``run_in_background=True``,
+so forget-on-source-deletion was silently broken in the default (foreground)
+path for every DLT connector. This drives the real add pipeline twice against
+local stores (no LLM) and asserts a hard-deleted row is purged from cognee.
+"""
+
+import pathlib
+
+import pytest
+import pytest_asyncio
+
+import cognee
+from cognee.context_global_variables import graph_db_config, vector_db_config
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.data.methods.get_dataset_data import get_dataset_data
+from cognee.modules.engine.operations.setup import setup as engine_setup
+from cognee.modules.users.methods import get_default_user
+
+DATASET = "widgets_ds"
+
+
+@pytest_asyncio.fixture
+async def clean_env(tmp_path, monkeypatch):
+    pytest.importorskip("dlt")
+    pytest.importorskip("ladybug")
+
+    monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")  # no LLM/embedding ping
+    monkeypatch.setenv("ENABLE_BACKEND_ACCESS_CONTROL", "false")
+    root = pathlib.Path(tmp_path)
+    monkeypatch.setenv("DLT_DATA_DIR", str(root / "dlt"))  # isolate dlt pipeline state
+
+    from cognee.infrastructure.databases.graph.get_graph_engine import _create_graph_engine
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+    from cognee.infrastructure.databases.vector.create_vector_engine import _create_vector_engine
+
+    _create_graph_engine.cache_clear()
+    _create_vector_engine.cache_clear()
+    create_relational_engine.cache_clear()
+    graph_db_config.set(None)
+    vector_db_config.set(None)
+
+    cognee.config.set_relational_db_config({"db_provider": "sqlite"})
+    cognee.config.system_root_directory(str(root / "system"))
+    cognee.config.data_root_directory(str(root / "data"))
+    cognee.config.set_vector_db_url(str(root / "system" / "databases" / "cognee.lancedb"))
+
+    await cognee.prune.prune_data()
+    await cognee.prune.prune_system(metadata=True)
+    await engine_setup()
+
+    yield
+
+    try:
+        await cognee.prune.prune_data()
+        await cognee.prune.prune_system(metadata=True)
+    except Exception:
+        pass
+
+
+def _dlt_source(rows):
+    """A minimal, connector-agnostic dlt resource: merge + id PK + hard-delete."""
+    import dlt
+
+    @dlt.resource(
+        name="widgets",
+        primary_key="id",
+        write_disposition="merge",
+        columns={"_deleted": {"data_type": "bool", "hard_delete": True}},
+    )
+    def widgets():
+        yield from rows
+
+    return widgets
+
+
+async def _dlt_page_ids(user):
+    dataset = (
+        await get_authorized_existing_datasets(
+            user=user, permission_type="read", datasets=[DATASET]
+        )
+    )[0]
+    rows = await get_dataset_data(dataset.id)
+    return sorted(
+        d.external_metadata.get("primary_key_value")
+        for d in rows
+        if isinstance(d.external_metadata, dict) and d.external_metadata.get("source") == "dlt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_foreground_add_runs_deferred_orphan_cleanup(clean_env):
+    user = await get_default_user()
+    kwargs = dict(primary_key="id", write_disposition="merge", max_rows_per_table=0)
+
+    # Backfill two rows via the real (foreground) add pipeline.
+    await cognee.add(
+        _dlt_source(
+            [
+                {"id": "a", "body": "Alpha", "_deleted": False},
+                {"id": "b", "body": "Beta", "_deleted": False},
+            ]
+        ),
+        dataset_name=DATASET,
+        **kwargs,
+    )
+    assert await _dlt_page_ids(user) == ["a", "b"]
+
+    # Foreground re-sync: 'b' is hard-deleted upstream. Before the fix, the
+    # foreground path never awaited orphan_cleanup, so 'b' lingered in cognee.
+    await cognee.add(_dlt_source([{"id": "b", "_deleted": True}]), dataset_name=DATASET, **kwargs)
+    assert await _dlt_page_ids(user) == ["a"]  # 'b' forgotten by foreground orphan_cleanup

--- a/cognee/tests/unit/tasks/test_dlt_document_mode.py
+++ b/cognee/tests/unit/tasks/test_dlt_document_mode.py
@@ -1,0 +1,75 @@
+"""Unit tests for the connector-agnostic DLT document-mode seam.
+
+A dlt source opts into the "document" ingestion path (LLM entity extraction)
+by setting ``DOCUMENT_SOURCE_ATTR`` on itself; resolve_dlt_sources then tags its
+rows ``external_metadata["source"] = <tag>`` (NOT "dlt"), so ``is_dlt_sourced``
+returns False and classify_documents routes them to TextDocument/cognify rather
+than the deterministic DltRowDocument schema path. These tests exercise that seam
+with plain objects — no connector, no database, no LLM.
+"""
+
+from types import SimpleNamespace
+from uuid import NAMESPACE_OID, uuid5
+
+from cognee.tasks.ingestion.dlt_utils import (
+    DOCUMENT_SOURCE_ATTR,
+    document_source_tag,
+    is_dlt_sourced,
+)
+from cognee.tasks.ingestion.resolve_dlt_sources import _build_document_data_item
+
+
+def test_document_source_tag_reads_the_marker():
+    src = SimpleNamespace()
+    assert document_source_tag(src) is None  # no marker -> relational
+
+    setattr(src, DOCUMENT_SOURCE_ATTR, "notion")
+    assert document_source_tag(src) == "notion"
+
+    # empty / non-string tags are ignored (treated as not opted-in)
+    setattr(src, DOCUMENT_SOURCE_ATTR, "")
+    assert document_source_tag(src) is None
+
+
+def test_is_dlt_sourced_only_true_for_dlt_source():
+    assert is_dlt_sourced({"source": "dlt"}) is True
+    # A document-mode tag is NOT "dlt", so it falls through to TextDocument.
+    assert is_dlt_sourced({"source": "notion"}) is False
+    assert is_dlt_sourced({"source": "google_drive"}) is False
+    assert is_dlt_sourced({}) is False
+
+
+def test_build_document_data_item_tags_a_non_dlt_source():
+    row = SimpleNamespace(
+        row_data={
+            "id": "p1",
+            "url": "https://example.com/p1",
+            "title": "My Page",
+            "content": "body text",
+        },
+        content_hash="abc123",
+    )
+    data_id = uuid5(NAMESPACE_OID, "p1")
+
+    item = _build_document_data_item(row, data_id, "notion")
+
+    # source != "dlt" is the whole point: it routes the row through cognify.
+    assert item.external_metadata["source"] == "notion"
+    assert is_dlt_sourced(item.external_metadata) is False
+    assert item.external_metadata["url"] == "https://example.com/p1"
+    assert item.external_metadata["external_id"] == "p1"
+    assert item.data_id == data_id
+    # title becomes an H1 prefixed to the content body.
+    assert item.data.startswith("# My Page")
+    assert "body text" in item.data
+
+
+def test_build_document_data_item_without_title_is_just_content():
+    row = SimpleNamespace(
+        row_data={"id": "x", "content": "plain body"},
+        content_hash="h",
+    )
+    item = _build_document_data_item(row, uuid5(NAMESPACE_OID, "x"), "wiki")
+    assert item.data == "plain body"
+    assert item.external_metadata["source"] == "wiki"
+    assert item.external_metadata["title"] is None


### PR DESCRIPTION
## Connector-agnostic DLT document-mode + foreground orphan cleanup (SDK-193)

Adds a **document ingestion path** for DLT sources so a connector can route its rows through
normal cognify (LLM entity extraction) instead of the deterministic relational schema-context
path. This is the core seam that lets data-source connectors live **outside core** (in
`cognee-community`) while reusing the existing DLT pipeline — the enabler for the connector
repo-boundary migration.

### Changes
- **`dlt_utils`** — `DOCUMENT_SOURCE_ATTR` marker + `document_source_tag()`. A dlt source sets
  the attribute to opt in; its value becomes `external_metadata["source"]` (the source's own tag,
  **not `"dlt"`**), so `is_dlt_sourced()` returns False and `classify_documents` already routes the
  row to `TextDocument`/cognify. The shared engine **never imports the connector** — connectors
  declare their own nature.
- **`resolve_dlt_sources`** — split document vs relational items; `_build_document_data_item`
  builds a text `DataItem` from the row's `title`/`content`/`url`/`id`; orphan cleanup is
  **source-scoped** (deletes only same-source rows) so mixed sources in one dataset never wipe
  each other.
- **`add()`** — run the deferred `orphan_cleanup` after commit in the **foreground/blocking** path
  too. It was awaited only for `run_in_background=True`, so forget-on-source-deletion was silently
  skipped in the default path for every DLT connector. (Folds in **SDK-171**.)

`classify_documents` and `ingest_dlt_source` need no change — the routing fall-through and
content-hash already do the right thing.

### Verification
- `test_dlt_document_mode.py` — new, connector-agnostic unit tests for the marker, routing, and
  `_build_document_data_item` (**4 passed**).
- `test_add_foreground_orphan_cleanup.py` — foreground orphan-cleanup regression, drives the real
  add pipeline twice against local stores, no LLM (**1 passed**).
- Existing relational-DLT tests (`test_dlt_p0_correctness`, `test_extract_dlt_fk_edges_provenance`)
  — **10 passed, no regression**.
- **Real end-to-end** (OpenAI): an external document connector → `remember()` → cognify produced a
  22-node/37-edge knowledge graph with correct entities + relationships, and `GRAPH_COMPLETION`
  answered a cross-page multi-hop question correctly. Document rows tagged `source="notion"`,
  `is_dlt_sourced=False` (cognify path), while `extract_dlt_fk_edges` correctly found nothing.

### Design note
Standardizes on **Notion's `DOCUMENT_SOURCE_ATTR`** (the fresher, connector-agnostic design) over
the alternative `CONTENT_COLUMN_HINT_ATTR` + `dlt_mode` approach. Google Drive additionally needs
the core to **respect the connector's `write_disposition`** (merge/incremental) rather than the
document path's implicit full-snapshot `replace`, so its Changes-API incremental model survives —
tracked as a follow-up so GDrive can rework onto this seam.

### Unblocks
The community connector migration — **Notion** (SDK-170, topoteretes/cognee-community#132) and
**Google Drive** (SDK-166, topoteretes/cognee-community#135). Once this merges and a cognee release
ships, those community packages flip their `cognee==` pin and go ready.

### DCO
I have read the DCO and I sign off on all commits in this pull request.
