### PR TITLE
fix(pipelines): repair provenance-mode gating TypeError breaking all CI [SDK-317]

### DIFF
--- a/cognee/modules/pipelines/operations/run_tasks_base.py
+++ b/cognee/modules/pipelines/operations/run_tasks_base.py
@@ -204,26 +204,22 @@ async def handle_task(
             provenance_visited = ctx._provenance_visited if ctx else None
             _provenance_config = get_provenance_config()
             async for result_data in running_task.execute(args, kwargs, next_task_batch_size):
-                if not _provenance_config.is_disabled():
-                    _stamp_provenance(
-                        result_data,
-                        pipe_name,
-                    )
                 if isinstance(result_data, list):
                     result_count += len(result_data)
                 else:
                     result_count += 1
 
-                _stamp_provenance(
-                    result_data,
-                    pipe_name,
-                    task_name,
-                    visited=provenance_visited,
-                    node_set=input_node_set,
-                    user_label=user_label,
-                    content_hash=input_content_hash,
-                    task_index=task_index,
-                )
+                if not _provenance_config.is_disabled():
+                    _stamp_provenance(
+                        result_data,
+                        pipe_name,
+                        task_name,
+                        visited=provenance_visited,
+                        node_set=input_node_set,
+                        user_label=user_label,
+                        content_hash=input_content_hash,
+                        task_index=task_index,
+                    )
 
                 async for result in run_tasks_base(leftover_tasks, result_data, user, ctx):
                     yield result

--- a/cognee/modules/pipelines/provenance_config.py
+++ b/cognee/modules/pipelines/provenance_config.py
@@ -67,10 +67,10 @@ def get_provenance_config() -> ProvenanceConfig:
     mode = config.provenance_mode
     if mode not in _VALID_MODES:
         from cognee.shared.logging_utils import get_logger
+
         logger = get_logger("provenance_config")
         logger.warning(
-            "Unknown COGNEE_PROVENANCE_MODE=%r — falling back to 'lightweight'. "
-            "Valid values: %s",
+            "Unknown COGNEE_PROVENANCE_MODE=%r — falling back to 'lightweight'. Valid values: %s",
             mode,
             ", ".join(sorted(_VALID_MODES)),
         )

--- a/cognee/tests/unit/modules/pipelines/test_provenance_mode.py
+++ b/cognee/tests/unit/modules/pipelines/test_provenance_mode.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field
 # Minimal DataPoint replica (avoids the full cognee import chain)
 # ---------------------------------------------------------------------------
 
+
 class DataPoint(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -45,6 +46,7 @@ class ChildDP(DataPoint):
 # ---------------------------------------------------------------------------
 # Inline _stamp_provenance (mirrors run_tasks_base, avoids import chain)
 # ---------------------------------------------------------------------------
+
 
 def _stamp_provenance(
     data,
@@ -93,8 +95,14 @@ def _stamp_provenance(
     elif isinstance(data, (list, tuple)):
         for item in data:
             _stamp_provenance(
-                item, pipeline_name, task_name, visited,
-                node_set, user_label, content_hash, task_index,
+                item,
+                pipeline_name,
+                task_name,
+                visited,
+                node_set,
+                user_label,
+                content_hash,
+                task_index,
             )
 
 
@@ -127,6 +135,7 @@ def _make_config(mode: str) -> _ProvenanceConfig:
 # Helper: simulate what handle_task does for a single DataPoint result
 # ---------------------------------------------------------------------------
 
+
 def _simulate_pipeline_task(
     data_point: DataPoint,
     mode: str = "lightweight",
@@ -155,6 +164,7 @@ def _simulate_pipeline_task(
 # ===========================================================================
 # Tests — lightweight mode (default)
 # ===========================================================================
+
 
 class TestLightweightMode:
     def test_source_pipeline_stamped(self):
@@ -230,6 +240,7 @@ class TestLightweightMode:
 # Tests — deep mode
 # ===========================================================================
 
+
 class TestDeepMode:
     """Deep mode must behave identically to lightweight for stamp semantics.
 
@@ -257,6 +268,7 @@ class TestDeepMode:
 # ===========================================================================
 # Tests — disabled mode
 # ===========================================================================
+
 
 class TestDisabledMode:
     def test_nothing_stamped_when_disabled(self):
@@ -296,6 +308,7 @@ class TestDisabledMode:
 # Tests — ProvenanceConfig validation
 # ===========================================================================
 
+
 class TestProvenanceConfig:
     def test_default_is_lightweight(self):
         cfg = _ProvenanceConfig()
@@ -327,6 +340,7 @@ class TestProvenanceConfig:
 # ===========================================================================
 # Tests — shared fixture: ingest → recall → provenance present
 # ===========================================================================
+
 
 class TestSharedFixture:
     """Simulate a minimal ingestion fixture: provenance present after ingest,


### PR DESCRIPTION
## Summary
`bbb768d82` (COGNEE_PROVENANCE_MODE flag) currently breaks CI for **every open PR** in two ways; this PR fixes both:

1. **`TypeError: _stamp_provenance() missing 1 required positional argument: 'task_name'`** on every pipeline run — the gating edit in `run_tasks_base.py` was half-applied, leaving a broken two-arg call *and* the original ungated call. This fails 5 unit tests directly and takes down every suite that runs a pipeline (Search, Temporal, E2E, Vector DB, Examples…). Fix: a single `_stamp_provenance` call with full args, gated on `get_provenance_config().is_disabled()` as the feature intended.
2. **Pre-commit job failure** — `provenance_config.py` and `test_provenance_mode.py` were committed unformatted (ruff-format + missing EOF newlines). Fixed with the pinned ruff 0.15.11.

Both commits are cherry-picked from PR #4106's branch where they were validated.

Linear: [SDK-317](https://linear.app/cognee/issue/SDK-317/dev-ci-red-for-all-prs-provenance-mode-half-applied-gating-typeerror)

## Test plan
- [x] `pytest cognee/tests/unit/modules/pipelines/` — 67 passed locally (5 previously failing)
- [x] `ruff format --check .` clean repo-wide with CI-pinned ruff 0.15.11
- [ ] Unit Tests (Mocked, No Secrets) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)