### PR TITLE
COG-5929 fix(mcp): cloud client works against Cognee Cloud (redirects, unscoped recall/search, env)

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -59,7 +59,13 @@ class CogneeClient:
             logger.info(f"Cognee client initialized in API mode: {self.api_url}")
             if self.tenant_id:
                 logger.info(f"Tenant ID extracted from URL: {self.tenant_id}")
-            self.client = httpx.AsyncClient(timeout=300.0)  # 5 minute timeout for long operations
+            # follow_redirects=True is required: the cloud API serves collection
+            # routes with a trailing slash (e.g. /api/v1/datasets/) and 307-redirects
+            # the slash-less form. Without following redirects, GETs like
+            # list_datasets() silently read the empty redirect body as "no data".
+            self.client = httpx.AsyncClient(
+                timeout=300.0, follow_redirects=True
+            )  # 5 minute timeout for long operations
         else:
             logger.info("Cognee client initialized in direct mode")
             # Import cognee only if we're using direct mode
@@ -230,6 +236,16 @@ class CogneeClient:
             # API mode: Make HTTP request
             endpoint = f"{self.api_url}/api/v1/search"
             payload = {"query": query_text, "search_type": query_type.upper(), "top_k": top_k}
+            if not datasets:
+                # Cloud search with no dataset targets the (usually empty) default
+                # dataset and 404s with NoDataError. Default to every dataset the
+                # caller can see so an unscoped query ("what do you know?") searches
+                # real memory instead of nothing. Unauthorized/empty datasets are
+                # filtered server-side, so passing them all is safe. A failure to
+                # list datasets (e.g. the cloud is unreachable) is left to
+                # propagate: it means the search would fail anyway, and surfacing
+                # it beats silently retrying the same query unscoped.
+                datasets = [d["name"] for d in await self.list_datasets() if d.get("name")]
             if datasets:
                 payload["datasets"] = datasets
             if system_prompt:
@@ -544,6 +560,15 @@ class CogneeClient:
             payload = {"query": query_text, "top_k": top_k, "search_type": None}
             if search_type:
                 payload["search_type"] = search_type.upper()
+            if not datasets and not session_id:
+                # A bare recall (no dataset and no session) targets the empty
+                # default dataset and 404s ("Recall prerequisites not met"). Fall
+                # back to every dataset the caller can see so an unscoped
+                # "what do you know?" recalls from real memory. A session-scoped
+                # recall is left untouched so it can search the session cache. A
+                # failure to list datasets (e.g. the cloud is unreachable) is left
+                # to propagate rather than silently retrying the same query unscoped.
+                datasets = [d["name"] for d in await self.list_datasets() if d.get("name")]
             if datasets:
                 payload["datasets"] = datasets
             if session_id:

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1914,15 +1914,17 @@ async def main():
     # Cognee API connection options
     parser.add_argument(
         "--api-url",
-        default=None,
-        help="Base URL of a running Cognee FastAPI server (e.g., http://localhost:8000). "
-        "If provided, the MCP server will connect to the API instead of using cognee directly.",
+        default=os.getenv("COGNEE_BASE_URL"),
+        help="Base URL of a running Cognee FastAPI server or Cognee Cloud tenant "
+        "(e.g., https://<tenant>.cognee.ai). If provided, the MCP server connects to the "
+        "API instead of using cognee directly. Can also be set via the COGNEE_BASE_URL env var.",
     )
 
     parser.add_argument(
         "--api-token",
-        default=None,
-        help="Authentication token for the API (optional, required if API has authentication enabled).",
+        default=os.getenv("COGNEE_API_KEY"),
+        help="Authentication token for the API, sent as X-Api-Key (required if the API has "
+        "authentication enabled). Can also be set via the COGNEE_API_KEY env var.",
     )
 
     # Cognee Cloud connection options


### PR DESCRIPTION
## Problem
`cognee-mcp` connected to a Cognee **Cloud** tenant reports it empty even when it has data. The raw REST API returns datasets and a dataset-scoped recall/search returns content, but the MCP tools (`remember`/`recall`/`forget`) see nothing.

Same fix as #4170 (which targets `dev`); this PR ports it to **main** so the published package + cloud onboarding cards work now.

## Fix (`cognee-mcp/src/cognee_client.py` + `server.py`)
1. **Redirects not followed.** The httpx client had no `follow_redirects=True`; the cloud serves `/api/v1/datasets/` and 307-redirects the slash-less form, so `list_datasets()` read the empty redirect body as "no datasets". → `follow_redirects=True`.
2. **Unscoped `recall`/`search` hit the empty default dataset** and 404. → when no `datasets` (and, for recall, no `session_id`) is given, default to every dataset the caller can see. Unauthorized/empty datasets are filtered server-side.
3. **`COGNEE_BASE_URL` / `COGNEE_API_KEY` env ignored.** → `--api-url` defaults to `COGNEE_BASE_URL`, `--api-token` to `COGNEE_API_KEY`.

## Review feedback applied
A failure to list datasets now **propagates** instead of being swallowed into `datasets = None`. An `httpx.HTTPError` means the cloud is unreachable — the search/recall would fail regardless — so surfacing it is strictly better than silently retrying the same query unscoped (which just re-hits the empty-default 404 this PR fixes).

## Notes
- `cognee_client.py` / `server.py` are identical on `main` and `dev`, so this applies cleanly.
- Companion to #4170 (→ `dev`).

Fixes COG-5929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)