### PR TITLE
fix(recall): scope session cache owner resolution

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -74,7 +74,48 @@ async def _resolve_user_id(user: str | None) -> str | None:
     return str(user.id) if hasattr(user, "id") else None
 
 
-async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | None) -> str | None:
+def _select_session_cache_owner(
+    rows: list,
+    caller_user_id: UUID,
+    permitted_dataset_ids: set[UUID],
+    requested_dataset_ids: set[UUID] | None,
+) -> UUID | None:
+    """Select one visible session owner without guessing between ambiguous rows."""
+    visible = [
+        row
+        for row in rows
+        if (row.user_id == caller_user_id or row.dataset_id in permitted_dataset_ids)
+        and (requested_dataset_ids is None or row.dataset_id in requested_dataset_ids)
+    ]
+    if not visible:
+        return None
+
+    # Dataset-backed records represent sessions written through the tracked
+    # lifecycle path. Preserve the legacy fallback to an unscoped caller row
+    # only when no dataset-backed record is visible.
+    with_dataset = [row for row in visible if row.dataset_id is not None]
+    candidates = with_dataset or visible
+
+    caller_rows = [row for row in candidates if row.user_id == caller_user_id]
+    if caller_rows:
+        return caller_user_id
+
+    owners = {row.user_id for row in candidates}
+    if len(owners) == 1:
+        return owners.pop()
+
+    logger.warning(
+        "Session cache owner is ambiguous for a shared session id; "
+        "provide a dataset scope that identifies one session."
+    )
+    return None
+
+
+async def _resolve_session_cache_user_id(
+    session_id: str,
+    caller_user_id: str | None,
+    dataset_ids: list[UUID] | None = None,
+) -> str | None:
     """Resolve the user_id to use when querying the session cache.
 
     Session-cache entries are keyed by the session's OWNER, not by the
@@ -83,24 +124,24 @@ async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | 
     return the owner's id so ``SessionManager.get_session`` finds the
     entries.
 
-    Two complications the resolver handles:
+    Resolution rules:
 
     * The same ``session_id`` can exist under multiple owners (the PK
-      is ``(session_id, user_id)``, not ``session_id`` alone). The
-      caller might own an empty row AND simultaneously have read
-      permission on a non-owned row that has all the cache content.
-      We pick the candidate most likely to have real entries — the
-      one with ``dataset_id`` populated wins over an empty row.
+      is ``(session_id, user_id)``, not ``session_id`` alone). An
+      explicit dataset scope filters candidates before an owner is
+      selected.
+
+    * The caller's own dataset-backed row takes precedence. A single
+      visible non-owned row remains supported for parent/agent flows,
+      but multiple non-owned candidates are treated as ambiguous.
 
     * Falls back to ``caller_user_id`` when nothing is in
       ``session_records`` yet so behaviour matches the pre-visibility
-      state.
+      state. This fallback is disabled for explicitly scoped requests.
     """
     if not session_id:
         return caller_user_id
     try:
-        from uuid import UUID
-
         from sqlalchemy import select
 
         from cognee.infrastructure.databases.relational import get_relational_engine
@@ -113,12 +154,12 @@ async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | 
         if caller_uuid is None:
             return caller_user_id
 
-        permitted_ids: list[UUID] = []
+        permitted_ids: set[UUID] = set()
         try:
             permitted = await get_specific_user_permission_datasets(caller_uuid, "read", None)
-            permitted_ids = [ds.id for ds in permitted] if permitted else []
+            permitted_ids = {ds.id for ds in permitted} if permitted else set()
         except Exception:
-            permitted_ids = []
+            permitted_ids = set()
 
         # Fetch ALL candidate rows the caller can see for this
         # session_id. Owner match OR permitted-dataset match.
@@ -128,31 +169,18 @@ async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | 
             rows = list((await session.execute(stmt)).scalars().all())
 
         if not rows:
-            return caller_user_id
+            return None if dataset_ids is not None else caller_user_id
 
