### PR TITLE
[CLO-330] Approximate agent-session token usage from transcript

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -633,4 +633,50 @@ async def recall(
             session_id or "-",
         )
 
+        # Context-only recalls run no LLM completion, so the completion usage
+        # scope records nothing and the session would show $0 for its reads
+        # (the common claude-code / agent pattern). Attribute the query + the
+        # served context to the session as a usage proxy. Guarded on
+        # only_context so a completion recall — already tracked by the usage
+        # scope — is never double-counted.
+        if session_id and only_context and merged:
+            await _record_recall_context_usage(
+                session_id=session_id, user=user, query_text=query_text, entries=merged
+            )
+
         return merged
+
+
+async def _record_recall_context_usage(
+    *,
+    session_id: str,
+    user: object | None,
+    query_text: str,
+    entries: list[RecallResponse],
+) -> None:
+    """Best-effort: approximate a context-only recall's token usage and
+    accumulate it onto its session. Never raises — usage accounting is
+    auxiliary to the recall itself."""
+    try:
+        user_id = await _resolve_user_id(user)
+        if not user_id:
+            return
+
+        def _entry_text(entry: RecallResponse) -> str:
+            dump = getattr(entry, "model_dump_json", None)
+            if callable(dump):
+                return dump()
+            return str(entry)
+
+        context_text = "\n".join(_entry_text(entry) for entry in entries)
+
+        from cognee.modules.session_lifecycle.usage_tracking import record_transcript_usage
+
+        await record_transcript_usage(
+            session_id=session_id,
+            user_id=user_id,
+            input_text=query_text,
+            output_text=context_text,
+        )
+    except Exception as exc:
+        logger.debug("recall: context-usage accounting failed (%s)", exc)

--- a/cognee/infrastructure/session/session_manager.py
+++ b/cognee/infrastructure/session/session_manager.py
@@ -217,6 +217,14 @@ class SessionManager:
             session_feedback=session_feedback,
         )
         await record_session_activity(user_id, session_id, errored=status == "error")
+        await self._record_trace_step_usage(
+            user_id=user_id,
+            session_id=session_id,
+            memory_query=memory_query,
+            memory_context=memory_context,
+            method_params=method_params,
+            method_return_value=method_return_value,
+        )
         await self._maybe_extract_agent_context(
             user_id=user_id,
             session_id=session_id,
@@ -226,6 +234,43 @@ class SessionManager:
             error_message=error_message,
         )
         return trace_id
