### PR TITLE
feat(vector): forward connection details to registry vector adapters

### DIFF
--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -238,11 +238,19 @@ def _create_vector_engine(
     if vector_db_provider in supported_databases:
         adapter = supported_databases[vector_db_provider]
 
+        # Forward the connection details the wrapper already accepts so registered
+        # community adapters can reach a store on a non-default host/port or one that
+        # needs credentials. Adapters that don't need them accept **kwargs and ignore
+        # the extras, so this stays backwards-compatible.
         return adapter(
             url=vector_db_url,
             api_key=vector_db_key,
             embedding_engine=embedding_engine,
             database_name=vector_db_name,
+            vector_db_host=vector_db_host,
+            vector_db_port=vector_db_port,
+            vector_db_username=vector_db_username,
+            vector_db_password=vector_db_password,
         )
 
     if vector_db_provider.lower() == "pgvector":

--- a/cognee/tests/unit/test_create_vector_engine_forwarding.py
+++ b/cognee/tests/unit/test_create_vector_engine_forwarding.py
@@ -1,0 +1,44 @@
+"""Unit test: create_vector_engine forwards connection params to registry adapters.
+
+A registered community vector adapter previously received only url/api_key/
+embedding_engine/database_name, so an adapter for a store on a non-default host/port
+or one needing credentials could not get them. This verifies the connection fields the
+wrapper already accepts are forwarded to the registry adapter constructor.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import cognee.infrastructure.databases.vector.create_vector_engine as cve
+from cognee.infrastructure.databases.vector.use_vector_adapter import use_vector_adapter
+
+
+def test_registry_adapter_receives_connection_params():
+    captured = {}
+
+    class _CapturingAdapter:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    use_vector_adapter("fake_conn_test_provider", _CapturingAdapter)
+
+    with patch.object(cve, "get_embedding_engine", return_value=MagicMock()):
+        cve._create_vector_engine(
+            vector_db_provider="fake_conn_test_provider",
+            vector_db_url="vec-host",
+            vector_db_name="vec-db",
+            vector_db_port="6399",
+            vector_db_key="vec-key",
+            vector_dataset_database_handler="",
+            vector_db_username="vec-user",
+            vector_db_password="vec-pass",
+            vector_db_host="vec-host-2",
+            vector_db_subprocess_enabled=True,
+        )
+
+    assert captured["url"] == "vec-host"
+    assert captured["api_key"] == "vec-key"
+    assert captured["database_name"] == "vec-db"
+    assert captured["vector_db_host"] == "vec-host-2"
+    assert captured["vector_db_port"] == "6399"
+    assert captured["vector_db_username"] == "vec-user"
+    assert captured["vector_db_password"] == "vec-pass"


### PR DESCRIPTION
## Description

While wiring a community FalkorDB hybrid adapter to a self-hosted FalkorDB on a non-default port protected with `requirepass`, I found the vector engine drops the connection details for registered (community) adapters. In `_create_vector_engine`, the registry branch forwards only `url`, `api_key`, `embedding_engine`, and `database_name` to the adapter constructor — but never `vector_db_host` / `vector_db_port` / `vector_db_username` / `vector_db_password`, even though `create_vector_engine` already accepts them (they are used only inside the hardcoded `pgvector` branch).

So any registered vector adapter that talks to a store on a non-default host/port, or one that needs credentials, cannot receive them and can only connect to a default host/port with no auth. This change forwards those four fields to the registry adapter constructor. Adapters that don't use them accept `**kwargs` and ignore the extras, so existing adapters behave exactly as before.

## Acceptance Criteria

- A registered vector adapter receives `vector_db_host` / `vector_db_port` / `vector_db_username` / `vector_db_password` from `create_vector_engine`.
- Existing adapters (which ignore the extra kwargs via `**kwargs`) are unaffected — backwards-compatible.
- Proof: a new unit test registers a capturing adapter and asserts the forwarded kwargs.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Local unit test run (`cognee/tests/unit/test_create_vector_engine_forwarding.py`):

```
cognee/tests/unit/test_create_vector_engine_forwarding.py::test_registry_adapter_receives_connection_params PASSED
======================== 1 passed, 10 warnings in 0.01s ========================
```

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines (ruff format + check clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
