### PR TITLE
fix(storage): serialize date values in JSONEncoder

### DIFF
--- a/cognee/modules/storage/utils/__init__.py
+++ b/cognee/modules/storage/utils/__init__.py
@@ -2,7 +2,7 @@ import json
 import copy
 from uuid import UUID
 from decimal import Decimal
-from datetime import datetime
+from datetime import date, datetime
 from pydantic_core import PydanticUndefined
 from pydantic import create_model, ConfigDict, BaseModel, Field
 
@@ -13,6 +13,8 @@ class JSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
             return obj.isoformat()  # Convert datetime to ISO 8601 string
+        elif isinstance(obj, date):
+            return obj.isoformat()
         elif isinstance(obj, UUID):
             # if the obj is uuid, we simply return the value of uuid
             return str(obj)

--- a/cognee/tests/unit/modules/storage/test_json_encoder.py
+++ b/cognee/tests/unit/modules/storage/test_json_encoder.py
@@ -1,0 +1,28 @@
+import json
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+
+from cognee.modules.storage.utils import JSONEncoder
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (date(2026, 6, 5), "2026-06-05"),
+        (datetime(2026, 6, 5, 14, 30, tzinfo=timezone.utc), "2026-06-05T14:30:00+00:00"),
+        (UUID("12345678-1234-5678-1234-567812345678"), "12345678-1234-5678-1234-567812345678"),
+        (Decimal("12.5"), 12.5),
+    ],
+)
+def test_json_encoder_serializes_supported_types(value, expected):
+    encoded = json.dumps({"value": value}, cls=JSONEncoder)
+
+    assert json.loads(encoded) == {"value": expected}
+
+
+def test_json_encoder_rejects_unsupported_types():
+    with pytest.raises(TypeError):
+        json.dumps({"value": object()}, cls=JSONEncoder)


### PR DESCRIPTION
## Description

Fixes #4239.

JSON Schema fields with `format: "date"` are materialized as `datetime.date` values. The
shared storage `JSONEncoder` handled `datetime`, UUID, and Decimal values, but plain dates
fell through to the standard encoder and raised `TypeError`.

This change serializes plain dates with `date.isoformat()`. The date branch follows the
existing datetime branch so the established datetime behavior remains unchanged.

## Acceptance Criteria

- [x] Plain `datetime.date` values serialize as ISO-8601 strings.
- [x] Existing datetime, UUID, and Decimal serialization remains covered.
- [x] Unsupported objects still raise `TypeError`.
- [x] The regression test fails on `dev` before the production change and passes afterward.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="1320" height="982" alt="Actual local Terminal validation for Cognee issue 4239" src="https://github.com/user-attachments/assets/79a0d2b3-7f5b-4953-b713-8a6f12b8d2be" />

## Validation

```text
uv run pytest cognee/tests/unit/modules/storage/test_json_encoder.py -q
5 passed

uv run pytest \
  cognee/tests/unit/modules/storage/test_json_encoder.py \
  cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py \
  cognee/tests/unit/infrastructure/databases/graph/test_postgres_adapter.py \
  cognee/tests/unit/tasks/storage/test_add_data_points.py \
  cognee/tests/test_graph_model_utils.py -q --disable-warnings
107 passed, 51 warnings

uv run pytest \
  cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py \
  -q --disable-warnings
56 passed, 4 xfailed, 2 xpassed, 10 warnings

uv run pre-commit run --all-files
All hooks passed
```

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] Documentation is not required for this internal serialization fix
- [ ] All new and existing tests pass (see the unrelated `dev` failure above)
- [x] I have searched existing PRs to ensure this change has not been submitted already
- [x] I have linked the relevant issue in the description
- [x] My commit has a clear, semantic subject

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the
Topoteretes Developer Certificate of Origin.
