### PR TITLE
docs: fix broken stars-badge link (github removed /stargazers page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 
   [![GitHub forks](https://img.shields.io/github/forks/topoteretes/cognee.svg?style=social&label=Fork&maxAge=2592000)](https://GitHub.com/topoteretes/cognee/network/)
-  [![GitHub stars](https://img.shields.io/github/stars/topoteretes/cognee.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/topoteretes/cognee/stargazers/)
+  [![GitHub stars](https://img.shields.io/github/stars/topoteretes/cognee.svg?style=social&label=Star&maxAge=2592000)](https://github.com/topoteretes/cognee)
   [![GitHub commits](https://badgen.net/github/commits/topoteretes/cognee)](https://GitHub.com/topoteretes/cognee/commit/)
   [![GitHub tag](https://badgen.net/github/tag/topoteretes/cognee)](https://github.com/topoteretes/cognee/tags/)
   [![Downloads](https://static.pepy.tech/badge/cognee)](https://pepy.tech/project/cognee)

--- a/README_ko.md
+++ b/README_ko.md
@@ -23,7 +23,7 @@
 
 
   [![GitHub forks](https://img.shields.io/github/forks/topoteretes/cognee.svg?style=social&label=Fork&maxAge=2592000)](https://GitHub.com/topoteretes/cognee/network/)
-  [![GitHub stars](https://img.shields.io/github/stars/topoteretes/cognee.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/topoteretes/cognee/stargazers/)
+  [![GitHub stars](https://img.shields.io/github/stars/topoteretes/cognee.svg?style=social&label=Star&maxAge=2592000)](https://github.com/topoteretes/cognee)
   [![GitHub commits](https://badgen.net/github/commits/topoteretes/cognee)](https://GitHub.com/topoteretes/cognee/commit/)
   [![GitHub tag](https://badgen.net/github/tag/topoteretes/cognee)](https://github.com/topoteretes/cognee/tags/)
   [![Downloads](https://static.pepy.tech/badge/cognee)](https://pepy.tech/project/cognee)


### PR DESCRIPTION
## Summary

The "GitHub stars" badge in `README.md` and `README_ko.md` links to `github.com/topoteretes/cognee/stargazers/`, which returns **HTTP 404**. GitHub has retired the `/stargazers` route at the platform level.

## Verification

Confirmed globally, not repo-specific:

```console
$ for r in topoteretes/cognee torvalds/linux microsoft/vscode facebook/react; do
    /usr/bin/curl -s -o /dev/null -w '%{http_code} https://github.com/'"$r"'/stargazers\n' \
      -L -A 'Mozilla/5.0' "https://github.com/$r/stargazers"
  done
404 https://github.com/topoteretes/cognee/stargazers
404 https://github.com/torvalds/linux/stargazers
404 https://github.com/microsoft/vscode/stargazers
404 https://github.com/facebook/react/stargazers
```

## Fix

Point the badge click target at the repo home URL, where the star count is displayed alongside the interactive Star button. Also normalized `GitHub.com` → `github.com` on that line to match the other badge links.

## Scope

- `README.md` — 1 line
- `README_ko.md` — 1 line
- No code paths touched
- The shields.io badge image itself was unaffected and still renders the current star count

## Notes

The sibling `/network/` and `/commit/` links in the same badge block still work (verified 200 OK) and were left unchanged. Only the `/stargazers/` target is broken.