### PR TITLE
Feature/clo 351 combine cognify file into remember

### DIFF
--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -494,7 +494,7 @@ The MCP server exposes its functionality through tools. Call them from any MCP c
 
 The MCP server exposes three tools:
 
-- **remember**: Store data in memory. With `session_id`: fast session cache. Without `session_id`: permanent graph memory
+- **remember**: Store data in memory. Pass `data` for text, or `filename` + `content_base64` to ingest an uploaded file (up to 10 MB). With `session_id`: fast session cache (text only). Without `session_id`: permanent graph memory
 - **recall**: Search memory with auto-routing. Searches session cache first when `session_id` is provided, then falls through to the permanent graph
 - **forget**: Delete memory by dataset name, or delete all owned memory with `everything=True`
 
@@ -503,7 +503,6 @@ The MCP server exposes three tools:
 - **visualize_graph_ui**: Open the workspace and render the current knowledge graph
 - **upload_file_ui**: Open the workspace for file upload
 - **open_cognee_workspace**: Generic "open the cognee UI" entry point
-- **cognify_file**: Ingest an uploaded file (used by the workspace; accepts base64 content)
 - **list_datasets_json / list_dataset_data_json / create_dataset_json / get_client_info_json**: Structured-JSON helpers powering the workspace dropdown
 
 The workspace lets you create/switch/delete datasets, upload files, add text, search, and view the graph from one inline panel.
