### PR TITLE
fix(vector): batch LanceDB delete_data_points predicates

### DIFF
--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBAdapter.py
@@ -1115,6 +1115,14 @@ class LanceDBAdapter(VectorDBInterface):
             ]
         )
 
+    # Ids per `IN (...)` delete predicate. Each `collection.delete` is a
+    # LanceDB commit that appends a table version, and manifest listing slows
+    # down as versions accumulate — a delete per id turns a 13k-id wipe into
+    # 13k increasingly slow commits (observed as a multi-hour "hang" during
+    # `forget(everything=True)`). Batching bounds both the commit count and
+    # the predicate size.
+    DELETE_PREDICATE_BATCH_SIZE = 1000
+
     async def delete_data_points(self, collection_name: str, data_point_ids: list[UUID]):
         # Idempotent: a missing collection (or empty id list) is a no-op.
         if not await self.has_collection(collection_name):
@@ -1126,11 +1134,14 @@ class LanceDBAdapter(VectorDBInterface):
 
         # ids may be UUIDs or graph-computed deterministic strings; the stored
         # `id` column is a str, so match by string and escape single quotes to
-        # keep the predicate injection-safe (mirrors create_data_points). One
-        # delete per id to avoid commit conflicts; a non-existent id no-ops.
-        for data_point_id in data_point_ids:
-            escaped_id = str(data_point_id).replace("'", "''")
-            await collection.delete(f"id = '{escaped_id}'")
+        # keep the predicate injection-safe (mirrors create_data_points). The
+        # sequential batches cannot commit-conflict with each other, and a
+        # non-existent id no-ops.
+        for start in range(0, len(data_point_ids), self.DELETE_PREDICATE_BATCH_SIZE):
+            batch = data_point_ids[start : start + self.DELETE_PREDICATE_BATCH_SIZE]
+            escaped_ids = [str(data_point_id).replace("'", "''") for data_point_id in batch]
+            id_list = ", ".join(f"'{escaped_id}'" for escaped_id in escaped_ids)
+            await collection.delete(f"id IN ({id_list})")
 
     async def remove_belongs_to_set_tags(
         self,

--- a/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_delete_data_points.py
+++ b/cognee/tests/unit/infrastructure/databases/vector/test_lancedb_delete_data_points.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel
+
+try:
+    from cognee.infrastructure.databases.vector.lancedb.LanceDBAdapter import LanceDBAdapter
+
+    HAS_LANCEDB = True
+except ModuleNotFoundError:
+    HAS_LANCEDB = False
+
+
+class _FakeEmbeddingEngine:
+    def get_vector_size(self):
+        return 3
+
+    def get_batch_size(self):
+        return 100
+
+    async def embed_text(self, _texts):
+        raise AssertionError("delete tests must not call embed_text")
+
+
+class _Payload(BaseModel):
+    label: str
+
+
+def _make_adapter(tmp_path) -> LanceDBAdapter:
+    return LanceDBAdapter(
+        url=str(tmp_path / "db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+
+
+async def _seed(adapter: LanceDBAdapter, collection: str, ids: list) -> None:
+    await adapter.upsert_raw_vectors(
+        collection,
+        [
+            {
+                "id": point_id,
+                "vector": [1.0, 0.0, 0.0],
+                "payload": {"label": f"row_{index}"},
+            }
+            for index, point_id in enumerate(ids)
+        ],
+        payload_schema=_Payload,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_delete_data_points_removes_only_matching_rows(tmp_path):
+    adapter = _make_adapter(tmp_path)
+    collection = "DeleteTarget_vector"
+    ids = [uuid4() for _ in range(6)]
+    await _seed(adapter, collection, ids)
+
+    doomed, survivors = ids[:4], ids[4:]
+    # Non-existent ids (and a quote-bearing id exercising predicate escaping)
+    # must no-op rather than raise or over-delete.
+    await adapter.delete_data_points(collection, [*doomed, uuid4(), "o'brien"])
+
+    remaining = await adapter.retrieve(collection, [str(point_id) for point_id in ids])
+    remaining_ids = {str(row.id) for row in remaining}
+    assert remaining_ids == {str(point_id) for point_id in survivors}
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_delete_data_points_batches_predicates(tmp_path, monkeypatch):
+    """Regression: a large id list must not issue one delete commit per id.
+
+    Every ``collection.delete`` is a LanceDB commit appending a table version;
+    per-id commits made a 13k-id wipe degrade into a multi-hour stall during
+    ``forget(everything=True)``.
+    """
+    adapter = _make_adapter(tmp_path)
+
+    predicates: list[str] = []
+
+    class _SpyCollection:
+        async def delete(self, predicate: str) -> None:
+            predicates.append(predicate)
+
+    async def _has_collection(_name):
+        return True
+
+    async def _get_collection(_name):
+        return _SpyCollection()
+
+    monkeypatch.setattr(adapter, "has_collection", _has_collection)
+    monkeypatch.setattr(adapter, "get_collection", _get_collection)
+
+    batch_size = LanceDBAdapter.DELETE_PREDICATE_BATCH_SIZE
+    ids = [uuid4() for _ in range(2 * batch_size + 500)]
+    await adapter.delete_data_points("AnyCollection", ids)
+
+    assert len(predicates) == 3
+    assert all(predicate.startswith("id IN (") for predicate in predicates)
+    # Every id appears exactly once across the batched predicates.
+    joined = "".join(predicates)
+    assert all(f"'{point_id}'" in joined for point_id in map(str, ids))


### PR DESCRIPTION
## Problem

`forget(everything=True)` appeared to hang indefinitely (observed: 15+ minutes with no log output, no timeout, no error) right after the provenance planner logged `Deleted 13207 orphaned EdgeType node(s)`.

The stall was in the very next await: `vector_engine.delete_data_points("EdgeType_relationship_name", <13,207 ids>)`.

## Root cause

`LanceDBAdapter.delete_data_points` issued **one `collection.delete` per id**. Each delete is a LanceDB commit that appends a table version, and manifest listing degrades as versions accumulate — so a 13k-id wipe became 13k increasingly slow commits (measured: ~7 deletes/sec and falling, 36MB of manifest files). Every safety net misses this shape:

- the subprocess harness's 300s per-call timeout never fires — each individual RPC completes fast; there are just 13,207 of them
- worker-death detection never fires — the worker is healthy at ~100% CPU
- nothing raises, and there is no log line inside the loop

## Fix

Delete in `id IN (...)` batches of 1000 (`DELETE_PREDICATE_BATCH_SIZE`). Sequential batches from one caller cannot commit-conflict (the concern the old per-id comment cited only applies to concurrent writers), and per-id quote escaping is preserved.

Measured: the same 13,207-id delete drops from 30+ minutes (killed, unfinished) to **0.1s**; a 2,500-row real-deletion run completes in 0.04s with 10 total table versions instead of one per id.

## Verification

- New unit tests (`test_lancedb_delete_data_points.py`): real-LanceDB correctness (deletes exactly the requested rows, no-ops on missing ids, escaping) and a batching regression test that fails on per-id implementations
- Hardened manual verification: exact batch boundaries (1000/1001), quote-bearing id deletion, empty/missing-collection no-ops, bounded version growth
- All 43 vector unit tests pass; full forget → remember → recall example runs clean on the branch

Other providers audited and already correct: PGVector and Turso batch with `IN` + `QUERY_BATCH_SIZE`, hybrid Postgres delegates to the batched vector engine, Neptune uses a single `IN $node_ids` query. LanceDB (the default backend) was the only offender.

## Note

Follow-up candidate (not in this PR): occasional `compact_files`/`cleanup_old_versions` after bulk deletes, to recover tables that already accumulated large version histories under the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)