### PR TITLE
fix(security): require superuser to modify LLM/vector DB settings

### DIFF
--- a/cognee/api/v1/settings/routers/get_settings_router.py
+++ b/cognee/api/v1/settings/routers/get_settings_router.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
 from cognee.api.DTO import InDTO, OutDTO
 from typing import Union, Optional, Literal
 from cognee.modules.users.methods import get_authenticated_user
-from fastapi import Depends
 from cognee.modules.users.models import User
 from cognee.modules.settings.get_settings import LLMConfig, VectorDBConfig
 
@@ -89,9 +89,16 @@ def get_settings_router() -> APIRouter:
         No content returned on successful save.
 
         ## Error Codes
+        - **403 Forbidden**: Caller is not a superuser
         - **400 Bad Request**: Invalid settings provided
         - **500 Internal Server Error**: Error saving settings
         """
+        if not user.is_superuser:
+            return JSONResponse(
+                status_code=403,
+                content={"error": "Superuser privileges required to modify settings"},
+            )
+
         from cognee.modules.settings import save_llm_config, save_vector_db_config
 
         if new_settings.llm is not None:

--- a/cognee/tests/api/test_settings_authorization.py
+++ b/cognee/tests/api/test_settings_authorization.py
@@ -1,0 +1,87 @@
+import os
+import pytest
+from unittest.mock import patch
+
+with patch("dotenv.load_dotenv"):
+    os.environ["REQUIRE_AUTHENTICATION"] = "true"
+    os.environ["ENABLE_BACKEND_ACCESS_CONTROL"] = "false"
+    os.environ["HASH_API_KEY"] = "false"
+
+    from fastapi.testclient import TestClient
+
+
+TEST_USER_EMAIL = "settings_test_user@example.com"
+TEST_USER_PASSWORD = "securepassword123!"
+
+DEFAULT_SUPERUSER_EMAIL = "default_user@example.com"
+DEFAULT_SUPERUSER_PASSWORD = "default_password"
+
+
+class TestSettingsAuthorization:
+    """
+    Regression test for CVE-2026-58473 / GHSA-49f7-whx5-4256.
+
+    POST /api/v1/settings must require superuser privileges. A previous
+    fix (#3115) was accidentally reverted; this test guards against that
+    happening silently again.
+    """
+
+    @pytest.fixture(scope="class")
+    def client(self):
+        from cognee.api.client import app
+
+        with TestClient(app) as client:
+            yield client
+
+    def _get_auth_header(self, client, email, password):
+        login_response = client.post(
+            "/api/v1/auth/login",
+            data={"username": email, "password": password},
+        )
+        assert login_response.status_code == 200
+        token = login_response.json()["access_token"]
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_non_superuser_cannot_modify_settings(self, client):
+        # Register a normal (non-superuser) user
+        register_response = client.post(
+            "/api/v1/auth/register",
+            json={"email": TEST_USER_EMAIL, "password": TEST_USER_PASSWORD},
+        )
+        assert register_response.status_code in (201, 400)
+
+        headers = self._get_auth_header(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+
+        response = client.post(
+            "/api/v1/settings",
+            json={"llm": {"provider": "openai", "model": "gpt-4o-mini", "api_key": "attacker-key"}},
+            headers=headers,
+        )
+
+        assert response.status_code == 403, (
+            "Non-superuser was able to modify global settings — CVE-2026-58473 regression!"
+        )
+
+    def test_superuser_can_modify_settings(self, client):
+        headers = self._get_auth_header(
+            client, DEFAULT_SUPERUSER_EMAIL, DEFAULT_SUPERUSER_PASSWORD
+        )
+
+        response = client.get("/api/v1/settings", headers=headers)
+        assert response.status_code == 200
+
+        current = response.json()
+        response = client.post(
+            "/api/v1/settings",
+            json={
+                "llm": {
+                    "provider": current["llm"]["provider"],
+                    "model": current["llm"]["model"],
+                    "api_key": "test-key-not-attacker-controlled",
+                }
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200, (
+            f"Superuser should still be able to modify settings. Got: {response.text}"
+        )


### PR DESCRIPTION
Description
Re-adds the is_superuser guard on POST /api/v1/settings that was introduced in #3115 but reverted 6 minutes later in 10971db1b0bd along with unrelated changes. This PR contains only the guard.

What was broken: POST /api/v1/settings only checked get_authenticated_user, not is_superuser so any registered account could overwrite the global LLM/vector DB config.

Why it was reverted before: I checked the original revert diff  PR #3115 bundled the guard together with two unrelated changes (a registration-disable env var, and API key masking changes). This PR restores only the guard, nothing else.

Addresses CVE-2026-58473 / GHSA-49f7-whx5-4256.

Testing: Added test_settings_authorization.py with two tests 
<img width="1397" height="887" alt="3" src="https://github.com/user-attachments/assets/ea2e3a3e-6923-4496-8105-c86bebf17957" />
<img width="1402" height="912" alt="Screenshot 2026-07-29 005019" src="https://github.com/user-attachments/assets/a262b843-9e28-44a5-94a8-3eb0277ae877" />

non-superuser POST returns 403, superuser POST still returns 200. Ran locally, both pass (screenshot below).

Note: Saw @nightcityblade express interest in #4146, but no PR had appeared after several days, so I went ahead given how long this CVE's been unpatched.

Fixes #4146 
Pre-submission Checklist
 [✅]I have tested my changes thoroughly before submitting this PR
 [✅]This PR contains minimal changes necessary to address the issue/feature
 [✅]My code follows the project's coding standards and style guidelines
 [✅]I have added tests that prove my fix is effective
 [✅]I have added necessary documentation (if applicable)
 [✅]All new and existing tests pass
 [✅]I have searched existing PRs to ensure this change hasn't been submitted already
 [✅]I have linked any relevant issues in the description
 [✅]My commits have clear and descriptive messages