### PR TITLE
fix(improve): pass user to add/cognify in agent trace feedback persistence

### DIFF
--- a/cognee/memify_pipelines/persist_agent_trace_feedbacks_in_knowledge_graph.py
+++ b/cognee/memify_pipelines/persist_agent_trace_feedbacks_in_knowledge_graph.py
@@ -74,6 +74,7 @@ async def persist_agent_trace_feedbacks_in_knowledge_graph_pipeline(
             cognify_agent_trace_feedback,
             dataset_id=dataset_to_write[0].id,
             node_set_name=node_set_name,
+            user=user,
         ),
     ]
 

--- a/cognee/tasks/memify/cognify_agent_trace_feedback.py
+++ b/cognee/tasks/memify/cognify_agent_trace_feedback.py
@@ -4,6 +4,7 @@ from uuid import UUID
 import cognee
 
 from cognee.exceptions import CogneeSystemError, CogneeValidationError
+from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("cognify_agent_trace_feedback")
@@ -13,6 +14,7 @@ async def cognify_agent_trace_feedback(
     data: str,
     dataset_id: Optional[UUID | str] = None,
     node_set_name: str = "agent_trace_feedbacks",
+    user: Optional[User] = None,
 ) -> None:
     """
     Process and cognify agent trace session text into the knowledge graph.
@@ -23,6 +25,8 @@ async def cognify_agent_trace_feedback(
             raw method return values.
         dataset_id: Dataset identifier to write to.
         node_set_name: Node-set name used when adding the trace text.
+        user: User the add/cognify calls run as. Without it they fall back to
+            the default user, which has no write ACL on multi-tenant deployments.
 
     Raises:
         CogneeValidationError: If data is None or empty.
@@ -40,12 +44,12 @@ async def cognify_agent_trace_feedback(
 
         logger.info("Processing agent trace content for cognification")
 
-        await cognee.add(data, dataset_id=dataset_id, node_set=[node_set_name])
+        await cognee.add(data, dataset_id=dataset_id, node_set=[node_set_name], user=user)
         logger.debug(
             "Agent trace content added to cognee with node_set: %s",
             node_set_name,
         )
-        await cognee.cognify(datasets=[dataset_id])
+        await cognee.cognify(datasets=[dataset_id], user=user)
         logger.info("Agent trace content successfully cognified")
 
     except CogneeValidationError:

--- a/cognee/tests/unit/memify_pipelines/test_persist_agent_trace_feedbacks_pipeline.py
+++ b/cognee/tests/unit/memify_pipelines/test_persist_agent_trace_feedbacks_pipeline.py
@@ -60,3 +60,4 @@ async def test_persist_agent_trace_feedbacks_pipeline_wires_memify_tasks():
     assert extraction_task.default_params["kwargs"]["last_n_steps"] == 3
     assert enrichment_task.default_params["kwargs"]["dataset_id"] == "dataset-1"
     assert enrichment_task.default_params["kwargs"]["node_set_name"] == "custom_feedbacks"
+    assert enrichment_task.default_params["kwargs"]["user"] == user

--- a/cognee/tests/unit/modules/memify_tasks/test_cognify_agent_trace_feedback.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_cognify_agent_trace_feedback.py
@@ -20,8 +20,30 @@ async def test_cognify_agent_trace_feedback_success():
         trace_content,
         dataset_id="123",
         node_set=["agent_trace_feedbacks"],
+        user=None,
     )
-    mock_cognify.assert_called_once_with(datasets=["123"])
+    mock_cognify.assert_called_once_with(datasets=["123"], user=None)
+
+
+@pytest.mark.asyncio
+async def test_cognify_agent_trace_feedback_forwards_user():
+    """Test user is forwarded to cognee.add/cognee.cognify."""
+    trace_content = "Session ID: trace_session\n\ndraft plan succeeded."
+    user = object()
+
+    with (
+        patch("cognee.add", new_callable=AsyncMock) as mock_add,
+        patch("cognee.cognify", new_callable=AsyncMock) as mock_cognify,
+    ):
+        await cognify_agent_trace_feedback(trace_content, dataset_id="123", user=user)
+
+    mock_add.assert_called_once_with(
+        trace_content,
+        dataset_id="123",
+        node_set=["agent_trace_feedbacks"],
+        user=user,
+    )
+    mock_cognify.assert_called_once_with(datasets=["123"], user=user)
 
 
 @pytest.mark.asyncio
@@ -42,6 +64,7 @@ async def test_cognify_agent_trace_feedback_custom_node_set_name():
         trace_content,
         dataset_id="123",
         node_set=["custom_trace_feedbacks"],
+        user=None,
     )
 
 


### PR DESCRIPTION
## Problem

On multi-tenant deployments (`ENABLE_BACKEND_ACCESS_CONTROL=true`), every `improve()` run fails its trace-persist stage:

```
Coroutine task errored: `cognify_agent_trace_feedback`
PermissionDeniedError: Request owner does not have necessary permission: [write] for all datasets requested. (Status code: 403)
```

`cognify_agent_trace_feedback` calls `cognee.add()` / `cognee.cognify()` without `user`, so `resolve_authorized_user_datasets()` falls back to `get_default_user()` — which has no write ACL on tenant datasets. Result: agent trace feedbacks are silently never persisted on cloud pods, and each improve burst records an ERRORED `memify_pipeline` run (which the Cloud UI surfaces as a failed improve).

Works fine in single-user OSS setups where the default user owns everything — which is why it slipped through. `cognify_session` had the identical bug and was already fixed; this applies the same treatment to the trace-feedback task that was missed.

## Fix

- `cognify_agent_trace_feedback` accepts `user` and forwards it to `add()`/`cognify()`
- `persist_agent_trace_feedbacks_in_knowledge_graph_pipeline` passes `user` into the enrichment Task

## Verification

- Observed the 403 on every improve run in dev-cluster pod logs (tenant `f0b20ed4`, 2026-07-17); other improve stages complete
- Unit tests updated: existing call assertions now include `user`, new `test_cognify_agent_trace_feedback_forwards_user` mirrors the `cognify_session` user-forwarding test — 19/19 pass
- `ruff check` / `ruff format` clean

Closes COG-5893

🤖 Generated with [Claude Code](https://claude.com/claude-code)