### PR TITLE
fix(ingestion): derive basename from Windows paths in classify() [SDK-235]

### DIFF
--- a/cognee/modules/ingestion/classify.py
+++ b/cognee/modules/ingestion/classify.py
@@ -14,7 +14,11 @@ def classify(
         return TextData(data)
 
     if isinstance(data, BufferedReader) or isinstance(data, SpooledTemporaryFile):
-        return BinaryData(data, filename if filename else str(data.name).split("/")[-1])
+        # Normalize Windows ("\") and POSIX ("/") separators before taking the
+        # basename; on Windows `data.name` is a backslash path, so splitting on
+        # "/" alone would keep the full path as the file name.
+        derived_name = str(data.name).replace("\\", "/").split("/")[-1]
+        return BinaryData(data, filename if filename else derived_name)
 
     try:
         from s3fs import S3File

--- a/cognee/tests/unit/modules/ingestion/test_classify_basename.py
+++ b/cognee/tests/unit/modules/ingestion/test_classify_basename.py
@@ -1,0 +1,56 @@
+"""Regression test for filename derivation in ``classify``.
+
+``classify`` derived the ``BinaryData`` name with ``str(data.name).split("/")[-1]``.
+On Windows, an opened file's ``.name`` is a backslash path (e.g.
+``C:\\audio\\clip.mp3``) with no forward slashes, so the split kept the *entire
+path* as the name instead of the basename.
+
+The fix normalizes both ``\\`` and ``/`` before taking the basename (matching the
+Mistral transcription fix and ``_normalize_filename``). This test is
+cross-platform strict: the Windows-style ``.name`` contains backslashes
+regardless of host, so a revert to splitting on ``/`` only fails on any OS.
+"""
+
+import io
+
+from cognee.modules.ingestion.classify import classify
+
+
+class _NamedRaw(io.RawIOBase):
+    """A minimal raw stream exposing a controllable ``.name`` (proxied by
+    ``BufferedReader.name``), so the test can force a Windows-style path on any
+    host without touching the real filesystem."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, b) -> int:
+        return 0
+
+
+def _reader(name: str) -> io.BufferedReader:
+    return io.BufferedReader(_NamedRaw(name))
+
+
+def test_windows_path_name_becomes_basename():
+    result = classify(_reader(r"C:\Users\me\audio\clip.mp3"))
+    assert result.name == "clip.mp3"
+
+
+def test_posix_path_name_becomes_basename():
+    result = classify(_reader("/home/me/audio/clip.mp3"))
+    assert result.name == "clip.mp3"
+
+
+def test_explicit_filename_takes_precedence():
+    # When a filename is passed explicitly, it is used verbatim and the
+    # backslash path in ``.name`` is ignored.
+    result = classify(_reader(r"C:\ignored\path.mp3"), filename="explicit.wav")
+    assert result.name == "explicit.wav"


### PR DESCRIPTION
## What

Follow-up to #3588 (Windows basename fix for Mistral transcription, gh #3587).

While reviewing #3588 I found the **same separator bug still live** in `classify()` — the exact function the original issue believed was "already fixed". `classify()` derived the `BinaryData` name with:

```python
str(data.name).split("/")[-1]
```

On Windows, an opened file's `.name` is a backslash path (e.g. `C:\Users\me\audio\clip.mp3`) with no forward slashes, so the split kept the **entire path** as the `BinaryData` name instead of the basename `clip.mp3`.

## Fix

```diff
-        return BinaryData(data, filename if filename else str(data.name).split("/")[-1])
+        derived_name = str(data.name).replace("\\", "/").split("/")[-1]
+        return BinaryData(data, filename if filename else derived_name)
```

Normalizes both `\` and `/` before taking the basename — identical to the `_normalize_filename` helper in `cognee/tasks/ingestion/utils.py` and the Mistral fix in #3588. Deliberately not `os.path.basename`, which is platform-dependent (on Linux it does not split backslashes).

A repo-wide grep confirmed this was the only other genuine instance of this class of bug (the `.split("/")` uses in `measure.py` and `RDFLibOntologyResolver.py` are model-id / URI splits where `/` is the correct separator).

## Testing

Adds `cognee/tests/unit/modules/ingestion/test_classify_basename.py`:

- Windows-style `.name` (`C:\Users\me\audio\clip.mp3`) → name == `clip.mp3`
- POSIX-style `.name` (`/home/me/audio/clip.mp3`) → name == `clip.mp3`
- Explicit `filename` arg takes precedence (backslash `.name` ignored)

The test builds a `BufferedReader` over a minimal raw stream whose `.name` returns a Windows-style path regardless of host, so a revert to splitting on `/` only fails on any OS. Verified locally: 3 pass with the fix; reverting fails the Windows case on macOS.

Relates to #3587. Follow-up to #3588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)