### PR TITLE
fix(security): restrict global settings updates

### DIFF
--- a/cognee/api/v1/settings/routers/get_settings_router.py
+++ b/cognee/api/v1/settings/routers/get_settings_router.py
@@ -1,8 +1,7 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 from cognee.api.DTO import InDTO, OutDTO
 from typing import Union, Optional, Literal
 from cognee.modules.users.methods import get_authenticated_user
-from fastapi import Depends
 from cognee.modules.users.models import User
 from cognee.modules.settings.get_settings import LLMConfig, VectorDBConfig
 
@@ -90,8 +89,14 @@ def get_settings_router() -> APIRouter:
 
         ## Error Codes
         - **400 Bad Request**: Invalid settings provided
+        - **403 Forbidden**: User is not a superuser
         - **500 Internal Server Error**: Error saving settings
         """
+        if not user.is_superuser:
+            raise HTTPException(
+                status_code=403, detail="Only superusers can modify global settings."
+            )
+
         from cognee.modules.settings import save_llm_config, save_vector_db_config
 
         if new_settings.llm is not None:

--- a/cognee/tests/unit/api/test_settings_router_authorization.py
+++ b/cognee/tests/unit/api/test_settings_router_authorization.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from cognee.api.v1.settings.routers.get_settings_router import (
+    SettingsPayloadDTO,
+    get_settings_router,
+)
+
+
+@pytest.mark.asyncio
+async def test_save_settings_requires_superuser():
+    router = get_settings_router()
+    save_settings = next(route.endpoint for route in router.routes if "POST" in route.methods)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await save_settings(
+            new_settings=SettingsPayloadDTO(),
+            user=SimpleNamespace(is_superuser=False),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Only superusers can modify global settings."


### PR DESCRIPTION
## Description

Fixes #4146.

Restore the superuser authorization check for `POST /api/v1/settings` without reintroducing the unrelated changes from the reverted security PR. Non-superusers now receive a 403 response before either settings persistence path can run.

## Acceptance Criteria

- Only superusers can modify the global LLM or vector database settings.
- A regression test verifies that a non-superuser receives the expected 403 response.
- The existing settings read endpoint is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

N/A — this is a non-visual API authorization change. Local verification:

```text
uv run pytest -q cognee/tests/unit/api/test_settings_router_authorization.py
1 passed

REQUIRE_AUTHENTICATION=false ENABLE_BACKEND_ACCESS_CONTROL=false uv run pytest -q cognee/tests/api/test_conditional_authentication_endpoints.py -k settings
1 passed, 9 deselected

uv run ruff check cognee/api/v1/settings/routers/get_settings_router.py cognee/tests/unit/api/test_settings_router_authorization.py
All checks passed!
```

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass (targeted new and existing settings tests pass; full suite was not run)
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
