### PR TITLE
fix(cache): stop duplicate-row 503s in cache_session_context (#4226)

### DIFF
--- a/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
@@ -42,6 +42,28 @@ _DEADLOCK_ATTEMPTS = 3
 # Advisory-lock id guarding the throttled global TTL sweep on Postgres.
 _PURGE_LOCK_ID = int.from_bytes(sha256(b"cognee_cache_ttl_sweep").digest()[:8], "big", signed=True)
 
+# Unique key that keeps one session-context row per (user, session, entry). Its
+# absence let a timed-out-then-retried write insert duplicate rows, after which
+# scalar_one_or_none() raised and the session 503'd forever (issue #4226). It is
+# enforced as a create-on-init unique index rather than a table-level constraint
+# so pre-existing deployments (whose table predates the fix) get it too. This is
+# orthogonal to _lock_session_writes, which only serializes concurrent writers and
+# does not make a client retry across separate transactions idempotent.
+_SESSION_CONTEXT_UNIQUE_INDEX = "uq_cache_session_context_entry"
+
+_CREATE_SESSION_CONTEXT_UNIQUE_INDEX_SQL = (
+    f"CREATE UNIQUE INDEX IF NOT EXISTS {_SESSION_CONTEXT_UNIQUE_INDEX} "
+    "ON cache_session_context (user_id, session_id, entry_id)"
+)
+
+# Collapse pre-existing duplicate rows to the newest (highest seq) per key so the
+# unique index can be built on a legacy table that already accumulated dupes.
+_DEDUPE_SESSION_CONTEXT_SQL = (
+    "DELETE FROM cache_session_context WHERE seq NOT IN "
+    "(SELECT MAX(seq) FROM cache_session_context "
+    "GROUP BY user_id, session_id, entry_id)"
+)
+
 
 def _is_deadlock_error(error: Exception) -> bool:
     """Best-effort detection of a Postgres deadlock without importing asyncpg."""
@@ -176,11 +198,34 @@ class SqlCacheAdapter(CacheDBInterface):
             try:
                 async with self.engine.begin() as connection:
                     await connection.run_sync(cache_metadata.create_all, checkfirst=True)
+                await self._migrate_session_context_uniqueness()
             except Exception as error:
                 error_msg = f"Failed to connect to SQL cache database: {error}"
                 logger.error(error_msg)
                 raise CacheConnectionError(error_msg) from error
             self._initialized = True
+
+    async def _migrate_session_context_uniqueness(self) -> None:
+        """Ensure the (user_id, session_id, entry_id) unique index on cache_session_context.
+
+        Fresh databases get it directly. Legacy tables that already accumulated
+        duplicate rows (issue #4226) fail the create; those dupes are collapsed to
+        the newest row per key and the index is created on the retry. Each statement
+        runs in its own transaction so the failed create (which aborts the surrounding
+        transaction on Postgres) doesn't poison the dedupe that follows. On the common
+        path — index already present or table clean — this is a single no-op statement.
+        """
+        try:
+            async with self.engine.begin() as connection:
+                await connection.execute(text(_CREATE_SESSION_CONTEXT_UNIQUE_INDEX_SQL))
+            return
+        except DBAPIError:
+            # Pre-existing duplicate keys block the unique index; collapse and retry.
+            pass
+        async with self.engine.begin() as connection:
+            await connection.execute(text(_DEDUPE_SESSION_CONTEXT_SQL))
+        async with self.engine.begin() as connection:
+            await connection.execute(text(_CREATE_SESSION_CONTEXT_UNIQUE_INDEX_SQL))
 
     @staticmethod
     def _now() -> datetime:
@@ -835,31 +880,51 @@ class SqlCacheAdapter(CacheDBInterface):
     async def create_session_context_entry(
         self, user_id: str, session_id: str, entry_dump: dict
     ) -> None:
-        """Append one session-context entry (kind-discriminated dict) to the session.
+        """Upsert one session-context entry (kind-discriminated dict) into the session.
 
-        The caller validates the payload; we only promote its ``id`` to the
-        ``entry_id`` column so updates can target a single row directly.
+        The caller validates the payload; we promote its ``id`` to the ``entry_id``
+        column so a single row is addressable per entry. Re-writing the same
+        ``entry_id`` updates that row in place instead of appending a duplicate,
+        which makes a timed-out-then-retried write idempotent — the missing piece
+        that let retries pile up duplicate rows and permanently 503 the session
+        (issue #4226).
         """
         await self._ensure_initialized()
         # Redis/FS append regardless of "id" (an id-less entry is simply never
-        # targetable by update). Mirror that: fall back to a synthetic entry_id
-        # only to satisfy the NOT NULL column; the stored payload is untouched.
+        # targetable by update). Mirror the "not updatable" part: fall back to a
+        # synthetic entry_id only to satisfy the NOT NULL column. A synthetic id is
+        # unique per call, so id-less entries still append rather than collapse.
         entry_id = entry_dump.get("id") or str(uuid.uuid4())
         try:
+            if self._is_postgres:
+                from sqlalchemy.dialects.postgresql import insert as upsert_insert
+            else:
+                from sqlalchemy.dialects.sqlite import insert as upsert_insert
+
+            statement = upsert_insert(cache_session_context).values(
+                user_id=user_id,
+                session_id=session_id,
+                entry_id=entry_id,
+                payload=entry_dump,
+                expires_at=self._session_expiry(),
+            )
+            statement = statement.on_conflict_do_update(
+                index_elements=[
+                    cache_session_context.c.user_id,
+                    cache_session_context.c.session_id,
+                    cache_session_context.c.entry_id,
+                ],
+                set_={
+                    "payload": statement.excluded.payload,
+                    "expires_at": statement.excluded.expires_at,
+                },
+            )
             async with self.sessionmaker() as session, session.begin():
                 await self._lock_session_writes(session, cache_session_context, user_id, session_id)
                 await self._purge_session_expired(
                     session, cache_session_context, user_id, session_id
                 )
-                await session.execute(
-                    insert(cache_session_context).values(
-                        user_id=user_id,
-                        session_id=session_id,
-                        entry_id=entry_id,
-                        payload=entry_dump,
-                        expires_at=self._session_expiry(),
-                    )
-                )
+                await session.execute(statement)
                 await self._refresh_session_ttl(session, cache_session_context, user_id, session_id)
         except Exception as error:
             error_msg = f"Unexpected error while adding session context to SQL cache: {error}"
@@ -901,6 +966,10 @@ class SqlCacheAdapter(CacheDBInterface):
                     await self._lock_session_writes(
                         session, cache_session_context, user_id, session_id
                     )
+                    # Prefer the newest row and cap at one: the unique index now keeps
+                    # this to a single row, but any duplicate that predates the migration
+                    # must resolve to the newest instead of raising MultipleResultsFound
+                    # (the original 503 trigger, issue #4226).
                     result = await session.execute(
                         select(cache_session_context.c.payload)
                         .where(
@@ -908,9 +977,11 @@ class SqlCacheAdapter(CacheDBInterface):
                             cache_session_context.c.entry_id == entry_id,
                             self._not_expired(cache_session_context),
                         )
+                        .order_by(cache_session_context.c.seq.desc())
+                        .limit(1)
                         .with_for_update()
                     )
-                    payload = result.scalar_one_or_none()
+                    payload = result.scalars().first()
                     if payload is None:
                         return False
                     merged = {**dict(payload), **merge}

--- a/cognee/infrastructure/databases/cache/sql/tables.py
+++ b/cognee/infrastructure/databases/cache/sql/tables.py
@@ -114,9 +114,12 @@ Index(
     sqlite_where=cache_trace_entries.c.expires_at.isnot(None),
 )
 
-# Session-context entries: append-only, kind-discriminated ("context"/"feedback").
-# entry_id is promoted from the payload's "id" to a column for direct UPDATE,
-# mirroring how cache_qa_entries promotes qa_id.
+# Session-context entries: one row per (user_id, session_id, entry_id), kind-
+# discriminated ("context"/"feedback"). entry_id is promoted from the payload's
+# "id" to a column for direct UPDATE, mirroring how cache_qa_entries promotes qa_id.
+# Uniqueness on (user_id, session_id, entry_id) is enforced by a create-on-init
+# unique index in SqlCacheAdapter (not a table constraint here) so it also backfills
+# onto pre-existing tables after collapsing legacy duplicate rows — see issue #4226.
 cache_session_context = Table(
     "cache_session_context",
     cache_metadata,

--- a/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
@@ -882,3 +882,75 @@ async def test_uuid_ids_across_trace_context_and_usage(adapter):
 
     assert await adapter.delete_session(user_uuid, session_uuid) is True
     assert await adapter.get_all_qa_entries(str(user_uuid), str(session_uuid)) == []
+
+
+@pytest.mark.asyncio
+async def test_create_session_context_entry_same_id_upserts_not_duplicates(adapter):
+    """Re-writing the same entry_id updates the row in place (issue #4226 regression).
+
+    A retried write that reuses an entry_id must not pile up duplicate rows — the
+    original cause of the permanent 503s. The newest payload wins.
+    """
+    await adapter.create_session_context_entry("u1", "s1", _ctx("c1", content="first"))
+    await adapter.create_session_context_entry("u1", "s1", _ctx("c1", content="second"))
+    await adapter.create_session_context_entry("u1", "s1", _ctx("c1", content="third"))
+
+    entries = await adapter.get_session_context_entries("u1", "s1")
+    matching = [e for e in entries if e["id"] == "c1"]
+    assert len(matching) == 1
+    assert matching[0]["content"] == "third"
+
+    # Update still resolves to a single row instead of raising MultipleResultsFound.
+    assert (
+        await adapter.update_session_context_entry("u1", "s1", "c1", {"content": "final"}) is True
+    )
+    (entry,) = await adapter.get_session_context_entries("u1", "s1")
+    assert entry["content"] == "final"
+
+
+@pytest.mark.asyncio
+async def test_session_context_idless_entries_still_append(adapter):
+    """Id-less payloads get synthetic ids, so they append rather than collapse."""
+    await adapter.create_session_context_entry("u1", "s1", {"kind": "context", "content": "a"})
+    await adapter.create_session_context_entry("u1", "s1", {"kind": "context", "content": "b"})
+    entries = await adapter.get_session_context_entries("u1", "s1")
+    assert [e["content"] for e in entries] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_session_context_legacy_duplicates_are_migrated_and_updatable(tmp_path):
+    """Pre-existing duplicate rows collapse to the newest on migration; update no longer 503s.
+
+    Reproduces the corrupt on-disk state from issue #4226 by dropping the unique index
+    and injecting a duplicate row directly, then re-runs the create-on-init migration.
+    """
+    inst = _make_adapter(tmp_path)
+    try:
+        await inst.create_session_context_entry("u1", "s1", _ctx("c1", content="v1"))
+
+        # Simulate a legacy table: remove the guard, then inject a duplicate row.
+        async with inst.engine.begin() as connection:
+            await connection.execute(text("DROP INDEX uq_cache_session_context_entry"))
+            await connection.execute(
+                cache_session_context.insert().values(
+                    user_id="u1",
+                    session_id="s1",
+                    entry_id="c1",
+                    payload={"id": "c1", "kind": "context", "section": "goals", "content": "v2"},
+                )
+            )
+
+        # Before the fix this session is poisoned: update would raise on two rows.
+        await inst._migrate_session_context_uniqueness()
+
+        matching = [
+            e for e in await inst.get_session_context_entries("u1", "s1") if e["id"] == "c1"
+        ]
+        assert len(matching) == 1
+        assert matching[0]["content"] == "v2"  # newest (highest seq) survives
+
+        assert await inst.update_session_context_entry("u1", "s1", "c1", {"content": "v3"}) is True
+        (entry,) = await inst.get_session_context_entries("u1", "s1")
+        assert entry["content"] == "v3"
+    finally:
+        await inst.close()


### PR DESCRIPTION
## Description

`cache_session_context` was returning `503` errors because duplicate rows could exist for the same entry.

Root cause — three things together:
- there was no uniqueness guard on `(user_id, session_id, entry_id)`
- the write used a non-atomic update-then-create pattern, so a client retry inserted a second row instead of reusing the first
- the read used `scalar_one_or_none()`, which fails once more than one row matches

What this PR does:
- adds a unique index on `(user_id, session_id, entry_id)`
- makes writes idempotent with an upsert (`ON CONFLICT DO UPDATE`), so a retried write updates the existing row instead of adding a duplicate
- migrates existing tables by collapsing any duplicate rows (keeping the newest) before the unique index is created
- makes the read defensive with `ORDER BY seq DESC LIMIT 1`, so any leftover duplicate resolves to the newest row instead of raising

This is orthogonal to `_lock_session_writes`: that serializes concurrent writers to avoid deadlock, but does not make a client retry across separate transactions idempotent, so the unique index + upsert are still needed.

## Acceptance Criteria

- No duplicate rows can exist for a given `(user_id, session_id, entry_id)`.
- A retried create with the same `entry_id` updates the row instead of duplicating.
- Sessions that already have duplicate rows are repaired on init and stop returning 503.
- Existing session-context behaviour (append of distinct/id-less entries, TTL refresh, ordering, per-session isolation) is unchanged.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

Local run of the cache adapter unit tests (sqlite+aiosqlite):

```
pytest cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
...
56 passed
```

New regression tests: same-`entry_id` upsert keeps a single row, id-less entries still append, and a legacy table with injected duplicates is collapsed on init and stays updatable.

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR**
- [x] **This PR contains minimal changes necessary to address the issue**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective
- [ ] I have added necessary documentation (if applicable) — n/a
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.

Fixes #4226
