### PR TITLE
CLO-321: fix cognee-cli --api-url mode against cloud tenants

### DIFF
--- a/cognee/cli/api_client.py
+++ b/cognee/cli/api_client.py
@@ -32,6 +32,20 @@ def _import_httpx():
         )
 
 
+def is_connection_error(exc: BaseException) -> bool:
+    """True if *exc* is a transport-level failure — i.e. we could not reach or
+    get a response from the server (connect refused, DNS failure, timeout).
+
+    This is deliberately narrower than "any error": an HTTP 4xx/5xx means the
+    server *is* reachable, so those must not be reported as "cannot connect".
+    """
+    try:
+        import httpx
+    except ImportError:
+        return False
+    return isinstance(exc, httpx.TransportError)
+
+
 class CogneeApiClient:
     """Wrapper around the Cognee REST API with a shared connection pool."""
 
@@ -54,6 +68,12 @@ class CogneeApiClient:
             self._client = httpx.Client(
                 timeout=self.timeout,
                 headers=self._extra_headers,
+                # Collection routes are canonicalised differently across
+                # deployments (cloud serves "/api/v1/datasets/" with a slash,
+                # local OSS serves it without), so a request to the other form
+                # gets a 307.  Follow it automatically.  Safe now that the
+                # server no longer downgrades the redirect to http (CLO-320).
+                follow_redirects=True,
             )
         return self._client
 
@@ -84,12 +104,18 @@ class CogneeApiClient:
     # -- probes ----------------------------------------------------------
 
     def health(self) -> dict:
-        """Probe the server.  Uses a short timeout independent of self.timeout."""
-        httpx = _import_httpx()
-        with httpx.Client(timeout=5.0) as c:
-            r = c.get(self._url("/health"))
-            self._raise_for_status(r)
+        """Probe the server with a short timeout.
+
+        Reuses the shared client so auth headers and redirect handling apply.
+        Returns the parsed body for *any* HTTP response (including a 503 from a
+        degraded backend) — a reachable server must never look like a transport
+        failure.  Only genuine transport errors propagate to the caller.
+        """
+        r = self._get_client().get(self._url("/health"), timeout=5.0)
+        try:
             return r.json()
+        except Exception:
+            return {"status_code": r.status_code, "text": r.text}
 
     # -- add -------------------------------------------------------------
 
@@ -187,12 +213,12 @@ class CogneeApiClient:
     # -- datasets --------------------------------------------------------
 
     def datasets_list(self) -> list[dict]:
-        r = self._get_client().get(self._url("/api/v1/datasets"))
+        r = self._get_client().get(self._url("/api/v1/datasets/"))
         self._raise_for_status(r)
         return r.json()
 
     def datasets_create(self, name: str) -> dict:
-        r = self._get_client().post(self._url("/api/v1/datasets"), json={"name": name})
+        r = self._get_client().post(self._url("/api/v1/datasets/"), json={"name": name})
         self._raise_for_status(r)
         return r.json()
 
@@ -221,7 +247,7 @@ class CogneeApiClient:
         self._raise_for_status(r)
 
     def datasets_delete_all(self) -> None:
-        r = self._get_client().delete(self._url("/api/v1/datasets"))
+        r = self._get_client().delete(self._url("/api/v1/datasets/"))
         self._raise_for_status(r)
 
     # -- remember --------------------------------------------------------

--- a/cognee/cli/api_dispatch.py
+++ b/cognee/cli/api_dispatch.py
@@ -12,7 +12,7 @@ import json
 import os
 
 import cognee.cli.echo as fmt
