### PR TITLE
fix(ci): silence ty unresolved-import for optional PIL in image_loader [SDK-307]

### DIFF
--- a/cognee/infrastructure/loaders/core/image_loader.py
+++ b/cognee/infrastructure/loaders/core/image_loader.py
@@ -171,8 +171,8 @@ class ImageLoader(LoaderInterface):
         coordinates when available, or None if the image has no EXIF data.
         """
         try:
-            from PIL import Image
-            from PIL.ExifTags import TAGS
+            from PIL import Image  # ty: ignore[unresolved-import]
+            from PIL.ExifTags import TAGS  # ty: ignore[unresolved-import]
         except ImportError:
             return None
 
@@ -234,7 +234,7 @@ class ImageLoader(LoaderInterface):
         Returns the hash as a hex string, or None on failure.
         """
         try:
-            from PIL import Image
+            from PIL import Image  # ty: ignore[unresolved-import]
         except ImportError:
             return None
 
@@ -270,7 +270,7 @@ def _dhash(image, hash_size: int = 8) -> str:
     Difference hash: resize to (hash_size+1 x hash_size), convert to
     grayscale, compare adjacent columns, and pack bits into a hex string.
     """
-    from PIL import Image
+    from PIL import Image  # ty: ignore[unresolved-import]
 
     image = image.convert("L").resize((hash_size + 1, hash_size), Image.LANCZOS)
     pixels = list(image.getdata())
@@ -293,7 +293,7 @@ def _dhash(image, hash_size: int = 8) -> str:
 def _format_gps_info(gps_dict: dict) -> Optional[str]:
     """Format GPSInfo dict (tag 34853) into human-readable coordinates."""
     try:
-        from PIL.ExifTags import GPSTAGS
+        from PIL.ExifTags import GPSTAGS  # ty: ignore[unresolved-import]
     except ImportError:
         return None
 


### PR DESCRIPTION
## What & why

The **Code Quality** CI job (`uv run ty check .`) is currently **red on every PR**, including already-merged ones — the check is broken repo-wide, not by any individual PR.

**Root cause:** `cognee/infrastructure/loaders/core/image_loader.py` imports Pillow (`PIL`) for its optional EXIF-metadata and perceptual-hash features. The imports are guarded at runtime with `try/except ImportError` (graceful degradation), so Pillow is genuinely optional — but it is **not** installed by the Code Quality job (which runs only `uv sync --extra dev`; Pillow reaches the env only transitively via the `unstructured` extra). Because `[tool.ty.src].include` covers `cognee/infrastructure/loaders`, ty type-checks that file and emits **5 `unresolved-import` diagnostics** for `PIL` / `PIL.ExifTags`.

**Evidence it's pre-existing and repo-wide:** Code Quality = FAILURE on #4155, #4156, #4134 and the already-merged #4153; `image_loader.py` and the ty config are byte-identical across the last ~34 dev commits.

## Change

Add an inline `# ty: ignore[unresolved-import]` at each of the 5 optional `PIL` import sites — matching the existing convention in the repo (e.g. `litellm_instructor/.../azure_openai/adapter.py`). These imports are intentionally optional and already runtime-guarded, so suppressing the *static* unresolved-import there is the correct semantics. **No dependency or lockfile change**, and the `try/except` guards are untouched.

Alternative considered: add Pillow to the `dev` extra so ty can actually resolve it (real type coverage of the PIL path) — heavier (lockfile change) and inconsistent with how other optional imports are handled; left as a possible later improvement.

## Verification (local, ty resolving against a full dev env with Pillow absent)

- `ty check .`: **5 diagnostics → 0** ("All checks passed!").
- `ruff check` and `ruff format --check`: clean.

Linear: **SDK-307**. Unblocks the Code Quality gate for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
