### PR TITLE
feat(llm): auto-enable the RPM limiter on overload evidence

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -71,7 +71,9 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 # Examples: LLM_ARGS='{"max_tokens": 16384, "temperature": 0.7}'
 #LLM_ARGS='{}'
 
-# LLM rate limiting
+# LLM rate limiting. When LLM_RATE_LIMIT_REQUESTS is not set, the limiter
+# budget defaults to 60 requests per interval for cloud providers and 20 for
+# local inference servers (Ollama, LM Studio, vLLM, llama.cpp).
 #LLM_RATE_LIMIT_ENABLED=true
 #LLM_RATE_LIMIT_REQUESTS=60
 #LLM_RATE_LIMIT_INTERVAL=60

--- a/.env.template
+++ b/.env.template
@@ -72,7 +72,7 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 #LLM_ARGS='{}'
 
 # LLM rate limiting. When LLM_RATE_LIMIT_REQUESTS is not set, the limiter
-# budget defaults to 60 requests per interval for cloud providers and 20 for
+# budget defaults to 60 requests per interval for cloud providers and 10 for
 # serial local inference servers (Ollama, LM Studio, llama.cpp); vLLM
 # batches like a cloud endpoint and keeps the regular settings.
 #LLM_RATE_LIMIT_ENABLED=true

--- a/.env.template
+++ b/.env.template
@@ -77,9 +77,9 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 #LLM_RATE_LIMIT_ENABLED=true
 #LLM_RATE_LIMIT_REQUESTS=60
 #LLM_RATE_LIMIT_INTERVAL=60
-# Run at full speed, but when LLM requests hit rate limits, time out, or get
-# dangerously slow, log a warning and turn on the RPM limiter (with the budget
-# above) for the rest of the process. On by default; set to false to opt out.
+# Run at full speed, but when LLM requests hit rate limits (or time out), log
+# a warning and turn on the RPM limiter (with the budget above) until issues
+# stop. On by default; set to false to opt out.
 #AUTO_RATE_LIMIT=true
 
 # Per-stage model routing (optional). Unset means the stage uses the base LLM_* config above.

--- a/.env.template
+++ b/.env.template
@@ -75,8 +75,9 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 #LLM_RATE_LIMIT_ENABLED=true
 #LLM_RATE_LIMIT_REQUESTS=60
 #LLM_RATE_LIMIT_INTERVAL=60
-# Automatically enable the RPM limiter (with the budget above) after the LLM
-# provider reports a rate limit. On by default; set to false to opt out.
+# Run at full speed, but when LLM requests hit rate limits, time out, or get
+# dangerously slow, log a warning and turn on the RPM limiter (with the budget
+# above) for the rest of the process. On by default; set to false to opt out.
 #AUTO_RATE_LIMIT=true
 
 # Per-stage model routing (optional). Unset means the stage uses the base LLM_* config above.

--- a/.env.template
+++ b/.env.template
@@ -75,6 +75,9 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 #LLM_RATE_LIMIT_ENABLED=true
 #LLM_RATE_LIMIT_REQUESTS=60
 #LLM_RATE_LIMIT_INTERVAL=60
+# Automatically enable the RPM limiter (with the budget above) after the LLM
+# provider reports a rate limit. On by default; set to false to opt out.
+#AUTO_RATE_LIMIT=true
 
 # Per-stage model routing (optional). Unset means the stage uses the base LLM_* config above.
 # Route a cheap or local model to extraction (it runs per chunk and dominates token use),

--- a/.env.template
+++ b/.env.template
@@ -73,7 +73,8 @@ STRUCTURED_OUTPUT_FRAMEWORK="instructor"
 
 # LLM rate limiting. When LLM_RATE_LIMIT_REQUESTS is not set, the limiter
 # budget defaults to 60 requests per interval for cloud providers and 20 for
-# local inference servers (Ollama, LM Studio, vLLM, llama.cpp).
+# serial local inference servers (Ollama, LM Studio, llama.cpp); vLLM
+# batches like a cloud endpoint and keeps the regular settings.
 #LLM_RATE_LIMIT_ENABLED=true
 #LLM_RATE_LIMIT_REQUESTS=60
 #LLM_RATE_LIMIT_INTERVAL=60

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -346,7 +346,7 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
 
     if chunks_per_batch is None:
         chunks_per_batch = (
-            cognify_config.chunks_per_batch if cognify_config.chunks_per_batch is not None else 100
+            cognify_config.chunks_per_batch if cognify_config.chunks_per_batch is not None else 5000
         )
 
     default_tasks = [
@@ -412,8 +412,6 @@ async def get_temporal_tasks(
         list[Task]: A list of Task objects representing the temporal processing pipeline.
     """
     if chunks_per_batch is None:
-        from cognee.modules.cognify.config import get_cognify_config
-
         configured = get_cognify_config().chunks_per_batch
         chunks_per_batch = configured if configured is not None else 10
 

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -356,7 +356,7 @@ async def get_default_tasks(  # TODO: Find out a better way to do this (Boris's 
 
     if chunks_per_batch is None:
         chunks_per_batch = (
-            cognify_config.chunks_per_batch if cognify_config.chunks_per_batch is not None else 5000
+            cognify_config.chunks_per_batch if cognify_config.chunks_per_batch is not None else 2000
         )
 
     default_tasks = [

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -32,6 +32,12 @@ KNOWN_LLM_PROVIDERS = frozenset(
     }
 )
 
+# Default RPM budget for local inference servers (Ollama, LM Studio, vLLM,
+# llama.cpp) when LLM_RATE_LIMIT_REQUESTS is not explicitly configured — they
+# process requests (near-)serially, unlike cloud providers which keep the
+# regular default of 60.
+LOCAL_DEFAULT_RATE_LIMIT_REQUESTS = 20
+
 
 class LLMConfig(BaseSettings):
     """
@@ -101,6 +107,8 @@ class LLMConfig(BaseSettings):
     temporal_graph_prompt_path: str = "generate_event_graph_prompt.txt"
     event_entity_prompt_path: str = "generate_event_entity_prompt.txt"
     llm_rate_limit_enabled: bool = False
+    # Default 60 requests per interval; local inference servers get
+    # LOCAL_DEFAULT_RATE_LIMIT_REQUESTS instead (see default_local_rate_limit_budget).
     llm_rate_limit_requests: int = 60
     llm_rate_limit_interval: int = 60  # in seconds (default is 60 requests per minute)
     llm_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
@@ -169,6 +177,30 @@ class LLMConfig(BaseSettings):
                 from cognee.infrastructure.llm.exceptions import ProviderNotDeducibleError
 
                 raise ProviderNotDeducibleError(model)
+
+        return self
+
+    @model_validator(mode="after")
+    def default_local_rate_limit_budget(self) -> "LLMConfig":
+        """
+        Give local inference servers a smaller default RPM budget.
+
+        Local servers (Ollama, LM Studio, vLLM, llama.cpp) process requests
+        (near-)serially, so when the rate limiter engages, the regular cloud
+        default of 60 requests per interval would still flood them. An
+        explicitly configured ``LLM_RATE_LIMIT_REQUESTS`` always wins. Runs
+        after ``infer_provider_from_model`` so the provider is already
+        resolved.
+        """
+        if "llm_rate_limit_requests" in self.model_fields_set:
+            return self
+
+        provider = (self.llm_provider or "").lower()
+        model = (self.llm_model or "").lower()
+        local_providers = {"ollama", "llama_cpp"}
+        local_model_prefixes = ("lm_studio/", "hosted_vllm/", "vllm/")
+        if provider in local_providers or model.startswith(local_model_prefixes):
+            self.llm_rate_limit_requests = LOCAL_DEFAULT_RATE_LIMIT_REQUESTS
 
         return self
 

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -32,11 +32,24 @@ KNOWN_LLM_PROVIDERS = frozenset(
     }
 )
 
-# Default RPM budget for local inference servers (Ollama, LM Studio, vLLM,
-# llama.cpp) when LLM_RATE_LIMIT_REQUESTS is not explicitly configured — they
-# process requests (near-)serially, unlike cloud providers which keep the
-# regular default of 60.
+# Local inference servers process requests (near-)serially, unlike cloud
+# providers. One definition of the distinction, for everything that needs it:
+# by first-class provider name, or by litellm model routing prefix (LM Studio
+# and vLLM have no first-class provider in cognee).
+LOCAL_LLM_PROVIDERS = frozenset({"ollama", "llama_cpp"})
+LOCAL_LLM_MODEL_PREFIXES = ("lm_studio/", "hosted_vllm/", "vllm/")
+
+# Default RPM budget for local inference servers when LLM_RATE_LIMIT_REQUESTS
+# is not explicitly configured; cloud providers keep the regular default of 60.
 LOCAL_DEFAULT_RATE_LIMIT_REQUESTS = 20
+
+
+def is_local_llm(provider: str | None, model: str | None) -> bool:
+    """True when the provider/model points at a local inference server
+    (Ollama, llama.cpp by provider; LM Studio, vLLM by model prefix)."""
+    if (provider or "").lower() in LOCAL_LLM_PROVIDERS:
+        return True
+    return (model or "").lower().startswith(LOCAL_LLM_MODEL_PREFIXES)
 
 
 class LLMConfig(BaseSettings):
@@ -195,11 +208,7 @@ class LLMConfig(BaseSettings):
         if "llm_rate_limit_requests" in self.model_fields_set:
             return self
 
-        provider = (self.llm_provider or "").lower()
-        model = (self.llm_model or "").lower()
-        local_providers = {"ollama", "llama_cpp"}
-        local_model_prefixes = ("lm_studio/", "hosted_vllm/", "vllm/")
-        if provider in local_providers or model.startswith(local_model_prefixes):
+        if is_local_llm(self.llm_provider, self.llm_model):
             self.llm_rate_limit_requests = LOCAL_DEFAULT_RATE_LIMIT_REQUESTS
 
         return self

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -43,7 +43,7 @@ LOCAL_LLM_MODEL_PREFIXES = ("lm_studio/",)
 
 # Default RPM budget for local inference servers when LLM_RATE_LIMIT_REQUESTS
 # is not explicitly configured; cloud providers keep the regular default of 60.
-LOCAL_DEFAULT_RATE_LIMIT_REQUESTS = 20
+LOCAL_DEFAULT_RATE_LIMIT_REQUESTS = 10
 
 
 def is_local_llm(provider: str | None, model: str | None) -> bool:

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -35,9 +35,11 @@ KNOWN_LLM_PROVIDERS = frozenset(
 # Local inference servers process requests (near-)serially, unlike cloud
 # providers. One definition of the distinction, for everything that needs it:
 # by first-class provider name, or by litellm model routing prefix (LM Studio
-# and vLLM have no first-class provider in cognee).
+# has no first-class provider in cognee). vLLM is deliberately NOT here: it
+# serves with continuous batching and absorbs concurrency like a cloud
+# endpoint, so it keeps the regular settings.
 LOCAL_LLM_PROVIDERS = frozenset({"ollama", "llama_cpp"})
-LOCAL_LLM_MODEL_PREFIXES = ("lm_studio/", "hosted_vllm/", "vllm/")
+LOCAL_LLM_MODEL_PREFIXES = ("lm_studio/",)
 
 # Default RPM budget for local inference servers when LLM_RATE_LIMIT_REQUESTS
 # is not explicitly configured; cloud providers keep the regular default of 60.
@@ -45,8 +47,10 @@ LOCAL_DEFAULT_RATE_LIMIT_REQUESTS = 20
 
 
 def is_local_llm(provider: str | None, model: str | None) -> bool:
-    """True when the provider/model points at a local inference server
-    (Ollama, llama.cpp by provider; LM Studio, vLLM by model prefix)."""
+    """True when the provider/model points at a serial local inference server
+    (Ollama, llama.cpp by provider; LM Studio by model prefix). vLLM counts
+    as regular: continuous batching absorbs concurrency like a cloud endpoint.
+    """
     if (provider or "").lower() in LOCAL_LLM_PROVIDERS:
         return True
     return (model or "").lower().startswith(LOCAL_LLM_MODEL_PREFIXES)
@@ -198,7 +202,7 @@ class LLMConfig(BaseSettings):
         """
         Give local inference servers a smaller default RPM budget.
 
-        Local servers (Ollama, LM Studio, vLLM, llama.cpp) process requests
+        Serial local servers (Ollama, LM Studio, llama.cpp) process requests
         (near-)serially, so when the rate limiter engages, the regular cloud
         default of 60 requests per interval would still flood them. An
         explicitly configured ``LLM_RATE_LIMIT_REQUESTS`` always wins. Runs

--- a/cognee/infrastructure/llm/config.py
+++ b/cognee/infrastructure/llm/config.py
@@ -104,6 +104,9 @@ class LLMConfig(BaseSettings):
     llm_rate_limit_requests: int = 60
     llm_rate_limit_interval: int = 60  # in seconds (default is 60 requests per minute)
     llm_rate_limit_tokens: int = 0  # max tokens per interval (0 = disabled)
+    # When the provider reports a rate limit, warn and switch on the RPM limiter
+    # (with the llm_rate_limit_requests/interval budget) for the rest of the process.
+    auto_rate_limit: bool = True
 
     llama_cpp_model_path: str | None = None
     llama_cpp_n_ctx: int = 2048

--- a/cognee/infrastructure/llm/overload_policy.py
+++ b/cognee/infrastructure/llm/overload_policy.py
@@ -16,7 +16,7 @@ logger = get_logger("llm_dispatch")
 # How long one piece of overload evidence keeps dispatch paced; every further
 # piece extends the window. When it lapses, behavior returns to the
 # configured state — the reaction is never stuck on forever.
-COOLDOWN_SECONDS = 300.0
+COOLDOWN_SECONDS = 900.0
 
 # Server-overload statuses that arrive as plain HTTP errors: 503 (service
 # unavailable — e.g. Ollama's queue-full reply) and 529 (Anthropic overloaded).

--- a/cognee/infrastructure/llm/overload_policy.py
+++ b/cognee/infrastructure/llm/overload_policy.py
@@ -91,11 +91,12 @@ class OverloadPolicy:
         if new_episode:
             llm_config = get_llm_config()
             logger.warning(
-                "LLM requests are not being processed fast enough (%s) — enabling "
-                "the RPM limiter (%d requests per %ds) for the next %.0fs, extended "
-                "while issues persist. Tune LLM_RATE_LIMIT_REQUESTS / "
-                "LLM_RATE_LIMIT_INTERVAL to match what your provider or machine can "
-                "handle, or set AUTO_RATE_LIMIT=false to opt out.",
+                "Potential RPM issues detected (%s) — slowing down processing to "
+                "accommodate: enabling the RPM limiter (%d requests per %ds) for "
+                "the next %.0fs, extended while issues persist. Tune "
+                "LLM_RATE_LIMIT_REQUESTS / LLM_RATE_LIMIT_INTERVAL to match what "
+                "your provider or machine can handle, or set AUTO_RATE_LIMIT=false "
+                "to opt out.",
                 reason,
                 llm_config.llm_rate_limit_requests,
                 llm_config.llm_rate_limit_interval,

--- a/cognee/infrastructure/llm/overload_policy.py
+++ b/cognee/infrastructure/llm/overload_policy.py
@@ -18,9 +18,12 @@ logger = get_logger("llm_dispatch")
 # configured state — the reaction is never stuck on forever.
 COOLDOWN_SECONDS = 900.0
 
-# Server-overload statuses that arrive as plain HTTP errors: 503 (service
-# unavailable — e.g. Ollama's queue-full reply) and 529 (Anthropic overloaded).
-_OVERLOAD_STATUS_CODES = frozenset({503, 529})
+# Overload statuses, checked on any exception in the chain that exposes a
+# ``status_code`` attribute — openai, anthropic, and litellm error classes all
+# do, so the check is provider-neutral and needs no optional SDK imports:
+# 429 (rate limited), 503 (service unavailable — e.g. Ollama's queue-full
+# reply), 529 (Anthropic overloaded).
+_OVERLOAD_STATUS_CODES = frozenset({429, 503, 529})
 
 
 def overload_evidence(error: BaseException) -> str | None:
@@ -28,19 +31,26 @@ def overload_evidence(error: BaseException) -> str | None:
 
     Overload evidence is a rate-limit error (cloud providers), a timeout (how
     overwhelmed local servers usually surface — they never send rate limits),
-    or an HTTP 503/529 overload status. Wrappers hide the signal — instructor
-    re-raises provider errors inside InstructorRetryException — so the cause
-    chain is checked, not just the top-level type. The openai base classes
-    cover every client stack: litellm's exceptions subclass them, and
-    SDK-direct adapters raise them natively.
+    or an HTTP 429/503/529 overload status. Wrappers hide the signal —
+    instructor re-raises provider errors inside InstructorRetryException — so
+    the cause chain is checked, not just the top-level type.
+
+    Recognition is deliberately provider-neutral: HTTP statuses are read from
+    any exception's ``status_code`` attribute (openai, anthropic, and litellm
+    error classes all carry one), and timeouts are caught via the openai class
+    (litellm's subclass it), ``httpx.TimeoutException`` (the transport cause
+    SDK-direct clients such as anthropic chain their timeout errors from), and
+    the asyncio/builtin timeouts. Optional provider SDKs are never imported.
     """
     import asyncio
 
+    import httpx
     import openai
 
     overload_types = (
         openai.RateLimitError,
         openai.APITimeoutError,
+        httpx.TimeoutException,
         asyncio.TimeoutError,
         TimeoutError,
     )
@@ -49,11 +59,9 @@ def overload_evidence(error: BaseException) -> str | None:
     while node is not None and id(node) not in seen and len(seen) < 20:
         if isinstance(node, overload_types):
             return type(node).__name__
-        if (
-            isinstance(node, openai.APIStatusError)
-            and getattr(node, "status_code", None) in _OVERLOAD_STATUS_CODES
-        ):
-            return f"HTTP {node.status_code}"
+        status_code = getattr(node, "status_code", None)
+        if status_code in _OVERLOAD_STATUS_CODES:
+            return f"HTTP {status_code}"
         seen.add(id(node))
         node = node.__cause__ or node.__context__
     return None

--- a/cognee/infrastructure/llm/overload_policy.py
+++ b/cognee/infrastructure/llm/overload_policy.py
@@ -1,0 +1,107 @@
+"""Overload detection and reaction policy for LLM dispatch.
+
+Everything runs at full speed until there is evidence the provider cannot
+keep up; then dispatches are paced by the RPM limiter for a cooldown window
+that extends while evidence keeps arriving and lapses back to the configured
+state afterwards. The dispatch seam (``shared.rate_limiting``) consults a
+process-wide ``OverloadPolicy`` instance; tests construct their own.
+"""
+
+import time
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("llm_dispatch")
+
+# How long one piece of overload evidence keeps dispatch paced; every further
+# piece extends the window. When it lapses, behavior returns to the
+# configured state — the reaction is never stuck on forever.
+COOLDOWN_SECONDS = 300.0
+
+# Server-overload statuses that arrive as plain HTTP errors: 503 (service
+# unavailable — e.g. Ollama's queue-full reply) and 529 (Anthropic overloaded).
+_OVERLOAD_STATUS_CODES = frozenset({503, 529})
+
+
+def overload_evidence(error: BaseException) -> str | None:
+    """Name the overload cause in ``error``'s chain, or None.
+
+    Overload evidence is a rate-limit error (cloud providers), a timeout (how
+    overwhelmed local servers usually surface — they never send rate limits),
+    or an HTTP 503/529 overload status. Wrappers hide the signal — instructor
+    re-raises provider errors inside InstructorRetryException — so the cause
+    chain is checked, not just the top-level type. The openai base classes
+    cover every client stack: litellm's exceptions subclass them, and
+    SDK-direct adapters raise them natively.
+    """
+    import asyncio
+
+    import openai
+
+    overload_types = (
+        openai.RateLimitError,
+        openai.APITimeoutError,
+        asyncio.TimeoutError,
+        TimeoutError,
+    )
+    seen: set = set()
+    node: BaseException | None = error
+    while node is not None and id(node) not in seen and len(seen) < 20:
+        if isinstance(node, overload_types):
+            return type(node).__name__
+        if (
+            isinstance(node, openai.APIStatusError)
+            and getattr(node, "status_code", None) in _OVERLOAD_STATUS_CODES
+        ):
+            return f"HTTP {node.status_code}"
+        seen.add(id(node))
+        node = node.__cause__ or node.__context__
+    return None
+
+
+class OverloadPolicy:
+    """Pace-on-evidence policy with cooldown-episode semantics.
+
+    Warns once per overload episode; further evidence inside the window
+    extends it silently, and a fresh episode after a quiet cooldown warns
+    again.
+    """
+
+    def __init__(self, cooldown_seconds: float = COOLDOWN_SECONDS):
+        self.cooldown_seconds = cooldown_seconds
+        self._paced_until = 0.0
+
+    def is_paced(self) -> bool:
+        """Whether dispatches should currently be paced by the RPM limiter."""
+        return time.monotonic() < self._paced_until
+
+    def on_error(self, error: BaseException) -> None:
+        """Record a failed dispatch; overload errors count as evidence."""
+        evidence = overload_evidence(error)
+        if evidence is not None:
+            self._react(evidence)
+
+    def _react(self, reason: str) -> None:
+        # NOTE: Import inside function to avoid a circular import at module load.
+        from cognee.infrastructure.llm.config import get_llm_config
+
+        now = time.monotonic()
+        new_episode = now >= self._paced_until
+        self._paced_until = now + self.cooldown_seconds
+        if new_episode:
+            llm_config = get_llm_config()
+            logger.warning(
+                "LLM requests are not being processed fast enough (%s) — enabling "
+                "the RPM limiter (%d requests per %ds) for the next %.0fs, extended "
+                "while issues persist. Tune LLM_RATE_LIMIT_REQUESTS / "
+                "LLM_RATE_LIMIT_INTERVAL to match what your provider or machine can "
+                "handle, or set AUTO_RATE_LIMIT=false to opt out.",
+                reason,
+                llm_config.llm_rate_limit_requests,
+                llm_config.llm_rate_limit_interval,
+                self.cooldown_seconds,
+            )
+
+
+# Process-wide default instance consulted by the dispatch seam.
+llm_overload_policy = OverloadPolicy()

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_instructor/llm/bedrock/adapter.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import instructor
@@ -5,8 +6,13 @@ import litellm
 from instructor.exceptions import InstructorRetryException
 from litellm.exceptions import ContentPolicyViolationError
 from pydantic import BaseModel
+from tenacity import before_sleep_log, retry, wait_exponential_jitter
 
 from cognee.infrastructure.files.storage.s3_config import get_s3_config
+from cognee.infrastructure.llm.retry_config import (
+    llm_retry_condition,
+    llm_retry_stop_condition,
+)
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.instructor_modes import (
     get_instructor_mode,
 )
@@ -20,17 +26,14 @@ from cognee.infrastructure.llm.prompts.read_query_prompt import read_query_promp
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.llm_interface import (
     LLMInterface,
 )
-from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.rate_limiter import (
-    rate_limit_async,
-    rate_limit_sync,
-    sleep_and_retry_async,
-    sleep_and_retry_sync,
-)
 from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.types import (
     TranscriptionReturnType,
 )
 from cognee.modules.observability.get_observe import get_observe
+from cognee.shared.logging_utils import get_logger
+from cognee.shared.rate_limiting import llm_rate_limiter_context_manager
 
+logger = get_logger()
 observe = get_observe()
 
 
@@ -111,8 +114,13 @@ class BedrockAdapter(LLMInterface):
         return request_params
 
     @observe(as_type="generation")
-    @sleep_and_retry_async()
-    @rate_limit_async
+    @retry(
+        stop=llm_retry_stop_condition,
+        wait=wait_exponential_jitter(8, 128),
+        retry=llm_retry_condition,
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
     async def acreate_structured_output(
         self, text_input: str, system_prompt: str, response_model: type[BaseModel], **kwargs: Any
     ) -> BaseModel:
@@ -122,7 +130,10 @@ class BedrockAdapter(LLMInterface):
             request_params = self._create_bedrock_request(
                 text_input, system_prompt, response_model, **kwargs
             )
-            return await self.aclient.chat.completions.create(**request_params)
+            # Dispatch through the pacing seam so overload errors reach the
+            # OverloadPolicy and paced episodes throttle this adapter too.
+            async with llm_rate_limiter_context_manager():
+                return await self.aclient.chat.completions.create(**request_params)
 
         except (
             ContentPolicyViolationError,

--- a/cognee/shared/rate_limiting.py
+++ b/cognee/shared/rate_limiting.py
@@ -1,138 +1,60 @@
+"""Rate-limiting context managers for LLM and embedding dispatch.
+
+This module is the pacing seam: adapters wrap each dispatch attempt with
+``llm_rate_limiter_context_manager()`` (inside their tenacity retry) or
+``embedding_rate_limiter_context_manager()``. Overload detection and reaction
+policy live in ``cognee.infrastructure.llm.overload_policy``; configuration
+is read at use-time, never snapshotted at import.
+"""
+
 from contextlib import asynccontextmanager, nullcontext
 
 from aiolimiter import AsyncLimiter
 
-from cognee.infrastructure.llm.config import get_llm_config
-from cognee.shared.logging_utils import get_logger
-
-logger = get_logger("llm_dispatch")
-
-llm_config = get_llm_config()
-
-# The budget is provider-aware: LLMConfig gives local inference servers a
-# smaller default LLM_RATE_LIMIT_REQUESTS (see default_local_rate_limit_budget).
-llm_rate_limiter = AsyncLimiter(
-    llm_config.llm_rate_limit_requests, llm_config.llm_rate_limit_interval
-)
-# The embedding limiter reads its settings from EmbeddingConfig and is built
-# lazily to avoid a circular import at module load time (embedding engines, which
-# EmbeddingConfig is reached through, import this module).
-_embedding_rate_limiter = None
+# Limiters are built lazily on first use so their budgets bind the resolved
+# configuration (LLMConfig gives local inference servers a smaller default
+# LLM_RATE_LIMIT_REQUESTS) and so importing this module stays dependency-light.
+_llm_rate_limiter: "AsyncLimiter | None" = None
+_embedding_rate_limiter: "AsyncLimiter | None" = None
 
 
-# Early overload detection: a dispatch that SUCCEEDS but takes this long is
-# proof the server's queue is approaching the client timeout cliff (default
-# 600s) — react before anything actually fails. Healthy setups complete
-# calls in seconds to a couple of minutes and never approach this.
-SLOW_COMPLETION_SECONDS = 300.0
+def _get_llm_rate_limiter() -> AsyncLimiter:
+    global _llm_rate_limiter
+    if _llm_rate_limiter is None:
+        # NOTE: Import inside function to avoid a circular import at module load.
+        from cognee.infrastructure.llm.config import get_llm_config
 
-# When AUTO_RATE_LIMIT reacts to overload evidence, dispatch is paced by the
-# RPM limiter until this deadline; every further piece of evidence extends it.
-# Once it lapses, behavior returns to the configured state (unbounded unless
-# LLM_RATE_LIMIT_ENABLED is set) — the reaction is never stuck on forever.
-AUTO_RATE_LIMIT_COOLDOWN_SECONDS = 300.0
-
-_auto_paced_until = 0.0  # monotonic deadline of the current overload episode
-
-
-def _fall_back_to_rate_limiter(reason: str) -> None:
-    """Pace dispatches with the RPM limiter for a cooldown window.
-
-    Warns once per overload episode; further evidence inside the window
-    extends it silently, and a fresh episode after a quiet cooldown warns
-    again.
-    """
-    global _auto_paced_until
-    import time
-
-    now = time.monotonic()
-    new_episode = now >= _auto_paced_until
-    _auto_paced_until = now + AUTO_RATE_LIMIT_COOLDOWN_SECONDS
-    if new_episode:
-        logger.warning(
-            "LLM requests are not being processed fast enough (%s) — enabling "
-            "the RPM limiter (%d requests per %ds) for the next %.0fs, extended "
-            "while issues persist. Tune LLM_RATE_LIMIT_REQUESTS / "
-            "LLM_RATE_LIMIT_INTERVAL to match what your provider or machine can "
-            "handle, or set AUTO_RATE_LIMIT=false to opt out.",
-            reason,
-            llm_config.llm_rate_limit_requests,
-            llm_config.llm_rate_limit_interval,
-            AUTO_RATE_LIMIT_COOLDOWN_SECONDS,
+        llm_config = get_llm_config()
+        _llm_rate_limiter = AsyncLimiter(
+            llm_config.llm_rate_limit_requests, llm_config.llm_rate_limit_interval
         )
-
-
-def _overload_evidence(error: BaseException) -> str | None:
-    """Name the overload cause in ``error``'s chain, or None.
-
-    Overload evidence is a rate-limit error (cloud providers), a timeout (how
-    overwhelmed local servers usually surface — they never send rate limits),
-    or an HTTP 503/529 overload status (Ollama past its queue cap, Anthropic
-    overloaded). Wrappers hide the signal — instructor re-raises provider
-    errors inside InstructorRetryException — so the cause chain is checked,
-    not just the top-level type. The openai base classes cover every client
-    stack: litellm's exceptions subclass them, and SDK-direct adapters raise
-    them natively.
-    """
-    import asyncio
-
-    import openai
-
-    overload_types = (
-        openai.RateLimitError,
-        openai.APITimeoutError,
-        asyncio.TimeoutError,
-        TimeoutError,
-    )
-    # Server-overload statuses that arrive as plain HTTP errors: 503 (service
-    # unavailable — e.g. Ollama's queue-full reply) and 529 (Anthropic overloaded).
-    overload_statuses = frozenset({503, 529})
-    seen: set = set()
-    node: BaseException | None = error
-    while node is not None and id(node) not in seen and len(seen) < 20:
-        if isinstance(node, overload_types):
-            return type(node).__name__
-        if (
-            isinstance(node, openai.APIStatusError)
-            and getattr(node, "status_code", None) in overload_statuses
-        ):
-            return f"HTTP {node.status_code}"
-        seen.add(id(node))
-        node = node.__cause__ or node.__context__
-    return None
+    return _llm_rate_limiter
 
 
 @asynccontextmanager
 async def _governed_llm_dispatch():
     """Gate one LLM dispatch attempt.
 
-    Everything runs unbounded (the fast path). When there is evidence the
-    provider cannot keep up — a completion slow enough to prove the queue is
-    nearing the client timeout (detected BEFORE anything fails), a rate-limit
-    error, an HTTP 503/529, or a timeout — one warning is logged and the RPM
-    limiter paces dispatches for a cooldown window, extended while issues
-    persist; when it lapses, behavior returns to the configured state.
-    LLM_RATE_LIMIT_ENABLED paces from the start, unchanged. Adapters enter
-    this context manager INSIDE their tenacity retry, so retried attempts are
-    paced as well.
+    Everything runs unbounded (the fast path). The RPM limiter paces when
+    LLM_RATE_LIMIT_ENABLED is set, or while the overload policy reports an
+    active episode — evidence being a rate-limit error, an HTTP 503/529, or
+    a timeout, with the episode lapsing back to the configured state after a
+    quiet cooldown. Adapters enter this context manager INSIDE their tenacity
+    retry, so retried attempts are paced as well.
     """
-    import time
+    # NOTE: Imports inside function to avoid circular imports at module load.
+    from cognee.infrastructure.llm.config import get_llm_config
+    from cognee.infrastructure.llm.overload_policy import llm_overload_policy
 
-    pace = llm_config.llm_rate_limit_enabled or time.monotonic() < _auto_paced_until
-    async with llm_rate_limiter if pace else nullcontext():
-        started = time.monotonic()
+    llm_config = get_llm_config()
+    pace = llm_config.llm_rate_limit_enabled or llm_overload_policy.is_paced()
+    async with _get_llm_rate_limiter() if pace else nullcontext():
         try:
             yield
         except Exception as error:
             if llm_config.auto_rate_limit:
-                evidence = _overload_evidence(error)
-                if evidence is not None:
-                    _fall_back_to_rate_limiter(evidence)
+                llm_overload_policy.on_error(error)
             raise
-        else:
-            elapsed = time.monotonic() - started
-            if llm_config.auto_rate_limit and elapsed >= SLOW_COMPLETION_SECONDS:
-                _fall_back_to_rate_limiter(f"completion took {elapsed:.0f}s")
 
 
 def llm_rate_limiter_context_manager():
@@ -141,6 +63,9 @@ def llm_rate_limiter_context_manager():
 
 def embedding_rate_limiter_context_manager():
     global _embedding_rate_limiter
+    # NOTE: Import inside function to avoid a circular import at module load
+    # (embedding engines, which EmbeddingConfig is reached through, import
+    # this module).
     from cognee.infrastructure.databases.vector.embeddings.config import (
         get_embedding_config,
     )

--- a/cognee/shared/rate_limiting.py
+++ b/cognee/shared/rate_limiting.py
@@ -1,8 +1,11 @@
-from contextlib import nullcontext
+from contextlib import asynccontextmanager, nullcontext
 
 from aiolimiter import AsyncLimiter
 
 from cognee.infrastructure.llm.config import get_llm_config
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("llm_dispatch")
 
 llm_config = get_llm_config()
 
@@ -14,14 +17,95 @@ llm_rate_limiter = AsyncLimiter(
 # EmbeddingConfig is reached through, import this module).
 _embedding_rate_limiter = None
 
+# Set once AUTO_RATE_LIMIT reacts to a provider rate limit: from then on every
+# dispatch is paced by the RPM limiter above, exactly as if
+# LLM_RATE_LIMIT_ENABLED had been set.
+_auto_rate_limit_activated = False
+
+# Local inference servers never report rate limits — their overload signal is
+# a slow client timeout, far too late to react to. With AUTO_RATE_LIMIT they
+# are therefore paced from the very first dispatch instead of reactively.
+_LOCAL_LLM_PROVIDERS = frozenset({"ollama", "llama_cpp"})
+_LOCAL_MODEL_PREFIXES = ("lm_studio/", "hosted_vllm/", "vllm/")
+_local_pacing_active: bool | None = None  # resolved lazily on first dispatch
+
+
+def _local_pacing() -> bool:
+    """Pace local LLM servers up front (once, with a warning explaining why)."""
+    global _local_pacing_active
+    if _local_pacing_active is None:
+        provider = (llm_config.llm_provider or "").lower()
+        model = (llm_config.llm_model or "").lower()
+        is_local = provider in _LOCAL_LLM_PROVIDERS or model.startswith(_LOCAL_MODEL_PREFIXES)
+        _local_pacing_active = llm_config.auto_rate_limit and is_local
+        if _local_pacing_active:
+            logger.warning(
+                "Local LLM provider detected (%s / %s) — enabling the RPM limiter "
+                "(%d requests per %ds) up front, because local servers cannot absorb "
+                "unbounded request floods and never report rate limits themselves. "
+                "Tune LLM_RATE_LIMIT_REQUESTS / LLM_RATE_LIMIT_INTERVAL to match your "
+                "machine's real throughput, or set AUTO_RATE_LIMIT=false to disable "
+                "this behavior.",
+                llm_config.llm_provider,
+                llm_config.llm_model,
+                llm_config.llm_rate_limit_requests,
+                llm_config.llm_rate_limit_interval,
+            )
+    return _local_pacing_active
+
+
+def _activate_rate_limiter_on_rate_limit(error: BaseException) -> None:
+    """Warn and switch on the RPM limiter if the error (or its cause) is a rate limit.
+
+    Wrappers hide the signal — instructor re-raises provider errors inside
+    InstructorRetryException — so the cause chain is checked, not just the
+    top-level type. openai.RateLimitError covers every client stack: litellm's
+    exceptions subclass it, and SDK-direct adapters raise it natively.
+    """
+    global _auto_rate_limit_activated
+    import openai
+
+    seen: set = set()
+    node: BaseException | None = error
+    while node is not None and id(node) not in seen and len(seen) < 20:
+        if isinstance(node, openai.RateLimitError):
+            if not _auto_rate_limit_activated:
+                _auto_rate_limit_activated = True
+                logger.warning(
+                    "LLM provider reported a rate limit — enabling the RPM limiter "
+                    "(%d requests per %ds) for the rest of this process. Tune with "
+                    "LLM_RATE_LIMIT_REQUESTS / LLM_RATE_LIMIT_INTERVAL, or set "
+                    "AUTO_RATE_LIMIT=false to opt out.",
+                    llm_config.llm_rate_limit_requests,
+                    llm_config.llm_rate_limit_interval,
+                )
+            return
+        seen.add(id(node))
+        node = node.__cause__ or node.__context__
+
+
+@asynccontextmanager
+async def _governed_llm_dispatch():
+    """Gate one LLM dispatch attempt.
+
+    Cloud is unbounded by default; the RPM limiter paces when
+    LLM_RATE_LIMIT_ENABLED is set, when AUTO_RATE_LIMIT (default on) reacted
+    to a provider rate limit, or from the start for local inference servers.
+    Adapters enter this context manager INSIDE their tenacity retry, so
+    retried attempts are paced as well.
+    """
+    pace = llm_config.llm_rate_limit_enabled or _auto_rate_limit_activated or _local_pacing()
+    async with llm_rate_limiter if pace else nullcontext():
+        try:
+            yield
+        except Exception as error:
+            if llm_config.auto_rate_limit:
+                _activate_rate_limiter_on_rate_limit(error)
+            raise
+
 
 def llm_rate_limiter_context_manager():
-    global llm_rate_limiter
-    if llm_config.llm_rate_limit_enabled:
-        return llm_rate_limiter
-    else:
-        #  Return a no-op context manager if rate limiting is disabled
-        return nullcontext()
+    return _governed_llm_dispatch()
 
 
 def embedding_rate_limiter_context_manager():

--- a/cognee/shared/rate_limiting.py
+++ b/cognee/shared/rate_limiting.py
@@ -26,28 +26,40 @@ _embedding_rate_limiter = None
 # calls in seconds to a couple of minutes and never approach this.
 SLOW_COMPLETION_SECONDS = 300.0
 
-# Set once AUTO_RATE_LIMIT reacts to overload evidence: from then on every
-# dispatch is paced by the RPM limiter above, exactly as if
-# LLM_RATE_LIMIT_ENABLED had been set.
-_auto_rate_limit_activated = False
+# When AUTO_RATE_LIMIT reacts to overload evidence, dispatch is paced by the
+# RPM limiter until this deadline; every further piece of evidence extends it.
+# Once it lapses, behavior returns to the configured state (unbounded unless
+# LLM_RATE_LIMIT_ENABLED is set) — the reaction is never stuck on forever.
+AUTO_RATE_LIMIT_COOLDOWN_SECONDS = 300.0
+
+_auto_paced_until = 0.0  # monotonic deadline of the current overload episode
 
 
 def _fall_back_to_rate_limiter(reason: str) -> None:
-    """Warn once and pace all further dispatches with the RPM limiter."""
-    global _auto_rate_limit_activated
-    if _auto_rate_limit_activated:
-        return
-    _auto_rate_limit_activated = True
-    logger.warning(
-        "LLM requests are not being processed fast enough (%s) — enabling "
-        "the RPM limiter (%d requests per %ds) for the rest of this process. "
-        "Tune LLM_RATE_LIMIT_REQUESTS / LLM_RATE_LIMIT_INTERVAL to match what "
-        "your provider or machine can handle, or set AUTO_RATE_LIMIT=false to "
-        "opt out.",
-        reason,
-        llm_config.llm_rate_limit_requests,
-        llm_config.llm_rate_limit_interval,
-    )
+    """Pace dispatches with the RPM limiter for a cooldown window.
+
+    Warns once per overload episode; further evidence inside the window
+    extends it silently, and a fresh episode after a quiet cooldown warns
+    again.
+    """
+    global _auto_paced_until
+    import time
+
+    now = time.monotonic()
+    new_episode = now >= _auto_paced_until
+    _auto_paced_until = now + AUTO_RATE_LIMIT_COOLDOWN_SECONDS
+    if new_episode:
+        logger.warning(
+            "LLM requests are not being processed fast enough (%s) — enabling "
+            "the RPM limiter (%d requests per %ds) for the next %.0fs, extended "
+            "while issues persist. Tune LLM_RATE_LIMIT_REQUESTS / "
+            "LLM_RATE_LIMIT_INTERVAL to match what your provider or machine can "
+            "handle, or set AUTO_RATE_LIMIT=false to opt out.",
+            reason,
+            llm_config.llm_rate_limit_requests,
+            llm_config.llm_rate_limit_interval,
+            AUTO_RATE_LIMIT_COOLDOWN_SECONDS,
+        )
 
 
 def _overload_evidence(error: BaseException) -> str | None:
@@ -98,31 +110,28 @@ async def _governed_llm_dispatch():
     provider cannot keep up — a completion slow enough to prove the queue is
     nearing the client timeout (detected BEFORE anything fails), a rate-limit
     error, an HTTP 503/529, or a timeout — one warning is logged and the RPM
-    limiter paces all further dispatches with the configured budget.
+    limiter paces dispatches for a cooldown window, extended while issues
+    persist; when it lapses, behavior returns to the configured state.
     LLM_RATE_LIMIT_ENABLED paces from the start, unchanged. Adapters enter
     this context manager INSIDE their tenacity retry, so retried attempts are
     paced as well.
     """
     import time
 
-    pace = llm_config.llm_rate_limit_enabled or _auto_rate_limit_activated
+    pace = llm_config.llm_rate_limit_enabled or time.monotonic() < _auto_paced_until
     async with llm_rate_limiter if pace else nullcontext():
         started = time.monotonic()
         try:
             yield
         except Exception as error:
-            if llm_config.auto_rate_limit and not _auto_rate_limit_activated:
+            if llm_config.auto_rate_limit:
                 evidence = _overload_evidence(error)
                 if evidence is not None:
                     _fall_back_to_rate_limiter(evidence)
             raise
         else:
             elapsed = time.monotonic() - started
-            if (
-                llm_config.auto_rate_limit
-                and not _auto_rate_limit_activated
-                and elapsed >= SLOW_COMPLETION_SECONDS
-            ):
+            if llm_config.auto_rate_limit and elapsed >= SLOW_COMPLETION_SECONDS:
                 _fall_back_to_rate_limiter(f"completion took {elapsed:.0f}s")
 
 

--- a/cognee/shared/rate_limiting.py
+++ b/cognee/shared/rate_limiting.py
@@ -9,6 +9,8 @@ logger = get_logger("llm_dispatch")
 
 llm_config = get_llm_config()
 
+# The budget is provider-aware: LLMConfig gives local inference servers a
+# smaller default LLM_RATE_LIMIT_REQUESTS (see default_local_rate_limit_budget).
 llm_rate_limiter = AsyncLimiter(
     llm_config.llm_rate_limit_requests, llm_config.llm_rate_limit_interval
 )
@@ -16,6 +18,7 @@ llm_rate_limiter = AsyncLimiter(
 # lazily to avoid a circular import at module load time (embedding engines, which
 # EmbeddingConfig is reached through, import this module).
 _embedding_rate_limiter = None
+
 
 # Early overload detection: a dispatch that SUCCEEDS but takes this long is
 # proof the server's queue is approaching the client timeout cliff (default

--- a/cognee/shared/rate_limiting.py
+++ b/cognee/shared/rate_limiting.py
@@ -17,91 +17,110 @@ llm_rate_limiter = AsyncLimiter(
 # EmbeddingConfig is reached through, import this module).
 _embedding_rate_limiter = None
 
-# Set once AUTO_RATE_LIMIT reacts to a provider rate limit: from then on every
+# Early overload detection: a dispatch that SUCCEEDS but takes this long is
+# proof the server's queue is approaching the client timeout cliff (default
+# 600s) — react before anything actually fails. Healthy setups complete
+# calls in seconds to a couple of minutes and never approach this.
+SLOW_COMPLETION_SECONDS = 300.0
+
+# Set once AUTO_RATE_LIMIT reacts to overload evidence: from then on every
 # dispatch is paced by the RPM limiter above, exactly as if
 # LLM_RATE_LIMIT_ENABLED had been set.
 _auto_rate_limit_activated = False
 
-# Local inference servers never report rate limits — their overload signal is
-# a slow client timeout, far too late to react to. With AUTO_RATE_LIMIT they
-# are therefore paced from the very first dispatch instead of reactively.
-_LOCAL_LLM_PROVIDERS = frozenset({"ollama", "llama_cpp"})
-_LOCAL_MODEL_PREFIXES = ("lm_studio/", "hosted_vllm/", "vllm/")
-_local_pacing_active: bool | None = None  # resolved lazily on first dispatch
 
-
-def _local_pacing() -> bool:
-    """Pace local LLM servers up front (once, with a warning explaining why)."""
-    global _local_pacing_active
-    if _local_pacing_active is None:
-        provider = (llm_config.llm_provider or "").lower()
-        model = (llm_config.llm_model or "").lower()
-        is_local = provider in _LOCAL_LLM_PROVIDERS or model.startswith(_LOCAL_MODEL_PREFIXES)
-        _local_pacing_active = llm_config.auto_rate_limit and is_local
-        if _local_pacing_active:
-            logger.warning(
-                "Local LLM provider detected (%s / %s) — enabling the RPM limiter "
-                "(%d requests per %ds) up front, because local servers cannot absorb "
-                "unbounded request floods and never report rate limits themselves. "
-                "Tune LLM_RATE_LIMIT_REQUESTS / LLM_RATE_LIMIT_INTERVAL to match your "
-                "machine's real throughput, or set AUTO_RATE_LIMIT=false to disable "
-                "this behavior.",
-                llm_config.llm_provider,
-                llm_config.llm_model,
-                llm_config.llm_rate_limit_requests,
-                llm_config.llm_rate_limit_interval,
-            )
-    return _local_pacing_active
-
-
-def _activate_rate_limiter_on_rate_limit(error: BaseException) -> None:
-    """Warn and switch on the RPM limiter if the error (or its cause) is a rate limit.
-
-    Wrappers hide the signal — instructor re-raises provider errors inside
-    InstructorRetryException — so the cause chain is checked, not just the
-    top-level type. openai.RateLimitError covers every client stack: litellm's
-    exceptions subclass it, and SDK-direct adapters raise it natively.
-    """
+def _fall_back_to_rate_limiter(reason: str) -> None:
+    """Warn once and pace all further dispatches with the RPM limiter."""
     global _auto_rate_limit_activated
+    if _auto_rate_limit_activated:
+        return
+    _auto_rate_limit_activated = True
+    logger.warning(
+        "LLM requests are not being processed fast enough (%s) — enabling "
+        "the RPM limiter (%d requests per %ds) for the rest of this process. "
+        "Tune LLM_RATE_LIMIT_REQUESTS / LLM_RATE_LIMIT_INTERVAL to match what "
+        "your provider or machine can handle, or set AUTO_RATE_LIMIT=false to "
+        "opt out.",
+        reason,
+        llm_config.llm_rate_limit_requests,
+        llm_config.llm_rate_limit_interval,
+    )
+
+
+def _overload_evidence(error: BaseException) -> str | None:
+    """Name the overload cause in ``error``'s chain, or None.
+
+    Overload evidence is a rate-limit error (cloud providers), a timeout (how
+    overwhelmed local servers usually surface — they never send rate limits),
+    or an HTTP 503/529 overload status (Ollama past its queue cap, Anthropic
+    overloaded). Wrappers hide the signal — instructor re-raises provider
+    errors inside InstructorRetryException — so the cause chain is checked,
+    not just the top-level type. The openai base classes cover every client
+    stack: litellm's exceptions subclass them, and SDK-direct adapters raise
+    them natively.
+    """
+    import asyncio
+
     import openai
 
+    overload_types = (
+        openai.RateLimitError,
+        openai.APITimeoutError,
+        asyncio.TimeoutError,
+        TimeoutError,
+    )
+    # Server-overload statuses that arrive as plain HTTP errors: 503 (service
+    # unavailable — e.g. Ollama's queue-full reply) and 529 (Anthropic overloaded).
+    overload_statuses = frozenset({503, 529})
     seen: set = set()
     node: BaseException | None = error
     while node is not None and id(node) not in seen and len(seen) < 20:
-        if isinstance(node, openai.RateLimitError):
-            if not _auto_rate_limit_activated:
-                _auto_rate_limit_activated = True
-                logger.warning(
-                    "LLM provider reported a rate limit — enabling the RPM limiter "
-                    "(%d requests per %ds) for the rest of this process. Tune with "
-                    "LLM_RATE_LIMIT_REQUESTS / LLM_RATE_LIMIT_INTERVAL, or set "
-                    "AUTO_RATE_LIMIT=false to opt out.",
-                    llm_config.llm_rate_limit_requests,
-                    llm_config.llm_rate_limit_interval,
-                )
-            return
+        if isinstance(node, overload_types):
+            return type(node).__name__
+        if (
+            isinstance(node, openai.APIStatusError)
+            and getattr(node, "status_code", None) in overload_statuses
+        ):
+            return f"HTTP {node.status_code}"
         seen.add(id(node))
         node = node.__cause__ or node.__context__
+    return None
 
 
 @asynccontextmanager
 async def _governed_llm_dispatch():
     """Gate one LLM dispatch attempt.
 
-    Cloud is unbounded by default; the RPM limiter paces when
-    LLM_RATE_LIMIT_ENABLED is set, when AUTO_RATE_LIMIT (default on) reacted
-    to a provider rate limit, or from the start for local inference servers.
-    Adapters enter this context manager INSIDE their tenacity retry, so
-    retried attempts are paced as well.
+    Everything runs unbounded (the fast path). When there is evidence the
+    provider cannot keep up — a completion slow enough to prove the queue is
+    nearing the client timeout (detected BEFORE anything fails), a rate-limit
+    error, an HTTP 503/529, or a timeout — one warning is logged and the RPM
+    limiter paces all further dispatches with the configured budget.
+    LLM_RATE_LIMIT_ENABLED paces from the start, unchanged. Adapters enter
+    this context manager INSIDE their tenacity retry, so retried attempts are
+    paced as well.
     """
-    pace = llm_config.llm_rate_limit_enabled or _auto_rate_limit_activated or _local_pacing()
+    import time
+
+    pace = llm_config.llm_rate_limit_enabled or _auto_rate_limit_activated
     async with llm_rate_limiter if pace else nullcontext():
+        started = time.monotonic()
         try:
             yield
         except Exception as error:
-            if llm_config.auto_rate_limit:
-                _activate_rate_limiter_on_rate_limit(error)
+            if llm_config.auto_rate_limit and not _auto_rate_limit_activated:
+                evidence = _overload_evidence(error)
+                if evidence is not None:
+                    _fall_back_to_rate_limiter(evidence)
             raise
+        else:
+            elapsed = time.monotonic() - started
+            if (
+                llm_config.auto_rate_limit
+                and not _auto_rate_limit_activated
+                and elapsed >= SLOW_COMPLETION_SECONDS
+            ):
+                _fall_back_to_rate_limiter(f"completion took {elapsed:.0f}s")
 
 
 def llm_rate_limiter_context_manager():

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -19,7 +19,6 @@ from cognee.modules.graph.utils import (
 from cognee.shared.data_models import KnowledgeGraph
 from cognee.infrastructure.llm.extraction import extract_content_graph
 from cognee.infrastructure.llm.pipeline_stage import pipeline_stage
-from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.engine import DataPoint
 from cognee.tasks.graph.exceptions import (
     InvalidGraphModelError,
@@ -27,8 +26,6 @@ from cognee.tasks.graph.exceptions import (
     InvalidChunkGraphInputError,
     InvalidOntologyAdapterError,
 )
-
-logger = get_logger("extract_graph_from_data")
 
 
 def _stamp_provenance_deep(data, pipeline_name, task_name, visited=None):
@@ -174,22 +171,13 @@ async def extract_graph_from_data(
         chunk_graphs = await extracted if inspect.isawaitable(extracted) else extracted
     else:
         with pipeline_stage("extraction"):
-            total = len(non_dlt_chunks)
-            log_every = max(1, total // 10)
-            completed = 0
-
-            async def _extract_with_progress(chunk):
-                nonlocal completed
-                graph = await extract_content_graph(
-                    chunk.text, graph_model, custom_prompt=custom_prompt, **kwargs
-                )
-                completed += 1
-                if completed % log_every == 0 or completed == total:
-                    logger.info("Graph extraction progress: %d/%d chunks", completed, total)
-                return graph
-
             chunk_graphs = await asyncio.gather(
-                *[_extract_with_progress(chunk) for chunk in non_dlt_chunks]
+                *[
+                    extract_content_graph(
+                        chunk.text, graph_model, custom_prompt=custom_prompt, **kwargs
+                    )
+                    for chunk in non_dlt_chunks
+                ]
             )
     cache_entity_embeddings = kwargs.get("cache_entity_embeddings")
     if callable(cache_entity_embeddings):

--- a/cognee/tasks/graph/extract_graph_from_data.py
+++ b/cognee/tasks/graph/extract_graph_from_data.py
@@ -19,6 +19,7 @@ from cognee.modules.graph.utils import (
 from cognee.shared.data_models import KnowledgeGraph
 from cognee.infrastructure.llm.extraction import extract_content_graph
 from cognee.infrastructure.llm.pipeline_stage import pipeline_stage
+from cognee.shared.logging_utils import get_logger
 from cognee.infrastructure.engine import DataPoint
 from cognee.tasks.graph.exceptions import (
     InvalidGraphModelError,
@@ -26,6 +27,8 @@ from cognee.tasks.graph.exceptions import (
     InvalidChunkGraphInputError,
     InvalidOntologyAdapterError,
 )
+
+logger = get_logger("extract_graph_from_data")
 
 
 def _stamp_provenance_deep(data, pipeline_name, task_name, visited=None):
@@ -171,13 +174,22 @@ async def extract_graph_from_data(
         chunk_graphs = await extracted if inspect.isawaitable(extracted) else extracted
     else:
         with pipeline_stage("extraction"):
+            total = len(non_dlt_chunks)
+            log_every = max(1, total // 10)
+            completed = 0
+
+            async def _extract_with_progress(chunk):
+                nonlocal completed
+                graph = await extract_content_graph(
+                    chunk.text, graph_model, custom_prompt=custom_prompt, **kwargs
+                )
+                completed += 1
+                if completed % log_every == 0 or completed == total:
+                    logger.info("Graph extraction progress: %d/%d chunks", completed, total)
+                return graph
+
             chunk_graphs = await asyncio.gather(
-                *[
-                    extract_content_graph(
-                        chunk.text, graph_model, custom_prompt=custom_prompt, **kwargs
-                    )
-                    for chunk in non_dlt_chunks
-                ]
+                *[_extract_with_progress(chunk) for chunk in non_dlt_chunks]
             )
     cache_entity_embeddings = kwargs.get("cache_entity_embeddings")
     if callable(cache_entity_embeddings):

--- a/cognee/tests/unit/infrastructure/llm/test_bedrock_overload_wiring.py
+++ b/cognee/tests/unit/infrastructure/llm/test_bedrock_overload_wiring.py
@@ -1,0 +1,90 @@
+"""Wiring test: BedrockAdapter dispatches through the pacing seam.
+
+The overload policy only sees errors raised inside
+``llm_rate_limiter_context_manager()``; this locks the Bedrock adapter to that
+seam so a recognized overload error paces the attempts that follow.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import openai
+import pytest
+from pydantic import BaseModel
+
+import cognee.infrastructure.llm.config as llm_config_module
+import cognee.infrastructure.llm.overload_policy as overload_policy_module
+from cognee.infrastructure.llm.overload_policy import OverloadPolicy
+from cognee.infrastructure.llm.structured_output_framework.litellm_instructor.llm.bedrock.adapter import (
+    BedrockAdapter,
+)
+from cognee.shared import rate_limiting
+from cognee.shared.rate_limiting import llm_rate_limiter_context_manager
+
+
+class PacerSpy:
+    def __init__(self):
+        self.entered = 0
+
+    async def __aenter__(self):
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+@pytest.fixture
+def seam(monkeypatch):
+    policy = OverloadPolicy()
+    monkeypatch.setattr(overload_policy_module, "llm_overload_policy", policy)
+    spy = PacerSpy()
+    monkeypatch.setattr(rate_limiting, "_llm_rate_limiter", spy)
+    monkeypatch.setattr(
+        llm_config_module,
+        "get_llm_config",
+        lambda: SimpleNamespace(
+            llm_rate_limit_enabled=False,
+            auto_rate_limit=True,
+            llm_rate_limit_requests=60,
+            llm_rate_limit_interval=60,
+        ),
+    )
+    return SimpleNamespace(policy=policy, spy=spy)
+
+
+class _Answer(BaseModel):
+    text: str
+
+
+def _rate_limit_error() -> openai.RateLimitError:
+    response = httpx.Response(429, request=httpx.Request("POST", "http://api.test"))
+    return openai.RateLimitError("rate limited", response=response, body=None)
+
+
+def _unwrapped(fn):
+    """The undecorated method body — skips tenacity's real backoff waits."""
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+@pytest.mark.asyncio
+async def test_bedrock_overload_error_reaches_policy_and_paces_next_dispatch(seam, monkeypatch):
+    adapter = BedrockAdapter(model="anthropic.claude-3-haiku", api_key="test-key")
+    monkeypatch.setattr(
+        adapter.aclient.chat.completions,
+        "create",
+        AsyncMock(side_effect=_rate_limit_error()),
+    )
+
+    body = _unwrapped(BedrockAdapter.acreate_structured_output)
+    with pytest.raises(openai.RateLimitError):
+        await body(adapter, "text", "prompt", _Answer)
+
+    assert seam.policy.is_paced() is True
+
+    async with llm_rate_limiter_context_manager():
+        pass
+    assert seam.spy.entered == 1  # the episode paces subsequent dispatches

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
@@ -1,0 +1,36 @@
+"""Tests for LLMConfig.default_local_rate_limit_budget (provider-aware RPM default)."""
+
+import pytest
+
+from cognee.infrastructure.llm.config import LOCAL_DEFAULT_RATE_LIMIT_REQUESTS, LLMConfig
+
+
+def _build(**kwargs):
+    defaults = dict(llm_api_key="test-key", llm_endpoint="http://localhost:11434/v1")
+    defaults.update(kwargs)
+    return LLMConfig(**defaults)
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("ollama", "phi4:latest"),
+        ("llama_cpp", "some-model"),
+        ("custom", "lm_studio/qwen2.5-7b"),
+        ("custom", "hosted_vllm/meta-llama/Llama-3-70B"),
+        ("custom", "vllm/some-model"),
+    ],
+)
+def test_local_providers_default_to_small_budget(provider, model):
+    config = _build(llm_provider=provider, llm_model=model)
+    assert config.llm_rate_limit_requests == LOCAL_DEFAULT_RATE_LIMIT_REQUESTS
+
+
+def test_cloud_providers_keep_regular_default():
+    config = _build(llm_provider="openai", llm_model="openai/gpt-5-mini")
+    assert config.llm_rate_limit_requests == 60
+
+
+def test_explicit_setting_wins_over_local_default():
+    config = _build(llm_provider="ollama", llm_model="phi4:latest", llm_rate_limit_requests=90)
+    assert config.llm_rate_limit_requests == 90

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
@@ -17,8 +17,6 @@ def _build(**kwargs):
         ("ollama", "phi4:latest"),
         ("llama_cpp", "some-model"),
         ("custom", "lm_studio/qwen2.5-7b"),
-        ("custom", "hosted_vllm/meta-llama/Llama-3-70B"),
-        ("custom", "vllm/some-model"),
     ],
 )
 def test_local_providers_default_to_small_budget(provider, model):
@@ -26,8 +24,16 @@ def test_local_providers_default_to_small_budget(provider, model):
     assert config.llm_rate_limit_requests == LOCAL_DEFAULT_RATE_LIMIT_REQUESTS
 
 
-def test_cloud_providers_keep_regular_default():
-    config = _build(llm_provider="openai", llm_model="openai/gpt-5-mini")
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("openai", "openai/gpt-5-mini"),
+        ("custom", "hosted_vllm/meta-llama/Llama-3-70B"),  # vLLM batches like a cloud endpoint
+        ("custom", "vllm/some-model"),
+    ],
+)
+def test_regular_providers_keep_regular_default(provider, model):
+    config = _build(llm_provider=provider, llm_model=model)
     assert config.llm_rate_limit_requests == 60
 
 
@@ -42,7 +48,7 @@ def test_explicit_setting_wins_over_local_default():
         ("ollama", "phi4:latest", True),
         ("llama_cpp", "some-model", True),
         ("custom", "lm_studio/qwen2.5-7b", True),
-        ("custom", "hosted_vllm/meta-llama/Llama-3-70B", True),
+        ("custom", "hosted_vllm/meta-llama/Llama-3-70B", False),
         ("openai", "openai/gpt-5-mini", False),
         (None, None, False),
     ],

--- a/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_config_rate_limit_defaults.py
@@ -34,3 +34,20 @@ def test_cloud_providers_keep_regular_default():
 def test_explicit_setting_wins_over_local_default():
     config = _build(llm_provider="ollama", llm_model="phi4:latest", llm_rate_limit_requests=90)
     assert config.llm_rate_limit_requests == 90
+
+
+@pytest.mark.parametrize(
+    ("provider", "model", "expected"),
+    [
+        ("ollama", "phi4:latest", True),
+        ("llama_cpp", "some-model", True),
+        ("custom", "lm_studio/qwen2.5-7b", True),
+        ("custom", "hosted_vllm/meta-llama/Llama-3-70B", True),
+        ("openai", "openai/gpt-5-mini", False),
+        (None, None, False),
+    ],
+)
+def test_is_local_llm(provider, model, expected):
+    from cognee.infrastructure.llm.config import is_local_llm
+
+    assert is_local_llm(provider, model) is expected

--- a/cognee/tests/unit/infrastructure/llm/test_overload_policy.py
+++ b/cognee/tests/unit/infrastructure/llm/test_overload_policy.py
@@ -1,0 +1,116 @@
+"""Tests for the LLM overload policy: evidence taxonomy and cooldown episodes."""
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import httpx
+import openai
+import pytest
+
+import cognee.infrastructure.llm.overload_policy as overload_policy_module
+from cognee.infrastructure.llm.overload_policy import OverloadPolicy, overload_evidence
+
+
+def _rate_limit_error() -> openai.RateLimitError:
+    response = httpx.Response(429, request=httpx.Request("POST", "http://api.test"))
+    return openai.RateLimitError("rate limited", response=response, body=None)
+
+
+def _timeout_error() -> openai.APITimeoutError:
+    return openai.APITimeoutError(request=httpx.Request("POST", "http://api.test"))
+
+
+def _status_error(status: int) -> openai.APIStatusError:
+    response = httpx.Response(status, request=httpx.Request("POST", "http://api.test"))
+    return openai.APIStatusError("overloaded", response=response, body=None)
+
+
+# --------------------------------------------------------------------------- #
+# Evidence taxonomy
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (_rate_limit_error(), "RateLimitError"),
+        (_timeout_error(), "APITimeoutError"),
+        (asyncio.TimeoutError(), "TimeoutError"),
+        (_status_error(503), "HTTP 503"),
+        (_status_error(529), "HTTP 529"),
+    ],
+)
+def test_overload_evidence_names_the_cause(error, expected):
+    assert overload_evidence(error) == expected
+
+
+def test_overload_evidence_sees_through_wrappers():
+    wrapper = RuntimeError("instructor wrapper")  # errors arrive wrapped in practice
+    wrapper.__cause__ = RuntimeError("retry wrapper")
+    wrapper.__cause__.__cause__ = _rate_limit_error()
+    assert overload_evidence(wrapper) == "RateLimitError"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [ValueError("schema mismatch"), _status_error(500)],
+)
+def test_ordinary_errors_are_not_evidence(error):
+    assert overload_evidence(error) is None
+
+
+# --------------------------------------------------------------------------- #
+# Policy episodes
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def warnings(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        overload_policy_module,
+        "logger",
+        SimpleNamespace(warning=lambda message, *args: captured.append(message % args)),
+    )
+    return captured
+
+
+def test_unpaced_until_evidence(warnings):
+    policy = OverloadPolicy()
+    assert policy.is_paced() is False
+
+    policy.on_error(ValueError("not overload"))
+    assert policy.is_paced() is False
+    assert warnings == []
+
+
+def test_overload_error_starts_a_warned_episode(warnings):
+    policy = OverloadPolicy()
+    policy.on_error(_rate_limit_error())
+    assert policy.is_paced() is True
+    assert len(warnings) == 1 and "not being processed fast enough" in warnings[0]
+
+
+def test_evidence_extends_episode_without_rewarning(warnings):
+    policy = OverloadPolicy(cooldown_seconds=5.0)
+    policy.on_error(_rate_limit_error())
+    first_deadline = policy._paced_until
+
+    time.sleep(0.01)
+    policy.on_error(_timeout_error())
+    assert policy._paced_until > first_deadline
+    assert len(warnings) == 1  # same episode: one warning
+
+
+def test_episode_lapses_and_a_fresh_one_rewarns(warnings):
+    policy = OverloadPolicy(cooldown_seconds=0.05)
+    policy.on_error(_rate_limit_error())
+    assert policy.is_paced() is True
+
+    time.sleep(0.06)
+    assert policy.is_paced() is False  # lapsed back to the configured state
+
+    policy.on_error(_rate_limit_error())
+    assert policy.is_paced() is True
+    assert len(warnings) == 2  # fresh episode warns again

--- a/cognee/tests/unit/infrastructure/llm/test_overload_policy.py
+++ b/cognee/tests/unit/infrastructure/llm/test_overload_policy.py
@@ -89,7 +89,7 @@ def test_overload_error_starts_a_warned_episode(warnings):
     policy = OverloadPolicy()
     policy.on_error(_rate_limit_error())
     assert policy.is_paced() is True
-    assert len(warnings) == 1 and "not being processed fast enough" in warnings[0]
+    assert len(warnings) == 1 and "Potential RPM issues detected" in warnings[0]
 
 
 def test_evidence_extends_episode_without_rewarning(warnings):

--- a/cognee/tests/unit/infrastructure/llm/test_overload_policy.py
+++ b/cognee/tests/unit/infrastructure/llm/test_overload_policy.py
@@ -114,3 +114,66 @@ def test_episode_lapses_and_a_fresh_one_rewarns(warnings):
     policy.on_error(_rate_limit_error())
     assert policy.is_paced() is True
     assert len(warnings) == 2  # fresh episode warns again
+
+
+# --------------------------------------------------------------------------- #
+# Provider-neutral evidence: native SDK errors outside the openai hierarchy
+# --------------------------------------------------------------------------- #
+
+
+class _DuckStatusError(Exception):
+    """Any exception exposing status_code, like every provider SDK's errors."""
+
+    def __init__(self, status_code: int):
+        super().__init__(f"status {status_code}")
+        self.status_code = status_code
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [(429, "HTTP 429"), (503, "HTTP 503"), (529, "HTTP 529"), (500, None), (400, None)],
+)
+def test_status_codes_are_recognized_on_any_exception(status, expected):
+    assert overload_evidence(_DuckStatusError(status)) == expected
+
+
+def test_httpx_timeout_is_evidence():
+    assert overload_evidence(httpx.ReadTimeout("read timed out")) == "ReadTimeout"
+
+
+def _native_anthropic_errors():
+    """Native Anthropic errors, built the way the SDK raises them."""
+    anthropic = pytest.importorskip("anthropic")
+    request = httpx.Request("POST", "http://api.test")
+
+    def status_error(status: int, cls):
+        return cls("overloaded", response=httpx.Response(status, request=request), body=None)
+
+    # The SDK raises APITimeoutError `from` the underlying httpx timeout;
+    # evidence detection walks the cause chain to the transport error.
+    timeout = anthropic.APITimeoutError(request=request)
+    timeout.__cause__ = httpx.ConnectTimeout("connect timed out")
+
+    return [
+        (status_error(429, anthropic.RateLimitError), "HTTP 429"),
+        (status_error(503, anthropic.APIStatusError), "HTTP 503"),
+        (status_error(529, anthropic.APIStatusError), "HTTP 529"),
+        (timeout, "ConnectTimeout"),
+        (status_error(400, anthropic.APIStatusError), None),
+    ]
+
+
+def test_native_anthropic_errors_are_recognized():
+    for error, expected in _native_anthropic_errors():
+        assert overload_evidence(error) == expected, type(error).__name__
+
+
+def test_instructor_wrapped_native_anthropic_error_is_recognized():
+    anthropic = pytest.importorskip("anthropic")
+    request = httpx.Request("POST", "http://api.test")
+    native = anthropic.RateLimitError(
+        "rate limited", response=httpx.Response(429, request=request), body=None
+    )
+    wrapper = RuntimeError("instructor wrapper")  # instructor re-raises with the cause chained
+    wrapper.__cause__ = native
+    assert overload_evidence(wrapper) == "HTTP 429"

--- a/cognee/tests/unit/shared/test_auto_rate_limit.py
+++ b/cognee/tests/unit/shared/test_auto_rate_limit.py
@@ -31,6 +31,9 @@ def _config(**overrides):
         auto_rate_limit=True,
         llm_rate_limit_requests=60,
         llm_rate_limit_interval=60,
+        llm_provider="openai",
+        llm_model="openai/gpt-5-mini",
+        model_fields_set=set(),
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)

--- a/cognee/tests/unit/shared/test_auto_rate_limit.py
+++ b/cognee/tests/unit/shared/test_auto_rate_limit.py
@@ -1,6 +1,6 @@
-"""Tests for AUTO_RATE_LIMIT: unbounded dispatch until a provider rate limit."""
+"""Tests for AUTO_RATE_LIMIT: full speed until overload, then warn and enable the RPM limiter."""
 
-from contextlib import asynccontextmanager
+import asyncio
 from types import SimpleNamespace
 
 import httpx
@@ -17,11 +17,6 @@ class PacerSpy:
     def __init__(self):
         self.entered = 0
 
-    @asynccontextmanager
-    async def _cm(self):
-        self.entered += 1
-        yield
-
     async def __aenter__(self):
         self.entered += 1
         return self
@@ -36,8 +31,6 @@ def _config(**overrides):
         auto_rate_limit=True,
         llm_rate_limit_requests=60,
         llm_rate_limit_interval=60,
-        llm_provider="openai",
-        llm_model="openai/gpt-5-mini",
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -45,9 +38,8 @@ def _config(**overrides):
 
 @pytest.fixture(autouse=True)
 def fresh_state(monkeypatch):
-    """Reset activation; default config: cloud provider, rate limiting off, auto on."""
+    """Reset activation; default config: rate limiting off, auto fallback on."""
     monkeypatch.setattr(rate_limiting, "_auto_rate_limit_activated", False)
-    monkeypatch.setattr(rate_limiting, "_local_pacing_active", None)
     monkeypatch.setattr(rate_limiting, "llm_config", _config())
     spy = PacerSpy()
     monkeypatch.setattr(rate_limiting, "llm_rate_limiter", spy)
@@ -59,16 +51,37 @@ def _rate_limit_error() -> openai.RateLimitError:
     return openai.RateLimitError("rate limited", response=response, body=None)
 
 
+def _timeout_error() -> openai.APITimeoutError:
+    return openai.APITimeoutError(request=httpx.Request("POST", "http://api.test"))
+
+
+def _status_error(status: int) -> openai.APIStatusError:
+    response = httpx.Response(status, request=httpx.Request("POST", "http://api.test"))
+    return openai.APIStatusError("overloaded", response=response, body=None)
+
+
 @pytest.mark.asyncio
-async def test_unbounded_and_unpaced_by_default(fresh_state):
+async def test_full_speed_by_default(fresh_state):
     async with llm_rate_limiter_context_manager():
         pass
     assert fresh_state.entered == 0
     assert rate_limiting._auto_rate_limit_activated is False
 
 
+@pytest.mark.parametrize(
+    ("overload_error", "expected_name"),
+    [
+        (_rate_limit_error(), "RateLimitError"),
+        (_timeout_error(), "APITimeoutError"),
+        (asyncio.TimeoutError(), "TimeoutError"),
+        (_status_error(503), "HTTP 503"),
+        (_status_error(529), "HTTP 529"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_rate_limit_error_activates_pacing_with_warning(fresh_state, monkeypatch):
+async def test_overload_enables_rate_limiter_with_warning(
+    fresh_state, monkeypatch, overload_error, expected_name
+):
     warnings = []
     monkeypatch.setattr(
         rate_limiting,
@@ -78,15 +91,17 @@ async def test_rate_limit_error_activates_pacing_with_warning(fresh_state, monke
 
     # Wrapped the way instructor surfaces provider errors: via the cause chain.
     wrapper = RuntimeError("instructor wrapper")
-    wrapper.__cause__ = _rate_limit_error()
+    wrapper.__cause__ = overload_error
     with pytest.raises(RuntimeError):
         async with llm_rate_limiter_context_manager():
             raise wrapper
 
     assert rate_limiting._auto_rate_limit_activated is True
-    assert len(warnings) == 1 and "rate limit" in warnings[0]
+    assert len(warnings) == 1
+    assert "not being processed fast enough" in warnings[0]
+    assert expected_name in warnings[0]
 
-    # Subsequent dispatches are paced; a repeat rate limit does not re-warn.
+    # Subsequent dispatches are paced; repeat overload does not re-warn.
     with pytest.raises(openai.RateLimitError):
         async with llm_rate_limiter_context_manager():
             raise _rate_limit_error()
@@ -95,74 +110,45 @@ async def test_rate_limit_error_activates_pacing_with_warning(fresh_state, monke
 
 
 @pytest.mark.asyncio
-async def test_auto_rate_limit_disabled_never_activates(fresh_state, monkeypatch):
-    monkeypatch.setattr(rate_limiting, "llm_config", _config(auto_rate_limit=False))
-    with pytest.raises(openai.RateLimitError):
-        async with llm_rate_limiter_context_manager():
-            raise _rate_limit_error()
-    assert rate_limiting._auto_rate_limit_activated is False
-    assert fresh_state.entered == 0
-
-
-@pytest.mark.parametrize(
-    ("provider", "model"),
-    [
-        ("ollama", "phi4:latest"),
-        ("llama_cpp", "some-model"),
-        ("custom", "lm_studio/qwen2.5-7b"),
-        ("custom", "hosted_vllm/meta-llama/Llama-3-70B"),
-    ],
-)
-@pytest.mark.asyncio
-async def test_local_provider_paced_from_first_dispatch(fresh_state, monkeypatch, provider, model):
+async def test_slow_completion_enables_rate_limiter_before_any_failure(fresh_state, monkeypatch):
+    monkeypatch.setattr(rate_limiting, "SLOW_COMPLETION_SECONDS", 0.05)
     warnings = []
     monkeypatch.setattr(
         rate_limiting,
         "logger",
         SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
     )
-    monkeypatch.setattr(
-        rate_limiting, "llm_config", _config(llm_provider=provider, llm_model=model)
-    )
-
     async with llm_rate_limiter_context_manager():
-        pass
-    assert fresh_state.entered == 1  # paced immediately, no error needed
-    assert len(warnings) == 1 and "Local LLM provider detected" in warnings[0]
-
-    async with llm_rate_limiter_context_manager():
-        pass
-    assert fresh_state.entered == 2
-    assert len(warnings) == 1  # warned exactly once
+        await asyncio.sleep(0.06)  # a successful but dangerously slow call
+    assert rate_limiting._auto_rate_limit_activated is True
+    assert len(warnings) == 1 and "completion took" in warnings[0]
 
 
 @pytest.mark.asyncio
-async def test_local_pacing_disabled_by_auto_rate_limit_flag(fresh_state, monkeypatch):
-    monkeypatch.setattr(
-        rate_limiting,
-        "llm_config",
-        _config(llm_provider="ollama", llm_model="phi4:latest", auto_rate_limit=False),
-    )
-    async with llm_rate_limiter_context_manager():
-        pass
+async def test_auto_rate_limit_disabled_never_activates(fresh_state, monkeypatch):
+    monkeypatch.setattr(rate_limiting, "llm_config", _config(auto_rate_limit=False))
+    for error in (_rate_limit_error(), _timeout_error(), _status_error(503)):
+        with pytest.raises(type(error)):
+            async with llm_rate_limiter_context_manager():
+                raise error
+    assert rate_limiting._auto_rate_limit_activated is False
     assert fresh_state.entered == 0
 
 
 @pytest.mark.asyncio
-async def test_non_rate_limit_errors_do_not_activate(fresh_state):
+async def test_ordinary_errors_do_not_activate(fresh_state):
     with pytest.raises(ValueError):
         async with llm_rate_limiter_context_manager():
             raise ValueError("schema mismatch")
+    with pytest.raises(openai.APIStatusError):
+        async with llm_rate_limiter_context_manager():
+            raise _status_error(500)  # a plain server error is not overload evidence
     assert rate_limiting._auto_rate_limit_activated is False
 
 
 @pytest.mark.asyncio
 async def test_explicit_rate_limit_setting_paces_from_the_start(fresh_state, monkeypatch):
-    monkeypatch.setattr(
-        rate_limiting,
-        "llm_config",
-        SimpleNamespace(llm_rate_limit_enabled=True, auto_rate_limit=True),
-    )
+    monkeypatch.setattr(rate_limiting, "llm_config", _config(llm_rate_limit_enabled=True))
     async with llm_rate_limiter_context_manager():
         pass
     assert fresh_state.entered == 1

--- a/cognee/tests/unit/shared/test_auto_rate_limit.py
+++ b/cognee/tests/unit/shared/test_auto_rate_limit.py
@@ -1,0 +1,168 @@
+"""Tests for AUTO_RATE_LIMIT: unbounded dispatch until a provider rate limit."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import httpx
+import openai
+import pytest
+
+from cognee.shared import rate_limiting
+from cognee.shared.rate_limiting import llm_rate_limiter_context_manager
+
+
+class PacerSpy:
+    """Stands in for the AsyncLimiter; records whether pacing was applied."""
+
+    def __init__(self):
+        self.entered = 0
+
+    @asynccontextmanager
+    async def _cm(self):
+        self.entered += 1
+        yield
+
+    async def __aenter__(self):
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _config(**overrides):
+    defaults = dict(
+        llm_rate_limit_enabled=False,
+        auto_rate_limit=True,
+        llm_rate_limit_requests=60,
+        llm_rate_limit_interval=60,
+        llm_provider="openai",
+        llm_model="openai/gpt-5-mini",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def fresh_state(monkeypatch):
+    """Reset activation; default config: cloud provider, rate limiting off, auto on."""
+    monkeypatch.setattr(rate_limiting, "_auto_rate_limit_activated", False)
+    monkeypatch.setattr(rate_limiting, "_local_pacing_active", None)
+    monkeypatch.setattr(rate_limiting, "llm_config", _config())
+    spy = PacerSpy()
+    monkeypatch.setattr(rate_limiting, "llm_rate_limiter", spy)
+    return spy
+
+
+def _rate_limit_error() -> openai.RateLimitError:
+    response = httpx.Response(429, request=httpx.Request("POST", "http://api.test"))
+    return openai.RateLimitError("rate limited", response=response, body=None)
+
+
+@pytest.mark.asyncio
+async def test_unbounded_and_unpaced_by_default(fresh_state):
+    async with llm_rate_limiter_context_manager():
+        pass
+    assert fresh_state.entered == 0
+    assert rate_limiting._auto_rate_limit_activated is False
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_error_activates_pacing_with_warning(fresh_state, monkeypatch):
+    warnings = []
+    monkeypatch.setattr(
+        rate_limiting,
+        "logger",
+        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
+    )
+
+    # Wrapped the way instructor surfaces provider errors: via the cause chain.
+    wrapper = RuntimeError("instructor wrapper")
+    wrapper.__cause__ = _rate_limit_error()
+    with pytest.raises(RuntimeError):
+        async with llm_rate_limiter_context_manager():
+            raise wrapper
+
+    assert rate_limiting._auto_rate_limit_activated is True
+    assert len(warnings) == 1 and "rate limit" in warnings[0]
+
+    # Subsequent dispatches are paced; a repeat rate limit does not re-warn.
+    with pytest.raises(openai.RateLimitError):
+        async with llm_rate_limiter_context_manager():
+            raise _rate_limit_error()
+    assert fresh_state.entered == 1
+    assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_rate_limit_disabled_never_activates(fresh_state, monkeypatch):
+    monkeypatch.setattr(rate_limiting, "llm_config", _config(auto_rate_limit=False))
+    with pytest.raises(openai.RateLimitError):
+        async with llm_rate_limiter_context_manager():
+            raise _rate_limit_error()
+    assert rate_limiting._auto_rate_limit_activated is False
+    assert fresh_state.entered == 0
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("ollama", "phi4:latest"),
+        ("llama_cpp", "some-model"),
+        ("custom", "lm_studio/qwen2.5-7b"),
+        ("custom", "hosted_vllm/meta-llama/Llama-3-70B"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_local_provider_paced_from_first_dispatch(fresh_state, monkeypatch, provider, model):
+    warnings = []
+    monkeypatch.setattr(
+        rate_limiting,
+        "logger",
+        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
+    )
+    monkeypatch.setattr(
+        rate_limiting, "llm_config", _config(llm_provider=provider, llm_model=model)
+    )
+
+    async with llm_rate_limiter_context_manager():
+        pass
+    assert fresh_state.entered == 1  # paced immediately, no error needed
+    assert len(warnings) == 1 and "Local LLM provider detected" in warnings[0]
+
+    async with llm_rate_limiter_context_manager():
+        pass
+    assert fresh_state.entered == 2
+    assert len(warnings) == 1  # warned exactly once
+
+
+@pytest.mark.asyncio
+async def test_local_pacing_disabled_by_auto_rate_limit_flag(fresh_state, monkeypatch):
+    monkeypatch.setattr(
+        rate_limiting,
+        "llm_config",
+        _config(llm_provider="ollama", llm_model="phi4:latest", auto_rate_limit=False),
+    )
+    async with llm_rate_limiter_context_manager():
+        pass
+    assert fresh_state.entered == 0
+
+
+@pytest.mark.asyncio
+async def test_non_rate_limit_errors_do_not_activate(fresh_state):
+    with pytest.raises(ValueError):
+        async with llm_rate_limiter_context_manager():
+            raise ValueError("schema mismatch")
+    assert rate_limiting._auto_rate_limit_activated is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_rate_limit_setting_paces_from_the_start(fresh_state, monkeypatch):
+    monkeypatch.setattr(
+        rate_limiting,
+        "llm_config",
+        SimpleNamespace(llm_rate_limit_enabled=True, auto_rate_limit=True),
+    )
+    async with llm_rate_limiter_context_manager():
+        pass
+    assert fresh_state.entered == 1

--- a/cognee/tests/unit/shared/test_auto_rate_limit.py
+++ b/cognee/tests/unit/shared/test_auto_rate_limit.py
@@ -42,7 +42,7 @@ def _config(**overrides):
 @pytest.fixture(autouse=True)
 def fresh_state(monkeypatch):
     """Reset activation; default config: rate limiting off, auto fallback on."""
-    monkeypatch.setattr(rate_limiting, "_auto_rate_limit_activated", False)
+    monkeypatch.setattr(rate_limiting, "_auto_paced_until", 0.0)
     monkeypatch.setattr(rate_limiting, "llm_config", _config())
     spy = PacerSpy()
     monkeypatch.setattr(rate_limiting, "llm_rate_limiter", spy)
@@ -68,7 +68,7 @@ async def test_full_speed_by_default(fresh_state):
     async with llm_rate_limiter_context_manager():
         pass
     assert fresh_state.entered == 0
-    assert rate_limiting._auto_rate_limit_activated is False
+    assert rate_limiting._auto_paced_until == 0.0
 
 
 @pytest.mark.parametrize(
@@ -99,7 +99,9 @@ async def test_overload_enables_rate_limiter_with_warning(
         async with llm_rate_limiter_context_manager():
             raise wrapper
 
-    assert rate_limiting._auto_rate_limit_activated is True
+    import time
+
+    assert time.monotonic() < rate_limiting._auto_paced_until
     assert len(warnings) == 1
     assert "not being processed fast enough" in warnings[0]
     assert expected_name in warnings[0]
@@ -121,9 +123,11 @@ async def test_slow_completion_enables_rate_limiter_before_any_failure(fresh_sta
         "logger",
         SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
     )
+    import time
+
     async with llm_rate_limiter_context_manager():
         await asyncio.sleep(0.06)  # a successful but dangerously slow call
-    assert rate_limiting._auto_rate_limit_activated is True
+    assert time.monotonic() < rate_limiting._auto_paced_until
     assert len(warnings) == 1 and "completion took" in warnings[0]
 
 
@@ -134,7 +138,7 @@ async def test_auto_rate_limit_disabled_never_activates(fresh_state, monkeypatch
         with pytest.raises(type(error)):
             async with llm_rate_limiter_context_manager():
                 raise error
-    assert rate_limiting._auto_rate_limit_activated is False
+    assert rate_limiting._auto_paced_until == 0.0
     assert fresh_state.entered == 0
 
 
@@ -146,7 +150,7 @@ async def test_ordinary_errors_do_not_activate(fresh_state):
     with pytest.raises(openai.APIStatusError):
         async with llm_rate_limiter_context_manager():
             raise _status_error(500)  # a plain server error is not overload evidence
-    assert rate_limiting._auto_rate_limit_activated is False
+    assert rate_limiting._auto_paced_until == 0.0
 
 
 @pytest.mark.asyncio
@@ -155,3 +159,54 @@ async def test_explicit_rate_limit_setting_paces_from_the_start(fresh_state, mon
     async with llm_rate_limiter_context_manager():
         pass
     assert fresh_state.entered == 1
+
+
+@pytest.mark.asyncio
+async def test_pacing_lapses_after_quiet_cooldown_and_rewarns(fresh_state, monkeypatch):
+    warnings = []
+    monkeypatch.setattr(
+        rate_limiting,
+        "logger",
+        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
+    )
+    monkeypatch.setattr(rate_limiting, "AUTO_RATE_LIMIT_COOLDOWN_SECONDS", 0.1)
+
+    for _ in range(2):  # two separate episodes with a quiet gap between them
+        with pytest.raises(openai.RateLimitError):
+            async with llm_rate_limiter_context_manager():
+                raise _rate_limit_error()
+        async with llm_rate_limiter_context_manager():
+            pass  # inside the episode: paced
+        await asyncio.sleep(0.15)  # cooldown lapses with no evidence
+        async with llm_rate_limiter_context_manager():
+            pass  # back to the configured (unpaced) state
+
+    assert fresh_state.entered == 2  # exactly one paced dispatch per episode
+    assert len(warnings) == 2  # each fresh episode warns again
+
+
+@pytest.mark.asyncio
+async def test_evidence_extends_the_cooldown_without_rewarning(fresh_state, monkeypatch):
+    import time
+
+    warnings = []
+    monkeypatch.setattr(
+        rate_limiting,
+        "logger",
+        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
+    )
+    monkeypatch.setattr(rate_limiting, "AUTO_RATE_LIMIT_COOLDOWN_SECONDS", 0.2)
+
+    with pytest.raises(openai.RateLimitError):
+        async with llm_rate_limiter_context_manager():
+            raise _rate_limit_error()
+    first_deadline = rate_limiting._auto_paced_until
+
+    await asyncio.sleep(0.05)
+    with pytest.raises(openai.RateLimitError):
+        async with llm_rate_limiter_context_manager():
+            raise _rate_limit_error()
+
+    assert rate_limiting._auto_paced_until > first_deadline  # extended
+    assert time.monotonic() < rate_limiting._auto_paced_until
+    assert len(warnings) == 1  # same episode: no second warning

--- a/cognee/tests/unit/shared/test_auto_rate_limit.py
+++ b/cognee/tests/unit/shared/test_auto_rate_limit.py
@@ -1,4 +1,4 @@
-"""Tests for AUTO_RATE_LIMIT: full speed until overload, then warn and enable the RPM limiter."""
+"""Seam tests: the dispatch context manager wires config, pacing, and the overload policy."""
 
 import asyncio
 from types import SimpleNamespace
@@ -7,6 +7,9 @@ import httpx
 import openai
 import pytest
 
+import cognee.infrastructure.llm.config as llm_config_module
+import cognee.infrastructure.llm.overload_policy as overload_policy_module
+from cognee.infrastructure.llm.overload_policy import OverloadPolicy
 from cognee.shared import rate_limiting
 from cognee.shared.rate_limiting import llm_rate_limiter_context_manager
 
@@ -31,22 +34,20 @@ def _config(**overrides):
         auto_rate_limit=True,
         llm_rate_limit_requests=60,
         llm_rate_limit_interval=60,
-        llm_provider="openai",
-        llm_model="openai/gpt-5-mini",
-        model_fields_set=set(),
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
 
 
 @pytest.fixture(autouse=True)
-def fresh_state(monkeypatch):
-    """Reset activation; default config: rate limiting off, auto fallback on."""
-    monkeypatch.setattr(rate_limiting, "_auto_paced_until", 0.0)
-    monkeypatch.setattr(rate_limiting, "llm_config", _config())
+def seam(monkeypatch):
+    """Fresh policy + pacer spy + config stub for every test."""
+    policy = OverloadPolicy()
+    monkeypatch.setattr(overload_policy_module, "llm_overload_policy", policy)
     spy = PacerSpy()
-    monkeypatch.setattr(rate_limiting, "llm_rate_limiter", spy)
-    return spy
+    monkeypatch.setattr(rate_limiting, "_llm_rate_limiter", spy)
+    monkeypatch.setattr(llm_config_module, "get_llm_config", lambda: _config())
+    return SimpleNamespace(policy=policy, spy=spy)
 
 
 def _rate_limit_error() -> openai.RateLimitError:
@@ -54,159 +55,41 @@ def _rate_limit_error() -> openai.RateLimitError:
     return openai.RateLimitError("rate limited", response=response, body=None)
 
 
-def _timeout_error() -> openai.APITimeoutError:
-    return openai.APITimeoutError(request=httpx.Request("POST", "http://api.test"))
-
-
-def _status_error(status: int) -> openai.APIStatusError:
-    response = httpx.Response(status, request=httpx.Request("POST", "http://api.test"))
-    return openai.APIStatusError("overloaded", response=response, body=None)
-
-
 @pytest.mark.asyncio
-async def test_full_speed_by_default(fresh_state):
+async def test_full_speed_by_default(seam):
     async with llm_rate_limiter_context_manager():
         pass
-    assert fresh_state.entered == 0
-    assert rate_limiting._auto_paced_until == 0.0
+    assert seam.spy.entered == 0
+    assert seam.policy.is_paced() is False
 
 
-@pytest.mark.parametrize(
-    ("overload_error", "expected_name"),
-    [
-        (_rate_limit_error(), "RateLimitError"),
-        (_timeout_error(), "APITimeoutError"),
-        (asyncio.TimeoutError(), "TimeoutError"),
-        (_status_error(503), "HTTP 503"),
-        (_status_error(529), "HTTP 529"),
-    ],
-)
 @pytest.mark.asyncio
-async def test_overload_enables_rate_limiter_with_warning(
-    fresh_state, monkeypatch, overload_error, expected_name
-):
-    warnings = []
-    monkeypatch.setattr(
-        rate_limiting,
-        "logger",
-        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
-    )
-
-    # Wrapped the way instructor surfaces provider errors: via the cause chain.
-    wrapper = RuntimeError("instructor wrapper")
-    wrapper.__cause__ = overload_error
-    with pytest.raises(RuntimeError):
-        async with llm_rate_limiter_context_manager():
-            raise wrapper
-
-    import time
-
-    assert time.monotonic() < rate_limiting._auto_paced_until
-    assert len(warnings) == 1
-    assert "not being processed fast enough" in warnings[0]
-    assert expected_name in warnings[0]
-
-    # Subsequent dispatches are paced; repeat overload does not re-warn.
+async def test_overload_error_reaches_the_policy_and_paces_next_dispatch(seam):
     with pytest.raises(openai.RateLimitError):
         async with llm_rate_limiter_context_manager():
             raise _rate_limit_error()
-    assert fresh_state.entered == 1
-    assert len(warnings) == 1
+    assert seam.policy.is_paced() is True
 
-
-@pytest.mark.asyncio
-async def test_slow_completion_enables_rate_limiter_before_any_failure(fresh_state, monkeypatch):
-    monkeypatch.setattr(rate_limiting, "SLOW_COMPLETION_SECONDS", 0.05)
-    warnings = []
-    monkeypatch.setattr(
-        rate_limiting,
-        "logger",
-        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
-    )
-    import time
-
-    async with llm_rate_limiter_context_manager():
-        await asyncio.sleep(0.06)  # a successful but dangerously slow call
-    assert time.monotonic() < rate_limiting._auto_paced_until
-    assert len(warnings) == 1 and "completion took" in warnings[0]
-
-
-@pytest.mark.asyncio
-async def test_auto_rate_limit_disabled_never_activates(fresh_state, monkeypatch):
-    monkeypatch.setattr(rate_limiting, "llm_config", _config(auto_rate_limit=False))
-    for error in (_rate_limit_error(), _timeout_error(), _status_error(503)):
-        with pytest.raises(type(error)):
-            async with llm_rate_limiter_context_manager():
-                raise error
-    assert rate_limiting._auto_paced_until == 0.0
-    assert fresh_state.entered == 0
-
-
-@pytest.mark.asyncio
-async def test_ordinary_errors_do_not_activate(fresh_state):
-    with pytest.raises(ValueError):
-        async with llm_rate_limiter_context_manager():
-            raise ValueError("schema mismatch")
-    with pytest.raises(openai.APIStatusError):
-        async with llm_rate_limiter_context_manager():
-            raise _status_error(500)  # a plain server error is not overload evidence
-    assert rate_limiting._auto_paced_until == 0.0
-
-
-@pytest.mark.asyncio
-async def test_explicit_rate_limit_setting_paces_from_the_start(fresh_state, monkeypatch):
-    monkeypatch.setattr(rate_limiting, "llm_config", _config(llm_rate_limit_enabled=True))
     async with llm_rate_limiter_context_manager():
         pass
-    assert fresh_state.entered == 1
+    assert seam.spy.entered == 1  # paced while the episode lasts
 
 
 @pytest.mark.asyncio
-async def test_pacing_lapses_after_quiet_cooldown_and_rewarns(fresh_state, monkeypatch):
-    warnings = []
-    monkeypatch.setattr(
-        rate_limiting,
-        "logger",
-        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
-    )
-    monkeypatch.setattr(rate_limiting, "AUTO_RATE_LIMIT_COOLDOWN_SECONDS", 0.1)
-
-    for _ in range(2):  # two separate episodes with a quiet gap between them
-        with pytest.raises(openai.RateLimitError):
-            async with llm_rate_limiter_context_manager():
-                raise _rate_limit_error()
+async def test_auto_rate_limit_off_bypasses_the_policy(seam, monkeypatch):
+    monkeypatch.setattr(llm_config_module, "get_llm_config", lambda: _config(auto_rate_limit=False))
+    with pytest.raises(openai.RateLimitError):
         async with llm_rate_limiter_context_manager():
-            pass  # inside the episode: paced
-        await asyncio.sleep(0.15)  # cooldown lapses with no evidence
-        async with llm_rate_limiter_context_manager():
-            pass  # back to the configured (unpaced) state
-
-    assert fresh_state.entered == 2  # exactly one paced dispatch per episode
-    assert len(warnings) == 2  # each fresh episode warns again
+            raise _rate_limit_error()
+    assert seam.policy.is_paced() is False
+    assert seam.spy.entered == 0
 
 
 @pytest.mark.asyncio
-async def test_evidence_extends_the_cooldown_without_rewarning(fresh_state, monkeypatch):
-    import time
-
-    warnings = []
+async def test_explicit_rate_limit_setting_paces_from_the_start(seam, monkeypatch):
     monkeypatch.setattr(
-        rate_limiting,
-        "logger",
-        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
+        llm_config_module, "get_llm_config", lambda: _config(llm_rate_limit_enabled=True)
     )
-    monkeypatch.setattr(rate_limiting, "AUTO_RATE_LIMIT_COOLDOWN_SECONDS", 0.2)
-
-    with pytest.raises(openai.RateLimitError):
-        async with llm_rate_limiter_context_manager():
-            raise _rate_limit_error()
-    first_deadline = rate_limiting._auto_paced_until
-
-    await asyncio.sleep(0.05)
-    with pytest.raises(openai.RateLimitError):
-        async with llm_rate_limiter_context_manager():
-            raise _rate_limit_error()
-
-    assert rate_limiting._auto_paced_until > first_deadline  # extended
-    assert time.monotonic() < rate_limiting._auto_paced_until
-    assert len(warnings) == 1  # same episode: no second warning
+    async with llm_rate_limiter_context_manager():
+        pass
+    assert seam.spy.entered == 1


### PR DESCRIPTION
## What this does

Cognee runs **unbounded, at full speed, for every provider**. When there is evidence the LLM provider cannot keep up, **one warning is logged and the existing RPM limiter is enabled** (`LLM_RATE_LIMIT_REQUESTS` per `LLM_RATE_LIMIT_INTERVAL`, default 60/min) for the rest of the process. That is the whole mechanism.

| Setting | Behavior |
|---|---|
| default (`AUTO_RATE_LIMIT=true`) | full speed until overload evidence → warning + RPM limiter for a 900s (15 min) cooldown, extended while issues persist; lapses back to the configured state afterwards |
| `AUTO_RATE_LIMIT=false` | fully unbounded always; errors handled by retries as before |
| `LLM_RATE_LIMIT_ENABLED=true` | RPM limiter on from the start (unchanged behavior) |

`AUTO_RATE_LIMIT` is a new config flag, on by default, documented in `.env.template` next to the other rate-limiter settings.

The RPM budget itself is provider-aware: when `LLM_RATE_LIMIT_REQUESTS` is not explicitly configured, serial local inference servers (Ollama, LM Studio, llama.cpp) default to **10** requests per interval instead of the regular 60 — vLLM deliberately keeps the regular settings, since its continuous batching absorbs concurrency like a cloud endpoint — resolved in `LLMConfig` as a `model_validator(mode="after")` post-step, so an explicitly set value always wins.

### Overload evidence
1. **A rate-limit error** — how cloud providers signal overload; both RPM and TPM limits arrive this way.
2. **HTTP 503 / 529** — Ollama past its queue cap, Anthropic overloaded.
3. **A timeout** — how overwhelmed local servers usually surface (they never send rate limits).

Response time is deliberately **not** evidence: a successful completion, however slow, proves the request was served — some models legitimately take 500 s while accepting all requests.

Errors are recognized through the exception **cause chain**, not the top-level type — instructor wraps provider errors in `InstructorRetryException` (found via live testing). `openai.RateLimitError`/`APITimeoutError`/`APIStatusError` cover every client stack: litellm's exceptions subclass them and SDK-direct adapters raise them natively. Detection lives in the dispatch seam (`llm_rate_limiter_context_manager()`) all 8 instructor adapters wrap around each attempt, inside their tenacity retry — so once enabled, retried attempts are paced too.

### Also in this PR
- **Default `chunks_per_batch` raised to 2000** (main cognify pipeline; `CHUNKS_PER_BATCH` config still overrides; temporal pipeline default unchanged at 10).

## Validation (live)
- **Ollama phi4, healthy**: full speed, no warnings, no pacing.
- **Ollama phi4, flooded (~690 concurrent from a full War-and-Peace cognify)**: overload detected; warning logged; limiter enabled.
- **OpenAI gpt-5-mini**: 50 concurrent extraction calls, 50/50 in 21 s, mechanism never engaged — zero interference on healthy cloud traffic.
- **29 unit tests** across the policy (evidence taxonomy, cooldown episodes), the dispatch seam (wiring, opt-outs, explicit `LLM_RATE_LIMIT_ENABLED` unchanged), and the config defaults (provider-aware budget, explicit values win).

## Notes
- The reaction is a cooldown, not a latch: it lapses after 900s (15 min) without overload evidence, returning to the configured state (unbounded unless `LLM_RATE_LIMIT_ENABLED` is set). A fresh episode warns again.
- On an already-flooded serial local server the limiter paces retries and later work; it cannot un-queue requests that were already dispatched.
- Known follow-up discovered during testing: `litellm.UnsupportedParamsError` (a permanent config error) is retried as transient for the full 240 s tenacity floor per call — belongs in the terminal error classification (separate PR).

---
⚠️ Note for reviewers: needs a Linear issue key added to the title (`linear-issue-check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
