### PR TITLE
fix(exceptions): call super().__init__ in CogneeError subclasses [SDK-240]

### DIFF
--- a/.github/workflows/community_tests.yml
+++ b/.github/workflows/community_tests.yml
@@ -109,6 +109,7 @@ jobs:
             cognee/tests/unit/infrastructure/test_rate_limiting_retry.py \
             cognee/tests/unit/tasks/storage/test_add_data_points.py \
             cognee/tests/unit/shared/ \
+            cognee/tests/unit/exceptions/ \
             -v --tb=short
 
   cli-unit-tests:

--- a/cognee/infrastructure/databases/exceptions/exceptions.py
+++ b/cognee/infrastructure/databases/exceptions/exceptions.py
@@ -60,10 +60,11 @@ class EntityNotFoundError(CogneeValidationError):
         name: str = "EntityNotFoundError",
         status_code=status.HTTP_404_NOT_FOUND,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
-        # super().__init__(message, name, status_code) :TODO: This is not an error anymore with the dynamic exception handling therefore we shouldn't log error
+        # log=False: this is raised in routine control flow (caught in user
+        # resolution, migrations, pruning, graph projection, etc.), so logging
+        # every occurrence at ERROR would be noise. super() still populates
+        # Exception.args and preserves chaining.
+        super().__init__(message, name, status_code, log=False)
 
 
 class EntityAlreadyExistsError(CogneeValidationError):
@@ -98,9 +99,9 @@ class NodesetFilterNotSupportedError(CogneeConfigurationError):
         name: str = "NodeSetFilterNotSupportedError",
         status_code=status.HTTP_404_NOT_FOUND,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
+        # log=False: a missing nodeset filter is a capability difference between
+        # backends, not an application error worth logging on every raise.
+        super().__init__(message, name, status_code, log=False)
 
 
 class EmbeddingException(CogneeConfigurationError):

--- a/cognee/modules/pipelines/exceptions/tasks.py
+++ b/cognee/modules/pipelines/exceptions/tasks.py
@@ -13,6 +13,4 @@ class WrongTaskTypeError(CogneeValidationError):
         name: str = "WrongTaskTypeError",
         status_code=status.HTTP_400_BAD_REQUEST,
     ):
-        self.message = message
-        self.name = name
-        self.status_code = status_code
+        super().__init__(message, name, status_code)

--- a/cognee/tests/unit/exceptions/test_cognee_error_contract.py
+++ b/cognee/tests/unit/exceptions/test_cognee_error_contract.py
@@ -78,19 +78,34 @@ def _parse(path: Path) -> ast.Module:
     return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
 
 
