### PR TITLE
fix(migration): stop an empty key alias from emptying Letta and Zep imports

### DIFF
--- a/cognee/modules/migration/sources/letta.py
+++ b/cognee/modules/migration/sources/letta.py
@@ -29,10 +29,18 @@ from cognee.modules.migration.sources.base import MemorySource
 
 
 def _first_list(container: Dict[str, Any], *keys: str) -> List[Dict[str, Any]]:
+    """Return the records under the first alias that carries any.
+
+    An agent file may emit several aliases for the same collection and fill
+    only one, so an empty alias must not shadow a populated one later in the
+    list -- returning on it imports nothing at all.
+    """
     for key in keys:
         value = container.get(key)
         if isinstance(value, list):
-            return [item for item in value if isinstance(item, dict)]
+            records = [item for item in value if isinstance(item, dict)]
+            if records:
+                return records
     return []
 
 

--- a/cognee/modules/migration/sources/zep.py
+++ b/cognee/modules/migration/sources/zep.py
@@ -38,10 +38,18 @@ from cognee.modules.migration.sources.base import MemorySource
 
 
 def _first_list(container: Dict[str, Any], *keys: str) -> List[Dict[str, Any]]:
+    """Return the records under the first alias that carries any.
+
+    A graph export may emit several aliases for the same collection and fill
+    only one, so an empty alias must not shadow a populated one later in the
+    list -- returning on it imports nothing at all.
+    """
     for key in keys:
         value = container.get(key)
         if isinstance(value, list):
-            return [item for item in value if isinstance(item, dict)]
+            records = [item for item in value if isinstance(item, dict)]
+            if records:
+                return records
     return []
 
 

--- a/cognee/tests/unit/migration/test_migration.py
+++ b/cognee/tests/unit/migration/test_migration.py
@@ -280,6 +280,28 @@ class TestLettaSource:
         transcript = loader.render_episode(episode)
         assert transcript.index("my order is late") < transcript.index("refunded you")
 
+    def test_empty_alias_does_not_shadow_the_populated_one(self):
+        # Letta renamed these collections across versions and an agent file can
+        # carry both spellings, the retired one left empty. The empty spelling
+        # must not stand in for the populated one.
+        agent_file = {
+            "agents": [
+                {
+                    "name": "assistant",
+                    "core_memory": [],
+                    "blocks": [{"label": "persona", "value": "I am helpful"}],
+                    "messages": [],
+                    "in_context_messages": [{"role": "user", "content": "hello"}],
+                    "archival_memory": [],
+                    "passages": [{"text": "archived note"}],
+                }
+            ]
+        }
+        kinds = [record.kind for record in collect(LettaSource(agent_file))]
+        assert kinds.count("memory_block") == 1
+        assert kinds.count("episode") == 1
+        assert kinds.count("document") == 1
+
 
 class TestZepSource:
     def test_graphiti_export(self):
@@ -327,6 +349,20 @@ class TestZepSource:
         assert fact.valid_at is not None
         assert fact.invalid_at is None
         assert fact.provenance == ["ep1"]
+
+    def test_empty_alias_does_not_shadow_the_populated_one(self):
+        # A Cypher dump names every collection it queried, so the ones that
+        # came back empty sit alongside the ones that did not.
+        export = {
+            "episodes": [],
+            "episodic_nodes": [{"uuid": "ep1", "content": "Alice moved to Berlin"}],
+            "entities": [],
+            "nodes": [{"uuid": "n1", "name": "Alice"}, {"uuid": "n2", "name": "Berlin"}],
+            "facts": [],
+            "edges": [{"uuid": "f1", "source_node_uuid": "n1", "target_node_uuid": "n2"}],
+        }
+        records = collect(GraphitiSource(export))
+        assert [record.kind for record in records] == ["episode", "entity", "entity", "fact"]
 
     def test_default_mode_is_hybrid(self):
         assert GraphitiSource({"nodes": []}).mode == "hybrid"


### PR DESCRIPTION
## Description

While reviewing the migration adapters (`letta.py` and `zep.py`), I noticed `_first_list(container, *keys)` returns on the **first key that evaluates to a list**, rather than the **first key that actually contains records**.

