### PR TITLE
fix(api): honor dataset read grants for raw downloads

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -22,6 +22,7 @@ from cognee.shared.logging_utils import get_logger
 from cognee.api.v1.exceptions import DataNotFoundError
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.permissions.methods import get_all_user_permission_datasets
 from cognee.modules.graph.methods import get_formatted_graph_data
 from cognee.modules.pipelines.models import PipelineRunStatus
@@ -33,6 +34,13 @@ logger = get_logger()
 
 class ErrorResponseDTO(BaseModel):
     message: str
+
+
+def _dataset_not_found_response(dataset_id: UUID) -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_404_NOT_FOUND,
+        content=ErrorResponseDTO(message=f"Dataset ({dataset_id}) not found.").model_dump(),
+    )
 
 
 class DatasetDTO(OutDTO):
@@ -368,15 +376,15 @@ def get_datasets_router() -> APIRouter:
         from cognee.modules.data.methods import get_dataset_data
 
         # Verify user has permission to read dataset
-        dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
+        try:
+            authorized_datasets = await get_authorized_existing_datasets([dataset_id], "read", user)
+        except PermissionDeniedError:
+            return _dataset_not_found_response(dataset_id)
 
-        if dataset is None:
-            return JSONResponse(
-                status_code=404,
-                content=ErrorResponseDTO(f"Dataset ({str(dataset_id)}) not found."),
-            )
+        if not authorized_datasets:
+            return _dataset_not_found_response(dataset_id)
 
-        dataset_id = dataset[0].id
+        dataset_id = authorized_datasets[0].id
 
         dataset_data = await get_dataset_data(dataset_id=dataset_id)
 
@@ -519,18 +527,18 @@ def get_datasets_router() -> APIRouter:
             },
         )
 
-        from cognee.modules.data.methods import get_data
         from cognee.modules.data.methods import get_dataset_data
 
         # Verify user has permission to read dataset
-        dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
+        try:
+            authorized_datasets = await get_authorized_existing_datasets([dataset_id], "read", user)
+        except PermissionDeniedError:
+            return _dataset_not_found_response(dataset_id)
 
-        if dataset is None:
-            return JSONResponse(
-                status_code=404, content={"detail": f"Dataset ({dataset_id}) not found."}
-            )
+        if not authorized_datasets:
+            return _dataset_not_found_response(dataset_id)
 
-        dataset_data = await get_dataset_data(dataset[0].id)
+        dataset_data = await get_dataset_data(authorized_datasets[0].id)
 
         if dataset_data is None:
             raise DataNotFoundError(message=f"No data found in dataset ({dataset_id}).")
@@ -543,12 +551,7 @@ def get_datasets_router() -> APIRouter:
                 message=f"Data ({data_id}) not found in dataset ({dataset_id})."
             )
 
-        data = await get_data(user.id, data_id)
-
-        if data is None:
-            raise DataNotFoundError(
-                message=f"Data ({data_id}) not found in dataset ({dataset_id})."
-            )
+        data = matching_data[0]
 
         raw_location = data.raw_data_location
         parsed_uri = urlparse(raw_location)

