### PR TITLE
fix(tests): repair the three failure classes breaking dev unit-test CI

### DIFF
--- a/cognee/modules/cognify/estimator.py
+++ b/cognee/modules/cognify/estimator.py
@@ -369,7 +369,13 @@ def _path_candidate(value: str) -> Optional[Path]:
             # Mirror the ACCEPT_LOCAL_FILE_PATH gate: an existing *absolute* file
             # path is rejected, while an existing *relative* path falls through to
             # raw text (save_data_item_to_storage has no reject branch for it).
-            if value.startswith("/"):
+            # Absolute-path detection matches save_data_item_to_storage exactly,
+            # including Windows drive-letter paths (C:\...), which "/"-prefix
+            # checking alone misses.
+            is_absolute_path = (
+                value.startswith("/") or (os.name == "nt" and len(value) > 1 and value[1] == ":")
+            ) and Path(os.path.normpath(value)).is_absolute()
+            if is_absolute_path:
                 raise ValueError(f"Local files are not accepted, got {value!r}.")
             return None
         return path

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -78,6 +78,40 @@ def client(app):
     return TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def _restore_api_package_functions():
+    """Undo the bare ``pkg.fn = AsyncMock(...)`` assignments the tests below make.
+
+    Without this, the last-installed mock leaks into every later test module
+    that resolves these package attributes lazily — e.g. remember()-based tests
+    failed on dev CI with whichever side_effect ran last here
+    (LLMPaymentRequiredError from the 402 test).
+    """
+    import cognee.api.v1.add as add_pkg
+    import cognee.api.v1.cognify as cognify_pkg
+    import cognee.api.v1.memify as memify_pkg
+    import cognee.api.v1.search as search_pkg
+    import cognee.api.v1.update as update_pkg
+
+    targets = [
+        (add_pkg, "add"),
+        (cognify_pkg, "cognify"),
+        (memify_pkg, "memify"),
+        (search_pkg, "search"),
+        (update_pkg, "update"),
+    ]
+    missing = object()
+    originals = [(pkg, name, getattr(pkg, name, missing)) for pkg, name in targets]
+    yield
+    for pkg, name, original in originals:
+        if original is missing:
+            # The attribute only exists because a test assigned it — remove it.
+            if hasattr(pkg, name):
+                delattr(pkg, name)
+        else:
+            setattr(pkg, name, original)
+
+
 # ---------------------------------------------------------------------------
 # Add endpoint
 # ---------------------------------------------------------------------------

