### PR TITLE
fix(neo4j): align has_edges with the interface contract and stop dropping edge properties in get_connections

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -1060,12 +1060,13 @@ class Neo4jAdapter(GraphDBInterface):
         Returns:
         --------
 
-            A list of boolean values indicating the existence of each edge.
+            The subset of the input edges that exist in the graph, as
+            (from_node, to_node, relationship_name) tuples.
         """
-        query = """
+        query = f"""
             UNWIND $edges AS edge
-            MATCH (a)-[r]->(b)
-            WHERE id(a) = edge.from_node AND id(b) = edge.to_node AND type(r) = edge.relationship_name
+            MATCH (a:`{BASE_LABEL}`)-[r]->(b:`{BASE_LABEL}`)
+            WHERE a.id = edge.from_node AND b.id = edge.to_node AND type(r) = edge.relationship_name
             RETURN edge.from_node AS from_node, edge.to_node AS to_node, edge.relationship_name AS relationship_name, count(r) > 0 AS edge_exists
         """
 
@@ -1082,7 +1083,11 @@ class Neo4jAdapter(GraphDBInterface):
             }
 
             results = await self.query(query, params)
-            return [result["edge_exists"] for result in results]
+            return [
+                (str(result["from_node"]), str(result["to_node"]), str(result["relationship_name"]))
+                for result in results
+                if result["edge_exists"]
+            ]
         except Neo4jError as error:
             logger.error("Neo4j query error: %s", error, exc_info=True)
             raise error
@@ -1608,15 +1613,17 @@ class Neo4jAdapter(GraphDBInterface):
 
             - list: A list of connections represented as tuples of details.
         """
+        # result.data() flattens a Relationship to (start_props, type, end_props)
+        # and discards its properties, so they must be returned explicitly.
         predecessors_query = f"""
         MATCH (node:`{BASE_LABEL}`)<-[relation]-(neighbour)
         WHERE node.id = $node_id
-        RETURN neighbour, relation, node
+        RETURN neighbour, relation, node, properties(relation) AS relation_properties
         """
         successors_query = f"""
         MATCH (node:`{BASE_LABEL}`)-[relation]->(neighbour)
         WHERE node.id = $node_id