-        visible: list[SessionRecord] = []
-        for r in rows:
-            if r.user_id == caller_uuid:
-                visible.append(r)
-            elif permitted_ids and r.dataset_id in permitted_ids:
-                visible.append(r)
-
-        if not visible:
-            return caller_user_id
-
-        # Prefer a row with dataset_id populated — those came through
-        # the proper write path and have cache content. Within that,
-        # prefer rows the caller does NOT own (the active writer of
-        # the session, e.g. an agent).
-        with_dataset = [r for r in visible if r.dataset_id is not None]
-        pool = with_dataset or visible
-        non_owner = [r for r in pool if r.user_id != caller_uuid]
-        chosen = (non_owner or pool)[0]
-        owner = getattr(chosen, "user_id", None)
-        return str(owner) if owner is not None else caller_user_id
+        owner = _select_session_cache_owner(
+            rows,
+            caller_uuid,
+            permitted_ids,
+            set(dataset_ids) if dataset_ids is not None else None,
+        )
+        return str(owner) if owner is not None else None
     except Exception:
-        pass
-    return caller_user_id
+        logger.debug("Failed to resolve session cache owner", exc_info=True)
+    return None if dataset_ids is not None else caller_user_id
 
 
 async def _search_session(
@@ -160,6 +188,7 @@ async def _search_session(
     session_id: str,
     top_k: int = 15,
     user: str | None = None,
+    dataset_ids: list[UUID] | None = None,
     _parent_span=None,
 ) -> list[ResponseQAEntry]:
     """Search session-cache QA entries by keyword matching.
@@ -174,7 +203,7 @@ async def _search_session(
     if not caller_user_id:
         return []
     # Cache is keyed by session owner — resolve cross-user grants.
-    cache_user_id = await _resolve_session_cache_user_id(session_id, caller_user_id)
+    cache_user_id = await _resolve_session_cache_user_id(session_id, caller_user_id, dataset_ids)
     if not cache_user_id:
         return []
 
@@ -218,6 +247,7 @@ async def _search_trace(
     session_id: str,
     top_k: int = 15,
     user: str | None = None,
+    dataset_ids: list[UUID] | None = None,
 ) -> list[ResponseAgentTraceEntry]:
     """Search session-cache agent trace steps by keyword matching.
 
@@ -232,7 +262,7 @@ async def _search_trace(
     caller_user_id = await _resolve_user_id(user)
     if not caller_user_id:
         return []
-    cache_user_id = await _resolve_session_cache_user_id(session_id, caller_user_id)
+    cache_user_id = await _resolve_session_cache_user_id(session_id, caller_user_id, dataset_ids)
     if not cache_user_id:
         return []
 
@@ -289,6 +319,7 @@ async def _fetch_session_context(
     session_id: str,
     context_profile: str,
     user: str | None = None,
+    dataset_ids: list[UUID] | None = None,
 ) -> list[ResponseSessionContextEntry]:
     """Render active session-context lessons for one profile as a one-item list.
 
@@ -301,7 +332,7 @@ async def _fetch_session_context(
     caller_user_id = await _resolve_user_id(user)
     if not caller_user_id:
         return []
-    cache_user_id = await _resolve_session_cache_user_id(session_id, caller_user_id)
+    cache_user_id = await _resolve_session_cache_user_id(session_id, caller_user_id, dataset_ids)
     if not cache_user_id:
         return []
 
@@ -474,51 +505,11 @@ async def recall(
             return results
 
         merged: list[RecallResponse] = []
+        resolved_dataset_ids = list(dataset_ids) if dataset_ids else None
+        dataset_scope_resolved = resolved_dataset_ids is not None or not datasets
 
-        async def _run_session() -> list[RecallResponse]:
-            if not session_id:
-                return []
-            return list(
-                await _search_session(
-                    query_text=query_text,
-                    session_id=session_id,
-                    top_k=top_k,
-                    user=user,
-                )
-            )
-
-        async def _run_trace() -> list[RecallResponse]:
-            if not session_id:
-                return []
-            return list(
-                await _search_trace(
-                    query_text=query_text,
-                    session_id=session_id,
-                    top_k=top_k,
-                    user=user,
-                )
-            )
-
-        async def _run_session_context() -> list[RecallResponse]:
-            if not session_id:
-                return []
-            return list(
-                await _fetch_session_context(
-                    query_text=query_text,
-                    session_id=session_id,
-                    context_profile=context_profile,
-                    user=user,
-                )
-            )
-
-        async def _run_graph() -> list[RecallResponse]:
-            nonlocal user, dataset_ids
-
-            from cognee.modules.recall.methods.normalize_search_payload import (
-                normalize_search_payload,
-            )
-            from cognee.modules.search.methods.search import authorized_search
-
+        async def _resolve_local_user():
+            nonlocal user
             if user is None:
                 try:
                     user = await get_default_user()
@@ -531,8 +522,72 @@ async def recall(
                         ),
                         name="RecallPreconditionError",
                     ) from error
+            return user
 
-            await set_session_user_context_variable(user)
+        async def _resolve_dataset_scope() -> list[UUID] | None:
+            nonlocal dataset_scope_resolved, resolved_dataset_ids
+            if dataset_scope_resolved:
+                return resolved_dataset_ids
+
+            resolved_user = await _resolve_local_user()
+            resolved_dataset_ids = [
+                dataset.id
+                for dataset in await get_authorized_existing_datasets(
+                    datasets, "read", resolved_user
+                )
+            ]
+            if not resolved_dataset_ids:
+                raise DatasetNotFoundError(message="No datasets found.")
+            dataset_scope_resolved = True
+            return resolved_dataset_ids
+
+        async def _run_session() -> list[RecallResponse]:
+            if not session_id:
+                return []
+            return list(
+                await _search_session(
+                    query_text=query_text,
+                    session_id=session_id,
+                    top_k=top_k,
+                    user=user,
+                    dataset_ids=await _resolve_dataset_scope(),
+                )
+            )
+
+        async def _run_trace() -> list[RecallResponse]:
+            if not session_id:
+                return []
+            return list(
+                await _search_trace(
+                    query_text=query_text,
+                    session_id=session_id,
+                    top_k=top_k,
+                    user=user,
+                    dataset_ids=await _resolve_dataset_scope(),
+                )
+            )
+
+        async def _run_session_context() -> list[RecallResponse]:
+            if not session_id:
+                return []
+            return list(
+                await _fetch_session_context(
+                    query_text=query_text,
+                    session_id=session_id,
+                    context_profile=context_profile,
+                    user=user,
+                    dataset_ids=await _resolve_dataset_scope(),
+                )
+            )
+
+        async def _run_graph() -> list[RecallResponse]:
+            from cognee.modules.recall.methods.normalize_search_payload import (
+                normalize_search_payload,
+            )
+            from cognee.modules.search.methods.search import authorized_search
+
+            resolved_user = await _resolve_local_user()
+            await set_session_user_context_variable(resolved_user)
 
             local_query_type = query_type
             if local_query_type is not None:
@@ -556,20 +611,13 @@ async def recall(
             )
 
             # Dataset UUIDs take precedence over names, matching /api/v1/search.
-            # String dataset names can only resolve for the current user.
-            search_dataset_ids = dataset_ids or None
-            if search_dataset_ids is None and datasets is not None:
-                search_dataset_ids = [
-                    dataset.id
-                    for dataset in await get_authorized_existing_datasets(datasets, "read", user)
-                ]
-                if not search_dataset_ids:
-                    raise DatasetNotFoundError(message="No datasets found.")
+            # The same resolved scope is used by session-backed recall sources.
+            search_dataset_ids = await _resolve_dataset_scope()
 
             graph_results = await authorized_search(
                 query_text=query_text,
                 query_type=local_query_type,
-                user=user,
+                user=resolved_user,
                 dataset_ids=search_dataset_ids,
                 system_prompt_path=system_prompt_path,
                 system_prompt=system_prompt,

--- a/cognee/tests/unit/api/v1/recall/test_recall_api.py
+++ b/cognee/tests/unit/api/v1/recall/test_recall_api.py
@@ -16,6 +16,98 @@ def api_recall_mod():
     return importlib.import_module("cognee.api.v1.recall.recall")
 
 
+def _session_row(user_id, dataset_id):
+    return types.SimpleNamespace(user_id=user_id, dataset_id=dataset_id)
+
+
+def test_session_cache_owner_prefers_callers_scoped_row(api_recall_mod):
+    caller_id = uuid4()
+    other_id = uuid4()
+    caller_dataset_id = uuid4()
+    other_dataset_id = uuid4()
+    rows = [
+        _session_row(other_id, other_dataset_id),
+        _session_row(caller_id, caller_dataset_id),
+    ]
+
+    owner = api_recall_mod._select_session_cache_owner(
+        rows,
+        caller_id,
+        {caller_dataset_id, other_dataset_id},
+        {caller_dataset_id, other_dataset_id},
+    )
+
+    assert owner == caller_id
+
+
+def test_session_cache_owner_honors_requested_dataset_scope(api_recall_mod):
+    caller_id = uuid4()
+    agent_id = uuid4()
+    caller_dataset_id = uuid4()
+    agent_dataset_id = uuid4()
+    rows = [
+        _session_row(caller_id, caller_dataset_id),
+        _session_row(agent_id, agent_dataset_id),
+    ]
+
+    owner = api_recall_mod._select_session_cache_owner(
+        rows,
+        caller_id,
+        {caller_dataset_id, agent_dataset_id},
+        {agent_dataset_id},
+    )
+
+    assert owner == agent_id
+    assert (
+        api_recall_mod._select_session_cache_owner(
+            rows,
+            caller_id,
+            {caller_dataset_id, agent_dataset_id},
+            {uuid4()},
+        )
+        is None
+    )
+
+
+def test_session_cache_owner_rejects_ambiguous_non_owner_rows(api_recall_mod):
+    caller_id = uuid4()
+    first_agent_id = uuid4()
+    second_agent_id = uuid4()
+    dataset_id = uuid4()
+    rows = [
+        _session_row(first_agent_id, dataset_id),
+        _session_row(second_agent_id, dataset_id),
+    ]
+
+    owner = api_recall_mod._select_session_cache_owner(
+        rows,
+        caller_id,
+        {dataset_id},
+        {dataset_id},
+    )
+
+    assert owner is None
+
+
+def test_session_cache_owner_preserves_single_agent_session_fallback(api_recall_mod):
+    caller_id = uuid4()
+    agent_id = uuid4()
+    dataset_id = uuid4()
+    rows = [
+        _session_row(caller_id, None),
+        _session_row(agent_id, dataset_id),
+    ]
+
+    owner = api_recall_mod._select_session_cache_owner(
+        rows,
+        caller_id,
+        {dataset_id},
+        None,
+    )
+
+    assert owner == agent_id
+
+
 @pytest.mark.asyncio
 async def test_recall_dataset_ids_takes_precedence_over_datasets(monkeypatch, api_recall_mod):
     user = _make_user()
@@ -135,6 +227,7 @@ async def test_recall_session_with_dataset_ids_does_not_short_circuit_graph(
         return None
 
     async def dummy_search_session(**kwargs):
+        captured["session_dataset_ids"] = kwargs.get("dataset_ids")
         return []
 
     async def dummy_search_trace(**kwargs):
@@ -169,7 +262,86 @@ async def test_recall_session_with_dataset_ids_does_not_short_circuit_graph(
 
     assert out == []
     assert captured["dataset_ids"] == [explicit_id]
+    assert captured["session_dataset_ids"] == [explicit_id]
     assert "resolved_from_datasets" not in captured
+
+
+@pytest.mark.asyncio
+async def test_recall_threads_dataset_scope_to_all_session_sources(monkeypatch, api_recall_mod):
+    user = _make_user()
+    explicit_id = uuid4()
+    captured = {}
+
+    async def dummy_search_session(**kwargs):
+        captured["session"] = kwargs.get("dataset_ids")
+        return []
+
+    async def dummy_search_trace(**kwargs):
+        captured["trace"] = kwargs.get("dataset_ids")
+        return []
+
+    async def dummy_fetch_session_context(**kwargs):
+        captured["session_context"] = kwargs.get("dataset_ids")
+        return []
+
+    monkeypatch.setattr(api_recall_mod, "_search_session", dummy_search_session)
+    monkeypatch.setattr(api_recall_mod, "_search_trace", dummy_search_trace)
+    monkeypatch.setattr(api_recall_mod, "_fetch_session_context", dummy_fetch_session_context)
+
+    serve_state = importlib.import_module("cognee.api.v1.serve.state")
+    monkeypatch.setattr(serve_state, "get_remote_client", lambda: None)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        dataset_ids=[explicit_id],
+        session_id="session-1",
+        scope=["session", "trace", "session_context"],
+        user=user,
+    )
+
+    assert out == []
+    assert captured == {
+        "session": [explicit_id],
+        "trace": [explicit_id],
+        "session_context": [explicit_id],
+    }
+
+
+@pytest.mark.asyncio
+async def test_recall_resolves_dataset_names_for_session_sources(monkeypatch, api_recall_mod):
+    user = _make_user()
+    resolved_id = uuid4()
+    captured = {}
+
+    async def dummy_get_authorized_existing_datasets(datasets, permission, resolved_user):
+        captured["authorization"] = (datasets, permission, resolved_user)
+        return [types.SimpleNamespace(id=resolved_id)]
+
+    async def dummy_search_session(**kwargs):
+        captured["session_dataset_ids"] = kwargs.get("dataset_ids")
+        return []
+
+    monkeypatch.setattr(
+        api_recall_mod,
+        "get_authorized_existing_datasets",
+        dummy_get_authorized_existing_datasets,
+    )
+    monkeypatch.setattr(api_recall_mod, "_search_session", dummy_search_session)
+
+    serve_state = importlib.import_module("cognee.api.v1.serve.state")
+    monkeypatch.setattr(serve_state, "get_remote_client", lambda: None)
+
+    out = await api_recall_mod.recall(
+        query_text="q",
+        datasets=["shared-dataset"],
+        session_id="session-1",
+        scope=["session"],
+        user=user,
+    )
+
+    assert out == []
+    assert captured["authorization"] == (["shared-dataset"], "read", user)
+    assert captured["session_dataset_ids"] == [resolved_id]
 
 
 # ----------------------------------------------------------------- session_context scope
@@ -192,7 +364,9 @@ async def test_recall_session_context_scope_threads_profile(monkeypatch, api_rec
     user = _make_user()
     captured = {}
 
-    async def dummy_fetch_session_context(query_text, session_id, context_profile, user=None):
+    async def dummy_fetch_session_context(
+        query_text, session_id, context_profile, user=None, dataset_ids=None
+    ):
         captured["context_profile"] = context_profile
         captured["session_id"] = session_id
         return [
@@ -405,7 +579,7 @@ async def test_fetch_session_context_renders_profile_read_only(monkeypatch, api_
 
     fake = _FakeSM()
 
-    async def fake_resolve_cache_user(session_id, caller_user_id):
+    async def fake_resolve_cache_user(session_id, caller_user_id, dataset_ids=None):
         return caller_user_id
 
     gsm_mod = importlib.import_module("cognee.infrastructure.session.get_session_manager")
@@ -434,7 +608,7 @@ async def test_fetch_session_context_empty_when_no_lessons(monkeypatch, api_reca
         async def get_session_context_entries(self, user_id, session_id):
             return []
 
-    async def fake_resolve_cache_user(session_id, caller_user_id):
+    async def fake_resolve_cache_user(session_id, caller_user_id, dataset_ids=None):
         return caller_user_id
 
     gsm_mod = importlib.import_module("cognee.infrastructure.session.get_session_manager")


### PR DESCRIPTION
## Description

  This PR fixes ambiguous session-cache owner resolution when the same `session_id` exists under multiple users or agents.

  Session records are keyed by `(session_id, user_id)`, so a single session ID may legitimately appear under multiple owners.
  The previous resolver loaded every visible record with that session ID, preferred non-owner records, and selected the first
  database result without deterministic ordering.

  This could cause Recall to query the wrong owner's cache when:

  - The caller and an agent reused the same session ID.
  - Multiple visible agents reused the same session ID.
  - The same session ID appeared in multiple datasets.
  - The Recall request specified a dataset, but session-backed sources ignored that dataset scope.

  The graph source already honored `dataset_ids`, while the `session`, `trace`, and `session_context` sources did not. This
  allowed a combined Recall response to include graph results from the requested dataset alongside session data from an
  unrelated visible dataset.

  ### Resolution rules

  Session-cache owner selection now follows explicit rules:

  1. Filter session records to those visible to the caller.
  2. If the Recall request contains a dataset scope, only consider records belonging to that scope.
  3. Prefer the caller's own matching dataset-backed session.
  4. Preserve parent/agent behavior when exactly one visible non-owner session remains.
  5. If multiple non-owner candidates remain, treat the session ID as ambiguous and return no session-backed result instead of
  selecting an arbitrary owner.
  6. Preserve the legacy caller fallback only for unscoped requests where no lifecycle record exists.

  The same resolved dataset scope is now passed to:

  - Session QA recall.
  - Agent trace recall.
  - Session-context recall.
  - Graph recall.

  Both dataset UUIDs and dataset names are resolved through the same path. Explicit `dataset_ids` continue to take precedence
  over dataset names.

  ## Acceptance Criteria

  - [x] Session-backed Recall honors explicit dataset UUIDs.
  - [x] Session-backed Recall honors resolved dataset names.
  - [x] Session, trace, session-context, and graph sources use the same dataset scope.
  - [x] The caller's matching session is preferred over visible non-owner sessions.
  - [x] A single visible agent-owned session remains accessible.
  - [x] Multiple visible non-owner sessions are treated as ambiguous.
  - [x] Candidate selection no longer depends on database row order.
  - [x] A scoped request does not fall back to an unrelated caller cache.
  - [x] Existing unscoped session behavior remains compatible.
  - [x] Existing Recall and session-memory tests continue to pass.

  ## Implementation Details

  A dedicated selection function now separates visibility and ownership rules from database access.

  The resolver:

  - Loads all lifecycle records matching the requested session ID.
  - Builds the caller's set of readable dataset IDs.
  - Filters records using both visibility and the requested dataset scope.
  - Applies deterministic caller/agent selection rules.
  - Returns no owner when multiple non-owner candidates remain.

  Dataset resolution was also centralized inside `recall()` so every local Recall source receives the same resolved IDs.

  This avoids resolving dataset names independently for graph and session-backed sources and preserves the existing rule that
  explicit UUIDs take precedence over names.

  No database schema or migration changes are required.

  ## Tests

  Added regression coverage for:

  - Caller-owned session precedence regardless of database row order.
  - Selection of an agent session when its dataset is explicitly requested.
  - Rejection of records outside the requested dataset scope.
  - Ambiguous session IDs shared by multiple non-owner agents.
  - Preservation of the single-agent fallback when the caller only has an unscoped lifecycle row.
  - Propagation of explicit dataset UUIDs to session, trace, and session-context sources.
  - Resolution and propagation of dataset names to session-backed sources.
  - Existing graph dataset precedence behavior.

  Commands run:

  ```bash
  uv run ruff format --check \
    cognee/api/v1/recall/recall.py \
    cognee/tests/unit/api/v1/recall/test_recall_api.py

  uv run ruff check \
    cognee/api/v1/recall/recall.py \
    cognee/tests/unit/api/v1/recall/test_recall_api.py

  git diff --check

  uv run pytest \
    cognee/tests/unit/api/v1/recall/ \
    cognee/tests/unit/api/v1/session/ \
    -q

  uv run pytest cognee/tests/unit/api/ -q

  Results:

  Ruff formatting passed
  Ruff lint passed
  No whitespace errors
  97 Recall and session tests passed
  275 unit API tests passed

  The reported warnings are existing Pydantic, FastAPI, Starlette, Alembic, and datetime.utcnow() deprecation warnings.