--- a/cognee/tests/unit/exceptions/test_cognee_error_contract.py
+++ b/cognee/tests/unit/exceptions/test_cognee_error_contract.py
@@ -50,6 +50,7 @@ SAMPLE_ARGUMENTS = {
     "got": "sample",
     "max_index": 2,
     "message": "contract message",
+    "model": "sample-provider/sample-model",
     "name": "ContractError",
     "observer": "sample-observer",
     "provider": "sample-provider",

--- a/cognee/tests/unit/modules/cognify/test_contradiction_detection_wiring.py
+++ b/cognee/tests/unit/modules/cognify/test_contradiction_detection_wiring.py
@@ -9,6 +9,7 @@ pipeline. No real API keys are required (get_cognify_config is patched; config +
 chunk_size are passed so no ontology/LLM setup runs).
 """
 
+import importlib
 import os
 import sys
 from unittest.mock import AsyncMock, patch
@@ -25,6 +26,19 @@ from cognee.tasks.graph.models import Contradiction, ContradictionList
 # cognify FUNCTION; grab the actual module objects for patching.
 cognify_module = sys.modules["cognee.api.v1.cognify.cognify"]
 remember_module = sys.modules["cognee.api.v1.remember.remember"]
+
+# String targets like patch("cognee.api.v1.serve.state.get_remote_client") break
+# on Python 3.10: its mock resolves dotted paths by getattr per component, and
+# package __init__ re-exports shadow submodules with same-named FUNCTIONS
+# (v1.serve is the serve() function), so resolution dies with
+# "'function' object has no attribute 'state'". Python 3.11+ resolves via
+# pkgutil.resolve_name (module-first) and doesn't hit this. Import the module
+# objects and use patch.object instead.
+_mod_serve_state = importlib.import_module("cognee.api.v1.serve.state")
+_mod_migrations_startup = importlib.import_module("cognee.modules.migrations.startup")
+_mod_engine_setup = importlib.import_module("cognee.modules.engine.operations.setup")
+_pkg_add = importlib.import_module("cognee.api.v1.add")
+_mod_users_methods = importlib.import_module("cognee.modules.users.methods")
 
 # The canonical pre-detection task order.
 _BASE_SEQUENCE = [
@@ -128,12 +142,13 @@ class TestRememberInheritsTheFlag:
             patch.dict(os.environ, {"TELEMETRY_DISABLED": "1"}),
             patch.object(cognify_module, "get_cognify_config", return_value=config),
             patch.object(cognify_module, "get_pipeline_executor", _fake_executor),
-            patch("cognee.modules.migrations.startup.run_migrations_and_block", new=AsyncMock()),
-            patch("cognee.api.v1.serve.state.get_remote_client", return_value=None),
-            patch("cognee.modules.engine.operations.setup.setup", new=AsyncMock()),
-            patch("cognee.api.v1.add.add", new=AsyncMock()),
-            patch(
-                "cognee.modules.users.methods.get_default_user",
+            patch.object(_mod_migrations_startup, "run_migrations_and_block", new=AsyncMock()),
+            patch.object(_mod_serve_state, "get_remote_client", return_value=None),
+            patch.object(_mod_engine_setup, "setup", new=AsyncMock()),
+            patch.object(_pkg_add, "add", new=AsyncMock()),
+            patch.object(
+                _mod_users_methods,
+                "get_default_user",
                 new=AsyncMock(return_value=object()),
             ),
             patch.object(


### PR DESCRIPTION
## Context

Every unit-test job on dev is red (e.g. [run 30442188890](https://github.com/topoteretes/cognee/actions/runs/30442188890) for `450d59181`): the same 3 tests fail on all platforms, plus a 4th on Windows. These are also the failures polluting CI on every open PR. Three distinct root causes:

## 1. `test_cognee_error_contract` — missing sample argument

`ProviderNotDeducibleError` gained a required `model` argument in `0cc96342d` and the contract test's `SAMPLE_ARGUMENTS` was never extended. One-line fix.

## 2. `test_contradiction_detection_wiring` remember-flag tests — cross-module mock leakage (not an LLM/budget problem)

The CI error says `LLMPaymentRequiredError (402)`, which looks like an exhausted LLM key — but no LLM is involved. The traceback bottoms out in `unittest/mock.py: raise effect`: tests in `test_api_error_responses.py` overwrite package attributes **directly** (`cognify_pkg.cognify = AsyncMock(side_effect=LLMPaymentRequiredError())`, same for `add`/`search`/`memify`/`update` — 17 assignments) and never restore them. Any later test that resolves those attributes lazily — `remember()`'s `cognify` call — inherits whichever mock ran last. That's why the failure shape changed between runs (`402` this week, `'function' object has no attribute 'state'` on Sunday) and never reproduced in isolation.

Fix: an autouse fixture in `test_api_error_responses.py` snapshots the five package attributes and restores them after every test (deleting attributes that only exist because a test assigned them — `memify` isn't exported until assigned).

Reproduced locally: running the poisoning file + victim file in one pytest invocation fails 2 tests before the fix, passes 36 after.

## 3. `test_estimator` local-path gate — Windows-only

`_path_candidate` detected absolute paths with `value.startswith("/")`, which never matches `C:\...`, so with `ACCEPT_LOCAL_FILE_PATH=false` an existing local file was **not** rejected on Windows (`DID NOT RAISE ValueError`). The fix mirrors the exact absolute-path detection already used (and Windows-proven) by the real ingestion gate in `save_data_item_to_storage`: drive-letter check + `normpath` + `is_absolute()`.

## Verification

- Locally (macOS): the previously failing tests pass; full `tests/unit/api` + `tests/unit/modules/cognify` + `tests/unit/exceptions` sweep = 332 passed.
- The Windows half of fix 3 is verified by this PR's own `windows-latest` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)