### PR TITLE
ci(nightly): compact Rust Slack blocks under GitHub template size limit

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -348,42 +348,11 @@ jobs:
                 text:
                   type: "mrkdwn"
                   text: |
-                    *🦀 Rust SDK (file_based) — 50 Small Documents — Mock LLM* (`${{ needs.perf-rust.result }}`)  •  runs `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *🦀 Rust SDK (file_based) — War and Peace — Mock LLM* (`${{ needs.perf-rust-wap.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_wap }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *🦀 Rust SDK (file_based) — 50 Small Documents — Real LLM* (`${{ needs.perf-rust-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_llm }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *🦀 Rust SDK (file_based) — War and Peace — Real LLM* (`${{ needs.perf-rust-wap-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_wap_llm }}|HTML report>
+                    *🦀 Rust SDK (file_based)* — total-latency percentiles; per-stage detail is in each HTML report
+                    50 small documents — mock LLM  (`${{ needs.perf-rust.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust }}|HTML report>
+                    War and Peace — mock LLM  (`${{ needs.perf-rust-wap.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_wap }}|HTML report>
+                    50 small documents — real LLM  (`${{ needs.perf-rust-llm.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_llm }}|HTML report>
+                    War and Peace — real LLM  (`${{ needs.perf-rust-wap-llm.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_wap_llm }}|HTML report>
               - type: "section"
                 text:
                   type: "mrkdwn"


### PR DESCRIPTION
## Problem

`dev` currently cannot load `.github/workflows/nightly_tests.yml` at all. Since #3981 merged, the `notify` job's single Slack `payload` template is **21,473 characters**, which exceeds GitHub's template-length limit. The symptom is unusual and easy to misread:

- The run fails **at creation**, with **zero jobs** and no logs.
- It is attributed to the `push` event even though this workflow has no `push` trigger.
- The run is named `.github/workflows/nightly_tests.yml` rather than `Nightly Tests`, because GitHub never got far enough to read `name:`.

Net effect: **the nightly performance suite does not run** — the 03:00 UTC cron produces a workflow-file error instead of jobs.

The cause is the merge of two independently-valid changes. `dev` had grown two Cognee Cloud sections (~18.7 KB of payload on its own); #3981 added four Rust arms with a full per-stage section each, which pushed it over.

## Measured ceiling

Bracketed by pushing variants to a throwaway branch — an invalid file produces a validation-failure run, a valid one produces nothing, and no jobs execute either way:

| payload size | result |
|---|---|
| 20,062 | accepted |
| 20,428 | accepted |
| 20,516 | accepted |
| 20,866 | **rejected** |
| 21,473 (current `dev`) | **rejected** |

The limit is length-driven, not expression-count-driven: the padded variants added no `${{ }}` expressions. Note that **no local validator catches this** — `actionlint`, YAML parsing, strict duplicate-key checks, and a full reusable-workflow caller/callee input+output contract check all pass on the broken file.

## Fix

Collapse the four per-arm Rust sections into one section carrying total p50/p90/p99 plus each arm's report link. Per-stage `add`/`cognify`/`search` percentiles remain available in the linked HTML reports.

Payload drops to **17,773** characters (13 blocks), leaving ~2.7 KB of headroom.

Verified by pushing this exact file to a scratch branch: GitHub created no validation-failure run, i.e. the workflow loads.

## Follow-up worth considering separately

`dev` was at ~18.7 KB with zero Rust arms, so the next arm anyone adds will hit this again. Generating the Slack blocks from a script (looping over a compact job→outputs map) would remove the ceiling permanently, but it rewrites a block that is actively edited and is better done on its own.