### PR TITLE
Replace utcnow with timezone-aware UTC

### DIFF
--- a/cognee/eval_framework/beam/eval/run_sweep.py
+++ b/cognee/eval_framework/beam/eval/run_sweep.py
@@ -48,7 +48,7 @@ BEAM_SUPPORTED_SPLITS = ("100K", "500K", "1M", "10M")
 
 
 def print_step(message: str) -> None:
-    print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}", flush=True)
+    print(f"[{datetime.now(timezone.utc).strftime('%H:%M:%S')}] {message}", flush=True)
 
 
 def configure_quiet_logging() -> None:

--- a/cognee/eval_framework/beam/local_ingest.py
+++ b/cognee/eval_framework/beam/local_ingest.py
@@ -109,11 +109,11 @@ def utc_now() -> str:
 
 
 def timestamp() -> str:
-    return datetime.now().strftime("%Y%m%d_%H%M%S")
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
 
 
 def print_step(message: str) -> None:
-    print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}", flush=True)
+    print(f"[{datetime.now(timezone.utc).strftime('%H:%M:%S')}] {message}", flush=True)
 
 
 def configure_quiet_logging() -> None:

--- a/cognee/eval_framework/beam/preprocessing/preprocess.py
+++ b/cognee/eval_framework/beam/preprocessing/preprocess.py
@@ -59,7 +59,7 @@ def utc_now() -> str:
 
 
 def timestamp() -> str:
-    return datetime.now().strftime("%Y%m%d_%H%M%S")
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
 
 
 def parse_csv(value: str | None) -> list[str] | None:

--- a/cognee/eval_framework/modal_run_eval.py
+++ b/cognee/eval_framework/modal_run_eval.py
@@ -60,7 +60,7 @@ async def modal_run_eval(eval_params=None):
 
     version_name = "baseline"
     benchmark_name = os.environ.get("BENCHMARK", eval_params.get("benchmark", "benchmark"))
-    timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
     answers_filename = (
         f"{version_name}_{benchmark_name}_{timestamp}_{eval_params.get('answers_path')}"

--- a/cognee/get_token.py
+++ b/cognee/get_token.py
@@ -10,7 +10,7 @@ def create_jwt(user_id: str, tenant_id: str, roles: list[str]):
         "user_id": user_id,
         "tenant_id": tenant_id,
         "roles": roles,
-        "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1),  # 1 hour expiry
+        "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),
     }
     return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 

--- a/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/fscache/FsCacheAdapter.py
@@ -1,7 +1,7 @@
 import json
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import diskcache as dc
 from pydantic import ValidationError
