### PR TITLE
fix(migration): return tz-aware UTC datetimes from parse_timestamp

### DIFF
--- a/cognee/modules/migration/cogx.py
+++ b/cognee/modules/migration/cogx.py
@@ -21,11 +21,19 @@ COGX_VERSION = "0.1"
 
 
 def parse_timestamp(value: Any) -> Optional[datetime]:
-    """Parse a timestamp from ISO strings or epoch seconds/milli/micro/nanoseconds."""
+    """Parse a timestamp from ISO strings or epoch seconds/milli/micro/nanoseconds.
+
+    Always returns a timezone-aware UTC datetime, or None. Inputs that carry no
+    offset — ``"2026-01-01T10:00:00"``, a bare date, a naive ``datetime`` — are
+    read as UTC, which is what the exporting systems store. Returning them naive
+    mixes naive and aware values across a single import: comparing two of them
+    raises TypeError, and sorting them applies the importing machine's local
+    offset instead of the real instant.
+    """
     if value is None or value == "":
         return None
     if isinstance(value, datetime):
-        return value
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
     if isinstance(value, (int, float)):
         # Heuristic: values past the year ~2603 in seconds are a finer epoch
         # unit (milli/micro/nanoseconds); scale down until plausible.
@@ -40,9 +48,10 @@ def parse_timestamp(value: Any) -> Optional[datetime]:
             return None
     if isinstance(value, str):
         try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
         except ValueError:
             return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
     return None
 
 

--- a/cognee/tests/unit/migration/test_migration.py
+++ b/cognee/tests/unit/migration/test_migration.py
@@ -62,6 +62,30 @@ class TestParseTimestamp:
         # Out-of-range epochs return None instead of raising.
         assert parse_timestamp(float("inf")) is None
 
+    def test_values_without_an_offset_are_read_as_utc(self):
+        # Exports that drop the offset must not be read in the importing
+        # machine's local timezone.
+        assert parse_timestamp("2024-03-01T12:00:00") == datetime(
+            2024, 3, 1, 12, 0, tzinfo=timezone.utc
+        )
+        assert parse_timestamp("2024-03-01") == datetime(2024, 3, 1, tzinfo=timezone.utc)
+        assert parse_timestamp(datetime(2024, 3, 1, 12, 0)) == datetime(
+            2024, 3, 1, 12, 0, tzinfo=timezone.utc
+        )
+
+    def test_explicit_offsets_are_preserved(self):
+        assert parse_timestamp("2024-03-01T17:30:00+05:30") == datetime(
+            2024, 3, 1, 12, 0, tzinfo=timezone.utc
+        )
+
+    def test_mixed_input_formats_stay_orderable(self):
+        # One record can carry an ISO created_at and an epoch updated_at;
+        # ordering them raises TypeError if either comes back naive.
+        created_at = parse_timestamp("2024-03-01T12:00:00")
+        updated_at = parse_timestamp(1709294400 + 3600)
+        assert created_at < updated_at
+        assert created_at == parse_timestamp(1709294400)
+
 
 class TestCOGXArchive:
     def _sample_records(self):
@@ -226,6 +250,35 @@ class TestLettaSource:
         block = next(r for r in records if r.kind == "memory_block")
         assert block.label == "persona"
         assert block.limit == 2000
+
+    def test_turns_with_mixed_timestamp_formats_order_by_instant(self):
+        # Letta serializes message created_at with or without an offset
+        # depending on version; both denote UTC instants.
+        agent_file = {
+            "agents": [
+                {
+                    "name": "support",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "my order is late",
+                            "created_at": "2024-03-01T06:00:00Z",
+                        },
+                        {
+                            "role": "assistant",
+                            "content": "refunded you",
+                            "created_at": "2024-03-01T10:00:00",
+                        },
+                    ],
+                }
+            ]
+        }
+        episode = next(r for r in collect(LettaSource(agent_file)) if r.kind == "episode")
+        earlier, later = episode.turns
+        assert earlier.occurred_at < later.occurred_at
+
+        transcript = loader.render_episode(episode)
+        assert transcript.index("my order is late") < transcript.index("refunded you")
 
 
 class TestZepSource:


### PR DESCRIPTION
## Description