+def _base_names(class_node: ast.ClassDef) -> set:
+    """Names of a class's bases, covering both ``Base`` and ``module.Base`` forms."""
+    names = set()
+    for base in class_node.bases:
+        if isinstance(base, ast.Name):
+            names.add(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.add(base.attr)
+    return names
+
+
 def _family_classes_in_repo():
-    """Statically discover every class in the family and where it is defined.
+    """Statically discover the family and where each class is defined.
 
     Resolution is by base-class *name* and iterated to a fixpoint, so multi-level
     subclasses (a class extending an intermediate subclass defined elsewhere) are
-    picked up too — no imports required.
+    picked up too — no imports required. Both ``Base`` and dotted ``module.Base``
+    references are recognised.
+
+    Returns ``(classes, family_names)`` where ``classes`` is a list of
+    ``(path, ClassDef)`` and ``family_names`` is the resolved set of every class
+    name in the hierarchy (used to validate base ``__init__`` calls precisely).
     """
-    # (module_path, ClassDef, {base names})
-    definitions = []
+    definitions = []  # (module_path, ClassDef, {base names})
     for path in _iter_source_files():
         for node in ast.walk(_parse(path)):
             if isinstance(node, ast.ClassDef):
-                base_names = {b.id for b in node.bases if isinstance(b, ast.Name)}
+                base_names = _base_names(node)
                 if base_names:
                     definitions.append((path, node, base_names))
 
@@ -103,14 +118,21 @@ def _family_classes_in_repo():
                 family_names.add(node.name)
                 changed = True
 
-    return [(path, node) for path, node, base_names in definitions if (base_names & family_names)]
+    classes = [
+        (path, node) for path, node, base_names in definitions if (base_names & family_names)
+    ]
+    return classes, family_names
 
 
-def _defines_init_without_base_call(class_node: ast.ClassDef) -> bool:
-    """True if the class overrides ``__init__`` but never calls a base ``__init__``.
+def _defines_init_without_base_call(class_node: ast.ClassDef, family_names: set) -> bool:
+    """True if the class overrides ``__init__`` but never calls a *family* base ``__init__``.
 
-    Accepts both ``super().__init__(...)`` and an explicit ``Base.__init__(self, ...)``.
-    A class that does not override ``__init__`` at all inherits the base and is fine.
+    A call only counts when its target is ``super()`` or a class in the Cognee error
+    hierarchy (``FamilyBase.__init__`` / ``module.FamilyBase.__init__``). Calling an
+    unrelated ``__init__`` — e.g. the grandparent ``Exception.__init__`` or a mixin's —
+    does NOT satisfy the contract, because it skips ``CogneeApiError.__init__`` (centralized
+    logging + status defaults). A class that does not override ``__init__`` inherits the
+    base and is fine.
     """
     init = next(
         (n for n in class_node.body if isinstance(n, ast.FunctionDef) and n.name == "__init__"),
@@ -119,18 +141,31 @@ def _defines_init_without_base_call(class_node: ast.ClassDef) -> bool:
     if init is None:
         return False
     for node in ast.walk(init):
-        if (
+        if not (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "__init__"
         ):
+            continue
+        target = node.func.value
+        # super().__init__(...)
+        if (
+            isinstance(target, ast.Call)
+            and isinstance(target.func, ast.Name)
+            and target.func.id == "super"
+        ):
+            return False
+        # FamilyBase.__init__(self, ...) or module.FamilyBase.__init__(self, ...)
+        if isinstance(target, ast.Name) and target.id in family_names:
+            return False
+        if isinstance(target, ast.Attribute) and target.attr in family_names:
             return False
     return True
 
 
 def test_no_cognee_error_subclass_bypasses_base_init():
-    """Static guard: no error subclass may skip its base ``__init__``."""
-    family = _family_classes_in_repo()
+    """Static guard: no error subclass may skip its ``CogneeApiError`` base ``__init__``."""
+    family, family_names = _family_classes_in_repo()
     # Sanity: the sweep actually found the hierarchy (guards against a silently
     # empty match, e.g. if discovery ever breaks).
     assert len(family) > 20, f"Only found {len(family)} family classes; discovery likely broke."
@@ -138,7 +173,7 @@ def test_no_cognee_error_subclass_bypasses_base_init():
     offenders = [
         f"{path.relative_to(PACKAGE_ROOT.parent)}:{node.lineno} {node.name}"
         for path, node in family
-        if _defines_init_without_base_call(node)
+        if _defines_init_without_base_call(node, family_names)
     ]
     assert not offenders, "CogneeError subclasses missing super().__init__():\n" + "\n".join(
         offenders
@@ -147,7 +182,8 @@ def test_no_cognee_error_subclass_bypasses_base_init():
 
 def _import_family_modules():
     """Import every module that defines a family class, tolerating optional extras."""
-    module_paths = {path for path, _node in _family_classes_in_repo()}
+    classes, _family_names = _family_classes_in_repo()
+    module_paths = {path for path, _node in classes}
     for path in module_paths:
         try:
             importlib.import_module(_module_name(path))
@@ -198,8 +234,13 @@ def test_cognee_error_subclasses_preserve_args_and_chaining():
     for cls in classes:
         exc = cls(**_build_kwargs(cls))
 
-        # super().__init__ ran -> Exception.args is populated.
-        assert exc.args, f"{cls.__name__}.args is empty; super().__init__ was not called."
+        # CogneeApiError.__init__ ran -> it forwards (message, name) to
+        # Exception.__init__, so args must be exactly that pair. An empty args
+        # (the original #3749 bug) or a differently-shaped args both fail here.
+        assert exc.args == (exc.message, exc.name), (
+            f"{cls.__name__}.args must be (message, name) from CogneeApiError.__init__; "
+            f"got {exc.args!r}."
+        )
         assert str(exc), f"{cls.__name__} has an empty str()."
         assert getattr(exc, "message", None), f"{cls.__name__} did not set .message."
 

--- a/cognee/tests/unit/exceptions/test_cognee_error_contract.py
+++ b/cognee/tests/unit/exceptions/test_cognee_error_contract.py
@@ -1,0 +1,210 @@
+"""Contract tests for the ``CogneeApiError`` exception hierarchy.
+
+Regression guard for https://github.com/topoteretes/cognee/issues/3749, where
+``EntityNotFoundError`` and ``NodesetFilterNotSupportedError`` (and, with the
+same root cause, ``WrongTaskTypeError``) overrode ``__init__`` but never called
+``super().__init__()``. That left ``Exception.args`` empty, breaking ``repr``,
+exception chaining, and centralized logging.
+
+Two complementary checks keep the whole bug class from returning:
+
+* ``test_no_cognee_error_subclass_bypasses_base_init`` — a **static** AST sweep
+  of every ``.py`` file in the package. It needs no imports, so it also covers
+  subclasses that live outside ``*/exceptions/`` packages or inside modules that
+  require optional extras (e.g. ``code_graph``, ``web_scraper``, ``neptune``).
+* ``test_cognee_error_subclasses_preserve_args_and_chaining`` — a **runtime**
+  check that instantiates every importable subclass and verifies the observable
+  contract (``args`` populated, ``str`` non-empty, ``__cause__`` preserved).
+"""
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+import pytest
+
+import cognee
+from cognee.exceptions import CogneeApiError
+
+
+# Root classes of the Cognee error hierarchy. Any class that (transitively)
+# subclasses one of these must run a base ``__init__``.
+FAMILY_ROOTS = {
+    "CogneeApiError",
+    "CogneeSystemError",
+    "CogneeValidationError",
+    "CogneeConfigurationError",
+    "CogneeTransientError",
+}
+
+PACKAGE_ROOT = Path(cognee.__file__).parent
+
+# Representative values for constructor arguments that have no default, so we can
+# instantiate every subclass regardless of its signature. A raw KeyError here is
+# turned into an actionable failure (see ``_build_kwargs``).
+SAMPLE_ARGUMENTS = {
+    "attribute": "sample_attribute",
+    "detail": "sample detail",
+    "dimension": 1,
+    "field": "sample_field",
+    "got": "sample",
+    "max_index": 2,
+    "message": "contract message",
+    "name": "ContractError",
+    "observer": "sample-observer",
+    "provider": "sample-provider",
+    "search_type": "sample-search",
+    "status_code": 400,
+    "value": 1,
+}
+
+
+def _iter_source_files():
+    """Yield every non-test, non-cache ``.py`` file in the ``cognee`` package."""
+    for path in PACKAGE_ROOT.rglob("*.py"):
+        parts = path.relative_to(PACKAGE_ROOT).parts
+        if "__pycache__" in parts or "tests" in parts:
+            continue
+        yield path
+
+
+def _module_name(path: Path) -> str:
+    relative = path.relative_to(PACKAGE_ROOT.parent).with_suffix("")
+    return ".".join(relative.parts)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _family_classes_in_repo():
+    """Statically discover every class in the family and where it is defined.
+
+    Resolution is by base-class *name* and iterated to a fixpoint, so multi-level
+    subclasses (a class extending an intermediate subclass defined elsewhere) are
+    picked up too — no imports required.
+    """
+    # (module_path, ClassDef, {base names})
+    definitions = []
+    for path in _iter_source_files():
+        for node in ast.walk(_parse(path)):
+            if isinstance(node, ast.ClassDef):
+                base_names = {b.id for b in node.bases if isinstance(b, ast.Name)}
+                if base_names:
+                    definitions.append((path, node, base_names))
+
+    family_names = set(FAMILY_ROOTS)
+    changed = True
+    while changed:
+        changed = False
+        for _path, node, base_names in definitions:
+            if node.name not in family_names and (base_names & family_names):
+                family_names.add(node.name)
+                changed = True
+
+    return [(path, node) for path, node, base_names in definitions if (base_names & family_names)]
+
+
+def _defines_init_without_base_call(class_node: ast.ClassDef) -> bool:
+    """True if the class overrides ``__init__`` but never calls a base ``__init__``.
+
+    Accepts both ``super().__init__(...)`` and an explicit ``Base.__init__(self, ...)``.
+    A class that does not override ``__init__`` at all inherits the base and is fine.
+    """
+    init = next(
+        (n for n in class_node.body if isinstance(n, ast.FunctionDef) and n.name == "__init__"),
+        None,
+    )
+    if init is None:
+        return False
+    for node in ast.walk(init):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "__init__"
+        ):
+            return False
+    return True
+
+
+def test_no_cognee_error_subclass_bypasses_base_init():
+    """Static guard: no error subclass may skip its base ``__init__``."""
+    family = _family_classes_in_repo()
+    # Sanity: the sweep actually found the hierarchy (guards against a silently
+    # empty match, e.g. if discovery ever breaks).
+    assert len(family) > 20, f"Only found {len(family)} family classes; discovery likely broke."
+
+    offenders = [
+        f"{path.relative_to(PACKAGE_ROOT.parent)}:{node.lineno} {node.name}"
+        for path, node in family
+        if _defines_init_without_base_call(node)
+    ]
+    assert not offenders, "CogneeError subclasses missing super().__init__():\n" + "\n".join(
+        offenders
+    )
+
+
+def _import_family_modules():
+    """Import every module that defines a family class, tolerating optional extras."""
+    module_paths = {path for path, _node in _family_classes_in_repo()}
+    for path in module_paths:
+        try:
+            importlib.import_module(_module_name(path))
+        except Exception:
+            # Modules behind optional extras (codegraph, scraping, neptune, ...)
+            # may not import in a minimal environment. The static test above
+            # already covers them; here we simply skip what we cannot load.
+            continue
+
+
+def _all_subclasses(root):
+    seen = set()
+    stack = list(root.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        if cls in seen:
+            continue
+        seen.add(cls)
+        stack.extend(cls.__subclasses__())
+    return seen
+
+
+def _build_kwargs(cls):
+    kwargs = {}
+    for name, parameter in inspect.signature(cls).parameters.items():
+        if name == "self" or parameter.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        if parameter.default is inspect.Parameter.empty:
+            if name not in SAMPLE_ARGUMENTS:
+                pytest.fail(
+                    f"{cls.__module__}.{cls.__name__} has required argument '{name}' with no "
+                    f"sample value; add one to SAMPLE_ARGUMENTS in this test."
+                )
+            kwargs[name] = SAMPLE_ARGUMENTS[name]
+    return kwargs
+
+
+def test_cognee_error_subclasses_preserve_args_and_chaining():
+    """Runtime contract for every importable subclass in the hierarchy."""
+    _import_family_modules()
+
+    classes = _all_subclasses(CogneeApiError)
+    assert classes, "No CogneeApiError subclasses discovered at runtime."
+
+    for cls in classes:
+        exc = cls(**_build_kwargs(cls))
+
+        # super().__init__ ran -> Exception.args is populated.
+        assert exc.args, f"{cls.__name__}.args is empty; super().__init__ was not called."
+        assert str(exc), f"{cls.__name__} has an empty str()."
+        assert getattr(exc, "message", None), f"{cls.__name__} did not set .message."
+
+        cause = RuntimeError("root cause")
+        try:
+            raise exc from cause
+        except cls as raised:
+            assert raised.__cause__ is cause, f"{cls.__name__} dropped exception chaining."

--- a/cognee/tests/unit/exceptions/test_cognee_error_contract.py
+++ b/cognee/tests/unit/exceptions/test_cognee_error_contract.py
@@ -28,15 +28,14 @@ import cognee
 from cognee.exceptions import CogneeApiError
 
 
-# Root classes of the Cognee error hierarchy. Any class that (transitively)
-# subclasses one of these must run a base ``__init__``.
-FAMILY_ROOTS = {
-    "CogneeApiError",
-    "CogneeSystemError",
-    "CogneeValidationError",
-    "CogneeConfigurationError",
-    "CogneeTransientError",
-}
+# The single root of the Cognee error hierarchy, read off the class itself so it
+# can never drift from the source. Every other error class is *discovered* from
+# here by name (see ``_family_classes_in_repo``): seeding the fixpoint with just
+# this name re-derives the intermediate roots (CogneeSystemError, …) and all
+# leaves, so nothing about the hierarchy is hard-coded beyond "CogneeApiError is
+# the root". The runtime test additionally asserts this static discovery misses
+# nothing the live ``__subclasses__()`` walk finds.
+ROOT_NAME = CogneeApiError.__name__
 
 PACKAGE_ROOT = Path(cognee.__file__).parent
 
@@ -109,7 +108,7 @@ def _family_classes_in_repo():
                 if base_names:
                     definitions.append((path, node, base_names))
 
-    family_names = set(FAMILY_ROOTS)
+    family_names = {ROOT_NAME}
     changed = True
     while changed:
         changed = False
@@ -230,6 +229,22 @@ def test_cognee_error_subclasses_preserve_args_and_chaining():
 
     classes = _all_subclasses(CogneeApiError)
     assert classes, "No CogneeApiError subclasses discovered at runtime."
+
+    # Consistency: the import-free static discovery must be a superset of what the
+    # live class tree reports (for cognee, non-test classes). If a real subclass
+    # slips past the AST sweep, the static guard is blind to it — fail loudly here
+    # rather than let coverage silently shrink.
+    static_family = _family_classes_in_repo()[1]
+    runtime_names = {
+        cls.__name__
+        for cls in classes
+        if (cls.__module__ or "").startswith("cognee.") and ".tests." not in (cls.__module__ or "")
+    }
+    missed = runtime_names - static_family
+    assert not missed, (
+        f"Static AST discovery missed live CogneeApiError subclasses {sorted(missed)}; "
+        f"the static guard would not check them."
+    )
 
     for cls in classes:
         exc = cls(**_build_kwargs(cls))


### PR DESCRIPTION
## Summary

Fixes GitHub #3749 (Linear **SDK-240**, related to **SDK-217**). Three `CogneeApiError` subclasses overrode `__init__` but never called `super().__init__()`, so `Exception.args` stayed empty `()` — breaking `repr()`, exception chaining, and the centralized logging in `CogneeApiError.__init__`.

An AST sweep of every family subclass in the repo confirms **exactly three** offenders on `dev`:

| Class | File | In #3749? |
|-------|------|-----------|
| `EntityNotFoundError` | `infrastructure/databases/exceptions/exceptions.py` | ✅ named |
| `NodesetFilterNotSupportedError` | `infrastructure/databases/exceptions/exceptions.py` | ✅ named |
| `WrongTaskTypeError` | `modules/pipelines/exceptions/tasks.py` | ❌ same bug, not named in the issue |

## The `log=False` nuance

`EntityNotFoundError` is raised in **routine control flow** and caught in ~10 places (`cli/user_resolution.py`, `migrations/runner.py`, `data/deletion/prune_system.py`, `brute_force_triplet_search.py`, `CogneeGraph` empty-graph/neighborhood cases, `create_authorized_dataset.py`, …). The original `# TODO … we shouldn't log error` comment was intentional. So the two database exceptions pass `super().__init__(..., log=False)` — restoring `args`/chaining **without** flooding logs with ERROR lines for expected conditions (matching the existing `UnsupportedProvenanceCapability` idiom). `WrongTaskTypeError` is a genuine programming error and keeps default logging.

## Regression guard

Adds `cognee/tests/unit/exceptions/test_cognee_error_contract.py` with two complementary checks:

1. **Static AST sweep** of every `.py` in the package — import-free, so it also covers `CogneeApiError` subclasses that live **outside** `*/exceptions/` (e.g. `modules/retrieval/code_retriever.py`, `tasks/web_scraper/ssrf_protection.py`, `tasks/code_graph/*`) and modules behind optional extras.
2. **Runtime contract** — instantiates every importable subclass and asserts `args` is populated, `str()` is non-empty, and `raise … from cause` preserves `__cause__`.

Verified both guards **fail** on the pre-fix code and **pass** after; existing `test_user_resolution.py` still green.

## Credit

Builds on the approach in #4138 by @silasbrookshaha, extending it to the third affected class (`WrongTaskTypeError`) and closing a coverage gap in the original reflection test's importer (subclasses outside `*/exceptions/`). Supersedes the partial fixes in #3750, #3803, #3837 (the latter two drop `log=False`, reintroducing ERROR-log noise for routinely-caught `EntityNotFoundError`).

## Checklist
- [x] Bug fix (non-breaking)
- [x] Tests added; verified they fail on the buggy code
- [x] `ruff format` / `ruff check` clean

I have read the CLA Document and I hereby sign the CLA.