### PR TITLE
fix(pipelines): lock datasets across workers

### DIFF
--- a/cognee/infrastructure/locks/dataset_pipeline_lock.py
+++ b/cognee/infrastructure/locks/dataset_pipeline_lock.py
@@ -1,0 +1,142 @@
+"""Cross-worker locking for pipeline runs that target the same dataset."""
+
+import asyncio
+import os
+import threading
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy import text
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+
+
+_SQLITE_LOCK_STRIPES = 256
+_SQLITE_LOCK_POLL_INTERVAL_SECONDS = 0.05
+
+
+@dataclass
+class _LocalLockEntry:
+    lock: asyncio.Lock
+    users: int = 0
+
+
+# Protecting this small registry with a threading lock avoids binding the guard to
+# one event loop. The registry key includes the loop because asyncio locks cannot
+# safely be shared between loops (which is common in SDK users and unit tests).
+_local_locks: dict[tuple[asyncio.AbstractEventLoop, UUID], _LocalLockEntry] = {}
+_local_locks_guard = threading.Lock()
+
+
+def _postgres_lock_key(dataset_id: UUID) -> int:
+    """Return a deterministic signed bigint key namespaced to pipeline locks."""
+    digest = sha256(b"cognee:dataset-pipeline:" + dataset_id.bytes).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
+
+
+def _sqlite_lock_path(engine, dataset_id: UUID) -> Path | None:
+    """Return one of a bounded number of lock files next to the SQLite database."""
+    database = engine.url.database
+    if not database or database == ":memory:":
+        return None
+
+    # A fixed number of stripes prevents an unbounded lock-file leak. A hash
+    # collision only serializes two unrelated datasets; it cannot compromise
+    # same-dataset exclusion.
+    stripe = sha256(dataset_id.bytes).digest()[0] % _SQLITE_LOCK_STRIPES
+    database_path = Path(os.path.abspath(database))
+    return database_path.parent / f".cognee-pipeline-{stripe:02x}.lock"
+
+
+@asynccontextmanager
+async def _local_dataset_lock(dataset_id: UUID) -> AsyncGenerator[None, None]:
+    """Serialize same-process callers and remove unused registry entries."""
+    loop = asyncio.get_running_loop()
+    key = (loop, dataset_id)
+    with _local_locks_guard:
+        entry = _local_locks.get(key)
+        if entry is None:
+            entry = _LocalLockEntry(asyncio.Lock())
+            _local_locks[key] = entry
+        entry.users += 1
+
+    try:
+        async with entry.lock:
+            yield
+    finally:
+        with _local_locks_guard:
+            entry.users -= 1
+            if entry.users == 0:
+                _local_locks.pop(key, None)
+
+
+@asynccontextmanager
+async def _sqlite_advisory_lock(engine, dataset_id: UUID) -> AsyncGenerator[None, None]:
+    """Use a host-wide OS advisory lock for a file-backed SQLite database."""
+    lock_path = _sqlite_lock_path(engine, dataset_id)
+    if lock_path is None:
+        # In-memory SQLite databases cannot be shared between worker processes.
+        yield
+        return
+
+    from filelock import FileLock, Timeout
+
+    lock = FileLock(lock_path, thread_local=False)
+    while True:
+        try:
+            # timeout=0 performs one non-blocking OS lock attempt. Polling with
+            # asyncio avoids retaining one worker thread for every long-running
+            # pipeline and makes cancellation immediate and leak-free.
+            lock.acquire(timeout=0)
+            break
+        except Timeout:
+            await asyncio.sleep(_SQLITE_LOCK_POLL_INTERVAL_SECONDS)
+
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+@asynccontextmanager
+async def _cross_worker_dataset_lock(dataset_id: UUID) -> AsyncGenerator[None, None]:
+    """Acquire the database-appropriate cross-worker lock for ``dataset_id``."""
+    engine = get_relational_engine().engine
+    if engine.dialect.name == "postgresql":
+        lock_key = _postgres_lock_key(dataset_id)
+        async with engine.connect() as connection:
+            await connection.execute(text("SELECT pg_advisory_lock(:key)"), {"key": lock_key})
+            # Do not hold an idle transaction for the lifetime of a pipeline run.
+            await connection.commit()
+            try:
+                yield
+            finally:
+                await connection.execute(text("SELECT pg_advisory_unlock(:key)"), {"key": lock_key})
+                await connection.commit()
+        return
+
+    if engine.dialect.name == "sqlite":
+        async with _sqlite_advisory_lock(engine, dataset_id):
+            yield
+        return
+
+    # Unknown relational backends retain process-local safety. SQLAlchemy
+    # adapters currently support PostgreSQL and SQLite, so this is defensive.
+    yield
+
+
+@asynccontextmanager
+async def dataset_pipeline_lock(dataset_id: UUID) -> AsyncGenerator[None, None]:
+    """Serialize pipeline runs for a dataset across tasks and API workers.
+
+    The cheap in-process lock is acquired first, so only one task per worker
+    contends for the cross-worker resource. PostgreSQL advisory locks coordinate
+    across hosts; file-backed SQLite uses host-wide file locks.
+    """
+    async with _local_dataset_lock(dataset_id):
+        async with _cross_worker_dataset_lock(dataset_id):
+            yield

