### PR TITLE
COG-5929 chore(mcp): bump cognee-mcp to 0.5.5

### DIFF
--- a/cognee-mcp/pyproject.toml
+++ b/cognee-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognee-mcp"
-version = "0.5.4"
+version = "0.5.5"
 description = "Cognee MCP server"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/cognee-mcp/uv.lock
+++ b/cognee-mcp/uv.lock
@@ -971,7 +971,7 @@ postgres-binary = [
 
 [[package]]
 name = "cognee-mcp"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "cognee", extra = ["docs", "neo4j", "postgres-binary"] },
@@ -1592,7 +1592,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## What

Bumps `cognee-mcp` `0.5.4` → `0.5.5` so the cloud-client fix from #4173 can be released to PyPI.

## Why

The published `cognee-mcp` on PyPI is still **0.5.4** (uploaded 2026-04-24), which predates #4173. As a result `uvx cognee-mcp@latest` still ships the pre-fix client, and an **unscoped** search/recall against Cognee Cloud 404s (`NoDataError`) because it targets the empty default dataset instead of expanding to the caller's datasets.

PyPI rejects re-uploading an existing version, so a bump is required before publishing.

## Release note

There is **no CI job** that publishes `cognee-mcp` to PyPI — the wheel is published manually by the maintainer (`npm run build` in `apps-src/` to produce the gitignored visualize-graph bundle → `uv build` → `uv publish`). This PR only lands the version bump; the actual publish is a manual follow-up.

## Follow-up

The fix + this bump still need to be back-ported to `dev` (the hotfix went straight to `main`), or the next `dev → main` release will revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)