### PR TITLE
fix(mcp): forward recall system prompts

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -535,6 +535,7 @@ class CogneeClient:
         search_type: Optional[str] = None,
         datasets: Optional[List[str]] = None,
         session_id: Optional[str] = None,
+        system_prompt: Optional[str] = None,
         top_k: int = 15,
     ) -> Any:
         """Search memory via recall() with auto-routing and session awareness."""
@@ -547,6 +548,8 @@ class CogneeClient:
                 payload["datasets"] = datasets
             if session_id:
                 payload["session_id"] = session_id
+            if system_prompt:
+                payload["system_prompt"] = system_prompt
             response = await self.client.post(endpoint, json=payload, headers=self._get_headers())
             response.raise_for_status()
             return response.json()
@@ -561,6 +564,8 @@ class CogneeClient:
                     kwargs["datasets"] = datasets
                 if session_id:
                     kwargs["session_id"] = session_id
+                if system_prompt:
+                    kwargs["system_prompt"] = system_prompt
                 return await self.cognee.recall(query_text=query_text, **kwargs)
 
     async def forget(

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1133,6 +1133,7 @@ async def recall(
     search_type: str = None,
     datasets: str = None,
     session_id: str = None,
+    system_prompt: str = None,
     top_k: int = 15,
 ) -> list:
     """Search memory with auto-routing and session awareness.
@@ -1156,6 +1157,8 @@ async def recall(
         Comma-separated dataset names to search within.
     session_id : str, optional
         Session ID for session-first search.
+    system_prompt : str, optional
+        Override the synthesis prompt for completion searches.
     top_k : int
         Maximum results to return (default: 10).
     """
@@ -1168,6 +1171,7 @@ async def recall(
                 search_type=search_type,
                 datasets=dataset_list,
                 session_id=session_id,
+                system_prompt=system_prompt,
                 top_k=normalized_top_k,
             )
             return [

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -197,7 +197,7 @@ async def test_cognee_client_api_remember_sends_session_id():
 
 
 @pytest.mark.asyncio
-async def test_cognee_client_api_recall_sends_session_id_and_null_search_type():
+async def test_cognee_client_api_recall_sends_session_id_prompt_and_null_search_type():
     requests: list[httpx.Request] = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -209,15 +209,56 @@ async def test_cognee_client_api_recall_sends_session_id_and_null_search_type():
     client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
     try:
-        await client.recall("hello", session_id="session-1", top_k=5)
+        await client.recall(
+            "hello",
+            session_id="session-1",
+            system_prompt="Answer with provenance.",
+            top_k=5,
+        )
     finally:
         await client.close()
 
     payload = json.loads(requests[0].content.decode())
     assert requests[0].url.path == "/api/v1/recall"
     assert payload["session_id"] == "session-1"
+    assert payload["system_prompt"] == "Answer with provenance."
     assert payload["search_type"] is None
     assert payload["top_k"] == 5
+
+
+@pytest.mark.asyncio
+async def test_mcp_recall_forwards_system_prompt(monkeypatch):
+    import src.server as server
+
+    class FakeClient:
+        def __init__(self):
+            self.recall_kwargs = None
+
+        async def recall(self, **kwargs):
+            self.recall_kwargs = kwargs
+            return [{"text": "ok"}]
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    result = await server.recall(
+        query="hello",
+        search_type="graph_completion",
+        datasets="main,docs",
+        session_id="session-1",
+        system_prompt="Answer with provenance.",
+        top_k=5,
+    )
+
+    assert "ok" in result[0].text
+    assert fake_client.recall_kwargs == {
+        "query_text": "hello",
+        "search_type": "graph_completion",
+        "datasets": ["main", "docs"],
+        "session_id": "session-1",
+        "system_prompt": "Answer with provenance.",
+        "top_k": 5,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #4120.

Summary:
- Add optional system_prompt to the MCP recall tool.
- Forward system_prompt through CogneeClient.recall in API mode to /api/v1/recall.
- Forward system_prompt through direct/SDK recall kwargs.
- Add regression coverage for API payload forwarding and MCP tool forwarding.

Testing:
- python3 -m py_compile cognee-mcp/src/cognee_client.py cognee-mcp/src/server.py cognee-mcp/tests/test_mcp_server_hardening.py
- git diff --check -- cognee-mcp/src/cognee_client.py cognee-mcp/src/server.py cognee-mcp/tests/test_mcp_server_hardening.py

Attempted but not completed locally:
- python3 -m pytest cognee-mcp/tests/test_mcp_server_hardening.py -q (collection failed because this sparse local environment is missing the structlog dependency).

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.