### PR TITLE
Add mem0 migration tutorial using Mem0Source

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ to verify behaviour across the SDK.
 | [`guides/`](guides/) | Short focused how-to guides | 13 |
 | [`integrations/`](integrations/) | Integrations Hub — first-class SaaS connectors (Gmail, …) | 1 |
 | [`pocs/`](pocs/) | Research-grade proofs of concept (entity disambiguation, canonicalization, prefetch) | 7 |
+| [`tutorials/`](tutorials/) | Step-by-step tutorials for common workflows (migration, ...) | 1 |
 
 Most runnable demos and backend examples use the v1.0 memory API (`remember`, `recall`, `forget`, `improve`). The lower-level `add`, `cognify`, `search`, and `prune` calls are intentionally kept in examples that demonstrate pipeline internals, permissions, relational migrations, or research POCs.
 

--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -1,0 +1,30 @@
+# Cognee Tutorials
+
+Step-by-step tutorials that walk through common workflows end-to-end.
+
+## Migration tutorials
+
+| Tutorial | Description |
+|---|---|
+| [`migrate_from_mem0_tutorial.py`](migrate_from_mem0_tutorial.py) | Import mem0 memories into Cognee using ``Mem0Source`` — covers preserve and re-derive modes, file-based and inline payloads, and recall verification |
+
+## Running a tutorial
+
+```bash
+# Install dev environment
+uv sync --dev --all-extras --reinstall
+
+# Configure LLM_API_KEY in .env (one-time)
+cp .env.template .env
+# edit .env: set LLM_API_KEY
+
+# Run the tutorial
+uv run python examples/tutorials/migrate_from_mem0_tutorial.py
+```
+
+## Contributing a new tutorial
+
+1. Place the tutorial script in this directory.
+2. If your tutorial needs sample data, place it in `data/`.
+3. Follow the style of existing tutorials: numbered steps, ``asyncio.run(main())``, ``forget(everything=True)`` for reproducibility.
+4. Add a row to the table above.

--- a/examples/tutorials/data/mem0_sample_export.json
+++ b/examples/tutorials/data/mem0_sample_export.json
@@ -1,0 +1,59 @@
+{
+  "results": [
+    {
+      "id": "mem-001",
+      "memory": "Albert Einstein developed the theory of general relativity in 1915, describing gravity as the curvature of spacetime.",
+      "user_id": "user-01",
+      "agent_id": "agent-science",
+      "run_id": "run-2024-03-15",
+      "categories": ["science", "physics"],
+      "metadata": {"confidence": 0.95, "source": "textbook"},
+      "created_at": "2024-03-15T10:30:00Z",
+      "updated_at": "2024-03-15T10:30:00Z"
+    },
+    {
+      "id": "mem-002",
+      "memory": "Marie Curie won Nobel Prizes in both Physics (1903) and Chemistry (1911) for her pioneering research on radioactivity.",
+      "user_id": "user-01",
+      "agent_id": "agent-science",
+      "run_id": "run-2024-03-15",
+      "categories": ["science", "chemistry", "history"],
+      "metadata": {"confidence": 0.98, "source": "encyclopedia"},
+      "created_at": "2024-03-15T10:31:00Z",
+      "updated_at": "2024-03-15T10:31:00Z"
+    },
+    {
+      "id": "mem-003",
+      "memory": "Niels Bohr proposed the atomic model with quantized electron orbits in 1913, and his debates with Einstein shaped quantum mechanics.",
+      "user_id": "user-01",
+      "agent_id": "agent-science",
+      "run_id": "run-2024-03-15",
+      "categories": ["science", "physics"],
+      "metadata": {"confidence": 0.92, "source": "lecture_notes"},
+      "created_at": "2024-03-15T10:32:00Z",
+      "updated_at": "2024-03-15T10:32:00Z"
+    },
+    {
+      "id": "mem-004",
+      "memory": "The University of Paris (Sorbonne) has been a center of academic excellence since the 13th century.",
+      "user_id": "user-01",
+      "agent_id": null,
+      "run_id": "run-2024-03-16",
+      "categories": ["education", "history"],
+      "metadata": {"confidence": 0.88, "source": "tour_guide"},
+      "created_at": "2024-03-16T09:00:00Z",
+      "updated_at": "2024-03-16T09:00:00Z"
+    },
+    {
+      "id": "mem-005",
+      "memory": "Max Planck introduced the quantum of action (h) in 1900, founding quantum theory with his work on black-body radiation.",
+      "user_id": "user-01",
+      "agent_id": "agent-science",
+      "run_id": "run-2024-03-16",
+      "categories": ["science", "physics"],
+      "metadata": {"confidence": 0.97, "source": "research_paper"},
+      "created_at": "2024-03-16T09:15:00Z",
+      "updated_at": "2024-03-16T09:15:00Z"
+    }
+  ]
+}

