### PR TITLE
fix(cognify): validate batch concurrency limits

### DIFF
--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -35,6 +35,7 @@ from cognee.tasks.temporal_graph.extract_knowledge_graph_from_events import (
     extract_knowledge_graph_from_events,
 )
 from cognee.modules.observability import new_span, COGNEE_PIPELINE_NAME, COGNEE_RESULT_SUMMARY
+from cognee.modules.pipelines.utils import validate_batch_size
 
 
 logger = get_logger("cognify")
@@ -203,6 +204,9 @@ async def cognify(
         - LLM_RATE_LIMIT_ENABLED: Enable rate limiting (default: False)
         - LLM_RATE_LIMIT_REQUESTS: Max requests per interval (default: 60)
     """
+    validate_batch_size(chunks_per_batch, "chunks_per_batch", allow_none=True)
+    validate_batch_size(data_per_batch, "data_per_batch")
+
     # Route to remote instance if connected via serve()
     from cognee.api.v1.serve.state import get_remote_client
 
@@ -322,6 +326,8 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
     chunks_per_batch: int = None,
     **kwargs,
 ) -> list[Task]:
+    validate_batch_size(chunks_per_batch, "chunks_per_batch", allow_none=True)
+
     if config is None:
         ontology_config = get_ontology_env_config()
         if (
@@ -346,6 +352,8 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
         chunks_per_batch = (
             cognify_config.chunks_per_batch if cognify_config.chunks_per_batch is not None else 100
         )
+
+    validate_batch_size(chunks_per_batch, "chunks_per_batch")
 
     default_tasks = [
         # EXTRACT: classify raw Data items into typed Document objects
@@ -400,11 +408,13 @@ async def get_temporal_tasks(
     Returns:
         list[Task]: A list of Task objects representing the temporal processing pipeline.
     """
-    if chunks_per_batch is None:
-        from cognee.modules.cognify.config import get_cognify_config
+    validate_batch_size(chunks_per_batch, "chunks_per_batch", allow_none=True)
 
+    if chunks_per_batch is None:
         configured = get_cognify_config().chunks_per_batch
         chunks_per_batch = configured if configured is not None else 10
+
+    validate_batch_size(chunks_per_batch, "chunks_per_batch")
 
     temporal_tasks = [
         # EXTRACT: classify raw Data items into typed Document objects

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -1,7 +1,7 @@
 import os
 import asyncio
 from uuid import UUID
-from pydantic import Field
+from pydantic import Field, StrictInt
 from typing import List, Optional
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
@@ -102,16 +102,18 @@ class CognifyPayloadDTO(InDTO):
             "entity extraction. Leave empty to process without an ontology."
         ),
     )
