### PR TITLE
docs: add Requesty as a custom LLM provider option

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -687,6 +687,15 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #LLM_MODEL="openrouter/google/gemini-2.0-flash-lite-preview-02-05:free"
 #LLM_ENDPOINT="https://openrouter.ai/api/v1"
 
+########## Requesty (LLM router, OpenAI-compatible) ###########################
+# One OpenAI-compatible endpoint in front of 400+ models. Model names are
+# provider/model (same convention as OpenRouter). EU endpoint:
+# https://router.eu.requesty.ai/v1 . Get a key at https://app.requesty.ai/router
+#LLM_API_KEY="your_requesty_api_key"
+#LLM_PROVIDER="custom"
+#LLM_MODEL="openai/openai/gpt-4o-mini"
+#LLM_ENDPOINT="https://router.requesty.ai/v1"
+
 ########## DeepInfra ##########################################################
 #LLM_API_KEY="<<>>"
 #LLM_PROVIDER="custom"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,6 +348,18 @@ LLM_ENDPOINT="https://openrouter.ai/api/v1"
 LLM_API_KEY="your_api_key"
 ```
 
+#### Requesty (LLM router, requires custom provider)
+Requesty exposes 400+ models behind a single OpenAI-compatible endpoint, using
+`provider/model` names (same convention as OpenRouter). Get a key at
+https://app.requesty.ai/router. Use the EU endpoint
+`https://router.eu.requesty.ai/v1` for EU data residency.
+```bash
+LLM_PROVIDER="custom"
+LLM_MODEL="openai/openai/gpt-4o-mini"
+LLM_ENDPOINT="https://router.requesty.ai/v1"
+LLM_API_KEY="your_requesty_api_key"
+```
+
 #### AWS Bedrock (requires aws extra)
 ```bash
 LLM_PROVIDER="bedrock"


### PR DESCRIPTION
## What

Adds [Requesty](https://requesty.ai) as a documented **custom LLM provider** option, mirroring the existing OpenRouter entry:

- `.env.template` — new commented Requesty block right after OpenRouter
- `CLAUDE.md` — new "Requesty" subsection under the LLM provider examples

## Why

Requesty is an OpenAI-compatible LLM router that puts 400+ models behind a single endpoint using `provider/model` names (the same convention OpenRouter uses). Because cognee already routes `LLM_PROVIDER="custom"` through LiteLLM (`GenericAPIAdapter` → `litellm.acompletion(model=..., api_base=LLM_ENDPOINT, api_key=...)`), Requesty works out of the box with no code changes — just config. This gives cognee users another drop-in gateway with smart routing, fallbacks, caching, spend limits, and EU data residency.

## Config

```bash
LLM_PROVIDER="custom"
LLM_MODEL="openai/openai/gpt-4o-mini"
LLM_ENDPOINT="https://router.requesty.ai/v1"
LLM_API_KEY="your_requesty_api_key"
```

The leading `openai/` is LiteLLM's OpenAI-compatible route selector (used because Requesty speaks the OpenAI Chat Completions API at `api_base`); the rest is the Requesty model name. EU endpoint: `https://router.eu.requesty.ai/v1`.

## Scope / testing

Docs + config only, no code paths changed. The wiring is the same `custom` → LiteLLM path OpenRouter and DeepInfra already use in these files; the values follow Requesty's documented OpenAI-compatible contract (base URL, Bearer auth, `provider/model` naming). Branched from `dev` per CONTRIBUTING.

## Disclosure

I work at Requesty. Opening this because cognee already documents comparable OpenAI-compatible gateways (OpenRouter, DeepInfra) and this is a natural, low-footprint addition for users who want them. Happy to adjust wording, drop the marketing framing, or trim to just `.env.template` if you'd prefer a smaller change.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
