### PR TITLE
fix(cache): stringify ids at the SQL bind layer and stop sliding-TTL …

### DIFF
--- a/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
@@ -202,8 +202,27 @@ class SqlCacheAdapter(CacheDBInterface):
         return or_(table.c.expires_at.is_(None), table.c.expires_at > self._now())
 
     def _session_filter(self, table, user_id: str, session_id: str):
-        """WHERE clause for one session's rows."""
+        """WHERE clause for one session's rows (StringKey columns stringify the binds)."""
         return (table.c.user_id == user_id) & (table.c.session_id == session_id)
+
+    async def _lock_session_writes(self, session, table, user_id: str, session_id: str) -> None:
+        """Serialize same-session write transactions on Postgres.
+
+        Session writes end with the sliding-TTL UPDATE over all of the session's
+        rows while already holding row locks taken earlier in the transaction
+        (a FOR UPDATE read or a fresh insert), so two concurrent writers acquire
+        row locks in opposite orders and deadlock. One transaction-scoped
+        advisory lock per (table, user, session) makes them queue instead; it
+        auto-releases at COMMIT/ROLLBACK. No-op on SQLite (single-writer lock).
+        """
+        if not self._is_postgres:
+            return
+        lock_id = int.from_bytes(
+            sha256(f"{table.name}:{user_id}:{session_id}".encode()).digest()[:8],
+            "big",
+            signed=True,
+        )
+        await session.execute(text("SELECT pg_advisory_xact_lock(:lock_id)"), {"lock_id": lock_id})
 
     async def _refresh_session_ttl(self, session, table, user_id: str, session_id: str) -> None:
         """Slide the whole session's expiry forward (Redis EXPIRE-on-write parity)."""
@@ -471,6 +490,7 @@ class SqlCacheAdapter(CacheDBInterface):
                 used_session_context_ids=used_session_context_ids,
             )
             async with self.sessionmaker() as session, session.begin():
+                await self._lock_session_writes(session, cache_qa_entries, user_id, session_id)
                 await self._purge_session_expired(session, cache_qa_entries, user_id, session_id)
                 await session.execute(
                     insert(cache_qa_entries).values(
@@ -566,6 +586,7 @@ class SqlCacheAdapter(CacheDBInterface):
         while True:
             try:
                 async with self.sessionmaker() as session, session.begin():
+                    await self._lock_session_writes(session, cache_qa_entries, user_id, session_id)
                     result = await session.execute(
                         select(cache_qa_entries.c.payload)
                         .where(
@@ -662,6 +683,7 @@ class SqlCacheAdapter(CacheDBInterface):
         await self._ensure_initialized()
         try:
             async with self.sessionmaker() as session, session.begin():
+                await self._lock_session_writes(session, cache_qa_entries, user_id, session_id)
                 result = await session.execute(
                     delete(cache_qa_entries).where(
                         self._session_filter(cache_qa_entries, user_id, session_id),
@@ -687,6 +709,10 @@ class SqlCacheAdapter(CacheDBInterface):
         try:
             async with self.sessionmaker() as session, session.begin():
                 deleted_rows = 0
+                # Fixed acquisition order (matching the tuple below) so this
+                # multi-table writer can never cycle with single-table writers.
+                for table in (cache_qa_entries, cache_trace_entries, cache_session_context):
+                    await self._lock_session_writes(session, table, user_id, session_id)
                 for table in (cache_qa_entries, cache_trace_entries, cache_session_context):
                     # Expired rows are invisible — drop them first so they don't
                     # count toward "session existed".
@@ -734,6 +760,7 @@ class SqlCacheAdapter(CacheDBInterface):
                 session_feedback=session_feedback,
             )
             async with self.sessionmaker() as session, session.begin():
+                await self._lock_session_writes(session, cache_trace_entries, user_id, session_id)
                 await self._purge_session_expired(session, cache_trace_entries, user_id, session_id)
                 await session.execute(
                     insert(cache_trace_entries).values(
@@ -820,6 +847,7 @@ class SqlCacheAdapter(CacheDBInterface):
         entry_id = entry_dump.get("id") or str(uuid.uuid4())
         try:
             async with self.sessionmaker() as session, session.begin():
+                await self._lock_session_writes(session, cache_session_context, user_id, session_id)
                 await self._purge_session_expired(
                     session, cache_session_context, user_id, session_id
                 )
@@ -870,6 +898,9 @@ class SqlCacheAdapter(CacheDBInterface):
         while True:
             try:
                 async with self.sessionmaker() as session, session.begin():
+                    await self._lock_session_writes(
+                        session, cache_session_context, user_id, session_id
+                    )
                     result = await session.execute(
                         select(cache_session_context.c.payload)
                         .where(
@@ -913,6 +944,7 @@ class SqlCacheAdapter(CacheDBInterface):
         await self._ensure_initialized()
         try:
             async with self.sessionmaker() as session, session.begin():
+                await self._lock_session_writes(session, cache_session_context, user_id, session_id)
                 await self._purge_session_expired(
                     session, cache_session_context, user_id, session_id
                 )

--- a/cognee/infrastructure/databases/cache/sql/tables.py
+++ b/cognee/infrastructure/databases/cache/sql/tables.py
@@ -17,12 +17,39 @@ from sqlalchemy import (
     MetaData,
     Table,
     Text,
+    TypeDecorator,
     UniqueConstraint,
     func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
 cache_metadata = MetaData()
+
+
+class StringKey(TypeDecorator):
+    """TEXT key column that coerces stringable ids (e.g. ``uuid.UUID``) to ``str``.
+
+    Client-side only: DDL is delegated to ``impl`` so the emitted column is a
+    plain TEXT, identical to before — existing tables need no migration. The
+    asyncpg dialect renders explicit bind casts, so an id bound as a
+    ``uuid.UUID`` would make Postgres parse ``text = uuid`` and raise 42883
+    ("operator does not exist") instead of coercing; sqlite rejects non-str
+    binds outright. Normalizing in the bind processor keeps every read and
+    write keyed by the same string no matter which type the caller holds.
+    """
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None or isinstance(value, str):
+            return value
+        return str(value)
+
+    def coerce_compared_value(self, op, value):
+        # Compare through this decorator (not the raw impl) so binds in
+        # WHERE/IN comparisons run through process_bind_param too.
+        return self
 
 
 def _payload_type():
@@ -40,9 +67,9 @@ cache_qa_entries = Table(
     "cache_qa_entries",
     cache_metadata,
     Column("seq", _seq_type(), primary_key=True, autoincrement=True),
-    Column("user_id", Text, nullable=False),
-    Column("session_id", Text, nullable=False),
-    Column("qa_id", Text, nullable=False),
+    Column("user_id", StringKey(), nullable=False),
+    Column("session_id", StringKey(), nullable=False),
+    Column("qa_id", StringKey(), nullable=False),
     Column("payload", _payload_type(), nullable=False),
     Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
     Column("expires_at", DateTime(timezone=True), nullable=True),
@@ -67,8 +94,8 @@ cache_trace_entries = Table(
     "cache_trace_entries",
     cache_metadata,
     Column("seq", _seq_type(), primary_key=True, autoincrement=True),
-    Column("user_id", Text, nullable=False),
-    Column("session_id", Text, nullable=False),
+    Column("user_id", StringKey(), nullable=False),
+    Column("session_id", StringKey(), nullable=False),
     Column("payload", _payload_type(), nullable=False),
     Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
     Column("expires_at", DateTime(timezone=True), nullable=True),
@@ -94,9 +121,9 @@ cache_session_context = Table(
     "cache_session_context",
     cache_metadata,
     Column("seq", _seq_type(), primary_key=True, autoincrement=True),
-    Column("user_id", Text, nullable=False),
-    Column("session_id", Text, nullable=False),
-    Column("entry_id", Text, nullable=False),
+    Column("user_id", StringKey(), nullable=False),
+    Column("session_id", StringKey(), nullable=False),
+    Column("entry_id", StringKey(), nullable=False),
     Column("payload", _payload_type(), nullable=False),
     Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
     Column("expires_at", DateTime(timezone=True), nullable=True),
@@ -120,8 +147,8 @@ cache_usage_logs = Table(
     "cache_usage_logs",
     cache_metadata,
     Column("seq", _seq_type(), primary_key=True, autoincrement=True),
-    Column("log_key", Text, nullable=False),
-    Column("user_id", Text, nullable=False),
+    Column("log_key", StringKey(), nullable=False),
+    Column("user_id", StringKey(), nullable=False),
     Column("payload", _payload_type(), nullable=False),
     Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
     Column("expires_at", DateTime(timezone=True), nullable=True),
@@ -138,7 +165,7 @@ Index(
 cache_kv = Table(
     "cache_kv",
     cache_metadata,
-    Column("key", Text, primary_key=True),
+    Column("key", StringKey(), primary_key=True),
     Column("value", Text, nullable=False),
     Column("expires_at", DateTime(timezone=True), nullable=True),
 )

--- a/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
@@ -839,3 +839,46 @@ async def test_session_context_reads_exclude_expired(adapter):
     await adapter.create_session_context_entry("u1", "s1", _ctx("c1"))
     await _backdate_expirations(adapter, cache_session_context, _past(), entry_id="c1")
     assert await adapter.get_session_context_entries("u1", "s1") == []
+
+
+@pytest.mark.asyncio
+async def test_uuid_ids_write_and_read_as_string_keys(adapter):
+    """uuid.UUID ids must key the same rows as their string form.
+
+    Callers sometimes hold ``user.id`` as a ``uuid.UUID``; on Postgres the
+    asyncpg bind cast then parses as ``text = uuid`` (42883) and on sqlite the
+    driver rejects the bind. The StringKey column type stringifies every bind.
+    """
+    user_uuid, session_uuid = uuid4(), uuid4()
+    await adapter.create_qa_entry(user_uuid, session_uuid, "Q", "C", "A", qa_id="id1")
+
+    via_uuid = await adapter.get_all_qa_entries(user_uuid, session_uuid)
+    via_str = await adapter.get_all_qa_entries(str(user_uuid), str(session_uuid))
+    assert [entry.qa_id for entry in via_uuid] == ["id1"]
+    assert [entry.qa_id for entry in via_str] == ["id1"]
+
+    latest = await adapter.get_latest_qa_entries(user_uuid, session_uuid, last_n=5)
+    assert [entry.qa_id for entry in latest] == ["id1"]
+
+
+@pytest.mark.asyncio
+async def test_uuid_ids_across_trace_context_and_usage(adapter):
+    """UUID user ids work for traces, session context, and usage logs alike."""
+    user_uuid, session_uuid = uuid4(), uuid4()
+
+    await adapter.append_agent_trace_step(
+        user_uuid, session_uuid, trace_id="t1", origin_function="f", status="ok"
+    )
+    traces = await adapter.get_agent_trace_session(str(user_uuid), str(session_uuid))
+    assert [trace.trace_id for trace in traces] == ["t1"]
+
+    await adapter.create_session_context_entry(user_uuid, session_uuid, _ctx("c1"))
+    entries = await adapter.get_session_context_entries(str(user_uuid), str(session_uuid))
+    assert [entry["id"] for entry in entries] == ["c1"]
+    assert await adapter.update_session_context_entry(user_uuid, session_uuid, "c1", {"note": "n"})
+
+    await adapter.log_usage(user_uuid, {"call": "search"})
+    assert len(await adapter.get_usage_logs(str(user_uuid))) == 1
+
+    assert await adapter.delete_session(user_uuid, session_uuid) is True
+    assert await adapter.get_all_qa_entries(str(user_uuid), str(session_uuid)) == []


### PR DESCRIPTION
…deadlocks

Two production failures on the Postgres cache backend, both in SqlCacheAdapter:

1. A caller holding user.id as uuid.UUID made the asyncpg dialect bind the parameter as $1::UUID, so Postgres parsed `text = uuid` and raised 42883 ("operator does not exist") instead of coercing; sqlite rejects such binds outright. Key columns (user_id/session_id/qa_id/entry_id/log_key/key) now use a StringKey TypeDecorator that coerces stringable ids to str in the bind processor, covering every read, write, and IN-list in one place. Client-side only: the emitted DDL is still plain TEXT (verified identical), so existing tables keep working with no migration.

2. Session writes end with the sliding-TTL UPDATE over all of the session's rows while already holding row locks taken earlier in the transaction, so concurrent same-session writers acquired row locks in opposite orders and deadlocked (40P01) faster than the 3-attempt retry could absorb. Write transactions now take a transaction-scoped pg_advisory_xact_lock keyed by (table, user, session) up front, so same-session writers queue instead. No-op on SQLite.

Verified on Postgres 17: uuid.UUID ids round-trip identically to their string form, a table created by the previous code (old DDL + legacy rows) is read and extended seamlessly, and an 8-worker concurrent-update hammer that previously produced 579 server-side deadlocks (189 surfaced as CacheConnectionError) now produces 0.

<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
