### PR TITLE
fix(pipelines): isolate background dataset failures

### DIFF
--- a/cognee/modules/pipelines/layers/pipeline_execution_mode.py
+++ b/cognee/modules/pipelines/layers/pipeline_execution_mode.py
@@ -6,6 +6,7 @@ from cognee.modules.users.methods.get_default_user import get_default_user
 from cognee.modules.data.methods.get_authorized_existing_datasets import (
     get_authorized_existing_datasets,
 )
+from cognee.shared.logging_utils import get_logger
 
 AsyncGenLike = Union[
     AsyncIterable[Any],
@@ -19,6 +20,87 @@ AsyncGenLike = Union[
 # an in-flight task before it completes, silently aborting the background run. Tasks
 # remove themselves on done, so this set's size tracks currently-running pipelines.
 _BACKGROUND_PIPELINE_TASKS: set[asyncio.Task] = set()
+logger = get_logger("pipeline_execution_mode")
+
+
+def _handle_background_task_done(task: asyncio.Task) -> None:
+    """Release a completed supervisor task and retrieve unexpected exceptions."""
+    _BACKGROUND_PIPELINE_TASKS.discard(task)
+    if task.cancelled():
+        return
+
+    error = task.exception()
+    if error is not None:
+        logger.error(
+            "Background pipeline supervisor failed: %s",
+            error,
+            exc_info=(type(error), error, error.__traceback__),
+        )
+
+
+async def _close_pipeline(pipeline: AsyncIterable[Any]) -> None:
+    close = getattr(pipeline, "aclose", None)
+    if not callable(close):
+        return
+
+    try:
+        await close()
+    except Exception:
+        logger.exception("Failed to close a background pipeline generator")
+
+
+async def _record_unhandled_pipeline_error(started_info, error: Exception) -> None:
+    """Persist an error when a custom pipeline fails without doing so itself."""
+    try:
+        from cognee.modules.pipelines.methods import get_pipeline_run
+        from cognee.modules.pipelines.operations import log_pipeline_run_error
+
+        pipeline_run = await get_pipeline_run(started_info.pipeline_run_id)
+        if pipeline_run is None:
+            return
+
+        run_info = pipeline_run.run_info if isinstance(pipeline_run.run_info, dict) else {}
+        await log_pipeline_run_error(
+            started_info.pipeline_run_id,
+            pipeline_run.pipeline_id,
+            pipeline_run.pipeline_name,
+            started_info.dataset_id,
+            run_info.get("data"),
+            error,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to persist background pipeline error for dataset %s",
+            started_info.dataset_id,
+        )
+
+
+async def _drain_background_pipeline(pipeline, started_info) -> None:
+    """Drain one pipeline without allowing its failure to abort later datasets."""
+    terminal_emitted = False
+    try:
+        async for pipeline_run_info in pipeline:
+            push_to_queue(pipeline_run_info.pipeline_run_id, pipeline_run_info)
+            if isinstance(pipeline_run_info, (PipelineRunCompleted, PipelineRunErrored)):
+                terminal_emitted = True
+    except asyncio.CancelledError:
+        raise
+    except Exception as error:
+        logger.exception(
+            "Background pipeline failed for dataset %s",
+            started_info.dataset_id,
+        )
+        if not terminal_emitted:
+            await _record_unhandled_pipeline_error(started_info, error)
+            pipeline_run_info = PipelineRunErrored(
+                pipeline_run_id=started_info.pipeline_run_id,
+                dataset_id=started_info.dataset_id,
+                dataset_name=started_info.dataset_name,
+                payload=repr(error),
+            )
+            push_to_queue(pipeline_run_info.pipeline_run_id, pipeline_run_info)
+    finally:
+        await _close_pipeline(pipeline)
 
 
 async def run_pipeline_blocking(pipeline: AsyncGenLike, **params) -> Dict[str, Any]:
@@ -91,38 +173,46 @@ async def run_pipeline_as_background_process(
     async def handle_rest_of_the_run(pipeline_list):
         # Execute all provided pipelines one by one to avoid database write conflicts
         # TODO: Convert to async gather task instead of for loop when Queue mechanism for database is created
-        for pipeline in pipeline_list:
-            while True:
-                try:
-                    pipeline_run_info = await anext(pipeline)
-                    push_to_queue(pipeline_run_info.pipeline_run_id, pipeline_run_info)
-                except StopAsyncIteration:
-                    break
+        try:
+            for pipeline_run, started_info in pipeline_list:
+                await _drain_background_pipeline(pipeline_run, started_info)
+        finally:
+            # Cancellation or an unexpected supervisor failure must also close
+            # generators that have emitted STARTED but have not been drained yet.
+            for pipeline_run, _ in pipeline_list:
+                await _close_pipeline(pipeline_run)
 
     # Start all pipelines to get started status
     pipeline_list = []
-    for dataset in datasets:
-        call_params = dict(params)
-        if "datasets" in call_params:
-            call_params["datasets"] = dataset
+    created_pipelines = []
+    try:
+        for dataset in datasets:
+            call_params = dict(params)
+            if "datasets" in call_params:
+                call_params["datasets"] = dataset
 
-        pipeline_run = pipeline(**call_params) if callable(pipeline) else pipeline
+            pipeline_run = pipeline(**call_params) if callable(pipeline) else pipeline
+            created_pipelines.append(pipeline_run)
 
-        # Save dataset Pipeline run started info
-        run_info = await anext(pipeline_run)
-        pipeline_run_started_info[run_info.dataset_id] = run_info
+            # Save dataset Pipeline run started info
+            run_info = await anext(pipeline_run)
+            pipeline_run_started_info[run_info.dataset_id] = run_info
 
-        if pipeline_run_started_info[run_info.dataset_id].payload:
-            # Remove payload info to avoid serialization
-            # TODO: Handle payload serialization
-            pipeline_run_started_info[run_info.dataset_id].payload = []
+            if pipeline_run_started_info[run_info.dataset_id].payload:
+                # Remove payload info to avoid serialization
+                # TODO: Handle payload serialization
+                pipeline_run_started_info[run_info.dataset_id].payload = []
 
-        pipeline_list.append(pipeline_run)
+            pipeline_list.append((pipeline_run, run_info))
+    except BaseException:
+        for created_pipeline in created_pipelines:
+            await _close_pipeline(created_pipeline)
+        raise
 
     # Send all started pipelines to execute one by one in background
     task = asyncio.create_task(handle_rest_of_the_run(pipeline_list=pipeline_list))
     _BACKGROUND_PIPELINE_TASKS.add(task)
-    task.add_done_callback(_BACKGROUND_PIPELINE_TASKS.discard)
+    task.add_done_callback(_handle_background_task_done)
 
     return pipeline_run_started_info
 

--- a/cognee/tests/unit/modules/pipelines/test_background_pipeline_task_anchoring.py
+++ b/cognee/tests/unit/modules/pipelines/test_background_pipeline_task_anchoring.py
@@ -9,10 +9,16 @@ module-level ``_BACKGROUND_PIPELINE_TASKS`` set and discards it on completion.
 
 import gc
 import asyncio
+from uuid import uuid4
 
 import pytest
 
 from cognee.modules.pipelines.layers import pipeline_execution_mode
+from cognee.modules.pipelines.models.PipelineRunInfo import (
+    PipelineRunCompleted,
+    PipelineRunErrored,
+    PipelineRunStarted,
+)
 from cognee.modules.pipelines.layers.pipeline_execution_mode import (
     run_pipeline_as_background_process,
 )
@@ -60,3 +66,196 @@ async def test_background_pipeline_task_is_anchored_until_done(monkeypatch):
     await asyncio.sleep(0)  # allow the done-callback to run
     assert task not in pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS
     assert len(pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS) == 0
+
+
+@pytest.mark.asyncio
+async def test_background_failure_does_not_abort_later_datasets(monkeypatch):
+    first_dataset_id = uuid4()
+    second_dataset_id = uuid4()
+    run_ids = {
+        first_dataset_id: uuid4(),
+        second_dataset_id: uuid4(),
+    }
+    queued = []
+    persisted_errors = []
+
+    async def record_error(*args):
+        persisted_errors.append(args)
+
+    monkeypatch.setattr(
+        pipeline_execution_mode,
+        "push_to_queue",
+        lambda pipeline_run_id, run_info: queued.append((pipeline_run_id, run_info)),
+    )
+    monkeypatch.setattr(
+        pipeline_execution_mode,
+        "_record_unhandled_pipeline_error",
+        record_error,
+    )
+
+    async def pipeline(datasets, **_kwargs):
+        run_id = run_ids[datasets]
+        yield PipelineRunStarted(
+            pipeline_run_id=run_id,
+            dataset_id=datasets,
+            dataset_name=str(datasets),
+        )
+        if datasets == first_dataset_id:
+            yield PipelineRunErrored(
+                pipeline_run_id=run_id,
+                dataset_id=datasets,
+                dataset_name=str(datasets),
+                payload="failed",
+            )
+            raise RuntimeError("first dataset failed")
+        yield PipelineRunCompleted(
+            pipeline_run_id=run_id,
+            dataset_id=datasets,
+            dataset_name=str(datasets),
+        )
+
+    started = await run_pipeline_as_background_process(
+        pipeline,
+        datasets=[first_dataset_id, second_dataset_id],
+    )
+    assert set(started) == {first_dataset_id, second_dataset_id}
+
+    task = next(iter(pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS))
+    await task
+    await asyncio.sleep(0)
+
+    first_updates = [info for _, info in queued if info.dataset_id == first_dataset_id]
+    second_updates = [info for _, info in queued if info.dataset_id == second_dataset_id]
+    assert [type(info) for info in first_updates] == [PipelineRunErrored]
+    assert [type(info) for info in second_updates] == [PipelineRunCompleted]
+    assert persisted_errors == []
+    assert task not in pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS
+
+
+@pytest.mark.asyncio
+async def test_background_supervisor_synthesizes_error_and_closes_generators(monkeypatch):
+    first_dataset_id = uuid4()
+    second_dataset_id = uuid4()
+    run_ids = {
+        first_dataset_id: uuid4(),
+        second_dataset_id: uuid4(),
+    }
+    queued = []
+    closed = []
+    persisted_errors = []
+
+    async def record_error(started_info, error):
+        persisted_errors.append((started_info, error))
+
+    monkeypatch.setattr(
+        pipeline_execution_mode,
+        "push_to_queue",
+        lambda pipeline_run_id, run_info: queued.append((pipeline_run_id, run_info)),
+    )
+    monkeypatch.setattr(
+        pipeline_execution_mode,
+        "_record_unhandled_pipeline_error",
+        record_error,
+    )
+
+    async def pipeline(datasets, **_kwargs):
+        try:
+            run_id = run_ids[datasets]
+            yield PipelineRunStarted(
+                pipeline_run_id=run_id,
+                dataset_id=datasets,
+                dataset_name=str(datasets),
+            )
+            if datasets == first_dataset_id:
+                raise RuntimeError("failed without a terminal update")
+            yield PipelineRunCompleted(
+                pipeline_run_id=run_id,
+                dataset_id=datasets,
+                dataset_name=str(datasets),
+            )
+        finally:
+            closed.append(datasets)
+
+    await run_pipeline_as_background_process(
+        pipeline,
+        datasets=[first_dataset_id, second_dataset_id],
+    )
+    task = next(iter(pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS))
+    await task
+    await asyncio.sleep(0)
+
+    first_updates = [info for _, info in queued if info.dataset_id == first_dataset_id]
+    second_updates = [info for _, info in queued if info.dataset_id == second_dataset_id]
+    assert len(first_updates) == 1
+    assert isinstance(first_updates[0], PipelineRunErrored)
+    assert "failed without a terminal update" in first_updates[0].payload
+    assert [type(info) for info in second_updates] == [PipelineRunCompleted]
+    assert set(closed) == {first_dataset_id, second_dataset_id}
+    assert len(persisted_errors) == 1
+    assert persisted_errors[0][0].dataset_id == first_dataset_id
+    assert str(persisted_errors[0][1]) == "failed without a terminal update"
+
+
+def test_background_done_callback_retrieves_and_logs_unexpected_exception(monkeypatch):
+    error = RuntimeError("supervisor failed")
+
+    class _FailedTask:
+        exception_calls = 0
+
+        def cancelled(self):
+            return False
+
+        def exception(self):
+            self.exception_calls += 1
+            return error
+
+    failed_task = _FailedTask()
+    logged = []
+    monkeypatch.setattr(
+        pipeline_execution_mode.logger,
+        "error",
+        lambda *args, **kwargs: logged.append((args, kwargs)),
+    )
+    pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS.add(failed_task)
+
+    pipeline_execution_mode._handle_background_task_done(failed_task)
+
+    assert failed_task.exception_calls == 1
+    assert failed_task not in pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS
+    assert logged
+
+
+@pytest.mark.asyncio
+async def test_background_cancellation_closes_all_started_generators(monkeypatch):
+    first_dataset_id = uuid4()
+    second_dataset_id = uuid4()
+    release = asyncio.Event()
+    closed = []
+
+    monkeypatch.setattr(pipeline_execution_mode, "push_to_queue", lambda *args: None)
+
+    async def pipeline(datasets, **_kwargs):
+        try:
+            yield PipelineRunStarted(
+                pipeline_run_id=uuid4(),
+                dataset_id=datasets,
+                dataset_name=str(datasets),
+            )
+            await release.wait()
+        finally:
+            closed.append(datasets)
+
+    await run_pipeline_as_background_process(
+        pipeline,
+        datasets=[first_dataset_id, second_dataset_id],
+    )
+    task = next(iter(pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS))
+    await asyncio.sleep(0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0)
+
+    assert set(closed) == {first_dataset_id, second_dataset_id}
+    assert task not in pipeline_execution_mode._BACKGROUND_PIPELINE_TASKS


### PR DESCRIPTION
## Description

  Closes #<ISSUE_NUMBER>

  This PR prevents a failure in one background dataset pipeline from aborting supervision of every dataset scheduled in the same
  request.

  Background execution starts each dataset generator far enough to obtain its initial `PipelineRunStarted` event. It then uses
  one supervisor task to drain the generators sequentially.

  Previously, the supervisor only handled `StopAsyncIteration`:

  ```python
  for pipeline in pipeline_list:
      while True:
          try:
              pipeline_run_info = await anext(pipeline)
              push_to_queue(
                  pipeline_run_info.pipeline_run_id,
                  pipeline_run_info,
              )
          except StopAsyncIteration:
              break

  run_tasks() emits PipelineRunErrored and then re-raises the original exception. The re-raised exception therefore escaped the
  background supervisor and terminated its task.

  This caused several related problems:

  - Later dataset generators were never drained.
  - Those datasets had already emitted PipelineRunStarted.
  - Their persisted status could remain STARTED.
  - Pending generators were not explicitly closed.
  - The supervisor task's done callback discarded the task without retrieving its exception.
  - asyncio could report Task exception was never retrieved.

  This PR introduces per-dataset supervision so one failed pipeline cannot abort later datasets.

  ## Acceptance Criteria

  - [x] A failure in one dataset does not stop subsequent datasets.
  - [x] An existing PipelineRunErrored update is not emitted twice.
  - [x] A generator that fails without emitting a terminal update receives a synthetic error update.
  - [x] Unhandled custom-pipeline failures are persisted as errored when a pipeline-run record exists.
  - [x] Every drained generator is explicitly closed.
  - [x] Cancellation closes the active generator.
  - [x] Cancellation also closes later generators that already emitted STARTED.
  - [x] Partially initialized generators are closed if startup fails.
  - [x] Background supervisor exceptions are retrieved and logged.
  - [x] Completed tasks are removed from the strong-reference task set.
  - [x] Existing sequential execution behavior remains unchanged.

  ## Implementation Details

  ### Per-dataset failure isolation

  Each pipeline generator is now drained through a dedicated helper.

  The helper:

  1. Pushes each yielded update to the pipeline queue.
  2. Tracks whether the pipeline emitted PipelineRunCompleted or PipelineRunErrored.
  3. Catches failures for that generator only.
  4. Logs the failure with its dataset ID.
  5. Continues supervision with the next dataset.
  6. Closes the generator in finally.

  asyncio.CancelledError is deliberately re-raised so cancellation semantics remain intact.

  ### Avoiding duplicate error events

  The standard run_tasks() implementation already:

  1. Persists an errored pipeline status.
  2. Yields PipelineRunErrored.
  3. Re-raises the original exception.

  The supervisor records whether a terminal event was already emitted. When the exception is raised after PipelineRunErrored, it
  logs the failure but does not create a second error event or status record.

  ### Handling custom generators

  A custom pipeline may raise without persisting or yielding an error.

  For this case, the supervisor:

  - Attempts to persist an errored pipeline-run status using the existing run metadata.
  - Pushes a synthetic PipelineRunErrored update to the queue.
  - Includes the original exception representation in the payload.
  - Continues to the next dataset.

  Persistence failures are logged without aborting the remaining pipelines.

  ### Generator cleanup

  All generators are closed through their aclose() method when available.

  Cleanup occurs:

  - After normal completion.
  - After a pipeline exception.
  - If pipeline initialization fails.
  - If the supervisor task is cancelled.
  - If the supervisor itself encounters an unexpected failure.
  - For later generators that emitted STARTED but were not yet drained.

  Cleanup failures are logged independently and do not hide the original pipeline failure.

  ### Task exception handling

  The background task callback now:

  - Removes the completed task from _BACKGROUND_PIPELINE_TASKS.
  - Ignores normal cancellation.
  - Calls task.exception() to retrieve unexpected exceptions.
  - Logs unexpected supervisor failures with traceback information.

  This prevents unhandled-task warnings while retaining strong task references during execution.

  ## Tests

  Added regression coverage for:

  - Strong task anchoring until completion.
  - Removal from the task set after completion.
  - A first dataset emitting PipelineRunErrored and re-raising.
  - Continued processing and completion of a second dataset.
  - No duplicate error update when one was already emitted.
  - A generator failing without a terminal update.
  - Synthetic PipelineRunErrored creation.
  - Persistence of an unhandled custom-pipeline failure.
  - Generator cleanup after failure and completion.
  - Retrieval and logging of unexpected supervisor exceptions.
  - Cancellation cleanup for active and pending generators.

  Commands run:

  uv run ruff format --check \
    cognee/modules/pipelines/layers/pipeline_execution_mode.py \
    cognee/tests/unit/modules/pipelines/test_background_pipeline_task_anchoring.py

  uv run ruff check \
    cognee/modules/pipelines/layers/pipeline_execution_mode.py \
    cognee/tests/unit/modules/pipelines/test_background_pipeline_task_anchoring.py

  git diff --check

  uv run pytest \
    cognee/tests/unit/modules/pipelines/test_background_pipeline_task_anchoring.py \
    -q

  uv run pytest \
    cognee/tests/unit/modules/pipelines/ \
    cognee/tests/unit/pipelines/ \
    -q

  uv run pytest cognee/tests/unit/api/ -q

  Results:

  Ruff formatting passed
  Ruff lint passed
  No whitespace errors
  5 background lifecycle tests passed
  81 pipeline tests passed
  269 unit API tests passed

  The test suites report existing dependency deprecation warnings. The broader pipeline suite also emits an existing aiohttp
  connector cleanup warning after completion; it does not fail the suite and is unrelated to this change.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Code refactoring
  - [ ] Other (please specify):

  ## Screenshots
  <!-- Add a screenshot showing the passing test output. -->

  ## Pre-submission Checklist

  - [x] I have tested my changes thoroughly before submitting this PR
  - [x] This PR contains minimal changes necessary to address the issue
  - [x] My code follows the project's coding standards and style guidelines
  - [x] I have added tests that prove my fix is effective
  - [x] I have added necessary documentation (not applicable)
  - [x] All new and existing relevant tests pass
  - [ ] I have searched existing PRs to ensure this change hasn't been submitted already
  - [x] I have linked the relevant issue in the description
  - [x] My commit has a clear and descriptive message

  ## DCO Affirmation

  I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of
  Origin.
