### PR TITLE
SDK-311 fix(embeddings): guard OpenRouter encoding_format=null 400 (gh #3660)

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -155,6 +155,24 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
                         "api_base": self.endpoint,
                         "api_version": self.api_version,
                     }
+                    # Older LiteLLM releases serialize an omitted encoding format as null,
+                    # which OpenRouter rejects (it only accepts "float"/"base64"). Cognee
+                    # always consumes float vectors, so make the valid format explicit for
+                    # every OpenRouter route: the "openrouter/" model prefix, an explicit
+                    # provider, or a custom endpoint aimed at openrouter.ai. The last case
+                    # (an unprefixed model + endpoint) is driven through litellm's OpenAI
+                    # handler -- the branch that historically injected the null -- so it is
+                    # the one that still needs the guard on current litellm. We keep this
+                    # scoped to OpenRouter because providers such as gemini/bedrock/vertex_ai
+                    # reject encoding_format and cognee does not enable litellm.drop_params.
+                    routed_to_openrouter = (
+                        (self.provider or "").lower() == "openrouter"
+                        or (self.model or "").lower().startswith("openrouter/")
+                        or "openrouter.ai" in (self.endpoint or "").lower()
+                    )
+                    if routed_to_openrouter:
+                        embedding_kwargs["encoding_format"] = "float"
+
                     # Pass through target embedding dimensions when supported
                     if self.dimensions is not None:
                         embedding_kwargs["dimensions"] = self.dimensions

--- a/cognee/tests/unit/test_litellm_embedding_sanitize.py
+++ b/cognee/tests/unit/test_litellm_embedding_sanitize.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
 
 from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
@@ -55,3 +58,69 @@ async def test_embed_text_filters_invalid_inputs(monkeypatch):
     assert result[1] == UNIQUE_B
     assert result[2] == UNIQUE_C
     assert result[4] == UNIQUE_E
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "model", "endpoint", "expected_encoding_format"),
+    [
+        # Documented OpenRouter config (issue #3660): "openrouter/" model prefix.
+        (
+            "custom",
+            "openrouter/openai/text-embedding-3-small",
+            "https://example.invalid/v1",
+            "float",
+        ),
+        # Explicit provider name.
+        ("openrouter", "text-embedding-3-small", "https://example.invalid/v1", "float"),
+        # Prefix detection is case-insensitive.
+        (
+            "custom",
+            "OpenRouter/openai/text-embedding-3-small",
+            "https://example.invalid/v1",
+            "float",
+        ),
+        # Custom endpoint aimed at openrouter.ai with an unprefixed model: litellm
+        # drives this through its OpenAI handler (the branch that injected the null),
+        # so the guard must still fire based on the endpoint host.
+        ("custom", "openai/text-embedding-3-small", "https://openrouter.ai/api/v1", "float"),
+        # Non-OpenRouter providers must be left untouched (encoding_format omitted).
+        ("gemini", "gemini/text-embedding-004", "https://example.invalid/v1", None),
+    ],
+)
+async def test_embed_text_sets_encoding_format_only_for_openrouter(
+    monkeypatch, provider, model, endpoint, expected_encoding_format
+):
+    monkeypatch.setenv("MOCK_EMBEDDING", "false")
+
+    with patch.object(LiteLLMEmbeddingEngine, "get_tokenizer", return_value=Mock()):
+        engine = LiteLLMEmbeddingEngine(
+            provider=provider,
+            model=model,
+            dimensions=2,
+            api_key="test-key",
+            endpoint=endpoint,
+        )
+
+    response = SimpleNamespace(data=[{"embedding": [0.1, 0.2]}])
+    mock_aembedding = AsyncMock(return_value=response)
+
+    import cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine as mod
+
+    monkeypatch.setattr(mod.litellm, "aembedding", mock_aembedding)
+
+    result = await engine.embed_text(["hello"])
+
+    expected_kwargs = {
+        "model": model,
+        "input": ["hello"],
+        "api_key": "test-key",
+        "api_base": endpoint,
+        "api_version": None,
+        "dimensions": 2,
+    }
+    if expected_encoding_format is not None:
+        expected_kwargs["encoding_format"] = expected_encoding_format
+
+    mock_aembedding.assert_awaited_once_with(**expected_kwargs)
+    assert result == [[0.1, 0.2]]


### PR DESCRIPTION
## Description

Lands the OpenRouter embedding `encoding_format` guard onto current `dev`, superseding maintainer PR topoteretes/cognee#4134 (whose branch `fix/3660-openrouter-encoding-format-v2` had gone badly stale vs `dev`). This combines the original topoteretes/cognee#4134 guard with the endpoint-host detection follow-up (topoteretes/cognee#4172, which was merged into topoteretes/cognee#4134's branch but never into `dev`).

Fixes GitHub bug topoteretes/cognee#3660 — "Interoperability not with LiteLLM and openrouter".

**The bug:** With an OpenRouter embedding config (`EMBEDDING_PROVIDER=custom`, `EMBEDDING_MODEL=openrouter/openai/text-embedding-3-small`), embeddings 400 with `invalid_value` on `encoding_format`. Older LiteLLM serializes an *omitted* `encoding_format` as JSON `null`; OpenAI tolerates it, OpenRouter rejects it (accepts only `"float"`/`"base64"`). Cognee's `LiteLLMEmbeddingEngine` never set the param.

**The fix:** In `LiteLLMEmbeddingEngine.embed_text`, set `encoding_format="float"` whenever the route is OpenRouter — detected via the `openrouter/` model prefix, an explicit `openrouter` provider, or an `openrouter.ai` endpoint host. The endpoint case routes through litellm's OpenAI handler (the branch that historically injected the null), so it needs the guard even on current litellm.

**Why the guard is scoped to OpenRouter (not unconditional):** cognee sets no global `litellm.drop_params`, and `encoding_format="float"` raises `UnsupportedParamsError` for gemini/bedrock/vertex_ai embeddings. An unconditional `"float"` would break those users.

**Scope note:** empirically the reported bug does not reproduce on cognee's pinned litellm range (`>=1.83.7`, lock `1.89.2`) for the `openrouter/`-prefixed path — litellm's dedicated openrouter branch drops the omitted param. So this is defensive hardening for users on older/sub-floor litellm (e.g. stale mcp docker images) and the endpoint-based config; a no-op on current deps.

## Acceptance Criteria

* OpenRouter embedding routes send `encoding_format="float"`; non-OpenRouter providers are untouched.
* Parametrized unit test covers all three detection paths (model prefix, provider, endpoint host, incl. case-insensitivity) + a gemini negative control.
* `pytest cognee/tests/unit/test_litellm_embedding_sanitize.py` → 6 passed; `ruff check` + `ruff format --check` clean.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)

## Pre-submission Checklist

- [X] I have tested my changes thoroughly before submitting this PR
- [X] This PR contains minimal changes necessary to address the issue
- [X] My code follows the project's coding standards and style guidelines
- [X] I have added tests that prove my fix is effective
- [X] All new and existing tests pass
- [X] I have linked any relevant issues in the description

Linear: [SDK-311](https://linear.app/cognee/issue/SDK-311/fix-openrouter-embedding-encoding-formatnull-400-gh-3660-land). Related: topoteretes/cognee#3660 (review), [COG-5382](https://linear.app/cognee/issue/COG-5382/reduce-workarounds-for-self-hosted-setup-openrouter-embeddings-docker) (self-hosted OpenRouter workarounds). Supersedes topoteretes/cognee#4134, topoteretes/cognee#4172.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)