### PR TITLE
COG-5975 fix(cache): unique constraint + upsert for cache_session_context so retried writes can't poison a session

### DIFF
--- a/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
@@ -9,7 +9,18 @@ from hashlib import sha256
 from typing import List, Optional
 
 from pydantic import ValidationError
-from sqlalchemy import create_engine, delete, event, func, insert, or_, select, text, update
+from sqlalchemy import (
+    create_engine,
+    delete,
+    event,
+    func,
+    insert,
+    inspect,
+    or_,
+    select,
+    text,
+    update,
+)
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -26,6 +37,7 @@ from cognee.modules.storage.utils import JSONEncoder
 from cognee.shared.logging_utils import get_logger
 
 from .tables import (
+    UQ_CACHE_SESSION_CONTEXT_ENTRY,
     cache_kv,
     cache_metadata,
     cache_qa_entries,
@@ -161,6 +173,11 @@ class SqlCacheAdapter(CacheDBInterface):
         self._initialized = False
         self._init_lock = asyncio.Lock()
         self._last_purge = 0.0
+        # Whether the unique index backing session-context upserts is in place;
+        # when the in-place upgrade of a legacy table fails, writes fall back to
+        # plain inserts (the pre-index behavior) instead of erroring on
+        # ON CONFLICT with no matching index.
+        self._session_context_unique = False
 
     # --------------------------------------------------------------------- #
     # Initialization / shared helpers
@@ -180,7 +197,55 @@ class SqlCacheAdapter(CacheDBInterface):
                 error_msg = f"Failed to connect to SQL cache database: {error}"
                 logger.error(error_msg)
                 raise CacheConnectionError(error_msg) from error
+            self._session_context_unique = await self._migrate_session_context_uniqueness()
             self._initialized = True
+
+    async def _migrate_session_context_uniqueness(self) -> bool:
+        """Upgrade pre-existing ``cache_session_context`` tables to the unique index.
+
+        ``create_all(checkfirst=True)`` never alters an existing table, so
+        databases created before ``uq_cache_session_context_entry`` existed have
+        no uniqueness guarantee on (user_id, session_id, entry_id) and a retried
+        write could stack duplicate rows. Collapse each duplicate group to its
+        newest row, then add the index. Returns True when the index is in place.
+        Failure is non-fatal: writes fall back to plain inserts and
+        update_session_context_entry self-heals duplicates, so the next
+        initialization can retry.
+        """
+        try:
+            async with self.engine.begin() as connection:
+                index_names = await connection.run_sync(
+                    lambda sync_connection: [
+                        index.get("name")
+                        for index in inspect(sync_connection).get_indexes("cache_session_context")
+                    ]
+                )
+                if UQ_CACHE_SESSION_CONTEXT_ENTRY in index_names:
+                    return True
+                newest_per_entry = select(func.max(cache_session_context.c.seq)).group_by(
+                    cache_session_context.c.user_id,
+                    cache_session_context.c.session_id,
+                    cache_session_context.c.entry_id,
+                )
+                await connection.execute(
+                    delete(cache_session_context).where(
+                        cache_session_context.c.seq.not_in(newest_per_entry)
+                    )
+                )
+                await connection.execute(
+                    text(
+                        f"CREATE UNIQUE INDEX IF NOT EXISTS {UQ_CACHE_SESSION_CONTEXT_ENTRY} "
+                        "ON cache_session_context (user_id, session_id, entry_id)"
+                    )
+                )
+            return True
+        except Exception as error:
+            logger.warning(
+                "Could not enforce session-context uniqueness "
+                "(falling back to non-upsert writes until next initialization): %s",
+                error,
+            )
+            return False
 
     @staticmethod
     def _now() -> datetime:
@@ -839,6 +904,10 @@ class SqlCacheAdapter(CacheDBInterface):
 
         The caller validates the payload; we only promote its ``id`` to the
         ``entry_id`` column so updates can target a single row directly.
+
+        Idempotent under client retries: re-sending the same (user, session,
+        entry id) replaces the stored payload in place instead of stacking a
+        duplicate row.
         """
         await self._ensure_initialized()
         # Redis/FS append regardless of "id" (an id-less entry is simply never
@@ -846,20 +915,39 @@ class SqlCacheAdapter(CacheDBInterface):
         # only to satisfy the NOT NULL column; the stored payload is untouched.
         entry_id = entry_dump.get("id") or str(uuid.uuid4())
         try:
+            row_values = dict(
+                user_id=user_id,
+                session_id=session_id,
+                entry_id=entry_id,
+                payload=entry_dump,
+                expires_at=self._session_expiry(),
+            )
+            if self._session_context_unique:
+                if self._is_postgres:
+                    from sqlalchemy.dialects.postgresql import insert as upsert_insert
+                else:
+                    from sqlalchemy.dialects.sqlite import insert as upsert_insert
+
+                statement = upsert_insert(cache_session_context).values(**row_values)
+                statement = statement.on_conflict_do_update(
+                    index_elements=[
+                        cache_session_context.c.user_id,
+                        cache_session_context.c.session_id,
+                        cache_session_context.c.entry_id,
+                    ],
+                    set_={
+                        "payload": statement.excluded.payload,
+                        "expires_at": statement.excluded.expires_at,
+                    },
+                )
+            else:
+                statement = insert(cache_session_context).values(**row_values)
             async with self.sessionmaker() as session, session.begin():
                 await self._lock_session_writes(session, cache_session_context, user_id, session_id)
                 await self._purge_session_expired(
                     session, cache_session_context, user_id, session_id
                 )
-                await session.execute(
-                    insert(cache_session_context).values(
-                        user_id=user_id,
-                        session_id=session_id,
-                        entry_id=entry_id,
-                        payload=entry_dump,
-                        expires_at=self._session_expiry(),
-                    )
-                )
+                await session.execute(statement)
                 await self._refresh_session_ttl(session, cache_session_context, user_id, session_id)
         except Exception as error:
             error_msg = f"Unexpected error while adding session context to SQL cache: {error}"
@@ -892,6 +980,10 @@ class SqlCacheAdapter(CacheDBInterface):
         """Shallow-merge ``merge`` into the entry whose id is ``entry_id``.
 
         Returns True if a matching entry was updated, False otherwise.
+
+        Duplicate rows for the key (possible in databases predating the unique
+        index) are self-healed: the newest row is kept and updated, the rest
+        are pruned, instead of erroring on every write until manual cleanup.
         """
         await self._ensure_initialized()
         attempt = 0
@@ -902,24 +994,31 @@ class SqlCacheAdapter(CacheDBInterface):
                         session, cache_session_context, user_id, session_id
                     )
                     result = await session.execute(
-                        select(cache_session_context.c.payload)
+                        select(cache_session_context.c.seq, cache_session_context.c.payload)
                         .where(
                             self._session_filter(cache_session_context, user_id, session_id),
                             cache_session_context.c.entry_id == entry_id,
                             self._not_expired(cache_session_context),
                         )
+                        .order_by(cache_session_context.c.seq.desc())
                         .with_for_update()
                     )
-                    payload = result.scalar_one_or_none()
-                    if payload is None:
+                    rows = result.all()
+                    if not rows:
                         return False
+                    newest_seq, payload = rows[0]
+                    if len(rows) > 1:
+                        await session.execute(
+                            delete(cache_session_context).where(
+                                cache_session_context.c.seq.in_(
+                                    [duplicate_seq for duplicate_seq, _ in rows[1:]]
+                                )
+                            )
+                        )
                     merged = {**dict(payload), **merge}
                     await session.execute(
                         update(cache_session_context)
-                        .where(
-                            self._session_filter(cache_session_context, user_id, session_id),
-                            cache_session_context.c.entry_id == entry_id,
-                        )
+                        .where(cache_session_context.c.seq == newest_seq)
                         .values(payload=merged)
                     )
                     await self._refresh_session_ttl(

--- a/cognee/infrastructure/databases/cache/sql/tables.py
+++ b/cognee/infrastructure/databases/cache/sql/tables.py
@@ -114,7 +114,7 @@ Index(
     sqlite_where=cache_trace_entries.c.expires_at.isnot(None),
 )
 
-# Session-context entries: append-only, kind-discriminated ("context"/"feedback").
+# Session-context entries: kind-discriminated ("context"/"feedback").
 # entry_id is promoted from the payload's "id" to a column for direct UPDATE,
 # mirroring how cache_qa_entries promotes qa_id.
 cache_session_context = Table(
@@ -127,6 +127,20 @@ cache_session_context = Table(
     Column("payload", _payload_type(), nullable=False),
     Column("created_at", DateTime(timezone=True), server_default=func.now(), nullable=False),
     Column("expires_at", DateTime(timezone=True), nullable=True),
+)
+
+# One row per (user, session, entry) so a retried write updates in place instead
+# of stacking duplicates. Declared as a unique Index rather than a UniqueConstraint
+# so tables created before it existed can be upgraded in place with
+# CREATE UNIQUE INDEX IF NOT EXISTS — see SqlCacheAdapter._ensure_initialized.
+UQ_CACHE_SESSION_CONTEXT_ENTRY = "uq_cache_session_context_entry"
+
+Index(
+    UQ_CACHE_SESSION_CONTEXT_ENTRY,
+    cache_session_context.c.user_id,
+    cache_session_context.c.session_id,
+    cache_session_context.c.entry_id,
+    unique=True,
 )
 
 Index(

--- a/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import select, text, update
+from sqlalchemy import insert, select, text, update
 
 from cognee.infrastructure.databases.cache.sql.SqlCacheAdapter import SqlCacheAdapter
 from cognee.infrastructure.databases.cache.sql.tables import (
@@ -815,6 +815,66 @@ async def test_session_context_isolated_per_session(adapter):
     assert await adapter.get_session_context_entries("u1", "s1") == []
     assert len(await adapter.get_session_context_entries("u1", "s2")) == 1
     assert len(await adapter.get_session_context_entries("u2", "s1")) == 1
+
+
+async def _stack_legacy_duplicates(inst, entry_id, payloads):
+    """Recreate the pre-#4226 state: no unique index, duplicate rows for one key."""
+    async with inst.engine.begin() as connection:
+        await connection.execute(text("DROP INDEX uq_cache_session_context_entry"))
+        for payload in payloads:
+            await connection.execute(
+                insert(cache_session_context).values(
+                    user_id="u1", session_id="s1", entry_id=entry_id, payload=payload
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_session_context_entry_retried_write_is_idempotent(adapter):
+    """Re-creating the same entry id upserts in place instead of stacking a duplicate (#4226)."""
+    await adapter.create_session_context_entry("u1", "s1", _ctx("c1", content="first"))
+    await adapter.create_session_context_entry("u1", "s1", _ctx("c1", content="retried"))
+    entries = await adapter.get_session_context_entries("u1", "s1")
+    assert len(entries) == 1
+    assert entries[0]["content"] == "retried"
+
+
+@pytest.mark.asyncio
+async def test_update_session_context_entry_heals_duplicate_rows(adapter):
+    """Duplicates from a pre-index database update the newest row and prune the rest,
+    instead of failing every write until manual cleanup (#4226)."""
+    await adapter.create_session_context_entry("u1", "s1", _ctx("c1", content="v1"))
+    await _stack_legacy_duplicates(
+        adapter, "c1", [_ctx("c1", content="v2"), _ctx("c1", content="v3")]
+    )
+
+    updated = await adapter.update_session_context_entry("u1", "s1", "c1", {"rating": "helpful"})
+
+    assert updated is True
+    (entry,) = await adapter.get_session_context_entries("u1", "s1")
+    assert entry["content"] == "v3"  # merged into the newest duplicate
+    assert entry["rating"] == "helpful"
+
+
+@pytest.mark.asyncio
+async def test_initialization_dedupes_legacy_table_and_restores_unique_index(tmp_path):
+    """A database predating the unique index is collapsed to newest-per-key on next
+    startup and upserts work again (#4226)."""
+    legacy = _make_adapter(tmp_path)
+    await legacy.create_session_context_entry("u1", "s1", _ctx("c1", content="old"))
+    await legacy.create_session_context_entry("u1", "s1", _ctx("other"))
+    await _stack_legacy_duplicates(legacy, "c1", [_ctx("c1", content="newest")])
+    await legacy.close()
+
+    inst = _make_adapter(tmp_path)
+    entries = await inst.get_session_context_entries("u1", "s1")
+    assert [(e["id"], e.get("content")) for e in entries] == [("other", "x"), ("c1", "newest")]
+
+    await inst.create_session_context_entry("u1", "s1", _ctx("c1", content="upserted"))
+    entries = await inst.get_session_context_entries("u1", "s1")
+    assert len(entries) == 2
+    assert {e["content"] for e in entries} == {"x", "upserted"}
+    await inst.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fixes #4226 — `cache_session_context` had no uniqueness on `(user_id, session_id, entry_id)` (unlike `cache_qa_entries`, which has `uq_cache_qa_entry`). The session-context write path is update-then-create across two transactions, so an ordinary client retry after a timeout — or two concurrent writers — inserted a duplicate row. Once duplicates existed, `scalar_one_or_none()` in `SqlCacheAdapter.update_session_context_entry` raised on **every** subsequent write for that session: a permanent 503 recoverable only by manual row deletion (the reporter hit 77 copies of one bookkeeping entry and ~36 failed writes/hour for 6.5 hours).

All four parts of the fix suggested in the issue:

- **Unique index** `uq_cache_session_context_entry` on `(user_id, session_id, entry_id)` — declared as a unique `Index` rather than a `UniqueConstraint` so tables created before it existed can be upgraded in place.
- **Upsert on create** — `create_session_context_entry` now uses `ON CONFLICT DO UPDATE` (Postgres + SQLite dialects, same pattern as `set_value`), so a retried write replaces the payload in place. Id-less entries keep their synthetic UUID and are unaffected.
- **In-place migration** — `_ensure_initialized` collapses each duplicate group to its newest row, then runs `CREATE UNIQUE INDEX IF NOT EXISTS`. Migration failure is non-fatal: the adapter logs a warning and falls back to plain inserts so `ON CONFLICT` can never error against a missing index.
- **Self-healing update** — `update_session_context_entry` fetches all rows for the key ordered by `seq`, merges into the newest, and prunes older duplicates in the same transaction, so even an un-migrated database recovers on the next write instead of 503ing forever.

The Redis and FS adapters don't share the crash (they update the first list match), so this fix is scoped to the SQL adapter. Follow-up noted in COG-5975: their `create_session_context_entry` still appends duplicates on retried creates (no crash, but duplicated context) — the adapter-parametrized contract tests from #4129 would be the natural home for cross-adapter idempotency coverage.

## Testing

New regression tests in `test_sql_adapter_crud.py` (sqlite+aiosqlite):

- retried create with the same entry id yields exactly one row with the retried payload
- with legacy duplicates simulated (index dropped, rows stacked), update succeeds, merges into the newest row, and exactly one row remains
- a legacy database is deduped (newest kept per key) and re-indexed on next adapter startup, after which upserts work

`pytest cognee/tests/unit/infrastructure/databases/cache/` — 139 passed; `cognee/tests/unit/infrastructure/session/` — 181 passed. Ruff lint + format clean.

## Related

- Linear: COG-5975
- Introduced in #3072 (table added without a uniqueness guarantee on the update key)
- Same defect class as #4029 / #4034; contract-test home #4129

🤖 Generated with [Claude Code](https://claude.com/claude-code)