### PR TITLE
fix(neo4j): bind filter values as parameters in get_filtered_graph_data

### DIFF
--- a/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/adapter.py
@@ -157,6 +157,10 @@ class Neo4jAdapter(GraphDBInterface):
     managing sessions and projecting graphs.
     """
 
+    # Attribute names allowed in get_filtered_graph_data, mirroring the
+    # postgres/turso adapters. Values are always bound as query parameters.
+    _ALLOWED_FILTER_ATTRS = {"id", "name", "type"}
+
     def __init__(
         self,
         graph_database_url: str,
@@ -2111,21 +2115,33 @@ class Neo4jAdapter(GraphDBInterface):
 
             A tuple containing filtered nodes and edges based on the specified criteria.
         """
-        where_clauses = []
-        for attribute, values in attribute_filters[0].items():
-            values_str = ", ".join(
-                f"'{value}'" if isinstance(value, str) else str(value) for value in values
-            )
-            where_clauses.append(f"n.{attribute} IN [{values_str}]")
+        # Validate attribute names against a whitelist and bind values as query
+        # parameters — mirroring the postgres/turso adapters — instead of
+        # interpolating names and values into the Cypher text (which broke on
+        # values containing quotes and left the query open to injection). The
+        # edge clause is built explicitly per alias rather than via the
+        # previous `where_clause.replace("n.", "m.")`, which corrupted any
+        # value containing the literal "n." substring.
+        node_clauses = []
+        edge_clauses = []
+        params: Dict[str, Any] = {}
+        for index, (attribute, values) in enumerate(attribute_filters[0].items()):
+            if attribute not in self._ALLOWED_FILTER_ATTRS:
+                raise ValueError(f"Invalid filter attribute: {attribute!r}")
+            param = f"filter_values_{index}"
+            node_clauses.append(f"n.{attribute} IN ${param}")
+            edge_clauses.append(f"m.{attribute} IN ${param}")
+            params[param] = list(values)
 
-        where_clause = " AND ".join(where_clauses)
+        node_where = " AND ".join(node_clauses)
+        edge_where = " AND ".join(node_clauses + edge_clauses)
 
         query_nodes = f"""
         MATCH (n)
-        WHERE {where_clause}
+        WHERE {node_where}
         RETURN n.id AS id, labels(n) AS labels, properties(n) AS properties
         """
-        result_nodes = await self.query(query_nodes)
+        result_nodes = await self.query(query_nodes, params)
 
         nodes = [
             (
@@ -2137,10 +2153,10 @@ class Neo4jAdapter(GraphDBInterface):
 
         query_edges = f"""
         MATCH (n)-[r]->(m)
-        WHERE {where_clause} AND {where_clause.replace("n.", "m.")}
+        WHERE {edge_where}
         RETURN n.id AS source, m.id AS target, TYPE(r) AS type, properties(r) AS properties
         """
-        result_edges = await self.query(query_edges)
+        result_edges = await self.query(query_edges, params)
 
         edges = []
         for record in result_edges:

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_filtered_graph_data.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_filtered_graph_data.py
@@ -36,3 +36,57 @@ async def test_filtered_graph_edges_fall_back_to_returned_endpoint_ids():
     assert edges == [("source", "target", "calls", {})]
     edge_query = adapter.query.await_args_list[1].args[0]
     assert "m.id AS target" in edge_query
+
+
+def _adapter_with_empty_results() -> Neo4jAdapter:
+    adapter = Neo4jAdapter(
+        "bolt://unused",
+        graph_database_allow_anonymous=True,
+        driver=object(),
+    )
+    adapter.query = AsyncMock(side_effect=[[], []])
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_filtered_graph_data_binds_values_as_parameters():
+    """Filter values must be bound as query parameters, not interpolated into
+    the Cypher text — a value containing a quote previously broke the query
+    (and left it open to injection)."""
+    adapter = _adapter_with_empty_results()
+
+    await adapter.get_filtered_graph_data([{"type": ["Entity", "it's quoted"]}])
+
+    node_call = adapter.query.await_args_list[0]
+    node_query = node_call.args[0]
+    assert "$filter_values_0" in node_query
+    assert "it's quoted" not in node_query
+    assert node_call.args[1] == {"filter_values_0": ["Entity", "it's quoted"]}
+
+
+@pytest.mark.asyncio
+async def test_filtered_graph_data_builds_edge_clause_per_alias():
+    """The edge clause must be built explicitly for both aliases — the previous
+    where_clause.replace("n.", "m.") corrupted values containing the literal
+    "n." substring."""
+    adapter = _adapter_with_empty_results()
+
+    await adapter.get_filtered_graph_data([{"type": ["Section n.1"]}])
+
+    edge_call = adapter.query.await_args_list[1]
+    edge_query = edge_call.args[0]
+    assert "n.type IN $filter_values_0" in edge_query
+    assert "m.type IN $filter_values_0" in edge_query
+    assert edge_call.args[1] == {"filter_values_0": ["Section n.1"]}
+
+
+@pytest.mark.asyncio
+async def test_filtered_graph_data_rejects_unknown_attribute():
+    """Attribute names are validated against a whitelist, mirroring the
+    postgres/turso adapters."""
+    adapter = _adapter_with_empty_results()
+
+    with pytest.raises(ValueError, match="Invalid filter attribute"):
+        await adapter.get_filtered_graph_data([{"type = 'x' OR 1=1 //": ["Entity"]}])
+
+    adapter.query.assert_not_awaited()


### PR DESCRIPTION
## Description

Fixes #4191 — `get_filtered_graph_data` in the Neo4j adapter interpolated attribute names and values directly into the Cypher text (bare quote wrapping broke on values containing quotes and permitted injection), and derived the edge clause via `where_clause.replace("n.", "m.")`, which silently corrupted any value containing the literal `"n."` substring.

The method now mirrors the guards the postgres and turso adapters already enforce for this same interface method:

- attribute names validated against `_ALLOWED_FILTER_ATTRS = {"id", "name", "type"}` (raising `ValueError` otherwise — the same whitelist and behavior as postgres);
- values bound as query parameters (`n.type IN $filter_values_0`) instead of interpolated;
- the edge clause built explicitly per alias (`n.` and `m.`) instead of string replacement.

Behavior is unchanged for all valid input: every in-repo caller passes whitelisted attributes (`type`/`name`/`id`) already, and since postgres enforces this exact whitelist for the same method, any caller that works there works here.

## Verification

- 3 new tests in `test_neo4j_filtered_graph_data.py`: quote-containing values are parameterized (and absent from the query text), values containing `"n."` survive the per-alias edge clause intact, and non-whitelisted attributes raise `ValueError` without touching the database.
- The existing endpoint-fallback test passes unchanged; full graph test directory: 39 passed.
- `ruff format --check` clean; commit is DCO signed-off.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin
