### PR TITLE
SDK-309 fix(tests): guard enola install exec-bit assertion on Windows

### DIFF
--- a/cognee/tests/unit/tasks/code_graph/test_install_enola.py
+++ b/cognee/tests/unit/tasks/code_graph/test_install_enola.py
@@ -1,6 +1,7 @@
 import hashlib
 import importlib
 import io
+import os
 import tarfile
 
 import pytest
@@ -63,8 +64,14 @@ def test_install_downloads_verifies_and_installs(monkeypatch, tmp_path):
     install_dir = tmp_path / "bin"
     binary_path = install_module.install_enola(install_dir=install_dir)
 
-    assert binary_path == str(install_dir / _expected_binary_name())
-    assert (install_dir / _expected_binary_name()).stat().st_mode & 0o111
+    installed = install_dir / _expected_binary_name()
+    assert binary_path == str(installed)
+    assert installed.is_file()
+    # POSIX execute bits are not modeled on Windows: os.chmod there only toggles
+    # the read-only flag, so st_mode never carries 0o111 no matter what
+    # install_enola sets. On Windows executability comes from the .exe extension.
+    if os.name != "nt":
+        assert installed.stat().st_mode & 0o111
     assert len(calls) == 1
     assert install_module.ENOLA_PINNED_VERSION in calls[0]
 


### PR DESCRIPTION
## Problem

The **Windows CI job on Python 3.13.x** fails one unit test:

`cognee/tests/unit/tasks/code_graph/test_install_enola.py::test_install_downloads_verifies_and_installs`

```
assert (install_dir / _expected_binary_name()).stat().st_mode & 0o111
AssertionError: assert (33206 & 73)
  where 33206 = os.stat_result(st_mode=33206, ...).st_mode
```

`33206 == 0o100666` (a regular file with mode `rw-rw-rw-`), so `0o100666 & 0o111 == 0`. The binary **is** installed correctly (the returned path equals the expected name and the file exists) — only the execute-bit assertion fails.

## Root cause (test-only)

`install_enola()` calls `staged_binary.chmod(0o755)` before `os.replace`. On POSIX that sets the execute bits, so `st_mode & 0o111` is truthy. On **Windows, `os.chmod` only honors the read-only flag** — it cannot set POSIX execute bits — so the installed file's mode is `0o100666` and the assertion can never be satisfied. On Windows executability comes from the file **extension** (`.exe`), not permission bits.

The production installer is already correct cross-platform: `installed_binary_path()` appends a `.exe` suffix on Windows, and the `chmod(0o755)` is a harmless no-op for exec bits there. **No production code change is needed** — the defect is purely in the test asserting a POSIX-only invariant unconditionally.

## Fix

Guard the exec-bit assertion behind `os.name != "nt"`; assert file existence unconditionally.

```python
installed = install_dir / _expected_binary_name()
assert binary_path == str(installed)
assert installed.is_file()
if os.name != "nt":
    assert installed.stat().st_mode & 0o111
```

## Scope check

Swept the sibling `code_graph` tests for other Windows-fragile spots: the only other `chmod(0o755)` calls are test **setup** helpers (`test_enola_runner.py` and the async tests here) that never assert exec bits and monkeypatch `asyncio.create_subprocess_exec`, so no real subprocess runs. `find_enola_binary` uses `os.path.isfile` (Windows-safe); archive-layout checks use `/`, matching tar member names. This one assertion is the sole Windows-fragile point.

## Verification

- POSIX (darwin, py3.14): full `test_install_enola.py` → **9 passed**. The guard keeps the assertion active on POSIX, so exec-bit behavior is still proven; I have not weakened the POSIX check.
- On Windows the assertion is skipped; the remaining assertions (path equality, file existence, single download call, version-in-URL) still run.
- `ruff format --check` and `ruff check` clean.

Linear: [SDK-309](https://linear.app/cognee/issue/SDK-309). The enola code-graph feature was added in #4037 (COG-5837 / SDK-196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)