### PR TITLE
Feature/cog 6011 add git commit style to claudemd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,6 +449,19 @@ this rule applies only to internal PRs.
 - **Type hints**: Encouraged (ty checks enabled)
 - **Important**: Always run `pre-commit run --all-files` before committing to catch formatting issues
 
+## Commit & PR Title Style
+- **Subject line (required):**
+  - The format is (type): (short summary)
+  - Write summary as if it is giving an instruction (e.g., "Fix bug" instead of "Fixed bug")
+  - 50 chars or less
+  - Capitalize first char of summary
+  - Do NOT end with a period
+- **Body (optional):**
+  - **Description:** Explain the motivation behind the change, what problem it solves, and any relevant background.
+  - **Use the body to explain what and why, not how.** The body of the commit message should explain why the change was made and what problem it solves. You don't need to explain how the code works, as the code itself should be clear enough for that.
+- **Include issue tracking numbers where applicable.** Reference an issue in at least the subject line (e.g., Fixes COG-24), making it easier to trace changes to their corresponding issue.
+- **Separate the subject line from the body with a blank line.** This helps differentiate the short description from the detailed explanation. Generally, all commits should have separate subject and body.
+
 ## Testing Strategy
 
 Tests are organized in `cognee/tests/`:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
Currently, CLAUDE.md has no guidelines for coding agents making commits. This means they can pollute our git history with commits that do not follow the format. 
This PR lifts the guidelines from our Commit/PR Title guidelines and adds them to CLAUDE.md. 

## Acceptance Criteria
Every point from the original document is covered.
- Imperative mood
- 50 char max
- Separate subject and body
- Capitalize subject line
- Don't end w period
- Use body to explain what, why
- Include issue tracking nums
- Sign your commits

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Code refactoring
- [ ] Other (please specify):

## Screenshots
Here is claude following the style guide while committing one of my changes:
<img width="472" height="89" alt="Screenshot 2026-07-29 at 6 05 34 PM" src="https://github.com/user-attachments/assets/01f19041-cc72-47b0-990a-b0fce2c85a13" />


## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [X] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [X] **This PR contains minimal changes necessary to address the issue/feature**
- [X] My code follows the project's coding standards and style guidelines
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if applicable)
- [X] All new and existing tests pass
- [X] I have searched existing PRs to ensure this change hasn't been submitted already
- [X] I have linked any relevant issues in the description
- [X] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.