@@ -514,7 +513,7 @@ The bundle that powers the workspace lives at `cognee-mcp/src/app_bundles/visual
 
 By default, each MCP client gets its own auto-named dataset (e.g. Cursor → `cursor_vscode_memory`, Claude Code → `claude_code_memory`) so different agents don't share memory unintentionally. The dataset is created on demand the first time a client calls a workspace tool.
 
-LLM-direct calls to `cognify`, `remember`, `improve`, `cognify_status`, and `cognify_file` route to the agent-scoped dataset when `dataset_name` is omitted. Pass `dataset_name` explicitly to override (e.g. `dataset_name="main_dataset"` still works).
+LLM-direct calls to `cognify`, `remember`, `improve`, and `cognify_status` route to the agent-scoped dataset when `dataset_name` is omitted. Pass `dataset_name` explicitly to override (e.g. `dataset_name="main_dataset"` still works).
 
 To disable agent scoping and have all clients share `main_dataset` as the default, set in `.env`:
 

--- a/cognee-mcp/apps-src/src/main.tsx
+++ b/cognee-mcp/apps-src/src/main.tsx
@@ -629,7 +629,7 @@ function Composer({
       const args: Record<string, string> = { filename: file.name, content_base64 };
       if (selectedDataset) args.dataset_name = selectedDataset;
       const result = await app.callServerTool({
-        name: "cognify_file",
+        name: "remember",
         arguments: args,
       });
       const msg = textOf(result) ?? JSON.stringify(result.content);

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -172,6 +172,15 @@ class CogneeClient:
         mime_type, _ = mimetypes.guess_type(safe_name)
         return {"data": (safe_name, raw_bytes, mime_type or "application/octet-stream")}
 
+    @staticmethod
+    def _path_upload(path: str) -> Dict[str, tuple[str, bytes, str]]:
+        """Create a real file upload (preserving basename) for an existing filesystem path."""
+        safe_name = Path(path).name or "upload"
+        with open(path, "rb") as f:
+            raw_bytes = f.read()
+        mime_type, _ = mimetypes.guess_type(safe_name)
+        return {"data": (safe_name, raw_bytes, mime_type or "application/octet-stream")}
+
     async def add(
         self, data: Any, dataset_name: str = "main_dataset", node_set: Optional[List[str]] = None
     ) -> Dict[str, Any]:
@@ -195,7 +204,10 @@ class CogneeClient:
         if self.use_api:
             endpoint = f"{self.api_url}/api/v1/add"
 
-            files = self._text_upload(data)
+            if isinstance(data, (str, Path)) and os.path.isfile(data):
+                files = self._path_upload(data)
+            else:
+                files = self._text_upload(data)
             form_data = {
                 "datasetName": dataset_name,
             }
@@ -601,6 +613,8 @@ class CogneeClient:
             endpoint = f"{self.api_url}/api/v1/remember"
             if content_base64:
                 files = self._file_upload(filename, content_base64)
+            elif isinstance(data, (str, Path)) and os.path.isfile(data):
+                files = self._path_upload(data)
             else:
                 files = self._text_upload(data)
             form_data = {"datasetName": dataset_name}

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -181,6 +181,24 @@ class CogneeClient:
         mime_type, _ = mimetypes.guess_type(safe_name)
         return {"data": (safe_name, raw_bytes, mime_type or "application/octet-stream")}
 
+    @staticmethod
+    def _build_upload(
+        data: Any = None,
+        filename: Optional[str] = None,
+        content_base64: Optional[str] = None,
+    ) -> Dict[str, tuple[str, Any, str]]:
+        """Pick the multipart upload for an API-mode ingestion payload.
+
+        Base64 uploads and real filesystem paths keep their original
+        basename (#4230); anything else is uploaded as content-addressed
+        text so repeated writes don't collide (#2747).
+        """
+        if content_base64:
+            return CogneeClient._file_upload(filename, content_base64)
+        if isinstance(data, (str, Path)) and os.path.isfile(data):
+            return CogneeClient._path_upload(data)
+        return CogneeClient._text_upload(data)
+
     async def add(
         self, data: Any, dataset_name: str = "main_dataset", node_set: Optional[List[str]] = None
     ) -> Dict[str, Any]:
@@ -204,10 +222,7 @@ class CogneeClient:
         if self.use_api:
             endpoint = f"{self.api_url}/api/v1/add"
 
-            if isinstance(data, (str, Path)) and os.path.isfile(data):
-                files = self._path_upload(data)
-            else:
-                files = self._text_upload(data)
+            files = self._build_upload(data)
             form_data = {
                 "datasetName": dataset_name,
             }
@@ -611,12 +626,7 @@ class CogneeClient:
                 return response.json()
 
             endpoint = f"{self.api_url}/api/v1/remember"
-            if content_base64:
-                files = self._file_upload(filename, content_base64)
-            elif isinstance(data, (str, Path)) and os.path.isfile(data):
-                files = self._path_upload(data)
-            else:
-                files = self._text_upload(data)
+            files = self._build_upload(data, filename, content_base64)
             form_data = {"datasetName": dataset_name}
             if custom_prompt:
                 form_data["custom_prompt"] = custom_prompt

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -8,7 +8,11 @@ This module provides a unified interface for interacting with Cognee, supporting
 
 import os
 import sys
+import base64
 import hashlib
+import mimetypes
+import tempfile
+from pathlib import Path
 from typing import Optional, Any, List, Dict
 from uuid import UUID
 from contextlib import redirect_stdout
@@ -143,6 +147,30 @@ class CogneeClient:
         content = str(data)
         digest = hashlib.md5(content.encode("utf-8")).hexdigest()
         return {"data": (f"text_{digest}.txt", content, "text/plain")}
+
+    @staticmethod
+    def _decode_upload(filename: str, content_base64: str) -> tuple[str, bytes]:
+        """Decode a base64 file upload and sanitize its filename.
+
+        Strips any directory components from `filename` (defends against
+        path traversal via multipart form fields) and falls back to a
+        generic name/extension when the caller didn't provide a usable one,
+        so the file always lands with a safe, non-empty basename.
+        """
+        raw_bytes = base64.b64decode(content_base64, validate=True)
+
+        safe_name = Path(filename or "").name or "upload"
+        if not Path(safe_name).suffix:
+            safe_name += ".txt"
+
+        return safe_name, raw_bytes
+
+    @staticmethod
+    def _file_upload(filename: str, content_base64: str) -> Dict[str, tuple[str, bytes, str]]:
+        """Create a real file upload (preserving basename) for API-mode ingestion."""
+        safe_name, raw_bytes = CogneeClient._decode_upload(filename, content_base64)
+        mime_type, _ = mimetypes.guess_type(safe_name)
+        return {"data": (safe_name, raw_bytes, mime_type or "application/octet-stream")}
 
     async def add(
         self, data: Any, dataset_name: str = "main_dataset", node_set: Optional[List[str]] = None
@@ -522,12 +550,22 @@ class CogneeClient:
         dataset_name: str = "main_dataset",
         session_id: Optional[str] = None,
         custom_prompt: Optional[str] = None,
+        filename: Optional[str] = None,
+        content_base64: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Store data in memory via remember().
 
         With session_id: stores in session cache only (fast).
         Without session_id: full add + cognify pipeline (permanent).
+
+        Pass either `data` (text) or `filename` + `content_base64` (file
+        upload), not both. File uploads are permanent-memory only.
         """
+        if content_base64 and data:
+            raise ValueError("Pass either `data` or `filename` + `content_base64`, not both.")
+        if content_base64 and session_id:
+            raise ValueError("File uploads (content_base64) do not support session_id.")
+
         if self.use_api:
             if session_id:
                 if custom_prompt:
@@ -561,7 +599,10 @@ class CogneeClient:
                 return response.json()
 
             endpoint = f"{self.api_url}/api/v1/remember"
-            files = self._text_upload(data)
+            if content_base64:
+                files = self._file_upload(filename, content_base64)
+            else:
+                files = self._text_upload(data)
             form_data = {"datasetName": dataset_name}
             if custom_prompt:
                 form_data["custom_prompt"] = custom_prompt
@@ -575,15 +616,38 @@ class CogneeClient:
             return response.json()
         else:
             with redirect_stdout(sys.stderr):
+                tmp_dir = None
+                if content_base64:
+                    safe_name, raw_bytes = self._decode_upload(filename, content_base64)
+                    tmp_dir = tempfile.mkdtemp(prefix="cognee_upload_")
+                    remember_data = os.path.join(tmp_dir, safe_name)
+                    with open(remember_data, "wb") as f:
+                        f.write(raw_bytes)
+                else:
+                    remember_data = data
+
                 kwargs = {
-                    "data": data,
+                    "data": remember_data,
                     "dataset_name": dataset_name,
                 }
                 if session_id:
                     kwargs["session_id"] = session_id
                 if custom_prompt:
                     kwargs["custom_prompt"] = custom_prompt
-                result = await self.cognee.remember(**kwargs)
+
+                try:
+                    result = await self.cognee.remember(**kwargs)
+                finally:
+                    if tmp_dir is not None:
+                        try:
+                            os.unlink(remember_data)
+                        except OSError:
+                            pass
+                        try:
+                            os.rmdir(tmp_dir)
+                        except OSError:
+                            pass
+
                 return {
                     "status": getattr(result, "status", "completed"),
                     "dataset_name": dataset_name,

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -190,8 +190,8 @@ class CogneeClient:
         """Pick the multipart upload for an API-mode ingestion payload.
 
         Base64 uploads and real filesystem paths keep their original
-        basename (#4230); anything else is uploaded as content-addressed
-        text so repeated writes don't collide (#2747).
+        basename; anything else is uploaded as content-addressed
+        text so repeated writes don't collide.
         """
         if content_base64:
             return CogneeClient._file_upload(filename, content_base64)

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -3,6 +3,7 @@ import os
 import sys
 import argparse
 import asyncio
+import base64
 import subprocess
 from collections import deque
 from datetime import datetime, timezone
@@ -80,6 +81,7 @@ cognee_client: Optional[CogneeClient] = None
 # unbounded memory). Each entry is (iso_timestamp, error_message).
 _TASK_ERROR_HISTORY = 50
 _task_errors: dict[str, Deque[Tuple[str, str]]] = {}
+_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 
 # Strong references to in-flight background tasks. asyncio's event loop only keeps
 # weak references to tasks, so a fire-and-forget task can be GC'd mid-execution if
@@ -1076,7 +1078,9 @@ async def prune():
 @mcp.tool()
 @log_usage(function_name="MCP remember", log_type="mcp_tool")
 async def remember(
-    data: str,
+    data: str = None,
+    filename: str = None,
+    content_base64: str = None,
     dataset_name: str = None,
     session_id: str = None,
     custom_prompt: str = None,
@@ -1092,10 +1096,20 @@ async def remember(
     cache only. Fast, no entity extraction. Omit session_id when the
     content should be stored as permanent graph memory.
 
+    Pass either `data` (text) or `filename` + `content_base64` (a file
+    upload, up to 10 MB), not both. File uploads are permanent-memory
+    only and don't support session_id.
+
     Parameters
     ----------
-    data : str
-        The data to store (text content).
+    data : str, optional
+        The text content to store. Mutually exclusive with
+        filename/content_base64.
+    filename : str, optional
+        Original filename for a file upload. Used to derive the stored
+        document's name. Requires content_base64.
+    content_base64 : str, optional
+        Base64-encoded file content to ingest. Requires filename.
     dataset_name : str, optional
         Target dataset name. Defaults to the current MCP client's
         agent-scoped dataset (e.g. "cursor_vscode_memory"), or
@@ -1105,11 +1119,48 @@ async def remember(
     custom_prompt : str, optional
         Custom prompt for entity extraction (permanent mode only).
     """
+    if content_base64 and data:
+        return [
+            types.TextContent(
+                type="text",
+                text="Error: pass either `data` or `filename` + `content_base64`, not both.",
+            )
+        ]
+    if not content_base64 and not data:
+        return [
+            types.TextContent(
+                type="text",
+                text="Error: provide `data` or `filename` + `content_base64`.",
+            )
+        ]
+    if content_base64 and session_id:
+        return [
+            types.TextContent(
+                type="text",
+                text="Error: file uploads (content_base64) don't support session_id.",
+            )
+        ]
+
+    if content_base64:
+        try:
+            decoded = base64.b64decode(content_base64, validate=True)
+        except Exception as e:
+            return [types.TextContent(type="text", text=f"Error: invalid base64 content ({e}).")]
+        if len(decoded) > _MAX_UPLOAD_BYTES:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=f"Error: file exceeds 10 MB limit ({len(decoded):,} bytes).",
+                )
+            ]
+
     dataset_name = dataset_name or _agent_scoped_default_dataset()
     with redirect_stdout(sys.stderr):
         try:
             result = await cognee_client.remember(
                 data=data,
+                filename=filename,
+                content_base64=content_base64,
                 dataset_name=dataset_name,
                 session_id=session_id,
                 custom_prompt=custom_prompt,
@@ -1117,6 +1168,11 @@ async def remember(
             status = result.get("status", "completed")
             if session_id:
                 text = f"Stored in session cache (session_id={session_id}, status={status})."
+            elif content_base64:
+                text = (
+                    f"Ingested '{filename}' ({len(decoded):,} bytes) into dataset "
+                    f"'{dataset_name}' (status={status})."
+                )
             else:
                 text = f"Stored permanently in knowledge graph (dataset={dataset_name}, status={status})."
             return [types.TextContent(type="text", text=text)]
@@ -1523,87 +1579,6 @@ async def open_cognee_workspace() -> types.CallToolResult:
     return types.CallToolResult(
         content=[types.TextContent(type="text", text="Cognee workspace opened.")],
     )
-
-
-_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
-
-
-@mcp.tool(
-    name="cognify_file",
-    description=(
-        "Ingest an uploaded file into Cognee memory. Accepts the file as base64. "
-        "Runs add synchronously, then launches cognify in the background."
-    ),
-)
-@log_usage(function_name="MCP cognify_file", log_type="mcp_tool")
-async def cognify_file(
-    filename: str,
-    content_base64: str,
-    dataset_name: str = None,
-) -> list:
-    import base64
-    import tempfile
-
-    dataset_name = dataset_name or _agent_scoped_default_dataset()
-
-    try:
-        data = base64.b64decode(content_base64, validate=True)
-    except Exception as e:
-        return [types.TextContent(type="text", text=f"Error: invalid base64 content ({e}).")]
-
-    if len(data) > _MAX_UPLOAD_BYTES:
-        return [
-            types.TextContent(
-                type="text",
-                text=f"Error: file exceeds 10 MB limit ({len(data):,} bytes).",
-            )
-        ]
-
-    # Sanitize to a basename with a fallback extension; preserves the original
-    # name so cognee's Data.name comes out as e.g. "alice_notes" rather than
-    # a tempfile slug like "tmp231sj_ac".
-    safe_name = Path(filename).name or "upload"
-    if not Path(safe_name).suffix:
-        safe_name += ".txt"
-
-    with redirect_stdout(sys.stderr):
-        tmp_dir = tempfile.mkdtemp(prefix="cognee_upload_")
-        tmp_path = os.path.join(tmp_dir, safe_name)
-        try:
-            with open(tmp_path, "wb") as f:
-                f.write(data)
-            await cognee_client.add(tmp_path, dataset_name=dataset_name)
-        finally:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            try:
-                os.rmdir(tmp_dir)
-            except OSError:
-                pass
-
-    async def _cognify_bg():
-        with redirect_stdout(sys.stderr):
-            try:
-                await cognee_client.cognify(datasets=[dataset_name])
-                logger.info(f"cognify_file: background cognify finished for '{dataset_name}'.")
-            except Exception as e:
-                ts = datetime.now(timezone.utc).isoformat()
-                _task_errors.setdefault(dataset_name, []).append((ts, str(e)))
-                logger.error(f"cognify_file: background cognify failed for '{dataset_name}': {e}")
-
-    asyncio.create_task(_cognify_bg())
-
-    return [
-        types.TextContent(
-            type="text",
-            text=(
-                f"Ingested '{filename}' ({len(data):,} bytes) into dataset '{dataset_name}'. "
-                f"Cognify is running in the background; refresh the workspace once it finishes."
-            ),
-        )
-    ]
 
 
 def _format_named_items(items, singular: str, plural: str, limit: int = 50) -> str:

--- a/cognee-mcp/src/test_client.py
+++ b/cognee-mcp/src/test_client.py
@@ -17,7 +17,6 @@ EXPECTED_TOOLS = {
     "visualize_graph_ui",
     "upload_file_ui",
     "open_cognee_workspace",
-    "cognify_file",
     "list_datasets_json",
     "list_dataset_data_json",
     "get_client_info_json",

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -1,7 +1,10 @@
 import asyncio
+import base64
 import hashlib
 import importlib
 import json
+import mimetypes
+import re
 import sys
 from pathlib import Path
 
@@ -166,6 +169,188 @@ async def test_cognee_client_api_add_uses_content_addressed_filename():
     body = requests[0].content.decode()
     assert f'filename="text_{digest}.txt"' in body
     assert "data.txt" not in body
+
+
+async def _mock_api_client(requests: list[httpx.Request], **kwargs) -> CogneeClient:
+    """API-mode client whose requests are recorded instead of sent over the wire."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = CogneeClient(api_url="http://cognee.local", **kwargs)
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _multipart_filenames(request: httpx.Request) -> list[str]:
+    """Filenames declared in a multipart body, in order."""
+    body = request.content.decode("latin-1")
+    return re.findall(r'filename="([^"]*)"', body)
+
+
+# Regression guards for issue #4230: in API mode `add()` used to stringify every
+# argument through `_text_upload`, so a real filesystem path was uploaded as the
+# *path text* under a content-addressed `text_<md5>.txt` name. Documents ingested
+# through the MCP file-upload path therefore showed up in the UI as opaque slugs
+# instead of their original filename. Paths must upload file bytes under the
+# original basename, while plain text must keep the content-addressed name that
+# fixed the silent `data.txt` collision (#2747).
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_uploads_file_path_under_original_basename(tmp_path):
+    upload = tmp_path / "meeting-notes.md"
+    upload.write_text("# Meeting notes\nagenda item", encoding="utf-8")
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    try:
+        await client.add(str(upload), dataset_name="ds")
+    finally:
+        await client.close()
+
+    body = requests[0].content.decode()
+    expected_mime = mimetypes.guess_type("meeting-notes.md")[0] or "application/octet-stream"
+
+    assert _multipart_filenames(requests[0]) == ["meeting-notes.md"]
+    # The bug: a content-addressed name derived from the path string.
+    assert 'filename="text_' not in body
+    # The file's bytes must be uploaded, not the path that pointed at them.
+    assert "# Meeting notes\nagenda item" in body
+    assert str(upload) not in body
+    assert f"Content-Type: {expected_mime}" in body
+    assert 'name="datasetName"' in body and "ds" in body
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_accepts_path_objects(tmp_path):
+    upload = tmp_path / "client-profile.md"
+    upload.write_text("profile", encoding="utf-8")
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    try:
+        await client.add(upload, dataset_name="ds")
+    finally:
+        await client.close()
+
+    assert _multipart_filenames(requests[0]) == ["client-profile.md"]
+    assert "profile" in requests[0].content.decode()
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_uploads_binary_file_bytes(tmp_path):
+    upload = tmp_path / "report.pdf"
+    raw_bytes = b"%PDF-1.4\n\x00\x80\xff binary payload"
+    upload.write_bytes(raw_bytes)
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    try:
+        await client.add(str(upload), dataset_name="ds")
+    finally:
+        await client.close()
+
+    expected_mime = mimetypes.guess_type("report.pdf")[0] or "application/octet-stream"
+
+    assert _multipart_filenames(requests[0]) == ["report.pdf"]
+    # Bytes are passed through untouched: a str()/utf-8 round trip would mangle them.
+    assert raw_bytes in requests[0].content
+    assert f"Content-Type: {expected_mime}".encode() in requests[0].content
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_keeps_content_addressed_name_for_non_file_text():
+    """Text that merely looks like a path stays a content-addressed text upload."""
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    content = "/definitely/not/on/disk/notes.md"
+    digest = hashlib.md5(content.encode("utf-8")).hexdigest()
+
+    try:
+        await client.add(content, dataset_name="ds")
+    finally:
+        await client.close()
+
+    body = requests[0].content.decode()
+    assert _multipart_filenames(requests[0]) == [f"text_{digest}.txt"]
+    assert 'filename="notes.md"' not in body
+    assert content in body
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_keeps_text_upload_for_directories_and_long_text(tmp_path):
+    """Non-file arguments must not trip the path branch (or raise from os.path.isfile)."""
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    long_text = "remember this\n" * 5000
+
+    try:
+        await client.add(str(tmp_path), dataset_name="ds")
+        await client.add(long_text, dataset_name="ds")
+    finally:
+        await client.close()
+
+    dir_digest = hashlib.md5(str(tmp_path).encode("utf-8")).hexdigest()
+    text_digest = hashlib.md5(long_text.encode("utf-8")).hexdigest()
+
+    assert _multipart_filenames(requests[0]) == [f"text_{dir_digest}.txt"]
+    assert _multipart_filenames(requests[1]) == [f"text_{text_digest}.txt"]
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_remember_uploads_file_path_under_original_basename(tmp_path):
+    """remember() shares add()'s path handling (issue #4230, "same pattern")."""
+    upload = tmp_path / "alice_notes.md"
+    upload.write_text("alice prefers async updates", encoding="utf-8")
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    try:
+        await client.remember(str(upload), dataset_name="ds")
+    finally:
+        await client.close()
+
+    body = requests[0].content.decode()
+    assert requests[0].url.path == "/api/v1/remember"
+    assert _multipart_filenames(requests[0]) == ["alice_notes.md"]
+    assert "alice prefers async updates" in body
+    assert str(upload) not in body
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_remember_base64_upload_preserves_and_sanitizes_filename():
+    """The MCP file-upload path keeps the caller's name but never a directory."""
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    payload = base64.b64encode(b"# Client profile").decode("ascii")
+
+    try:
+        await client.remember(
+            data=None,
+            dataset_name="ds",
+            filename="client-profile.md",
+            content_base64=payload,
+        )
+        await client.remember(
+            data=None,
+            dataset_name="ds",
+            filename="../../etc/passwd",
+            content_base64=payload,
+        )
+        await client.remember(data=None, dataset_name="ds", filename="", content_base64=payload)
+    finally:
+        await client.close()
+
+    assert _multipart_filenames(requests[0]) == ["client-profile.md"]
+    assert "# Client profile" in requests[0].content.decode()
+    assert _multipart_filenames(requests[1]) == ["passwd.txt"]
+    assert _multipart_filenames(requests[2]) == ["upload.txt"]
 
 
 @pytest.mark.asyncio

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib
 import json
 import mimetypes
+import os
 import re
 import sys
 from pathlib import Path
@@ -345,6 +346,158 @@ async def test_cognee_client_api_remember_base64_upload_preserves_and_sanitizes_
 
 
 @pytest.mark.asyncio
+async def test_cognee_client_remember_rejects_conflicting_upload_arguments():
+    """The client refuses ambiguous payloads before deciding on a transport."""
+    client = await _mock_api_client([])
+    payload = base64.b64encode(b"file bytes").decode("ascii")
+
+    try:
+        with pytest.raises(ValueError, match="not both"):
+            await client.remember(data="inline text", filename="notes.md", content_base64=payload)
+        with pytest.raises(ValueError, match="do not support session_id"):
+            await client.remember(
+                data=None, filename="notes.md", content_base64=payload, session_id="s-1"
+            )
+    finally:
+        await client.close()
+
+
+class FakeCogneeModule:
+    """Stand-in for the `cognee` module used by CogneeClient's direct mode."""
+
+    def __init__(self, result=None, error=None):
+        self.calls: list[dict] = []
+        self.seen_payloads: list[bytes] = []
+        self.seen_paths: list[str] = []
+        self._result = result
+        self._error = error
+
+    async def remember(self, **kwargs):
+        self.calls.append(kwargs)
+        data = kwargs.get("data")
+        # Read through the handed-off path while it is still on disk: the
+        # client deletes it as soon as remember() returns.
+        if isinstance(data, str) and os.path.isfile(data):
+            self.seen_paths.append(data)
+            with open(data, "rb") as handle:
+                self.seen_payloads.append(handle.read())
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+def _local_client(fake_cognee: FakeCogneeModule) -> CogneeClient:
+    """Direct-mode client with the real cognee module swapped out."""
+    client = CogneeClient()
+    client.cognee = fake_cognee
+    return client
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_writes_upload_to_a_temp_file():
+    """Direct mode materializes the upload on disk under its original name."""
+    fake = FakeCogneeModule()
+    client = _local_client(fake)
+    raw_bytes = b"%PDF-1.4\n\x00\x80\xff quarterly report"
+    payload = base64.b64encode(raw_bytes).decode("ascii")
+
+    result = await client.remember(
+        data=None,
+        dataset_name="ds",
+        filename="q3-report.pdf",
+        content_base64=payload,
+    )
+
+    assert len(fake.calls) == 1
+    handed_off = fake.calls[0]["data"]
+    assert Path(handed_off).name == "q3-report.pdf"
+    # Bytes survive the base64 -> disk round trip untouched.
+    assert fake.seen_payloads == [raw_bytes]
+    assert fake.calls[0]["dataset_name"] == "ds"
+    # File uploads are permanent-memory only, so no session_id is forwarded.
+    assert "session_id" not in fake.calls[0]
+    assert result["dataset_name"] == "ds"
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_sanitizes_upload_filename():
+    """Direct mode applies the same basename sanitizing as the API path."""
+    payload = base64.b64encode(b"contents").decode("ascii")
+
+    for supplied, expected in [
+        ("../../etc/passwd", "passwd.txt"),
+        ("", "upload.txt"),
+        ("notes", "notes.txt"),
+    ]:
+        fake = FakeCogneeModule()
+        client = _local_client(fake)
+
+        await client.remember(
+            data=None, dataset_name="ds", filename=supplied, content_base64=payload
+        )
+
+        written = Path(fake.calls[0]["data"])
+        assert written.name == expected
+        # The traversal segments must not survive into the staged path.
+        assert ".." not in written.parts
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_cleans_up_the_temp_upload():
+    """The staged file and its directory are removed once ingestion returns."""
+    fake = FakeCogneeModule()
+    client = _local_client(fake)
+    payload = base64.b64encode(b"transient").decode("ascii")
+
+    await client.remember(
+        data=None, dataset_name="ds", filename="scratch.md", content_base64=payload
+    )
+
+    staged = Path(fake.seen_paths[0])
+    assert not staged.exists()
+    assert not staged.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_cleans_up_when_ingestion_fails():
+    """A failing cognify must not leak the staged upload onto disk."""
+    fake = FakeCogneeModule(error=RuntimeError("cognify exploded"))
+    client = _local_client(fake)
+    payload = base64.b64encode(b"transient").decode("ascii")
+
+    with pytest.raises(RuntimeError, match="cognify exploded"):
+        await client.remember(
+            data=None, dataset_name="ds", filename="scratch.md", content_base64=payload
+        )
+
+    staged = Path(fake.seen_paths[0])
+    assert not staged.exists()
+    assert not staged.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_passes_text_through_untouched():
+    """Text payloads reach cognee.remember as-is, with no file staging."""
+    fake = FakeCogneeModule()
+    client = _local_client(fake)
+
+    await client.remember(
+        data="alice prefers async updates",
+        dataset_name="ds",
+        session_id="s-1",
+        custom_prompt="extract carefully",
+    )
+
+    assert fake.calls[0] == {
+        "data": "alice prefers async updates",
+        "dataset_name": "ds",
+        "session_id": "s-1",
+        "custom_prompt": "extract carefully",
+    }
+    assert fake.seen_paths == []
+
+
+@pytest.mark.asyncio
 async def test_cognee_client_api_remember_sends_session_id():
     requests: list[httpx.Request] = []
 
@@ -399,6 +552,187 @@ async def test_cognee_client_api_recall_sends_session_id_prompt_and_null_search_
     assert payload["system_prompt"] == "Answer with provenance."
     assert payload["search_type"] is None
     assert payload["top_k"] == 5
+
+
+class RecordingRememberClient:
+    """Fake cognee_client that records what the remember tool forwarded."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def remember(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"status": "completed"}
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_error",
+    [
+        pytest.param(
+            {"data": "inline text", "filename": "n.md", "content_base64": "aGk="},
+            "not both",
+            id="text_and_file",
+        ),
+        pytest.param({}, "provide `data`", id="neither"),
+        pytest.param({"data": ""}, "provide `data`", id="empty_data"),
+        pytest.param(
+            {"filename": "n.md", "content_base64": "aGk=", "session_id": "s-1"},
+            "don't support session_id",
+            id="upload_with_session",
+        ),
+        pytest.param(
+            {"filename": "n.md", "content_base64": "not valid base64!"},
+            "invalid base64",
+            id="malformed_base64",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_mcp_remember_rejects_invalid_payloads(monkeypatch, kwargs, expected_error):
+    """Bad argument combinations are refused before any ingestion is attempted."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    result = await server.remember(**kwargs)
+
+    assert expected_error in result[0].text
+    assert result[0].text.startswith("Error:")
+    assert fake_client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_rejects_uploads_over_the_size_limit(monkeypatch):
+    """Oversized uploads are rejected client-side rather than posted."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    oversized = base64.b64encode(b"x" * (server._MAX_UPLOAD_BYTES + 1)).decode("ascii")
+    result = await server.remember(filename="big.bin", content_base64=oversized)
+
+    assert "exceeds 10 MB limit" in result[0].text
+    assert fake_client.calls == []
+
+    at_limit = base64.b64encode(b"x" * server._MAX_UPLOAD_BYTES).decode("ascii")
+    result = await server.remember(filename="big.bin", content_base64=at_limit)
+
+    # The limit itself is inclusive.
+    assert not result[0].text.startswith("Error:")
+    assert len(fake_client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_forwards_file_uploads(monkeypatch):
+    """The merged tool hands filename + content_base64 straight to the client."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    raw_bytes = b"# Client profile\nprefers async updates"
+    payload = base64.b64encode(raw_bytes).decode("ascii")
+
+    result = await server.remember(
+        filename="client-profile.md",
+        content_base64=payload,
+        dataset_name="ds",
+        custom_prompt="extract carefully",
+    )
+
+    assert fake_client.calls == [
+        {
+            "data": None,
+            "filename": "client-profile.md",
+            "content_base64": payload,
+            "dataset_name": "ds",
+            "session_id": None,
+            "custom_prompt": "extract carefully",
+        }
+    ]
+    # The confirmation names the file and its decoded size, not the base64 length.
+    assert "client-profile.md" in result[0].text
+    assert f"{len(raw_bytes):,} bytes" in result[0].text
+    assert "ds" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_still_stores_text_and_session_entries(monkeypatch):
+    """Absorbing cognify_file left the pre-existing text paths intact."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    permanent = await server.remember(data="alice prefers async updates", dataset_name="ds")
+    session = await server.remember(data="scratch note", dataset_name="ds", session_id="s-1")
+
+    assert fake_client.calls[0]["data"] == "alice prefers async updates"
+    assert fake_client.calls[0]["content_base64"] is None
+    assert "knowledge graph" in permanent[0].text
+
+    assert fake_client.calls[1]["session_id"] == "s-1"
+    assert "session cache" in session[0].text
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_defaults_dataset_when_caller_omits_it(monkeypatch):
+    """Uploads inherit the agent-scoped default dataset, same as text writes."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+    monkeypatch.setattr(server, "_agent_scoped_default_dataset", lambda: "cursor_vscode_memory")
+
+    await server.remember(filename="n.md", content_base64=base64.b64encode(b"hi").decode("ascii"))
+
+    assert fake_client.calls[0]["dataset_name"] == "cursor_vscode_memory"
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_reports_client_failures(monkeypatch):
+    """Ingestion errors surface as tool errors instead of propagating."""
+    import src.server as server
+
+    class ExplodingClient:
+        async def remember(self, **kwargs):
+            raise RuntimeError("upstream is down")
+
+    monkeypatch.setattr(server, "cognee_client", ExplodingClient())
+
+    result = await server.remember(
+        filename="n.md", content_base64=base64.b64encode(b"hi").decode("ascii")
+    )
+
+    assert "Remember failed" in result[0].text
+    assert "upstream is down" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_mcp_no_longer_exposes_cognify_file():
+    """cognify_file was absorbed into remember and must be gone from the surface."""
+    import src.server as server
+
+    tools = await server.mcp.list_tools()
+
+    assert "cognify_file" not in {tool.name for tool in tools}
+    assert not hasattr(server, "cognify_file")
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_advertises_file_upload_parameters():
+    """The merged tool's schema is what tells an LLM it can send files."""
+    import src.server as server
+
+    tools = await server.mcp.list_tools()
+    remember_tool = next(tool for tool in tools if tool.name == "remember")
+    properties = remember_tool.inputSchema["properties"]
+
+    assert {"data", "filename", "content_base64"} <= set(properties)
+    assert "filename" in remember_tool.description
+    assert "content_base64" in remember_tool.description
 
 
 @pytest.mark.asyncio

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -125,7 +125,6 @@ WORKSPACE_UI_ENTRY_TOOLS = {
     "open_cognee_workspace",
 }
 WORKSPACE_INTERNAL_TOOLS = {
-    "cognify_file",
     "list_datasets_json",
     "list_dataset_data_json",
     "create_dataset_json",

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -190,15 +190,6 @@ def _multipart_filenames(request: httpx.Request) -> list[str]:
     return re.findall(r'filename="([^"]*)"', body)
 
 
-# Regression guards for issue #4230: in API mode `add()` used to stringify every
-# argument through `_text_upload`, so a real filesystem path was uploaded as the
-# *path text* under a content-addressed `text_<md5>.txt` name. Documents ingested
-# through the MCP file-upload path therefore showed up in the UI as opaque slugs
-# instead of their original filename. Paths must upload file bytes under the
-# original basename, while plain text must keep the content-addressed name that
-# fixed the silent `data.txt` collision (#2747).
-
-
 @pytest.mark.asyncio
 async def test_cognee_client_api_add_uploads_file_path_under_original_basename(tmp_path):
     upload = tmp_path / "meeting-notes.md"
@@ -215,7 +206,7 @@ async def test_cognee_client_api_add_uploads_file_path_under_original_basename(t
     expected_mime = mimetypes.guess_type("meeting-notes.md")[0] or "application/octet-stream"
 
     assert _multipart_filenames(requests[0]) == ["meeting-notes.md"]
-    # The bug: a content-addressed name derived from the path string.
+    # Bug from issue 4230: a content-addressed name derived from the path string.
     assert 'filename="text_' not in body
     # The file's bytes must be uploaded, not the path that pointed at them.
     assert "# Meeting notes\nagenda item" in body

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -26,7 +26,6 @@ EXPECTED_TOOLS = {
     "visualize_graph_ui",
     "upload_file_ui",
     "open_cognee_workspace",
-    "cognify_file",
     "list_datasets_json",
     "list_dataset_data_json",
     "create_dataset_json",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Merges cognify_file() and remember() into one unified remember() tool.
There are two tools defined which enable Cognee MCP's data ingestion: cognify_file() and remember(). The former receives a file input, and the latter a text string. This makes tool selection needlessly confusing, and creates the need for a unified remember() for all types of uploads. 
Here are all the parts of the change: 
1) remember() only ingested text. Now, a file-upload path has been added and its signature altered to reflect that change, giving it the same level of capability as cognify_file().
2) cognify_file() has been fully removed from the codebase & replaced with information reflecting the upgraded version of remember() (MCP UI frontend, MCP tools, documentation, all relevant tests, and API.)
3) I also found a bug (documented as issue 4230) and fixed it as well as writing some preventative tests. 
Relevant issues: #4230 

## Acceptance Criteria
Reproduction: in API mode, ingesting meeting-notes.md stored it as text_<md5>.txt whose body was the tempfile path string, not the document, so uploads showed up in the UI as opaque slugs with no content. After the fix it uploads as meeting-notes.md with the file's bytes and a guessed content type, while plain text keeps its content-addressed name.

MCP hardening suite: 56 passing (31 on dev, 21 new test functions, 25 additional collected cases with parametrisation).

The new tests fail on dev. 23 of the 56 fail against unfixed dev source. 4 are #4230-specific (add() with a path as str/Path/binary, and remember() with a path); the other 19 require the merged remember, which dev has no parameters for. Two tests pass both before and after (the content-addressed guards for text-that-looks-like-a-path and for directories) as protection against over-correcting and reopening #2747.

Backend router units: 311 passing across cognee/tests/unit/api/, unit/migration/test_remember_router_cogx.py and cli_tests/cli_unit_tests/test_api_client.py, which cover the /api/v1/add and /api/v1/remember contracts this client posts into.

Lint: ruff check and ruff format --check clean on both changed source files and the test file; all six pre-commit hooks pass on every file in the diff, nothing rewritten. No unrelated cleanup mixed in.

Deployment e2e runs before and after the PR.

Tests added in cognee-mcp/tests/test_mcp_server_hardening.py:
_**..._add_uploads_file_path_under_original_basename** checks that a path uploads file bytes as meeting-notes.md, not the path string
**..._add_accepts_path_objects** checks that Path behaves like str
**..._add_uploads_binary_file_bytes** checks that binary survives byte-for-byte; no utf-8 round trip
**..._add_keeps_content_addressed_name_for_non_file_text** checks that text that looks like a path stays text_<md5>.txt (#2747)
**..._add_keeps_text_upload_for_directories_and_long_text** checks that directories and long strings don't trip the path branch
**..._remember_uploads_file_path_under_original_basename** checks that remember() shares add()'s path handling
**..._remember_base64_upload_preserves_and_sanitizes_filename** checks that keeps the caller's name; strips ../../; (empty) goes into upload.txt
**..._local_remember_* (5 tests)** ensure that direct mode writes a temp file, sanitizes it, cleans up on success and failure, passes text through
**..._mcp_remember_rejects_invalid_payloads (5 cases)** check both-args, neither-arg, empty data, upload+session, malformed base64
**..._mcp_remember_forwards_file_uploads / _over_the_size_limit** checks that args reach the client; >10 MB rejected
**..._mcp_no_longer_exposes_cognify_file / _advertises_file_upload_parameters** checks that tool surface matches the merged contract_

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Code refactoring
- [ ] Other (please specify):

## Screenshots
MCP hardening tests (uv run pytest cognee-mcp/tests/test_mcp_server_hardening.py -v)
<img width="547" height="604" alt="Screenshot 2026-07-29 at 4 36 31 PM" src="https://github.com/user-attachments/assets/ad865367-d4f9-41e1-a024-1ce783f1437a" />

Backend router unit tests (uv run pytest cognee/tests/unit/api/ cognee/tests/unit/migration/test_remember_router_cogx.py cognee/tests/cli_tests/cli_unit_tests/test_api_client.py -q) - I had to use -q since warnings were a bit noisy
<img width="760" height="48" alt="Screenshot 2026-07-28 at 8 34 25 PM" src="https://github.com/user-attachments/assets/e9d588a7-e11e-47c9-83fa-39aaffbbd32d" />

MCP stdio smoke test (uv run cognee-mcp/src/test_client.py)
<img width="228" height="128" alt="Screenshot 2026-07-28 at 8 37 18 PM" src="https://github.com/user-attachments/assets/735cc4fc-51ca-431e-ae43-c03a56a96c0b" />

Deployment e2e test (docker build -f cognee-mcp/Dockerfile -t cognee-mcp:local . to build the docker image, then pytest cognee/tests/deployment/test_mcp_http_direct.py -m deployment -v)
<img width="508" height="161" alt="Screenshot 2026-07-28 at 8 39 08 PM" src="https://github.com/user-attachments/assets/1e73a0f6-6f1c-425f-a9c2-192f29cd7f9c" />
 
Building the MCP frontend, just to check my one-line UI change doesn't break anything (from root: cd cognee-mcp/apps-src && npm ci && npm run build)
<img width="560" height="486" alt="Screenshot 2026-07-29 at 12 58 47 PM" src="https://github.com/user-attachments/assets/e6748597-38a7-4d7a-bd45-8ba524a6f6e8" />

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [X] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [X] **This PR contains minimal changes necessary to address the issue/feature**
- [X] My code follows the project's coding standards and style guidelines
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if applicable)
- [X] All new and existing tests pass
- [X] I have searched existing PRs to ensure this change hasn't been submitted already
- [X] I have linked any relevant issues in the description
- [X] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.