--- a/cognee/tests/unit/api/test_get_raw_data_endpoint.py
+++ b/cognee/tests/unit/api/test_get_raw_data_endpoint.py
@@ -8,6 +8,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from cognee.api.v1.exceptions import DataNotFoundError
+from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.methods import get_authenticated_user
 
 
@@ -68,24 +70,22 @@ def _patch_raw_download_dependencies(
     monkeypatch.setattr(
         data_methods_module,
         "get_dataset_data",
-        AsyncMock(return_value=[SimpleNamespace(id=data_id)]),
-    )
-    monkeypatch.setattr(
-        data_methods_module,
-        "get_data",
         AsyncMock(
-            return_value=SimpleNamespace(
-                id=data_id,
-                raw_data_location=raw_data_location,
-                name=name,
-                mime_type=mime_type,
-            )
+            return_value=[
+                SimpleNamespace(
+                    id=data_id,
+                    owner_id=uuid.uuid4(),
+                    raw_data_location=raw_data_location,
+                    name=name,
+                    mime_type=mime_type,
+                )
+            ]
         ),
     )
 
 
-def test_get_raw_data_local_file_downloads_bytes(client, monkeypatch, tmp_path):
-    """Downloads bytes from a file:// raw_data_location."""
+def test_get_raw_data_allows_authorized_dataset_reader(client, monkeypatch, tmp_path):
+    """Dataset read access is sufficient even when the reader does not own the data row."""
     dataset_id = uuid.uuid4()
     data_id = uuid.uuid4()
 
@@ -204,3 +204,57 @@ def test_get_raw_data_encoded_path_downloads_bytes(client, monkeypatch, tmp_path
     response = client.get(f"/api/v1/datasets/{dataset_id}/data/{data_id}/raw")
     assert response.status_code == 200
     assert response.content == content
+
+
+@pytest.mark.parametrize("permission_denied", [False, True])
+@pytest.mark.parametrize("include_data_id", [False, True])
+def test_dataset_read_endpoints_return_404_when_dataset_is_unavailable(
+    client, monkeypatch, permission_denied, include_data_id
+):
+    import importlib
+
+    datasets_router_module = importlib.import_module(
+        "cognee.api.v1.datasets.routers.get_datasets_router"
+    )
+    dataset_id = uuid.uuid4()
+    data_id = uuid.uuid4()
+    result = (
+        AsyncMock(side_effect=PermissionDeniedError("denied"))
+        if permission_denied
+        else AsyncMock(return_value=[])
+    )
+    monkeypatch.setattr(datasets_router_module, "get_authorized_existing_datasets", result)
+
+    path = f"/api/v1/datasets/{dataset_id}/data"
+    if include_data_id:
+        path += f"/{data_id}/raw"
+
+    response = client.get(path)
+
+    assert response.status_code == 404
+    assert response.json() == {"message": f"Dataset ({dataset_id}) not found."}
+
+
+def test_get_raw_data_rejects_data_from_another_dataset(client, monkeypatch):
+    import importlib
+
+    datasets_router_module = importlib.import_module(
+        "cognee.api.v1.datasets.routers.get_datasets_router"
+    )
+    data_methods_module = importlib.import_module("cognee.modules.data.methods")
+    dataset_id = uuid.uuid4()
+    requested_data_id = uuid.uuid4()
+
+    monkeypatch.setattr(
+        datasets_router_module,
+        "get_authorized_existing_datasets",
+        AsyncMock(return_value=[SimpleNamespace(id=dataset_id)]),
+    )
+    monkeypatch.setattr(
+        data_methods_module,
+        "get_dataset_data",
+        AsyncMock(return_value=[SimpleNamespace(id=uuid.uuid4())]),
+    )
+
+    with pytest.raises(DataNotFoundError):
+        client.get(f"/api/v1/datasets/{dataset_id}/data/{requested_data_id}/raw")


### PR DESCRIPTION
  ## Description

  Closes #<ISSUE_NUMBER>

  This PR fixes inconsistent authorization and missing-dataset handling in the dataset read endpoints:

  - `GET /api/v1/datasets/{dataset_id}/data`
  - `GET /api/v1/datasets/{dataset_id}/data/{data_id}/raw`

  The raw-download endpoint first verified that the caller had `read` permission on the requested dataset and that the requested
  data item belonged to that dataset. It then called `get_data(user.id, data_id)`, which applied an additional owner-only check.

  As a result, users with a valid dataset read grant could list a shared dataset's data but could not download the raw content
  of those same data items.

  This change uses the data record already obtained through the authorized dataset membership check. It does not relax the
  owner-only behavior of `get_data()` globally.

  The PR also fixes missing and inaccessible dataset handling. Both endpoints previously checked whether the authorization
  result was `None`, although the helper returns a list or raises `PermissionDeniedError`. This made the intended 404 handling
  ineffective and left empty results vulnerable to `[0]` indexing.

  A shared response helper now:

  - Converts dataset read permission failures into the documented 404 response.
  - Handles empty authorization results safely.
  - Constructs `ErrorResponseDTO` using valid Pydantic keyword arguments.
  - Produces the same response shape for both dataset read endpoints.

  ## Acceptance Criteria

  - [x] Dataset owners can download raw data.
  - [x] Users with a dataset-level `read` grant can download raw data belonging to that dataset.
  - [x] The raw endpoint does not apply an additional data-owner requirement after dataset authorization.
  - [x] A data ID belonging to another dataset is rejected.
  - [x] Missing datasets return 404.
  - [x] Inaccessible datasets return 404, matching the documented endpoint contract.
  - [x] Empty authorization results do not cause `IndexError`.
  - [x] Error responses are valid JSON and use valid Pydantic construction.
  - [x] Local-file and S3 raw downloads continue to work.

  ## Implementation Details

  The raw-download flow now follows this authorization sequence:

  1. Verify that the caller has `read` permission on the requested dataset.
  2. Load data associated with the authorized dataset.
  3. Verify that `data_id` is present in that dataset.
  4. Use the matched data record to return the raw content.

  This preserves the important cross-dataset boundary: possession of read access to one dataset cannot be used to download a
  data item from another dataset.

  The owner-only `get_data()` method was left unchanged because other operations may rely on its existing semantics.

  ## Tests

  Added or updated coverage for:

  - Raw downloads by an authorized dataset reader who does not own the data row.
  - Missing datasets represented by an empty authorization result.
  - Inaccessible datasets represented by `PermissionDeniedError`.
  - Both dataset-listing and raw-download routes returning 404.
  - Rejection of a data ID associated with another dataset.
  - Existing local-file, plain-path, encoded-path, S3, and unsupported-scheme behavior.

  Commands run:

  ```bash
  uv run ruff format --check \
    cognee/api/v1/datasets/routers/get_datasets_router.py \
    cognee/tests/unit/api/test_get_raw_data_endpoint.py

  uv run ruff check \
    cognee/api/v1/datasets/routers/get_datasets_router.py \
    cognee/tests/unit/api/test_get_raw_data_endpoint.py

  git diff --check

  uv run pytest cognee/tests/unit/api/ -q

  Results:

  2 files already formatted
  All Ruff checks passed
  No whitespace errors
  274 passed

  The reported warnings are existing Pydantic, FastAPI, Starlette, Alembic, and datetime.utcnow() deprecation warnings.

 ## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

 ## Screenshots
  <!-- Add a screenshot showing the 274 passing unit API tests. -->

 ## Pre-submission Checklist

 - [x] I have tested my changes thoroughly before submitting this PR
 - [x] This PR contains minimal changes necessary to address the issue
 - [x] My code follows the project's coding standards and style guidelines
 - [x] I have added tests that prove my fix is effective
 - [x] I have added necessary documentation (not applicable)
 - [x] All new and existing relevant tests pass
 - [ ] I have searched existing PRs to ensure this change hasn't been submitted already
 - [x] I have linked the relevant issue in the description
 - [x] My commit has a clear and descriptive message

  ## DCO Affirmation

  I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of
  Origin.
