### PR TITLE
feat(mcp): add opt-in server-side default for recall system_prompt

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -6,6 +6,7 @@ This module provides a unified interface for interacting with Cognee, supporting
 - API mode: Makes HTTP requests to a running Cognee FastAPI server
 """
 
+import os
 import sys
 import hashlib
 from typing import Optional, Any, List, Dict
@@ -31,6 +32,34 @@ logger = get_logger()
 # 300s client timeout intended for long POSTs like cognify: a hung or black-holed
 # GET would otherwise freeze the caller for a full 5 minutes.
 READ_TIMEOUT_SECONDS = 30.0
+
+
+def _default_recall_system_prompt() -> Optional[str]:
+    """Return the server-side default synthesis prompt for recall, if configured.
+
+    Opt-in via environment:
+      COGNEE_MCP_RECALL_SYSTEM_PROMPT       inline prompt text
+      COGNEE_MCP_RECALL_SYSTEM_PROMPT_FILE  path to a file holding the prompt
+
+    Returns None when neither is set, leaving current behaviour untouched.
+    """
+    inline = os.environ.get("COGNEE_MCP_RECALL_SYSTEM_PROMPT")
+    if inline and inline.strip():
+        return inline.strip()
+
+    path = os.environ.get("COGNEE_MCP_RECALL_SYSTEM_PROMPT_FILE")
+    if path:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                text = handle.read().strip()
+        except OSError as error:
+            logger.warning(
+                "Could not read COGNEE_MCP_RECALL_SYSTEM_PROMPT_FILE %s: %s", path, error
+            )
+            return None
+        if text:
+            return text
+    return None
 
 
 class CogneeClient:
@@ -555,6 +584,8 @@ class CogneeClient:
         top_k: int = 15,
     ) -> Any:
         """Search memory via recall() with auto-routing and session awareness."""
+        if not system_prompt:
+            system_prompt = _default_recall_system_prompt()
         if self.use_api:
             endpoint = f"{self.api_url}/api/v1/recall"
             payload = {"query": query_text, "top_k": top_k, "search_type": None}

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1158,7 +1158,9 @@ async def recall(
     session_id : str, optional
         Session ID for session-first search.
     system_prompt : str, optional
-        Override the synthesis prompt for completion searches.
+        Override the synthesis prompt for completion searches. When omitted,
+        falls back to COGNEE_MCP_RECALL_SYSTEM_PROMPT / _FILE if configured
+        on the server.
     top_k : int
         Maximum results to return (default: 10).
     """

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -606,3 +606,105 @@ async def test_list_datasets_json_text_channel_over_mcp_protocol(monkeypatch):
     assert "2 datasets:" in text
     assert "alpha (id-alpha)" in text
     assert "beta (id-beta)" in text
