### PR TITLE
SDK-318 feat(integrations): stamp Slack as source node_set on remembered messages

### DIFF
--- a/cognee/modules/integrations/slack/remember_message.py
+++ b/cognee/modules/integrations/slack/remember_message.py
@@ -13,6 +13,12 @@ from cognee.modules.users.methods import get_user
 
 SLACK_DATASET_NAME = "slack"
 
+# Structured origin stamp: every integration that ingests data should tag it
+# with a node_set naming the source system, so the origin survives into the
+# graph (NodeSet node + belongs_to_set edges + source_node_set property)
+# instead of living only in the dataset name and the prose of the text.
+SLACK_NODE_SET = ["slack"]
+
 
 def _format_remembered_text(
     text: str, *, channel_name: Optional[str], author_id: Optional[str]
@@ -43,4 +49,5 @@ async def remember_message(
         dataset_name=SLACK_DATASET_NAME,
         user=owner,
         run_in_background=True,
+        node_set=SLACK_NODE_SET,
     )

--- a/cognee/tests/unit/modules/integrations/test_remember_message.py
+++ b/cognee/tests/unit/modules/integrations/test_remember_message.py
@@ -2,6 +2,7 @@
 
 Invariants: the enriched text carries channel/author provenance (falling
 back gracefully when either is missing), the Slack dataset name is used,
+the source node_set is stamped so the origin survives into the graph,
 and the background mode is always requested (no LLM work should block the
 3-second interactive-payload window).
 """
@@ -14,6 +15,7 @@ import pytest
 
 from cognee.modules.integrations.slack.remember_message import (
     SLACK_DATASET_NAME,
+    SLACK_NODE_SET,
     remember_message,
 )
 
@@ -35,6 +37,10 @@ async def test_remembers_with_channel_and_author():
     assert kwargs["dataset_name"] == SLACK_DATASET_NAME
     assert kwargs["user"] is owner
     assert kwargs["run_in_background"] is True
+    # Origin stamp: without this, a Slack-sourced document reaches the graph
+    # with no structured Slack marker at all (only the dataset name and the
+    # prose prefix), so it can't be grouped, colored, or filtered by source.
+    assert kwargs["node_set"] == SLACK_NODE_SET == ["slack"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Data ingested through integrations carries no structured origin marker. Slack's "Remember this" shortcut calls `remember()` with only `dataset_name="slack"` — no `node_set` — so a Slack-sourced document lands in the graph with **no Slack marker at all**: no `belongs_to_set` edge, no `source_node_set` property. The only trace of where the data came from is the dataset name (relational only) and the English prefix baked into the message text.

This stamps `node_set=["slack"]` in `remember_message.py`, so Slack data gets the same graph-visible source dimension as every other ingestion path: a `NodeSet` container node, `belongs_to_set` edges that propagate to chunks/entities/summaries, and the node-set color map in the visualization. It also establishes the pattern for future integrations (each stamps a node_set naming its source system).

One functional line plus a constant; covered by the existing `test_remember_message.py` suite with a new assertion.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How was this tested

- `pytest cognee/tests/unit/modules/integrations/test_remember_message.py test_handle_slack_interactive.py` — 13 passed
- `ruff format --check` / `ruff check` clean

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)