### PR TITLE
fix: simplify AgentContextExtraction schema + strip unpaired UTF-16 surrogates

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/utils.py
+++ b/cognee/infrastructure/databases/vector/embeddings/utils.py
@@ -22,6 +22,21 @@ def is_embeddable(s: str) -> bool:
     return False
 
 
+def _strip_surrogates(s: str) -> str:
+    """
+    Replace unpaired UTF-16 surrogate code points that cannot be encoded to UTF-8.
+
+    A lone/unpaired surrogate (e.g. a mis-decoded character from a Windows console or
+    clipboard boundary) is a valid Python `str` but is not valid UTF-8. Left unstripped it
+    crashes the tokenizer's `encode_batch()` with `TypeError: TextEncodeInput must be
+    Union[...]` (and equivalent 422 errors in other embedding engines this function feeds),
+    since embedding text is eventually encoded to bytes. Round-tripping through UTF-8 with
+    `errors="replace"` removes/replaces surrogates while leaving normal text -- including
+    valid multi-byte characters and properly paired surrogate emoji -- unchanged.
+    """
+    return s.encode("utf-8", errors="replace").decode("utf-8")
+
+
 def sanitize_embedding_text_inputs(text: Union[str, List[str]]) -> List[str]:
     """
     Transform invalid/empty inputs into a safe dummy to prevent API 422 embedding errors while
@@ -31,7 +46,7 @@ def sanitize_embedding_text_inputs(text: Union[str, List[str]]) -> List[str]:
     text_list = [text] if isinstance(text, str) else text
     dummy_value = "."
 
-    return [t if is_embeddable(t) else dummy_value for t in text_list]
+    return [_strip_surrogates(t) if is_embeddable(t) else dummy_value for t in text_list]
 
 
 def handle_embedding_response(

--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -12,6 +12,23 @@ from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.ll
 T = TypeVar("T", bound="BaseModel | str")
 
 
+def _strip_surrogates(s: str) -> str:
+    """
+    Replace unpaired UTF-16 surrogate code points that cannot be encoded to UTF-8.
+
+    A lone/unpaired surrogate is a valid Python `str` but is not valid UTF-8. Left
+    unstripped it crashes request serialization in every provider client (OpenAI,
+    Anthropic, Gemini, Ollama, ...) with a `UnicodeEncodeError`, since the request
+    body is eventually encoded to bytes. Applied once here, at the single call site
+    every structured-output/text call routes through, rather than per-adapter, so
+    no provider is left unprotected. Round-tripping through UTF-8 with
+    `errors="replace"` removes/replaces surrogates while leaving normal text --
+    including valid multi-byte characters and properly paired surrogate emoji --
+    unchanged.
+    """
+    return s.encode("utf-8", errors="replace").decode("utf-8")
+
+
 def _inject_agent_memory(text_input: str) -> str:
     from cognee.modules.agent_memory import get_current_agent_memory_context
 
@@ -63,7 +80,8 @@ class LLMGateway:
         response_model: type[T],
         **kwargs: Any,
     ) -> Coroutine[Any, Any, T]:
-        text_input = _inject_agent_memory(text_input)
+        text_input = _strip_surrogates(_inject_agent_memory(text_input))
+        system_prompt = _strip_surrogates(system_prompt)
         llm_config = get_llm_config()
         if llm_config.structured_output_framework.upper() == "BAML":
             from cognee.infrastructure.llm.structured_output_framework.baml.baml_src.extraction import (

--- a/cognee/infrastructure/session/session_context_models.py
+++ b/cognee/infrastructure/session/session_context_models.py
@@ -314,13 +314,37 @@ AgentCandidateContextUpdateVariant = Annotated[
 
 
 class AgentContextExtraction(BaseModel):
-    """LLM output for the batch pass: agent-profile lessons drawn from trace evidence."""
+    """LLM output for the batch pass: agent-profile lessons drawn from trace evidence.
 
