### PR TITLE
Normalize retrieval IDs for scoring and deduplication

### DIFF
--- a/cognee/modules/retrieval/temporal_retriever.py
+++ b/cognee/modules/retrieval/temporal_retriever.py
@@ -9,6 +9,7 @@ from cognee.infrastructure.databases.unified import get_unified_engine
 from cognee.infrastructure.llm.prompts import render_prompt
 from cognee.infrastructure.llm import LLMGateway
 from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
+from cognee.modules.retrieval.utils.ids import normalize_id
 from cognee.modules.retrieval.utils.used_graph_elements import extract_from_temporal_dict
 from cognee.shared.logging_utils import get_logger
 
@@ -108,11 +109,11 @@ class TemporalRetriever(GraphCompletionRetriever):
 
     async def filter_top_k_events(self, relevant_events, scored_results):
         # Build a score lookup from vector search results
-        score_lookup = {res.id: res.score for res in scored_results}
+        score_lookup = {normalize_id(res.id): res.score for res in scored_results}
 
         events_with_scores = []
         for event in relevant_events[0]["events"]:
-            score = score_lookup.get(event["id"], float("inf"))
+            score = score_lookup.get(normalize_id(event["id"]), float("inf"))
             events_with_scores.append({**event, "score": score})
 
         events_with_scores.sort(key=itemgetter("score"))

--- a/cognee/modules/retrieval/utils/ids.py
+++ b/cognee/modules/retrieval/utils/ids.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
+
+
+def normalize_id(value: Any) -> str:
+    """Return a stable string key for graph/vector identifiers."""
+    if value is None:
+        return ""
+    return str(value)
+
+
+def triplet_key(edge: Edge) -> tuple[str, str, bool, str]:
+    """Return a value-based key for a retrieved graph triplet."""
+    attributes = getattr(edge, "attributes", {})
+    if not isinstance(attributes, dict):
+        attributes = {}
+
+    node1 = getattr(edge, "node1", None)
+    node2 = getattr(edge, "node2", None)
+    source_id = normalize_id(getattr(node1, "id", None))
+    target_id = normalize_id(getattr(node2, "id", None))
+    if not source_id and not target_id and not attributes:
+        return ("", "", bool(getattr(edge, "directed", True)), repr(edge))
+
+    relationship_key = (
+        attributes.get("edge_object_id")
+        or attributes.get("edge_type_id")
+        or attributes.get("relationship_name")
+        or ""
+    )
+    return (
+        source_id,
+        target_id,
+        bool(getattr(edge, "directed", True)),
+        normalize_id(relationship_key),
+    )

--- a/cognee/modules/retrieval/utils/query_decomposition.py
+++ b/cognee/modules/retrieval/utils/query_decomposition.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
+from cognee.modules.retrieval.utils.ids import triplet_key
 
 
 class DecompositionMode(str, Enum):
@@ -60,13 +61,13 @@ def normalize_subqueries(original_query: str, subqueries: Optional[List[str]]) -
 
 
 def merge_deduplicated_edges(edge_batches: List[List[Edge]]) -> List[Edge]:
-    """Merge edge batches using identity-based deduplication."""
+    """Merge edge batches using value-based triplet deduplication."""
 
     merged_edges: List[Edge] = []
-    seen_ids: set[int] = set()
+    seen_ids: set[tuple[str, str, bool, str]] = set()
     for edge_batch in edge_batches:
         for edge in edge_batch:
-            edge_id = id(edge)
+            edge_id = triplet_key(edge)
             if edge_id in seen_ids:
                 continue
             merged_edges.append(edge)

--- a/cognee/modules/retrieval/utils/query_state.py
+++ b/cognee/modules/retrieval/utils/query_state.py
@@ -1,5 +1,6 @@
 from typing import List
 from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge
+from cognee.modules.retrieval.utils.ids import triplet_key
 
 
 class QueryState:
@@ -12,12 +13,13 @@ class QueryState:
         self.done = False
 
     def merge_triplets(self, new_triplets: List[Edge]):
-        """Merge new triplets with existing ones, deduplicating by identity."""
-        seen_ids = {id(t) for t in self.triplets}
+        """Merge new triplets with existing ones, deduplicating by triplet value."""
+        seen_ids = {triplet_key(t) for t in self.triplets}
         for t in new_triplets:
-            if id(t) not in seen_ids:
+            key = triplet_key(t)
+            if key not in seen_ids:
                 self.triplets.append(t)
-                seen_ids.add(id(t))
+                seen_ids.add(key)
 
     def check_convergence(self, prev_size: int):
         """Mark done if no new triplets were added."""

--- a/cognee/tests/unit/modules/retrieval/graph_completion_decomposition_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/graph_completion_decomposition_retriever_test.py
@@ -11,6 +11,7 @@ from cognee.modules.retrieval.utils.query_decomposition import (
     DecompositionRunState,
     QueryDecomposition,
     SubqueryRunState,
+    merge_deduplicated_edges,
     normalize_subqueries,
 )
 
@@ -86,6 +87,16 @@ def test_normalize_subqueries_strips_caps_and_falls_back():
         ["", "   "],
     )
     assert fallback == ["Original query"]
+
+
+def test_merge_deduplicated_edges_deduplicates_fresh_logically_equal_edges():
+    first = _make_edge(edge_object_id="edge-1", source_id="a", target_id="b")
+    duplicate = _make_edge(edge_object_id="edge-1", source_id="a", target_id="b")
+    distinct = _make_edge(edge_object_id="edge-2", source_id="a", target_id="b")
+
+    merged = merge_deduplicated_edges([[first], [duplicate, distinct]])
+
+    assert merged == [first, distinct]
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
+++ b/cognee/tests/unit/modules/retrieval/temporal_retriever_test.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from uuid import UUID
 import pytest
 import os
 from unittest.mock import AsyncMock, patch, MagicMock
@@ -76,6 +77,24 @@ async def test_filter_top_k_events_sorts_and_limits():
     assert all("score" in e for e in top)
     assert top[0]["score"] == 0.10
     assert top[1]["score"] == 0.20
+
+
+@pytest.mark.asyncio
+async def test_filter_top_k_events_matches_uuid_scores_to_string_event_ids():
+    tr = TemporalRetriever(top_k=2)
+    event_id = UUID("12345678-1234-5678-1234-567812345678")
+    other_id = UUID("87654321-4321-6789-4321-678943216789")
+
+    relevant_events = [{"events": [{"id": str(event_id)}, {"id": str(other_id)}]}]
+    scored_results = [
+        SimpleNamespace(id=other_id, score=0.30),
+        SimpleNamespace(id=event_id, score=0.05),
+    ]
+
+    top = await tr.filter_top_k_events(relevant_events, scored_results)
+
+    assert [e["id"] for e in top] == [str(event_id), str(other_id)]
+    assert [e["score"] for e in top] == [0.05, 0.30]
 
 
 # Test filter_top_k_events handles unknown ids as infinite scores

--- a/cognee/tests/unit/modules/retrieval/utils/test_query_state.py
+++ b/cognee/tests/unit/modules/retrieval/utils/test_query_state.py
@@ -1,0 +1,29 @@
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+from cognee.modules.retrieval.utils.query_state import QueryState
+
+
+def _edge(relationship_name: str = "likes") -> Edge:
+    return Edge(
+        Node("node-a", {"name": "A"}),
+        Node("node-b", {"name": "B"}),
+        attributes={"relationship_name": relationship_name},
+    )
+
+
+def test_merge_triplets_deduplicates_fresh_logically_equal_edges():
+    state = QueryState(triplets=[_edge()])
+    prev_size = len(state.triplets)
+
+    state.merge_triplets([_edge()])
+    state.check_convergence(prev_size)
+
+    assert len(state.triplets) == 1
+    assert state.done is True
+
+
+def test_merge_triplets_keeps_distinct_relationships_between_same_nodes():
+    state = QueryState(triplets=[_edge("likes")])
+
+    state.merge_triplets([_edge("knows")])
+
+    assert len(state.triplets) == 2


### PR DESCRIPTION
Fixes #4130

## Summary
- Add retrieval ID helpers for canonical graph/vector ID keys and value-based triplet keys.
- Use canonical IDs when Temporal search maps vector scores back to graph events, fixing UUID-vs-string score misses.
- Replace identity-based triplet deduplication in QueryState and query decomposition merges with value-based triplet keys.

## Audit summary
- cognee/modules/retrieval/temporal_retriever.py: fixed score_lookup writes and event reads to use normalize_id().
- cognee/modules/retrieval/utils/query_state.py: fixed context-extension and CoT triplet merging to use triplet_key().
- cognee/modules/retrieval/utils/query_decomposition.py: fixed decomposed-retrieval edge merging to use triplet_key().
- Searched cognee/modules/retrieval and cognee/modules/graph for Python id() calls after the change; no remaining identity-based dedup call sites were found.

## Tests
- /private/tmp/cognee-contract-venv/bin/python -m pytest cognee/tests/unit/modules/retrieval/temporal_retriever_test.py::test_filter_top_k_events_sorts_and_limits cognee/tests/unit/modules/retrieval/temporal_retriever_test.py::test_filter_top_k_events_matches_uuid_scores_to_string_event_ids cognee/tests/unit/modules/retrieval/temporal_retriever_test.py::test_filter_top_k_events_includes_unknown_as_infinite_but_not_in_top_k cognee/tests/unit/modules/retrieval/utils/test_query_state.py cognee/tests/unit/modules/retrieval/graph_completion_decomposition_retriever_test.py::test_merge_deduplicated_edges_deduplicates_fresh_logically_equal_edges -q
- /private/tmp/cognee-contract-venv/bin/python -m pytest cognee/tests/unit/modules/retrieval/graph_completion_retriever_context_extension_test.py::test_get_completion_context_extension_stops_early cognee/tests/unit/modules/retrieval/graph_completion_retriever_context_extension_test.py::test_get_completion_batch_queries_context_extension_stops_early -q
- /private/tmp/cognee-contract-venv/bin/python -m pytest cognee/tests/unit/modules/retrieval/graph_completion_decomposition_retriever_test.py -q
- /private/tmp/cognee-contract-venv/bin/python -m ruff check cognee/modules/retrieval/utils/ids.py cognee/modules/retrieval/temporal_retriever.py cognee/modules/retrieval/utils/query_state.py cognee/modules/retrieval/utils/query_decomposition.py cognee/tests/unit/modules/retrieval/temporal_retriever_test.py cognee/tests/unit/modules/retrieval/utils/test_query_state.py cognee/tests/unit/modules/retrieval/graph_completion_decomposition_retriever_test.py --output-format concise
- /private/tmp/cognee-contract-venv/bin/python -m py_compile changed Python files
- git diff --check

Note: I also tried running all of cognee/tests/unit/modules/retrieval/temporal_retriever_test.py locally; one existing test reaches the LLM gateway and fails in this environment because no LLM API key is configured.