### PR TITLE
fix(embeddings): detect OpenRouter via endpoint host for encoding_format guard (SDK-243, follow-up to #4134, gh #3660)

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -156,12 +156,21 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
                         "api_version": self.api_version,
                     }
                     # Older LiteLLM releases serialize an omitted encoding format as null,
-                    # which OpenRouter rejects. Cognee consumes float vectors, so make the
-                    # valid format explicit without passing an OpenAI-only option to other
-                    # providers.
-                    if (self.provider or "").lower() == "openrouter" or (
-                        self.model or ""
-                    ).lower().startswith("openrouter/"):
+                    # which OpenRouter rejects (it only accepts "float"/"base64"). Cognee
+                    # always consumes float vectors, so make the valid format explicit for
+                    # every OpenRouter route: the "openrouter/" model prefix, an explicit
+                    # provider, or a custom endpoint aimed at openrouter.ai. The last case
+                    # (an unprefixed model + endpoint) is driven through litellm's OpenAI
+                    # handler -- the branch that historically injected the null -- so it is
+                    # the one that still needs the guard on current litellm. We keep this
+                    # scoped to OpenRouter because providers such as gemini/bedrock/vertex_ai
+                    # reject encoding_format and cognee does not enable litellm.drop_params.
+                    routed_to_openrouter = (
+                        (self.provider or "").lower() == "openrouter"
+                        or (self.model or "").lower().startswith("openrouter/")
+                        or "openrouter.ai" in (self.endpoint or "").lower()
+                    )
+                    if routed_to_openrouter:
                         embedding_kwargs["encoding_format"] = "float"
 
                     # Pass through target embedding dimensions when supported

--- a/cognee/tests/unit/test_litellm_embedding_sanitize.py
+++ b/cognee/tests/unit/test_litellm_embedding_sanitize.py
@@ -62,14 +62,34 @@ async def test_embed_text_filters_invalid_inputs(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("provider", "model", "expected_encoding_format"),
+    ("provider", "model", "endpoint", "expected_encoding_format"),
     [
-        ("custom", "openrouter/openai/text-embedding-3-small", "float"),
-        ("gemini", "gemini/text-embedding-004", None),
+        # Documented OpenRouter config (issue #3660): "openrouter/" model prefix.
+        (
+            "custom",
+            "openrouter/openai/text-embedding-3-small",
+            "https://example.invalid/v1",
+            "float",
+        ),
+        # Explicit provider name.
+        ("openrouter", "text-embedding-3-small", "https://example.invalid/v1", "float"),
+        # Prefix detection is case-insensitive.
+        (
+            "custom",
+            "OpenRouter/openai/text-embedding-3-small",
+            "https://example.invalid/v1",
+            "float",
+        ),
+        # Custom endpoint aimed at openrouter.ai with an unprefixed model: litellm
+        # drives this through its OpenAI handler (the branch that injected the null),
+        # so the guard must still fire based on the endpoint host.
+        ("custom", "openai/text-embedding-3-small", "https://openrouter.ai/api/v1", "float"),
+        # Non-OpenRouter providers must be left untouched (encoding_format omitted).
+        ("gemini", "gemini/text-embedding-004", "https://example.invalid/v1", None),
     ],
 )
 async def test_embed_text_sets_encoding_format_only_for_openrouter(
-    monkeypatch, provider, model, expected_encoding_format
+    monkeypatch, provider, model, endpoint, expected_encoding_format
 ):
     monkeypatch.setenv("MOCK_EMBEDDING", "false")
 
@@ -79,7 +99,7 @@ async def test_embed_text_sets_encoding_format_only_for_openrouter(
             model=model,
             dimensions=2,
             api_key="test-key",
-            endpoint="https://example.invalid/v1",
+            endpoint=endpoint,
         )
 
     response = SimpleNamespace(data=[{"embedding": [0.1, 0.2]}])
@@ -95,7 +115,7 @@ async def test_embed_text_sets_encoding_format_only_for_openrouter(
         "model": model,
         "input": ["hello"],
         "api_key": "test-key",
-        "api_base": "https://example.invalid/v1",
+        "api_base": endpoint,
         "api_version": None,
         "dimensions": 2,
     }


### PR DESCRIPTION
## Description

Follow-up to #4134 (SDK-243) for GitHub bug #3660. #4134 sets `encoding_format="float"` for OpenRouter embeddings so LiteLLM can't serialize an omitted value as `null` (which OpenRouter 400s). Its guard fires on the `openrouter/` model prefix or an explicit `openrouter` provider.

This PR closes the one remaining gap: a config using `EMBEDDING_ENDPOINT=https://openrouter.ai/api/v1` with an **unprefixed** model (e.g. `openai/text-embedding-3-small`). LiteLLM drives that through its **OpenAI** embedding handler — the branch that historically injected the `null` — so #4134's model/provider checks miss it and it can still 400 on older LiteLLM. This is exactly the scenario flagged in COG-5382 ("surface a better error than 400 when `EMBEDDING_ENDPOINT` is set alongside an OpenRouter model").

Change: extend the guard to also fire when the endpoint host is `openrouter.ai`. Kept deliberately scoped to OpenRouter — `gemini`/`bedrock`/`vertex_ai` embedding configs **reject** `encoding_format` (raise `UnsupportedParamsError`) and cognee does not enable `litellm.drop_params`, so an unconditional `"float"` would break those providers.

## Acceptance Criteria

- Endpoint-based OpenRouter (`EMBEDDING_ENDPOINT=…openrouter.ai…` + unprefixed model) now sends `encoding_format="float"`.
- Non-OpenRouter providers are untouched (no `encoding_format` added).
- New parametrized test rows cover the explicit-provider branch, case-insensitive `OpenRouter/` prefix, and the endpoint route. `6 passed`; guard-tightness verified (removing the endpoint clause fails only the endpoint row). `ruff check` + `ruff format` clean. No regression across the embedding unit tests (`17 passed, 2 skipped`).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Notes for reviewer
Stacked on #4134 (base branch `fix/3660-openrouter-encoding-format-v2`) so the diff shows only the incremental change. GitHub will auto-retarget this to `dev` once #4134 merges. Linear: SDK-243. Related: COG-5382.

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