While reading through the migration source adapters (`mem0`, `zep`, `letta`, `langmem`) I noticed `parse_timestamp` returns different datetime types depending on the input format:

- Epoch values and ISO strings with an explicit `Z` or offset → timezone-**aware** (UTC).
- ISO strings with no offset, bare dates, and naive `datetime` passthrough → **naive**.

Most adapters only ever see one of those shapes, so it doesn't show up. `LettaSource` is the exception: it builds a multi-turn `COGXEpisode` from an agent's message history, and Letta serializes message `created_at` with or without an offset depending on version, so a single conversation can carry both.

That breaks in two ways:

1. `render_episode` (`loader.py:86`) sorts turns by `.timestamp()`. On a naive datetime `.timestamp()` assumes the **importing machine's** local timezone, so a naive `10:00` is read as `04:30Z` on a machine in `Asia/Kolkata` and sorts *before* a message stamped `06:00Z`.
2. Comparing a naive and an aware value directly raises `TypeError: can't compare offset-naive and offset-aware datetimes`.

The practical effect of (1) is that the assistant's reply is rendered above the user message it's answering, and that reordered transcript is what gets ingested into the graph. It only reproduces off UTC, so CI can't catch it.

**Why fix the parser instead of the sorting logic?**

`parse_timestamp` feeds all five migration adapters plus `export.py` — 17 call sites. Sorting is one symptom; the `TypeError` in (2) is another. Fixing it at the source gives consistent UTC handling everywhere instead of patching one caller.

**Why UTC for values with no offset?** It's what the exporting systems (Mem0, Zep, Graphiti, Letta, LangMem) store, and it's what every other branch of this function already returned. Reading them as local is what makes the result depend on which machine ran the import. Values that carry an explicit offset are left untouched.

**Behaviour note:** `external_created_at` / `external_updated_at` metadata and rendered episode timestamps now carry `+00:00` where a naive value previously rendered without one.

No existing issue for this — I found it while reading the adapters, so the report is above rather than linked.

## Acceptance Criteria

- **Reproduction:** a two-message Letta agent file (user at `2024-03-01T06:00:00Z`, assistant at `2024-03-01T10:00:00` with no offset) renders correctly under `TZ=UTC` and **inverted** under `TZ=Asia/Kolkata`. After the fix it renders in real-instant order under both.
- **Migration suite:** 138 passing under `TZ=UTC`, `TZ=Asia/Kolkata` and `TZ=America/Los_Angeles` (134 before, 4 added).
- **The new tests fail on `dev`** — 3 of the 4 fail against the unfixed parser, in *every* timezone including UTC, because they assert the invariant (always aware) rather than manipulating `TZ`. The 4th asserts that explicit offsets are preserved and passes both before and after, as a guard against over-correcting.
- **Full unit suite:** identical results with and without this change — 17 failures / 63 passes both ways, all pre-existing and confined to `modules/retrieval/` and the rate-limiting tests. (Two files also fail collection locally on missing optional extras, `neo4j` and the eval dashboard, before and after.)
- **Lint:** `ruff format --check` reports both files already formatted; `ruff check` reports the same 55 pre-existing findings before and after — none introduced. I deliberately left those alone rather than mixing unrelated cleanup into this diff.

Tests added in `cognee/tests/unit/migration/test_migration.py`, extending the existing `TestParseTimestamp` and `TestLettaSource` classes:

| Test | Asserts |
|---|---|
| `test_values_without_an_offset_are_read_as_utc` | naive ISO / bare date / naive `datetime` → UTC-aware |
| `test_mixed_input_formats_stay_orderable` | an ISO `created_at` and an epoch `updated_at` on one record are orderable |
| `test_turns_with_mixed_timestamp_formats_order_by_instant` | a Letta transcript renders in real-instant order |
| `test_explicit_offsets_are_preserved` | `+05:30` is not rewritten |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="2000" height="1250" alt="PR-cognee" src="https://github.com/user-attachments/assets/4f119c9d-fe3b-41ee-be2c-a1b28ca44092" />

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable) — `parse_timestamp` docstring updated
- [x] All new and existing tests pass — the pre-existing failures noted above are unrelated and unchanged by this PR
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description — no existing issue; reported inline
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.