### PR TITLE
fix(tests): move Mistral transcript-basename test to integration [SDK-250]

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -114,8 +114,9 @@ jobs:
         with:
           python-version: '3.11.x'
           # fastembed so the embedding tokenizer delegation tests can import
-          # FastembedEmbeddingEngine.
-          extra-dependencies: "scraping fastembed"
+          # FastembedEmbeddingEngine; mistral so the Mistral transcript-basename
+          # test can import MistralAdapter (pulls in the mistralai SDK).
+          extra-dependencies: "scraping fastembed mistral"
 
       - name: Run Infrastructure Tests
         run: uv run pytest cognee/tests/integration/infrastructure/ --splits 3 --group ${{ matrix.split-group }}

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --extra api --extra docs --extra evals --extra codegraph --extra ollama \
     --extra dev --extra neo4j --extra redis --extra postgres --extra aws \
     --extra baml --extra distributed --extra deepeval --extra scraping \
-    --extra notebook --extra docling --extra turso
+    --extra notebook --extra docling --extra turso --extra mistral
 
 # Marker file for container detection in cognee_setup
 RUN echo "test-machine" > /app/.anon_id

--- a/cognee/tests/integration/infrastructure/llm/test_mistral_transcript_basename.py
+++ b/cognee/tests/integration/infrastructure/llm/test_mistral_transcript_basename.py
@@ -8,6 +8,10 @@ Mistral API instead of the basename.
 The fix normalizes both ``\\`` and ``/`` before taking the basename. This test is
 cross-platform strict: the Windows-style input contains backslashes regardless of
 host, so a revert to splitting on ``/`` only fails on any OS.
+
+Lives under ``integration/`` because importing ``MistralAdapter`` pulls in the
+``mistralai`` SDK, which is only present with the ``mistral`` extra (installed by
+the integration-infra CI job, not the base unit-test job).
 """
 
 import io


### PR DESCRIPTION
## Problem

The `Run Unit Tests` job (`basic_tests.yml`) failed at **collection**:

```
ERROR collecting cognee/tests/unit/infrastructure/llm/test_mistral_transcript_basename.py
adapter.py:8: from mistralai import Mistral
E   ModuleNotFoundError: No module named 'mistralai'
```

## Root cause

`test_mistral_transcript_basename.py` (added in #3588) lived under `cognee/tests/unit/`. Importing `MistralAdapter` triggers a module-level `from mistralai import Mistral`, and `mistralai` ships only with the **`mistral`** extra — which the base unit-test install does not include. It's an integration-style test: it requires an optional provider SDK.

## Fix

**1. Move the test to integration.**
`test_mistral_transcript_basename.py` → `cognee/tests/integration/infrastructure/llm/`, alongside `test_embedding_tokenizer_delegation.py` (which likewise needs an optional extra). Logic unchanged — fully mocked, no network.

**2. Make the `mistral` extra available where that test runs — both CI paths:**

- **Containerized CI (same-repo PRs):** tests run inside the pre-baked `ci-env` image, where `cognee_setup` does `uv sync --frozen --inexact` and **ignores** the workflow `extra-dependencies` input. The image only bakes the extras in `Dockerfile.ci`, which lacked `mistral`. Added `--extra mistral` there. Its hash is part of the image tag (`test_suites.yml` → `build-ci-env`), so this produces a new tag and rebuilds the image with `mistralai` baked in.
- **Bare-runner CI (fork PRs, where the image build is skipped):** added `mistral` to the `integration-infra` job's `extra-dependencies` in `integration_tests.yml`.

## Verification

- No-`mistral` env (mirrors unit job): full `cognee/tests/unit/` tree collects with **no error** (was 1 collection error).
- `mistral` env at the new integration location: **2 passed**.
- `uv sync --frozen --extra mistral` resolves `mistralai==1.12.4` / `mistral-common==1.11.3` from the existing lockfile (no lock change needed).
- `ruff check` / `ruff format --check`: clean.

Linear: SDK-250

🤖 Generated with [Claude Code](https://claude.com/claude-code)