### PR TITLE
test(cli): fix user-resolution fallback test after exception narrowing (SDK-202)

### DIFF
--- a/cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_user_resolution.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from cognee.cli.user_resolution import resolve_cli_user, scoped_session_id
+from cognee.infrastructure.databases.exceptions import EntityNotFoundError
 
 
 class TestScopedSessionId:
@@ -59,7 +60,7 @@ class TestResolveCliUser:
     def test_valid_uuid_unknown_user_warns_and_falls_back(self):
         uid = "550e8400-e29b-41d4-a716-446655440000"
         default_user = MagicMock()
-        mock_get_user = AsyncMock(side_effect=Exception("not found"))
+        mock_get_user = AsyncMock(side_effect=EntityNotFoundError("User not found"))
         mock_get_default = AsyncMock(return_value=default_user)
 
         with patch("cognee.modules.users.methods.get_user", mock_get_user):


### PR DESCRIPTION
## What this fixes

`dev` is red on `test_user_resolution.py::TestResolveCliUser::test_valid_uuid_unknown_user_warns_and_falls_back`, which fails the CLI/unit CI on every open PR.

Commit `e5ad6e13f` ("narrow cli user resolution exception", #3276/#3327) correctly narrowed `resolve_cli_user`'s handler from `except Exception:` to `except EntityNotFoundError:`, but did not update this test — it still mocks `get_user` with a bare `Exception("not found")`, which the narrowed handler no longer catches, so it propagates and the test fails.

## Fix

Align the test with the narrowed behavior: an unknown user surfaces as `EntityNotFoundError` (what `get_user` raises and what the handler catches), so mock that instead of a bare `Exception`. Test-only, no product change.

Verified: the full `test_user_resolution.py` now passes (9 passed). Found while working on SDK-167 (Langfuse via OTEL), whose CI inherited this dev-side failure.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
