### PR TITLE
fix: invalidate pg session on request cancellation

### DIFF
--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -155,8 +155,25 @@ class SQLAlchemyAdapter:
         async with async_session_maker() as session:
             try:
                 yield session
-            finally:
-                await session.close()  # Ensure the session is closed
+            except asyncio.CancelledError:
+                # A cancelled request can leave the connection in an open
+                # transaction; returning it to the pool leaks an "idle in
+                # transaction" backend. Invalidate (drop) it instead, shielded
+                # so the cleanup is not cut short by the same cancellation.
+                await asyncio.shield(self._discard_cancelled_session(session))
+                raise
+            # Happy path and ordinary exceptions: the sessionmaker context
+            # manager closes and rolls back, so no explicit close is needed.
+
+    @staticmethod
+    async def _discard_cancelled_session(session: AsyncSession) -> None:
+        # A graceful close needs a ROLLBACK round-trip that the cancellation
+        # keeps interrupting; invalidate() drops the DBAPI connection without
+        # it, so the connection is never reused dirty.
+        try:
+            await session.invalidate()
+        except Exception:
+            logger.exception("Failed to invalidate session on cancellation")
 
     def get_session(self):
         """

--- a/cognee/tests/unit/infrastructure/databases/relational/test_SqlAlchemyAdapter.py
+++ b/cognee/tests/unit/infrastructure/databases/relational/test_SqlAlchemyAdapter.py
@@ -1,7 +1,9 @@
 import asyncio
 from unittest.mock import patch, MagicMock
 
+import pytest
 from sqlalchemy import text, NullPool
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
     SQLAlchemyAdapter,
@@ -194,3 +196,92 @@ class TestSQLAlchemyAdapterSqliteConcurrencyModel:
                     return (await inner.execute(text("SELECT 2"))).scalar()
 
         assert asyncio.run(asyncio.wait_for(run(), timeout=15)) == 2
+
+
+class TestGetAsyncSessionCancellation:
+    """
+    get_async_session must invalidate the connection when its task is cancelled.
+
+    A cancelled request can leave the DBAPI connection inside an open
+    transaction. Returning it to the pool leaks an "idle in transaction"
+    backend until the pool ceiling is hit and every request fails. On
+    cancellation the session must be invalidated (connection dropped), and
+    only on cancellation. See issue #4197.
+
+    These tests assert the invalidate-on-cancel contract on the three paths
+    (happy, ordinary exception, cancellation). They run on SQLite, which has
+    no QueuePool or "idle in transaction" state, so they guard the behaviour
+    that fixes the leak rather than reproducing the pool exhaustion itself.
+    The end-to-end Postgres reproduction is the curl-abort + pg_stat_activity
+    check documented in the issue.
+    """
+
+    def _spy_adapter(self, monkeypatch):
+        adapter = SQLAlchemyAdapter("sqlite+aiosqlite:///:memory:")
+        calls = {"invalidate": 0}
+        original = AsyncSession.invalidate
+
+        async def spy(self):
+            calls["invalidate"] += 1
+            return await original(self)
+
+        monkeypatch.setattr(AsyncSession, "invalidate", spy)
+        return adapter, calls
+
+    @pytest.mark.asyncio
+    async def test_happy_path_does_not_invalidate(self, monkeypatch):
+        adapter, calls = self._spy_adapter(monkeypatch)
+        async with adapter.get_async_session() as session:
+            await session.execute(text("SELECT 1"))
+        assert calls["invalidate"] == 0
+
+    @pytest.mark.asyncio
+    async def test_ordinary_exception_does_not_invalidate(self, monkeypatch):
+        adapter, calls = self._spy_adapter(monkeypatch)
+        with pytest.raises(ValueError):
+            async with adapter.get_async_session() as session:
+                await session.execute(text("SELECT 1"))
+                raise ValueError("boom")
+        assert calls["invalidate"] == 0
+
+    @pytest.mark.asyncio
+    async def test_cancellation_invalidates_and_reraises(self, monkeypatch):
+        adapter, calls = self._spy_adapter(monkeypatch)
+        with pytest.raises(asyncio.CancelledError):
+            async with adapter.get_async_session() as session:
+                await session.execute(text("SELECT 1"))
+                raise asyncio.CancelledError()
+        assert calls["invalidate"] == 1
+
+    @pytest.mark.asyncio
+    async def test_outer_task_cancellation_invalidates(self, monkeypatch):
+        adapter, calls = self._spy_adapter(monkeypatch)
+        started = asyncio.Event()
+
+        async def worker():
+            async with adapter.get_async_session() as session:
+                await session.execute(text("SELECT 1"))
+                started.set()
+                await asyncio.sleep(10)
+
+        task = asyncio.create_task(worker())
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert calls["invalidate"] == 1
+
+    @pytest.mark.asyncio
+    async def test_invalidate_failure_does_not_mask_cancellation(self, monkeypatch):
+        adapter, calls = self._spy_adapter(monkeypatch)
+
+        async def failing_invalidate(self):
+            calls["invalidate"] += 1
+            raise RuntimeError("invalidate failed")
+
+        monkeypatch.setattr(AsyncSession, "invalidate", failing_invalidate)
+        with pytest.raises(asyncio.CancelledError):
+            async with adapter.get_async_session() as session:
+                await session.execute(text("SELECT 1"))
+                raise asyncio.CancelledError()
+        assert calls["invalidate"] == 1


### PR DESCRIPTION
## Description

Fixes #4197. A cancelled or disconnected request was leaking a Postgres session stuck in `idle in transaction`. The connection went back to the pool without a ROLLBACK, and once enough piled up the pool hit its ceiling and every request started failing, auth included, since the API-key lookup is a DB query too.

The cause is the `finally: await session.close()` in `get_async_session`. It runs before the `async_sessionmaker` context manager's own exit, and when the task is being cancelled that await gets interrupted before the rollback reaches Postgres, so the connection returns dirty.

I removed the explicit close (the sessionmaker already closes and rolls back on the happy path and on ordinary exceptions) and added a cancellation branch that invalidates the connection instead. Invalidate drops it from the pool without needing a rollback round-trip, which is the part cancellation keeps interrupting. That's also why the earlier `shield(session.close())` attempt in the report didn't change the leak rate. The invalidate runs inside `asyncio.shield` so it isn't cut short by the same cancellation, then the `CancelledError` is re-raised.

The leaked backends in the report all showed the auth users/principals lookup as their last statement. That path goes through `modules/users/get_user_db.py`, which wraps this method, so the fix covers it.

The background-pipeline shutdown leak noted in the same issue is a separate concern and not part of this PR. Happy to open a separate issue for it.

## Acceptance Criteria

- A cancelled request no longer returns its connection to the pool `idle in transaction`.
- Happy path and ordinary exceptions are unchanged (closed and rolled back by the sessionmaker).
- New unit tests cover all three paths.

Proof: reproduced against a local Postgres 16 (Docker) with a size-1 pool. With the old code, one request cancelled the way Starlette cancels a client disconnect leaves the pool exhausted and the next request times out (the `QueuePool` error from the issue). With this change the pool stays usable. Unit tests cover the three cancellation paths (happy, ordinary exception, cancellation).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots

_local tests passing (added on review)_

## Pre-submission Checklist
- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
