### PR TITLE
CLO-319: surface dataset/data names in MCP tool text channel

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1604,6 +1604,28 @@ async def cognify_file(
     ]
 
 
+def _format_named_items(items, singular: str, plural: str, limit: int = 50) -> str:
+    """Render a list of {id, name} dicts into human-readable text content.
+
+    Text-only MCP clients (e.g. agents in Cursor) never see structuredContent,
+    so the names have to be serialized into the text channel too — otherwise
+    they only get a count and have to fall back to raw HTTP to learn what
+    exists. Long lists are capped to keep the text payload reasonable; the full
+    set always remains in structuredContent.
+    """
+    count = len(items)
+    if count == 0:
+        return f"No {plural} found."
+    lines = [f"{count} {singular if count == 1 else plural}:"]
+    for item in items[:limit]:
+        name = item.get("name") or "(unnamed)"
+        item_id = item.get("id") or ""
+        lines.append(f"- {name} ({item_id})" if item_id else f"- {name}")
+    if count > limit:
+        lines.append(f"… and {count - limit} more (see structuredContent).")
+    return "\n".join(lines)
+
+
 @mcp.tool(
     name="list_datasets_json",
     description=(
@@ -1624,7 +1646,12 @@ async def list_datasets_json() -> types.CallToolResult:
             datasets.append({"id": str(ds.id), "name": ds.name})
 
     return types.CallToolResult(
-        content=[types.TextContent(type="text", text=f"{len(datasets)} dataset(s).")],
+        content=[
+            types.TextContent(
+                type="text",
+                text=_format_named_items(datasets, "dataset", "datasets"),
+            )
+        ],
         structuredContent={"datasets": datasets},
     )
 
@@ -1674,7 +1701,12 @@ async def list_dataset_data_json(dataset_id: str) -> types.CallToolResult:
 
     data = [{"id": str(item.id), "name": item.name or "(unnamed)"} for item in items]
     return types.CallToolResult(
-        content=[types.TextContent(type="text", text=f"{len(data)} data item(s).")],
+        content=[
+            types.TextContent(
+                type="text",
+                text=_format_named_items(data, "data item", "data items"),
+            )
+        ],
         structuredContent={"data": data},
     )
 

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -516,3 +516,93 @@ async def test_document_retrieval_tools_format_json(monkeypatch):
     neighbor_payload = json.loads(neighbors_result[0].text)
     assert neighbor_payload["target_chunk_id"] == "chunk-1"
     assert neighbor_payload["direction"] == "forward"
+
+
+def test_format_named_items_lists_names_and_ids():
+    import src.server as server
+
+    assert server._format_named_items([], "dataset", "datasets") == "No datasets found."
+
+    rendered = server._format_named_items(
+        [{"id": "a1", "name": "docs"}, {"id": "", "name": ""}],
+        "dataset",
+        "datasets",
+    )
+    assert rendered.startswith("2 datasets:")
+    assert "- docs (a1)" in rendered
+    assert "- (unnamed)" in rendered
+
+    singular = server._format_named_items([{"id": "x", "name": "only"}], "data item", "data items")
+    assert singular.startswith("1 data item:")
+
+
+def test_format_named_items_caps_long_lists():
+    import src.server as server
+
+    items = [{"id": str(i), "name": f"n{i}"} for i in range(52)]
+    rendered = server._format_named_items(items, "dataset", "datasets", limit=3)
+
+    assert rendered.startswith("52 datasets:")
+    assert "- n0 (0)" in rendered
+    assert "- n3 (3)" not in rendered
+    assert "… and 49 more (see structuredContent)." in rendered
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_json_puts_names_in_text_channel(monkeypatch):
+    import src.server as server
+
+    class FakeClient:
+        async def list_datasets(self):
+            return [
+                {"id": "id-1", "name": "alpha"},
+                {"id": "id-2", "name": "beta"},
+            ]
+
+    monkeypatch.setattr(server, "cognee_client", FakeClient())
+
+    result = await server.list_datasets_json()
+
+    text = result.content[0].text
+    assert "2 datasets:" in text
+    assert "alpha (id-1)" in text
+    assert "beta (id-2)" in text
+    # Structured payload is preserved for the workspace UI.
+    assert result.structuredContent == {
+        "datasets": [
+            {"id": "id-1", "name": "alpha"},
+            {"id": "id-2", "name": "beta"},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_json_text_channel_over_mcp_protocol(monkeypatch):
+    """End-to-end over the real MCP protocol: a client that reads only the text
+    content blocks must still see dataset names (regression guard for CLO-319)."""
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    import src.server as server
+
+    class FakeClient:
+        async def list_datasets(self):
+            return [
+                {"id": "id-alpha", "name": "alpha"},
+                {"id": "id-beta", "name": "beta"},
+            ]
+
+    monkeypatch.setattr(server, "cognee_client", FakeClient())
+
+    async with create_connected_server_and_client_session(server.mcp) as client:
+        await client.initialize()
+
+        tool_names = {tool.name for tool in (await client.list_tools()).tools}
+        assert "list_datasets_json" in tool_names
+
+        result = await client.call_tool("list_datasets_json", {})
+
+    assert result.isError is False
+    text = "\n".join(block.text for block in result.content if block.type == "text")
+    assert "2 datasets:" in text
+    assert "alpha (id-alpha)" in text
+    assert "beta (id-beta)" in text


### PR DESCRIPTION
## Summary

`list_datasets_json` (and its sibling `list_dataset_data_json`) put dataset **names only in `structuredContent`** and emitted just a **count** (`"8 dataset(s)."`) in the text channel. Text-only MCP clients — e.g. agents in Cursor — never see `structuredContent`, so they couldn't tell what existed and fell back to raw HTTP during debugging (the friction that kicked off the [CLO-316](https://linear.app/cognee/issue/CLO-316) investigation).

## Change

* New shared `_format_named_items()` helper in `cognee-mcp/src/server.py` that serializes `name (id)` lines into the **text** content, capped at 50 items with an `… and N more (see structuredContent)` overflow note.
* Wired into `list_datasets_json` and `list_dataset_data_json`. `structuredContent` is unchanged, so the workspace UI is unaffected.
* Audited the sibling `*_json` tools: `get_client_info_json` and `create_dataset_json` already emit usable text, so no change needed there.

**Before** → `8 dataset(s).`
**After** →
```
8 datasets:
- alpha (id-alpha)
- beta (id-beta)
...
```

## Tests

* Unit tests for the formatter (empty / unnamed / singular / 50-item cap).
* Tool-level test asserting names land in `content[0].text` while `structuredContent` is preserved.
* **End-to-end over the real MCP protocol** (`create_connected_server_and_client_session`): a client calls `list_datasets_json` and reads only the text content blocks — confirms names reach a text-only client (closes acceptance criterion #3).
* `27 passed`; `ruff check` + `ruff format --check` clean.

Closes CLO-319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)