### PR TITLE
fix: guard optional Postgres adapter imports in Cypher and natural language retrievers

### DIFF
--- a/cognee/modules/retrieval/cypher_search_retriever.py
+++ b/cognee/modules/retrieval/cypher_search_retriever.py
@@ -35,12 +35,18 @@ class CypherSearchRetriever(BaseRetriever):
             graph_engine = await get_graph_engine()
 
             # Postgres backends do not support raw Cypher queries
-            from cognee.infrastructure.databases.graph.postgres.adapter import PostgresAdapter
-            from cognee.infrastructure.databases.hybrid.postgres.adapter import (
-                PostgresHybridAdapter,
-            )
+            # The postgres driver is optional; without it the engine cannot be Postgres.
+            try:
+                from cognee.infrastructure.databases.graph.postgres.adapter import PostgresAdapter
+                from cognee.infrastructure.databases.hybrid.postgres.adapter import (
+                    PostgresHybridAdapter,
+                )
 
-            if isinstance(graph_engine, (PostgresAdapter, PostgresHybridAdapter)):
+                unsupported_backends: tuple = (PostgresAdapter, PostgresHybridAdapter)
+            except ImportError:
+                unsupported_backends = ()
+
+            if isinstance(graph_engine, unsupported_backends):
                 raise SearchTypeNotSupported(
                     "Cypher search is not supported with the Postgres graph backend. "
                     "Use a Cypher-capable graph backend (Neo4j, Ladybug) for raw Cypher queries."

--- a/cognee/modules/retrieval/natural_language_retriever.py
+++ b/cognee/modules/retrieval/natural_language_retriever.py
@@ -108,10 +108,18 @@ class NaturalLanguageRetriever(BaseRetriever):
         graph_engine = await get_graph_engine()
 
         # Postgres backends do not support Cypher generation/execution
-        from cognee.infrastructure.databases.graph.postgres.adapter import PostgresAdapter
-        from cognee.infrastructure.databases.hybrid.postgres.adapter import PostgresHybridAdapter
+        # The postgres driver is optional; without it the engine cannot be Postgres.
+        try:
+            from cognee.infrastructure.databases.graph.postgres.adapter import PostgresAdapter
+            from cognee.infrastructure.databases.hybrid.postgres.adapter import (
+                PostgresHybridAdapter,
+            )
 
-        if isinstance(graph_engine, (PostgresAdapter, PostgresHybridAdapter)):
+            unsupported_backends: tuple = (PostgresAdapter, PostgresHybridAdapter)
+        except ImportError:
+            unsupported_backends = ()
+
+        if isinstance(graph_engine, unsupported_backends):
             raise SearchTypeNotSupported(
                 "Natural language search is not supported with the Postgres graph backend. "
                 "This retriever generates and executes Cypher queries, which require a "

--- a/cognee/tests/unit/modules/retrieval/cypher_search_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/cypher_search_retriever_test.py
@@ -1,0 +1,62 @@
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.modules.retrieval.cypher_search_retriever import CypherSearchRetriever
+from cognee.modules.retrieval.natural_language_retriever import NaturalLanguageRetriever
+
+POSTGRES_ADAPTER_MODULES = [
+    "cognee.infrastructure.databases.graph.postgres.adapter",
+    "cognee.infrastructure.databases.hybrid.postgres.adapter",
+]
+
+
+@pytest.fixture
+def missing_postgres_driver(monkeypatch):
+    """Force the Postgres adapter imports to fail, as on installs without the postgres extra."""
+    for module_name in POSTGRES_ADAPTER_MODULES:
+        monkeypatch.setitem(sys.modules, module_name, None)
+
+
+@pytest.mark.asyncio
+async def test_cypher_search_executes_without_postgres_driver(missing_postgres_driver):
+    """The query must still run when the optional Postgres driver is not installed."""
+    mock_engine = AsyncMock()
+    mock_engine.is_empty = AsyncMock(return_value=False)
+    mock_engine.query = AsyncMock(return_value=[(10,)])
+
+    retriever = CypherSearchRetriever()
+
+    with patch(
+        "cognee.modules.retrieval.cypher_search_retriever.get_graph_engine",
+        return_value=mock_engine,
+    ):
+        result = await retriever.get_retrieved_objects("MATCH (n) RETURN count(n)")
+
+    assert result == [(10,)]
+    mock_engine.query.assert_awaited_once_with("MATCH (n) RETURN count(n)")
+
+
+@pytest.mark.asyncio
+async def test_natural_language_search_executes_without_postgres_driver(missing_postgres_driver):
+    """The backend check must not require the optional Postgres driver."""
+    mock_engine = AsyncMock()
+    mock_engine.is_empty = AsyncMock(return_value=False)
+
+    retriever = NaturalLanguageRetriever()
+
+    with (
+        patch(
+            "cognee.modules.retrieval.natural_language_retriever.get_graph_engine",
+            return_value=mock_engine,
+        ),
+        patch.object(
+            NaturalLanguageRetriever,
+            "_execute_cypher_query",
+            AsyncMock(return_value=[("node_count", 10)]),
+        ),
+    ):
+        result = await retriever.get_retrieved_objects("How many nodes are there?")
+
+    assert result == [("node_count", 10)]


### PR DESCRIPTION

<img width="2201" height="915" alt="Screenshot 2026-07-19 025235" src="https://github.com/user-attachments/assets/7bed3c98-b6de-4ae2-821d-ecc403822eb5" />
<img width="2203" height="1064" alt="Screenshot 2026-07-19 025018" src="https://github.com/user-attachments/assets/65783969-bfe2-407e-8b6a-3059ea2013ac" />
<!-- .github/pull_request_template.md -->

## Description
Fixes #4123 

## Problem
On installs without the `postgres` extra, `SearchType.CYPHER` fails with a generic
`CypherSearchError` and `SearchType.NATURAL_LANGUAGE` propagates a raw
`ModuleNotFoundError`. Both retrievers import the Postgres adapters to reject
unsupported backends, and the adapter module imports `asyncpg` at import time,
so the backend check itself crashes when the optional driver is absent.

## Fix
Wrap the adapter imports in `try/except ImportError` and skip the check when the
driver is missing. This is safe by construction: without the driver the engine
factory could never have produced a Postgres adapter. Behaviour for Postgres
users is unchanged; they still get the clear `SearchTypeNotSupported` message.

The codebase already uses this pattern for the same reason in
`cognee/modules/migrations/versions/postgres_graph_provenance_columns.py`
(`_is_postgres_graph`). If preferred, I am happy to extract a shared helper for
all three sites in a follow-up.

## Tests
`cognee/tests/unit/modules/retrieval/cypher_search_retriever_test.py` simulates
the missing driver via `sys.modules`, so it exercises the failure on any CI
machine, including those with the postgres extra installed. Both tests fail
against the unfixed code and pass with the fix. Full retrieval unit suite: 346
passed. Verified end to end on Kuzu: the repro from the issue returns query rows.

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):


## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
