### PR TITLE
fix(auth): replace hardcoded 'super_secret' JWT fallback with random per-process key

### DIFF
--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -17,6 +17,7 @@ from cognee.modules.graph.methods import get_formatted_graph_data
 from cognee.modules.users.get_user_manager import get_user_manager_context
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.users.authentication.default.default_jwt_strategy import DefaultJWTStrategy
+from cognee.shared.auth_secrets import resolve_secret
 from cognee.shared.data_models import KnowledgeGraph
 from cognee.shared.graph_model_utils import graph_schema_to_graph_model
 from cognee.modules.pipelines.models.PipelineRunInfo import (
@@ -300,7 +301,7 @@ def get_cognify_router() -> APIRouter:
         access_token = websocket.cookies.get(os.getenv("AUTH_TOKEN_COOKIE_NAME", "auth_token"))
 
         try:
-            secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+            secret = resolve_secret("FASTAPI_USERS_JWT_SECRET")
 
             strategy = DefaultJWTStrategy(secret, lifetime_seconds=3600)
 

--- a/cognee/get_token.py
+++ b/cognee/get_token.py
@@ -1,8 +1,9 @@
 import jwt
-import os
 import datetime
 
-SECRET_KEY = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+from cognee.shared.auth_secrets import resolve_secret
+
+SECRET_KEY = resolve_secret("FASTAPI_USERS_JWT_SECRET")
 
 
 def create_jwt(user_id: str, tenant_id: str, roles: list[str]):

--- a/cognee/modules/users/authentication/get_api_auth_backend.py
+++ b/cognee/modules/users/authentication/get_api_auth_backend.py
@@ -7,6 +7,8 @@ from fastapi_users.authentication import (
     AuthenticationBackend,
 )
 
+from cognee.shared.auth_secrets import resolve_secret
+
 from .api_bearer import api_bearer_transport, APIJWTStrategy
 
 
@@ -15,7 +17,7 @@ def get_api_auth_backend():
     transport = api_bearer_transport
 
     def get_jwt_strategy() -> JWTStrategy[models.UP, models.ID]:
-        secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+        secret = resolve_secret("FASTAPI_USERS_JWT_SECRET")
         lifetime_seconds = int(os.getenv("JWT_LIFETIME_SECONDS", "3600"))
 
         return APIJWTStrategy(secret, lifetime_seconds=lifetime_seconds)

--- a/cognee/modules/users/authentication/get_client_auth_backend.py
+++ b/cognee/modules/users/authentication/get_client_auth_backend.py
@@ -7,6 +7,8 @@ from fastapi_users.authentication import (
     AuthenticationBackend,
 )
 
+from cognee.shared.auth_secrets import resolve_secret
+
 from .default import default_transport
 
 
@@ -17,7 +19,7 @@ def get_client_auth_backend():
     def get_jwt_strategy() -> JWTStrategy[models.UP, models.ID]:
         from .default.default_jwt_strategy import DefaultJWTStrategy
 
-        secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+        secret = resolve_secret("FASTAPI_USERS_JWT_SECRET")
         lifetime_seconds = int(os.getenv("JWT_LIFETIME_SECONDS", "3600"))
 
         return DefaultJWTStrategy(secret, lifetime_seconds=lifetime_seconds)

--- a/cognee/modules/users/get_user_manager.py
+++ b/cognee/modules/users/get_user_manager.py
@@ -17,15 +17,16 @@ from .get_user_db import get_user_db
 from cognee.modules.users.models.UserApiKey import UserApiKey
 from cognee.modules.users.api_key.hash_api_key import prepare_api_key
 from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.shared.auth_secrets import resolve_secret
 
 logger = logging.getLogger(__name__)
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
-    reset_password_token_secret = os.getenv(
-        "FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET", "super_secret"
+    reset_password_token_secret = resolve_secret(
+        "FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET"
     )
-    verification_token_secret = os.getenv("FASTAPI_USERS_VERIFICATION_TOKEN_SECRET", "super_secret")
+    verification_token_secret = resolve_secret("FASTAPI_USERS_VERIFICATION_TOKEN_SECRET")
 
     async def on_after_login(
         self, user: User, request: Optional[Request] = None, response: Optional[Response] = None

--- a/cognee/shared/auth_secrets.py
+++ b/cognee/shared/auth_secrets.py
@@ -1,0 +1,54 @@
+"""Centralized secret resolution for authentication tokens.
+
+All auth-related secrets (JWT signing, password reset, email verification)
+flow through :func:`resolve_secret`.  When the configured value is the
+well-known insecure placeholder ``"super_secret"`` (the default shipped in
+``.env.template``), a cryptographically random key is generated instead so
+that a default deployment cannot be exploited with a publicly known signing
+key (#4265).
+
+The generated key is stable for the lifetime of the process.  For
+multi-instance deployments (e.g. multiple Kubernetes pods that must accept
+each other's tokens), operators **must** set the corresponding environment
+variable to a long random string — the per-process random fallback is only
+suitable for single-instance development use.
+"""
+
+import logging
+import os
+import secrets
+
+logger = logging.getLogger(__name__)
+
+# The insecure placeholder shipped in .env.template.  Any secret still holding
+# this value at resolution time is replaced with a random key.
+_INSECURE_PLACEHOLDER = "super_secret"
+
+# Cache generated fallbacks per env-var name so repeated lookups within a
+# process return the same key (tokens signed earlier remain verifiable).
+_generated_fallbacks: dict[str, str] = {}
+
+
+def resolve_secret(env_var: str, *, length: int = 64) -> str:
+    """Return the secret for *env_var*, replacing the insecure placeholder.
+
+    If the environment variable is unset or equals ``"super_secret"``, a
+    cryptographically random URL-safe key is generated (and cached for the
+    process lifetime) and a warning is logged.  Otherwise the configured
+    value is returned unchanged.
+    """
+    value = os.getenv(env_var, "")
+    if value and value != _INSECURE_PLACEHOLDER:
+        return value
+
+    if env_var not in _generated_fallbacks:
+        _generated_fallbacks[env_var] = secrets.token_urlsafe(length)
+        logger.warning(
+            "%s is unset or still the insecure default %r; using a random "
+            "per-process key. Set %s to a long random string in production "
+            "(required for multi-instance deployments).",
+            env_var,
+            _INSECURE_PLACEHOLDER,
+            env_var,
+        )
+    return _generated_fallbacks[env_var]

--- a/cognee/tests/unit/shared/test_auth_secrets.py
+++ b/cognee/tests/unit/shared/test_auth_secrets.py
@@ -1,0 +1,69 @@
+"""Tests for cognee.shared.auth_secrets (#4265)."""
+
+import os
+
+import pytest
+
+from cognee.shared import auth_secrets
+from cognee.shared.auth_secrets import resolve_secret
+
+
+@pytest.fixture(autouse=True)
+def _clear_fallback_cache():
+    """Ensure each test starts with an empty generated-fallback cache."""
+    auth_secrets._generated_fallbacks.clear()
+    yield
+    auth_secrets._generated_fallbacks.clear()
+
+
+def test_configured_secret_returned_unchanged(monkeypatch):
+    """A real configured secret must be returned verbatim."""
+    monkeypatch.setenv("FASTAPI_USERS_JWT_SECRET", "my-real-production-secret")
+    assert resolve_secret("FASTAPI_USERS_JWT_SECRET") == "my-real-production-secret"
+
+
+def test_insecure_placeholder_replaced_with_random(monkeypatch):
+    """The well-known insecure placeholder must NOT be returned as-is."""
+    monkeypatch.setenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+    secret = resolve_secret("FASTAPI_USERS_JWT_SECRET")
+    assert secret != "super_secret"
+    assert len(secret) >= 32  # token_urlsafe(64) yields a long key
+
+
+def test_unset_env_replaced_with_random(monkeypatch):
+    """An unset secret must also be replaced with a random key."""
+    monkeypatch.delenv("FASTAPI_USERS_JWT_SECRET", raising=False)
+    secret = resolve_secret("FASTAPI_USERS_JWT_SECRET")
+    assert secret != "super_secret"
+    assert len(secret) >= 32
+
+
+def test_fallback_is_stable_within_process(monkeypatch):
+    """Repeated lookups for the same env var return the same generated key,
+    so tokens signed earlier remain verifiable within the process."""
+    monkeypatch.setenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+    first = resolve_secret("FASTAPI_USERS_JWT_SECRET")
+    second = resolve_secret("FASTAPI_USERS_JWT_SECRET")
+    assert first == second
+
+
+def test_different_env_vars_get_different_keys(monkeypatch):
+    """Distinct env vars must not share the same generated fallback."""
+    monkeypatch.setenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+    monkeypatch.setenv("FASTAPI_USERS_VERIFICATION_TOKEN_SECRET", "super_secret")
+    jwt_key = resolve_secret("FASTAPI_USERS_JWT_SECRET")
+    verification_key = resolve_secret("FASTAPI_USERS_VERIFICATION_TOKEN_SECRET")
+    assert jwt_key != verification_key
+
+
+def test_get_token_module_does_not_use_placeholder(monkeypatch):
+    """Regression: cognee.get_token.SECRET_KEY must never be 'super_secret'."""
+    monkeypatch.setenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+    auth_secrets._generated_fallbacks.clear()
+
+    import importlib
+
+    from cognee import get_token
+
+    importlib.reload(get_token)
+    assert get_token.SECRET_KEY != "super_secret"


### PR DESCRIPTION
## Summary

Fixes #4265

All six auth-related secrets (JWT signing, password reset, email verification) fell back to the publicly known placeholder `"super_secret"` when the corresponding env var was unset or still held the `.env.template` default. An attacker could forge a valid admin JWT and bypass every auth layer on any default deployment.

## Fix

Introduce `cognee.shared.auth_secrets.resolve_secret()`: when the configured value is unset or equals `"super_secret"`, a cryptographically random URL-safe key is generated (cached per env-var for process lifetime) and a warning is logged. Real configured secrets are returned unchanged.

Updated all six call sites:
- `cognee/get_token.py` (SECRET_KEY)
- `cognee/modules/users/authentication/get_api_auth_backend.py`
- `cognee/modules/users/authentication/get_client_auth_backend.py`
- `cognee/api/v1/cognify/routers/get_cognify_router.py` (websocket auth)
- `cognee/modules/users/get_user_manager.py` (reset_password_token_secret, verification_token_secret)

**Note:** the per-process random fallback is suitable for single-instance development only. Multi-instance deployments (e.g. multiple K8s pods) must still set the env vars to a shared long random string, as documented in `.env.template`.

## Tests

Added `cognee/tests/unit/shared/test_auth_secrets.py` with 6 tests:

```
$ pytest cognee/tests/unit/shared/test_auth_secrets.py -q
6 passed
```

- Configured secret passthrough
- Placeholder replacement with random key
- Unset env var replacement
- Per-process stability (same key on repeated lookups)
- Distinct keys per env var
- Regression: `get_token.SECRET_KEY` is never `"super_secret"`

Verified the regression test **fails** on the unfixed code and **passes** with the fix.