### PR TITLE
Add cache adapter contract tests

### DIFF
--- a/cognee/infrastructure/databases/cache/cache_db_interface.py
+++ b/cognee/infrastructure/databases/cache/cache_db_interface.py
@@ -102,6 +102,10 @@ class CacheDBInterface(ABC):
     ) -> list[SessionQAEntry]:
         """
         Retrieve the most recent Q/A/context triplets for a session.
+
+        Implementations must return entries in chronological order, return an
+        empty list when no entries exist, and return an empty list when
+        last_n <= 0. They must never return None.
         """
         pass
 
@@ -112,7 +116,8 @@ class CacheDBInterface(ABC):
     @abstractmethod
     async def get_all_qa_entries(self, user_id: str, session_id: str) -> list[SessionQAEntry]:
         """
-        Retrieve all Q/A/context triplets for the given session.
+        Retrieve all Q/A/context triplets for the given session in chronological
+        order. Implementations must return an empty list when no entries exist.
         """
         pass
 
@@ -230,7 +235,10 @@ class CacheDBInterface(ABC):
         self, user_id: str, session_id: str, last_n: int | None = None
     ) -> list[SessionAgentTraceEntry]:
         """
-        Retrieve agent trace steps for the given session.
+        Retrieve agent trace steps for the given session in chronological order.
+
+        Implementations must return an empty list when no entries exist and when
+        last_n <= 0. They must never return None.
         """
         pass
 
@@ -239,7 +247,9 @@ class CacheDBInterface(ABC):
         self, user_id: str, session_id: str, last_n: int | None = None
     ) -> list[str]:
         """
-        Retrieve per-step feedback strings for the given trace session.
+        Retrieve per-step feedback strings for the given trace session in
+        chronological order. Implementations must return an empty list when no
+        entries exist and when last_n <= 0.
         """
         pass
 

--- a/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
@@ -239,6 +239,9 @@ class FSCacheAdapter(CacheDBInterface):
         self, user_id: str, session_id: str, last_n: int = 5
     ) -> list[SessionQAEntry]:
         """Return the most recent QA entries stored for the given session."""
+        if last_n <= 0:
+            return []
+
         session_key = self._session_key(user_id, session_id)
         entries = [SessionQAEntry(**entry) for entry in self._load_entries(session_key)]
         if not entries:
@@ -454,6 +457,8 @@ class FSCacheAdapter(CacheDBInterface):
         trace_key = self._agent_trace_key(user_id, session_id)
         entries = [SessionAgentTraceEntry(**entry) for entry in self._load_entries(trace_key)]
         if last_n is not None:
+            if last_n <= 0:
+                return []
             return entries[-last_n:]
         return entries
 

--- a/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
+++ b/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
@@ -328,10 +328,13 @@ class RedisAdapter(CacheDBInterface):
         """
         Retrieve the most recent Q/A/context triplet(s) for the given session.
         """
+        if last_n <= 0:
+            return []
+
         session_key = self._session_key(user_id, session_id)
         if last_n == 1:
             data = await self.async_redis.lindex(session_key, -1)
-            return [SessionQAEntry.model_validate_json(data)] if data else None
+            return [SessionQAEntry.model_validate_json(data)] if data else []
         data = await self.async_redis.lrange(session_key, -last_n, -1)
         return [SessionQAEntry.model_validate_json(d) for d in data] if data else []
 
@@ -574,6 +577,8 @@ class RedisAdapter(CacheDBInterface):
         """Retrieve stored trace steps for the given session."""
         trace_key = self._agent_trace_key(user_id, session_id)
         if last_n is not None:
+            if last_n <= 0:
+                return []
             return [
                 SessionAgentTraceEntry(**entry)
                 for entry in await self._load_entries(trace_key, -last_n, -1)

--- a/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
@@ -492,6 +492,9 @@ class SqlCacheAdapter(CacheDBInterface):
         self, user_id: str, session_id: str, last_n: int = 5
     ) -> List[SessionQAEntry]:
         """Return the most recent QA entries (chronological); [] when none, for all last_n."""
+        if last_n <= 0:
+            return []
+
         await self._ensure_initialized()
         try:
             async with self.sessionmaker() as session:
@@ -754,6 +757,9 @@ class SqlCacheAdapter(CacheDBInterface):
         self, user_id: str, session_id: str, last_n: Optional[int] = None
     ) -> List[SessionAgentTraceEntry]:
         """Retrieve stored trace steps for the given session (reads don't refresh TTL)."""