--- a/cognee/modules/pipelines/operations/pipeline.py
+++ b/cognee/modules/pipelines/operations/pipeline.py
@@ -1,8 +1,9 @@
 import asyncio
 from contextvars import ContextVar
+from typing import Any, AsyncIterator, Awaitable, Callable, Optional, Union
 from uuid import UUID
-from typing import AsyncIterator, Awaitable, Callable, Optional, Union
 
+from cognee.infrastructure.locks.dataset_pipeline_lock import dataset_pipeline_lock
 from cognee.modules.pipelines.layers.setup_and_check_environment import (
     setup_and_check_environment,
 )
@@ -23,37 +24,17 @@ from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
 from cognee.modules.pipelines.layers.check_pipeline_run_qualification import (
     check_pipeline_run_qualification,
 )
-from typing import Any
 
 logger = get_logger("cognee.pipeline")
 
 update_status_lock = asyncio.Lock()
 
-# Per-dataset locks so concurrent pipeline runs on the SAME dataset are serialized:
-# a run waits until any in-flight run for that dataset finishes, while different
-# datasets still run in parallel.
-# NOTE: process-local only (asyncio) — this does NOT protect against multiple
-# processes/workers running against the same dataset. To be replaced by a
-# cross-process mechanism (e.g. DB-backed lock) later.
-_dataset_locks: dict[UUID, asyncio.Lock] = {}
-_dataset_locks_guard = asyncio.Lock()
-
 # Tracks the dataset ids whose per-dataset lock is already held by the current
 # execution. A pipeline task may legitimately start another pipeline on the same
 # dataset (e.g. cognify_session -> add()/cognify()); without this, re-acquiring the
-# non-reentrant _dataset_locks[dataset_id] from the same execution self-deadlocks.
+# non-reentrant dataset lock from the same execution self-deadlocks.
 # ContextVar propagates into the child tasks run_tasks spawns via asyncio.create_task.
 _held_datasets: ContextVar[frozenset] = ContextVar("_held_datasets", default=frozenset())
