### PR TITLE
fix(api): scope configuration lookup to authenticated owner

### DIFF
--- a/cognee/api/v1/users/routers/get_configuration_router.py
+++ b/cognee/api/v1/users/routers/get_configuration_router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 from fastapi import Form, Depends, Path
+from typing import cast
 from uuid import UUID
 
 from pydantic import Field
@@ -91,7 +92,10 @@ def get_configuration_router() -> APIRouter:
         Returns the stored configuration data as a JSON object. Returns an empty object {}
         with HTTP 200 (not 404) when no configuration with that id exists.
         """
-        return await method_get_principal_configuration(config_id=config_id)
+        return await method_get_principal_configuration(
+            config_id=config_id,
+            principal_id=cast(UUID, user.id),
+        )
 
     @router.get("/get_user_configuration/", response_model=list)
     async def get_user_all_configuration(

--- a/cognee/api/v1/users/routers/get_configuration_router.py
+++ b/cognee/api/v1/users/routers/get_configuration_router.py
@@ -1,3 +1,4 @@
+from typing import cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Form, Path
@@ -92,7 +93,10 @@ def get_configuration_router() -> APIRouter:
         Returns the stored configuration data as a JSON object. Returns an empty object {}
         with HTTP 200 (not 404) when no configuration with that id exists.
         """
-        return await method_get_principal_configuration(config_id=config_id)
+        return await method_get_principal_configuration(
+            config_id=config_id,
+            principal_id=cast(UUID, user.id),
+        )
 
     @router.get("/get_user_configuration/", response_model=list)
     async def get_user_all_configuration(

--- a/cognee/modules/users/methods/get_principal_configuration.py
+++ b/cognee/modules/users/methods/get_principal_configuration.py
@@ -4,19 +4,23 @@ from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.users.models.PrincipalConfiguration import PrincipalConfiguration
 
 
-async def get_principal_configuration(config_id: UUID) -> dict:
+async def get_principal_configuration(config_id: UUID, principal_id: UUID) -> dict:
     """
-    Retrieves a specific Cognee configuration for a principal by its name.
+    Retrieves a specific Cognee configuration by identifier and owner.
 
     Args:
-        config_id (str): The unique identifier of the config.
+        config_id (UUID): The unique identifier of the config.
+        principal_id (UUID): The unique identifier of the config owner.
 
     Returns:
-        dict: The configuration data if found, or an empty dictionary (or None) if not found.
+        dict: The configuration data if found, or an empty dictionary if not found.
     """
     relational_engine = get_relational_engine()
     async with relational_engine.get_async_session() as session:
-        query = select(PrincipalConfiguration).where(PrincipalConfiguration.id == config_id)
+        query = select(PrincipalConfiguration).where(
+            PrincipalConfiguration.id == config_id,
+            PrincipalConfiguration.owner_id == principal_id,
+        )
 
         result = await session.execute(query)
         config_record = result.scalars().first()

--- a/cognee/modules/users/methods/get_principal_configuration.py
+++ b/cognee/modules/users/methods/get_principal_configuration.py
@@ -6,19 +6,23 @@ from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.users.models.PrincipalConfiguration import PrincipalConfiguration
 
 
-async def get_principal_configuration(config_id: UUID) -> dict:
+async def get_principal_configuration(config_id: UUID, principal_id: UUID) -> dict:
     """
-    Retrieves a specific Cognee configuration for a principal by its name.
+    Retrieves a specific Cognee configuration by identifier and owner.
 
     Args:
-        config_id (str): The unique identifier of the config.
+        config_id (UUID): The unique identifier of the config.
+        principal_id (UUID): The unique identifier of the config owner.
 
     Returns:
-        dict: The configuration data if found, or an empty dictionary (or None) if not found.
+        dict: The configuration data if found, or an empty dictionary if not found.
     """
     relational_engine = get_relational_engine()
     async with relational_engine.get_async_session() as session:
-        query = select(PrincipalConfiguration).where(PrincipalConfiguration.id == config_id)
+        query = select(PrincipalConfiguration).where(
+            PrincipalConfiguration.id == config_id,
+            PrincipalConfiguration.owner_id == principal_id,
+        )
 
         result = await session.execute(query)
         config_record = result.scalars().first()

--- a/cognee/tests/unit/api/test_configuration_router_authorization.py
+++ b/cognee/tests/unit/api/test_configuration_router_authorization.py
@@ -1,0 +1,35 @@
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+router_module = import_module("cognee.api.v1.users.routers.get_configuration_router")
+
+
+def test_get_configuration_scopes_lookup_to_authenticated_user(monkeypatch):
+    principal_id = uuid4()
+    config_id = uuid4()
+    get_configuration = AsyncMock(return_value={})
+    monkeypatch.setattr(
+        router_module,
+        "method_get_principal_configuration",
+        get_configuration,
+    )
+
+    app = FastAPI()
+    app.include_router(router_module.get_configuration_router(), prefix="/configuration")
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=principal_id
+    )
+
+    response = TestClient(app).get(f"/configuration/get_user_configuration/{config_id}")
+
+    assert response.status_code == 200
+    get_configuration.assert_awaited_once_with(
+        config_id=config_id,
+        principal_id=principal_id,
+    )

