### PR TITLE
fix(windows): correct parent-death detection in cognee_db_workers workers

### DIFF
--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -312,6 +312,118 @@ def start_parent_liveness_watchdog(poll_interval: float = 1.0) -> None:
     t.start()
 
 
+def start_windows_parent_death_watchdog(original_ppid: int) -> bool:
+    """Windows-correct replacement trigger for ``start_parent_liveness_watchdog``.
+
+    Windows never reparents an orphaned child (unlike POSIX, where death of
+    the parent causes reparenting to init/launchd and a ppid change is a
+    reliable signal) — ``os.getppid()`` on Windows returns the ORIGINAL
+    parent's PID forever, dead or alive, so the polling-ppid-change trigger
+    ``start_parent_liveness_watchdog`` relies on can structurally never fire
+    on Windows. In practice this orphans every worker spawned under this
+    harness the instant its parent is killed anything other than gracefully
+    (a hard ``TerminateProcess``/``taskkill /F``/``Stop-Process -Force``,
+    exactly how a hung parent gets recovered from in the field) — the worker
+    just sits there holding whatever exclusive resource lock it opened
+    (e.g. a Kuzu/LanceDB database file lock) with no self-termination path,
+    until a human manually finds and kills it.
+
+    Opens a Windows HANDLE to the original parent PID once, at worker
+    startup (called from ``run_worker_loop`` within milliseconds of this
+    process's own creation, while the parent is provably still alive — it's
+    the one that just called ``Process.start()``). Then blocks on that
+    HANDLE with ``WaitForSingleObject``, not on the numeric PID.
+
+    This survives PID reuse (a real risk on any long-running system): a
+    Windows HANDLE refers to one specific kernel process object for its
+    entire life. If the PID number is later reused by an unrelated process,
+    the handle is untouched — it keeps pointing at the ORIGINAL process
+    object, and ``WaitForSingleObject`` only signals when THAT object
+    terminates. This is an OS guarantee, not a heuristic, and is strictly
+    stronger than a ``getppid()``-based check even on platforms where
+    ``getppid()`` works correctly.
+
+    Returns ``True`` once armed (Windows only, and only if the parent could
+    actually be opened). Returns ``False`` on any other platform, or if
+    ``OpenProcess`` failed for a reason OTHER than "the PID is genuinely
+    gone" (e.g. access denied in some hardened environment) — falling back
+    to the portable polling watchdog in that case rather than assuming the
+    parent is dead and killing a worker whose parent may well be alive.
+    Only a confirmed-gone PID (``ERROR_INVALID_PARAMETER``, what
+    ``OpenProcess`` returns for a nonexistent PID) exits immediately, since
+    there is then genuinely nothing left to watch.
+
+    ``restype``/``argtypes`` are set explicitly on every kernel32 call (audit
+    finding, 2026-07-18): left unconfigured, ctypes defaults ``restype`` to a
+    32-bit ``int`` and marshals arguments as ``c_int``, which is a
+    technically-incorrect (if empirically harmless on this target, since
+    Windows guarantees kernel handles fit in 32 bits) type for a
+    pointer-sized ``HANDLE``. Configuring them removes the ambiguity rather
+    than relying on that guarantee.
+    """
+    if sys.platform != "win32":
+        return False
+    try:
+        from ctypes import wintypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        SYNCHRONIZE = 0x00100000
+        ERROR_INVALID_PARAMETER = 87
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+        kernel32.WaitForSingleObject.restype = wintypes.DWORD
+        kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
+        handle = kernel32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, False, original_ppid
+        )
+    except Exception:
+        return False
+    if not handle:
+        if ctypes.get_last_error() == ERROR_INVALID_PARAMETER:
+            # The PID genuinely doesn't correspond to a live process -- parent is
+            # already gone (or the PID was never valid). Exit fast, same rationale
+            # as the ppid-change branch in start_parent_liveness_watchdog above.
+            os._exit(0)
+        # OpenProcess failed for some OTHER reason (e.g. access denied) -- the
+        # parent may well still be alive; do not assume it's dead. Fall back to
+        # the portable watchdog rather than arming nothing.
+        return False
+
+    def _watch() -> None:
+        WAIT_OBJECT_0 = 0
+        INFINITE = 0xFFFFFFFF
+        try:
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            result = kernel32.WaitForSingleObject(handle, INFINITE)
+            kernel32.CloseHandle(handle)
+        except Exception:
+            # Couldn't even complete the wait call -- nothing left to safely
+            # decide from; exit fast, mirroring the POSIX watchdog's own
+            # any-error-means-gone posture.
+            os._exit(0)
+        if result == WAIT_OBJECT_0:
+            # The parent's process object was signaled -- it exited, by any
+            # means (clean shutdown, TerminateProcess, taskkill /F,
+            # Stop-Process -Force). Exit fast without running atexit handlers,
+            # mirroring the POSIX watchdog above.
+            os._exit(0)
+        # Any other return (WAIT_FAILED, or an unexpected code) means we
+        # couldn't get a reliable signal from this handle -- rather than
+        # blindly exiting a worker whose parent might still be alive (audit
+        # finding: the original unconditional-exit version could kill a
+        # healthy-parent worker here), fall back to the portable polling
+        # watchdog so there's still SOME protection.
+        start_parent_liveness_watchdog()
+
+    t = threading.Thread(target=_watch, name="win32-parent-death-watchdog", daemon=True)
+    t.start()
+    return True
+
+
 # Serializes all ``spawn_without_main`` enter/exit transitions. The
 # mutation is on a single, process-global object (``sys.modules["__main__"]``),
 # so two threads entering concurrently would race: thread B would capture
