### PR TITLE
fix(memify): skip the memory-fragment projection when nothing consumes it

### DIFF
--- a/cognee/modules/memify/memify.py
+++ b/cognee/modules/memify/memify.py
@@ -49,7 +49,10 @@ async def memify(
         enrichment_tasks: List of Cognee Tasks to handle enrichment of provided graph/data from extraction tasks.
         data: The data to ingest. Can be anything when custom extraction and enrichment tasks are used.
               Data provided here will be forwarded to the first extraction task in the pipeline as input.
-              If no data is provided the whole graph (or subgraph if node_name/node_type is specified) will be forwarded
+              If no data is provided the whole graph (or subgraph if node_name/node_type is specified) will be forwarded.
+              The graph projection is skipped entirely when there are no extraction tasks to consume it
+              and the caller did not supply its own enrichment tasks, since the default enrichment task
+              discards non-DataPoint input. Pass data explicitly to run an enrichment-only pipeline.
         dataset: Dataset name or dataset uuid to process.
         user: User context for authentication and data access. Uses default if None.
         node_type: Filter graph to specific entity types (for advanced filtering). Used when no data is provided.
@@ -86,6 +89,11 @@ async def memify(
         ```
     """
 
+    # Track whether the caller supplied enrichment tasks before defaults are
+    # filled in: a caller-provided enrichment-only pipeline may legitimately
+    # consume the memory fragment itself, so it must keep receiving one.
+    caller_supplied_enrichment_tasks = bool(enrichment_tasks)
+
     # Use default triplet embedding tasks if no tasks were provided
     if not extraction_tasks:
         extraction_tasks = get_default_memify_extraction_tasks()
@@ -97,13 +105,32 @@ async def memify(
     user, authorized_dataset_list = await resolve_authorized_user_datasets(dataset, user)
     authorized_dataset = authorized_dataset_list[0]
 
-    if not data:
+    # The memory fragment exists to feed the first extraction task. Projecting it
+    # reads the entire graph into memory, so skip it when nothing can consume it:
+    # with no extraction tasks the fragment goes straight to the default
+    # enrichment task (index_data_points), which explicitly skips non-DataPoint
+    # objects like CogneeGraph and therefore discards it.
+    #
+    # This is the common case, not an edge case: get_default_memify_extraction_tasks()
+    # returns [] unless the triplet_embedding config flag is set, and that flag is
+    # off by default. Every default-configuration memify call was paying a
+    # full-graph read to build an object that was then thrown away -- which also
+    # taxes every remember(), since remember() runs improve() -> memify() by
+    # default (self_improvement=True).
+    should_build_memory_fragment = bool(extraction_tasks) or caller_supplied_enrichment_tasks
+
+    if not data and should_build_memory_fragment:
         async with set_database_global_context_variables(
             authorized_dataset.id, authorized_dataset.owner_id
         ):
             memory_fragment = await get_memory_fragment(node_type=node_type, node_name=node_name)
             # Subgraphs should be a single element in the list to represent one data item
             data = [memory_fragment]
+    elif not data:
+        logger.debug(
+            "memify: no extraction tasks resolved, skipping the memory-fragment "
+            "projection because the default enrichment task cannot consume it"
+        )
 
     memify_tasks = [
         *extraction_tasks,  # Unpack tasks provided to memify pipeline

--- a/cognee/tests/unit/modules/memify/test_memify_fragment_projection.py
+++ b/cognee/tests/unit/modules/memify/test_memify_fragment_projection.py
@@ -1,0 +1,125 @@
+"""Unit tests for when ``memify`` projects the memory fragment.
+
+Everything is mocked: no graph backend, no vector backend, no network. These
+tests pin *whether* ``get_memory_fragment`` is called, because projecting it
+reads the entire graph into memory and the default configuration had no
+consumer for the result.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognee.modules.memify.memify import memify
+
+
+def _make_async_ctx_mock():
+    """Build a ``MagicMock`` that behaves as an async-context-manager factory."""
+    inner = MagicMock()
+    inner.__aenter__ = AsyncMock(return_value=inner)
+    inner.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=inner)
+
+
+def _patches(*, extraction_tasks, fragment=None):
+    """Patch every backend boundary ``memify`` touches.
+
+    Returns (context_managers, handles) so each test can assert on the mocks it
+    cares about.
+    """
+    authorized_dataset = SimpleNamespace(id="dataset-1", owner_id="owner-1")
+
+    get_fragment = AsyncMock(return_value=fragment or MagicMock(name="CogneeGraph"))
+    executor = AsyncMock(return_value={"status": "ok"})
+
+    handles = {"get_fragment": get_fragment, "executor": executor}
+
+    ctxs = [
+        patch("cognee.modules.memify.memify.setup", new=AsyncMock()),
+        patch(
+            "cognee.modules.memify.memify.resolve_authorized_user_datasets",
+            new=AsyncMock(return_value=(MagicMock(), [authorized_dataset])),
+        ),
+        patch(
+            "cognee.modules.memify.memify.set_database_global_context_variables",
+            new=_make_async_ctx_mock(),
+        ),
+        patch("cognee.modules.memify.memify.get_memory_fragment", new=get_fragment),
+        patch(
+            "cognee.modules.memify.memify.get_default_memify_extraction_tasks",
+            return_value=extraction_tasks,
+        ),
+        patch(
+            "cognee.modules.memify.memify.get_default_memify_enrichment_tasks",
+            return_value=[MagicMock(name="index_data_points_task")],
+        ),
+        patch(
+            "cognee.modules.memify.memify.get_pipeline_executor",
+            return_value=executor,
+        ),
+    ]
+    return ctxs, handles
+
+
+@pytest.mark.asyncio
+async def test_skips_fragment_projection_when_no_extraction_tasks():
+    """The default config (triplet_embedding off) resolves to no extraction tasks.
+
+    The fragment would go straight to the default enrichment task, which skips
+    non-DataPoint objects -- so building it is a wasted full-graph read.
+    """
+    ctxs, handles = _patches(extraction_tasks=[])
+
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4], ctxs[5], ctxs[6]:
+        result = await memify()
+
+    assert result == {"status": "ok"}
+    handles["get_fragment"].assert_not_awaited()
+    # The pipeline still runs; it simply receives no fragment.
+    assert handles["executor"].await_args.kwargs["data"] is None
+
+
+@pytest.mark.asyncio
+async def test_projects_fragment_when_extraction_tasks_exist():
+    """With triplet_embedding on there is a real consumer, so keep projecting."""
+    fragment = MagicMock(name="CogneeGraph")
+    ctxs, handles = _patches(
+        extraction_tasks=[MagicMock(name="get_triplet_datapoints_task")],
+        fragment=fragment,
+    )
+
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4], ctxs[5], ctxs[6]:
+        await memify()
+
+    handles["get_fragment"].assert_awaited_once()
+    assert handles["executor"].await_args.kwargs["data"] == [fragment]
+
+
+@pytest.mark.asyncio
+async def test_projects_fragment_for_caller_supplied_enrichment_only_pipeline():
+    """No regression for an enrichment-only pipeline the caller built itself.
+
+    Such a pipeline may consume the fragment directly, so it must still get one
+    even though no extraction tasks resolve.
+    """
+    fragment = MagicMock(name="CogneeGraph")
+    ctxs, handles = _patches(extraction_tasks=[], fragment=fragment)
+
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4], ctxs[5], ctxs[6]:
+        await memify(enrichment_tasks=[MagicMock(name="custom_enrichment_task")])
+
+    handles["get_fragment"].assert_awaited_once()
+    assert handles["executor"].await_args.kwargs["data"] == [fragment]
+
+
+@pytest.mark.asyncio
+async def test_explicit_data_is_never_overwritten_by_a_projection():
+    """Caller-supplied data short-circuits the projection, as before."""
+    ctxs, handles = _patches(extraction_tasks=[MagicMock(name="task")])
+
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4], ctxs[5], ctxs[6]:
+        await memify(data=["explicit"])
+
+    handles["get_fragment"].assert_not_awaited()
+    assert handles["executor"].await_args.kwargs["data"] == ["explicit"]


### PR DESCRIPTION
Fixes item (2) of #4233.

## Problem

`memify()` builds its memory fragment whenever `data is None`, before anything considers whether the resolved task list can use it:

```python
if not data:
    async with set_database_global_context_variables(...):
        memory_fragment = await get_memory_fragment(node_type=node_type, node_name=node_name)
        data = [memory_fragment]
```

`get_memory_fragment()` reads the **entire graph** into memory. In the default configuration nothing consumes the result:

- `get_default_memify_extraction_tasks()` returns `[]` unless the `triplet_embedding` config flag is set, and it is `False` by default.
- With no extraction tasks the fragment goes straight to the default enrichment task, `index_data_points`, which already documents that it discards such objects:

```python
# Skip non-DataPoint objects (e.g. CogneeGraph) that may be
# passed through the memify pipeline without metadata.
if not hasattr(data_point, "metadata") or not data_point.metadata:
    continue
```

So every default-configuration `memify()` call paid a full-graph read to build an object that was immediately thrown away.

This is not a rare path: **`remember()` runs `improve()` → `memify()` by default** (`self_improvement=True`), so ordinary `remember()` calls inherit the cost. On our graph (~27k nodes / ~86k edges) that was several seconds and ~1 GB resident per call, and it scales with total graph size rather than with what was just remembered.

## Change

Build the fragment only when something can consume it:

```python
should_build_memory_fragment = bool(extraction_tasks) or caller_supplied_enrichment_tasks
```

`caller_supplied_enrichment_tasks` is captured **before** defaults are filled in. This deliberately preserves the one case that could otherwise regress: a caller who passes their own enrichment tasks and no extraction tasks may be consuming the fragment directly, so they keep receiving one. Passing `data` explicitly is unaffected.

Also documents the behaviour in the `data:` docstring entry, and logs at debug level when the projection is skipped.

If you'd rather narrow or widen the condition — e.g. skip whenever `extraction_tasks` is empty regardless of caller-supplied enrichment tasks — I'm happy to adjust; I chose the conservative version to guarantee no behaviour change for existing callers.

## Tests

New file: `cognee/tests/unit/modules/memify/test_memify_fragment_projection.py`. Fully mocked — no graph backend, no vector backend, no network. Four cases: the fix itself, plus three guards that pin the behaviour which must *not* change.

```
$ uv run pytest cognee/tests/unit/modules/memify/test_memify_fragment_projection.py -v
cognee/tests/unit/modules/memify/test_memify_fragment_projection.py::test_skips_fragment_projection_when_no_extraction_tasks PASSED
cognee/tests/unit/modules/memify/test_memify_fragment_projection.py::test_projects_fragment_when_extraction_tasks_exist PASSED
cognee/tests/unit/modules/memify/test_memify_fragment_projection.py::test_projects_fragment_for_caller_supplied_enrichment_only_pipeline PASSED
cognee/tests/unit/modules/memify/test_memify_fragment_projection.py::test_explicit_data_is_never_overwritten_by_a_projection PASSED
============================== 4 passed in 0.02s ===============================
```

**The new test fails without the fix** (verified by reverting `memify.py` and re-running), so it genuinely pins the behaviour rather than passing vacuously:

```
$ git stash push cognee/modules/memify/memify.py && uv run pytest <new test file> -q
E  AssertionError: Expected mock to not have been awaited. Awaited 1 times.
1 failed, 3 passed
```

The three guards pass either way, which is what you want from a no-regression test.

### Surrounding suites

```
$ uv run pytest cognee/tests/unit/memify_pipelines/ cognee/tests/unit/modules/memify_tasks/ \
    cognee/tests/unit/tasks/memify/ cognee/tests/unit/api/v1/improve/ \
    cognee/tests/unit/api/test_improve_global_context_index.py cognee/tests/unit/modules/memify/ -q
180 passed in 0.40s
```

### Full unit suite

```
$ uv run pytest cognee/tests/unit/ -q \
    --ignore=cognee/tests/unit/eval_framework/dashboard_test.py \
    --ignore=cognee/tests/unit/infrastructure/databases/graph/neo4j_deadlock_test.py
13 failed, 3369 passed, 51 skipped in 455.21s
```

**All 13 failures are pre-existing on `dev` and unrelated to this change.** I verified rather than assumed:

- Running those same 13 in isolation gives an identical result **with and without** this patch: `11 failed, 2 passed`, same test names both times.
- The two that pass in isolation but fail in the full suite (`test_contradiction_detection_wiring.py::TestRememberInheritsTheFlag`) are order-dependent, and cannot be affected by this change — that file contains no reference to `memify` or `get_memory_fragment` and calls `remember(self_improvement=False)`, so it never reaches the modified path.
- The remaining 11 are in `graph_completion_retriever_cot_test.py`, `temporal_retriever_test.py`, `triplet_retriever_test.py` and `test_cognee_error_contract.py`.

The two `--ignore`d files fail at collection with `ModuleNotFoundError: No module named 'neo4j'` (optional dependency not installed locally), also independent of this change.

### Checks

```
$ uvx ruff@0.15.11 check <changed files>          # All checks passed!
$ uvx ruff@0.15.11 format --check <changed files> # 2 files already formatted
```
Trailing-whitespace and end-of-file hooks verified clean on both files.

A note on your PR checklist: it asks for screenshots of tests passing. I've pasted the terminal output verbatim above instead, since it's copy-pasteable and greppable — happy to attach images too if that's a hard requirement.

## Notes

- Branched from `dev` per CONTRIBUTING; commit is DCO signed-off.
- No changelog entry added — happy to add one under `Unreleased` → `Fixed` if you'd like.
- Items (1) and (3) of #4233 (exposing `self_improvement` through `cognee-mcp`, and the `triplet_embedding` blast radius) are untouched here and want separate decisions.
