### PR TITLE
feat(activity): expose pipeline-run error in /v1/activity/pipeline-runs

### DIFF
--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -67,6 +67,17 @@ def get_activity_router() -> APIRouter:
             result = await session.execute(stmt)
             rows = result.all()
 
+        def run_error(run) -> Optional[str]:
+            # Errored runs store the exception text in run_info["error"]
+            # (log_pipeline_run_error) — surface it so clients can say why a
+            # run failed. Bounded because run_info is caller-controlled JSON.
+            if not isinstance(run.run_info, dict):
+                return None
+            error = run.run_info.get("error")
+            if not isinstance(error, str) or not error.strip():
+                return None
+            return error.strip()[:500]
+
         return [
             {
                 "id": str(run.id),
@@ -78,6 +89,7 @@ def get_activity_router() -> APIRouter:
                 "owner_email": owner_email,
                 "created_at": run.created_at.isoformat() if run.created_at else None,
                 "pipeline_run_id": str(run.pipeline_run_id) if run.pipeline_run_id else None,
+                "error": run_error(run),
             }
             for run, ds_name, owner_id, owner_email in rows
         ]


### PR DESCRIPTION
## Why

Errored pipeline runs store the exception text in `run_info["error"]` (written by `log_pipeline_run_error`), but `GET /v1/activity/pipeline-runs` returns only the status. Clients — e.g. the Cloud UI's sessions page — can see that a run failed but have no way to tell the user why.

## What

Adds an `error` field to each row of the pipeline-runs response: the `run_info["error"]` string for errored runs (trimmed, bounded to 500 chars), `null` otherwise. Purely additive — existing consumers are unaffected.

## Context

Companion to the Cloud UI change that shows a short failure reason on improve runs that failed completely. Related: #4097 / COG-5893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)