### PR TITLE
fix(mcp): expose remember self-improvement control

### DIFF
--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -494,7 +494,7 @@ The MCP server exposes its functionality through tools. Call them from any MCP c
 
 The MCP server exposes three tools:
 
-- **remember**: Store data in memory. With `session_id`: fast session cache. Without `session_id`: permanent graph memory
+- **remember**: Store data in memory. With `session_id`: fast session cache. Without `session_id`: permanent graph memory. Set `self_improvement=false` to skip the follow-up improve/memify pass
 - **recall**: Search memory with auto-routing. Searches session cache first when `session_id` is provided, then falls through to the permanent graph
 - **forget**: Delete memory by dataset name, or delete all owned memory with `everything=True`
 
@@ -546,6 +546,13 @@ rm -rf "$DATA_ROOT/.cognee_system" "$DATA_ROOT/.data_storage"
 ```bash
 # Store permanent memory
 remember(data="Cognee MCP now exposes a focused memory API.", dataset_name="main_dataset")
+
+# Store permanent memory without the follow-up improve/memify pass
+remember(
+    data="A latency-sensitive memory.",
+    dataset_name="main_dataset",
+    self_improvement=False,
+)
 
 # Store session memory
 remember(data="Temporary working note", session_id="agent-session-1")

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -522,11 +522,15 @@ class CogneeClient:
         dataset_name: str = "main_dataset",
         session_id: Optional[str] = None,
         custom_prompt: Optional[str] = None,
+        self_improvement: bool = True,
     ) -> Dict[str, Any]:
         """Store data in memory via remember().
 
         With session_id: stores in session cache only (fast).
         Without session_id: full add + cognify pipeline (permanent).
+
+        Set self_improvement to False to skip the improve/memify step that
+        follows the core remember operation.
         """
         if self.use_api:
             if session_id:
@@ -562,7 +566,10 @@ class CogneeClient:
 
             endpoint = f"{self.api_url}/api/v1/remember"
             files = self._text_upload(data)
-            form_data = {"datasetName": dataset_name}
+            form_data = {
+                "datasetName": dataset_name,
+                "self_improvement": "true" if self_improvement else "false",
+            }
             if custom_prompt:
                 form_data["custom_prompt"] = custom_prompt
             response = await self.client.post(
@@ -578,6 +585,7 @@ class CogneeClient:
                 kwargs = {
                     "data": data,
                     "dataset_name": dataset_name,
+                    "self_improvement": self_improvement,
                 }
                 if session_id:
                     kwargs["session_id"] = session_id

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -1080,6 +1080,7 @@ async def remember(
     dataset_name: str = None,
     session_id: str = None,
     custom_prompt: str = None,
+    self_improvement: bool = True,
 ) -> list:
     """Store data in memory.
 
@@ -1104,6 +1105,9 @@ async def remember(
         Session ID. When set, stores in session cache only.
     custom_prompt : str, optional
         Custom prompt for entity extraction (permanent mode only).
+    self_improvement : bool, optional
+        Whether to run improve/memify after remembering. Defaults to True.
+        Set to False to avoid the graph-wide self-improvement pass.
     """
     dataset_name = dataset_name or _agent_scoped_default_dataset()
     with redirect_stdout(sys.stderr):
@@ -1113,6 +1117,7 @@ async def remember(
                 dataset_name=dataset_name,
                 session_id=session_id,
                 custom_prompt=custom_prompt,
+                self_improvement=self_improvement,
             )
             status = result.get("status", "completed")
             if session_id:

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -144,6 +144,21 @@ async def test_mcp_exposes_only_memory_tools():
 
 
 @pytest.mark.asyncio
+async def test_mcp_remember_exposes_self_improvement():
+    import src.server as server
+
+    tools = await server.mcp.list_tools()
+    remember_tool = next(tool for tool in tools if tool.name == "remember")
+
+    self_improvement = remember_tool.inputSchema["properties"]["self_improvement"]
+    assert self_improvement == {
+        "default": True,
+        "title": "Self Improvement",
+        "type": "boolean",
+    }
+
+
+@pytest.mark.asyncio
 async def test_cognee_client_api_add_uses_content_addressed_filename():
     requests: list[httpx.Request] = []
 
@@ -194,6 +209,47 @@ async def test_cognee_client_api_remember_sends_session_id():
     assert payload["session_id"] == "session-1"
     assert payload["entry"]["type"] == "qa"
     assert payload["entry"]["answer"] == content
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_direct_remember_forwards_self_improvement():
+    class FakeCognee:
+        def __init__(self):
+            self.remember_kwargs = None
+
+        async def remember(self, **kwargs):
+            self.remember_kwargs = kwargs
+            return None
+
+    client = CogneeClient()
+    client.cognee = FakeCognee()
+
+    await client.remember("hello", dataset_name="ds", self_improvement=False)
+
+    assert client.cognee.remember_kwargs["self_improvement"] is False
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_remember_forwards_self_improvement():
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = CogneeClient(api_url="http://cognee.local")
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    try:
+        await client.remember("hello", dataset_name="ds", self_improvement=False)
+    finally:
+        await client.close()
+
+    body = requests[0].content.decode()
+    assert requests[0].url.path == "/api/v1/remember"
+    assert 'name="self_improvement"' in body
+    assert "\r\nfalse\r\n" in body
 
 
 @pytest.mark.asyncio
@@ -259,6 +315,31 @@ async def test_mcp_recall_forwards_system_prompt(monkeypatch):
         "system_prompt": "Answer with provenance.",
         "top_k": 5,
     }
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_forwards_self_improvement(monkeypatch):
+    import src.server as server
+
+    class FakeClient:
+        def __init__(self):
+            self.remember_kwargs = None
+
+        async def remember(self, **kwargs):
+            self.remember_kwargs = kwargs
+            return {"status": "completed"}
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    result = await server.remember(
+        data="hello",
+        dataset_name="ds",
+        self_improvement=False,
+    )
+
+    assert "Stored permanently" in result[0].text
+    assert fake_client.remember_kwargs["self_improvement"] is False
 
 
 @pytest.mark.asyncio

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -149,6 +149,13 @@ def get_remember_router() -> APIRouter:
                 "for large files."
             ),
         ),
+        self_improvement: bool = Form(
+            default=True,
+            description=(
+                "If true, runs improve() after remembering to enrich graph memory. "
+                "Set to false to skip the self-improvement pass."
+            ),
+        ),
         custom_prompt: Optional[str] = Form(
             default="",
             description=(
@@ -244,6 +251,7 @@ def get_remember_router() -> APIRouter:
           data is ingested directly via add + cognify.
         - **node_set** (Optional[List[str]]): Node identifiers for graph organisation.
         - **run_in_background** (Optional[bool]): Run the cognify step asynchronously (default: False).
+        - **self_improvement** (bool): Run improve/memify after remembering (default: True).
         - **custom_prompt** (Optional[str]): Custom prompt for entity extraction.
         - **chunk_size** (Optional[int]): Maximum tokens per chunk (default: 4096).
         - **chunks_per_batch** (Optional[int]): Chunks per cognify batch.
@@ -355,6 +363,7 @@ def get_remember_router() -> APIRouter:
                 dataset_id=datasetId if datasetId else None,
                 node_set=[tag for tag in (node_set or []) if tag] or None,
                 run_in_background=run_in_background or False,
+                self_improvement=self_improvement,
                 custom_prompt=custom_prompt or None,
                 chunk_size=chunk_size,
                 chunks_per_batch=chunks_per_batch,

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -165,6 +165,28 @@ class TestRememberEndpoint:
         remember.assert_awaited_once()
         assert remember.await_args.kwargs["chunk_size"] == 42
 
+    def test_remember_passes_self_improvement(self, client, monkeypatch):
+        remember_pkg = importlib.import_module("cognee.api.v1.remember")
+
+        class RememberResultStub:
+            status = "completed"
+
+            def to_dict(self):
+                return {"status": "completed", "dataset_name": "test_dataset"}
+
+        remember = AsyncMock(return_value=RememberResultStub())
+        monkeypatch.setattr(remember_pkg, "remember", remember)
+
+        resp = client.post(
+            "/remember",
+            data={"datasetName": "test_dataset", "self_improvement": "false"},
+            files={"data": ("test.txt", b"Cognee is an AI memory platform.", "text/plain")},
+        )
+
+        assert resp.status_code == 200
+        remember.assert_awaited_once()
+        assert remember.await_args.kwargs["self_improvement"] is False
+
 
 # ---------------------------------------------------------------------------
 # Cognify endpoint


### PR DESCRIPTION
## Description

Addresses item (1) of #4233.

The core `remember()` function already accepts `self_improvement=False`, but the current
MCP does not expose the same option. This makes MCP users get stuck with the default
`True`, which can trigger the additional `improve()` / `memify()` work after storing the
memory.

This change exposes the option on the MCP `remember` tool and forwards an explicit `False`
through direct mode and permanent API mode. API session entries already bypass that
follow-up path, so this does not add a parameter there that core would ignore. The default
stays `True`, so existing direct and permanent-memory behavior remains the same unless the
caller chooses to opt out.

## Acceptance Criteria

- [x] The MCP `remember` tool exposes `self_improvement` as a boolean.
- [x] An explicit `False` reaches the core `remember()` call in direct mode.
- [x] Permanent API requests forward the option to the core `remember()` call.
- [x] Session API behavior remains unchanged because typed entries do not run the follow-up pass.
- [x] The default remains `True` for backward compatibility.
- [x] The MCP documentation includes an opt-out example.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="1554" height="977" alt="Final local Terminal validation for PR #4246" src="https://github.com/user-attachments/assets/3549b518-3e2a-44d3-8309-1170de144048" />

## Validation

```text
cd cognee-mcp && uv run pytest tests/test_mcp_server_hardening.py -q
35 passed

uv run pytest \
  cognee/tests/unit/api/test_api_error_responses.py \
  cognee/tests/unit/migration/test_remember_router_cogx.py \
  cognee/tests/unit/api/v1/session/test_session_memory_flows.py -q
68 passed

uv run pre-commit run --all-files
All hooks passed
```

The broader unit suite currently has one pre-existing
`ProviderNotDeducibleError` contract-test failure. I reproduced the same failure on
unchanged `dev`; this PR does not touch that exception or its contract test.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove the fix is effective
- [x] I have added necessary documentation
- [ ] All new and existing tests pass (one existing `dev` failure is documented above)
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked the relevant issue in the description
- [x] My commit has a clear, semantic subject

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
