### PR TITLE
fix(graph/ladybug): filter get_neighborhood edge_types in Python to avoid Kuzu RECURSIVE_REL assertion [SDK-245]

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -2719,18 +2719,36 @@ class LadybugAdapter(GraphDBInterface):
                 logger.warning("No node IDs provided for neighborhood retrieval.")
                 return [], []
 
-            # Use variable-length path to find all nodes within depth hops
-            path_query = f"""
-            MATCH (seed:Node)-[r*1..{depth}]-(neighbor:Node)
-            WHERE seed.id IN $node_ids{" AND ALL(rel IN r WHERE rel.relationship_name IN $edge_types)" if edge_types else ""}
-            RETURN DISTINCT neighbor.id
-            """
-            params = {"node_ids": node_ids}
+            # Use variable-length path to find all nodes within depth hops.
+            # Kuzu's `r` from `-[r*1..N]-` is a RECURSIVE_REL, not a LIST, so the
+            # engine rejects `ALL(rel IN r WHERE ...)` with a binder error (and an
+            # internal assertion when combined with a parameter reference). When
+            # edge_types is set, fetch paths unfiltered and discard neighbors whose
+            # every path crosses a disallowed edge type (#3585).
             if edge_types:
-                params["edge_types"] = edge_types
-
-            neighbor_rows = await self.query(path_query, params)
-            neighbor_ids = [row[0] for row in neighbor_rows if row[0]]
+                path_query = f"""
+                MATCH (seed:Node)-[r*1..{depth}]-(neighbor:Node)
+                WHERE seed.id IN $node_ids
+                RETURN neighbor.id, r
+                """
+                path_rows = await self.query(path_query, {"node_ids": node_ids})
+                allowed = set(edge_types)
+                neighbor_ids_set: set = set()
+                for neighbor_id, path in path_rows:
+                    if not neighbor_id or neighbor_id in neighbor_ids_set:
+                        continue
+                    rels = path.get("_RELS", []) if isinstance(path, dict) else []
+                    if rels and all(rel.get("relationship_name") in allowed for rel in rels):
+                        neighbor_ids_set.add(neighbor_id)
+                neighbor_ids = list(neighbor_ids_set)
+            else:
+                path_query = f"""
+                MATCH (seed:Node)-[r*1..{depth}]-(neighbor:Node)
+                WHERE seed.id IN $node_ids
+                RETURN DISTINCT neighbor.id
+                """
+                neighbor_rows = await self.query(path_query, {"node_ids": node_ids})
+                neighbor_ids = [row[0] for row in neighbor_rows if row[0]]
 
             # Combine seed nodes and neighbor nodes
             all_ids = list(set(node_ids) | set(neighbor_ids))

--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -2708,7 +2708,18 @@ class LadybugAdapter(GraphDBInterface):
         Get the k-hop neighborhood subgraph around a set of seed nodes.
 
         Returns all nodes and edges within `depth` hops of any seed node,
