### PR TITLE
feat(frontend): add collapsible sidebar to the web UI

### DIFF
--- a/cognee-frontend/src/ui/layout/Navbar/CustomAppShellNavbar.tsx
+++ b/cognee-frontend/src/ui/layout/Navbar/CustomAppShellNavbar.tsx
@@ -92,6 +92,28 @@ function KeyIcon({ active }: { active: boolean }) {
   );
 }
 
+// Double chevron for the collapse toggle. Points left («) when expanded and
+// rotates to point right (») when collapsed, mirroring the action it performs.
+function CollapseChevron({ collapsed }: { collapsed: boolean }) {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ flexShrink: 0, transform: collapsed ? "rotate(180deg)" : "none", transition: "transform 200ms ease" }}
+      aria-hidden="true"
+    >
+      <path d="M13 17l-5-5 5-5" />
+      <path d="M18 17l-5-5 5-5" />
+    </svg>
+  );
+}
+
 // -- Navigation data --
 
 // Routes that require the tenant pod — dimmed/locked while it provisions.
@@ -144,7 +166,7 @@ const NAV_SECTIONS: NavSection[] = [
 
 export default function CustomAppShellNavbar() {
   const pathname = usePathname();
-  const { isOpen, close } = useNavbar();
+  const { isOpen, close, isCollapsed, toggleCollapsed } = useNavbar();
   const { tenantReady } = useTenant();
   const [feedbackOpen, setFeedbackOpen] = useState(false);
 
@@ -162,10 +184,11 @@ export default function CustomAppShellNavbar() {
         className={`
           flex-shrink-0 flex flex-col
           fixed sm:relative z-40 sm:z-auto h-full sm:h-auto
-          transition-transform sm:translate-x-0
+          w-[240px] ${isCollapsed ? "sm:w-[72px]" : "sm:w-[240px]"}
+          transition-[transform,width] duration-200 ease-in-out sm:translate-x-0
           ${isOpen ? "translate-x-0" : "-translate-x-full sm:translate-x-0"}
         `}
-        style={{ width: 240, maxHeight: "100vh", overflow: "hidden", background: "rgba(0,0,0,0.6)", backdropFilter: "blur(12px)", borderRight: "1px solid rgba(255,255,255,0.08)" }}
+        style={{ maxHeight: "100vh", overflow: "hidden", background: "rgba(0,0,0,0.6)", backdropFilter: "blur(12px)", borderRight: "1px solid rgba(255,255,255,0.08)" }}
       >
         {/* Close button on mobile */}
         <div className="flex sm:hidden justify-end p-2">
@@ -184,7 +207,7 @@ export default function CustomAppShellNavbar() {
           {NAV_SECTIONS.map((section) => (
             <div key={section.label} className="mb-4">
               <div
-                className="px-3 mb-1"
+                className={`px-3 mb-1 whitespace-nowrap ${isCollapsed ? "sm:hidden" : ""}`}
                 style={{
                   fontSize: 11,
                   fontWeight: 700,
@@ -203,12 +226,12 @@ export default function CustomAppShellNavbar() {
                     <div
                       key={item.link}
                       title="Available once your workspace is ready"
-                      className="flex items-center gap-[10px] rounded-[6px] px-3 py-2 text-[14px]"
+                      className={`flex items-center rounded-[6px] px-3 py-2 text-[14px] ${isCollapsed ? "gap-[10px] sm:gap-0 sm:justify-center" : "gap-[10px]"}`}
                       style={{ color: "rgba(237,236,234,0.3)", cursor: "not-allowed", userSelect: "none" }}
                       aria-disabled="true"
                     >
                       {item.icon({ active: false })}
-                      {item.text}
+                      <span className={`whitespace-nowrap ${isCollapsed ? "sm:hidden" : ""}`}>{item.text}</span>
                     </div>
                   );
                 }
@@ -218,6 +241,7 @@ export default function CustomAppShellNavbar() {
                     text={item.text}
                     link={item.link}
                     isActive={isActive}
+                    collapsed={isCollapsed}
                     icon={item.icon({ active: isActive })}
                   />
                 );
@@ -226,10 +250,40 @@ export default function CustomAppShellNavbar() {
           ))}
         </nav>
 
-        {/* Feedback + Billing pinned to the bottom-left of the sidebar */}
+        {/* Collapse toggle + Feedback + Billing pinned to the bottom of the sidebar */}
         <div style={{ padding: 12, borderTop: "1px solid rgba(255,255,255,0.08)", display: "flex", flexDirection: "column", gap: 8 }}>
+          {/* Desktop-only collapse/expand toggle. Mobile uses the drawer close
+              button and the floating hamburger instead. */}
+          <button
+            onClick={toggleCollapsed}
+            aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            aria-expanded={!isCollapsed}
+            title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            className={`hidden sm:flex cursor-pointer items-center ${isCollapsed ? "sm:justify-center" : ""}`}
+            style={{
+              gap: 7,
+              width: "100%",
+              padding: "7px 12px",
+              background: "transparent",
+              border: "none",
+              borderRadius: 8,
+              fontFamily: "inherit",
+              fontSize: 12.5,
+              fontWeight: 500,
+              color: "rgba(237,236,234,0.35)",
+              transition: "color 120ms ease, background 120ms ease",
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = "#EDECEA"; e.currentTarget.style.background = "rgba(255,255,255,0.06)"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(237,236,234,0.35)"; e.currentTarget.style.background = "transparent"; }}
+          >
+            <CollapseChevron collapsed={isCollapsed} />
+            {!isCollapsed && <span className="whitespace-nowrap">Collapse</span>}
+          </button>
+
           <button
             onClick={() => setFeedbackOpen(true)}
+            title={isCollapsed ? "Give feedback" : undefined}
+            aria-label={isCollapsed ? "Give feedback" : undefined}
             className="cursor-pointer"
             style={{
               display: "flex",
@@ -250,13 +304,15 @@ export default function CustomAppShellNavbar() {
             onMouseEnter={(e) => { e.currentTarget.style.color = "#EDECEA"; e.currentTarget.style.background = "rgba(255,255,255,0.06)"; }}
             onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(237,236,234,0.35)"; e.currentTarget.style.background = "transparent"; }}
           >
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.7 }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.7, flexShrink: 0 }}>
               <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
             </svg>
-            Give feedback
+            <span className={isCollapsed ? "sm:hidden" : ""}>Give feedback</span>
           </button>
           <Link
             href="/billing"
+            title={isCollapsed ? "Billing / Pricing" : undefined}
+            aria-label={isCollapsed ? "Billing / Pricing" : undefined}
             className="flex items-center justify-center rounded-[8px] w-full"
             style={{
               padding: "10px 12px",
@@ -269,7 +325,12 @@ export default function CustomAppShellNavbar() {
             onMouseEnter={e => ((e.currentTarget as HTMLElement).style.background = "#A988F0")}
             onMouseLeave={e => ((e.currentTarget as HTMLElement).style.background = "#BC9BFF")}
           >
-            Billing / Pricing
+            {/* Card icon shown only on the desktop rail when collapsed. */}
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={isCollapsed ? "hidden sm:block" : "hidden"} aria-hidden="true">
+              <rect x="2" y="5" width="20" height="14" rx="2" />
+              <line x1="2" y1="10" x2="22" y2="10" />
+            </svg>
+            <span className={isCollapsed ? "sm:hidden" : ""}>Billing / Pricing</span>
           </Link>
         </div>
       </aside>

--- a/cognee-frontend/src/ui/layout/Navbar/NavbarIconLink.tsx
+++ b/cognee-frontend/src/ui/layout/Navbar/NavbarIconLink.tsx
@@ -10,6 +10,7 @@ interface NavbarIconLinkProps {
   link: string;
   isActive: boolean;
   external?: boolean;
+  collapsed?: boolean;
   onClick?: () => void;
 }
 
@@ -19,13 +20,16 @@ export default function NavbarIconLink({
   link,
   isActive,
   external,
+  collapsed = false,
   onClick,
 }: NavbarIconLinkProps) {
   const classes = classNames(
-    "flex items-center gap-[10px] rounded-[6px] px-3 py-2 text-[14px] transition-colors",
+    "flex items-center rounded-[6px] px-3 py-2 text-[14px] transition-colors",
+    // Collapsing only applies to the desktop rail (`sm` and up); the mobile
+    // drawer always shows full-width labels.
+    collapsed ? "gap-[10px] sm:gap-0 sm:justify-center" : "gap-[10px]",
     {
       "font-medium": isActive,
-      "": !isActive,
     }
   );
 
@@ -40,13 +44,15 @@ export default function NavbarIconLink({
       href={link}
       className={classes}
       style={linkStyle}
+      title={collapsed ? text : undefined}
+      aria-label={collapsed ? text : undefined}
       {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
       onClick={onClick}
       onMouseEnter={!isActive ? (e) => { (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.06)"; } : undefined}
       onMouseLeave={!isActive ? (e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; } : undefined}
     >
       {icon}
-      {text}
+      <span className={classNames("whitespace-nowrap", { "sm:hidden": collapsed })}>{text}</span>
     </Link>
   );
 }

--- a/cognee-frontend/src/ui/layout/NavbarContext.tsx
+++ b/cognee-frontend/src/ui/layout/NavbarContext.tsx
@@ -2,24 +2,37 @@
 
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
+import { getSidebarCollapsed, setSidebarCollapsed } from "@/utils/browserStorage";
 
 interface NavbarContextType {
+  /** Mobile drawer open/closed (below the `sm` breakpoint). */
   isOpen: boolean;
   toggle: () => void;
   close: () => void;
+  /** Desktop icon-rail collapsed/expanded (`sm` breakpoint and up). */
+  isCollapsed: boolean;
+  toggleCollapsed: () => void;
 }
 
 const NavbarContext = createContext<NavbarContextType>({
   isOpen: false,
   toggle: () => {},
   close: () => {},
+  isCollapsed: false,
+  toggleCollapsed: () => {},
 });
 
 export function NavbarProvider({ children }: PropsWithChildren) {
   const [isOpen, setIsOpen] = useState(false);
+  // Desktop collapse preference is read synchronously on the first render via a
+  // lazy initializer — not an effect — so a user who collapsed the sidebar
+  // doesn't see it flash open on every navigation. localGet is SSR-safe
+  // (returns false when localStorage is unavailable).
+  const [isCollapsed, setIsCollapsed] = useState(getSidebarCollapsed);
   const pathname = usePathname();
 
-  // Close sidebar whenever the route changes (user tapped a nav link)
+  // Close the mobile drawer whenever the route changes (user tapped a nav
+  // link). The desktop collapse state is intentionally left untouched.
   useEffect(() => {
     setIsOpen(false);
   }, [pathname]);
@@ -30,6 +43,13 @@ export function NavbarProvider({ children }: PropsWithChildren) {
         isOpen,
         toggle: () => setIsOpen((v) => !v),
         close: () => setIsOpen(false),
+        isCollapsed,
+        toggleCollapsed: () =>
+          setIsCollapsed((collapsed) => {
+            const next = !collapsed;
+            setSidebarCollapsed(next);
+            return next;
+          }),
       }}
     >
       {children}

--- a/cognee-frontend/src/ui/layout/TopBar.tsx
+++ b/cognee-frontend/src/ui/layout/TopBar.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import HelpMenu from "./HelpMenu";
 import ProfileMenu from "./ProfileMenu";
 import { useFilter } from "./FilterContext";
+import { useNavbar } from "./NavbarContext";
 import { useTenant } from "@/modules/tenant/TenantContext";
 import useBoolean from "@/utils/useBoolean";
 import useOutsideClick from "@/utils/useOutsideClick";
@@ -66,6 +67,27 @@ function PlusIcon() {
   return <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style={{ flexShrink: 0 }}><line x1="6" y1="2" x2="6" y2="10" stroke="#6510F4" strokeWidth="1.5" strokeLinecap="round" /><line x1="2" y1="6" x2="10" y2="6" stroke="#6510F4" strokeWidth="1.5" strokeLinecap="round" /></svg>;
 }
 
+// Compact Cognee brain-mark shown on the collapsed desktop rail, where the full
+// wordmark no longer fits. The path is the mark glyph lifted from the brand
+// logo so it stays pixel-consistent with the wordmark it replaces.
+function CogneeMark({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="21"
+      height="24"
+      viewBox="607 464 1441 1627"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ flexShrink: 0 }}
+      role="img"
+      aria-label="Cognee"
+    >
+      <path d="M1514.86 2090.35C1427.39 2090.35 1356.25 2014.59 1356.25 1921.47V632.789C1356.25 609.821 1341.17 593.817 1327.65 593.817C1314.13 593.817 1299.05 609.821 1299.05 632.789V1921.47C1299.05 2014.59 1227.91 2090.35 1140.45 2090.35C1052.98 2090.35 981.846 2014.59 981.846 1921.47V913.389C981.846 890.421 966.766 874.417 953.246 874.417C939.725 874.417 924.645 890.421 924.645 913.389V1547.34C924.645 1640.45 853.508 1716.22 766.042 1716.22C678.577 1716.22 607.439 1640.45 607.439 1547.34V1240.76C607.439 1147.64 683.257 1071.88 776.442 1071.88C782.786 1071.88 788.819 1072.81 794.643 1074.47V913.389C794.643 820.271 865.78 744.509 953.246 744.509C1040.71 744.509 1111.85 820.271 1111.85 913.389V1921.47C1111.85 1944.44 1126.93 1960.44 1140.45 1960.44C1153.97 1960.44 1169.05 1944.44 1169.05 1921.47V632.789C1169.05 539.671 1240.19 463.909 1327.65 463.909C1415.12 463.909 1486.26 539.671 1486.26 632.789V1921.47C1486.26 1944.44 1501.34 1960.44 1514.86 1960.44C1528.38 1960.44 1543.46 1944.44 1543.46 1921.47V913.389C1543.46 820.271 1614.59 744.509 1702.06 744.509C1789.52 744.509 1860.66 820.271 1860.66 913.389V1074.47C1866.49 1072.81 1872.52 1071.88 1878.86 1071.88C1972.05 1071.88 2047.87 1147.64 2047.87 1240.76V1547.34C2047.87 1640.45 1976.73 1716.22 1889.26 1716.22C1801.8 1716.22 1730.66 1640.45 1730.66 1547.34V913.389C1730.66 890.421 1715.58 874.417 1702.06 874.417C1688.54 874.417 1673.46 890.421 1673.46 913.389V1921.47C1673.46 2014.59 1602.32 2090.35 1514.86 2090.35ZM1860.66 1199.19V1547.34C1860.66 1570.3 1875.74 1586.31 1889.26 1586.31C1902.78 1586.31 1917.86 1570.3 1917.86 1547.34V1240.76C1917.86 1219.66 1899.97 1201.78 1878.86 1201.78C1872.52 1201.78 1866.49 1200.85 1860.66 1199.19ZM794.643 1199.19C788.819 1200.85 782.786 1201.78 776.442 1201.78C755.33 1201.78 737.442 1219.66 737.442 1240.76V1547.34C737.442 1570.3 752.522 1586.31 766.042 1586.31C779.562 1586.31 794.643 1570.3 794.643 1547.34V1199.19Z" fill="#fff" />
+    </svg>
+  );
+}
+
 export default function TopBar() {
   const [localUser, setLocalUser] = useState<CogneeUser>();
   const cloud = isCloudEnvironment();
@@ -74,6 +96,7 @@ export default function TopBar() {
   const pathname = usePathname();
   const { workspace, workspaces, setWorkspace } = useFilter();
   const { requestCreateWorkspace, availableTenants } = useTenant();
+  const { isCollapsed } = useNavbar();
 
   useEffect(() => {
     if (!cloud) getLocalUser().then((u) => { if (u) setLocalUser(u); });
@@ -90,9 +113,22 @@ export default function TopBar() {
     <header className="flex items-center justify-between flex-shrink-0" style={{ height: 53, paddingInline: 24, position: "relative", zIndex: 300, background: "rgba(0,0,0,0.65)", backdropFilter: "blur(12px)", borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
       {/* Left: logo + breadcrumbs */}
       <div className="flex items-center" style={{ gap: 8 }}>
-        {/* Logo fixed-width box so workspace aligns with right edge of navbar (240px - 24px padding) */}
-        <div style={{ width: 240, flexShrink: 0, display: "flex", alignItems: "center" }}>
-          <Image src="/cognee-logo-black.svg" alt="Cognee" width={110} height={24} style={{ flexShrink: 0, filter: "invert(1)" }} />
+        {/* Logo box width tracks the sidebar so the workspace switcher stays
+            aligned with the navbar's right edge in both states. On the collapsed
+            desktop rail the full wordmark is swapped for the compact mark. */}
+        <div
+          className={`items-center transition-[width] duration-200 ease-in-out w-[240px] ${isCollapsed ? "sm:w-[72px] sm:justify-center" : "sm:w-[240px]"}`}
+          style={{ flexShrink: 0, display: "flex" }}
+        >
+          <Image
+            src="/cognee-logo-black.svg"
+            alt="Cognee"
+            width={110}
+            height={24}
+            className={`block ${isCollapsed ? "sm:hidden" : "sm:block"}`}
+            style={{ flexShrink: 0, filter: "invert(1)" }}
+          />
+          <CogneeMark className={`hidden ${isCollapsed ? "sm:block" : "sm:hidden"}`} />
         </div>
 
         {/* 1. Workspace switcher */}

--- a/cognee-frontend/src/utils/browserStorage.ts
+++ b/cognee-frontend/src/utils/browserStorage.ts
@@ -18,6 +18,7 @@ const KEYS = {
   creditsBannerDismissed:"cognee-credits-banner-dismissed",
   // localStorage
   connectedIntegrations: (tenantId: string) => `cognee-connected-integrations-${tenantId}`,
+  sidebarCollapsed:      "cognee-sidebar-collapsed",
 } as const;
 
 // ── Low-level safe I/O ────────────────────────────────────────────────────
@@ -110,4 +111,16 @@ export function setConnectedIntegrations(tenantId: string, value: Record<string,
 /** Clears integration state for a tenant (called on workspace switch). */
 export function clearConnectedIntegrations(tenantId: string): void {
   localRemove(KEYS.connectedIntegrations(tenantId));
+}
+
+// cognee-sidebar-collapsed (localStorage) ---------------------------------
+
+/** Returns true if the user collapsed the desktop sidebar to an icon rail. */
+export function getSidebarCollapsed(): boolean {
+  return localGet(KEYS.sidebarCollapsed) === "1";
+}
+
+/** Persists the desktop sidebar collapsed/expanded preference. */
+export function setSidebarCollapsed(collapsed: boolean): void {
+  localSet(KEYS.sidebarCollapsed, collapsed ? "1" : "0");
 }


### PR DESCRIPTION
The self-hosted Web UI sidebar was permanently open at 240px, eating a lot of screen real estate on small or split-screen windows.

Add a desktop collapse toggle that shrinks the sidebar to a 72px icon rail (labels hidden, icons kept with tooltips) and swaps the wordmark for the compact brand mark so the top bar stays aligned. The choice is persisted in localStorage. The existing mobile drawer and floating hamburger are unchanged.

Closes topoteretes/cognee#4143

## Description

The desktop sidebar in the self-hosted Web UI had no way to collapse — it stayed<br>fixed at 240px, which is costly on small or split-screen viewports. Mobile already<br>had a slide-in drawer plus a floating hamburger, but there was no equivalent<br>affordance on desktop.

This PR adds a collapse toggle (pinned to the bottom of the sidebar, desktop only)<br>that switches between the full 240px panel and a compact 72px icon rail:

* When collapsed, section labels and nav link text are hidden; icons stay centered<br>and each gains a `title` + `aria-label` tooltip so items remain identifiable.
* The top bar's logo box tracks the sidebar width and swaps the full "cognee"<br>wordmark for the compact brand mark, keeping the workspace switcher aligned with<br>the sidebar's right edge.
* The bottom actions (Give feedback / Billing) become icon-only with tooltips.
* The preference is persisted in `localStorage` (`cognee-sidebar-collapsed`) using<br>the existing `browserStorage` accessor pattern, and read synchronously on first<br>render so it never flashes open while navigating.
* The toggle exposes `aria-expanded`, and a 200ms width transition keeps the<br>change smooth.

All collapse styling is scoped to the `sm` breakpoint and up, so the mobile drawer<br>and floating hamburger behave exactly as before.

**Files changed**

* `cognee-frontend/src/ui/layout/NavbarContext.tsx` — `isCollapsed` / `toggleCollapsed` state (persisted, lazy-initialised).
* `cognee-frontend/src/utils/browserStorage.ts` — `get/setSidebarCollapsed` accessors for the new key.
* `cognee-frontend/src/ui/layout/Navbar/NavbarIconLink.tsx` — `collapsed` prop (centered icon, hidden label, tooltip).
* `cognee-frontend/src/ui/layout/Navbar/CustomAppShellNavbar.tsx` — responsive rail width, hidden labels, collapse toggle, icon-only bottom actions.
* `cognee-frontend/src/ui/layout/TopBar.tsx` — logo box width tracks the rail; compact brand mark when collapsed.

## Acceptance Criteria

- [X] A control on desktop collapses/expands the sidebar.
- [X] Collapsed state reduces the sidebar to an icon-only rail (72px).
- [X] Icons remain visible with tooltips identifying each destination when collapsed.
- [X] The top bar stays visually aligned with the sidebar in both states.
- [X] The collapsed/expanded choice persists across reloads and navigation.
- [X] Existing mobile behavior (slide-in drawer + floating hamburger) is unchanged.
- [X] No regression to the expanded desktop layout.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Pre-submission Checklist

- [X] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [X] **This PR contains minimal changes necessary to address the issue/feature**
- [X] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [X] All new and existing tests pass
- [X] I have searched existing PRs to ensure this change hasn't been submitted already
- [X] I have linked any relevant issues in the description
- [X] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.