--- a/cognee/tests/unit/api/test_configuration_router_authorization.py
+++ b/cognee/tests/unit/api/test_configuration_router_authorization.py
@@ -1,0 +1,34 @@
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+router_module = import_module("cognee.api.v1.users.routers.get_configuration_router")
+
+
+def test_get_configuration_scopes_lookup_to_authenticated_user(monkeypatch):
+    principal_id = uuid4()
+    config_id = uuid4()
+    get_configuration = AsyncMock(return_value={})
+    monkeypatch.setattr(
+        router_module,
+        "method_get_principal_configuration",
+        get_configuration,
+    )
+
+    app = FastAPI()
+    app.include_router(router_module.get_configuration_router(), prefix="/configuration")
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=principal_id
+    )
+
+    response = TestClient(app).get(f"/configuration/get_user_configuration/{config_id}")
+
+    assert response.status_code == 200
+    get_configuration.assert_awaited_once_with(
+        config_id=config_id,
+        principal_id=principal_id,
+    )

--- a/cognee/tests/unit/modules/users/test_get_principal_configuration.py
+++ b/cognee/tests/unit/modules/users/test_get_principal_configuration.py
@@ -1,0 +1,63 @@
+from importlib import import_module
+from uuid import uuid4
+
+import pytest
+
+
+configuration_module = import_module("cognee.modules.users.methods.get_principal_configuration")
+
+
+class _Result:
+    class _Scalars:
+        @staticmethod
+        def first():
+            return None
+
+    @staticmethod
+    def scalars():
+        return _Result._Scalars()
+
+
+class _Session:
+    statement = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return _Result()
+
+
+class _Engine:
+    def __init__(self, session):
+        self.session = session
+
+    def get_async_session(self):
+        return self.session
+
+
+@pytest.mark.asyncio
+async def test_configuration_query_is_scoped_to_principal(monkeypatch):
+    config_id = uuid4()
+    principal_id = uuid4()
+    session = _Session()
+    monkeypatch.setattr(
+        configuration_module,
+        "get_relational_engine",
+        lambda: _Engine(session),
+    )
+
+    result = await configuration_module.get_principal_configuration(
+        config_id=config_id,
+        principal_id=principal_id,
+    )
+
+    assert result == {}
+    compiled = session.statement.compile()
+    assert "principal_configuration.id =" in str(compiled)
+    assert "principal_configuration.owner_id =" in str(compiled)
+    assert set(compiled.params.values()) == {config_id, principal_id}

--- a/cognee/tests/unit/modules/users/test_get_principal_configuration.py
+++ b/cognee/tests/unit/modules/users/test_get_principal_configuration.py
@@ -1,0 +1,62 @@
+from importlib import import_module
+from uuid import uuid4
+
+import pytest
+
+configuration_module = import_module("cognee.modules.users.methods.get_principal_configuration")
+
+
+class _Result:
+    class _Scalars:
+        @staticmethod
+        def first():
+            return None
+
+    @staticmethod
+    def scalars():
+        return _Result._Scalars()
+
+
+class _Session:
+    statement = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return _Result()
+
+
+class _Engine:
+    def __init__(self, session):
+        self.session = session
+
+    def get_async_session(self):
+        return self.session
+
+
+@pytest.mark.asyncio
+async def test_configuration_query_is_scoped_to_principal(monkeypatch):
+    config_id = uuid4()
+    principal_id = uuid4()
+    session = _Session()
+    monkeypatch.setattr(
+        configuration_module,
+        "get_relational_engine",
+        lambda: _Engine(session),
+    )
+
+    result = await configuration_module.get_principal_configuration(
+        config_id=config_id,
+        principal_id=principal_id,
+    )
+
+    assert result == {}
+    compiled = session.statement.compile()
+    assert "principal_configuration.id =" in str(compiled)
+    assert "principal_configuration.owner_id =" in str(compiled)
+    assert set(compiled.params.values()) == {config_id, principal_id}


### PR DESCRIPTION
An authenticated user could request a configuration using its UUID without verifying that the configuration belonged to them. This change passes the authenticated principal ID into the lookup and filters by both configuration ID and owner ID.

Unauthorized and nonexistent configurations continue returning the existing empty-object response, avoiding resource enumeration.

Acceptance Criteria

A configuration is returned only when it belongs to the authenticated principal.

Another user’s configuration cannot be retrieved by UUID.

Missing and unauthorized configurations return `{}`.

Regression tests cover both the API route and database query.

Type of Change

Check only:

- [x] Bug fix (non-breaking change that fixes an issue)

Screenshots

No UI change. Local verification:

- Focused route/query tests: 2 passed
- User-module plus authorization tests: 34 passed
- Ruff check: passed
- Ruff format check: passed
- GitHub Community Tests: passed (code quality/`ty`, telemetry, CLI, mocked Python 3.11 unit tests)

Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
