### PR TITLE
fix(tests): execute async telemetry test bodies

### DIFF
--- a/cognee/tests/test_telemetry.py
+++ b/cognee/tests/test_telemetry.py
@@ -1,125 +1,59 @@
-import unittest
+import asyncio
 import os
-import uuid
-import pytest
-from unittest.mock import patch, MagicMock
-import sys
+import unittest
+from unittest.mock import AsyncMock, patch
 
-# Import the telemetry function to test
 from cognee.shared.utils import send_telemetry
 
 
-class TestTelemetry(unittest.TestCase):
-    @pytest.mark.asyncio
-    @patch("aiohttp.ClientSession.post")
-    async def test_telemetry_enabled(self, mock_post):
-        # Setup mock response
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_post.return_value = mock_response
+class TestTelemetry(unittest.IsolatedAsyncioTestCase):
+    @patch("cognee.shared.utils._get_api_key_tracking_id", return_value="api-key-test-id")
+    @patch("cognee.shared.utils.get_persistent_id", return_value="persistent-test-id")
+    @patch("cognee.shared.utils.get_anonymous_id", return_value="anonymous-test-id")
+    @patch("cognee.shared.utils._send_telemetry_request", new_callable=AsyncMock)
+    async def test_telemetry_enabled(
+        self,
+        mock_send_telemetry_request,
+        _mock_get_anonymous_id,
+        _mock_get_persistent_id,
+        _mock_get_api_key_tracking_id,
+    ):
+        request_started = asyncio.Event()
 
-        # Check if .anon_id exists in the project root
-        anon_id_path = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(__file__))), ".anon_id"
-        )
+        async def capture_request(_payload):
+            request_started.set()
 
-        if not os.path.exists(anon_id_path):
-            # Create the file with a test ID if it doesn't exist
-            with open(anon_id_path, "w") as f:
-                f.write("test-machine")
-            print(f"Created .anon_id file at {anon_id_path}", file=sys.stderr)
+        mock_send_telemetry_request.side_effect = capture_request
 
-        self.assertTrue(os.path.exists(anon_id_path), "The .anon_id file should exist")
+        with patch.dict(os.environ, {"ENV": "prod"}, clear=False):
+            os.environ.pop("TELEMETRY_DISABLED", None)
+            send_telemetry("test_event", "test-user-id", {"test_key": "test_value"})
+            await asyncio.wait_for(request_started.wait(), timeout=1)
 
-        # Verify the file has content
-        with open(anon_id_path, "r") as f:
-            content = f.read().strip()
+        mock_send_telemetry_request.assert_awaited_once()
+        payload = mock_send_telemetry_request.await_args.args[0]
 
-        self.assertTrue(len(content) > 0, "The .anon_id file should not be empty")
+        self.assertEqual(payload["event_name"], "test_event")
+        self.assertEqual(payload["user_properties"]["user_id"], "test-user-id")
+        self.assertEqual(payload["properties"]["user_id"], "test-user-id")
+        self.assertEqual(payload["properties"]["test_key"], "test_value")
+        self.assertEqual(payload["properties"]["anonymous_id"], "anonymous-test-id")
+        self.assertEqual(payload["properties"]["persistent_id"], "persistent-test-id")
 
-        # Ensure telemetry is enabled for this test
-        if "TELEMETRY_DISABLED" in os.environ:
-            del os.environ["TELEMETRY_DISABLED"]
+    @patch("cognee.shared.utils._send_telemetry_request", new_callable=AsyncMock)
+    async def test_telemetry_disabled(self, mock_send_telemetry_request):
+        with patch.dict(os.environ, {"TELEMETRY_DISABLED": "1"}, clear=False):
+            send_telemetry("disabled_test", "user123", {"key": "value"})
 
-        # Make sure ENV is not test or dev
-        original_env = os.environ.get("ENV")
-        os.environ["ENV"] = "prod"  # Set to dev to ensure telemetry is sent
+        mock_send_telemetry_request.assert_not_called()
 
-        # Generate a random user ID for testing
-        test_user_id = str(uuid.uuid4())
+    @patch("cognee.shared.utils._send_telemetry_request", new_callable=AsyncMock)
+    async def test_telemetry_dev_env(self, mock_send_telemetry_request):
+        with patch.dict(os.environ, {"ENV": "dev"}, clear=False):
+            os.environ.pop("TELEMETRY_DISABLED", None)
+            send_telemetry("dev_test", "user123", {"key": "value"})
 