--- a/examples/tutorials/migrate_from_mem0_tutorial.py
+++ b/examples/tutorials/migrate_from_mem0_tutorial.py
@@ -1,0 +1,197 @@
+# ruff: noqa: E402
+"""
+Tutorial: Migrate from mem0 to Cognee (using Mem0Source)
+
+This tutorial demonstrates how to bring **mem0** memories into Cognee using
+the built-in ``Mem0Source`` importer. The importer reads a mem0 export and
+translates each memory into a :class:`COGXMemory` record, which lands in the
+Cognee knowledge graph.
+
+What this tutorial covers
+-------------------------
+- Obtaining or preparing a mem0 dump (platform export / ``get_all()`` output).
+- Importing with **preserve** mode (memories map directly to graph nodes with
+  zero LLM calls — fast, no token cost).
+- Importing with **re-derive** mode (cognee re-runs its extraction pipeline on
+  the raw memory text — you get entity/relation extraction in addition to the
+  raw memories).
+- Querying the migrated memories with ``cognee.recall()`` to prove the data
+  landed correctly.
+
+Usage::
+
+    uv run python examples/tutorials/migrate_from_mem0_tutorial.py
+
+Requires:
+    ``LLM_API_KEY`` set in ``.env`` or environment (required for recall, and
+    for ``re-derive`` mode).
+
+Reference
+---------
+- ``cognee/modules/migration/sources/mem0.py`` — the Mem0Source adapter.
+- ``cognee/modules/migration/cogx.py`` — the COGXMemory record definition.
+- ``examples/demos/remember_recall_improve_example.py`` — the v1.0 memory API.
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+# Set up caching and environment BEFORE importing cognee.
+# Cognee reads env-backed settings at import time, so values assigned later
+# may not override defaults or ``.env``.
+os.environ["CACHING"] = "true"
+os.environ["CACHE_BACKEND"] = "fs"
+
+import cognee
+from cognee.modules.migration.cogx import COGXMemory
+from cognee.modules.migration.sources.mem0 import Mem0Source
+
+DATASET = "mem0_migration_tutorial"
+SAMPLE_EXPORT = Path(__file__).parent / "data" / "mem0_sample_export.json"
+
+
+async def main():
+    """Run the mem0 migration tutorial end-to-end."""
+
+    from cognee.infrastructure.databases.relational.create_db_and_tables import (
+        create_db_and_tables,
+    )
+
+    await create_db_and_tables()
+
+    # Clear cached config so the env vars above take effect.
+    from cognee.infrastructure.databases.cache.config import get_cache_config
+
+    get_cache_config.cache_clear()
+
+    # ------------------------------------------------------------------
+    # Step 1: Start clean
+    # ------------------------------------------------------------------
+    print("--- Step 1: forget(everything=True) ---")
+    await cognee.forget(everything=True)
+    print("  All existing data cleared.\n")
+
+    # ------------------------------------------------------------------
+    # Step 2: Import with preserve mode (zero LLM calls)
+    # ------------------------------------------------------------------
+    # preserve mode maps each memory straight into a graph node — no LLM
+    # extraction is run.  This is fast and cost-free; useful when you
+    # want to keep the external system's memories exactly as they are.
+    print("--- Step 2: remember(Mem0Source, mode='preserve') ---")
+    await cognee.remember(
+        Mem0Source(SAMPLE_EXPORT, mode="preserve"),
+        dataset_name=DATASET,
+    )
+    print("  Mem0 export ingested in preserve mode.\n")
+
+    # ------------------------------------------------------------------
+    # Step 3: Recall — prove the memories are queryable
+    # ------------------------------------------------------------------
+    print("--- Step 3: recall() — query migrated memories ---")
+    answer = await cognee.recall(
+        "Who developed the theory of general relativity and when?",
+        datasets=[DATASET],
+    )
+    print(f"  Answer: {answer}\n")
+
+    print("--- Step 4: recall() — query across multiple facts ---")
+    answer = await cognee.recall(
+        "Which scientists won Nobel Prizes?",
+        datasets=[DATASET],
+    )
+    print(f"  Answer: {answer}\n")
+
+    print("--- Step 5: recall() — query by category ---")
+    answer = await cognee.recall(
+        "What scientific discoveries were made in the early 20th century?",
+        datasets=[DATASET],
+    )
+    print(f"  Answer: {answer}\n")
+
+    # ------------------------------------------------------------------
+    # Step 6: Import the same data with re-derive mode
+    # ------------------------------------------------------------------
+    # re-derive mode makes cognee re-run its extraction pipeline (cognify)
+    # on the raw memory text.  This costs LLM tokens but produces richer
+    # entities, relationships, and facts on top of the source memories.
+    DATASET_REDERIVE = "mem0_migration_tutorial_rederive"
+
+    print("--- Step 6: remember(Mem0Source, mode='re-derive') ---")
+    await cognee.remember(
+        Mem0Source(SAMPLE_EXPORT, mode="re-derive"),
+        dataset_name=DATASET_REDERIVE,
+    )
+    print("  Mem0 export ingested in re-derive mode (cognify ran).\n")
+
+    print("--- Step 7: recall() — query re-derived dataset ---")
+    answer = await cognee.recall(
+        "Where did Marie Curie conduct her research?",
+        datasets=[DATASET_REDERIVE],
+    )
+    print(f"  Answer: {answer}\n")
+
+    # ------------------------------------------------------------------
+    # Step 8: Using an inline payload (no file needed)
+    # ------------------------------------------------------------------
+    # Mem0Source also accepts already-parsed Python lists/dicts — useful
+    # when you fetch memories from the mem0 live API and want to pipe them
+    # straight into Cognee without touching the filesystem.
+    print("--- Step 8: remember() with inline Python dict ---")
+    inline_data = {
+        "results": [
+            {
+                "id": "inline-001",
+                "memory": "Alan Turing proposed the Turing Test in 1950, laying the philosophical foundations of artificial intelligence.",
+                "user_id": "user-inline",
+                "categories": ["computer_science", "ai"],
+                "created_at": "2024-06-01T12:00:00Z",
+            }
+        ]
+    }
+    await cognee.remember(
+        Mem0Source(inline_data, mode="preserve"),
+        dataset_name=DATASET,
+    )
+    print("  Inline payload ingested.\n")
+
+    print("--- Step 9: recall() — query inline-imported memory ---")
+    answer = await cognee.recall(
+        "What did Alan Turing propose?",
+        datasets=[DATASET],
+    )
+    print(f"  Answer: {answer}\n")
+
+    # ------------------------------------------------------------------
+    # Step 10: Manual inspection — see the COGXMemory records
+    # ------------------------------------------------------------------
+    # The raw COGXMemory records are available when you iterate over the
+    # source's records() generator directly.  Each one represents a mem0
+    # memory mapped into the standard COGX exchange format.
+    print("--- Step 10: inspect Mem0Source.records() ---")
+    source = Mem0Source(SAMPLE_EXPORT, mode="preserve")
+    record_count = 0
+    async for record in source.records():
+        assert isinstance(record, COGXMemory), (
+            f"Expected COGXMemory, got {type(record).__name__}"
+        )
+        record_count += 1
+        print(
+            f"  [{record.external_id}] {record.content[:80]}..."
+            if len(record.content) > 80
+            else f"  [{record.external_id}] {record.content}"
+        )
+    print(f"  Total records yielded: {record_count}\n")
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+    print("--- Step 11: forget(everything=True) ---")
+    result = await cognee.forget(everything=True)
+    print(f"  {result}")
+
+    print("\nDone.  Mem0 memories have been migrated and are queryable via cognee.recall().")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds a runnable tutorial (`examples/tutorials/migrate_from_mem0_tutorial.py`) that demonstrates how to import **mem0** memories into Cognee using the built-in `Mem0Source` importer.

The `Mem0Source` adapter already exists in `cognee/modules/migration/sources/mem0.py` — this tutorial documents and demonstrates it, not build it.

## What the tutorial covers

- **Preserve mode**: Memories map directly to graph nodes with zero LLM calls (fast, no token cost)
- **Re-derive mode**: Cognee re-runs its extraction pipeline (cognify) on the raw memory text for richer entities/relations
- **Inline payloads**: Mem0Source accepts Python dicts directly — useful for live-API integration
- **Recall verification**: Multiple `cognee.recall()` queries prove the migrated data is queryable
- **Direct inspection**: Iterates over `Mem0Source.records()` to show COGXMemory records

## Files changed

| File | Description |
|---|---|
| `examples/tutorials/migrate_from_mem0_tutorial.py` | The runnable tutorial (11 numbered steps, asyncio, forget cleanup) |
| `examples/tutorials/data/mem0_sample_export.json` | Sample mem0 export with 5 scientist memories |
| `examples/tutorials/README.md` | Tutorials directory README with running instructions |
| `examples/README.md` | Added `tutorials/` row to the top-level layout table |

## Acceptance criteria (from #3397)

- `uv run python examples/tutorials/migrate_from_mem0_tutorial.py` ingests the mem0 sample and a follow-up `recall` returns the migrated content
- Sample mem0 dump included inline (`examples/tutorials/data/`)
- Row added to `examples/tutorials/README.md`

Closes #3397