### PR TITLE
fix(mcp): track cognify file background tasks

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1587,11 +1587,10 @@ async def cognify_file(
                 await cognee_client.cognify(datasets=[dataset_name])
                 logger.info(f"cognify_file: background cognify finished for '{dataset_name}'.")
             except Exception as e:
-                ts = datetime.now(timezone.utc).isoformat()
-                _task_errors.setdefault(dataset_name, []).append((ts, str(e)))
+                _record_task_error(dataset_name, str(e))
                 logger.error(f"cognify_file: background cognify failed for '{dataset_name}': {e}")
 
-    asyncio.create_task(_cognify_bg())
+    _track_background(_cognify_bg())
 
     return [
         types.TextContent(

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -1,8 +1,10 @@
 import asyncio
+import base64
 import hashlib
 import importlib
 import json
 import sys
+from collections import deque
 from pathlib import Path
 
 import httpx
@@ -339,6 +341,83 @@ async def test_cognify_tool_batches_add_calls(monkeypatch, tmp_path):
         "custom_prompt": "extract carefully",
         "graph_model": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_cognify_file_tracks_task_and_records_error_in_bounded_history(monkeypatch):
+    import src.server as server
+
+    dataset_name = "cognify_file_failure_ds"
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class FakeClient:
+        async def add(self, data, dataset_name=None):
+            return None
+
+        async def cognify(self, datasets=None):
+            started.set()
+            await release.wait()
+            raise RuntimeError("cognify failed")
+
+    tracked_tasks = []
+    original_track_background = server._track_background
+
+    def capture_tracked_task(coro):
+        task = original_track_background(coro)
+        tracked_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(server, "cognee_client", FakeClient())
+    monkeypatch.setattr(server, "_track_background", capture_tracked_task)
+    server._task_errors.pop(dataset_name, None)
+
+    try:
+        result = await server.cognify_file(
+            filename="memory.txt",
+            content_base64=base64.b64encode(b"memory").decode("ascii"),
+            dataset_name=dataset_name,
+        )
+
+        await started.wait()
+        assert "Cognify is running in the background" in result[0].text
+        assert len(tracked_tasks) == 1
+        task = tracked_tasks[0]
+        assert task in server._background_tasks
+
+        release.set()
+        await task
+        await asyncio.sleep(0)
+
+        assert task not in server._background_tasks
+        errors = server._task_errors[dataset_name]
+        assert isinstance(errors, deque)
+        assert errors.maxlen == server._TASK_ERROR_HISTORY
+        assert errors[-1][1] == "cognify failed"
+    finally:
+        release.set()
+        await asyncio.gather(*tracked_tasks, return_exceptions=True)
+        server._task_errors.pop(dataset_name, None)
+
+
+def test_task_error_history_is_bounded():
+    import src.server as server
+
+    dataset_name = "bounded_error_history_ds"
+    server._task_errors.pop(dataset_name, None)
+
+    try:
+        for index in range(server._TASK_ERROR_HISTORY + 5):
+            server._record_task_error(dataset_name, f"error-{index}")
+
+        errors = server._task_errors[dataset_name]
+        assert isinstance(errors, deque)
+        assert errors.maxlen == server._TASK_ERROR_HISTORY
+        assert len(errors) == server._TASK_ERROR_HISTORY
+        assert errors[0][1] == "error-5"
+        assert errors[-1][1] == f"error-{server._TASK_ERROR_HISTORY + 4}"
+    finally:
+        server._task_errors.pop(dataset_name, None)
 
 
 class FakeGraph:


### PR DESCRIPTION
### Description

  - Fixes #4159.
  - cognify_file previously launched cognification with raw asyncio.create_task().
  - This bypassed the MCP server’s _track_background() helper and left the task outside the module’s established lifecycle
    management.

  - The failure handler also wrote directly to _task_errors using setdefault(dataset_name, []).
  - For a dataset without an existing error bucket, this created an unbounded list instead of the intended
    deque(maxlen=_TASK_ERROR_HISTORY).

  - The implementation now launches the task through _track_background() and records failures through _record_task_error().
  - This makes cognify_file consistent with the other MCP background operations.

  ### Acceptance Criteria

  - Background cognification started by cognify_file remains referenced in _background_tasks while running.
  - The completed task is removed from _background_tasks.
  - Cognification failures use the shared bounded error-history implementation.
  - No dataset’s error history can exceed _TASK_ERROR_HISTORY.
  - Regression tests cover task anchoring, cleanup, failure recording, and error-history eviction.

  ### Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Code refactoring
  - [ ] Other (please specify):

  ### Screenshots

  Add a screenshot showing this result:

  uv run --project cognee-mcp pytest cognee-mcp/tests -q

  25 passed, 10 warnings in 2.86s

  The warnings are existing Pydantic deprecation warnings from dependencies.

  ### Testing

  Commands run:

  uv run --project cognee-mcp pytest cognee-mcp/tests -q
  uv run ruff format --check \
    cognee-mcp/src/server.py \
    cognee-mcp/tests/test_mcp_server_hardening.py
  uv run ruff check \
    cognee-mcp/src/server.py \
    cognee-mcp/tests/test_mcp_server_hardening.py
  git diff --check

  Results:

  25 tests passed
  2 files already formatted
  All Ruff checks passed
  No whitespace errors

  ### Pre-submission Checklist

  - [x] I have tested my changes thoroughly before submitting this PR
  - [x] This PR contains minimal changes necessary to address the issue
  - [x] My code follows the project's coding standards and style guidelines
  - [x] I have added tests that prove the fix is effective
  - [x] I have added necessary documentation (not applicable)
  - [x] All new and existing MCP tests pass
  - [ ] I have searched existing PRs to ensure this change hasn't been submitted already
  - [x] I have linked the relevant issue in the description
  - [x] My commit has a clear and descriptive message

  Verify the unchecked existing-PR item manually before selecting it.

  ### DCO Affirmation

  I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of
  Origin.

  Changed files:

  - cognee-mcp/src/server.py:1584
  - cognee-mcp/tests/test_mcp_server_hardening.py:346