### PR TITLE
COG-5822 docs: minimal docker-compose for local try-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ Prefer containers? Cognee publishes prebuilt images to Docker Hub on every push 
 [`cognee/cognee`](https://hub.docker.com/r/cognee/cognee) (the API server) and
 [`cognee/cognee-mcp`](https://hub.docker.com/r/cognee/cognee-mcp) (the MCP server).
 
+> **Just want to try it?** Follow the
+> [minimal docker-compose try-out](docs/minimal-docker-compose.md) — a single
+> copy-pasteable compose file that runs the prebuilt image, no clone or build needed.
+
 ### Option A — Docker Compose (build from source)
 
 Clone the repo, create a `.env` with at least `LLM_API_KEY`, then:

--- a/docs/minimal-docker-compose.md
+++ b/docs/minimal-docker-compose.md
@@ -1,0 +1,99 @@
+# Minimal docker-compose for a local try-out
+
+Try the Cognee API server with a single copy-pasteable file — no cloning, no
+building. It uses the prebuilt [`cognee/cognee`](https://hub.docker.com/r/cognee/cognee)
+image with the default local databases (SQLite, LanceDB, Ladybug), so the only
+thing you need to provide is an LLM API key.
+
+## Prerequisites
+
+- Docker with the Compose plugin (Docker Desktop, Colima, or any OCI-compatible
+  runtime — see [Docker & Colima Setup](docker-colima-setup.md))
+- An OpenAI API key (the default LLM and embedding provider)
+
+## 1. Save this as `docker-compose.yml` in an empty directory
+
+```yaml
+services:
+  cognee:
+    image: cognee/cognee:main
+    ports:
+      - "8000:8000"
+    environment:
+      LLM_API_KEY: ${LLM_API_KEY:?set LLM_API_KEY to your OpenAI API key}
+      # Single-user try-out: no auth, shared local databases.
+      # Remove this line (or set it to true) for multi-tenant mode,
+      # which requires authentication on every API call.
+      ENABLE_BACKEND_ACCESS_CONTROL: "false"
+```
+
+## 2. Start it
+
+```bash
+export LLM_API_KEY="sk-..."   # your OpenAI API key
+docker compose up
+```
+
+## 3. Verify it works
+
+```bash
+curl http://localhost:8000/health
+```
+
+Then open <http://localhost:8000/docs> for the interactive API reference and
+send your first requests:
+
+```bash
+# Ingest a text file
+echo "Cognee turns documents into AI memory." > note.txt
+curl -X POST http://localhost:8000/api/v1/add \
+  -F "data=@note.txt" \
+  -F "datasetName=main_dataset"
+
+# Build the knowledge graph
+curl -X POST http://localhost:8000/api/v1/cognify \
+  -H "Content-Type: application/json" \
+  -d '{"datasets": ["main_dataset"]}'
+
+# Search it
+curl -X POST http://localhost:8000/api/v1/search \
+  -H "Content-Type: application/json" \
+  -d '{"searchType": "GRAPH_COMPLETION", "query": "What does Cognee do?", "datasets": ["main_dataset"]}'
+```
+
+## Keeping data across restarts
+
+The minimal file above stores everything inside the container, so removing the
+container removes your data. To persist it, point Cognee's data directories at
+a named volume:
+
+```yaml
+services:
+  cognee:
+    image: cognee/cognee:main
+    ports:
+      - "8000:8000"
+    environment:
+      LLM_API_KEY: ${LLM_API_KEY:?set LLM_API_KEY to your OpenAI API key}
+      ENABLE_BACKEND_ACCESS_CONTROL: "false"
+      DATA_ROOT_DIRECTORY: /cognee-data/data
+      SYSTEM_ROOT_DIRECTORY: /cognee-data/system
+    volumes:
+      - cognee_data:/cognee-data
+
+volumes:
+  cognee_data:
+```
+
+## Going further
+
+- **Other LLM providers** (Anthropic, Gemini, Ollama, …): add the matching
+  `LLM_PROVIDER` / `LLM_MODEL` / `LLM_ENDPOINT` variables — see
+  [`.env.template`](../.env.template) for the full list.
+- **UI, MCP server, Postgres, Neo4j**: the repository's
+  [`docker-compose.yml`](../docker-compose.yml) provides these as opt-in
+  profiles — see [Run with Docker](../README.md#run-with-docker) in the README.
+- **Production**: multi-tenant mode (`ENABLE_BACKEND_ACCESS_CONTROL=true`, the
+  default) requires authentication and isolates data per user and dataset.
+  Review the security variables in [`.env.template`](../.env.template) before
+  exposing the API.


### PR DESCRIPTION
## Description
Adds a minimal, copy-pasteable Docker Compose guide for trying Cognee locally, per #4005.

The existing `docker-compose.yml` requires cloning the repo and building from source. This PR closes the actual gap: a single-file compose using the prebuilt `cognee/cognee:main` image — save one file, `docker compose up`, done.

**What's included** (`docs/minimal-docker-compose.md`):
- Minimal compose file: prebuilt image, `LLM_API_KEY` via a `${VAR:?}` guard, and `ENABLE_BACKEND_ACCESS_CONTROL=false` for a friction-free single-user try-out (the default posture requires auth on every call, which trips up first-time users)
- Verified `curl` examples for `/health`, add (multipart file upload — the endpoint does not accept inline text), cognify, and search, with payload field names checked against the actual routers/DTOs
- An optional persistence variant (`DATA_ROOT_DIRECTORY`/`SYSTEM_ROOT_DIRECTORY` on a named volume) since the default stores data inside the container
- Pointers to the full profile-based compose, `.env.template`, and the security posture for production
- Linked from the README's **Run with Docker** section for discoverability

**Validation:** live-tested end-to-end with the published `cognee/cognee:main` image, running the doc verbatim (only the host port differed, to avoid a local conflict):
- minimal variant: boots, `/health` 200, then the doc's `curl` examples — add → 200, cognify → 200, search → 200 with a correct GRAPH_COMPLETION answer from the ingested note
- persistence variant: data/system dirs land on the named volume (`/cognee-data/{data,system}`), and survive `docker compose down` + `up` (full container removal and recreate)
- both snippets pass `docker compose config`; `pre-commit run` passes on the changed files

**Relation to #4011:** that PR adds a CONTRIBUTING pointer to the existing build-from-source flow; this PR is complementary and addresses the issue's core ask (a minimal, no-clone try-out). Happy to rebase either around the other.

## Acceptance criteria (from #4005)
- [x] Doc section exists and is linked (from README)
- [x] Example is copy-pasteable (single file, no clone/build)
- [x] No unrelated refactors

## Type of Change
- [x] Other: documentation update

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Closes #4005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