-        RETURN node, relation, neighbour
+        RETURN node, relation, neighbour, properties(relation) AS relation_properties
         """
 
         predecessors, successors = await asyncio.gather(
@@ -1626,23 +1633,27 @@ class Neo4jAdapter(GraphDBInterface):
 
         connections = []
 
-        for neighbour in predecessors:
-            neighbour = neighbour["relation"]
+        for record in predecessors:
+            relation = record["relation"]
+            edge = {"relationship_name": relation[1]}
+            edge.update(record["relation_properties"] or {})
             connections.append(
                 (
-                    _strip_provenance(neighbour[0]),
-                    {"relationship_name": neighbour[1]},
-                    _strip_provenance(neighbour[2]),
+                    _strip_provenance(relation[0]),
+                    edge,
+                    _strip_provenance(relation[2]),
                 )
             )
 
-        for neighbour in successors:
-            neighbour = neighbour["relation"]
+        for record in successors:
+            relation = record["relation"]
+            edge = {"relationship_name": relation[1]}
+            edge.update(record["relation_properties"] or {})
             connections.append(
                 (
-                    _strip_provenance(neighbour[0]),
-                    {"relationship_name": neighbour[1]},
-                    _strip_provenance(neighbour[2]),
+                    _strip_provenance(relation[0]),
+                    edge,
+                    _strip_provenance(relation[2]),
                 )
             )
 

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_edge_contract.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_edge_contract.py
@@ -1,0 +1,110 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("neo4j")
+
+from cognee.infrastructure.databases.graph.neo4j_driver.adapter import Neo4jAdapter
+
+
+def _make_adapter() -> Neo4jAdapter:
+    return Neo4jAdapter(
+        "bolt://unused",
+        graph_database_allow_anonymous=True,
+        driver=object(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_has_edges_returns_existing_edge_tuples():
+    """has_edges must return the subset of input edges that exist, as
+    (from_node, to_node, relationship_name) tuples — the graph_db_interface
+    contract shared with the ladybug/postgres/neptune adapters — not a list
+    of booleans."""
+    adapter = _make_adapter()
+    adapter.query = AsyncMock(
+        return_value=[
+            {
+                "from_node": "node-a",
+                "to_node": "node-b",
+                "relationship_name": "knows",
+                "edge_exists": True,
+            },
+            {
+                "from_node": "node-a",
+                "to_node": "node-c",
+                "relationship_name": "likes",
+                "edge_exists": False,
+            },
+        ]
+    )
+
+    result = await adapter.has_edges([("node-a", "node-b", "knows"), ("node-a", "node-c", "likes")])
+
+    assert result == [("node-a", "node-b", "knows")]
+
+
+@pytest.mark.asyncio
+async def test_has_edges_matches_on_id_property_not_internal_id():
+    """Nodes are stored with an ``id`` property (a UUID string); Neo4j's
+    internal ``id()`` is an integer and never equals it, which made the
+    previous query match nothing and existing-edge deduplication silently
+    return empty."""
+    adapter = _make_adapter()
+    adapter.query = AsyncMock(return_value=[])
+
+    await adapter.has_edges([("node-a", "node-b", "knows")])
+
+    query = adapter.query.await_args.args[0]
+    assert "a.id = edge.from_node" in query
+    assert "b.id = edge.to_node" in query
+    assert "id(a)" not in query
+    assert "id(b)" not in query
+
+
+@pytest.mark.asyncio
+async def test_get_connections_preserves_edge_properties():
+    """get_connections must merge the relationship's properties into the edge
+    dict (as the postgres/ladybug/neptune adapters do), not reduce it to just
+    the relationship name — consumers such as legacy_delete read keys like
+    ``edge_text`` from it."""
+    adapter = _make_adapter()
+    relation_tuple = ({"id": "node-a"}, "knows", {"id": "node-b"})
+    adapter.query = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "relation": relation_tuple,
+                    "relation_properties": {"edge_text": "a knows b", "weight": 0.7},
+                }
+            ],
+            [],
+        ]
+    )
+
+    connections = await adapter.get_connections("node-b")
+
+    assert connections == [
+        (
+            {"id": "node-a"},
+            {"relationship_name": "knows", "edge_text": "a knows b", "weight": 0.7},
+            {"id": "node-b"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_connections_handles_missing_edge_properties():
+    """Edges without extra properties still yield a relationship_name-only dict."""
+    adapter = _make_adapter()
+    relation_tuple = ({"id": "node-a"}, "knows", {"id": "node-b"})
+    adapter.query = AsyncMock(
+        side_effect=[
+            [],
+            [{"relation": relation_tuple, "relation_properties": {}}],
+        ]
+    )
+
+    connections = await adapter.get_connections("node-a")
+
+    assert connections == [({"id": "node-a"}, {"relationship_name": "knows"}, {"id": "node-b"})]


### PR DESCRIPTION
## Description

Fixes #4187 — two contract violations in the Neo4j graph adapter where ladybug/postgres/neptune behave correctly and Neo4j silently diverged.

**`has_edges`**: matched nodes with Neo4j's internal `id()` (an integer that never equals the string UUID in the `id` property), so the query matched nothing and existing-edge deduplication on the cognify path silently returned empty — accumulating duplicate edges on every re-cognify. It also returned raw booleans instead of the `(from_node, to_node, relationship_name)` tuples that `graph_db_interface` declares. Now matches on the `id` property (like every other query in this adapter) and returns the existing subset as string tuples, mirroring the Neptune fix from #2384.

**`get_connections`**: the driver's `result.data()` flattens a relationship to `(start_props, type, end_props)` and discards its properties, so the edge dict only ever contained `relationship_name` — `edge_text`, weights and timestamps were unrecoverable, and legacy delete computed `EdgeType` vector deletions from incomplete data (orphaned vector rows on Neo4j only). The queries now return `properties(relation)` explicitly and merge them into the edge dict, matching the postgres/ladybug/neptune shape.

## Verification

**Unit tests** — 4 new tests in `cognee/tests/unit/infrastructure/databases/graph/test_neo4j_edge_contract.py` (mocked `query`, covering the returned shape, the `a.id`/`b.id` match assertions, edge-property merging, and property-less edges):

```
uv run pytest cognee/tests/unit/infrastructure/databases/graph/test_neo4j_edge_contract.py -q
4 passed in 0.41s
```

Full unit suite: `3079 passed, 50 skipped, 10 failed` — the 10 failures reproduce identically on a clean `dev` checkout (pre-existing, unrelated to this change; the plotly-dependent `dashboard_test.py` module was excluded for the same reason).

**Integration** — verified against a real `neo4j:5.26` + APOC container, exercising the adapter's own write path (`add_edges`) for setup:

```
[old query] rows returned for an EXISTING edge: []
[fixed has_edges] [('node-a', 'node-b', 'knows')]
[fixed get_connections] [({'name': 'A', 'id': 'node-a'},
  {'relationship_name': 'knows', 'source_node_id': 'node-a', 'weight': 0.7,
   'created_at': 1784738586495, 'updated_at': 1784738586495,
   'target_node_id': 'node-b', 'edge_text': 'a knows b'},
  {'name': 'B', 'id': 'node-b'})]

ALL INTEGRATION CHECKS PASSED against real Neo4j 5.26 + APOC
```

The `[old query]` line runs the pre-fix Cypher verbatim against the live database with an edge that exists — demonstrating the internal-`id()` match returns zero rows.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin
