### PR TITLE
Fix #3397: Tutorial: Migrate from mem0 to Cognee (using the existing Mem0Source)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ to verify behaviour across the SDK.
 | [`guides/`](guides/) | Short focused how-to guides | 13 |
 | [`integrations/`](integrations/) | Data-source connectors — installed from cognee-community | 1 |
 | [`pocs/`](pocs/) | Research-grade proofs of concept (entity disambiguation, canonicalization, prefetch) | 7 |
+| [`tutorials/`](tutorials/) | Step-by-step migration and workflow tutorials | 1 |
 
 Most runnable demos and backend examples use the v1.0 memory API (`remember`, `recall`, `forget`, `improve`). The lower-level `add`, `cognify`, `search`, and `prune` calls are intentionally kept in examples that demonstrate pipeline internals, permissions, relational migrations, or research POCs.
 
@@ -165,6 +166,7 @@ Same scripts, indexed by what they demonstrate.
 
 ### Connectors / Integrations
 - [`integrations/`](integrations/) — data-source connectors (installed from cognee-community)
+- [`tutorials/migrate_from_mem0_tutorial.py`](tutorials/migrate_from_mem0_tutorial.py) — import mem0 memories into Cognee
 
 ### SQL → knowledge graph
 - [`custom_pipelines/relational_database_to_knowledge_graph_migration_example.py`](custom_pipelines/relational_database_to_knowledge_graph_migration_example.py)

--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -1,0 +1,15 @@
+# Cognee Tutorials
+
+Runnable tutorials that walk through a specific workflow end-to-end.
+
+| Tutorial | What you'll learn |
+|---|---|
+| [`migrate_from_mem0_tutorial.py`](migrate_from_mem0_tutorial.py) | Import mem0 memories into Cognee using `Mem0Source` (`preserve` and `re-derive` modes) |
+
+## Running a tutorial
+
+```bash
+uv run python examples/tutorials/<tutorial_name>.py
+```
+
+Requires `LLM_API_KEY` in `.env` (for `re-derive` mode and `recall`).

--- a/examples/tutorials/data/mem0_export.json
+++ b/examples/tutorials/data/mem0_export.json
@@ -1,0 +1,36 @@
+{
+  "results": [
+    {
+      "id": "m01",
+      "memory": "Alice prefers dark mode and uses VS Code as her editor.",
+      "user_id": "alice",
+      "categories": ["preferences", "tools"],
+      "created_at": "2025-01-10T14:30:00Z",
+      "metadata": {"source": "onboarding_chat"}
+    },
+    {
+      "id": "m02",
+      "memory": "The project uses PostgreSQL for the main database and Redis for caching.",
+      "user_id": "alice",
+      "categories": ["infrastructure"],
+      "created_at": "2025-01-12T09:00:00Z",
+      "metadata": {"source": "team_wiki"}
+    },
+    {
+      "id": "m03",
+      "memory": "Alice's manager is Bob, who leads the platform engineering team.",
+      "user_id": "alice",
+      "categories": ["people"],
+      "created_at": "2025-02-01T11:00:00Z",
+      "metadata": {}
+    },
+    {
+      "id": "m04",
+      "memory": "The Q2 OKRs include reducing p95 latency by 30% and launching the new API gateway.",
+      "user_id": "alice",
+      "categories": ["goals"],
+      "created_at": "2025-03-15T16:00:00Z",
+      "metadata": {"source": "okr_review"}
+    }
+  ]
+}

--- a/examples/tutorials/migrate_from_mem0_tutorial.py
+++ b/examples/tutorials/migrate_from_mem0_tutorial.py
@@ -1,0 +1,93 @@
+"""
+Migrate from mem0 to Cognee using Mem0Source.
+
+Demonstrates how to import a mem0 export (platform JSON or OSS dump)
+into Cognee's knowledge graph and query the migrated memory.
+
+Three import modes:
+  - ``"preserve"``  — map mem0 memories straight to graph nodes (no LLM).
+  - ``"re-derive"`` — ingest raw text and run Cognee's own extraction.
+  - ``"hybrid"``    — preserve the graph *and* cognify raw content.
+
+Usage:
+    uv run python examples/tutorials/migrate_from_mem0_tutorial.py
+
+Requires:
+    LLM_API_KEY set in .env (needed for re-derive mode and recall).
+
+The sample mem0 export lives at ``examples/tutorials/data/mem0_export.json``.
+"""
+
+import asyncio
+from pathlib import Path
+
+import cognee
+from cognee.migration import Mem0Source
+from cognee.shared.logging_utils import ERROR, setup_logging
+
+DATA_FILE = Path(__file__).parent / "data" / "mem0_export.json"
+
+
+async def main():
+    from cognee.infrastructure.databases.relational.create_db_and_tables import (
+        create_db_and_tables,
+    )
+
+    await create_db_and_tables()
+
+    await cognee.forget(everything=True)
+
+    # ------------------------------------------------------------------
+    # Step 1: Inspect the mem0 export
+    # ------------------------------------------------------------------
+    print("Step 1 — Mem0 export file:", DATA_FILE)
+
+    # ------------------------------------------------------------------
+    # Step 2: Import with preserve mode (no LLM, fastest)
+    # ------------------------------------------------------------------
+    print("\nStep 2 — Importing mem0 memories (mode=preserve) …")
+    source = Mem0Source(DATA_FILE, mode="preserve")
+    result = await cognee.remember(source)
+    print("  ", result)
+
+    # ------------------------------------------------------------------
+    # Step 3: Query the migrated memory
+    # ------------------------------------------------------------------
+    print("\nStep 3 — Recall: what database does the project use?")
+    answers = await cognee.recall("What database does the project use?")
+    for answer in answers:
+        print("  ", answer)
+
+    print("\nStep 4 — Recall: who is Alice's manager?")
+    answers = await cognee.recall("Who is Alice's manager?")
+    for answer in answers:
+        print("  ", answer)
+
+    # ------------------------------------------------------------------
+    # Step 5: Re-import with re-derive mode (runs cognify)
+    # ------------------------------------------------------------------
+    await cognee.forget(everything=True)
+    print("\nStep 5 — Re-importing with mode=re-derive (runs cognify) …")
+    source = Mem0Source(DATA_FILE, mode="re-derive")
+    result = await cognee.remember(source)
+    print("  ", result)
+
+    # ------------------------------------------------------------------
+    # Step 6: Query again after re-derive
+    # ------------------------------------------------------------------
+    print("\nStep 6 — Recall after re-derive: what are the Q2 OKRs?")
+    answers = await cognee.recall("What are the Q2 OKRs?")
+    for answer in answers:
+        print("  ", answer)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+    print("\nStep 7 — Cleanup")
+    await cognee.forget(everything=True)
+    print("  Done.")
+
+
+if __name__ == "__main__":
+    logger = setup_logging(log_level=ERROR)
+    asyncio.run(main())


### PR DESCRIPTION
Fixes #3397

Added a runnable tutorial demonstrating mem0-to-Cognee migration via the existing `Mem0Source` class. Created three new files (`examples/tutorials/migrate_from_mem0_tutorial.py`, `examples/tutorials/data/mem0_export.json`, `examples/tutorials/README.md`) and added the tutorials folder + mem0 migration entry to `examples/README.md`. The tutorial covers `preserve` and `re-derive` modes, shows `recall` queries after each import, and follows the existing example conventions (`asyncio.run`, `forget(everything=True)`, numbered steps).

Local test infra unavailable in CI sandbox.

---
This change was prepared with AI assistance under human direction and review.