-from cognee.cli.api_client import CogneeApiClient
+from cognee.cli.api_client import CogneeApiClient, is_connection_error
 
 SUPPORTED_COMMANDS = {
     "add",
@@ -61,16 +61,6 @@ def dispatch(args: argparse.Namespace) -> None:
         headers["Authorization"] = f"Bearer {api_token}"
 
     with CogneeApiClient(args.api_url, headers=headers) as client:
-        # Health probe — fail fast with a clear message
-        try:
-            client.health()
-        except Exception:
-            raise RuntimeError(
-                f"Cannot connect to Cognee API at {args.api_url}.  "
-                f"Is the server running?  Start it with:  "
-                f"uvicorn cognee.api.client:app --port 8000"
-            )
-
         dispatchers = {
             "add": _dispatch_add,
             "cognify": _dispatch_cognify,
@@ -92,7 +82,22 @@ def dispatch(args: argparse.Namespace) -> None:
                 f"Run without --api-url to execute it locally."
             )
 
-        handler(client, args)
+        # No pre-flight /health probe: it queried a DB-backed endpoint that can
+        # hang or return 503 on an otherwise-reachable server (and sent no auth
+        # headers), so it mis-reported healthy cloud tenants as "not running".
+        # Run the real command and only translate genuine transport failures
+        # into a friendly, URL-bearing message; HTTP status errors surface with
+        # their real detail via _raise_for_status.
+        try:
+            handler(client, args)
+        except Exception as exc:
+            if is_connection_error(exc):
+                raise RuntimeError(
+                    f"Could not reach the Cognee API at {args.api_url}: {exc}\n"
+                    f"Check the --api-url value and that the server is reachable "
+                    f"(local server: uvicorn cognee.api.client:app --port 8000)."
+                ) from exc
+            raise
 
 
 # -- individual dispatchers -----------------------------------------------

--- a/cognee/tests/cli_tests/cli_unit_tests/test_api_client.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_api_client.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cognee.cli.api_client import CogneeApiClient
+from cognee.cli.api_client import CogneeApiClient, is_connection_error
 
 
 class TestCogneeApiClientInit:
@@ -50,6 +50,82 @@ class TestCogneeApiClientSharedConnection:
             assert c1 is c2
             # httpx.Client should only have been constructed once
             assert mock_httpx.return_value.Client.call_count == 1
+
+    def test_client_follows_redirects(self):
+        """The client must follow the collection-slash canonicalisation 307 so
+        it works against both cloud (slash) and local (no-slash) deployments."""
+        with patch("cognee.cli.api_client._import_httpx") as mock_httpx:
+            api = CogneeApiClient("http://localhost:8000", headers={"X-Api-Key": "k"})
+            api._get_client()
+
+            kwargs = mock_httpx.return_value.Client.call_args.kwargs
+            assert kwargs["follow_redirects"] is True
+            assert kwargs["headers"] == {"X-Api-Key": "k"}
+
+
+class TestDatasetsEndpoints:
+    """Dataset collection calls must use the canonical trailing-slash form."""
+
+    def _client_with_mock(self, json_body):
+        with patch("cognee.cli.api_client._import_httpx"):
+            client = CogneeApiClient("https://tenant.aws.cognee.ai")
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = json_body
+            http = MagicMock()
+            http.get.return_value = resp
+            http.post.return_value = resp
+            http.delete.return_value = resp
+            client._client = http
+            return client, http
+
+    def test_datasets_list_uses_trailing_slash(self):
+        client, http = self._client_with_mock([{"id": "1", "name": "alpha"}])
+        result = client.datasets_list()
+        assert http.get.call_args[0][0] == "https://tenant.aws.cognee.ai/api/v1/datasets/"
+        assert result == [{"id": "1", "name": "alpha"}]
+
+    def test_datasets_create_uses_trailing_slash(self):
+        client, http = self._client_with_mock({"id": "1", "name": "alpha"})
+        client.datasets_create("alpha")
+        assert http.post.call_args[0][0] == "https://tenant.aws.cognee.ai/api/v1/datasets/"
+
+    def test_datasets_delete_all_uses_trailing_slash(self):
+        client, http = self._client_with_mock(None)
+        client.datasets_delete_all()
+        assert http.delete.call_args[0][0] == "https://tenant.aws.cognee.ai/api/v1/datasets/"
+
+
+class TestHealthProbe:
+    """health() must reuse the pooled (authed) client and never turn a
+    reachable-but-degraded server (503) into a raised error."""
+
+    def test_health_returns_body_on_503_without_raising(self):
+        with patch("cognee.cli.api_client._import_httpx"):
+            client = CogneeApiClient("https://tenant.aws.cognee.ai", headers={"X-Api-Key": "k"})
+            resp = MagicMock(status_code=503)
+            resp.json.return_value = {"status": "not ready", "health": "unhealthy"}
+            http = MagicMock()
+            http.get.return_value = resp
+            client._client = http
+
+            result = client.health()
+
+            # Reused the shared client (which carries auth headers), hit /health.
+            assert http.get.call_args[0][0] == "https://tenant.aws.cognee.ai/health"
+            assert result["status"] == "not ready"
+
+
+class TestIsConnectionError:
+    def test_transport_errors_are_connection_errors(self):
+        import httpx
+
+        assert is_connection_error(httpx.ConnectError("refused")) is True
+        assert is_connection_error(httpx.ConnectTimeout("timed out")) is True
+        assert is_connection_error(httpx.ReadTimeout("slow")) is True
+
+    def test_http_and_other_errors_are_not_connection_errors(self):
+        assert is_connection_error(RuntimeError("API error 500")) is False
+        assert is_connection_error(ValueError("bad")) is False
 
     def test_close_resets_client(self):
         with patch("cognee.cli.api_client._import_httpx") as mock_httpx:

--- a/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_api_dispatch.py
@@ -74,9 +74,13 @@ class TestDispatchRouting:
             dispatch(args)
 
     @patch("cognee.cli.api_dispatch.CogneeApiClient")
-    def test_health_probe_failure_gives_clear_message(self, MockClient):
+    def test_transport_error_gives_clear_message_with_url(self, MockClient):
+        """A genuine transport failure on the real request is reported with the
+        attempted URL (CLO-321) — no separate /health probe is used."""
+        import httpx
+
         mock_instance = MagicMock()
-        mock_instance.health.side_effect = Exception("connection refused")
+        mock_instance.add.side_effect = httpx.ConnectError("connection refused")
         MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
         MockClient.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -84,8 +88,33 @@ class TestDispatchRouting:
             api_url="http://localhost:9999",
             command="add",
             user_id=None,
+            data=["test"],
+            dataset_name="ds",
         )
