### PR TITLE
fix(mcp): preserve original filename for API-mode file uploads

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -6,15 +6,19 @@ This module provides a unified interface for interacting with Cognee, supporting
 - API mode: Makes HTTP requests to a running Cognee FastAPI server
 """
 
+import hashlib
+import json
+import mimetypes
 import os
 import sys
-import hashlib
-from typing import Optional, Any, List, Dict
-from uuid import UUID
 from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
 import httpx
+
 from cognee.shared.logging_utils import get_logger
-import json
 
 try:
     from .server_utils import normalize_delete_mode
@@ -144,6 +148,29 @@ class CogneeClient:
         digest = hashlib.md5(content.encode("utf-8")).hexdigest()
         return {"data": (f"text_{digest}.txt", content, "text/plain")}
 
+    @staticmethod
+    def _file_upload(file_path: Path) -> Dict[str, tuple[str, bytes, str]]:
+        """Upload real file bytes using the original basename.
+
+        Used by cognify_file, which writes a tempfile named after the source
+        file so Data.name stays readable instead of text_<md5>.txt.
+        """
+        mime = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
+        return {"data": (file_path.name, file_path.read_bytes(), mime)}
+
+    @staticmethod
+    def _resolve_existing_file(data: Any) -> Optional[Path]:
+        """Return a Path when data points at an existing filesystem file."""
+        if isinstance(data, Path):
+            return data if data.is_file() else None
+        if isinstance(data, str):
+            candidate = Path(data)
+            # Avoid treating arbitrary short text / multiline notes as paths.
+            if "\n" in data or len(data) > 4096:
+                return None
+            return candidate if candidate.is_file() else None
+        return None
+
     async def add(
         self, data: Any, dataset_name: str = "main_dataset", node_set: Optional[List[str]] = None
     ) -> Dict[str, Any]:
@@ -167,7 +194,11 @@ class CogneeClient:
         if self.use_api:
             endpoint = f"{self.api_url}/api/v1/add"
 
-            files = self._text_upload(data)
+            file_path = self._resolve_existing_file(data)
+            if file_path is not None:
+                files = self._file_upload(file_path)
+            else:
+                files = self._text_upload(data)
             form_data = {
                 "datasetName": dataset_name,
             }

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -170,6 +170,37 @@ async def test_cognee_client_api_add_uses_content_addressed_filename():
 
 
 @pytest.mark.asyncio
+async def test_cognee_client_api_add_uploads_existing_file_with_basename(tmp_path):
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = CogneeClient(api_url="http://cognee.local")
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    # Mimic cognify_file: tempfile dir + original basename.
+    upload_dir = tmp_path / "cognee_upload_abc"
+    upload_dir.mkdir()
+    file_path = upload_dir / "meeting-notes.md"
+    payload = b"# Meeting notes\nAction items for Alice.\n"
+    file_path.write_bytes(payload)
+
+    try:
+        await client.add(str(file_path), dataset_name="ds")
+    finally:
+        await client.close()
+
+    assert requests[0].url.path == "/api/v1/add"
+    body = requests[0].content
+    assert b'filename="meeting-notes.md"' in body
+    assert payload in body
+    assert b"text_" not in body
+
+
+@pytest.mark.asyncio
 async def test_cognee_client_api_remember_sends_session_id():
     requests: list[httpx.Request] = []
 


### PR DESCRIPTION
### Description

- Fixes #4230.
- `cognify_file` intentionally writes a tempfile whose basename is the sanitized original filename so `Data.name` stays readable.
- In API mode, `CogneeClient.add()` always called `_text_upload(data)`, which:
  1. stringified the path and uploaded it as text content, and
  2. forced a content-addressed `text_<md5>.txt` name.
- That content-addressed behavior is still correct for raw text (keeps #2747 fixed).
- When `data` is an existing filesystem path, `add()` now multipart-uploads the real file bytes with the original basename.

### Acceptance Criteria

- [x] `add("plain text")` in API mode still uploads as `text_<md5>.txt` (no `data.txt` regression).
- [x] `add("/tmp/.../meeting-notes.md")` for an existing file uploads bytes with `filename="meeting-notes.md"`.
- [x] Unit coverage for both paths.
- [x] No change to auth / Bearer vs X-Api-Key behavior.

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

### Screenshots

```text
$ uv run --python 3.12 --project cognee-mcp pytest \
    cognee-mcp/tests/test_mcp_server_hardening.py::test_cognee_client_api_add_uses_content_addressed_filename \
    cognee-mcp/tests/test_mcp_server_hardening.py::test_cognee_client_api_add_uploads_existing_file_with_basename -q

2 passed, 10 warnings in 16.23s
```

(Existing Pydantic deprecation warnings from dependencies.)

### Testing

Commands run:

```bash
uv run --python 3.12 --project cognee-mcp pytest \
  cognee-mcp/tests/test_mcp_server_hardening.py::test_cognee_client_api_add_uses_content_addressed_filename \
  cognee-mcp/tests/test_mcp_server_hardening.py::test_cognee_client_api_add_uploads_existing_file_with_basename -q
```

Results: **2 passed**.

### Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove the fix is effective
- [x] I have added necessary documentation (not applicable)
- [x] All new and existing MCP tests relevant to this change pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked the relevant issue in the description
- [x] My commit has a clear and descriptive message

### DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Changed files:

- `cognee-mcp/src/cognee_client.py`
- `cognee-mcp/tests/test_mcp_server_hardening.py`

Made with [Cursor](https://cursor.com)