### PR TITLE
fix(baml): map PEP 604 `X | None` unions in create_dynamic_baml_type

### DIFF
--- a/cognee/infrastructure/llm/structured_output_framework/baml/baml_src/extraction/create_dynamic_baml_type.py
+++ b/cognee/infrastructure/llm/structured_output_framework/baml/baml_src/extraction/create_dynamic_baml_type.py
@@ -1,3 +1,4 @@
+import types
 from datetime import datetime
 from enum import Enum
 from typing import Union, get_args, get_origin
@@ -25,7 +26,9 @@ def create_dynamic_baml_type(tb, baml_model, pydantic_model):
         # ------------------------------------------------------------------
         # 1. Optional / Union  ------------------------------------------------
         # ------------------------------------------------------------------
-        if origin is Union:
+        # `typing.Union[...]` has origin `typing.Union`, but PEP 604 syntax
+        # (`X | None`) has origin `types.UnionType` — handle both.
+        if origin is Union or origin is types.UnionType:
             non_none_args = [t for t in args if t is not type(None)]
 
             # Optional[T]  ⇢  exactly (T, NoneType)


### PR DESCRIPTION
## Problem
With `STRUCTURED_OUTPUT_FRAMEWORK=baml`, BAML extraction/recall fails for any
response model containing a PEP 604 optional (`X | None`) field:

    ValueError: Unsupported type for BAML mapping: str | None

In practice this makes `GRAPH_COMPLETION` recall unusable with BAML on
local/Ollama setups, since the completion response model has `str | None` fields.

## Root cause
`create_dynamic_baml_type.map_type()` only matches `origin is Union`
(`typing.Union`). PEP 604 unions (`X | None`) have `get_origin() == types.UnionType`,
so they miss the Optional/Union branch and fall through to the unsupported-type
error. `typing.Optional[str]` works; the equivalent `str | None` does not.

## Fix
Also match `types.UnionType` (available on Python >= 3.10, the project minimum):

    if origin is Union or origin is types.UnionType:

## Verification
Reproduced on a local Ollama + BAML config: `GRAPH_COMPLETION` recall raised
`Unsupported type for BAML mapping: str | None`. With this change the same recall
succeeds and returns correct answers. `ruff check` and `ruff format --check` pass.

No existing tests cover `create_dynamic_baml_type` (it needs a real `baml_py`
`TypeBuilder`) - happy to add one if you point me at the preferred harness.

## Note (out of scope)
A separate mapping gap exists for `Annotated[Union[...], discriminator=...]` in the
session-context models - same error class, different fix. Flagging for awareness;
not addressed here to keep this focused.

Branched from `dev` per CONTRIBUTING; external fork PR.