-        in the same format as get_graph_data().
+        in the same format as get_graph_data(). A neighbor is included iff there
+        exists a path of length 1..depth reaching it whose every edge type is in
+        `edge_types` (matching the Neo4j/Postgres backends); `edge_types=None` or
+        `[]` disables the filter.
+
+        Performance note: the `edge_types` branch enumerates every path up to
+        `depth` (Kuzu cannot filter a variable-length relationship binding in
+        Cypher — see #3585) and post-filters in Python, so its cost grows
+        combinatorially with node degree × depth on dense graphs. It is intended
+        for shallow, targeted neighborhoods; a future refactor could push per-hop
+        type filtering into Cypher via a fixed-length UNION to return distinct
+        neighbors instead of walks.
         """
         import time
 

--- a/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
+++ b/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
@@ -295,6 +295,75 @@ async def test_get_filtered_graph_data(adapter):
 
 
 # ---------------------------------------------------------------------------
+# get_neighborhood with edge_types filter
+# Regression for #3585: ALL(rel IN r WHERE ...) over a variable-length path
+# binding crashes Kuzu (RECURSIVE_REL vs LIST). Filter in Python instead.
+# ---------------------------------------------------------------------------
+
+
+class _NeighborhoodNode:
+    """Minimal pydantic-shaped payload compatible with add_nodes."""
+
+    def __init__(self, node_id: str, name: str = "", type: str = ""):
+        self._d = {"id": str(node_id), "name": name, "type": type}
+
+    def model_dump(self):
+        return dict(self._d)
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_unfiltered_returns_all_reachable(adapter):
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "D"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "B", "KNOWS", {}),
+            ("A", "D", "WORKS_AT", {}),
+        ]
+    )
+
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2)
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "B", "D"]
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_edge_type_filter_excludes_other_edges(adapter):
+    """Regression for #3585: edge_types filter must not crash and must exclude
+    neighbors reachable only via disallowed edge types."""
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "D"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "B", "KNOWS", {}),
+            ("A", "D", "WORKS_AT", {}),
+        ]
+    )
+
+    # Filter to KNOWS only — D (reachable only via WORKS_AT) must be excluded.
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2, edge_types=["KNOWS"])
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "B"]
+
+    # Symmetric: filter to WORKS_AT only — B must be excluded.
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2, edge_types=["WORKS_AT"])
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "D"]
+
+    # Both allowed — full neighborhood.
+    rows, _ = await adapter.get_neighborhood(
+        node_ids=["A"], depth=2, edge_types=["KNOWS", "WORKS_AT"]
+    )
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "B", "D"]
+
+    # No matching edge type — only the seed itself is in the neighborhood.
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2, edge_types=["NONEXISTENT"])
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A"]
+
+
+# ---------------------------------------------------------------------------
 # get_predecessors / get_successors
 # Known adapter bug: RETURN properties(m) fails with current Kuzu version.
 # ---------------------------------------------------------------------------

--- a/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
+++ b/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
@@ -363,6 +363,113 @@ async def test_get_neighborhood_edge_type_filter_excludes_other_edges(adapter):
     assert ids == ["A"]
 
 
+@pytest.mark.asyncio
+async def test_get_neighborhood_edge_filter_follows_longer_all_allowed_path(adapter):
+    """#3585 semantic guard (the load-bearing case).
+
+    A neighbor reachable via a disallowed SHORT path AND an allowed LONGER path
+    must be included: the filter keeps a neighbor iff SOME path within depth is
+    entirely allowed, matching Neo4j (ALL over relationships(path)) and Postgres
+    (per-hop recursive CTE). The star-graph tests above cannot distinguish this
+    correct semantic from a buggy "exclude if ANY path crosses a disallowed edge",
+    so this case is what actually pins the fix.
+    """
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "C"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "C", "WORKS_AT", {}),  # 1-hop route to C, disallowed under KNOWS
+            ("A", "B", "KNOWS", {}),
+            ("B", "C", "KNOWS", {}),  # A-KNOWS-B-KNOWS-C: a 2-hop all-KNOWS route to C
+        ]
+    )
+
+    # depth 2: C included via the all-KNOWS path, despite the shorter WORKS_AT edge.
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2, edge_types=["KNOWS"])
+    assert sorted(n for n, _ in rows) == ["A", "B", "C"]
+
+    # depth 1: within one hop C is only reachable via WORKS_AT -> excluded.
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=1, edge_types=["KNOWS"])
+    assert sorted(n for n, _ in rows) == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_multi_hop_depth_is_a_real_bound(adapter):
+    """depth genuinely bounds a chain (the 1-hop star can't test this), and multi-hop
+    filtering walks the full path via all(rel ...) over more than one relationship."""
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "C", "D"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "B", "KNOWS", {}),
+            ("B", "C", "KNOWS", {}),
+            ("C", "D", "KNOWS", {}),
+        ]
+    )
+
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=2)
+    assert sorted(n for n, _ in rows) == ["A", "B", "C"]  # D is 3 hops away
+
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=3, edge_types=["KNOWS"])
+    assert sorted(n for n, _ in rows) == ["A", "B", "C", "D"]
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_disallowed_mid_edge_cuts_path(adapter):
+    """A single disallowed edge in the middle of the only route excludes everything
+    beyond it — verifies the per-path all() spans every hop, not just the first."""
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "C", "D"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "B", "KNOWS", {}),
+            ("B", "C", "WORKS_AT", {}),  # only route to C/D crosses WORKS_AT
+            ("C", "D", "KNOWS", {}),
+        ]
+    )
+
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=3, edge_types=["KNOWS"])
+    assert sorted(n for n, _ in rows) == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_multi_seed_union_with_filter(adapter):
+    """Per-seed ego-graphs are unioned and deduped, with the edge_type filter applied
+    across every component."""
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "D", "X", "Y"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "B", "KNOWS", {}),
+            ("A", "D", "WORKS_AT", {}),  # excluded under KNOWS
+            ("X", "Y", "KNOWS", {}),
+        ]
+    )
+
+    rows, _ = await adapter.get_neighborhood(node_ids=["A", "X"], depth=1, edge_types=["KNOWS"])
+    assert sorted(n for n, _ in rows) == ["A", "B", "X", "Y"]
+
+
+@pytest.mark.asyncio
+async def test_get_neighborhood_edge_filter_handles_cycles(adapter):
+    """Kuzu returns walks that revisit nodes; a genuine cycle must neither crash nor
+    duplicate a neighbor, and the per-neighbor dedup set must converge."""
+    nodes = [_NeighborhoodNode(i) for i in ["A", "B", "C"]]
+    await adapter.add_nodes(nodes)
+    await adapter.add_edges(
+        [
+            ("A", "B", "KNOWS", {}),
+            ("B", "C", "KNOWS", {}),
+            ("C", "A", "KNOWS", {}),  # triangle
+        ]
+    )
+
+    rows, _ = await adapter.get_neighborhood(node_ids=["A"], depth=3, edge_types=["KNOWS"])
+    ids = sorted(n for n, _ in rows)
+    assert ids == ["A", "B", "C"]
+    assert len(ids) == len(set(ids))  # no duplicate nodes from revisiting walks
+
+
 # ---------------------------------------------------------------------------
 # get_predecessors / get_successors
 # Known adapter bug: RETURN properties(m) fails with current Kuzu version.


### PR DESCRIPTION
## Description

Carries the community fix in #3591 (@ly-wang19) onto `dev` and hardens it. Fixes #3585 — `LadybugAdapter.get_neighborhood(edge_types=[...])` crashing with a Kuzu internal assertion (`UNREACHABLE_CODE` in `parsed_parameter_expression.h:21`) whenever an edge-type allow-list is supplied. Unfiltered calls worked; only the filtered path was broken. Since Ladybug is the default graph backend, edge-filtered neighborhood queries were unusable out of the box (Neo4j/Postgres were fine). Surfaced by `SearchType.NEIGHBORHOOD` (#3376 / #3586).

### Root cause

The query used `ALL(rel IN r WHERE rel.relationship_name IN $edge_types)` over a variable-length path binding `r` from `-[r*1..N]-`. In Kuzu, `r` is a `RECURSIVE_REL`, not a `LIST`, so `ALL(...)` is a binder-type mismatch, and combined with the `$edge_types` parameter reference it drives the engine past the binder into a failed internal assertion.

### Fix (@ly-wang19, commit unchanged from #3591)

Drop the `ALL()` predicate. When `edge_types` is set, fetch paths unfiltered (`RETURN neighbor.id, r`) and post-filter in Python — keep a neighbor iff **some** returned path to it has every relationship in the allowed set. This matches the Neo4j (`ALL(r IN relationships(path) ...)`) and Postgres (per-hop recursive CTE) semantic: *include a neighbor iff there exists an all-allowed-edge path of length 1..depth (undirected)*. The `edge_types=None` fast path is unchanged.

### Hardening added on top

- **Regression tests that actually pin the semantic.** #3591's original two tests use a 1-hop star graph; combined with `get_neighborhood`'s unconditional seed-union, they pass under both the correct semantic **and** a plausible buggy "exclude if any path crosses a disallowed edge" one. Added tests (running in both direct and subprocess Kuzu modes via the parametrized `adapter` fixture) for: the divergence case (neighbor reachable via a disallowed short path *and* an allowed longer path — included at depth 2, excluded at depth 1), multi-hop depth as a genuine bound, a disallowed mid-path edge cutting off everything beyond it, multi-seed union with a filter, and cycles.
- **Documented the cost.** The docstring now states the canonical `edge_types` semantic and notes that the filtered branch enumerates all paths and post-filters in Python (combinatorial in degree × depth on dense graphs), with a fixed-length `UNION`-per-hop refactor called out as the scalable follow-up.

### Deferred (tracked, not in this PR)

The filtered branch has no `DISTINCT`, so Kuzu materializes one row per *walk* — combinatorial on dense graphs at high depth (measured: ~137k rows / ~6.7 s to return 8 neighbors on `K_8` depth 6, vs 33 ms unfiltered). Correctness is unaffected (it never truncates) and it is off the default retrieval hot path today. The scalable remedy (per-hop `relationship_name` filtering pushed into Cypher via a fixed-length `UNION`) is deferred and documented.

## Verification

Verified against real Kuzu 0.17.1 / ladybug: the buggy predicate reproduces the exact assertion; the fix returns the canonical filtered set across the full battery. Neighborhood tests: **14 passed** (7 tests × direct + subprocess modes). `ruff check` + `ruff format` clean.

## Coordination note

#3586 (feat `SearchType.NEIGHBORHOOD`) carries a `strict=True` xfail (`test_depth2_edge_type_filter_xfail_on_ladybug`) that expects this call to raise on Ladybug. Once this fix lands that test no longer raises; its expected set is also `{A, B, C}` where the correct all-KNOWS set is `{A, B, C, E}`. Whichever of {this PR, #3586} merges second must remove that xfail **and** correct its assertion.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue
- [x] My code follows the project's coding standards (`ruff check` + `ruff format` clean)
- [x] I have added tests that prove the fix is effective
- [x] All new and existing tests pass
- [x] I have linked the relevant issue

## Attribution

The fix commit is authored by @ly-wang19 (from #3591), preserved intact; the hardening commit adds tests and documentation.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)