-        # Test sending telemetry
-        event_name = "test_event"
-        additional_props = {"test_key": "test_value"}
-
-        send_telemetry(event_name, test_user_id, additional_props)
-
-        # Verify telemetry was sent
-        mock_post.assert_called_once()
-
-        # Get the args that were passed to post
-        args, kwargs = mock_post.call_args
-
-        # Check that the payload contains our data
-        self.assertIn("json", kwargs)
-        payload = kwargs["json"]
-
-        # Verify payload contains expected data
-        self.assertEqual(payload.get("event_name"), event_name)
-
-        # Check that user_id is in the correct nested structure
-        self.assertIn("user_properties", payload)
-        self.assertEqual(payload["user_properties"].get("user_id"), str(test_user_id))
-
-        # Also check that user_id is in the properties
-        self.assertIn("properties", payload)
-        self.assertEqual(payload["properties"].get("user_id"), str(test_user_id))
-
-        # Check that additional properties are included
-        self.assertEqual(payload["properties"].get("test_key"), "test_value")
-
-        # Restore original ENV if it existed
-        if original_env is not None:
-            os.environ["ENV"] = original_env
-        else:
-            del os.environ["ENV"]
-
-    @pytest.mark.asyncio
-    @patch("aiohttp.ClientSession.post")
-    async def test_telemetry_disabled(self, mock_post):
-        # Enable the TELEMETRY_DISABLED environment variable
-        os.environ["TELEMETRY_DISABLED"] = "1"
-
-        # Test sending telemetry
-        send_telemetry("disabled_test", "user123", {"key": "value"})
-
-        # Verify telemetry was not sent
-        mock_post.assert_not_called()
-
-        # Clean up
-        del os.environ["TELEMETRY_DISABLED"]
-
-    @pytest.mark.asyncio
-    @patch("aiohttp.ClientSession.post")
-    async def test_telemetry_dev_env(self, mock_post):
-        # Set ENV to dev which should disable telemetry
-        original_env = os.environ.get("ENV")
-        os.environ["ENV"] = "dev"
-
-        if "TELEMETRY_DISABLED" in os.environ:
-            del os.environ["TELEMETRY_DISABLED"]
-
-        # Test sending telemetry
-        send_telemetry("dev_test", "user123", {"key": "value"})
-
-        # Verify telemetry was not sent in dev environment
-        mock_post.assert_not_called()
-
-        # Restore original ENV if it existed
-        if original_env is not None:
-            os.environ["ENV"] = original_env
-        else:
-            del os.environ["ENV"]
+        mock_send_telemetry_request.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes the telemetry tests that pytest previously reported as passing without executing their async bodies.

- runs the tests with `unittest.IsolatedAsyncioTestCase`, preserving both pytest and direct Python execution
- mocks the internal async telemetry sender instead of `aiohttp`, preventing real network requests and session leaks
- waits deterministically for the scheduled sender before checking the payload
- patches telemetry identities and environment state so the suite performs no filesystem writes

Fixes #4110.

## Acceptance Criteria

- [x] All three async test bodies execute before they pass
- [x] The enabled case validates the generated telemetry payload
- [x] Disabled and development environments do not schedule telemetry
- [x] Tests remain fully local and deterministic
- [x] Both pytest and direct unittest entry points pass

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

Not applicable.

## Testing

- `uv run pytest cognee/tests/test_telemetry.py -q -W error::RuntimeWarning -W error::pytest.PytestUnraisableExceptionWarning -W error::pytest.PytestUnhandledCoroutineWarning`
- `uv run python cognee/tests/test_telemetry.py`
- `uv run pytest cognee/tests/unit/shared/test_telemetry_tracking.py cognee/tests/test_telemetry.py -q`
- `uv run ruff check cognee/tests/test_telemetry.py`
- `uv run ruff format --check cognee/tests/test_telemetry.py`

## Pre-submission Checklist

- [x] I have tested the change thoroughly
- [x] This PR contains the minimal changes necessary to fix the issue
- [x] The test follows the repository coding style
- [x] I have linked the related issue
- [x] The commit has a clear, semantic subject

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.