-    lessons: List[AgentCandidateContextUpdateVariant] = Field(
+    ``lessons`` is intentionally typed as the plain base model, not the section-specific
+    discriminated union (``AgentCandidateContextUpdateVariant``). instructor's structured-output
+    modes ask the model to pick one of N pydantic classes via a discriminator field before the
+    fields even validate -- reliable for large/cloud models, but empirically unreliable for
+    smaller local models (measured against a local Ollama `llama3.1:8b`, both with instructor's
+    default `json_mode` and with `json_schema_mode`): the model frequently omits the discriminator
+    field entirely or returns a shape `union_tag_not_found` can't resolve, so most extractions are
+    rejected outright. The base model enforces the identical constraint
+    (``AgentCandidateContextUpdate.section_valid`` already restricts ``section`` to
+    ``AGENT_VALID_SECTIONS``) without requiring a discriminator match, and the only real consumer
+    of this output (``extract_batch_agent_context`` -> ``apply_candidate_updates`` ->
+    ``_coerce_candidate_model``) accepts any ``CandidateContextUpdate`` subclass via `isinstance`,
+    so nothing downstream depends on the specific subclass identity -- only on ``section`` already
+    being valid, which the base model guarantees on its own. In local testing against
+    `llama3.1:8b`, the discriminated union was rejected outright on most trials while this
+    base-model schema was consistently accepted -- and, since it asks the model to fill in fewer
+    structural fields, also faster. This does loosen the JSON schema instructor emits for every
+    provider (``section`` becomes a free-form string instead of an enumerated discriminator), but
+    ``section_valid`` remains the actual enforcement point regardless of provider, so correctness
+    is unaffected -- an invalid ``section`` is still rejected, just via the validator instead of
+    the schema.
+    """
+
+    lessons: List[AgentCandidateContextUpdate] = Field(
         default_factory=list,
         description=(
-            "Reusable agent/tool lessons drawn from the traces. Each item must be one of the "
-            "section-specific agent candidate types."
+            "Reusable agent/tool lessons drawn from the traces. Each item's `section` must be "
+            "one of tool_rules, workflow_state, success_patterns, failure_lessons, or "
+            "environment_facts, matching the kind of tool/workflow lesson the content is."
         ),
     )
 

--- a/cognee/tests/unit/infrastructure/databases/vector/embeddings/test_embedding_utils_sanitize.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/embeddings/test_embedding_utils_sanitize.py
@@ -1,0 +1,55 @@
+import pytest
+
+from cognee.infrastructure.databases.vector.embeddings.utils import (
+    _strip_surrogates,
+    handle_embedding_response,
+    is_embeddable,
+    sanitize_embedding_text_inputs,
+)
+
+
+def test_is_embeddable_rejects_empty_and_whitespace():
+    assert is_embeddable("") is False
+    assert is_embeddable("   ") is False
+    assert is_embeddable(123) is False
+
+
+def test_is_embeddable_accepts_non_empty():
+    assert is_embeddable("hello") is True
+    assert is_embeddable("!") is True
+
+
+def test_strip_surrogates_removes_unpaired_surrogate():
+    poisoned = "some text \udc8f more text"
+    cleaned = _strip_surrogates(poisoned)
+    assert "\udc8f" not in cleaned
+    cleaned.encode("utf-8")  # must not raise
+
+
+def test_strip_surrogates_leaves_normal_text_unchanged():
+    assert _strip_surrogates("hello world") == "hello world"
+    assert _strip_surrogates("emoji 🎉 unicode café") == "emoji 🎉 unicode café"
+
+
+def test_sanitize_embedding_text_inputs_strips_surrogates_in_valid_entries():
+    result = sanitize_embedding_text_inputs(["ok \udc8f text", "", "   ", "fine"])
+    assert "\udc8f" not in result[0]
+    result[0].encode("utf-8")
+    assert result[1] == "."
+    assert result[2] == "."
+    assert result[3] == "fine"
+
+
+def test_sanitize_embedding_text_inputs_single_string():
+    result = sanitize_embedding_text_inputs("just one \udc8f string")
+    assert len(result) == 1
+    assert "\udc8f" not in result[0]
+    result[0].encode("utf-8")
+
+
+def test_handle_embedding_response_zeroes_out_junk():
+    original = ["", "valid"]
+    embeddings = [[9.9, 9.9], [1.0, 2.0]]
+    result = handle_embedding_response(original, embeddings, dimensions=2)
+    assert result[0] == [0.0, 0.0]
+    assert result[1] == [1.0, 2.0]

--- a/cognee/tests/unit/infrastructure/llm/test_llm_gateway_sanitize.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_gateway_sanitize.py
@@ -1,0 +1,67 @@
+"""LLMGateway.acreate_structured_output must strip unpaired UTF-16 surrogates from both
+text_input and system_prompt before delegating to ANY provider client (OpenAI, Anthropic,
+Gemini, Ollama, ...) -- this is the single choke point every provider routes through, so
+sanitizing here (rather than per-adapter) protects all of them, not just Ollama.
+"""
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.infrastructure.llm.LLMGateway import LLMGateway
+
+_CONFIG_TARGET = "cognee.infrastructure.llm.LLMGateway.get_llm_config"
+_CLIENT_TARGET = (
+    "cognee.infrastructure.llm.structured_output_framework.litellm_instructor"
+    ".llm.get_llm_client.get_llm_client"
+)
+
+
+class _Resp(BaseModel):
+    value: str
+
+
+def _mock_config():
+    config = Mock()
+    config.structured_output_framework = "instructor"
+    return config
+
+
+@pytest.mark.asyncio
+async def test_acreate_structured_output_strips_surrogates_for_every_provider():
+    fake_client = Mock()
+    fake_client.acreate_structured_output = AsyncMock(return_value=_Resp(value="ok"))
+
+    poisoned_input = "some session text \udc8f more text"
+    poisoned_system = "system prompt with \udc8f surrogate"
+
+    with (
+        patch(_CONFIG_TARGET, return_value=_mock_config()),
+        patch(_CLIENT_TARGET, return_value=fake_client),
+    ):
+        await LLMGateway.acreate_structured_output(poisoned_input, poisoned_system, _Resp)
+
+    call_kwargs = fake_client.acreate_structured_output.call_args.kwargs
+    sent_input = call_kwargs["text_input"]
+    sent_system = call_kwargs["system_prompt"]
+
+    assert "\udc8f" not in sent_input
+    assert "\udc8f" not in sent_system
+    sent_input.encode("utf-8")
+    sent_system.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_acreate_structured_output_leaves_normal_text_unchanged():
+    fake_client = Mock()
+    fake_client.acreate_structured_output = AsyncMock(return_value=_Resp(value="ok"))
+
+    with (
+        patch(_CONFIG_TARGET, return_value=_mock_config()),
+        patch(_CLIENT_TARGET, return_value=fake_client),
+    ):
+        await LLMGateway.acreate_structured_output("hello world", "system prompt", _Resp)
+
+    call_kwargs = fake_client.acreate_structured_output.call_args.kwargs
+    assert call_kwargs["text_input"] == "hello world"
+    assert call_kwargs["system_prompt"] == "system prompt"

--- a/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
+++ b/cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py
@@ -58,3 +58,7 @@ async def test_acreate_structured_output_awaits_async_client():
     # ...not offloaded to a worker thread, and its result is returned unchanged.
     assert not to_thread_spy.called, "structured call must be awaited natively, not offloaded"
     assert result is sentinel
+
+
+# Unpaired-UTF-16-surrogate sanitization is centralized in LLMGateway.acreate_structured_output
+# (covers every provider adapter, not just Ollama) -- see test_llm_gateway_sanitize.py.

--- a/cognee/tests/unit/infrastructure/session/test_session_context_models.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_context_models.py
@@ -255,3 +255,34 @@ def test_agent_context_extraction_normalizes_lessons():
 def test_agent_context_extraction_defaults_to_empty():
     assert AgentContextExtraction().lessons == []
     assert AgentContextExtraction(lessons="not-a-list").lessons == []
+
+
+def test_agent_context_extraction_lessons_use_base_model_not_discriminated_union():
+    # AgentContextExtraction.lessons is intentionally typed as the plain base model, not the
+    # AgentCandidateContextUpdateVariant discriminated union -- see the class docstring for why
+    # (small local models via instructor are unreliable at picking a discriminator tag). Lock the
+    # resulting item type so a future edit doesn't silently reintroduce the union.
+    extraction = AgentContextExtraction(
+        lessons=[{"section": "tool_rules", "content": "Use uv run", "confidence": 0.9}]
+    )
+    assert type(extraction.lessons[0]) is AgentCandidateContextUpdate
+
+
+def test_agent_context_extraction_rejects_invalid_section():
+    # The base model's own field_validator must still enforce AGENT_VALID_SECTIONS even without
+    # a discriminator -- this is what makes dropping the union safe.
+    with pytest.raises(ValidationError):
+        AgentContextExtraction(
+            lessons=[{"section": "not_a_real_section", "content": "x", "confidence": 0.9}]
+        )
+
+
+def test_agent_context_extraction_all_valid_sections_parse():
+    extraction = AgentContextExtraction(
+        lessons=[
+            {"section": section, "content": "lesson", "confidence": 0.9}
+            for section in AGENT_VALID_SECTIONS
+        ]
+    )
+    assert {lesson.section for lesson in extraction.lessons} == AGENT_VALID_SECTIONS
+    assert all(isinstance(lesson, AgentCandidateContextUpdate) for lesson in extraction.lessons)


### PR DESCRIPTION
## Summary

Two related reliability fixes surfaced while running the agent-context-extraction pipeline against a local Ollama model:

**1. `AgentContextExtraction.lessons` schema simplification**

`lessons` was typed as a section-specific discriminated union (`AgentCandidateContextUpdateVariant`). `instructor`'s structured-output modes ask the model to pick one of N pydantic classes via a discriminator field before the fields even validate — reliable for large/cloud models, but in local testing against `llama3.1:8b` the discriminated union was rejected outright on most trials (model frequently omits the discriminator field, or returns a shape the union can't resolve).

Switching `lessons` to the plain base model (`AgentCandidateContextUpdate`) fixes this: its own `section_valid` field validator already enforces the identical section-membership constraint without needing a discriminator match, and the only real consumer (`extract_batch_agent_context` → `apply_candidate_updates` → `_coerce_candidate_model`) accepts any `CandidateContextUpdate` subclass via `isinstance`, so nothing downstream depends on the specific subclass identity — only on `section` already being valid, which the base model still guarantees.

**Trade-off, called out explicitly:** this does loosen the JSON schema `instructor` emits for every provider — `section` becomes a free-form string instead of an enumerated discriminator, rather than only affecting the Ollama path. Correctness is unaffected (`section_valid` is the real enforcement point either way, so an invalid `section` is still rejected — just via the validator instead of the schema), but it's a real, deliberate trade: a slightly more permissive schema for all providers in exchange for reliability against smaller local models. Happy to gate this behind a config flag instead if maintainers would prefer providers keep the stricter discriminated schema by default.

**2. Unpaired UTF-16 surrogate crash**

An unpaired UTF-16 surrogate code point (e.g. from a mis-decoded text boundary) is a valid Python `str` but is not valid UTF-8. Left unstripped, it crashes request serialization with `UnicodeEncodeError` wherever such text reaches a provider client or the embedding tokenizer.

Added a `_strip_surrogates()` helper (UTF-8 round-trip with `errors="replace"`) and applied it at the two real choke points, rather than patching individual adapters:
- `LLMGateway.acreate_structured_output` — the single call site every LLM provider (OpenAI, Anthropic, Gemini, Ollama, ...) routes through, so this protects all of them, not just one.
- `sanitize_embedding_text_inputs` — already the single choke point all 4 embedding engines route through.

`errors="replace"` (→ U+FFFD) was chosen over `errors="ignore"` since it preserves one character per surrogate rather than silently deleting, and nothing downstream indexes by character position in a way that would be corrupted by the substitution. Verified paired surrogates (proper emoji) and normal multi-byte text round-trip unchanged.

## Test plan

- [x] `cognee/tests/unit/infrastructure/session/test_session_context_models.py` — 33 tests pass (3 new)
- [x] `cognee/tests/unit/infrastructure/session/test_agent_context_extraction.py` — existing suite unaffected
- [x] `cognee/tests/unit/infrastructure/llm/test_ollama_adapter.py` — existing test still passes
- [x] `cognee/tests/unit/infrastructure/llm/test_llm_gateway_sanitize.py` — new, 2 tests covering surrogate stripping at the gateway layer for both `text_input` and `system_prompt`
- [x] `cognee/tests/unit/infrastructure/databases/vector/embeddings/test_embedding_utils_sanitize.py` — new, 7 tests covering `_strip_surrogates`/`sanitize_embedding_text_inputs`, including that normal/emoji text is left unchanged
- [x] `cognee/tests/unit/test_litellm_embedding_sanitize.py` — existing suite unaffected
- [x] Full combined run: 63 passed, 0 failed