### PR TITLE
fix(cli): reject dry runs in API dispatch mode

### DIFF
--- a/cognee/cli/api_dispatch.py
+++ b/cognee/cli/api_dispatch.py
@@ -38,6 +38,12 @@ def dispatch(args: argparse.Namespace) -> None:
     command = args.command
     user_id = getattr(args, "user_id", None)
 
+    if getattr(args, "dry_run", False):
+        raise RuntimeError(
+            "--dry-run is not supported in --api-url mode. "
+            "Run without --api-url to estimate locally without remote side effects."
+        )
+
     # Build optional auth header so the server can identify the caller.
     headers: dict[str, str] = {}
     if user_id:

--- a/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
@@ -23,6 +23,28 @@ class TestCanDispatch:
 
 
 class TestDispatchRouting:
+    @pytest.mark.parametrize("command", ["cognify", "remember"])
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_dry_run_rejected_before_remote_request(self, MockClient, command):
+        args = argparse.Namespace(
+            api_url="http://localhost:8000",
+            command=command,
+            user_id=None,
+            dry_run=True,
+            data=["test"],
+            dataset_name="ds",
+            datasets=None,
+            background=False,
+            chunker="TextChunker",
+            chunk_size=None,
+            chunks_per_batch=None,
+        )
+
+        with pytest.raises(RuntimeError, match="--dry-run is not supported in --api-url mode"):
+            dispatch(args)
+
+        MockClient.assert_not_called()
+
     @patch("cognee.cli.api_dispatch.CogneeApiClient")
     def test_unsupported_command_raises(self, MockClient):
         mock_instance = MagicMock()


### PR DESCRIPTION
## Description

Prevent `remember --dry-run` and `cognify --dry-run` from silently executing ordinary remote operations when `--api-url` is supplied.

The API dispatch path bypassed the local command implementations that honor `dry_run` and ignored the flag. The centralized guard now rejects this unsupported combination before constructing `CogneeApiClient`, ensuring that no health check or operation request occurs.

Closes #4125

## Changes

- Reject `--dry-run` in API dispatch mode with actionable guidance to run locally.
- Add parameterized regression coverage for both `remember` and `cognify`.
- Assert that the remote client is never constructed.
- Preserve ordinary API-mode and server behavior.

## Red/Green Evidence

Before the production fix:

- 2 regression cases failed because no `RuntimeError` was raised.
- Captured output showed normal remote cognify and remember execution.

After the fix:

- Focused API-dispatch tests: 11 passed.
- Complete CLI unit suite: 122 passed.

## Validation

- `uv run pytest cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py -q`
- `uv run pytest cognee/tests/cli_tests/cli_unit_tests -q`
- `uv run ruff check cognee/cli/api_dispatch.py cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py`
- `uv run ruff format --check cognee/cli/api_dispatch.py cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py`
- `uv run ty check cognee/cli/api_dispatch.py cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py`
- `git diff --check`

## Scope

Two files changed, 28 insertions.

No API endpoint, dependency, lockfile, database, or unrelated behavior changes.

## DCO

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.