-        with pytest.raises(RuntimeError, match="Cannot connect to Cognee API"):
+        with pytest.raises(
+            RuntimeError, match="Could not reach the Cognee API at http://localhost:9999"
+        ):
+            dispatch(args)
+        # The old design pre-probed /health; the new one goes straight to the command.
+        mock_instance.health.assert_not_called()
+
+    @patch("cognee.cli.api_dispatch.CogneeApiClient")
+    def test_http_status_error_is_not_masked_as_connection_failure(self, MockClient):
+        """A reachable server returning 4xx/5xx must surface its real error, not
+        be relabelled 'cannot connect' (the bug behind CLO-321)."""
+        mock_instance = MagicMock()
+        mock_instance.add.side_effect = RuntimeError("API error 401: unauthorized")
+        MockClient.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        args = argparse.Namespace(
+            api_url="https://tenant.aws.cognee.ai",
+            command="add",
+            user_id=None,
+            data=["test"],
+            dataset_name="ds",
+        )
+        with pytest.raises(RuntimeError, match="API error 401"):
             dispatch(args)
 
     def test_supported_commands_match_dispatchers(self):


### PR DESCRIPTION
## Summary

`cognee-cli --api-url <cloud> --api-key <key> datasets list` failed with *"Cannot connect to Cognee API… Is the server running?"* even though the tenant was reachable. The flags were **not** ignored — the failure came from a fatal pre-flight health probe.

## Root cause

`api_dispatch.dispatch()` ran `client.health()` before every command. That probe:

1. Hit **`/health`** — a DB-backed endpoint that **hangs on a stuck tenant** ([CLO-318](https://linear.app/cognee/issue/CLO-318)) and returns **503** when the backend is degraded.
2. Used **its own httpx client with no auth headers**.
3. Wrapped everything in `except Exception → "Cannot connect… Is the server running?"`.

So any non-200 (503/404/401) or a hang was mislabeled as "server not running", and the command aborted before `datasets_list()` ran. Even past that, `datasets_list()` used `/api/v1/datasets` without the trailing slash — the [CLO-320](https://linear.app/cognee/issue/CLO-320) redirect footgun.

## Changes

- **Remove the fatal `/health` pre-flight probe.** Run the real command; translate only genuine **transport** failures (`httpx.TransportError`) into a friendly, URL-bearing message. Real HTTP status errors (e.g. `401`) surface with their actual detail via `_raise_for_status`.
- **`is_connection_error()`** helper to classify transport vs HTTP errors.
- **Canonical trailing slash + `follow_redirects=True`** on the datasets collection calls (`list`/`create`/`delete-all`), so they work against cloud (slash-canonical) and local OSS (no-slash) alike — safe now that CLO-320 stops the redirect `https→http` downgrade.
- **`health()`** reuses the pooled (authed) client and returns the body on 503 instead of raising (kept as an optional explicit check; no longer on the command path).

## Acceptance criteria

- [x] `datasets list` against a cloud tenant no longer dies at a bogus health probe (probe removed; real request runs with auth + canonical slash).
- [x] Connection-failure error reports the URL that was attempted.

## Tests

New/updated unit tests: transport error → friendly URL message (and `/health` not probed); HTTP 401 **not** masked as a connection failure; canonical trailing slash on dataset calls; `follow_redirects` set; `health()` tolerates 503; `is_connection_error` classification. **Full CLI unit suite green — 130 passed.** `ruff check` + `ruff format --check` clean.

> Note: verified via unit tests with mocked transport, not against a live cloud tenant (would need a real tenant + key). The change is transport-layer only.

Closes CLO-321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)