### PR TITLE
CLO-287 fix(postgres-graph): scope graph reads by dataset to stop cross-dataset recall

### DIFF
--- a/cognee/infrastructure/databases/graph/postgres/adapter.py
+++ b/cognee/infrastructure/databases/graph/postgres/adapter.py
@@ -183,6 +183,24 @@ class PostgresAdapter(GraphDBInterface):
             data.update(props)
         return data
 
+    @staticmethod
+    def _active_dataset_id() -> Optional[str]:
+        """The dataset the current request is scoped to, or None when unscoped.
+
+        Under access control ``set_database_global_context_variables`` sets
+        ``current_dataset_id`` to the dataset being served. On this backend every
+        dataset shares the ``graph_node`` / ``graph_edge`` tables and is
+        distinguished only by the ``source_dataset_ids`` array column, so reads
+        must filter by that id — otherwise they return rows from other datasets
+        in the same tenant (cross-dataset leak). Returns None in single-user mode
+        (no context set), leaving queries unscoped exactly as before.
+        """
+        # Imported lazily to avoid a circular import at module load.
+        from cognee.context_global_variables import current_dataset_id
+
+        dataset_id = current_dataset_id.get()
+        return str(dataset_id) if dataset_id else None
+
     async def query(self, query_str: str, params: Optional[dict] = None) -> List[Any]:
         """Not supported. Use typed adapter methods or a Cypher-capable graph backend.
 
@@ -358,11 +376,14 @@ class PostgresAdapter(GraphDBInterface):
         """
         if not node_ids:
             return []
+        params: Dict[str, Any] = {"ids": node_ids}
+        sql = "SELECT id, name, type, properties FROM graph_node WHERE id = ANY(:ids)"
+        dataset_id = self._active_dataset_id()
+        if dataset_id is not None:
+            sql += " AND :dataset_id = ANY(source_dataset_ids)"
+            params["dataset_id"] = dataset_id
         async with self._session() as session:
-            result = await session.execute(
-                text("SELECT id, name, type, properties FROM graph_node WHERE id = ANY(:ids)"),
-                {"ids": node_ids},
-            )
+            result = await session.execute(text(sql), params)
             return [self._parse_node_row(row) for row in result.fetchall()]
 
     async def add_edge(
@@ -666,14 +687,20 @@ class PostgresAdapter(GraphDBInterface):
             return [], []
         ids = [str(i) for i in target_ids]
 
+        dataset_id = self._active_dataset_id()
+        dataset_filter = " AND :dataset_id = ANY(source_dataset_ids)" if dataset_id else ""
+
         async with self._session() as session:
+            edge_params: Dict[str, Any] = {"ids": ids}
+            if dataset_id:
+                edge_params["dataset_id"] = dataset_id
             edge_result = await session.execute(
-                text("""
+                text(f"""
                     SELECT source_id, target_id, relationship_name, properties
                     FROM graph_edge
-                    WHERE source_id = ANY(:ids) OR target_id = ANY(:ids)
+                    WHERE (source_id = ANY(:ids) OR target_id = ANY(:ids)){dataset_filter}
                 """),
-                {"ids": ids},
+                edge_params,
             )
             edges = []
             endpoint_ids = set()
@@ -687,9 +714,15 @@ class PostgresAdapter(GraphDBInterface):
             if not endpoint_ids:
                 return [], []
 
+            node_params: Dict[str, Any] = {"ids": list(endpoint_ids)}
+            if dataset_id:
+                node_params["dataset_id"] = dataset_id
             node_result = await session.execute(
-                text("SELECT id, name, type, properties FROM graph_node WHERE id = ANY(:ids)"),
-                {"ids": list(endpoint_ids)},
+                text(
+                    "SELECT id, name, type, properties FROM graph_node "
+                    f"WHERE id = ANY(:ids){dataset_filter}"
+                ),
+                node_params,
             )
             nodes = []
             for row in node_result.fetchall():


### PR DESCRIPTION
Fixes [CLO-287](https://linear.app/cognee/issue/CLO-287).

## Problem (reproduced live on cloud)

On the Postgres graph backend (cloud v2), a recall/search **scoped to one dataset returns another dataset's data**. Reproduced against a live tenant with two same-owner datasets, `homer` (Iliad) and `war-and-peace` (Tolstoy):

- `datasets=["homer"]`, ask about Pierre Bezukhov/Natasha → returned full **War & Peace** content ❌
- `datasets=["war-and-peace"]`, ask about Achilles/Odysseus (GRAPH_COMPLETION) → returned full **Iliad** content ❌

Controls pass (each dataset answers its own content). The response's `dataset_name` is the requested dataset, but the graph rows came from the other one.

## Root cause

On this backend all datasets share the `graph_node` / `graph_edge` tables and are distinguished only by the `source_dataset_ids` array column (`graph/postgres/tables.py`). The write path tags rows with it, but the **retrieval methods never filter by it** and never read `current_dataset_id` — so reads span every dataset in the tenant. (Local Kuzu/LanceDB use separate physical DB files per dataset, so they don't leak — which is why this is cloud-only.)

## Fix

- Add `PostgresAdapter._active_dataset_id()` — returns the dataset the request is scoped to (`current_dataset_id`, set per-dataset by `set_database_global_context_variables` under access control), or `None` when unset.
- Apply a `:dataset_id = ANY(source_dataset_ids)` predicate on the **graph-projection read path** used by search: `get_nodes` and `get_id_filtered_graph_data` (both the edge and node queries).
- **No-op when no dataset context is set** (single-user mode / access control disabled), so behavior on Kuzu/LanceDB and single-tenant deployments is unchanged.

## Scope of this PR / follow-ups (same issue)

This fixes the **default GRAPH_COMPLETION projection path** — the reproduced leak. Two follow-ups belong to CLO-287 and are intentionally **not** in this PR so each can be verified against Postgres:
1. **pgvector seed** — `RAG_COMPLETION` leaked too; the pgvector search needs the same `source_dataset_ids` filter.
2. **Remaining graph read methods** — `get_edges`, `get_neighbors`, `get_connections`, `get_graph_data`, `get_nodeset_subgraph`, `get_filtered_graph_data` should get the same predicate (joined queries need the filter qualified per node alias).

## Verification (reviewer — needs a Postgres backend)

I could not run this against Postgres locally (no `asyncpg`/Postgres in my env); it passes `ruff` + syntax. Please verify by re-running the cross-dataset queries against a Postgres-backed build / dev tenant:

```
POST /api/v1/search/  {"query":"Who are Pierre Bezukhov and Natasha?","searchType":"GRAPH_COMPLETION","datasets":["homer"]}
# expect: no War & Peace content
```

Note: assumes `current_dataset_id` (str of dataset UUID) matches the values stored in `source_dataset_ids`; worth confirming during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)