### PR TITLE
test(mcp): fix recall prompt tests broken by bare-recall dataset preflight [SDK-315]

### DIFF
--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -608,6 +608,12 @@ async def test_list_datasets_json_text_channel_over_mcp_protocol(monkeypatch):
     assert "beta (id-beta)" in text
 
 
+def _recall_payload(requests: "list[httpx.Request]") -> dict:
+    """Payload of the recall POST; a bare recall sends a GET /datasets preflight first."""
+    recall_request = next(r for r in requests if r.url.path == "/api/v1/recall")
+    return json.loads(recall_request.content.decode())
+
+
 @pytest.mark.asyncio
 async def test_recall_uses_env_default_system_prompt_when_caller_omits_it(monkeypatch):
     """The env default is injected when the caller passes no system_prompt."""
@@ -629,7 +635,7 @@ async def test_recall_uses_env_default_system_prompt_when_caller_omits_it(monkey
     finally:
         await client.close()
 
-    payload = json.loads(requests[0].content.decode())
+    payload = _recall_payload(requests)
     assert payload["system_prompt"] == "Answer with provenance."
 
 
@@ -654,7 +660,7 @@ async def test_recall_caller_system_prompt_wins_over_env_default(monkeypatch):
     finally:
         await client.close()
 
-    payload = json.loads(requests[0].content.decode())
+    payload = _recall_payload(requests)
     assert payload["system_prompt"] == "Caller wins."
 
 
@@ -681,7 +687,7 @@ async def test_recall_reads_env_default_system_prompt_from_file(monkeypatch, tmp
     finally:
         await client.close()
 
-    payload = json.loads(requests[0].content.decode())
+    payload = _recall_payload(requests)
     assert payload["system_prompt"] == "Prompt from file."
 
 
@@ -706,5 +712,5 @@ async def test_recall_without_env_default_omits_system_prompt(monkeypatch):
     finally:
         await client.close()
 
-    payload = json.loads(requests[0].content.decode())
+    payload = _recall_payload(requests)
     assert "system_prompt" not in payload


### PR DESCRIPTION
## Summary
Fixes 4 tests failing in the **MCP Tests** job on every PR into `dev`:

- `test_recall_uses_env_default_system_prompt_when_caller_omits_it`
- `test_recall_caller_system_prompt_wins_over_env_default`
- `test_recall_reads_env_default_system_prompt_from_file`
- `test_recall_without_env_default_omits_system_prompt`

**Root cause:** a bare `recall()` (no datasets, no session) now sends a `GET /api/v1/datasets` preflight before `POST /api/v1/recall` (dataset fallback in `cognee_client.py`). These tests read the payload from `requests[0]`, which is now the bodyless preflight GET, so they crash with `JSONDecodeError: Expecting value: line 1 column 1`.

**Fix:** add a `_recall_payload()` helper that selects the request by path (`/api/v1/recall`) instead of position, and use it in all four tests. The `remember` and session-scoped recall tests keep `requests[0]` — they trigger no preflight.

Note: the companion `dev` CI breakage (unformatted `langmem.py` failing pre-commit) already landed on `dev` as `f63801918`, so this PR carries only the test fix.

Linear: [SDK-315](https://linear.app/cognee/issue/SDK-315/fix-dev-ci-langmem-ruff-format-failure-mcp-recall-test-breakage)

## Test plan
- [x] `uv run pytest tests/test_mcp_server_hardening.py` in `cognee-mcp/` — 31 passed locally
- [ ] MCP Tests job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)