### PR TITLE
COG-5961 style: fix ruff-format violation breaking basic checks on dev

### DIFF
--- a/examples/tutorials/migrate_from_mem0_tutorial.py
+++ b/examples/tutorials/migrate_from_mem0_tutorial.py
@@ -172,9 +172,7 @@ async def main():
     source = Mem0Source(SAMPLE_EXPORT, mode="preserve")
     record_count = 0
     async for record in source.records():
-        assert isinstance(record, COGXMemory), (
-            f"Expected COGXMemory, got {type(record).__name__}"
-        )
+        assert isinstance(record, COGXMemory), f"Expected COGXMemory, got {type(record).__name__}"
         record_count += 1
         print(
             f"  [{record.external_id}] {record.content[:80]}..."


### PR DESCRIPTION
## Description
Commit 863eccb57 ("Add mem0 migration tutorial using Mem0Source") landed on `dev` with `examples/tutorials/migrate_from_mem0_tutorial.py` failing the pinned ruff-format hook (v0.15.11).

Since "basic checks / Lockfile and Pre-commit Hooks" runs `pre-commit run --all-files`, **dev itself is red and every PR that merges current dev inherits the failure** (first hit on #2876).

One-file, format-only change: collapses a 3-line assert to one line, exactly what `ruff format` produces. `pre-commit run --all-files` passes locally after this.

## Type of Change
- [x] Other: style/CI fix

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)