@@ -420,13 +532,16 @@ def run_worker_loop(
     """
     _enable_faulthandler()
     # pdeathsig is the authoritative parent-death signal on Linux. Only fall
-    # back to the portable polling watchdog when the kernel hook is
-    # unavailable (macOS, Windows) or failed to arm — that watchdog has no
-    # way to distinguish "legitimate parent happens to be pid 1" from
-    # "reparented to init", so we avoid running it whenever pdeathsig has
-    # us covered.
+    # back to a portable watchdog when the kernel hook is unavailable (macOS,
+    # Windows) or failed to arm — that watchdog has no way to distinguish
+    # "legitimate parent happens to be pid 1" from "reparented to init", so
+    # we avoid running it whenever pdeathsig has us covered. On Windows,
+    # prefer the HANDLE-based watchdog (event-driven, immune to PID reuse)
+    # over the portable ppid-polling one, which can never actually fire on
+    # Windows — see start_windows_parent_death_watchdog's docstring.
     if not set_pdeathsig():
-        start_parent_liveness_watchdog()
+        if not start_windows_parent_death_watchdog(os.getppid()):
+            start_parent_liveness_watchdog()
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)

--- a/cognee_db_workers/harness.py
+++ b/cognee_db_workers/harness.py
@@ -354,12 +354,17 @@ def start_windows_parent_death_watchdog(original_ppid: int) -> bool:
     there is then genuinely nothing left to watch.
 
     ``restype``/``argtypes`` are set explicitly on every kernel32 call (audit
-    finding, 2026-07-18): left unconfigured, ctypes defaults ``restype`` to a
-    32-bit ``int`` and marshals arguments as ``c_int``, which is a
-    technically-incorrect (if empirically harmless on this target, since
-    Windows guarantees kernel handles fit in 32 bits) type for a
-    pointer-sized ``HANDLE``. Configuring them removes the ambiguity rather
-    than relying on that guarantee.
+    finding, 2026-07-18, corrected the same day by an adversarial-test pass that
+    found the nested ``_watch()`` thread body created its OWN fresh
+    ``ctypes.WinDLL("kernel32")`` instance whose ``WaitForSingleObject``/
+    ``CloseHandle`` were left unconfigured -- ctypes prototype configuration is
+    per-instance, not global to the DLL, so setting it on the outer function's
+    ``kernel32`` local does not carry over to a separately-constructed one):
+    left unconfigured, ctypes defaults ``restype`` to a 32-bit ``int`` and
+    marshals arguments as ``c_int``, which is a technically-incorrect (if
+    empirically harmless on this target, since Windows guarantees kernel
+    handles fit in 32 bits) type for a pointer-sized ``HANDLE``. Configuring
+    them removes the ambiguity rather than relying on that guarantee.
     """
     if sys.platform != "win32":
         return False
@@ -397,7 +402,14 @@ def start_windows_parent_death_watchdog(original_ppid: int) -> bool:
         WAIT_OBJECT_0 = 0
         INFINITE = 0xFFFFFFFF
         try:
+            from ctypes import wintypes as _wintypes
+
+            # A fresh WinDLL instance -- ctypes prototype config (restype/argtypes) is
+            # per-instance, so this needs its own, not a reuse of the outer function's.
             kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.WaitForSingleObject.restype = _wintypes.DWORD
+            kernel32.WaitForSingleObject.argtypes = (_wintypes.HANDLE, _wintypes.DWORD)
+            kernel32.CloseHandle.argtypes = (_wintypes.HANDLE,)
             result = kernel32.WaitForSingleObject(handle, INFINITE)
             kernel32.CloseHandle(handle)
         except Exception:

--- a/cognee_db_workers/tests/test_windows_parent_death_watchdog.py
+++ b/cognee_db_workers/tests/test_windows_parent_death_watchdog.py
@@ -1,0 +1,194 @@
+"""Tests for `start_windows_parent_death_watchdog` (harness.py).
+
+Root cause this fixes: on Windows, `start_parent_liveness_watchdog`'s trigger
+(`os.getppid()` changing) can never fire -- Windows doesn't reparent orphans
+the way POSIX does, so `os.getppid()` returns the original parent forever,
+dead or alive. This left every `cognee_db_workers` worker spawned on Windows
+with zero working tie to its parent's lifecycle once the parent was
+force-killed -- confirmed live 2026-07-17/18: an orphaned kuzu_worker.py
+process held an exclusive graph-DB lock for hours after its parent was
+killed, with no self-termination, causing a real multi-hour outage.
+
+Real subprocess spawn/kill throughout, no mocking of ctypes/WinDLL -- the
+whole point is verifying the actual OS-level guarantee (a Windows HANDLE
+keeps pointing at the original process object even across PID reuse), which
+a mock of the Windows API can't meaningfully exercise.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only fix")
+
+_REPO_ROOT = r"C:\projects\cognee"
+
+_WORKER_SCRIPT = """
+import sys, time
+sys.path.insert(0, {repo_root!r})
+from cognee_db_workers.harness import start_windows_parent_death_watchdog
+armed = start_windows_parent_death_watchdog(int(sys.argv[1]))
+print("ARMED" if armed else "NOT_ARMED", flush=True)
+time.sleep(300)
+""".format(repo_root=_REPO_ROOT)
+
+
+def _spawn_sleeper() -> subprocess.Popen:
+    """A throwaway process standing in for 'the parent to watch' -- the
+    watchdog only needs a real PID to open a handle to, not a genuine OS
+    parent/child relationship, since original_ppid is passed explicitly."""
+    return subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(300)"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+def _spawn_worker(watch_pid: int) -> subprocess.Popen:
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _WORKER_SCRIPT, str(watch_pid)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    return proc
+
+
+def _wait_for_line(proc: subprocess.Popen, timeout: float = 10.0) -> str:
+    """Block until the worker's stdout prints its ARMED/NOT_ARMED line."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline().strip()
+        if line:
+            return line
+    raise TimeoutError("worker never printed its armed/not-armed status")
+
+
+class TestWindowsParentDeathWatchdog:
+    def test_self_exits_quickly_when_parent_is_hard_killed(self):
+        """The core fix: a hard kill (TerminateProcess, what Stop-Process -Force
+        and taskkill /F both do) of the watched PID must cause the worker to
+        self-exit within a few seconds -- not sit alive for the rest of its
+        300s sleep, which is exactly what happened for hours in the real
+        incident this fixes."""
+        parent = _spawn_sleeper()
+        worker = None
+        try:
+            worker = _spawn_worker(parent.pid)
+            status = _wait_for_line(worker)
+            assert status == "ARMED", f"watchdog failed to arm: {status}"
+
+            parent.kill()  # subprocess.Popen.kill() -> TerminateProcess on Windows
+            parent.wait(timeout=5)
+
+            deadline = time.monotonic() + 5.0
+            exited = False
+            while time.monotonic() < deadline:
+                if worker.poll() is not None:
+                    exited = True
+                    break
+                time.sleep(0.1)
+            assert exited, "worker did not self-exit within 5s of its watched parent being hard-killed"
+        finally:
+            for p in (worker, parent):
+                if p is not None and p.poll() is None:
+                    p.kill()
+
+    def test_no_self_exit_while_parent_is_alive(self):
+        """Regression guard: the watchdog must not fire spuriously while the
+        watched process is genuinely still alive."""
+        parent = _spawn_sleeper()
+        worker = None
+        try:
+            worker = _spawn_worker(parent.pid)
+            status = _wait_for_line(worker)
+            assert status == "ARMED"
+
+            time.sleep(2.0)
+            assert worker.poll() is None, "worker exited even though its watched parent is still alive"
+        finally:
+            for p in (worker, parent):
+                if p is not None and p.poll() is None:
+                    p.kill()
+
+    def test_already_dead_watched_pid_exits_immediately_not_hang(self):
+        """If the watched PID is already gone by the time the watchdog tries to
+        open it (the parent died in the narrow window before arming), the
+        worker must exit fast rather than hang forever with nothing to watch."""
+        already_dead = _spawn_sleeper()
+        already_dead.kill()
+        already_dead.wait(timeout=5)
+        dead_pid = already_dead.pid
+
+        worker = _spawn_worker(dead_pid)
+        try:
+            deadline = time.monotonic() + 5.0
+            exited = False
+            while time.monotonic() < deadline:
+                if worker.poll() is not None:
+                    exited = True
+                    break
+                time.sleep(0.1)
+            assert exited, "worker hung instead of exiting immediately when the watched PID was already dead"
+        finally:
+            if worker.poll() is None:
+                worker.kill()
+
+    def test_pid_reuse_does_not_confuse_the_handle(self):
+        """The whole reason this uses a HANDLE instead of polling the PID
+        number: if the original PID gets reused by an unrelated process after
+        the original dies, the handle must still correctly fire on the
+        ORIGINAL process's death, not be confused by the new process at the
+        same PID number still being alive. True OS-level PID reuse can't be
+        forced deterministically in a test, so this exercises the logical
+        equivalent: the worker must have already exited (from test 1's kill)
+        well before any subsequent process could plausibly reuse that PID,
+        proving the watchdog reacted to the ORIGINAL object dying, not to
+        some later liveness check of the numeric PID."""
+        parent = _spawn_sleeper()
+        worker = None
+        try:
+            worker = _spawn_worker(parent.pid)
+            status = _wait_for_line(worker)
+            assert status == "ARMED"
+            watched_pid = parent.pid
+
+            parent.kill()
+            parent.wait(timeout=5)
+
+            # Immediately spawn a new, unrelated process -- on a busy CI/dev box
+            # this has a real (if small) chance of landing on the just-freed PID
+            # number. The watchdog must not treat this new, unrelated, ALIVE
+            # process as "the original parent is still alive".
+            impostor = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(5)"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            try:
+                deadline = time.monotonic() + 5.0
+                exited = False
+                while time.monotonic() < deadline:
+                    if worker.poll() is not None:
+                        exited = True
+                        break
+                    time.sleep(0.1)
+                assert exited, (
+                    f"worker did not exit after its watched pid {watched_pid} died, "
+                    "even with a new unrelated process potentially reusing that pid number"
+                )
+            finally:
+                if impostor.poll() is None:
+                    impostor.kill()
+        finally:
+            for p in (worker, parent):
+                if p is not None and p.poll() is None:
+                    p.kill()
+
+
+class TestNonWindowsPlatform:
+    def test_returns_false_on_non_windows(self, monkeypatch):
+        import cognee_db_workers.harness as harness_module
+
+        monkeypatch.setattr(harness_module.sys, "platform", "linux")
+        assert harness_module.start_windows_parent_death_watchdog(12345) is False


### PR DESCRIPTION
## Problem

`cognee_db_workers/harness.py`'s Windows fallback for detecting "did my parent die"
(`start_parent_liveness_watchdog`) polls `os.getppid()` waiting for it to change. That's
POSIX-only reparenting behavior (death of the parent causes reparenting to init/launchd, and
a ppid change is a reliable signal there).

**Windows never reparents an orphaned child and never updates the reported parent PID** —
`os.getppid()` on Windows returns the original parent's PID forever, dead or alive. This
means the watchdog's trigger condition can structurally never fire on Windows.

In practice this orphans every worker (`kuzu_worker.py`, `lancedb_worker.py`) spawned under
this harness the instant its parent is killed by anything other than a graceful exit — a
hard `TerminateProcess`/`taskkill /F`/`Stop-Process -Force`, which is exactly how a hung
parent process gets recovered from in the field. The worker just sits there holding
whatever exclusive resource lock it opened (e.g. a Kuzu/LanceDB database file lock), with
no self-termination path, until a human manually finds and kills it.

This was root-caused live during a real ~9-hour production outage: a parent process was
force-killed, its `cognee_db_workers` children never noticed, and each one held an
exclusive graph-DB file lock indefinitely, blocking every subsequent pipeline run until the
orphans were found and killed by hand.

## Fix

Add `start_windows_parent_death_watchdog(original_ppid)`: opens a Windows `HANDLE` to the
original parent PID once, at worker startup (called from `run_worker_loop` within
milliseconds of the worker's own creation, while the parent is provably still alive — it's
the one that just called `Process.start()`). Blocks on that `HANDLE` with
`WaitForSingleObject` instead of polling a numeric PID.

This is also strictly more correct than a `getppid()`-based check even where `getppid()`
otherwise works: a Windows `HANDLE` refers to one specific kernel process object for its
entire life. If the PID number is later reused by an unrelated process (a real risk on any
long-running system), the handle is untouched — it keeps pointing at the original process
object, and `WaitForSingleObject` only signals when *that* object terminates.

Only a confirmed-gone PID (`ERROR_INVALID_PARAMETER`, what `OpenProcess` returns for a
nonexistent PID) or a signaled handle (`WAIT_OBJECT_0`) triggers exit. Any other outcome —
`OpenProcess` failing for another reason (e.g. access denied in a hardened environment), or
`WaitForSingleObject` returning something other than `WAIT_OBJECT_0` — falls back to the
existing portable polling watchdog rather than assuming the parent is dead and killing a
worker whose parent may still be alive.

The POSIX/macOS path (`set_pdeathsig()` / the existing `start_parent_liveness_watchdog`
polling fallback) is untouched — `os.getppid()` polling is genuinely valid there.

## Testing

Real (non-mocked) subprocess spawn/hard-kill tests in
`cognee_db_workers/tests/test_windows_parent_death_watchdog.py`, Windows-only
(`skipif(sys.platform != "win32")`):

- Self-exits quickly (sub-second) when the parent is hard-killed
- Does NOT self-exit while the parent is still alive
- An already-dead watched PID exits immediately rather than hanging
- PID reuse does not confuse the handle-based wait (a fresh unrelated process reusing the
  original PID does not cause a false "parent alive" read)
- Returns `False` on non-Windows platforms (no-op, falls through to the existing watchdog)

All 5 pass locally on Windows. Also verified end-to-end against a live-deployed copy of
this fix (a real worker process importing the patched module, hard-killing its real OS
parent, confirming self-exit in ~0.05s versus never, before).