+
+    async def _record_trace_step_usage(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        memory_query: str,
+        memory_context: str,
+        method_params: Any,
+        method_return_value: Any,
+    ) -> None:
+        """Estimate this trace step's token usage and accumulate it onto the
+        session row. Best-effort — never let usage accounting break a write."""
+
+        def _as_text(value: Any) -> str:
+            if value is None:
+                return ""
+            if isinstance(value, str):
+                return value
+            try:
+                import json
+
+                return json.dumps(value, default=str)
+            except (TypeError, ValueError):
+                return str(value)
+
+        try:
+            from cognee.modules.session_lifecycle.usage_tracking import record_transcript_usage
+
+            await record_transcript_usage(
+                session_id=session_id,
+                user_id=user_id,
+                input_text=f"{memory_query}\n{_as_text(method_params)}",
+                output_text=f"{memory_context}\n{_as_text(method_return_value)}",
+            )
+        except Exception as exc:
+            logger.debug("_record_trace_step_usage failed (%s)", exc)
 
     async def _maybe_extract_agent_context(
         self,

--- a/cognee/modules/session_lifecycle/__init__.py
+++ b/cognee/modules/session_lifecycle/__init__.py
@@ -19,7 +19,7 @@ from .metrics import (
     mark_ended,
     touch_session,
 )
-from .usage_tracking import record_llm_call, track_session_usage
+from .usage_tracking import record_llm_call, record_transcript_usage, track_session_usage
 
 __all__ = [
     "SessionListPage",
@@ -33,6 +33,7 @@ __all__ = [
     "list_session_rows",
     "mark_ended",
     "record_llm_call",
+    "record_transcript_usage",
     "touch_session",
     "track_session_usage",
 ]

--- a/cognee/modules/session_lifecycle/usage_tracking.py
+++ b/cognee/modules/session_lifecycle/usage_tracking.py
@@ -6,6 +6,11 @@ Call sites that know the active session_id wrap their work in
 opts in) calls ``record_llm_call`` after each LLM completion. The
 tracker accumulates into the ``SessionRecord`` row.
 
+Agent-facing operations (``remember`` and ``@agent_memory`` tool calls)
+don't run under that completion scope, so ``add_agent_trace_step`` calls
+``record_transcript_usage`` to approximate their usage from the trace
+step's text instead — otherwise those sessions would always show $0.
+
 Token counts are approximate — we don't currently extract
 ``response.usage`` from the litellm/instructor client (requires
 changes deeper in the stack). A ~chars/4 heuristic is close enough
@@ -167,3 +172,48 @@ async def record_llm_call(
         )
     except Exception as exc:
         logger.debug("record_llm_call: accumulate failed (%s)", exc)
+
+
+async def record_transcript_usage(
+    *,
+    session_id: str,
+    user_id: "str | UUIDType",
+    input_text: str = "",
+    output_text: str = "",
+) -> None:
+    """Accumulate *estimated* token usage for one transcript step onto its session.
+
+    Agent-facing operations (``remember`` and ``@agent_memory``-decorated tool
+    calls, via ``SessionManager.add_agent_trace_step``) never enter the
+    ``track_session_usage`` completion scope, so their usage is otherwise never
+    counted and the session shows $0. We approximate tokens from the step's own
+    text (the same ~chars/4 heuristic as ``record_llm_call``) and store them in
+    the same ``tokens_in``/``tokens_out`` columns the dashboard reads; cost is
+    derived downstream from the token totals.
+
+    This path is disjoint from ``record_llm_call`` — the completion retrievers
+    that use the usage scope do not emit trace steps — so there is no
+    double-counting. Cost is intentionally left to the caller (the cloud UI
+    prices tokens at the gateway rate), so no ``cost_usd`` is written here.
+    """
+    tokens_in = _estimate_tokens(input_text)
+    tokens_out = _estimate_tokens(output_text)
+    if not tokens_in and not tokens_out:
+        return
+
+    try:
+        uid = user_id if isinstance(user_id, UUIDType) else UUIDType(str(user_id))
+    except (ValueError, TypeError):
+        return
+
+    try:
+        from cognee.modules.session_lifecycle.metrics import accumulate_usage
+
+        await accumulate_usage(
+            session_id=session_id,
+            user_id=uid,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        )
+    except Exception as exc:
+        logger.debug("record_transcript_usage: accumulate failed (%s)", exc)

--- a/cognee/modules/session_lifecycle/usage_tracking.py
+++ b/cognee/modules/session_lifecycle/usage_tracking.py
@@ -181,20 +181,25 @@ async def record_transcript_usage(
     input_text: str = "",
     output_text: str = "",
 ) -> None:
-    """Accumulate *estimated* token usage for one transcript step onto its session.
+    """Accumulate *estimated* token usage for one agent-facing operation.
 
-    Agent-facing operations (``remember`` and ``@agent_memory``-decorated tool
-    calls, via ``SessionManager.add_agent_trace_step``) never enter the
-    ``track_session_usage`` completion scope, so their usage is otherwise never
-    counted and the session shows $0. We approximate tokens from the step's own
-    text (the same ~chars/4 heuristic as ``record_llm_call``) and store them in
-    the same ``tokens_in``/``tokens_out`` columns the dashboard reads; cost is
-    derived downstream from the token totals.
+    Agent-facing operations never enter the ``track_session_usage`` completion
+    scope, so their usage is otherwise never counted and the session shows $0.
+    Callers approximate tokens from the operation's own text (the same
+    ~chars/4 heuristic as ``record_llm_call``) and store them in the same
+    ``tokens_in``/``tokens_out`` columns the dashboard reads; cost is derived
+    downstream from the token totals. Current callers:
 