```python
# Before
def _first_list(container, *keys):
    for key in keys:
        value = container.get(key)
        if isinstance(value, list):
            return [item for item in value if isinstance(item, dict)]
    return []
```

Since `[]` is a list, an alias that is present but empty satisfies the check and returns immediately. The remaining aliases are never read.

Both adapters use this helper to accept the different spellings an export can use for the same collection:

```python
_first_list(agent, "messages", "in_context_messages", "message_history")
```

So a file carrying `messages: []` with the real history under `in_context_messages` imports nothing. Nothing raises — `records()` yields an empty stream and the import reports success on an empty result.

This is the case the aliasing exists for. `letta.py`'s docstring says the parser is "tolerant of key-name variations across Letta versions", and an agent file spanning a rename is exactly the file that carries both spellings with the retired one empty. On the Zep side, a Graphiti Cypher dump names every collection it queried, so the ones that returned no rows sit in the JSON next to the ones that did.

Six call sites are affected:

| Adapter | Aliases | Lost |
|---|---|---|
| `letta.py` | `core_memory` / `blocks` / `memory_blocks` | core memory blocks |
| `letta.py` | `messages` / `in_context_messages` / `message_history` | the conversation history |
| `letta.py` | `archival_memory` / `passages` / `archival_passages` | archival passages |
| `zep.py` | `episodes` / `episodic_nodes` | episodes |
| `zep.py` | `entities` / `nodes` / `entity_nodes` | entities |
| `zep.py` | `facts` / `edges` / `entity_edges` | facts |

The fix keeps scanning until an alias yields records:

```python
# After
records = [item for item in value if isinstance(item, dict)]
if records:
    return records
```

**Why the helper and not the call sites** — the call sites pass sensible alias orders. The wrong assumption is the helper's, that "present and a list" means "this is the one". Fixing it once covers all six, and any alias list added later.

**Why first-populated and not merging every populated alias** — merging changes what a file with two populated aliases means. That is a semantic decision this bug doesn't require, and I don't know of an exporter that produces that shape.

**Behaviour change** — limited to inputs that imported nothing before. A populated alias still wins in the same priority order, and all-empty still yields nothing.

**Scope** — the helper is duplicated verbatim in both files. Hoisting it into a shared module is the obvious follow-up, but that is a refactor rather than this fix, so I corrected both copies in place.

No existing issue — I found this by reading the adapters, so the report is above rather than linked.

## Acceptance Criteria

- **Reproduction:** a Letta agent file carrying `messages: []` alongside a populated
  `in_context_messages` imports **0 records** on `dev` and 1 after. A Graphiti dump of
  1 episode + 2 entities + 1 fact that names every alias imports **0 records** on `dev` and
  all 4 after. Both shapes are covered by the tests below.
- **The new tests fail on `dev`.** Both assert on records imported, not on the helper, so
  they fail against the unfixed adapters and pass after.
- **Migration suite:** 140 passing (138 before, 2 added) — `cognee/tests/unit/migration/`.
- **Full unit suite:** `19 failed / 3402 passed / 45 skipped` on `dev` and
  `19 failed / 3404 passed / 45 skipped` with this change — same failures, +2 passes, which are
  the two tests added here. The 19 are pre-existing and confined to `modules/retrieval/`
  (10 failed / 370 passed in that directory, identical both ways). Two further files fail
  collection locally on missing optional extras (`neo4j`, the eval dashboard), before and after.
- **Lint:** `ruff format --check` reports all three files already formatted. `ruff check`
  reports the identical set of pre-existing findings before and after — none introduced. I
  left those alone rather than mixing unrelated cleanup into this diff.

| Test | Asserts |
|---|---|
| `TestLettaSource::test_empty_alias_does_not_shadow_the_populated_one` | blocks, history and passages all survive when the retired alias is present but empty |
| `TestZepSource::test_empty_alias_does_not_shadow_the_populated_one` | a dump listing every alias imports its episode, both entities and its fact |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="1440" height="900" alt="PR2-cognee" src="https://github.com/user-attachments/assets/ae369e3d-7ccf-4ea9-8b9f-02ada2d87cfb" />

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable) — `_first_list` docstring added
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description — no existing issue; reported inline
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.