### PR TITLE
Release v1.4.0 (SDK-197)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cognee"
 
-version = "1.3.0"
+version = "1.4.0"
 description = "Cognee - is a library for enriching LLM context with a semantic layer for better understanding and reasoning."
 authors = [
     { name = "Vasilije Markovic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Description
Bump cognee version `1.3.0` → `1.4.0`.

- `pyproject.toml`: `version = "1.4.0"`
- `uv.lock`: editable `cognee` self-reference bumped to `1.4.0`

`poetry.lock` has no `cognee` package block, and `cognee-mcp/uv.lock` resolves `cognee` from PyPI (published version), so neither requires a version-bump edit. `uv lock --check` passes.

Linear: SDK-197 (Cycle 63)

## Type of Change
- [x] Other (please specify): release / version bump

## Pre-submission Checklist
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)