-    This path is disjoint from ``record_llm_call`` — the completion retrievers
-    that use the usage scope do not emit trace steps — so there is no
-    double-counting. Cost is intentionally left to the caller (the cloud UI
-    prices tokens at the gateway rate), so no ``cost_usd`` is written here.
+    * ``SessionManager.add_agent_trace_step`` — ``remember`` and
+      ``@agent_memory``-decorated tool calls.
+    * ``recall`` — context-only recalls (``only_context=True``), which run no
+      LLM completion so nothing else would track them.
+
+    All these paths are disjoint from ``record_llm_call`` — completion
+    retrievers, which use the usage scope, neither emit trace steps nor take
+    the ``only_context`` branch — so there is no double-counting. Cost is
+    intentionally left to the consumer (the cloud UI prices tokens at the
+    gateway rate), so no ``cost_usd`` is written here.
     """
     tokens_in = _estimate_tokens(input_text)
     tokens_out = _estimate_tokens(output_text)

--- a/cognee/tests/unit/api/v1/recall/test_recall_api.py
+++ b/cognee/tests/unit/api/v1/recall/test_recall_api.py
@@ -466,3 +466,59 @@ async def test_cloud_client_recall_payload_includes_context_profile(monkeypatch)
     )
 
     assert fake.last_json.get("context_profile") == "agent"
+
+
+@pytest.mark.asyncio
+async def test_record_recall_context_usage_accumulates(monkeypatch, api_recall_mod):
+    """Context-only recall attributes query + served context to the session."""
+
+    class _Entry:
+        def __init__(self, text):
+            self._text = text
+
+        def model_dump_json(self):
+            return self._text
+
+    recorded = {}
+
+    async def fake_record(**kwargs):
+        recorded.update(kwargs)
+
+    monkeypatch.setattr(
+        "cognee.modules.session_lifecycle.usage_tracking.record_transcript_usage", fake_record
+    )
+
+    await api_recall_mod._record_recall_context_usage(
+        session_id="s1",
+        user=_make_user(),
+        query_text="what did I do",
+        entries=[_Entry("ctx-a"), _Entry("ctx-b")],
+    )
+
+    assert recorded["session_id"] == "s1"
+    assert recorded["input_text"] == "what did I do"
+    assert "ctx-a" in recorded["output_text"] and "ctx-b" in recorded["output_text"]
+
+
+@pytest.mark.asyncio
+async def test_record_recall_context_usage_noop_without_user_id(monkeypatch, api_recall_mod):
+    """No attribution when the user id can't be resolved."""
+    called = False
+
+    async def fake_record(**kwargs):
+        nonlocal called
+        called = True
+
+    async def no_user(_user):
+        return None
+
+    monkeypatch.setattr(
+        "cognee.modules.session_lifecycle.usage_tracking.record_transcript_usage", fake_record
+    )
+    monkeypatch.setattr(api_recall_mod, "_resolve_user_id", no_user)
+
+    await api_recall_mod._record_recall_context_usage(
+        session_id="s1", user=None, query_text="q", entries=[]
+    )
+
+    assert called is False

--- a/cognee/tests/unit/infrastructure/session/test_session_manager.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_manager.py
@@ -320,6 +320,36 @@ class TestSessionManager:
         assert call_kw["session_feedback"] == "Trip plan created successfully."
 
     @pytest.mark.asyncio