-
-
-async def _get_dataset_lock(dataset_id: UUID) -> asyncio.Lock:
-    """Return the asyncio.Lock for a dataset, creating it on first use."""
-    async with _dataset_locks_guard:
-        lock = _dataset_locks.get(dataset_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            _dataset_locks[dataset_id] = lock
-        return lock
 
 
 async def _drive_marking_held(dataset_id: UUID, source: AsyncIterator[Any]) -> AsyncIterator[Any]:
@@ -183,6 +164,6 @@ async def run_pipeline_per_dataset(
 
     # External run: serialize on the per-dataset lock, marking the dataset held so
     # any nested run on it takes the re-entrant path above.
-    async with await _get_dataset_lock(dataset.id):
+    async with dataset_pipeline_lock(dataset.id):
         async for run_info in _drive_marking_held(dataset.id, _run_body()):
             yield run_info

--- a/cognee/tests/test_concurrent_cognify_e2e.py
+++ b/cognee/tests/test_concurrent_cognify_e2e.py
@@ -5,9 +5,10 @@ Flow (exactly as a caller would do it):
     add(file_two)   -> cognify(run_in_background=True)   # run #2 starts, returns immediately
     gather both runs to completion
 
-The per-dataset asyncio lock in `run_pipeline_per_dataset` serializes everything
-touching the dataset, so the two runs cannot clobber each other. We assert, purely
-from each run's return value (its PipelineRunCompleted.data_ingestion_info):
+The per-dataset pipeline lock in `run_pipeline_per_dataset` serializes everything
+touching the dataset, including runs started by different worker processes, so the
+two runs cannot clobber each other. We assert, purely from each run's return value
+(its PipelineRunCompleted.data_ingestion_info):
 
     * both runs complete successfully (no errored run),
     * they are two distinct pipeline runs, and

--- a/cognee/tests/unit/infrastructure/locks/test_dataset_pipeline_lock.py
+++ b/cognee/tests/unit/infrastructure/locks/test_dataset_pipeline_lock.py
@@ -1,0 +1,191 @@
+import asyncio
+import importlib
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+lock_module = importlib.import_module("cognee.infrastructure.locks.dataset_pipeline_lock")
+
+
+@pytest.mark.asyncio
+async def test_local_lock_serializes_callers_and_cleans_registry():
+    dataset_id = uuid4()
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+
+    async def first():
+        async with lock_module._local_dataset_lock(dataset_id):
+            first_entered.set()
+            await release_first.wait()
+
+    async def second():
+        await first_entered.wait()
+        async with lock_module._local_dataset_lock(dataset_id):
+            second_entered.set()
+
+    first_task = asyncio.create_task(first())
+    second_task = asyncio.create_task(second())
+    await first_entered.wait()
+    await asyncio.sleep(0)
+
+    assert not second_entered.is_set()
+
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert lock_module._local_locks == {}
+
+
+@pytest.mark.asyncio
+async def test_cancelled_local_waiter_does_not_leak_registry_entry():
+    dataset_id = uuid4()
+    holder_entered = asyncio.Event()
+    release_holder = asyncio.Event()
+
+    async def holder():
+        async with lock_module._local_dataset_lock(dataset_id):
+            holder_entered.set()
+            await release_holder.wait()
+
+    async def waiter():
+        async with lock_module._local_dataset_lock(dataset_id):
+            pass
+
+    holder_task = asyncio.create_task(holder())
+    await holder_entered.wait()
+    waiter_task = asyncio.create_task(waiter())
+
+    while next(iter(lock_module._local_locks.values())).users != 2:
+        await asyncio.sleep(0)
+    waiter_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter_task
+
+    release_holder.set()
+    await holder_task
+
+    assert lock_module._local_locks == {}
+
+
+@pytest.mark.asyncio
+async def test_sqlite_advisory_lock_serializes_independent_callers(tmp_path):
+    engine = SimpleNamespace(url=SimpleNamespace(database=str(tmp_path / "cognee.db")))
+    dataset_id = uuid4()
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+
+    async def first():
+        async with lock_module._sqlite_advisory_lock(engine, dataset_id):
+            first_entered.set()
+            await release_first.wait()
+
+    async def second():
+        await first_entered.wait()
+        async with lock_module._sqlite_advisory_lock(engine, dataset_id):
+            second_entered.set()
+
+    first_task = asyncio.create_task(first())
+    second_task = asyncio.create_task(second())
+    await first_entered.wait()
+    await asyncio.sleep(0.05)
+
+    assert not second_entered.is_set()
+
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert lock_module._sqlite_lock_path(engine, dataset_id).name.startswith(".cognee-pipeline-")
+
+
+@pytest.mark.asyncio
+async def test_cancelled_sqlite_waiter_does_not_orphan_os_lock(tmp_path):
+    engine = SimpleNamespace(url=SimpleNamespace(database=str(tmp_path / "cognee.db")))
+    dataset_id = uuid4()
+    holder_entered = asyncio.Event()
+    release_holder = asyncio.Event()
+
+    async def holder():
+        async with lock_module._sqlite_advisory_lock(engine, dataset_id):
+            holder_entered.set()
+            await release_holder.wait()
+
+    async def waiter():
+        async with lock_module._sqlite_advisory_lock(engine, dataset_id):
+            pass
+
+    holder_task = asyncio.create_task(holder())
+    await holder_entered.wait()
+    waiter_task = asyncio.create_task(waiter())
+    await asyncio.sleep(0.05)
+
+    waiter_task.cancel()
+    release_holder.set()
+    await holder_task
+    with pytest.raises(asyncio.CancelledError):
+        await waiter_task
+
+    async with asyncio.timeout(1):
+        async with lock_module._sqlite_advisory_lock(engine, dataset_id):
+            pass
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.statements = []
+        self.commits = 0
+
+    async def execute(self, statement, parameters):
+        self.statements.append((str(statement), parameters))
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _FakeConnectionContext:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_postgres_advisory_lock_is_released_after_pipeline_error(monkeypatch):
+    connection = _FakeConnection()
+    engine = SimpleNamespace(
+        dialect=SimpleNamespace(name="postgresql"),
+        connect=lambda: _FakeConnectionContext(connection),
+    )
+    monkeypatch.setattr(
+        lock_module,
+        "get_relational_engine",
+        lambda: SimpleNamespace(engine=engine),
+    )
+    dataset_id = UUID("12345678-1234-5678-1234-567812345678")
+
+    with pytest.raises(RuntimeError, match="pipeline failed"):
+        async with lock_module._cross_worker_dataset_lock(dataset_id):
+            raise RuntimeError("pipeline failed")
+
+    expected_key = lock_module._postgres_lock_key(dataset_id)
+    assert connection.statements == [
+        ("SELECT pg_advisory_lock(:key)", {"key": expected_key}),
+        ("SELECT pg_advisory_unlock(:key)", {"key": expected_key}),
+    ]
+    assert connection.commits == 2
+
+
+def test_sqlite_lock_files_are_bounded_to_fixed_stripes(tmp_path):
+    engine = SimpleNamespace(url=SimpleNamespace(database=str(tmp_path / "cognee.db")))
+    paths = {
+        lock_module._sqlite_lock_path(engine, UUID(int=dataset_number))
+        for dataset_number in range(1_000)
+    }
+
+    assert len(paths) <= lock_module._SQLITE_LOCK_STRIPES

--- a/cognee/tests/unit/modules/pipelines/test_pipeline_dataset_lock.py
+++ b/cognee/tests/unit/modules/pipelines/test_pipeline_dataset_lock.py
@@ -1,0 +1,74 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.pipelines.operations import pipeline
+
+
+@pytest.mark.asyncio
+async def test_pipeline_holds_dataset_lock_until_generator_finishes(monkeypatch):
+    dataset = SimpleNamespace(id=uuid4())
+    events = []
+
+    @asynccontextmanager
+    async def fake_dataset_lock(dataset_id):
+        events.append(("lock", dataset_id))
+        try:
+            yield
+        finally:
+            events.append(("unlock", dataset_id))
+
+    async def fake_run_tasks():
+        events.append(("run", dataset.id))
+        yield "completed"
+
+    monkeypatch.setattr(pipeline, "dataset_pipeline_lock", fake_dataset_lock)
+    monkeypatch.setattr(pipeline, "run_tasks", lambda *args, **kwargs: fake_run_tasks())
+
+    results = [
+        result
+        async for result in pipeline.run_pipeline_per_dataset(
+            dataset=dataset,
+            user=SimpleNamespace(),
+            tasks=[],
+            data=[SimpleNamespace()],
+        )
+    ]
+
+    assert results == ["completed"]
+    assert events == [
+        ("lock", dataset.id),
+        ("run", dataset.id),
+        ("unlock", dataset.id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_nested_pipeline_on_held_dataset_does_not_reacquire_lock(monkeypatch):
+    dataset = SimpleNamespace(id=uuid4())
+
+    def unexpected_lock(dataset_id):
+        raise AssertionError(f"nested run unexpectedly locked {dataset_id}")
+
+    async def fake_run_tasks():
+        yield "completed"
+
+    monkeypatch.setattr(pipeline, "dataset_pipeline_lock", unexpected_lock)
+    monkeypatch.setattr(pipeline, "run_tasks", lambda *args, **kwargs: fake_run_tasks())
+    token = pipeline._held_datasets.set(frozenset({dataset.id}))
+    try:
+        results = [
+            result
+            async for result in pipeline.run_pipeline_per_dataset(
+                dataset=dataset,
+                user=SimpleNamespace(),
+                tasks=[],
+                data=[SimpleNamespace()],
+            )
+        ]
+    finally:
+        pipeline._held_datasets.reset(token)
+
+    assert results == ["completed"]


### PR DESCRIPTION
## Summary

  Pipeline execution currently uses an asyncio.Lock keyed by dataset ID. Because this registry exists only within one Python
  process, separate FastAPI workers can run pipelines against the same dataset concurrently.

  This PR introduces cross-worker locking for per-dataset pipeline execution while retaining an in-process lock as a lightweight
  first layer.

  ## Problem

  Concurrent pipeline runs for the same dataset can currently be started by different FastAPI workers. The process-local lock
  does not coordinate those workers, which may lead to:

  - duplicate extraction and processing;
  - concurrent graph and vector writes;
  - inconsistent pipeline run statuses;
  - database write conflicts.

  The existing _dataset_locks registry also retains one asyncio.Lock for every dataset processed and never removes unused
  entries.

  ## Changes

  - Added a database-aware dataset_pipeline_lock abstraction.
  - Added PostgreSQL cross-worker locking using session-level advisory locks.
      - Lock keys are deterministic, signed 64-bit values derived from dataset UUIDs.
      - The advisory lock uses a dedicated database connection for its lifetime.
      - The transaction opened while acquiring the lock is committed immediately.
      - The lock is released in finally, including when pipeline execution fails.

  - Added host-wide locking for file-backed SQLite and Turso using OS advisory file locks.
      - Lock acquisition uses non-blocking polling so the event loop is not blocked.
      - Lock paths use 256 deterministic stripes, preventing an unbounded number of lock files.
      - Stripe collisions may serialize unrelated datasets but cannot weaken same-dataset exclusion.

  - Retained an in-process asyncio.Lock as an optimization so only one task per worker contends for the cross-worker resource.
  - Made the local lock registry reference-counted.
      - Entries are removed after the final holder or waiter exits.
      - Cancelled waiters do not leave stale entries.

  - Preserved the existing re-entrant behavior for nested pipelines operating on the same dataset.
  - Updated the concurrent cognify test documentation to reflect cross-worker locking.

  ## Backend Behavior

   Relational backend          Coordination scope
  ━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   PostgreSQL                  Across workers and hosts sharing the same database
  ──────────────────────────  ─────────────────────────────────────────────────────────────────
   File-backed SQLite/Turso    Across workers on the same host
  ──────────────────────────  ─────────────────────────────────────────────────────────────────
   In-memory SQLite            Current process only, because the database itself is not shared

  ## Testing

  Added tests covering:

  - serialization of concurrent local callers;
  - cleanup of local registry entries;
  - cleanup when a waiting task is cancelled;
  - SQLite advisory-lock contention;
  - cancellation without orphaning a SQLite lock;
  - bounded SQLite lock-file stripes;
  - PostgreSQL advisory-lock release after pipeline failure;
  - lock lifetime around the complete pipeline generator;
  - nested same-dataset pipeline execution without lock reacquisition.

  Commands run:

  uv run ruff check cognee/infrastructure/locks/dataset_pipeline_lock.py \
    cognee/modules/pipelines/operations/pipeline.py \
    cognee/tests/unit/infrastructure/locks/test_dataset_pipeline_lock.py \
    cognee/tests/unit/modules/pipelines/test_pipeline_dataset_lock.py \
    cognee/tests/test_concurrent_cognify_e2e.py

  uv run ruff format --check cognee/infrastructure/locks/dataset_pipeline_lock.py \
    cognee/modules/pipelines/operations/pipeline.py \
    cognee/tests/unit/infrastructure/locks/test_dataset_pipeline_lock.py \
    cognee/tests/unit/modules/pipelines/test_pipeline_dataset_lock.py \
    cognee/tests/test_concurrent_cognify_e2e.py

  uv run pytest \
    cognee/tests/unit/modules/pipelines \
    cognee/tests/unit/modules/cognify \
    cognee/tests/unit/modules/memify_tasks \
    cognee/tests/unit/memify_pipelines \
    -q --timeout=60

  Result: `132 passed`.

  The complete unit suite could not be collected in the current local environment because the optional `plotly` and `neo4j`
  packages are not installed. The failure occurs during test collection and is unrelated to these changes.

  ## Impact

  - Prevents simultaneous same-dataset pipeline execution across FastAPI workers.
  - Reduces the risk of duplicate processing and conflicting graph/vector writes.
  - Prevents unbounded growth of the process-local dataset lock registry.
  - Does not change the public API, MCP server, or frontend.
  - Different datasets can still execute concurrently, except for occasional SQLite lock-stripe collisions.

  ## Checklist

  - [x] Code formatted with Ruff
  - [x] Ruff checks pass
  - [x] Targeted regression tests added
  - [x] Relevant pipeline, cognify, and memify tests pass
  - [x] Existing nested pipeline behavior preserved
  - [x] Commit signed
  - [x] DCO sign-off included