-    chunks_per_batch: Optional[int] = Field(
+    chunks_per_batch: Optional[StrictInt] = Field(
         default=None,
+        gt=0,
         examples=[None],
         description=(
             "Number of chunks to process per task batch (e.g. 36). Controls processing "
             "parallelism/throughput; leave null for the pipeline default. Higher the value higher the parallelism/throughput"
         ),
     )
-    data_per_batch: Optional[int] = Field(
+    data_per_batch: StrictInt = Field(
         default=20,
+        gt=0,
         examples=[20],
         description="Maximum number of data items to process concurrently within a dataset.",
     )

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -14,7 +14,7 @@ from cognee.infrastructure.llm.config import LLMConfig
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.users.methods import get_default_user
-from cognee.modules.pipelines.utils import generate_pipeline_id
+from cognee.modules.pipelines.utils import generate_pipeline_id, validate_batch_size
 from cognee.modules.pipelines.exceptions import PipelineRunFailedError
 from cognee.tasks.ingestion import resolve_data_directories
 from cognee.modules.pipelines.models import PipelineContext
@@ -69,6 +69,8 @@ async def run_tasks(
     embedding_config: Optional[EmbeddingConfig] = None,
     data_cache: bool = False,
 ):
+    validate_batch_size(data_per_batch, "data_per_batch")
+
     if not user:
         user = await get_default_user()
 

--- a/cognee/modules/pipelines/operations/run_tasks_distributed.py
+++ b/cognee/modules/pipelines/operations/run_tasks_distributed.py
@@ -19,7 +19,7 @@ from cognee.modules.pipelines.operations import (
     log_pipeline_run_complete,
     log_pipeline_run_error,
 )
-from cognee.modules.pipelines.utils import generate_pipeline_id
+from cognee.modules.pipelines.utils import generate_pipeline_id, validate_batch_size
 from cognee.modules.users.methods import get_default_user
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.users.models import User
@@ -99,6 +99,8 @@ async def run_tasks_distributed(
     embedding_config: Optional[EmbeddingConfig] = None,
     data_cache: bool = False,
 ):
+    validate_batch_size(data_per_batch, "data_per_batch")
+
     if not user:
         user = await get_default_user()
 

--- a/cognee/modules/pipelines/utils/__init__.py
+++ b/cognee/modules/pipelines/utils/__init__.py
@@ -1,3 +1,4 @@
 from .generate_pipeline_id import generate_pipeline_id
 from .generate_pipeline_run_id import generate_pipeline_run_id
 from .summarize_run_info_data import summarize_run_info_data
+from .validate_batch_size import validate_batch_size

--- a/cognee/modules/pipelines/utils/validate_batch_size.py
+++ b/cognee/modules/pipelines/utils/validate_batch_size.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+
+def validate_batch_size(
+    value: Optional[int], parameter_name: str, *, allow_none: bool = False
+) -> None:
+    """Require a positive integer for pipeline batch and concurrency limits."""
+    if value is None and allow_none:
+        return
+
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{parameter_name} must be a positive integer.")

--- a/cognee/tests/unit/api/v1/cognify/test_batch_validation.py
+++ b/cognee/tests/unit/api/v1/cognify/test_batch_validation.py
@@ -1,0 +1,93 @@
+import importlib
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from cognee.api.v1.cognify.routers.get_cognify_router import CognifyPayloadDTO
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("chunks_per_batch", 0),
+        ("chunks_per_batch", -1),
+        ("chunks_per_batch", True),
+        ("chunks_per_batch", 1.5),
+        ("data_per_batch", 0),
+        ("data_per_batch", -1),
+        ("data_per_batch", None),
+        ("data_per_batch", True),
+        ("data_per_batch", 1.5),
+    ],
+)
+def test_cognify_payload_rejects_invalid_batch_sizes(field_name, value):
+    with pytest.raises(ValidationError):
+        CognifyPayloadDTO(datasets=["dataset"], **{field_name: value})
+
+
+def test_cognify_payload_allows_default_and_positive_batch_sizes():
+    payload = CognifyPayloadDTO(
+        datasets=["dataset"],
+        chunks_per_batch=None,
+        data_per_batch=1,
+    )
+
+    assert payload.chunks_per_batch is None
+    assert payload.data_per_batch == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("chunks_per_batch", 0),
+        ("chunks_per_batch", -1),
+        ("data_per_batch", 0),
+        ("data_per_batch", -1),
+        ("data_per_batch", None),
+    ],
+)
+async def test_python_cognify_rejects_invalid_batch_sizes_before_starting(field_name, value):
+    cognify_module = importlib.import_module("cognee.api.v1.cognify.cognify")
+
+    with pytest.raises(ValueError, match=rf"^{field_name} must be a positive integer\.$"):
+        await cognify_module.cognify(**{field_name: value})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_builder_name", ["get_default_tasks", "get_temporal_tasks"])
+async def test_task_builders_reject_invalid_configured_chunk_batch_size(
+    monkeypatch, task_builder_name
+):
+    cognify_module = importlib.import_module("cognee.api.v1.cognify.cognify")
+    monkeypatch.setattr(
+        cognify_module,
+        "get_cognify_config",
+        lambda: SimpleNamespace(chunks_per_batch=0, triplet_embedding=False),
+    )
+
+    task_builder = getattr(cognify_module, task_builder_name)
+    kwargs = {"config": {}} if task_builder_name == "get_default_tasks" else {}
+    with pytest.raises(ValueError, match="chunks_per_batch must be a positive integer"):
+        await task_builder(**kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("data_per_batch", [0, -1, None, True, 1.5])
+async def test_run_tasks_rejects_invalid_concurrency_before_creating_a_run(
+    monkeypatch, data_per_batch
+):
+    run_tasks_module = importlib.import_module("cognee.modules.pipelines.operations.run_tasks")
+    monkeypatch.delenv("COGNEE_DISTRIBUTED", raising=False)
+
+    pipeline = run_tasks_module.run_tasks(
+        tasks=[],
+        dataset_id=uuid4(),
+        data=[],
+        data_per_batch=data_per_batch,
+    )
+
+    with pytest.raises(ValueError, match="data_per_batch must be a positive integer"):
+        await anext(pipeline)


### PR DESCRIPTION
## Description

  This PR prevents Cognify pipelines from hanging or failing with low-level asyncio errors when invalid batch settings are
  supplied.

  Previously, neither `data_per_batch` nor `chunks_per_batch` was required to be a positive integer.

  In particular:

  ```python
  asyncio.Semaphore(data_per_batch)

  with data_per_batch=0 creates a permanently locked semaphore. Every scheduled data item then waits indefinitely, potentially
  leaving the pipeline run in STARTED.

  Other invalid inputs also produced undesirable behavior:

  - Negative values raised a low-level ValueError while constructing the semaphore.
  - None raised a TypeError.
  - Zero or negative chunk batch sizes prevented normal task-batch flushing.
  - Boolean or fractional values could be accepted or coerced despite not being valid concurrency limits.
  - Invalid configuration-derived chunk batch sizes were not checked.

  This PR adds consistent positive-integer validation at each relevant boundary:

  - FastAPI request payload validation.
  - Public Python cognify() API.
  - Default and temporal Cognify task builders.
  - Local pipeline execution.
  - Distributed pipeline execution.

  Invalid values now fail immediately, before migrations, remote dispatch, database access, or creation of a pipeline run.

  ## Acceptance Criteria

  - [x] data_per_batch must be a strict positive integer.
  - [x] chunks_per_batch must be a strict positive integer when supplied.
  - [x] chunks_per_batch=None remains supported and selects the configured/default value.
  - [x] data_per_batch=None is rejected.
  - [x] Zero and negative values are rejected.
  - [x] Boolean and fractional values are rejected.
  - [x] Invalid Python SDK arguments fail before pipeline startup.
  - [x] Invalid configuration-derived chunk batch sizes are rejected.
  - [x] Local and distributed pipelines validate concurrency before creating a run.
  - [x] Existing valid Cognify and pipeline behavior remains unchanged.

  ## Implementation Details

  ### FastAPI validation

  The Cognify request DTO now uses strict integer fields with gt=0 constraints:

  - chunks_per_batch remains optional because None means to use the pipeline default.
  - data_per_batch is no longer nullable and defaults to 20.

  Using strict integer types prevents Pydantic from silently coercing values such as true or 1.5 into concurrency settings.

  ### Shared core validation

  A shared validate_batch_size() helper enforces the same rule outside FastAPI:

  validate_batch_size(chunks_per_batch, "chunks_per_batch", allow_none=True)
  validate_batch_size(data_per_batch, "data_per_batch")

  The helper rejects:

  - None, unless explicitly allowed.
  - Booleans.
  - Non-integer values.
  - Zero.
  - Negative integers.

  ### Public Python API

  cognee.cognify() validates both parameters before checking for a remote client or starting migrations. SDK users therefore
  receive a clear ValueError immediately rather than a later pipeline failure or hang.

  ### Task builders

  Both default and temporal task builders validate:

  1. An explicitly supplied chunks_per_batch.
  2. The effective value after applying configuration or fallback defaults.

  This also protects against invalid values loaded from configuration.

  ### Pipeline execution

  Local and distributed run_tasks implementations validate data_per_batch before:

  - Looking up the default user.
  - Accessing the database.
  - Logging a pipeline run.
  - Yielding PipelineRunStarted.
  - Constructing an asyncio semaphore.

  This ensures invalid concurrency cannot leave a run recorded as active.

  ## Tests

  Added regression coverage for:

  - FastAPI rejection of zero chunk batch sizes.
  - FastAPI rejection of negative chunk batch sizes.
  - FastAPI rejection of zero data concurrency.
  - FastAPI rejection of negative data concurrency.
  - FastAPI rejection of null data concurrency.
  - FastAPI rejection of booleans and fractional values.
  - Valid positive values and the default chunks_per_batch=None behavior.
  - Python API validation before pipeline startup.
  - Invalid configuration-derived values in default task construction.
  - Invalid configuration-derived values in temporal task construction.
  - Pipeline validation before database access or run creation.
  - Non-integer values at the core pipeline boundary.

  Commands run:

  uv run ruff format --check \
    cognee/api/v1/cognify/routers/get_cognify_router.py \
    cognee/api/v1/cognify/cognify.py \
    cognee/modules/pipelines/operations/run_tasks.py \
    cognee/modules/pipelines/operations/run_tasks_distributed.py \
    cognee/modules/pipelines/utils \
    cognee/tests/unit/api/v1/cognify/test_batch_validation.py

  uv run ruff check \
    cognee/api/v1/cognify/routers/get_cognify_router.py \
    cognee/api/v1/cognify/cognify.py \
    cognee/modules/pipelines/operations/run_tasks.py \
    cognee/modules/pipelines/operations/run_tasks_distributed.py \
    cognee/modules/pipelines/utils \
    cognee/tests/unit/api/v1/cognify/test_batch_validation.py

  git diff --check

  uv run pytest \
    cognee/tests/unit/api/v1/cognify/test_batch_validation.py \
    cognee/tests/unit/modules/cognify/ \
    cognee/tests/unit/modules/pipelines/ \
    cognee/tests/unit/pipelines/ \
    -q

  uv run pytest cognee/tests/unit/api/ -q

  Results:

  Ruff formatting passed
  Ruff lint passed
  No whitespace errors
  137 Cognify and pipeline tests passed
  291 unit API tests passed

  The test suites report existing dependency deprecation warnings. One pipeline-suite process also emitted an aiohttp connector
  cleanup warning after the tests completed; it did not fail the suite and is unrelated to this change.