+    async def test_add_agent_trace_step_records_transcript_usage(self, sm, mock_cache, monkeypatch):
+        """Each trace step feeds an estimated token count onto the session row so
+        agent sessions (which never enter the completion usage scope) accrue cost."""
+        import cognee.modules.session_lifecycle.usage_tracking as ut
+
+        usage_spy = AsyncMock()
+        monkeypatch.setattr(ut, "record_transcript_usage", usage_spy)
+
+        await sm.add_agent_trace_step(
+            user_id="u1",
+            origin_function="remember",
+            status="success",
+            session_id="s1",
+            memory_query="what did I do",
+            memory_context="context text",
+            method_params={"data": "hello"},
+            method_return_value={"ok": True},
+            generate_feedback_with_llm=False,
+        )
+
+        usage_spy.assert_awaited_once()
+        kw = usage_spy.await_args.kwargs
+        assert kw["session_id"] == "s1"
+        assert kw["user_id"] == "u1"
+        # Inputs (query + params) and outputs (context + return value) are both
+        # folded into the estimate.
+        assert "what did I do" in kw["input_text"] and "hello" in kw["input_text"]
+        assert "context text" in kw["output_text"] and "ok" in kw["output_text"]
+
+    @pytest.mark.asyncio
     async def test_add_agent_trace_step_falls_back_when_summary_is_empty(self, sm, mock_cache):
         """Empty LLM summaries fall back to the deterministic feedback string."""
         with (

--- a/cognee/tests/unit/modules/session_lifecycle/test_record_transcript_usage.py
+++ b/cognee/tests/unit/modules/session_lifecycle/test_record_transcript_usage.py
@@ -1,0 +1,59 @@
+"""Tests for transcript-derived token approximation.
+
+Agent-facing operations (remember / @agent_memory tool calls) never enter the
+LLM-completion usage scope, so their session rows would show 0 tokens (and thus
+$0 cost). ``record_transcript_usage`` approximates tokens from the trace step's
+text and accumulates them onto the session. These tests pin that behavior.
+"""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.session_lifecycle.usage_tracking import record_transcript_usage
+
+ACCUMULATE = "cognee.modules.session_lifecycle.metrics.accumulate_usage"
+
+
+@pytest.mark.asyncio
+async def test_estimates_tokens_and_accumulates_tokens_only():
+    uid = uuid4()
+    with patch(ACCUMULATE, new=AsyncMock()) as acc:
+        # ~chars/4 heuristic: 400 -> 100 in, 80 -> 20 out.
+        await record_transcript_usage(
+            session_id="s1", user_id=str(uid), input_text="x" * 400, output_text="y" * 80
+        )
+    acc.assert_awaited_once()
+    kwargs = acc.await_args.kwargs
+    assert kwargs["tokens_in"] == 100
+    assert kwargs["tokens_out"] == 20
+    assert kwargs["session_id"] == "s1"
+    assert kwargs["user_id"] == uid  # coerced from str to UUID
+    # Cost is priced downstream from tokens, so none is written here.
+    assert "cost_usd" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_no_accumulate_when_no_text():
+    with patch(ACCUMULATE, new=AsyncMock()) as acc:
+        await record_transcript_usage(session_id="s2", user_id=str(uuid4()))
+    acc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invalid_user_id_is_swallowed():
+    with patch(ACCUMULATE, new=AsyncMock()) as acc:
+        await record_transcript_usage(
+            session_id="s3", user_id="not-a-uuid", input_text="hello world"
+        )
+    acc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_accepts_uuid_directly():
+    uid = uuid4()
+    with patch(ACCUMULATE, new=AsyncMock()) as acc:
+        await record_transcript_usage(session_id="s4", user_id=uid, input_text="a" * 40)
+    acc.assert_awaited_once()
+    assert acc.await_args.kwargs["user_id"] == uid


### PR DESCRIPTION
Companion to the cognee-saas frontend PR `fix/session-cost-display` (see CLO-330). This is the **backend half** — it populates token counts for the session paths that never entered the LLM-completion usage scope, so agent sessions stop showing $0.

## Why
Session costs showed $0 because agent-facing operations don't run under `track_session_usage`, so their session rows recorded zero tokens. Only UI search (which runs completions) was tracked. Cost itself is priced downstream in the cloud UI from token counts, so this PR only needs to populate tokens.

## What
- **`record_transcript_usage()`** (`usage_tracking.py`) — estimates tokens (chars/4, the same heuristic the completion path uses) from text and accumulates into the existing `tokens_in/out` columns. No `cost_usd` written (the UI prices it).
- **`SessionManager.add_agent_trace_step`** — calls it for every `remember` and `@agent_memory`-decorated tool call.
- **`recall` (`only_context=True`)** — attributes query + served context to the session; these run no completion so nothing else tracks them.

All three paths are **disjoint** from `record_llm_call` (completion retrievers neither emit trace steps nor take the `only_context` branch), so there is **no double-counting**.

## Scope / limitations
- Figures are **estimates** — char-based token counts, not real `response.usage`. The exact-accounting follow-up is described in CLO-330.
- Reflects cognee's own processing spend per session, not the agent's own model spend.

## Tests
- New unit tests for `record_transcript_usage` and the recall hook; a wiring test on `add_agent_trace_step`. 91 session/recall unit tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)