+        if last_n is not None and last_n <= 0:
+            return []
+
         await self._ensure_initialized()
         try:
             async with self.sessionmaker() as session:

--- a/cognee/tests/unit/infrastructure/databases/cache/test_cache_adapter_contract.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_cache_adapter_contract.py
@@ -1,0 +1,181 @@
+"""Shared contract tests for concrete CacheDBInterface adapters."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+
+class _InMemoryRedisList:
+    """Minimal async Redis list emulation for adapter contract tests."""
+
+    def __init__(self):
+        self.data: dict[str, list[str]] = {}
+        self.ttls: dict[str, int] = {}
+
+    async def rpush(self, key: str, *values: str):
+        self.data.setdefault(key, []).extend(values)
+
+    async def lrange(self, key: str, start: int, end: int):
+        values = self.data.get(key, [])
+        start_index = start if start >= 0 else max(len(values) + start, 0)
+        end_index = len(values) if end == -1 else end + 1
+        return values[start_index:end_index]
+
+    async def lindex(self, key: str, index: int):
+        values = self.data.get(key, [])
+        return values[index] if -len(values) <= index < len(values) else None
+
+    async def llen(self, key: str):
+        return len(self.data.get(key, []))
+
+    async def lset(self, key: str, index: int, value: str):
+        self.data[key][index] = value
+
+    async def delete(self, key: str):
+        self.ttls.pop(key, None)
+        return 1 if self.data.pop(key, None) is not None else 0
+
+    async def expire(self, key: str, ttl: int):
+        self.ttls[key] = ttl
+
+    async def ttl(self, key: str):
+        if key not in self.data:
+            return -2
+        return self.ttls.get(key, -1)
+
+
+@pytest_asyncio.fixture(params=["fs", "sql", "redis"])
+async def cache_adapter(request, tmp_path):
+    """Yield each cache adapter behind the same CacheDBInterface surface."""
+    if request.param == "fs":
+        with patch(
+            "cognee.infrastructure.databases.cache.fscache.FsCacheAdapter.get_storage_config",
+            return_value={"data_root_directory": str(tmp_path / "fs")},
+        ):
+            from cognee.infrastructure.databases.cache.fscache.FsCacheAdapter import (
+                FSCacheAdapter,
+            )
+
+            adapter = FSCacheAdapter()
+            yield adapter
+            adapter.cache.close()
+        return
+
+    if request.param == "sql":
+        from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import SqlCacheAdapter
+
+        adapter = SqlCacheAdapter(f"sqlite+aiosqlite:///{Path(tmp_path) / 'cache.db'}")
+        yield adapter
+        await adapter.close()
+        return
+
+    redis_store = _InMemoryRedisList()
+    patch_module = "cognee.infrastructure.databases.cache.redis.RedisAdapter"
+    with (
+        patch(f"{patch_module}.redis.Redis", return_value=MagicMock(ping=MagicMock())),
+        patch(f"{patch_module}.aioredis.Redis", return_value=redis_store),
+    ):
+        from cognee.infrastructure.databases.cache.redis.RedisAdapter import RedisAdapter
+
+        yield RedisAdapter(host="localhost", port=6379)
+
+
+@pytest.mark.asyncio
+async def test_qa_collection_methods_return_empty_lists_for_empty_sessions(cache_adapter):
+    assert await cache_adapter.get_latest_qa_entries("user", "missing", last_n=0) == []
+    assert await cache_adapter.get_latest_qa_entries("user", "missing", last_n=1) == []
+    assert await cache_adapter.get_latest_qa_entries("user", "missing", last_n=5) == []
+    assert await cache_adapter.get_all_qa_entries("user", "missing") == []
+    assert await cache_adapter.get_qa_entries_by_ids("user", "missing", ["qa-1"]) == []
+    assert await cache_adapter.get_qa_entries_by_ids("user", "missing", []) == []
+
+
+@pytest.mark.asyncio
+async def test_latest_qa_entries_respect_last_n_edges_and_chronological_order(cache_adapter):
+    for index in range(1, 4):
+        await cache_adapter.create_qa_entry(
+            "user",
+            "session",
+            f"Question {index}",
+            f"Context {index}",
+            f"Answer {index}",
+            qa_id=f"qa-{index}",
+        )
+
+    latest_zero = await cache_adapter.get_latest_qa_entries("user", "session", last_n=0)
+    latest_one = await cache_adapter.get_latest_qa_entries("user", "session", last_n=1)
+    latest_many = await cache_adapter.get_latest_qa_entries("user", "session", last_n=5)
+    all_entries = await cache_adapter.get_all_qa_entries("user", "session")
+
+    assert latest_zero == []
+    assert [entry.qa_id for entry in latest_one] == ["qa-3"]
+    assert [entry.qa_id for entry in latest_many] == ["qa-1", "qa-2", "qa-3"]
+    assert [entry.qa_id for entry in all_entries] == ["qa-1", "qa-2", "qa-3"]
+
+
+@pytest.mark.asyncio
+async def test_qa_entries_by_ids_returns_empty_or_chronological_matches(cache_adapter):
+    for index in range(1, 4):
+        await cache_adapter.create_qa_entry(
+            "user",
+            "session",
+            f"Question {index}",
+            f"Context {index}",
+            f"Answer {index}",
+            qa_id=f"qa-{index}",
+        )
+
+    assert await cache_adapter.get_qa_entries_by_ids("user", "session", []) == []
+
+    matches = await cache_adapter.get_qa_entries_by_ids(
+        "user", "session", ["qa-3", "missing", "qa-1"]
+    )
+    assert [entry.qa_id for entry in matches] == ["qa-1", "qa-3"]
+
+
+@pytest.mark.asyncio
+async def test_agent_trace_collections_share_empty_and_last_n_contract(cache_adapter):
+    assert await cache_adapter.get_agent_trace_session("user", "missing") == []
+    assert await cache_adapter.get_agent_trace_session("user", "missing", last_n=1) == []
+    assert await cache_adapter.get_agent_trace_feedback("user", "missing") == []
+
+    for index in range(1, 4):
+        await cache_adapter.append_agent_trace_step(
+            "user",
+            "trace-session",
+            trace_id=f"trace-{index}",
+            origin_function="contract_test",
+            status="success",
+            session_feedback=f"feedback-{index}",
+        )
+
+    latest_zero = await cache_adapter.get_agent_trace_session(
+        "user", "trace-session", last_n=0
+    )
+    latest_one = await cache_adapter.get_agent_trace_session("user", "trace-session", last_n=1)
+    latest_many = await cache_adapter.get_agent_trace_session("user", "trace-session", last_n=5)
+    feedback_one = await cache_adapter.get_agent_trace_feedback(
+        "user", "trace-session", last_n=1
+    )
+
+    assert latest_zero == []
+    assert [entry.trace_id for entry in latest_one] == ["trace-3"]
+    assert [entry.trace_id for entry in latest_many] == ["trace-1", "trace-2", "trace-3"]
+    assert feedback_one == ["feedback-3"]
+
+
+@pytest.mark.asyncio
+async def test_session_context_collection_returns_empty_or_chronological_entries(cache_adapter):
+    assert await cache_adapter.get_session_context_entries("user", "missing") == []
+
+    await cache_adapter.create_session_context_entry(
+        "user", "context-session", {"id": "ctx-1", "kind": "context", "text": "first"}
+    )
+    await cache_adapter.create_session_context_entry(
+        "user", "context-session", {"id": "ctx-2", "kind": "feedback", "text": "second"}
+    )
+
+    entries = await cache_adapter.get_session_context_entries("user", "context-session")
+    assert [entry["id"] for entry in entries] == ["ctx-1", "ctx-2"]


### PR DESCRIPTION
## Description
Fixes #4129.

This adds a shared CacheDBInterface contract test suite across the FS, SQL, and Redis adapters. The contract covers empty-session reads, last_n edge cases, chronological ordering, QA id filtering, trace feedback, and session context reads.

While adding the contract coverage, I aligned adapter behavior on the edge cases it exposes:
- last_n <= 0 now returns [] for latest QA and trace-session reads.
- Redis get_latest_qa_entries(..., last_n=1) now returns [] for a missing session instead of None.

## Acceptance Criteria
- Added adapter-parametrized contract coverage for fs, sql, and redis cache backends.
- Verified missing sessions return empty lists instead of None.
- Verified last_n=0, last_n=1, and over-sized last_n behavior.
- Verified returned QA, trace, feedback, and session context entries stay in chronological order.

Tests run:
- /private/tmp/cognee-contract-venv/bin/python -m pytest --confcutdir=cognee/tests/unit/infrastructure/databases/cache cognee/tests/unit/infrastructure/databases/cache/test_cache_adapter_contract.py
- /private/tmp/cognee-contract-venv/bin/python -m pytest --confcutdir=cognee/tests/unit/infrastructure/databases/cache cognee/tests/unit/infrastructure/databases/cache/test_fs_adapter_crud.py cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
N/A - local pytest commands above passed: 15 contract tests and 105 existing cache CRUD tests.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and relevant existing cache tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