@@ -66,7 +66,7 @@ class FSCacheAdapter(CacheDBInterface):
     ) -> dict:
         """Serialize one QA entry into the normalized cache payload shape."""
         entry = SessionQAEntry(
-            time=datetime.utcnow().isoformat(),
+            time=datetime.now(timezone.utc).isoformat(),
             question=question,
             context=context,
             answer=answer,

--- a/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
+++ b/cognee/infrastructure/databases/cache/redis/RedisAdapter.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 
 import redis
 import redis.asyncio as aioredis
@@ -119,7 +119,7 @@ class RedisAdapter(CacheDBInterface):
     ) -> dict:
         """Serialize one QA entry into the normalized Redis payload shape."""
         entry = SessionQAEntry(
-            time=datetime.utcnow().isoformat(),
+            time=datetime.now(timezone.utc).isoformat(),
             question=question,
             context=context,
             answer=answer,

--- a/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
@@ -283,7 +283,7 @@ class SqlCacheAdapter(CacheDBInterface):
     ) -> dict:
         """Serialize one QA entry into the normalized cache payload shape."""
         entry = SessionQAEntry(
-            time=datetime.utcnow().isoformat(),
+            time=datetime.now(timezone.utc).isoformat(),
             question=question,
             context=context,
             answer=answer,

--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -1,7 +1,7 @@
 import os
 import asyncio
 from typing import Any, Dict, List, Optional, Type
-from datetime import datetime
+from datetime import datetime, timezone
 
 from operator import itemgetter
 from cognee.base_config import get_base_config
@@ -93,7 +93,7 @@ class TemporalRetriever(GraphCompletionRetriever):
         else:
             base_directory = None
 
-        time_now = datetime.now().strftime("%d-%m-%Y")
+        time_now = datetime.now(timezone.utc).strftime("%d-%m-%Y")
 
         system_prompt = render_prompt(
             prompt_path, {"time_now": time_now}, base_directory=base_directory

--- a/cognee/modules/session_distillation/distill.py
+++ b/cognee/modules/session_distillation/distill.py
@@ -13,7 +13,7 @@ work, never the whole run.
 
 import asyncio
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Union
 from uuid import UUID
 
@@ -365,7 +365,7 @@ async def publish_distilled_lessons(
     scope: SessionDistillationScope,
     accepted: List[WrittenLesson],
 ) -> List[str]:
-    distilled_on = datetime.utcnow().strftime("%Y-%m-%d")
+    distilled_on = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     documents = [
         render_lesson_document(lesson, session_id=scope.session_id, distilled_on=distilled_on)
         for lesson in accepted

--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 import traceback
 from collections.abc import MutableMapping
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -183,7 +183,7 @@ class PlainFileHandler(logging.handlers.RotatingFileHandler):
                 logger_name = record.msg.get("logger", record.name)
 
                 # Format timestamp
-                timestamp = datetime.now().strftime(get_timestamp_format())
+                timestamp = datetime.now(timezone.utc).strftime(get_timestamp_format())
 
                 # Create the log entry
                 log_entry = f"{timestamp} [{record.levelname.ljust(8)}] {message}{context_str} [{logger_name}]\n"
@@ -529,7 +529,7 @@ def setup_logging(log_level=None, name=None) -> bool:
         log_file_path = os.environ.get("LOG_FILE_NAME")
         if not log_file_path and logs_dir is not None:
             # Create a new log file name with the cognee start time
-            start_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            start_time = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
             log_file_path = str((logs_dir / f"{start_time}.log").resolve())
             os.environ["LOG_FILE_NAME"] = log_file_path
 
@@ -631,7 +631,7 @@ def get_timestamp_format() -> str:
     try:
         # We call datetime.now() here to test if microseconds are supported.
         # If they are not supported a ValueError will be raised
-        datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f")
+        datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")
         return "%Y-%m-%dT%H:%M:%S.%f"
     except Exception as e:
         logger.debug(f"Exception caught: {e}")
@@ -639,6 +639,6 @@ def get_timestamp_format() -> str:
             "Could not use microseconds for the logging timestamp, defaulting to use hours minutes and seconds only"
         )
         # We call datetime.now() here to test if won't break.
-        datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
         # We return the timestamp format without microseconds as they are not supported
         return "%Y-%m-%dT%H:%M:%S"

--- a/cognee/tasks/web_scraper/web_scraper_task.py
+++ b/cognee/tasks/web_scraper/web_scraper_task.py
@@ -7,7 +7,7 @@ scheduled scraping tasks and ensures that node updates preserve existing graph e
 
 import os
 import hashlib
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Union, List
 from urllib.parse import urlparse
 from uuid import uuid5, NAMESPACE_OID, NAMESPACE_URL
@@ -75,7 +75,7 @@ async def cron_web_scraper_task(
         ValueError: If the schedule is an invalid cron expression.
         ImportError: If APScheduler is not installed.
     """
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     job_name = job_name or f"scrape_{now.strftime('%Y%m%d_%H%M%S')}"
     if schedule:
         try:
@@ -106,7 +106,7 @@ async def cron_web_scraper_task(
         return
 
     # If no schedule, run immediately
-    logger.info(f"[{datetime.now()}] Running web scraper task immediately...")
+    logger.info(f"[{datetime.now(timezone.utc)}] Running web scraper task immediately...")
     return await web_scraper_task(
         url=url,
         schedule=schedule,
@@ -163,7 +163,7 @@ async def web_scraper_task(
     soup_crawler_config, tavily_config, preferred_tool = check_arguments(
         tavily_api_key, extraction_rules, tavily_config, soup_crawler_config
     )
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     job_name = job_name or f"scrape_{now.strftime('%Y%m%d_%H%M%S')}"
     provenance_kwargs = await graph_provenance_write_kwargs(
         graph_db,

--- a/cognee/tests/performance/batch_add_cognify_test.py
+++ b/cognee/tests/performance/batch_add_cognify_test.py
@@ -19,7 +19,7 @@ import time
 import uuid
 import urllib.error
 import urllib.request
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
@@ -116,7 +116,7 @@ def wait_for_server(url: str, timeout: float = 240.0) -> None:
 
 
 def log(msg: str) -> None:
-    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     print(f"[{ts}] {msg}", flush=True)
 
 

--- a/cognee/tests/performance/locust_performance_analysis.py
+++ b/cognee/tests/performance/locust_performance_analysis.py
@@ -28,7 +28,7 @@ import random
 import uuid
 
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from locust import HttpUser, SequentialTaskSet, between, events, tag, task
 
 API_KEY = os.environ.get("COGNEE_API_KEY", "")
@@ -360,7 +360,7 @@ if __name__ == "__main__":
         wait_for_server(f"{base_url}/health")
         env = {**os.environ, "COGNEE_API_KEY": api_key}
         # Timestamped results to avoid overwriting previous runs and for easier identification of test runs.
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         timestamp = now.strftime("%Y%m%d_%H%M%S")
         # Results will be saved in the `results` directory with a unique name based on the timestamp of the test run.
         result_folder = Path("results")

--- a/cognee/tests/performance/statistics_percentile_report.py
+++ b/cognee/tests/performance/statistics_percentile_report.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -143,7 +143,7 @@ def print_report(stats: dict, num_runs: int, config: dict, runs: list[dict]):
 
 
 def generate_html(stats: dict, num_runs: int, config: dict, runs: list[dict], path: Path):
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     pct_keys = ["min", "p50", "p75", "p90", "p95", "p99", "max", "mean"]
 
     # Build table rows

--- a/cognee/tests/test_release_multi_user_e2e.py
+++ b/cognee/tests/test_release_multi_user_e2e.py
@@ -38,7 +38,7 @@ import time
 import urllib.error
 import urllib.request
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import httpx
 
@@ -68,7 +68,7 @@ ALL_SENTINELS: dict[int, set[str]] = {index: set() for index in range(NUM_USERS)
 
 
 def log(message: str) -> None:
-    timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+    timestamp = datetime.now(timezone.utc).strftime("%H:%M:%S.%f")[:-3]
     print(f"[{timestamp}] {message}", flush=True)
 
 

--- a/cognee/tests/unit/api/v1/session/test_session_memory_flows.py
+++ b/cognee/tests/unit/api/v1/session/test_session_memory_flows.py
@@ -1,7 +1,7 @@
 import asyncio
 import importlib
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -433,13 +433,13 @@ class TestSearchSession:
 
         entries = [
             SessionQAEntry(
-                time=datetime.utcnow().isoformat(),
+                time=datetime.now(timezone.utc).isoformat(),
                 question="What is a paragraph?",
                 context="",
                 answer="A block of text.",
             ),
             SessionQAEntry(
-                time=datetime.utcnow().isoformat(),
+                time=datetime.now(timezone.utc).isoformat(),
                 question="What is a graph?",
                 context="",
                 answer="Nodes and edges.",
@@ -472,13 +472,13 @@ class TestSearchSession:
 
         entries = [
             SessionQAEntry(
-                time=datetime.utcnow().isoformat(),
+                time=datetime.now(timezone.utc).isoformat(),
                 question="Tell me about cats",
                 context="",
                 answer="Cats are animals.",
             ),
             SessionQAEntry(
-                time=datetime.utcnow().isoformat(),
+                time=datetime.now(timezone.utc).isoformat(),
                 question="Tell me about cats and dogs",
                 context="",
                 answer="Both are pets.",
@@ -512,7 +512,7 @@ class TestSearchSession:
 
         entries = [
             SessionQAEntry(
-                time=datetime.utcnow().isoformat(),
+                time=datetime.now(timezone.utc).isoformat(),
                 question="What is Einstein?",
                 context="",
                 answer="A physicist.",
@@ -567,7 +567,7 @@ class TestSearchSession:
 
         entries = [
             SessionQAEntry(
-                time=datetime.utcnow().isoformat(),
+                time=datetime.now(timezone.utc).isoformat(),
                 question="I have a cat",
                 context="",
                 answer="Nice.",
@@ -615,7 +615,7 @@ class TestRecallSessionMode:
 
         session_entries = [
             ResponseQAEntry(
-                time=datetime.utcnow().isoformat(),
+                time=datetime.now(timezone.utc).isoformat(),
                 question="test",
                 context="",
                 answer="result",
@@ -788,7 +788,7 @@ class TestRecallSessionMode:
 
         session_entries = [
             ResponseQAEntry(
-                time=datetime.utcnow().isoformat(),
+                time=datetime.now(timezone.utc).isoformat(),
                 question="test",
                 context="",
                 answer="session result",

--- a/cognee/tests/unit/infrastructure/session/test_session_context_builder.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_context_builder.py
@@ -5,7 +5,7 @@ run anywhere. They verify ranker ordering, budget capping, candidate validation/
 fail-open contract.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -28,7 +28,7 @@ def _entry(section, content, **kwargs):
         section=section,
         content=content,
         normalized_content=normalize_content(content),
-        created_at=kwargs.pop("created_at", datetime.utcnow().isoformat()),
+        created_at=kwargs.pop("created_at", datetime.now(timezone.utc).isoformat()),
         **kwargs,
     )
 

--- a/cognee/tests/unit/infrastructure/session/test_session_embeddings.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_embeddings.py
@@ -1,7 +1,7 @@
 """Unit tests for session QA vector recall and active-context helpers."""
 
 import importlib
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -47,7 +47,7 @@ def _entry(section, content, **kwargs):
         section=section,
         content=content,
         normalized_content=normalize_content(content),
-        created_at=kwargs.pop("created_at", datetime.utcnow().isoformat()),
+        created_at=kwargs.pop("created_at", datetime.now(timezone.utc).isoformat()),
         **kwargs,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
+extend-select = ["DTZ003", "DTZ005"]
 ignore = ["F401"]
 
 [tool.ty.src]


### PR DESCRIPTION
Fixes #4128

## Summary
- Enable ruff DTZ003 and DTZ005 checks to prevent naive UTC datetime regressions.
- Replace existing utcnow() usages and newly flagged naive datetime.now() calls with timezone-aware UTC datetimes.
- Update affected tests and fixtures to use timezone-aware timestamps.

## Tests
- /private/tmp/cognee-contract-venv/bin/python -m ruff check . --output-format concise
- /private/tmp/cognee-contract-venv/bin/python -m ruff check . --select DTZ003,DTZ005 --output-format concise
- /private/tmp/cognee-contract-venv/bin/python -m pytest cognee/tests/unit/infrastructure/session/test_session_context_builder.py cognee/tests/unit/infrastructure/session/test_session_embeddings.py cognee/tests/unit/api/v1/session/test_session_memory_flows.py -q
- /private/tmp/cognee-contract-venv/bin/python -m pytest --confcutdir=cognee/tests/unit/infrastructure/databases/cache cognee/tests/unit/infrastructure/databases/cache/test_fs_adapter_crud.py cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py cognee/tests/unit/infrastructure/databases/cache/test_redis_adapter_crud.py -q
- /private/tmp/cognee-contract-venv/bin/python -m py_compile changed Python files
- git diff --check