### PR TITLE
docs: fix Rust install command (`cargo add cognee` → `cognee-lib`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Prefer something other than Python? Cognee also ships official clients for Rust 
 Use the [cognee-rs](https://github.com/topoteretes/cognee-rs) crate to add, cognify, and search from Rust.
 
 ```bash
-cargo add cognee
+cargo add cognee-lib
 ```
 
 See the [cognee-rs repository](https://github.com/topoteretes/cognee-rs) for full setup and examples.


### PR DESCRIPTION
## What

Fixes the "Getting Started with Rust" snippet in the README.

```diff
-cargo add cognee
+cargo add cognee-lib
```

## Why

The crate name `cognee` **does not exist** on crates.io, so `cargo add cognee` fails:

```
crate `cognee` does not exist
```

The published umbrella crate for the Rust client is [`cognee-lib`](https://crates.io/crates/cognee-lib) (currently `v0.1.3`). This was reported by a community member who hit the error following the README.

## Also checked

- The TypeScript client references (`@cognee/cognee-ts`, lines 78/391/394/397) — verified present on npm (`v0.1.3`); **no change needed**.
- The `cognee-rs` repository links — resolve correctly; no change needed.

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)