+
+
+@pytest.mark.asyncio
+async def test_recall_uses_env_default_system_prompt_when_caller_omits_it(monkeypatch):
+    """The env default is injected when the caller passes no system_prompt."""
+    monkeypatch.setenv("COGNEE_MCP_RECALL_SYSTEM_PROMPT", "Answer with provenance.")
+    monkeypatch.delenv("COGNEE_MCP_RECALL_SYSTEM_PROMPT_FILE", raising=False)
+
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[])
+
+    client = CogneeClient(api_url="http://cognee.local")
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    try:
+        await client.recall("hello")
+    finally:
+        await client.close()
+
+    payload = json.loads(requests[0].content.decode())
+    assert payload["system_prompt"] == "Answer with provenance."
+
+
+@pytest.mark.asyncio
+async def test_recall_caller_system_prompt_wins_over_env_default(monkeypatch):
+    """An explicit caller prompt always takes precedence over the env default."""
+    monkeypatch.setenv("COGNEE_MCP_RECALL_SYSTEM_PROMPT", "Env default.")
+    monkeypatch.delenv("COGNEE_MCP_RECALL_SYSTEM_PROMPT_FILE", raising=False)
+
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[])
+
+    client = CogneeClient(api_url="http://cognee.local")
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    try:
+        await client.recall("hello", system_prompt="Caller wins.")
+    finally:
+        await client.close()
+
+    payload = json.loads(requests[0].content.decode())
+    assert payload["system_prompt"] == "Caller wins."
+
+
+@pytest.mark.asyncio
+async def test_recall_reads_env_default_system_prompt_from_file(monkeypatch, tmp_path):
+    """The default can be supplied through a file for larger prompts."""
+    prompt_file = tmp_path / "recall_prompt.txt"
+    prompt_file.write_text("Prompt from file.\n", encoding="utf-8")
+    monkeypatch.delenv("COGNEE_MCP_RECALL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.setenv("COGNEE_MCP_RECALL_SYSTEM_PROMPT_FILE", str(prompt_file))
+
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[])
+
+    client = CogneeClient(api_url="http://cognee.local")
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    try:
+        await client.recall("hello")
+    finally:
+        await client.close()
+
+    payload = json.loads(requests[0].content.decode())
+    assert payload["system_prompt"] == "Prompt from file."
+
+
+@pytest.mark.asyncio
+async def test_recall_without_env_default_omits_system_prompt(monkeypatch):
+    """With no default configured, the payload carries no system_prompt."""
+    monkeypatch.delenv("COGNEE_MCP_RECALL_SYSTEM_PROMPT", raising=False)
+    monkeypatch.delenv("COGNEE_MCP_RECALL_SYSTEM_PROMPT_FILE", raising=False)
+
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[])
+
+    client = CogneeClient(api_url="http://cognee.local")
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    try:
+        await client.recall("hello")
+    finally:
+        await client.close()
+
+    payload = json.loads(requests[0].content.decode())
+    assert "system_prompt" not in payload


### PR DESCRIPTION
Follow-up to #4120 / #4122.

First of all, thank you for taking #4120 into account so quickly — the per-call `system_prompt` shipped in #4122 within a day, and it already unblocks clients that can set the parameter themselves. Much appreciated.

While adopting it, I ran into one remaining case that #4122 does not cover. When a caller omits `system_prompt`, the request falls back to the terse `RecallPayloadDTO` default, which also short-circuits `answer_simple_question.txt`. So a deployment cannot define a **default** synthesis policy.

This matters for a cognee instance used as shared long-term memory by several MCP clients: there is currently no way to set a synthesis policy server-side — every client would have to resend the full prompt text on every call, and any client that forgets silently falls back to the terse default.

**Would it be possible to also support an opt-in server-side default?** This PR proposes one, kept as small and conservative as I could make it. I would of course be glad to reshape it if you would rather see it done differently.

### Change

- Add an opt-in, env-driven default, resolved once at the top of `CogneeClient.recall`:
  - `COGNEE_MCP_RECALL_SYSTEM_PROMPT` — inline prompt text
  - `COGNEE_MCP_RECALL_SYSTEM_PROMPT_FILE` — path to a file holding the prompt
- Precedence is **explicit caller argument > env default > backend default**.
- Because the default is resolved before the API/SDK branches, both paths are covered without touching either.
- When neither variable is set, behaviour is unchanged: no `system_prompt` is added to the payload.
- `search()` is deliberately left untouched; this only affects `recall()`.

### Testing

Four tests added to `cognee-mcp/tests/test_mcp_server_hardening.py`, following the `httpx.MockTransport` pattern introduced by #4122:

- the env default is injected when the caller omits `system_prompt`;
- an explicit caller prompt takes precedence over the env default;
- the default can be supplied through a file (`..._FILE`);
- with nothing configured, no `system_prompt` is added to the payload.

The tests are written against the existing fixtures but I could not run the suite locally: my environment is missing the dependencies needed to import `src.cognee_client`. Happy to iterate if CI surfaces anything.

**On naming and placement:** the variable names are only a suggestion — happy to rename them, or to move the resolution to the server layer instead of the client, if that fits your conventions better. Thanks again for the quick follow-up on #4120, and thanks in advance for taking a look at this one.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
