### PR TITLE
fix(llm): stop HTML-escaping .txt prompt templates [SDK-203]

### DIFF
--- a/cognee/infrastructure/llm/prompts/render_prompt.py
+++ b/cognee/infrastructure/llm/prompts/render_prompt.py
@@ -28,10 +28,13 @@ def render_prompt(filename: str, context: dict, base_directory: str | None = Non
     if base_directory is None:
         base_directory = get_absolute_path("./infrastructure/llm/prompts")
 
-    # Initialize the Jinja2 environment to load templates from the filesystem
+    # Initialize the Jinja2 environment to load templates from the filesystem.
+    # Autoescape only markup templates: the .txt prompt templates must render
+    # interpolated content verbatim — HTML-escaping them corrupts every LLM
+    # prompt on the wire (`'` -> `&#39;`, `-->` -> `--&gt;`, ...).
     env = Environment(
         loader=FileSystemLoader(base_directory),
-        autoescape=select_autoescape(["html", "xml", "txt"]),
+        autoescape=select_autoescape(["html", "xml"]),
     )
 
     # Load the template by name

--- a/cognee/tests/unit/infrastructure/llm/test_render_prompt.py
+++ b/cognee/tests/unit/infrastructure/llm/test_render_prompt.py
@@ -1,0 +1,44 @@
+"""Tests for prompt template rendering (SDK-203).
+
+The Jinja2 environment previously enabled autoescape for ``.txt`` templates,
+HTML-escaping every interpolated variable in every LLM prompt on the wire
+(``'`` -> ``&#39;``, ``-->`` -> ``--&gt;``). Prompts must render content
+verbatim; only markup templates (``.html``/``.xml``) stay escaped.
+"""
+
+from cognee.infrastructure.llm.prompts.render_prompt import render_prompt
+
+RAW_TEXT = 'Zara\'s graph: a --> b & <c> "quoted"'
+
+
+def test_txt_prompt_renders_content_verbatim():
+    rendered = render_prompt(
+        "context_for_question.txt",
+        {"question": "What is Zara's plan?", "context": RAW_TEXT},
+    )
+
+    assert "What is Zara's plan?" in rendered
+    assert RAW_TEXT in rendered
+    for entity in ("&#39;", "&amp;", "&lt;", "&gt;", "&#34;", "&quot;"):
+        assert entity not in rendered
+
+
+def test_custom_base_directory_txt_template_not_escaped(tmp_path):
+    (tmp_path / "custom.txt").write_text("value: {{ value }}", encoding="utf-8")
+
+    rendered = render_prompt("custom.txt", {"value": RAW_TEXT}, base_directory=str(tmp_path))
+
+    assert rendered == f"value: {RAW_TEXT}"
+
+
+def test_html_templates_remain_autoescaped(tmp_path):
+    # The markup-only autoescape posture is deliberate: .html/.xml templates
+    # must keep escaping interpolated content.
+    (tmp_path / "page.html").write_text("<p>{{ value }}</p>", encoding="utf-8")
+
+    rendered = render_prompt(
+        "page.html", {"value": "<script>alert(1)</script>"}, base_directory=str(tmp_path)
+    )
+
+    assert "<script>" not in rendered
+    assert "&lt;script&gt;" in rendered


### PR DESCRIPTION
## Description

`render_prompt` configures its Jinja2 environment with `autoescape=select_autoescape(["html", "xml", "txt"])`. Every prompt template in the repo is a `.txt` file, so every interpolated variable in every rendered LLM prompt has been HTML-escaped on the wire, for all providers: apostrophes arrive as `&#39;`, triplet arrows in retrieval context as `--&gt;`, ampersands as `&amp;` — including the user's own question in completion prompts.

We found this while auditing raw `sampling/createMessage` traffic during end-to-end verification of PR #3982: the wire logs showed escaped entities in every completion prompt, and tracing the escaping back landed on this one line (it's the only `autoescape` site in the repo). Reproduction on dev tip:

```python
render_prompt("context_for_question.txt", {"question": "What is Zara's plan?", "context": "a --> b & <c>"})
# before: "The question is: `What is Zara&#39;s plan?`\nAnd here is the context: `a --&gt; b &amp; &lt;c&gt;`"
# after:  "The question is: `What is Zara's plan?`\nAnd here is the context: `a --> b & <c>`"
```

Models usually cope with the entities, which is why this stayed invisible — but it silently degrades prompt fidelity everywhere (quotes, code snippets, comparison operators, any `&`/`<`/`>` in user data), wastes tokens, and can distort extraction and grading.

The fix keeps autoescape for markup templates only (`["html", "xml"]`, Jinja's recommended posture) so `.txt` prompts render verbatim while any future `.html`/`.xml` template stays escaped. Verified before changing: all `render_prompt` call sites use `.txt` templates, and no test depends on escaped output.

Linear: SDK-203.

## Acceptance Criteria

* Rendered `.txt` prompts contain raw `'`, `&`, `<`, `>`, `-->` verbatim — pinned by regression tests against both a real repo template (`context_for_question.txt`) and a custom `base_directory` template.
* `.html` templates remain autoescaped (test pins `<script>` → `&lt;script&gt;`), so the markup-safety posture is unchanged.
* No regressions: full `cognee/tests/unit/infrastructure/llm/` suite passes (61 passed, 1 skipped); `ruff check`/`ruff format --check` and `ty check` clean.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

```
$ pytest cognee/tests/unit/infrastructure/llm/test_render_prompt.py -q
3 passed

$ pytest cognee/tests/unit/infrastructure/llm/ -q
61 passed, 1 skipped

$ ruff check ... && ruff format --check ...
All checks passed! / 2 files already formatted
```

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
