### PR TITLE
Feature/clo 348 create lazy load tool router for cognee mcp

### DIFF
--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -507,6 +507,18 @@ The MCP server exposes three tools:
 
 The workspace lets you create/switch/delete datasets, upload files, add text, search, and view the graph from one inline panel.
 
+### Tool surface (`COGNEE_MCP_TOOL_MODE`)
+
+Advertising every tool up front costs agent context and hurts tool-selection accuracy, so by default the server pins a small set in `tools/list` and makes the rest discoverable through FastMCP's built-in `search_tools`. **Unadvertised tools stay callable by name**, so the workspace UI (which calls its internals directly) is unaffected.
+
+```bash
+COGNEE_MCP_TOOL_MODE=default   # pinned: remember, recall, forget + the 3 workspace UI entry tools
+COGNEE_MCP_TOOL_MODE=minimal   # pinned: remember, recall, forget
+COGNEE_MCP_TOOL_MODE=all       # no search transform; advertise all 11 tools
+```
+
+Also settable per-process with `--tool-mode`. In `default`/`minimal` an agent calls `search_tools(query=...)` to find a tool and either calls it by name or goes through the `call_tool` proxy. Tiers are declared per tool via `@registry.tool(tags={...})` in `src/server.py`, so the pinned set is derived from the decorators rather than a separate list.
+
 The bundle that powers the workspace lives at `cognee-mcp/src/app_bundles/visualize-graph.html`. It is built from `cognee-mcp/apps-src/` via `npm run build` and is gitignored. The Docker image builds it as part of the image; PyPI wheels carry it (the maintainer runs `npm run build` before `uv build`); from-source users build it manually (see [Quick Start](#-quick-start) step 7). If the bundle is missing at runtime, the workspace tools raise a `FileNotFoundError` pointing back to the build command.
 
 ### Agent Scoping (per-client default datasets)

--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -521,7 +521,20 @@ Also settable per-process with `--tool-mode`. In `default`/`minimal` an agent ca
 
 `search_tools` returns up to `TOOL_SEARCH_MAX_RESULTS` (10) tools, sized for a catalog that will grow. The window only costs context on turns that actually call search; `tools/list` stays constant either way. See `tests/test_tool_search_benchmark.py` for the recall sweep behind the number.
 
-**When adding a tool, write its description in the words an agent would use — including plurals.** BM25 drops tools that score zero and its tokenizer does no stemming, so a wide window does not guarantee coverage: the query `dataset` matches `create_dataset_json` but *not* `list_datasets_json` (whose token is `datasets`). Misses come from vocabulary, not from the result limit.
+#### Writing a tool so search can find it
+
+Search works well on natural-language queries. Every phrasing below returns its target ranked first (covered by `tests/test_tool_search.py`):
+
+| query | returns |
+|---|---|
+| "what datasets do I have?" | `list_datasets_json` |
+| "show the data inside a dataset" | `list_dataset_data_json` |
+| "make a new dataset" | `create_dataset_json` |
+| "upload and ingest this file" | `cognify_file` |
+
+The one thing to know when **adding** a tool: matching is purely lexical. FastMCP's BM25 tokenizer does no stemming and drops tools that score zero, so a query shares no credit with a word it doesn't literally contain — the bare query `dataset` matches `create_dataset_json` but *not* `list_datasets_json`, whose token is `datasets`. Multi-word queries paper over this (they usually contain some matching token), which is why the table above passes, but terse queries won't.
+
+So: **write descriptions in the words an agent would use, including both singular and plural.** Recall is bounded by vocabulary, not by `TOOL_SEARCH_MAX_RESULTS`. If lexical matching ever stops being enough, `BaseSearchTransform` leaves `_search()` abstract — a semantic ranker over cognee's own embeddings can be dropped in without touching the rest of the plumbing.
 
 The bundle that powers the workspace lives at `cognee-mcp/src/app_bundles/visualize-graph.html`. It is built from `cognee-mcp/apps-src/` via `npm run build` and is gitignored. The Docker image builds it as part of the image; PyPI wheels carry it (the maintainer runs `npm run build` before `uv build`); from-source users build it manually (see [Quick Start](#-quick-start) step 7). If the bundle is missing at runtime, the workspace tools raise a `FileNotFoundError` pointing back to the build command.
 

--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -530,7 +530,7 @@ Search works well on natural-language queries. Every phrasing below returns its 
 | "what datasets do I have?" | `list_datasets_json` |
 | "show the data inside a dataset" | `list_dataset_data_json` |
 | "make a new dataset" | `create_dataset_json` |
-| "upload and ingest this file" | `cognify_file` |
+| "which client am I connected as" | `get_client_info_json` |
 
 The one thing to know when **adding** a tool: matching is purely lexical. FastMCP's BM25 tokenizer does no stemming and drops tools that score zero, so a query shares no credit with a word it doesn't literally contain — the bare query `dataset` matches `create_dataset_json` but *not* `list_datasets_json`, whose token is `datasets`. Multi-word queries paper over this (they usually contain some matching token), which is why the table above passes, but terse queries won't.
 

--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -519,6 +519,10 @@ COGNEE_MCP_TOOL_MODE=all       # no search transform; advertise all 11 tools
 
 Also settable per-process with `--tool-mode`. In `default`/`minimal` an agent calls `search_tools(query=...)` to find a tool and either calls it by name or goes through the `call_tool` proxy. Tiers are declared per tool via `@registry.tool(tags={...})` in `src/server.py`, so the pinned set is derived from the decorators rather than a separate list.
 
+`search_tools` returns up to `TOOL_SEARCH_MAX_RESULTS` (10) tools, sized for a catalog that will grow. The window only costs context on turns that actually call search; `tools/list` stays constant either way. See `tests/test_tool_search_benchmark.py` for the recall sweep behind the number.
+
+**When adding a tool, write its description in the words an agent would use — including plurals.** BM25 drops tools that score zero and its tokenizer does no stemming, so a wide window does not guarantee coverage: the query `dataset` matches `create_dataset_json` but *not* `list_datasets_json` (whose token is `datasets`). Misses come from vocabulary, not from the result limit.
+
 The bundle that powers the workspace lives at `cognee-mcp/src/app_bundles/visualize-graph.html`. It is built from `cognee-mcp/apps-src/` via `npm run build` and is gitignored. The Docker image builds it as part of the image; PyPI wheels carry it (the maintainer runs `npm run build` before `uv build`); from-source users build it manually (see [Quick Start](#-quick-start) step 7). If the bundle is missing at runtime, the workspace tools raise a `FileNotFoundError` pointing back to the build command.
 
 ### Agent Scoping (per-client default datasets)

--- a/cognee-mcp/README.md
+++ b/cognee-mcp/README.md
@@ -494,7 +494,7 @@ The MCP server exposes its functionality through tools. Call them from any MCP c
 
 The MCP server exposes three tools:
 
-- **remember**: Store data in memory. With `session_id`: fast session cache. Without `session_id`: permanent graph memory
+- **remember**: Store data in memory. Pass `data` for text, or `filename` + `content_base64` to ingest an uploaded file (up to 10 MB). With `session_id`: fast session cache (text only). Without `session_id`: permanent graph memory
 - **recall**: Search memory with auto-routing. Searches session cache first when `session_id` is provided, then falls through to the permanent graph
 - **forget**: Delete memory by dataset name, or delete all owned memory with `everything=True`
 
@@ -503,7 +503,6 @@ The MCP server exposes three tools:
 - **visualize_graph_ui**: Open the workspace and render the current knowledge graph
 - **upload_file_ui**: Open the workspace for file upload
 - **open_cognee_workspace**: Generic "open the cognee UI" entry point
-- **cognify_file**: Ingest an uploaded file (used by the workspace; accepts base64 content)
 - **list_datasets_json / list_dataset_data_json / create_dataset_json / get_client_info_json**: Structured-JSON helpers powering the workspace dropdown
 
 The workspace lets you create/switch/delete datasets, upload files, add text, search, and view the graph from one inline panel.
@@ -514,7 +513,7 @@ The bundle that powers the workspace lives at `cognee-mcp/src/app_bundles/visual
 
 By default, each MCP client gets its own auto-named dataset (e.g. Cursor → `cursor_vscode_memory`, Claude Code → `claude_code_memory`) so different agents don't share memory unintentionally. The dataset is created on demand the first time a client calls a workspace tool.
 
-LLM-direct calls to `cognify`, `remember`, `improve`, `cognify_status`, and `cognify_file` route to the agent-scoped dataset when `dataset_name` is omitted. Pass `dataset_name` explicitly to override (e.g. `dataset_name="main_dataset"` still works).
+LLM-direct calls to `cognify`, `remember`, `improve`, and `cognify_status` route to the agent-scoped dataset when `dataset_name` is omitted. Pass `dataset_name` explicitly to override (e.g. `dataset_name="main_dataset"` still works).
 
 To disable agent scoping and have all clients share `main_dataset` as the default, set in `.env`:
 

--- a/cognee-mcp/apps-src/src/main.tsx
+++ b/cognee-mcp/apps-src/src/main.tsx
@@ -629,7 +629,7 @@ function Composer({
       const args: Record<string, string> = { filename: file.name, content_base64 };
       if (selectedDataset) args.dataset_name = selectedDataset;
       const result = await app.callServerTool({
-        name: "cognify_file",
+        name: "remember",
         arguments: args,
       });
       const msg = textOf(result) ?? JSON.stringify(result.content);

--- a/cognee-mcp/pyproject.toml
+++ b/cognee-mcp/pyproject.toml
@@ -9,7 +9,11 @@ dependencies = [
     # For local cognee repo usage remove comment below and add absolute path to cognee. Then run `uv sync --reinstall` in the mcp folder on local cognee changes.
     #"cognee[postgres,docs,neo4j] @ file:/Users/igorilic/Desktop/cognee",
     "cognee[postgres-binary,docs,neo4j]>=1.1.0,<2.0.0",
-    "mcp>=1.12.0,<2.0.0",
+    # FastMCP 3 ships tag-based visibility and the tool-search transform this
+    # server relies on; the FastMCP vendored in the `mcp` SDK is an older fork
+    # that has neither. `mcp` is still a direct dependency for its wire types.
+    "fastmcp>=3.4.0,<4.0.0",
+    "mcp>=1.24.0,<2.0.0",
     "uv>=0.6.3,<1.0.0",
     "httpx>=0.27.0,<1.0.0",
 ]

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -172,6 +172,15 @@ class CogneeClient:
         mime_type, _ = mimetypes.guess_type(safe_name)
         return {"data": (safe_name, raw_bytes, mime_type or "application/octet-stream")}
 
+    @staticmethod
+    def _path_upload(path: str) -> Dict[str, tuple[str, bytes, str]]:
+        """Create a real file upload (preserving basename) for an existing filesystem path."""
+        safe_name = Path(path).name or "upload"
+        with open(path, "rb") as f:
+            raw_bytes = f.read()
+        mime_type, _ = mimetypes.guess_type(safe_name)
+        return {"data": (safe_name, raw_bytes, mime_type or "application/octet-stream")}
+
     async def add(
         self, data: Any, dataset_name: str = "main_dataset", node_set: Optional[List[str]] = None
     ) -> Dict[str, Any]:
@@ -195,7 +204,10 @@ class CogneeClient:
         if self.use_api:
             endpoint = f"{self.api_url}/api/v1/add"
 
-            files = self._text_upload(data)
+            if isinstance(data, (str, Path)) and os.path.isfile(data):
+                files = self._path_upload(data)
+            else:
+                files = self._text_upload(data)
             form_data = {
                 "datasetName": dataset_name,
             }
@@ -601,6 +613,8 @@ class CogneeClient:
             endpoint = f"{self.api_url}/api/v1/remember"
             if content_base64:
                 files = self._file_upload(filename, content_base64)
+            elif isinstance(data, (str, Path)) and os.path.isfile(data):
+                files = self._path_upload(data)
             else:
                 files = self._text_upload(data)
             form_data = {"datasetName": dataset_name}

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -181,6 +181,24 @@ class CogneeClient:
         mime_type, _ = mimetypes.guess_type(safe_name)
         return {"data": (safe_name, raw_bytes, mime_type or "application/octet-stream")}
 
+    @staticmethod
+    def _build_upload(
+        data: Any = None,
+        filename: Optional[str] = None,
+        content_base64: Optional[str] = None,
+    ) -> Dict[str, tuple[str, Any, str]]:
+        """Pick the multipart upload for an API-mode ingestion payload.
+
+        Base64 uploads and real filesystem paths keep their original
+        basename (#4230); anything else is uploaded as content-addressed
+        text so repeated writes don't collide (#2747).
+        """
+        if content_base64:
+            return CogneeClient._file_upload(filename, content_base64)
+        if isinstance(data, (str, Path)) and os.path.isfile(data):
+            return CogneeClient._path_upload(data)
+        return CogneeClient._text_upload(data)
+
     async def add(
         self, data: Any, dataset_name: str = "main_dataset", node_set: Optional[List[str]] = None
     ) -> Dict[str, Any]:
@@ -204,10 +222,7 @@ class CogneeClient:
         if self.use_api:
             endpoint = f"{self.api_url}/api/v1/add"
 
-            if isinstance(data, (str, Path)) and os.path.isfile(data):
-                files = self._path_upload(data)
-            else:
-                files = self._text_upload(data)
+            files = self._build_upload(data)
             form_data = {
                 "datasetName": dataset_name,
             }
@@ -611,12 +626,7 @@ class CogneeClient:
                 return response.json()
 
             endpoint = f"{self.api_url}/api/v1/remember"
-            if content_base64:
-                files = self._file_upload(filename, content_base64)
-            elif isinstance(data, (str, Path)) and os.path.isfile(data):
-                files = self._path_upload(data)
-            else:
-                files = self._text_upload(data)
+            files = self._build_upload(data, filename, content_base64)
             form_data = {"datasetName": dataset_name}
             if custom_prompt:
                 form_data["custom_prompt"] = custom_prompt

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -8,7 +8,11 @@ This module provides a unified interface for interacting with Cognee, supporting
 
 import os
 import sys
+import base64
 import hashlib
+import mimetypes
+import tempfile
+from pathlib import Path
 from typing import Optional, Any, List, Dict
 from uuid import UUID
 from contextlib import redirect_stdout
@@ -143,6 +147,30 @@ class CogneeClient:
         content = str(data)
         digest = hashlib.md5(content.encode("utf-8")).hexdigest()
         return {"data": (f"text_{digest}.txt", content, "text/plain")}
+
+    @staticmethod
+    def _decode_upload(filename: str, content_base64: str) -> tuple[str, bytes]:
+        """Decode a base64 file upload and sanitize its filename.
+
+        Strips any directory components from `filename` (defends against
+        path traversal via multipart form fields) and falls back to a
+        generic name/extension when the caller didn't provide a usable one,
+        so the file always lands with a safe, non-empty basename.
+        """
+        raw_bytes = base64.b64decode(content_base64, validate=True)
+
+        safe_name = Path(filename or "").name or "upload"
+        if not Path(safe_name).suffix:
+            safe_name += ".txt"
+
+        return safe_name, raw_bytes
+
+    @staticmethod
+    def _file_upload(filename: str, content_base64: str) -> Dict[str, tuple[str, bytes, str]]:
+        """Create a real file upload (preserving basename) for API-mode ingestion."""
+        safe_name, raw_bytes = CogneeClient._decode_upload(filename, content_base64)
+        mime_type, _ = mimetypes.guess_type(safe_name)
+        return {"data": (safe_name, raw_bytes, mime_type or "application/octet-stream")}
 
     async def add(
         self, data: Any, dataset_name: str = "main_dataset", node_set: Optional[List[str]] = None
@@ -522,12 +550,22 @@ class CogneeClient:
         dataset_name: str = "main_dataset",
         session_id: Optional[str] = None,
         custom_prompt: Optional[str] = None,
+        filename: Optional[str] = None,
+        content_base64: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Store data in memory via remember().
 
         With session_id: stores in session cache only (fast).
         Without session_id: full add + cognify pipeline (permanent).
+
+        Pass either `data` (text) or `filename` + `content_base64` (file
+        upload), not both. File uploads are permanent-memory only.
         """
+        if content_base64 and data:
+            raise ValueError("Pass either `data` or `filename` + `content_base64`, not both.")
+        if content_base64 and session_id:
+            raise ValueError("File uploads (content_base64) do not support session_id.")
+
         if self.use_api:
             if session_id:
                 if custom_prompt:
@@ -561,7 +599,10 @@ class CogneeClient:
                 return response.json()
 
             endpoint = f"{self.api_url}/api/v1/remember"
-            files = self._text_upload(data)
+            if content_base64:
+                files = self._file_upload(filename, content_base64)
+            else:
+                files = self._text_upload(data)
             form_data = {"datasetName": dataset_name}
             if custom_prompt:
                 form_data["custom_prompt"] = custom_prompt
@@ -575,15 +616,38 @@ class CogneeClient:
             return response.json()
         else:
             with redirect_stdout(sys.stderr):
+                tmp_dir = None
+                if content_base64:
+                    safe_name, raw_bytes = self._decode_upload(filename, content_base64)
+                    tmp_dir = tempfile.mkdtemp(prefix="cognee_upload_")
+                    remember_data = os.path.join(tmp_dir, safe_name)
+                    with open(remember_data, "wb") as f:
+                        f.write(raw_bytes)
+                else:
+                    remember_data = data
+
                 kwargs = {
-                    "data": data,
+                    "data": remember_data,
                     "dataset_name": dataset_name,
                 }
                 if session_id:
                     kwargs["session_id"] = session_id
                 if custom_prompt:
                     kwargs["custom_prompt"] = custom_prompt
-                result = await self.cognee.remember(**kwargs)
+
+                try:
+                    result = await self.cognee.remember(**kwargs)
+                finally:
+                    if tmp_dir is not None:
+                        try:
+                            os.unlink(remember_data)
+                        except OSError:
+                            pass
+                        try:
+                            os.rmdir(tmp_dir)
+                        except OSError:
+                            pass
+
                 return {
                     "status": getattr(result, "status", "completed"),
                     "dataset_name": dataset_name,

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -190,8 +190,8 @@ class CogneeClient:
         """Pick the multipart upload for an API-mode ingestion payload.
 
         Base64 uploads and real filesystem paths keep their original
-        basename (#4230); anything else is uploaded as content-addressed
-        text so repeated writes don't collide (#2747).
+        basename; anything else is uploaded as content-addressed
+        text so repeated writes don't collide.
         """
         if content_base64:
             return CogneeClient._file_upload(filename, content_base64)

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -18,6 +18,8 @@ import importlib.util
 from contextlib import redirect_stdout
 import mcp.types as types
 from fastmcp import FastMCP
+from fastmcp.server.transforms.search import BM25SearchTransform
+from fastmcp.server.transforms.search.base import BaseSearchTransform
 from fastmcp.tools.tool import ToolResult
 from cognee.modules.storage.utils import JSONEncoder
 from starlette.responses import JSONResponse
@@ -34,6 +36,11 @@ try:
     from .strip_vectors import strip_vectors
 except ImportError:
     from strip_vectors import strip_vectors
+
+try:
+    from .tool_registry import DEFAULT_TAG, MEMORY_TAG, ToolRegistry
+except ImportError:
+    from tool_registry import DEFAULT_TAG, MEMORY_TAG, ToolRegistry
 
 try:
     from .server_utils import (
@@ -72,6 +79,10 @@ except ModuleNotFoundError:
 
 
 mcp = FastMCP("Cognee")
+
+# Tools register through this rather than @mcp.tool directly, so each one
+# declares its tier at the definition site (see apply_tool_mode()).
+registry = ToolRegistry(mcp)
 
 logger = get_logger()
 
@@ -150,6 +161,55 @@ def _transport_security_kwargs(host: str) -> dict:
     # Loopback-only with no extra hosts — let FastMCP use its own defaults.
     logger.info("MCP transport security: using FastMCP defaults (localhost only)")
     return {}
+
+
+TOOL_MODES = ("default", "minimal", "all")
+
+
+def apply_tool_mode(mode: str = None) -> str:
+    """Gate the advertised tool surface behind FastMCP's tool-search transform.
+
+    Every tool stays registered and directly callable by name; the transform
+    only changes what ``tools/list`` advertises, replacing the non-pinned tools
+    with ``search_tools``/``call_tool``. That keeps the workspace UI working
+    (it calls internals by name via app.callServerTool) while a fresh agent
+    sees a handful of tools instead of the whole catalog.
+
+    Modes (COGNEE_MCP_TOOL_MODE):
+        default: pin the DEFAULT_TAG tools (memory API + workspace UI entry).
+        minimal: pin only the memory API.
+        all:     no transform, advertise everything (pre-3.x behavior).
+
+    Returns the mode actually applied.
+    """
+    mode = (mode or os.getenv("COGNEE_MCP_TOOL_MODE") or "default").lower()
+
+    if mode not in TOOL_MODES:
+        logger.warning(
+            "Unknown COGNEE_MCP_TOOL_MODE=%r; falling back to 'default'. Valid: %s",
+            mode,
+            ", ".join(TOOL_MODES),
+        )
+        mode = "default"
+
+    # Drop any transform a previous call installed: add_transform() appends, so
+    # calling this twice would otherwise stack search transforms on top of each
+    # other and hide the first one's pinned tools.
+    mcp._transforms = [t for t in mcp._transforms if not isinstance(t, BaseSearchTransform)]
+
+    if mode == "all":
+        logger.info("MCP tool mode 'all': advertising all %d tools", len(registry.tags))
+        return mode
+
+    pinned = registry.names_with_tag(DEFAULT_TAG if mode == "default" else MEMORY_TAG)
+    mcp.add_transform(BM25SearchTransform(max_results=5, always_visible=pinned))
+    logger.info(
+        "MCP tool mode %r: advertising %s + search_tools/call_tool (%d tools searchable)",
+        mode,
+        pinned,
+        len(registry.tags) - len(pinned),
+    )
+    return mode
 
 
 def _is_running_in_docker() -> bool:
@@ -1056,8 +1116,7 @@ async def prune():
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool()
-@log_usage(function_name="MCP remember", log_type="mcp_tool")
+@registry.tool(tags={DEFAULT_TAG, MEMORY_TAG})
 async def remember(
     data: str = None,
     filename: str = None,
@@ -1163,8 +1222,7 @@ async def remember(
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
 
 
-@mcp.tool()
-@log_usage(function_name="MCP recall", log_type="mcp_tool")
+@registry.tool(tags={DEFAULT_TAG, MEMORY_TAG})
 async def recall(
     query: str,
     search_type: str = None,
@@ -1225,8 +1283,7 @@ async def recall(
             return [types.TextContent(type="text", text=f"Error: {error_msg}")]
 
 
-@mcp.tool()
-@log_usage(function_name="MCP forget", log_type="mcp_tool")
+@registry.tool(tags={DEFAULT_TAG, MEMORY_TAG})
 async def forget(
     dataset: str = None,
     everything: bool = False,
@@ -1469,7 +1526,8 @@ def _inject_graph_viz_overrides(html: str) -> str:
     return html
 
 
-@mcp.tool(
+@registry.tool(
+    tags={DEFAULT_TAG, "workspace"},
     name="visualize_graph_ui",
     description=(
         "Open the Cognee workspace UI and render the current knowledge graph. "
@@ -1477,7 +1535,6 @@ def _inject_graph_viz_overrides(html: str) -> str:
     ),
     meta={"ui": {"resourceUri": _VISUALIZE_APP_URI}},
 )
-@log_usage(function_name="MCP visualize_graph_ui", log_type="mcp_tool")
 async def visualize_graph_ui(dataset_name: str = None) -> ToolResult:
     """Render the Cognee graph for a specific dataset.
 
@@ -1530,7 +1587,8 @@ async def visualize_graph_ui(dataset_name: str = None) -> ToolResult:
     )
 
 
-@mcp.tool(
+@registry.tool(
+    tags={DEFAULT_TAG, "workspace"},
     name="upload_file_ui",
     description=(
         "Open the Cognee workspace UI so the user can upload files to memory. "
@@ -1538,14 +1596,14 @@ async def visualize_graph_ui(dataset_name: str = None) -> ToolResult:
     ),
     meta={"ui": {"resourceUri": _VISUALIZE_APP_URI}},
 )
-@log_usage(function_name="MCP upload_file_ui", log_type="mcp_tool")
 async def upload_file_ui() -> ToolResult:
     return ToolResult(
         content=[types.TextContent(type="text", text="Cognee workspace opened.")],
     )
 
 
-@mcp.tool(
+@registry.tool(
+    tags={DEFAULT_TAG, "workspace"},
     name="open_cognee_workspace",
     description=(
         "Open the Cognee workspace UI. Use for generic intents like "
@@ -1555,7 +1613,6 @@ async def upload_file_ui() -> ToolResult:
     ),
     meta={"ui": {"resourceUri": _VISUALIZE_APP_URI}},
 )
-@log_usage(function_name="MCP open_cognee_workspace", log_type="mcp_tool")
 async def open_cognee_workspace() -> ToolResult:
     return ToolResult(
         content=[types.TextContent(type="text", text="Cognee workspace opened.")],
@@ -1584,14 +1641,14 @@ def _format_named_items(items, singular: str, plural: str, limit: int = 50) -> s
     return "\n".join(lines)
 
 
-@mcp.tool(
+@registry.tool(
+    tags={"workspace", "datasets"},
     name="list_datasets_json",
     description=(
         "List datasets as structured JSON for the Cognee workspace UI. "
         "Returns {datasets: [{id, name}, ...]} in structuredContent."
     ),
 )
-@log_usage(function_name="MCP list_datasets_json", log_type="mcp_tool")
 async def list_datasets_json() -> ToolResult:
     with redirect_stdout(sys.stderr):
         raw = await cognee_client.list_datasets()
@@ -1614,14 +1671,14 @@ async def list_datasets_json() -> ToolResult:
     )
 
 
-@mcp.tool(
+@registry.tool(
+    tags={"workspace", "datasets"},
     name="list_dataset_data_json",
     description=(
         "List data items in a dataset as structured JSON for the Cognee workspace UI. "
         "Returns {data: [{id, name}, ...]} in structuredContent."
     ),
 )
-@log_usage(function_name="MCP list_dataset_data_json", log_type="mcp_tool")
 async def list_dataset_data_json(dataset_id: str) -> ToolResult:
     from uuid import UUID
     from cognee.modules.data.methods import get_dataset, get_dataset_data
@@ -1717,7 +1774,8 @@ def _agent_scoped_default_dataset() -> str:
     return "main_dataset"
 
 
-@mcp.tool(
+@registry.tool(
+    tags={"workspace"},
     name="get_client_info_json",
     description=(
         "Return the current MCP client identity and its agent-scoped default dataset. "
@@ -1727,7 +1785,6 @@ def _agent_scoped_default_dataset() -> str:
         "Returns {client: {name, version}, default_dataset} in structuredContent."
     ),
 )
-@log_usage(function_name="MCP get_client_info_json", log_type="mcp_tool")
 async def get_client_info_json() -> ToolResult:
     from mcp.server.lowlevel.server import request_ctx
 
@@ -1772,14 +1829,14 @@ async def get_client_info_json() -> ToolResult:
     )
 
 
-@mcp.tool(
+@registry.tool(
+    tags={"workspace", "datasets"},
     name="create_dataset_json",
     description=(
         "Create an empty dataset with the given name (idempotent). "
         "Returns {dataset: {id, name}} in structuredContent."
     ),
 )
-@log_usage(function_name="MCP create_dataset_json", log_type="mcp_tool")
 async def create_dataset_json(name: str) -> ToolResult:
     name = (name or "").strip()
     if not name:
@@ -1901,6 +1958,16 @@ async def main():
         help="Argument stops database migration from being attempted",
     )
 
+    parser.add_argument(
+        "--tool-mode",
+        default=None,
+        choices=TOOL_MODES,
+        help="How many tools to advertise in tools/list. 'default' pins the memory API "
+        "and workspace UI entry tools and makes the rest discoverable via search_tools; "
+        "'minimal' pins only the memory API; 'all' advertises every tool. "
+        "Can also be set via COGNEE_MCP_TOOL_MODE. (default: default)",
+    )
+
     # Cognee API connection options
     parser.add_argument(
         "--api-url",
@@ -1939,6 +2006,7 @@ async def main():
 
     host = args.host
     port = int(args.port)
+    apply_tool_mode(args.tool_mode)
 
     # Resolve cloud connection: CLI args take precedence over env vars
     serve_url = args.serve_url or os.environ.get("COGNEE_SERVICE_URL", "")

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -165,6 +165,26 @@ def _transport_security_kwargs(host: str) -> dict:
 
 TOOL_MODES = ("default", "minimal", "all")
 
+# How many tools search_tools returns. Chosen from the recall sweep in
+# tests/test_tool_search_benchmark.py: over a 500-tool catalog, BM25 recall@k
+# goes 60% -> 80% between k=5 and k=10 and then plateaus, because the ranker was
+# placing the right tool just outside a 5-wide window. Recall is the metric that
+# matters — the agent sees every returned schema and picks for itself, so a tool
+# missing from the window is unrecoverable while its rank inside the window
+# barely costs anything.
+#
+# With today's 11 tools this exceeds the unpinned count, so the window is never
+# the binding constraint — but that does NOT mean every search returns every
+# tool. BM25 drops zero-scoring tools, and its tokenizer does no stemming, so
+# query "dataset" matches `create_dataset_json` but not `list_datasets_json`
+# (token "datasets"). Misses come from vocabulary, not from k. When adding a
+# tool, put the words an agent would actually use — in both singular and plural
+# — in its description.
+#
+# The window costs context only on turns that call search, never on the
+# per-turn tools/list payload.
+TOOL_SEARCH_MAX_RESULTS = 10
+
 
 def apply_tool_mode(mode: str = None) -> str:
     """Gate the advertised tool surface behind FastMCP's tool-search transform.
@@ -202,7 +222,9 @@ def apply_tool_mode(mode: str = None) -> str:
         return mode
 
     pinned = registry.names_with_tag(DEFAULT_TAG if mode == "default" else MEMORY_TAG)
-    mcp.add_transform(BM25SearchTransform(max_results=5, always_visible=pinned))
+    mcp.add_transform(
+        BM25SearchTransform(max_results=TOOL_SEARCH_MAX_RESULTS, always_visible=pinned)
+    )
     logger.info(
         "MCP tool mode %r: advertising %s + search_tools/call_tool (%d tools searchable)",
         mode,

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -3,6 +3,7 @@ import os
 import sys
 import argparse
 import asyncio
+import base64
 import subprocess
 from collections import deque
 from datetime import datetime, timezone
@@ -80,6 +81,7 @@ cognee_client: Optional[CogneeClient] = None
 # unbounded memory). Each entry is (iso_timestamp, error_message).
 _TASK_ERROR_HISTORY = 50
 _task_errors: dict[str, Deque[Tuple[str, str]]] = {}
+_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 
 # Strong references to in-flight background tasks. asyncio's event loop only keeps
 # weak references to tasks, so a fire-and-forget task can be GC'd mid-execution if
@@ -1076,7 +1078,9 @@ async def prune():
 @mcp.tool()
 @log_usage(function_name="MCP remember", log_type="mcp_tool")
 async def remember(
-    data: str,
+    data: str = None,
+    filename: str = None,
+    content_base64: str = None,
     dataset_name: str = None,
     session_id: str = None,
     custom_prompt: str = None,
@@ -1092,10 +1096,20 @@ async def remember(
     cache only. Fast, no entity extraction. Omit session_id when the
     content should be stored as permanent graph memory.
 
+    Pass either `data` (text) or `filename` + `content_base64` (a file
+    upload, up to 10 MB), not both. File uploads are permanent-memory
+    only and don't support session_id.
+
     Parameters
     ----------
-    data : str
-        The data to store (text content).
+    data : str, optional
+        The text content to store. Mutually exclusive with
+        filename/content_base64.
+    filename : str, optional
+        Original filename for a file upload. Used to derive the stored
+        document's name. Requires content_base64.
+    content_base64 : str, optional
+        Base64-encoded file content to ingest. Requires filename.
     dataset_name : str, optional
         Target dataset name. Defaults to the current MCP client's
         agent-scoped dataset (e.g. "cursor_vscode_memory"), or
@@ -1105,11 +1119,48 @@ async def remember(
     custom_prompt : str, optional
         Custom prompt for entity extraction (permanent mode only).
     """
+    if content_base64 and data:
+        return [
+            types.TextContent(
+                type="text",
+                text="Error: pass either `data` or `filename` + `content_base64`, not both.",
+            )
+        ]
+    if not content_base64 and not data:
+        return [
+            types.TextContent(
+                type="text",
+                text="Error: provide `data` or `filename` + `content_base64`.",
+            )
+        ]
+    if content_base64 and session_id:
+        return [
+            types.TextContent(
+                type="text",
+                text="Error: file uploads (content_base64) don't support session_id.",
+            )
+        ]
+
+    if content_base64:
+        try:
+            decoded = base64.b64decode(content_base64, validate=True)
+        except Exception as e:
+            return [types.TextContent(type="text", text=f"Error: invalid base64 content ({e}).")]
+        if len(decoded) > _MAX_UPLOAD_BYTES:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=f"Error: file exceeds 10 MB limit ({len(decoded):,} bytes).",
+                )
+            ]
+
     dataset_name = dataset_name or _agent_scoped_default_dataset()
     with redirect_stdout(sys.stderr):
         try:
             result = await cognee_client.remember(
                 data=data,
+                filename=filename,
+                content_base64=content_base64,
                 dataset_name=dataset_name,
                 session_id=session_id,
                 custom_prompt=custom_prompt,
@@ -1117,6 +1168,11 @@ async def remember(
             status = result.get("status", "completed")
             if session_id:
                 text = f"Stored in session cache (session_id={session_id}, status={status})."
+            elif content_base64:
+                text = (
+                    f"Ingested '{filename}' ({len(decoded):,} bytes) into dataset "
+                    f"'{dataset_name}' (status={status})."
+                )
             else:
                 text = f"Stored permanently in knowledge graph (dataset={dataset_name}, status={status})."
             return [types.TextContent(type="text", text=text)]
@@ -1523,87 +1579,6 @@ async def open_cognee_workspace() -> types.CallToolResult:
     return types.CallToolResult(
         content=[types.TextContent(type="text", text="Cognee workspace opened.")],
     )
-
-
-_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
-
-
-@mcp.tool(
-    name="cognify_file",
-    description=(
-        "Ingest an uploaded file into Cognee memory. Accepts the file as base64. "
-        "Runs add synchronously, then launches cognify in the background."
-    ),
-)
-@log_usage(function_name="MCP cognify_file", log_type="mcp_tool")
-async def cognify_file(
-    filename: str,
-    content_base64: str,
-    dataset_name: str = None,
-) -> list:
-    import base64
-    import tempfile
-
-    dataset_name = dataset_name or _agent_scoped_default_dataset()
-
-    try:
-        data = base64.b64decode(content_base64, validate=True)
-    except Exception as e:
-        return [types.TextContent(type="text", text=f"Error: invalid base64 content ({e}).")]
-
-    if len(data) > _MAX_UPLOAD_BYTES:
-        return [
-            types.TextContent(
-                type="text",
-                text=f"Error: file exceeds 10 MB limit ({len(data):,} bytes).",
-            )
-        ]
-
-    # Sanitize to a basename with a fallback extension; preserves the original
-    # name so cognee's Data.name comes out as e.g. "alice_notes" rather than
-    # a tempfile slug like "tmp231sj_ac".
-    safe_name = Path(filename).name or "upload"
-    if not Path(safe_name).suffix:
-        safe_name += ".txt"
-
-    with redirect_stdout(sys.stderr):
-        tmp_dir = tempfile.mkdtemp(prefix="cognee_upload_")
-        tmp_path = os.path.join(tmp_dir, safe_name)
-        try:
-            with open(tmp_path, "wb") as f:
-                f.write(data)
-            await cognee_client.add(tmp_path, dataset_name=dataset_name)
-        finally:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            try:
-                os.rmdir(tmp_dir)
-            except OSError:
-                pass
-
-    async def _cognify_bg():
-        with redirect_stdout(sys.stderr):
-            try:
-                await cognee_client.cognify(datasets=[dataset_name])
-                logger.info(f"cognify_file: background cognify finished for '{dataset_name}'.")
-            except Exception as e:
-                ts = datetime.now(timezone.utc).isoformat()
-                _task_errors.setdefault(dataset_name, []).append((ts, str(e)))
-                logger.error(f"cognify_file: background cognify failed for '{dataset_name}': {e}")
-
-    asyncio.create_task(_cognify_bg())
-
-    return [
-        types.TextContent(
-            type="text",
-            text=(
-                f"Ingested '{filename}' ({len(data):,} bytes) into dataset '{dataset_name}'. "
-                f"Cognify is running in the background; refresh the workspace once it finishes."
-            ),
-        )
-    ]
 
 
 def _format_named_items(items, singular: str, plural: str, limit: int = 50) -> str:

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -17,8 +17,8 @@ from cognee.shared.usage_logger import log_usage
 import importlib.util
 from contextlib import redirect_stdout
 import mcp.types as types
-from mcp.server import FastMCP
-from mcp.server.transport_security import TransportSecuritySettings
+from fastmcp import FastMCP
+from fastmcp.tools.tool import ToolResult
 from cognee.modules.storage.utils import JSONEncoder
 from starlette.responses import JSONResponse
 from starlette.middleware import Middleware
@@ -105,11 +105,11 @@ def _record_task_error(dataset: str, error: str) -> None:
     bucket.append((datetime.now(timezone.utc).isoformat(), error))
 
 
-def _configure_transport_security(host: str) -> None:
-    """Configure MCP transport security based on env vars and bind host.
+def _transport_security_kwargs(host: str) -> dict:
+    """Build the Host/Origin guard kwargs for mcp.http_app() from env and bind host.
 
-    Must be called before run_sse_with_cors() or run_http_with_cors(), since
-    the SDK reads mcp.settings.transport_security lazily when creating the app.
+    FastMCP 3 takes these per-app rather than off a mutable settings object, so
+    this returns kwargs instead of configuring global state.
 
     Env vars:
         MCP_DISABLE_DNS_REBINDING_PROTECTION: Set to "true" to disable all
@@ -121,17 +121,14 @@ def _configure_transport_security(host: str) -> None:
     disable = os.getenv("MCP_DISABLE_DNS_REBINDING_PROTECTION", "false").lower() == "true"
 
     if disable:
-        mcp.settings.transport_security = TransportSecuritySettings(
-            enable_dns_rebinding_protection=False,
-        )
         logger.info("MCP transport security: DNS rebinding protection disabled")
-        return
+        return {"host_origin_protection": False}
 
     extra_hosts = [h.strip() for h in os.getenv("MCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
 
-    # The SDK only auto-populates localhost defaults when transport_security is
-    # None AND host is a loopback address. When the user binds to 0.0.0.0 or a
-    # LAN IP, we must provide the full allowed list ourselves.
+    # "auto" only guards loopback binds and explicit allowlists. When the user
+    # binds to 0.0.0.0 or a LAN IP, we must provide the full allowed list
+    # ourselves and turn the guard on unconditionally.
     localhost_hosts = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
     localhost_origins = ["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"]
 
@@ -140,18 +137,19 @@ def _configure_transport_security(host: str) -> None:
     allowed_origins = localhost_origins + [f"http://{h}" for h in extra_hosts]
 
     if host not in ("127.0.0.1", "localhost", "::1") or extra_hosts:
-        mcp.settings.transport_security = TransportSecuritySettings(
-            enable_dns_rebinding_protection=True,
-            allowed_hosts=allowed_hosts,
-            allowed_origins=allowed_origins,
-        )
         logger.info(
             "MCP transport security: allowed_hosts=%s",
             allowed_hosts,
         )
-    else:
-        # Loopback-only with no extra hosts — let the SDK use its own defaults.
-        logger.info("MCP transport security: using SDK defaults (localhost only)")
+        return {
+            "host_origin_protection": True,
+            "allowed_hosts": allowed_hosts,
+            "allowed_origins": allowed_origins,
+        }
+
+    # Loopback-only with no extra hosts — let FastMCP use its own defaults.
+    logger.info("MCP transport security: using FastMCP defaults (localhost only)")
+    return {}
 
 
 def _is_running_in_docker() -> bool:
@@ -165,10 +163,14 @@ def _get_cors_origins() -> list[str]:
     return [o.strip() for o in raw.split(",") if o.strip()]
 
 
-async def run_sse_with_cors():
-    """Custom SSE transport with CORS middleware."""
-    sse_app = mcp.sse_app()
-    sse_app.add_middleware(
+async def _serve_with_cors(transport: str, host: str, port: int, log_level: str):
+    """Serve one of FastMCP's HTTP transports under uvicorn with CORS added.
+
+    FastMCP's own run_http_async() would bind the socket for us but gives no
+    seam for the CORS middleware, so we keep building the ASGI app ourselves.
+    """
+    app = mcp.http_app(transport=transport, **_transport_security_kwargs(host))
+    app.add_middleware(
         CORSMiddleware,
         allow_origins=_get_cors_origins(),
         allow_credentials=True,
@@ -177,31 +179,10 @@ async def run_sse_with_cors():
     )
 
     config = uvicorn.Config(
-        sse_app,
-        host=mcp.settings.host,
-        port=mcp.settings.port,
-        log_level=mcp.settings.log_level.lower(),
-    )
-    server = uvicorn.Server(config)
-    await server.serve()
-
-
-async def run_http_with_cors():
-    """Custom HTTP transport with CORS middleware."""
-    http_app = mcp.streamable_http_app()
-    http_app.add_middleware(
-        CORSMiddleware,
-        allow_origins=_get_cors_origins(),
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-
-    config = uvicorn.Config(
-        http_app,
-        host=mcp.settings.host,
-        port=mcp.settings.port,
-        log_level=mcp.settings.log_level.lower(),
+        app,
+        host=host,
+        port=port,
+        log_level=log_level.lower(),
     )
     server = uvicorn.Server(config)
     await server.serve()
@@ -1497,7 +1478,7 @@ def _inject_graph_viz_overrides(html: str) -> str:
     meta={"ui": {"resourceUri": _VISUALIZE_APP_URI}},
 )
 @log_usage(function_name="MCP visualize_graph_ui", log_type="mcp_tool")
-async def visualize_graph_ui(dataset_name: str = None) -> types.CallToolResult:
+async def visualize_graph_ui(dataset_name: str = None) -> ToolResult:
     """Render the Cognee graph for a specific dataset.
 
     With ENABLE_BACKEND_ACCESS_CONTROL=true, each (user, dataset) pair has its
@@ -1516,8 +1497,8 @@ async def visualize_graph_ui(dataset_name: str = None) -> types.CallToolResult:
     # source. Reject explicit dataset selection there instead of silently
     # falling back to a different graph.
     if explicit_dataset and cognee_client.use_api:
-        return types.CallToolResult(
-            isError=True,
+        return ToolResult(
+            is_error=True,
             content=[
                 types.TextContent(
                     type="text",
@@ -1543,9 +1524,9 @@ async def visualize_graph_ui(dataset_name: str = None) -> types.CallToolResult:
 
     html = _inject_graph_viz_overrides(html)
 
-    return types.CallToolResult(
+    return ToolResult(
         content=[types.TextContent(type="text", text="Cognee knowledge graph rendered.")],
-        structuredContent={"html": html},
+        structured_content={"html": html},
     )
 
 
@@ -1558,8 +1539,8 @@ async def visualize_graph_ui(dataset_name: str = None) -> types.CallToolResult:
     meta={"ui": {"resourceUri": _VISUALIZE_APP_URI}},
 )
 @log_usage(function_name="MCP upload_file_ui", log_type="mcp_tool")
-async def upload_file_ui() -> types.CallToolResult:
-    return types.CallToolResult(
+async def upload_file_ui() -> ToolResult:
+    return ToolResult(
         content=[types.TextContent(type="text", text="Cognee workspace opened.")],
     )
 
@@ -1575,8 +1556,8 @@ async def upload_file_ui() -> types.CallToolResult:
     meta={"ui": {"resourceUri": _VISUALIZE_APP_URI}},
 )
 @log_usage(function_name="MCP open_cognee_workspace", log_type="mcp_tool")
-async def open_cognee_workspace() -> types.CallToolResult:
-    return types.CallToolResult(
+async def open_cognee_workspace() -> ToolResult:
+    return ToolResult(
         content=[types.TextContent(type="text", text="Cognee workspace opened.")],
     )
 
@@ -1611,7 +1592,7 @@ def _format_named_items(items, singular: str, plural: str, limit: int = 50) -> s
     ),
 )
 @log_usage(function_name="MCP list_datasets_json", log_type="mcp_tool")
-async def list_datasets_json() -> types.CallToolResult:
+async def list_datasets_json() -> ToolResult:
     with redirect_stdout(sys.stderr):
         raw = await cognee_client.list_datasets()
 
@@ -1622,14 +1603,14 @@ async def list_datasets_json() -> types.CallToolResult:
         else:
             datasets.append({"id": str(ds.id), "name": ds.name})
 
-    return types.CallToolResult(
+    return ToolResult(
         content=[
             types.TextContent(
                 type="text",
                 text=_format_named_items(datasets, "dataset", "datasets"),
             )
         ],
-        structuredContent={"datasets": datasets},
+        structured_content={"datasets": datasets},
     )
 
 
@@ -1641,13 +1622,13 @@ async def list_datasets_json() -> types.CallToolResult:
     ),
 )
 @log_usage(function_name="MCP list_dataset_data_json", log_type="mcp_tool")
-async def list_dataset_data_json(dataset_id: str) -> types.CallToolResult:
+async def list_dataset_data_json(dataset_id: str) -> ToolResult:
     from uuid import UUID
     from cognee.modules.data.methods import get_dataset, get_dataset_data
 
     if cognee_client.use_api:
-        return types.CallToolResult(
-            isError=True,
+        return ToolResult(
+            is_error=True,
             content=[
                 types.TextContent(
                     type="text",
@@ -1659,8 +1640,8 @@ async def list_dataset_data_json(dataset_id: str) -> types.CallToolResult:
     try:
         dataset_uuid = UUID(dataset_id)
     except ValueError as e:
-        return types.CallToolResult(
-            isError=True,
+        return ToolResult(
+            is_error=True,
             content=[types.TextContent(type="text", text=f"Error: invalid dataset_id ({e}).")],
         )
 
@@ -1668,8 +1649,8 @@ async def list_dataset_data_json(dataset_id: str) -> types.CallToolResult:
         user = await get_default_user()
         dataset = await get_dataset(user.id, dataset_uuid)
         if not dataset:
-            return types.CallToolResult(
-                isError=True,
+            return ToolResult(
+                is_error=True,
                 content=[
                     types.TextContent(type="text", text=f"Error: dataset not found: {dataset_id}.")
                 ],
@@ -1677,14 +1658,14 @@ async def list_dataset_data_json(dataset_id: str) -> types.CallToolResult:
         items = await get_dataset_data(dataset.id)
 
     data = [{"id": str(item.id), "name": item.name or "(unnamed)"} for item in items]
-    return types.CallToolResult(
+    return ToolResult(
         content=[
             types.TextContent(
                 type="text",
                 text=_format_named_items(data, "data item", "data items"),
             )
         ],
-        structuredContent={"data": data},
+        structured_content={"data": data},
     )
 
 
@@ -1747,7 +1728,7 @@ def _agent_scoped_default_dataset() -> str:
     ),
 )
 @log_usage(function_name="MCP get_client_info_json", log_type="mcp_tool")
-async def get_client_info_json() -> types.CallToolResult:
+async def get_client_info_json() -> ToolResult:
     from mcp.server.lowlevel.server import request_ctx
 
     client_name = "unknown"
@@ -1776,14 +1757,14 @@ async def get_client_info_json() -> types.CallToolResult:
     else:
         default_dataset = "main_dataset"
 
-    return types.CallToolResult(
+    return ToolResult(
         content=[
             types.TextContent(
                 type="text",
                 text=f"Agent: {client_name} → default dataset: {default_dataset}",
             )
         ],
-        structuredContent={
+        structured_content={
             "client": {"name": client_name, "version": client_version},
             "default_dataset": default_dataset,
             "agent_scoped": agent_scoped,
@@ -1799,16 +1780,16 @@ async def get_client_info_json() -> types.CallToolResult:
     ),
 )
 @log_usage(function_name="MCP create_dataset_json", log_type="mcp_tool")
-async def create_dataset_json(name: str) -> types.CallToolResult:
+async def create_dataset_json(name: str) -> ToolResult:
     name = (name or "").strip()
     if not name:
-        return types.CallToolResult(
-            isError=True,
+        return ToolResult(
+            is_error=True,
             content=[types.TextContent(type="text", text="Error: dataset name is required.")],
         )
     if cognee_client.use_api:
-        return types.CallToolResult(
-            isError=True,
+        return ToolResult(
+            is_error=True,
             content=[
                 types.TextContent(
                     type="text",
@@ -1825,9 +1806,9 @@ async def create_dataset_json(name: str) -> types.CallToolResult:
         user = await get_default_user()
         dataset = await create_authorized_dataset(name, user)
 
-    return types.CallToolResult(
+    return ToolResult(
         content=[types.TextContent(type="text", text=f"Dataset '{dataset.name}' ready.")],
-        structuredContent={"dataset": {"id": str(dataset.id), "name": dataset.name}},
+        structured_content={"dataset": {"id": str(dataset.id), "name": dataset.name}},
     )
 
 
@@ -1956,9 +1937,8 @@ async def main():
     # Initialize the global CogneeClient
     cognee_client = CogneeClient(api_url=args.api_url, api_token=args.api_token)
 
-    mcp.settings.host = args.host
-    mcp.settings.port = int(args.port)
-    _configure_transport_security(args.host)
+    host = args.host
+    port = int(args.port)
 
     # Resolve cloud connection: CLI args take precedence over env vars
     serve_url = args.serve_url or os.environ.get("COGNEE_SERVICE_URL", "")
@@ -1999,16 +1979,18 @@ async def main():
     try:
         match args.transport.lower():
             case "sse":
-                logger.info(f"Running MCP server with SSE transport on {args.host}:{args.port}")
-                await run_sse_with_cors()
+                logger.info(f"Running MCP server with SSE transport on {host}:{port}")
+                await _serve_with_cors("sse", host, port, args.log_level)
             case "http":
                 logger.info(
-                    f"Running MCP server with Streamable HTTP transport on {args.host}:{args.port}{args.path}"
+                    f"Running MCP server with Streamable HTTP transport on {host}:{port}{args.path}"
                 )
-                await run_http_with_cors()
+                await _serve_with_cors("http", host, port, args.log_level)
             case _:
                 logger.info("Running MCP server with stdio")
-                await mcp.run_stdio_async()
+                # show_banner=False: the banner is cosmetic and its version check
+                # makes a network call on every startup.
+                await mcp.run_stdio_async(show_banner=False)
     finally:
         # Drain background tasks with a bounded timeout so a hung cognify can't
         # block shutdown indefinitely. Then close the HTTP client pool.

--- a/cognee-mcp/src/test_client.py
+++ b/cognee-mcp/src/test_client.py
@@ -17,7 +17,6 @@ EXPECTED_TOOLS = {
     "visualize_graph_ui",
     "upload_file_ui",
     "open_cognee_workspace",
-    "cognify_file",
     "list_datasets_json",
     "list_dataset_data_json",
     "get_client_info_json",

--- a/cognee-mcp/src/test_client.py
+++ b/cognee-mcp/src/test_client.py
@@ -10,18 +10,22 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 
-EXPECTED_TOOLS = {
-    "remember",
-    "recall",
-    "forget",
-    "visualize_graph_ui",
-    "upload_file_ui",
-    "open_cognee_workspace",
-    "list_datasets_json",
-    "list_dataset_data_json",
-    "get_client_info_json",
-    "create_dataset_json",
-}
+try:
+    from .server import registry
+    from .tool_registry import DEFAULT_TAG
+except ImportError:
+    from server import registry
+    from tool_registry import DEFAULT_TAG
+
+# Derived from the @registry.tool declarations rather than duplicated here, so
+# adding or retiering a tool can't leave this list stale. The server runs in
+# COGNEE_MCP_TOOL_MODE=default, so tools/list carries the pinned tools plus the
+# two synthetic tools FastMCP's search transform adds.
+SEARCH_TRANSFORM_TOOLS = {"search_tools", "call_tool"}
+EXPECTED_TOOLS = set(registry.names_with_tag(DEFAULT_TAG)) | SEARCH_TRANSFORM_TOOLS
+
+# Registered but not advertised in default mode; must still be callable by name.
+HIDDEN_TOOL = "list_datasets_json"
 
 
 class CogneeTestClient:
@@ -81,6 +85,39 @@ class CogneeTestClient:
             }
             print(f"FAIL tool discovery: {e}")
 
+    async def test_hidden_tool_is_still_callable(self):
+        """An unadvertised tool must remain callable by name over the real protocol."""
+        print("\nTesting hidden tool reachability...")
+
+        try:
+            async with self.mcp_server_session() as session:
+                tools_result = await session.list_tools()
+                if HIDDEN_TOOL in {tool.name for tool in tools_result.tools}:
+                    raise AssertionError(f"{HIDDEN_TOOL} should not be advertised")
+
+                direct = await session.call_tool(HIDDEN_TOOL, arguments={})
+                if direct.isError:
+                    raise AssertionError(f"Direct call failed: {self._content_text(direct)}")
+
+                found = await session.call_tool(
+                    "search_tools", arguments={"query": "list the datasets"}
+                )
+                if HIDDEN_TOOL not in self._content_text(found):
+                    raise AssertionError(f"search_tools did not surface {HIDDEN_TOOL}")
+
+            self.test_results["hidden_tool"] = {
+                "status": "PASS",
+                "message": f"{HIDDEN_TOOL} is searchable and directly callable while unlisted",
+            }
+            print("PASS hidden tool reachability")
+        except Exception as e:
+            self.test_results["hidden_tool"] = {
+                "status": "FAIL",
+                "error": str(e),
+                "message": "Hidden tool reachability failed",
+            }
+            print(f"FAIL hidden tool reachability: {e}")
+
     async def test_memory_tools(self):
         """Exercise the three public tools without deleting existing memory."""
         print("\nTesting memory tool calls...")
@@ -132,6 +169,7 @@ class CogneeTestClient:
         print("=" * 50)
 
         await self.test_tool_discovery()
+        await self.test_hidden_tool_is_still_callable()
         await self.test_memory_tools()
         self.print_test_summary()
 

--- a/cognee-mcp/src/tool_registry.py
+++ b/cognee-mcp/src/tool_registry.py
@@ -1,0 +1,64 @@
+"""Tag-driven tool registration for the MCP server.
+
+Wraps FastMCP's ``@mcp.tool`` so every tool declares which tier it belongs to
+at its definition site, and the set of always-advertised tools is *derived*
+from those declarations instead of maintained as a list somewhere else.
+
+FastMCP's decorator returns the bare function (``FASTMCP_DECORATOR_MODE``
+defaults to ``function``), so tags can't be read back off the return value, and
+the server exposes no synchronous tool accessor — ``list_tools()`` is async and
+returns the post-transform catalog. Recording tags here at decoration time
+sidesteps both.
+
+The wrapper also applies ``@log_usage`` so the two can't drift: every tool is
+logged as ``MCP <tool_name>``, which is what all of them already did by hand.
+"""
+
+from typing import Any, Callable, Iterable
+
+from cognee.shared.usage_logger import log_usage
+
+# Advertised in tools/list without a search. Everything else is reachable
+# through the search transform (and remains directly callable by name).
+DEFAULT_TAG = "default"
+
+# The LLM-facing memory API. Tagged separately so a deployment can pin the
+# advertised surface to just these via COGNEE_MCP_TOOL_MODE=minimal.
+MEMORY_TAG = "memory"
+
+
+class ToolRegistry:
+    """Registers tools with a FastMCP instance and remembers their tags."""
+
+    def __init__(self, mcp: Any) -> None:
+        self._mcp = mcp
+        self.tags: dict[str, set[str]] = {}
+
+    def tool(
+        self,
+        *,
+        tags: Iterable[str],
+        name: str | None = None,
+        **tool_kwargs: Any,
+    ) -> Callable[[Callable], Callable]:
+        """Register an MCP tool, tag it, and wrap it in usage logging.
+
+        Args:
+            tags: Tier/group tags. Include ``DEFAULT_TAG`` to keep the tool
+                advertised when the search transform is active.
+            name: Tool name; defaults to the function name.
+            **tool_kwargs: Passed through to ``mcp.tool`` (description, meta, ...).
+        """
+        tag_set = set(tags)
+
+        def decorator(fn: Callable) -> Callable:
+            tool_name = name or fn.__name__
+            self.tags[tool_name] = tag_set
+            logged = log_usage(function_name=f"MCP {tool_name}", log_type="mcp_tool")(fn)
+            return self._mcp.tool(name=tool_name, tags=tag_set, **tool_kwargs)(logged)
+
+        return decorator
+
+    def names_with_tag(self, tag: str) -> list[str]:
+        """Sorted names of every registered tool carrying ``tag``."""
+        return sorted(name for name, tags in self.tags.items() if tag in tags)

--- a/cognee-mcp/tests/conftest.py
+++ b/cognee-mcp/tests/conftest.py
@@ -1,0 +1,103 @@
+"""Flags MCP tools that no test ever exercises.
+
+A tool is registered by decorator, so adding one is easy and forgetting to test
+it is easier. At the end of the run this reports every name in
+``server.registry`` that was never invoked.
+
+What it measures is invocation, not assertion quality: a tool called incidentally
+by an unrelated test counts as covered. That is enough to catch the case this
+exists for — a new tool with no test at all — and not enough to catch a test that
+calls a tool and asserts nothing.
+
+Warn-only by default. Set ``COGNEE_MCP_STRICT_TOOL_COVERAGE=1`` to fail the run
+instead, which is the useful setting for CI. Strict mode only makes sense on a
+full ``pytest tests/`` run: a filtered run (``-k``, or a single file) exercises
+fewer tools and will report the rest as uncovered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import os
+import sys
+from pathlib import Path
+
+MCP_ROOT = Path(__file__).resolve().parents[1]  # cognee-mcp/
+if str(MCP_ROOT) not in sys.path:
+    sys.path.insert(0, str(MCP_ROOT))
+
+_STRICT_ENV = "COGNEE_MCP_STRICT_TOOL_COVERAGE"
+
+_called: set[str] = set()
+_uninstrumented: set[str] = set()
+
+
+def _instrument(tool, module, name: str) -> None:
+    """Route every call to ``name`` through a recorder.
+
+    Both bindings need patching. ``registry.tool`` hands FastMCP the same
+    function object it binds at module level, so rebinding one leaves the other
+    pointing at the original: ``Tool.fn`` is what a client call reaches (directly
+    or via the call_tool proxy) and the module attribute is what a test calling
+    ``await server.forget()`` reaches.
+    """
+    original = tool.fn
+
+    @functools.wraps(original)
+    async def recording(*args, **kwargs):
+        _called.add(name)
+        return await original(*args, **kwargs)
+
+    tool.fn = recording
+    setattr(module, name, recording)
+
+
+def pytest_sessionstart(session):
+    import src.server as server
+
+    # No transform is installed at import time, so this is the full catalog.
+    tools = {tool.name: tool for tool in asyncio.run(server.mcp.list_tools())}
+
+    for name in server.registry.tags:
+        tool = tools.get(name)
+        if tool is None or not hasattr(tool, "fn"):
+            _uninstrumented.add(name)
+            continue
+        _instrument(tool, server, name)
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    import src.server as server
+
+    registered = set(server.registry.tags)
+    uncovered = sorted(registered - _called - _uninstrumented)
+
+    if not uncovered and not _uninstrumented:
+        terminalreporter.write_line(
+            f"MCP tool coverage: all {len(registered)} registered tools exercised.",
+            green=True,
+        )
+        return
+
+    terminalreporter.section("MCP tool coverage", sep="-", yellow=True)
+    for name in uncovered:
+        terminalreporter.write_line(f"  {name} has no test coverage", yellow=True)
+    for name in sorted(_uninstrumented):
+        terminalreporter.write_line(
+            f"  {name} could not be instrumented (coverage unknown)", yellow=True
+        )
+    if uncovered and not os.getenv(_STRICT_ENV):
+        terminalreporter.write_line(f"  (set {_STRICT_ENV}=1 to fail on this)")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Turn the report into a failure when strict mode is on."""
+    if not os.getenv(_STRICT_ENV):
+        return
+
+    import src.server as server
+
+    uncovered = set(server.registry.tags) - _called - _uninstrumented
+    if uncovered:
+        session.exitstatus = 1

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -1,7 +1,10 @@
 import asyncio
+import base64
 import hashlib
 import importlib
 import json
+import mimetypes
+import re
 import sys
 from pathlib import Path
 
@@ -166,6 +169,188 @@ async def test_cognee_client_api_add_uses_content_addressed_filename():
     body = requests[0].content.decode()
     assert f'filename="text_{digest}.txt"' in body
     assert "data.txt" not in body
+
+
+async def _mock_api_client(requests: list[httpx.Request], **kwargs) -> CogneeClient:
+    """API-mode client whose requests are recorded instead of sent over the wire."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = CogneeClient(api_url="http://cognee.local", **kwargs)
+    await client.client.aclose()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return client
+
+
+def _multipart_filenames(request: httpx.Request) -> list[str]:
+    """Filenames declared in a multipart body, in order."""
+    body = request.content.decode("latin-1")
+    return re.findall(r'filename="([^"]*)"', body)
+
+
+# Regression guards for issue #4230: in API mode `add()` used to stringify every
+# argument through `_text_upload`, so a real filesystem path was uploaded as the
+# *path text* under a content-addressed `text_<md5>.txt` name. Documents ingested
+# through the MCP file-upload path therefore showed up in the UI as opaque slugs
+# instead of their original filename. Paths must upload file bytes under the
+# original basename, while plain text must keep the content-addressed name that
+# fixed the silent `data.txt` collision (#2747).
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_uploads_file_path_under_original_basename(tmp_path):
+    upload = tmp_path / "meeting-notes.md"
+    upload.write_text("# Meeting notes\nagenda item", encoding="utf-8")
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    try:
+        await client.add(str(upload), dataset_name="ds")
+    finally:
+        await client.close()
+
+    body = requests[0].content.decode()
+    expected_mime = mimetypes.guess_type("meeting-notes.md")[0] or "application/octet-stream"
+
+    assert _multipart_filenames(requests[0]) == ["meeting-notes.md"]
+    # The bug: a content-addressed name derived from the path string.
+    assert 'filename="text_' not in body
+    # The file's bytes must be uploaded, not the path that pointed at them.
+    assert "# Meeting notes\nagenda item" in body
+    assert str(upload) not in body
+    assert f"Content-Type: {expected_mime}" in body
+    assert 'name="datasetName"' in body and "ds" in body
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_accepts_path_objects(tmp_path):
+    upload = tmp_path / "client-profile.md"
+    upload.write_text("profile", encoding="utf-8")
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    try:
+        await client.add(upload, dataset_name="ds")
+    finally:
+        await client.close()
+
+    assert _multipart_filenames(requests[0]) == ["client-profile.md"]
+    assert "profile" in requests[0].content.decode()
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_uploads_binary_file_bytes(tmp_path):
+    upload = tmp_path / "report.pdf"
+    raw_bytes = b"%PDF-1.4\n\x00\x80\xff binary payload"
+    upload.write_bytes(raw_bytes)
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    try:
+        await client.add(str(upload), dataset_name="ds")
+    finally:
+        await client.close()
+
+    expected_mime = mimetypes.guess_type("report.pdf")[0] or "application/octet-stream"
+
+    assert _multipart_filenames(requests[0]) == ["report.pdf"]
+    # Bytes are passed through untouched: a str()/utf-8 round trip would mangle them.
+    assert raw_bytes in requests[0].content
+    assert f"Content-Type: {expected_mime}".encode() in requests[0].content
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_keeps_content_addressed_name_for_non_file_text():
+    """Text that merely looks like a path stays a content-addressed text upload."""
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    content = "/definitely/not/on/disk/notes.md"
+    digest = hashlib.md5(content.encode("utf-8")).hexdigest()
+
+    try:
+        await client.add(content, dataset_name="ds")
+    finally:
+        await client.close()
+
+    body = requests[0].content.decode()
+    assert _multipart_filenames(requests[0]) == [f"text_{digest}.txt"]
+    assert 'filename="notes.md"' not in body
+    assert content in body
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_add_keeps_text_upload_for_directories_and_long_text(tmp_path):
+    """Non-file arguments must not trip the path branch (or raise from os.path.isfile)."""
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    long_text = "remember this\n" * 5000
+
+    try:
+        await client.add(str(tmp_path), dataset_name="ds")
+        await client.add(long_text, dataset_name="ds")
+    finally:
+        await client.close()
+
+    dir_digest = hashlib.md5(str(tmp_path).encode("utf-8")).hexdigest()
+    text_digest = hashlib.md5(long_text.encode("utf-8")).hexdigest()
+
+    assert _multipart_filenames(requests[0]) == [f"text_{dir_digest}.txt"]
+    assert _multipart_filenames(requests[1]) == [f"text_{text_digest}.txt"]
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_remember_uploads_file_path_under_original_basename(tmp_path):
+    """remember() shares add()'s path handling (issue #4230, "same pattern")."""
+    upload = tmp_path / "alice_notes.md"
+    upload.write_text("alice prefers async updates", encoding="utf-8")
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    try:
+        await client.remember(str(upload), dataset_name="ds")
+    finally:
+        await client.close()
+
+    body = requests[0].content.decode()
+    assert requests[0].url.path == "/api/v1/remember"
+    assert _multipart_filenames(requests[0]) == ["alice_notes.md"]
+    assert "alice prefers async updates" in body
+    assert str(upload) not in body
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_api_remember_base64_upload_preserves_and_sanitizes_filename():
+    """The MCP file-upload path keeps the caller's name but never a directory."""
+    requests: list[httpx.Request] = []
+    client = await _mock_api_client(requests)
+
+    payload = base64.b64encode(b"# Client profile").decode("ascii")
+
+    try:
+        await client.remember(
+            data=None,
+            dataset_name="ds",
+            filename="client-profile.md",
+            content_base64=payload,
+        )
+        await client.remember(
+            data=None,
+            dataset_name="ds",
+            filename="../../etc/passwd",
+            content_base64=payload,
+        )
+        await client.remember(data=None, dataset_name="ds", filename="", content_base64=payload)
+    finally:
+        await client.close()
+
+    assert _multipart_filenames(requests[0]) == ["client-profile.md"]
+    assert "# Client profile" in requests[0].content.decode()
+    assert _multipart_filenames(requests[1]) == ["passwd.txt"]
+    assert _multipart_filenames(requests[2]) == ["upload.txt"]
 
 
 @pytest.mark.asyncio

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -1077,7 +1077,7 @@ async def test_list_datasets_json_puts_names_in_text_channel(monkeypatch):
     assert "alpha (id-1)" in text
     assert "beta (id-2)" in text
     # Structured payload is preserved for the workspace UI.
-    assert result.structuredContent == {
+    assert result.structured_content == {
         "datasets": [
             {"id": "id-1", "name": "alpha"},
             {"id": "id-2", "name": "beta"},
@@ -1102,7 +1102,9 @@ async def test_list_datasets_json_text_channel_over_mcp_protocol(monkeypatch):
 
     monkeypatch.setattr(server, "cognee_client", FakeClient())
 
-    async with create_connected_server_and_client_session(server.mcp) as client:
+    # FastMCP 3 keeps the low-level Server on _mcp_server; the SDK helper needs that,
+    # not the FastMCP wrapper.
+    async with create_connected_server_and_client_session(server.mcp._mcp_server) as client:
         await client.initialize()
 
         tool_names = {tool.name for tool in (await client.list_tools()).tools}

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib
 import json
 import mimetypes
+import os
 import re
 import sys
 from pathlib import Path
@@ -345,6 +346,158 @@ async def test_cognee_client_api_remember_base64_upload_preserves_and_sanitizes_
 
 
 @pytest.mark.asyncio
+async def test_cognee_client_remember_rejects_conflicting_upload_arguments():
+    """The client refuses ambiguous payloads before deciding on a transport."""
+    client = await _mock_api_client([])
+    payload = base64.b64encode(b"file bytes").decode("ascii")
+
+    try:
+        with pytest.raises(ValueError, match="not both"):
+            await client.remember(data="inline text", filename="notes.md", content_base64=payload)
+        with pytest.raises(ValueError, match="do not support session_id"):
+            await client.remember(
+                data=None, filename="notes.md", content_base64=payload, session_id="s-1"
+            )
+    finally:
+        await client.close()
+
+
+class FakeCogneeModule:
+    """Stand-in for the `cognee` module used by CogneeClient's direct mode."""
+
+    def __init__(self, result=None, error=None):
+        self.calls: list[dict] = []
+        self.seen_payloads: list[bytes] = []
+        self.seen_paths: list[str] = []
+        self._result = result
+        self._error = error
+
+    async def remember(self, **kwargs):
+        self.calls.append(kwargs)
+        data = kwargs.get("data")
+        # Read through the handed-off path while it is still on disk: the
+        # client deletes it as soon as remember() returns.
+        if isinstance(data, str) and os.path.isfile(data):
+            self.seen_paths.append(data)
+            with open(data, "rb") as handle:
+                self.seen_payloads.append(handle.read())
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+def _local_client(fake_cognee: FakeCogneeModule) -> CogneeClient:
+    """Direct-mode client with the real cognee module swapped out."""
+    client = CogneeClient()
+    client.cognee = fake_cognee
+    return client
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_writes_upload_to_a_temp_file():
+    """Direct mode materializes the upload on disk under its original name."""
+    fake = FakeCogneeModule()
+    client = _local_client(fake)
+    raw_bytes = b"%PDF-1.4\n\x00\x80\xff quarterly report"
+    payload = base64.b64encode(raw_bytes).decode("ascii")
+
+    result = await client.remember(
+        data=None,
+        dataset_name="ds",
+        filename="q3-report.pdf",
+        content_base64=payload,
+    )
+
+    assert len(fake.calls) == 1
+    handed_off = fake.calls[0]["data"]
+    assert Path(handed_off).name == "q3-report.pdf"
+    # Bytes survive the base64 -> disk round trip untouched.
+    assert fake.seen_payloads == [raw_bytes]
+    assert fake.calls[0]["dataset_name"] == "ds"
+    # File uploads are permanent-memory only, so no session_id is forwarded.
+    assert "session_id" not in fake.calls[0]
+    assert result["dataset_name"] == "ds"
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_sanitizes_upload_filename():
+    """Direct mode applies the same basename sanitizing as the API path."""
+    payload = base64.b64encode(b"contents").decode("ascii")
+
+    for supplied, expected in [
+        ("../../etc/passwd", "passwd.txt"),
+        ("", "upload.txt"),
+        ("notes", "notes.txt"),
+    ]:
+        fake = FakeCogneeModule()
+        client = _local_client(fake)
+
+        await client.remember(
+            data=None, dataset_name="ds", filename=supplied, content_base64=payload
+        )
+
+        written = Path(fake.calls[0]["data"])
+        assert written.name == expected
+        # The traversal segments must not survive into the staged path.
+        assert ".." not in written.parts
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_cleans_up_the_temp_upload():
+    """The staged file and its directory are removed once ingestion returns."""
+    fake = FakeCogneeModule()
+    client = _local_client(fake)
+    payload = base64.b64encode(b"transient").decode("ascii")
+
+    await client.remember(
+        data=None, dataset_name="ds", filename="scratch.md", content_base64=payload
+    )
+
+    staged = Path(fake.seen_paths[0])
+    assert not staged.exists()
+    assert not staged.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_cleans_up_when_ingestion_fails():
+    """A failing cognify must not leak the staged upload onto disk."""
+    fake = FakeCogneeModule(error=RuntimeError("cognify exploded"))
+    client = _local_client(fake)
+    payload = base64.b64encode(b"transient").decode("ascii")
+
+    with pytest.raises(RuntimeError, match="cognify exploded"):
+        await client.remember(
+            data=None, dataset_name="ds", filename="scratch.md", content_base64=payload
+        )
+
+    staged = Path(fake.seen_paths[0])
+    assert not staged.exists()
+    assert not staged.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_cognee_client_local_remember_passes_text_through_untouched():
+    """Text payloads reach cognee.remember as-is, with no file staging."""
+    fake = FakeCogneeModule()
+    client = _local_client(fake)
+
+    await client.remember(
+        data="alice prefers async updates",
+        dataset_name="ds",
+        session_id="s-1",
+        custom_prompt="extract carefully",
+    )
+
+    assert fake.calls[0] == {
+        "data": "alice prefers async updates",
+        "dataset_name": "ds",
+        "session_id": "s-1",
+        "custom_prompt": "extract carefully",
+    }
+    assert fake.seen_paths == []
+
+
+@pytest.mark.asyncio
 async def test_cognee_client_api_remember_sends_session_id():
     requests: list[httpx.Request] = []
 
@@ -399,6 +552,187 @@ async def test_cognee_client_api_recall_sends_session_id_prompt_and_null_search_
     assert payload["system_prompt"] == "Answer with provenance."
     assert payload["search_type"] is None
     assert payload["top_k"] == 5
+
+
+class RecordingRememberClient:
+    """Fake cognee_client that records what the remember tool forwarded."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def remember(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"status": "completed"}
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_error",
+    [
+        pytest.param(
+            {"data": "inline text", "filename": "n.md", "content_base64": "aGk="},
+            "not both",
+            id="text_and_file",
+        ),
+        pytest.param({}, "provide `data`", id="neither"),
+        pytest.param({"data": ""}, "provide `data`", id="empty_data"),
+        pytest.param(
+            {"filename": "n.md", "content_base64": "aGk=", "session_id": "s-1"},
+            "don't support session_id",
+            id="upload_with_session",
+        ),
+        pytest.param(
+            {"filename": "n.md", "content_base64": "not valid base64!"},
+            "invalid base64",
+            id="malformed_base64",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_mcp_remember_rejects_invalid_payloads(monkeypatch, kwargs, expected_error):
+    """Bad argument combinations are refused before any ingestion is attempted."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    result = await server.remember(**kwargs)
+
+    assert expected_error in result[0].text
+    assert result[0].text.startswith("Error:")
+    assert fake_client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_rejects_uploads_over_the_size_limit(monkeypatch):
+    """Oversized uploads are rejected client-side rather than posted."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    oversized = base64.b64encode(b"x" * (server._MAX_UPLOAD_BYTES + 1)).decode("ascii")
+    result = await server.remember(filename="big.bin", content_base64=oversized)
+
+    assert "exceeds 10 MB limit" in result[0].text
+    assert fake_client.calls == []
+
+    at_limit = base64.b64encode(b"x" * server._MAX_UPLOAD_BYTES).decode("ascii")
+    result = await server.remember(filename="big.bin", content_base64=at_limit)
+
+    # The limit itself is inclusive.
+    assert not result[0].text.startswith("Error:")
+    assert len(fake_client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_forwards_file_uploads(monkeypatch):
+    """The merged tool hands filename + content_base64 straight to the client."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    raw_bytes = b"# Client profile\nprefers async updates"
+    payload = base64.b64encode(raw_bytes).decode("ascii")
+
+    result = await server.remember(
+        filename="client-profile.md",
+        content_base64=payload,
+        dataset_name="ds",
+        custom_prompt="extract carefully",
+    )
+
+    assert fake_client.calls == [
+        {
+            "data": None,
+            "filename": "client-profile.md",
+            "content_base64": payload,
+            "dataset_name": "ds",
+            "session_id": None,
+            "custom_prompt": "extract carefully",
+        }
+    ]
+    # The confirmation names the file and its decoded size, not the base64 length.
+    assert "client-profile.md" in result[0].text
+    assert f"{len(raw_bytes):,} bytes" in result[0].text
+    assert "ds" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_still_stores_text_and_session_entries(monkeypatch):
+    """Absorbing cognify_file left the pre-existing text paths intact."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+
+    permanent = await server.remember(data="alice prefers async updates", dataset_name="ds")
+    session = await server.remember(data="scratch note", dataset_name="ds", session_id="s-1")
+
+    assert fake_client.calls[0]["data"] == "alice prefers async updates"
+    assert fake_client.calls[0]["content_base64"] is None
+    assert "knowledge graph" in permanent[0].text
+
+    assert fake_client.calls[1]["session_id"] == "s-1"
+    assert "session cache" in session[0].text
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_defaults_dataset_when_caller_omits_it(monkeypatch):
+    """Uploads inherit the agent-scoped default dataset, same as text writes."""
+    import src.server as server
+
+    fake_client = RecordingRememberClient()
+    monkeypatch.setattr(server, "cognee_client", fake_client)
+    monkeypatch.setattr(server, "_agent_scoped_default_dataset", lambda: "cursor_vscode_memory")
+
+    await server.remember(filename="n.md", content_base64=base64.b64encode(b"hi").decode("ascii"))
+
+    assert fake_client.calls[0]["dataset_name"] == "cursor_vscode_memory"
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_reports_client_failures(monkeypatch):
+    """Ingestion errors surface as tool errors instead of propagating."""
+    import src.server as server
+
+    class ExplodingClient:
+        async def remember(self, **kwargs):
+            raise RuntimeError("upstream is down")
+
+    monkeypatch.setattr(server, "cognee_client", ExplodingClient())
+
+    result = await server.remember(
+        filename="n.md", content_base64=base64.b64encode(b"hi").decode("ascii")
+    )
+
+    assert "Remember failed" in result[0].text
+    assert "upstream is down" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_mcp_no_longer_exposes_cognify_file():
+    """cognify_file was absorbed into remember and must be gone from the surface."""
+    import src.server as server
+
+    tools = await server.mcp.list_tools()
+
+    assert "cognify_file" not in {tool.name for tool in tools}
+    assert not hasattr(server, "cognify_file")
+
+
+@pytest.mark.asyncio
+async def test_mcp_remember_advertises_file_upload_parameters():
+    """The merged tool's schema is what tells an LLM it can send files."""
+    import src.server as server
+
+    tools = await server.mcp.list_tools()
+    remember_tool = next(tool for tool in tools if tool.name == "remember")
+    properties = remember_tool.inputSchema["properties"]
+
+    assert {"data", "filename", "content_base64"} <= set(properties)
+    assert "filename" in remember_tool.description
+    assert "content_base64" in remember_tool.description
 
 
 @pytest.mark.asyncio

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -125,7 +125,6 @@ WORKSPACE_UI_ENTRY_TOOLS = {
     "open_cognee_workspace",
 }
 WORKSPACE_INTERNAL_TOOLS = {
-    "cognify_file",
     "list_datasets_json",
     "list_dataset_data_json",
     "create_dataset_json",

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -728,7 +728,9 @@ async def test_mcp_remember_advertises_file_upload_parameters():
 
     tools = await server.mcp.list_tools()
     remember_tool = next(tool for tool in tools if tool.name == "remember")
-    properties = remember_tool.inputSchema["properties"]
+    # FastMCP 3 returns its own Tool objects, whose JSON schema is `parameters`;
+    # `inputSchema` is the name on the MCP wire type a client receives.
+    properties = remember_tool.parameters["properties"]
 
     assert {"data", "filename", "content_base64"} <= set(properties)
     assert "filename" in remember_tool.description

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -190,15 +190,6 @@ def _multipart_filenames(request: httpx.Request) -> list[str]:
     return re.findall(r'filename="([^"]*)"', body)
 
 
-# Regression guards for issue #4230: in API mode `add()` used to stringify every
-# argument through `_text_upload`, so a real filesystem path was uploaded as the
-# *path text* under a content-addressed `text_<md5>.txt` name. Documents ingested
-# through the MCP file-upload path therefore showed up in the UI as opaque slugs
-# instead of their original filename. Paths must upload file bytes under the
-# original basename, while plain text must keep the content-addressed name that
-# fixed the silent `data.txt` collision (#2747).
-
-
 @pytest.mark.asyncio
 async def test_cognee_client_api_add_uploads_file_path_under_original_basename(tmp_path):
     upload = tmp_path / "meeting-notes.md"
@@ -215,7 +206,7 @@ async def test_cognee_client_api_add_uploads_file_path_under_original_basename(t
     expected_mime = mimetypes.guess_type("meeting-notes.md")[0] or "application/octet-stream"
 
     assert _multipart_filenames(requests[0]) == ["meeting-notes.md"]
-    # The bug: a content-addressed name derived from the path string.
+    # Bug from issue 4230: a content-addressed name derived from the path string.
     assert 'filename="text_' not in body
     # The file's bytes must be uploaded, not the path that pointed at them.
     assert "# Meeting notes\nagenda item" in body

--- a/cognee-mcp/tests/test_tool_search.py
+++ b/cognee-mcp/tests/test_tool_search.py
@@ -115,6 +115,37 @@ async def test_apply_tool_mode_is_idempotent():
 # --- the lazy-loading guarantee ------------------------------------------------
 
 
+async def test_result_window_is_not_the_binding_constraint():
+    """TOOL_SEARCH_MAX_RESULTS is sized for a catalog we expect to grow, so today
+    it exceeds the number of hidden tools: no hidden tool can be pushed out of the
+    window by the limit alone."""
+    hidden = set(server.registry.tags) - set(server.registry.names_with_tag(DEFAULT_TAG))
+    assert len(hidden) <= server.TOOL_SEARCH_MAX_RESULTS
+
+
+async def test_search_matches_on_vocabulary_not_on_the_result_limit():
+    """The window being wide enough does NOT mean every search returns everything.
+
+    BM25 drops zero-scoring tools and its tokenizer does no stemming, so "dataset"
+    does not match `list_datasets_json` (token "datasets"). This is the behavior
+    that makes tool *descriptions* the lever for recall, and it is surprising
+    enough to pin: if a future fastmcp adds stemming, we want to notice.
+    """
+    server.apply_tool_mode("default")
+    hidden = set(server.registry.tags) - set(server.registry.names_with_tag(DEFAULT_TAG))
+
+    async with Client(server.mcp) as client:
+        singular = set(await search(client, "dataset"))
+        plural = set(await search(client, "datasets"))
+        combined = set(await search(client, "dataset datasets file client info create list"))
+
+    assert "create_dataset_json" in singular
+    assert "list_datasets_json" not in singular, "unexpected stemming — revisit the docs"
+    assert "list_datasets_json" in plural
+    # Covering both forms does reach everything, confirming the limit is not the cap.
+    assert combined == hidden
+
+
 async def test_hidden_tools_are_discoverable_by_search():
     server.apply_tool_mode("default")
 

--- a/cognee-mcp/tests/test_tool_search.py
+++ b/cognee-mcp/tests/test_tool_search.py
@@ -24,13 +24,16 @@ from src.tool_registry import DEFAULT_TAG, MEMORY_TAG  # noqa: E402
 SYNTHETIC_TOOLS = {"search_tools", "call_tool"}
 MEMORY_TOOLS = {"remember", "recall", "forget"}
 WORKSPACE_UI_ENTRY_TOOLS = {"visualize_graph_ui", "upload_file_ui", "open_cognee_workspace"}
-WORKSPACE_INTERNAL_TOOLS = {
-    "cognify_file",
-    "list_datasets_json",
-    "list_dataset_data_json",
-    "create_dataset_json",
-    "get_client_info_json",
-}
+
+# Deliberately not enumerated: the unpinned tools are derived from the registry so
+# this file keeps working as the catalog changes (cognify_file in particular is
+# being merged into remember). Only the pinned sets are spelled out, because those
+# are the contract worth reviewing by eye.
+
+
+def hidden_tools() -> set[str]:
+    """Registered but not advertised in default mode."""
+    return set(server.registry.tags) - set(server.registry.names_with_tag(DEFAULT_TAG))
 
 
 @pytest.fixture(autouse=True)
@@ -56,12 +59,17 @@ async def search(client, query: str) -> list[str]:
 # --- tier declarations ---------------------------------------------------------
 
 
-def test_every_tool_declares_a_tier():
-    """A tool registered without going through @registry.tool would be missed by
-    names_with_tag(), so assert the registry covers the whole catalog."""
-    assert set(server.registry.tags) == (
-        MEMORY_TOOLS | WORKSPACE_UI_ENTRY_TOOLS | WORKSPACE_INTERNAL_TOOLS
-    )
+async def test_every_tool_declares_a_tier():
+    """A tool registered with a bare @mcp.tool would be invisible to
+    names_with_tag(), so it would never be pinned and never be counted as hidden.
+
+    Compared against the live catalog rather than a hardcoded list, so adding or
+    removing a tool needs no edit here.
+    """
+    server.apply_tool_mode("all")
+    advertised_names = {tool.name for tool in await server.mcp.list_tools()}
+
+    assert set(server.registry.tags) == advertised_names
     assert all(tags for tags in server.registry.tags.values())
 
 
@@ -119,7 +127,7 @@ async def test_result_window_is_not_the_binding_constraint():
     """TOOL_SEARCH_MAX_RESULTS is sized for a catalog we expect to grow, so today
     it exceeds the number of hidden tools: no hidden tool can be pushed out of the
     window by the limit alone."""
-    hidden = set(server.registry.tags) - set(server.registry.names_with_tag(DEFAULT_TAG))
+    hidden = hidden_tools()
     assert len(hidden) <= server.TOOL_SEARCH_MAX_RESULTS
 
 
@@ -131,7 +139,6 @@ async def test_result_window_is_not_the_binding_constraint():
         ("show me all the datasets", "list_datasets_json"),
         ("show the data inside a dataset", "list_dataset_data_json"),
         ("make a new dataset", "create_dataset_json"),
-        ("upload and ingest this file", "cognify_file"),
         ("which client am I connected as", "get_client_info_json"),
     ],
 )
@@ -160,7 +167,7 @@ async def test_search_matches_on_vocabulary_not_on_the_result_limit():
     enough to pin: if a future fastmcp adds stemming, we want to notice.
     """
     server.apply_tool_mode("default")
-    hidden = set(server.registry.tags) - set(server.registry.names_with_tag(DEFAULT_TAG))
+    hidden = hidden_tools()
 
     async with Client(server.mcp) as client:
         singular = set(await search(client, "dataset"))
@@ -179,7 +186,7 @@ async def test_hidden_tools_are_discoverable_by_search():
 
     async with Client(server.mcp) as client:
         assert "list_datasets_json" in await search(client, "list all of my datasets")
-        assert "cognify_file" in await search(client, "ingest an uploaded file")
+        assert "create_dataset_json" in await search(client, "create a new dataset")
 
 
 async def test_search_never_returns_pinned_tools():

--- a/cognee-mcp/tests/test_tool_search.py
+++ b/cognee-mcp/tests/test_tool_search.py
@@ -1,0 +1,219 @@
+"""Behavior of the tool-search gating added in CLO-352.
+
+The guarantee these tests protect: shrinking what ``tools/list`` advertises must
+not shrink what is *callable*. Every unadvertised tool has to stay reachable
+both directly by name (how the workspace UI calls its internals) and through
+the ``call_tool`` proxy (how an agent calls something it just found).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+MCP_ROOT = Path(__file__).resolve().parents[1]  # cognee-mcp/
+if str(MCP_ROOT) not in sys.path:
+    sys.path.insert(0, str(MCP_ROOT))
+
+import src.server as server  # noqa: E402
+from src.tool_registry import DEFAULT_TAG, MEMORY_TAG  # noqa: E402
+
+SYNTHETIC_TOOLS = {"search_tools", "call_tool"}
+MEMORY_TOOLS = {"remember", "recall", "forget"}
+WORKSPACE_UI_ENTRY_TOOLS = {"visualize_graph_ui", "upload_file_ui", "open_cognee_workspace"}
+WORKSPACE_INTERNAL_TOOLS = {
+    "cognify_file",
+    "list_datasets_json",
+    "list_dataset_data_json",
+    "create_dataset_json",
+    "get_client_info_json",
+}
+
+
+@pytest.fixture(autouse=True)
+def restore_tool_mode():
+    """Tests mutate the module-global server's transforms; put them back."""
+    saved = list(server.mcp._transforms)
+    yield
+    server.mcp._transforms = saved
+
+
+async def advertised(mode: str) -> set[str]:
+    server.apply_tool_mode(mode)
+    return {tool.name for tool in await server.mcp.list_tools()}
+
+
+async def search(client, query: str) -> list[str]:
+    result = await client.call_tool("search_tools", {"query": query})
+    if not result.content:  # no match -> empty content rather than an empty array
+        return []
+    return [tool["name"] for tool in json.loads(result.content[0].text)]
+
+
+# --- tier declarations ---------------------------------------------------------
+
+
+def test_every_tool_declares_a_tier():
+    """A tool registered without going through @registry.tool would be missed by
+    names_with_tag(), so assert the registry covers the whole catalog."""
+    assert set(server.registry.tags) == (
+        MEMORY_TOOLS | WORKSPACE_UI_ENTRY_TOOLS | WORKSPACE_INTERNAL_TOOLS
+    )
+    assert all(tags for tags in server.registry.tags.values())
+
+
+def test_pinned_sets_are_derived_from_tags():
+    assert set(server.registry.names_with_tag(MEMORY_TAG)) == MEMORY_TOOLS
+    assert set(server.registry.names_with_tag(DEFAULT_TAG)) == (
+        MEMORY_TOOLS | WORKSPACE_UI_ENTRY_TOOLS
+    )
+
+
+# --- what each mode advertises ------------------------------------------------
+
+
+async def test_default_mode_advertises_pinned_plus_synthetic():
+    assert await advertised("default") == (
+        MEMORY_TOOLS | WORKSPACE_UI_ENTRY_TOOLS | SYNTHETIC_TOOLS
+    )
+
+
+async def test_minimal_mode_advertises_only_the_memory_api():
+    assert await advertised("minimal") == MEMORY_TOOLS | SYNTHETIC_TOOLS
+
+
+async def test_all_mode_restores_the_flat_surface():
+    names = await advertised("all")
+    assert names == set(server.registry.tags)
+    assert not names & SYNTHETIC_TOOLS
+
+
+async def test_unknown_mode_falls_back_to_default():
+    assert server.apply_tool_mode("banana") == "default"
+    assert {tool.name for tool in await server.mcp.list_tools()} == (
+        MEMORY_TOOLS | WORKSPACE_UI_ENTRY_TOOLS | SYNTHETIC_TOOLS
+    )
+
+
+async def test_apply_tool_mode_is_idempotent():
+    """add_transform() appends, so a second call must not stack a second search
+    transform (which would hide the first one's pinned tools)."""
+    await advertised("default")
+    first = {tool.name for tool in await server.mcp.list_tools()}
+
+    server.apply_tool_mode("default")
+    assert {tool.name for tool in await server.mcp.list_tools()} == first
+
+    # ...and switching modes replaces rather than layers.
+    server.apply_tool_mode("minimal")
+    assert {tool.name for tool in await server.mcp.list_tools()} == MEMORY_TOOLS | SYNTHETIC_TOOLS
+
+
+# --- the lazy-loading guarantee ------------------------------------------------
+
+
+async def test_hidden_tools_are_discoverable_by_search():
+    server.apply_tool_mode("default")
+
+    async with Client(server.mcp) as client:
+        assert "list_datasets_json" in await search(client, "list all of my datasets")
+        assert "cognify_file" in await search(client, "ingest an uploaded file")
+
+
+async def test_search_never_returns_pinned_tools():
+    """Pinned tools are already in tools/list; echoing them back would waste the
+    result budget the search transform exists to protect."""
+    server.apply_tool_mode("default")
+
+    async with Client(server.mcp) as client:
+        for query in ("remember this for later", "search my memory", "delete a dataset"):
+            assert not (MEMORY_TOOLS | WORKSPACE_UI_ENTRY_TOOLS) & set(await search(client, query))
+
+
+async def test_hidden_tool_is_callable_directly(monkeypatch):
+    """How the workspace UI reaches its internals: by name, never via tools/list."""
+
+    class FakeClient:
+        async def list_datasets(self):
+            return [{"id": "id-1", "name": "alpha"}]
+
+    monkeypatch.setattr(server, "cognee_client", FakeClient())
+    server.apply_tool_mode("default")
+
+    async with Client(server.mcp) as client:
+        assert "list_datasets_json" not in {tool.name for tool in await client.list_tools()}
+
+        result = await client.call_tool("list_datasets_json", {})
+        assert "alpha (id-1)" in result.content[0].text
+
+
+async def test_hidden_tool_is_callable_through_the_proxy(monkeypatch):
+    """How an agent reaches a tool it just found via search_tools."""
+
+    class FakeClient:
+        async def list_datasets(self):
+            return [{"id": "id-2", "name": "beta"}]
+
+    monkeypatch.setattr(server, "cognee_client", FakeClient())
+    server.apply_tool_mode("default")
+
+    async with Client(server.mcp) as client:
+        result = await client.call_tool(
+            "call_tool", {"name": "list_datasets_json", "arguments": {}}
+        )
+        assert "beta (id-2)" in result.content[0].text
+
+
+async def test_proxy_refuses_to_call_the_synthetic_tools():
+    server.apply_tool_mode("default")
+
+    async with Client(server.mcp) as client:
+        for name in SYNTHETIC_TOOLS:
+            with pytest.raises(ToolError):
+                await client.call_tool("call_tool", {"name": name, "arguments": {}})
+
+
+async def test_hidden_tools_keep_their_schemas_and_ui_metadata():
+    """Search results must carry enough for an agent to call the tool without a
+    second round trip, and the workspace UI's resourceUri must survive."""
+    server.apply_tool_mode("minimal")
+
+    async with Client(server.mcp) as client:
+        result = await client.call_tool("search_tools", {"query": "data items inside a dataset"})
+        tools = {tool["name"]: tool for tool in json.loads(result.content[0].text)}
+
+    # Full input schema, so the agent can call it straight away.
+    assert "dataset_id" in tools["list_dataset_data_json"]["inputSchema"]["properties"]
+    # MCP App metadata survives the transform.
+    assert tools["visualize_graph_ui"]["meta"]["ui"]["resourceUri"]
+
+
+async def test_usage_logging_name_survives_the_registry_wrapper():
+    """@registry.tool folds in @log_usage; every tool must still log as
+    'MCP <tool_name>' the way the hand-written decorators did."""
+    calls = []
+
+    async def fake_log(**kwargs):
+        calls.append(kwargs)
+
+    import cognee.shared.usage_logger as usage_logger
+
+    original_log = usage_logger._log_usage_async
+    original_config = usage_logger.get_cache_config
+
+    class Config:
+        usage_logging = True
+
+    usage_logger._log_usage_async = fake_log
+    usage_logger.get_cache_config = lambda: Config()
+    try:
+        await server.forget()  # validation-only path, touches no databases
+    finally:
+        usage_logger._log_usage_async = original_log
+        usage_logger.get_cache_config = original_config
+
+    assert [c["function_name"] for c in calls] == ["MCP forget"]
+    assert calls[0]["log_type"] == "mcp_tool"

--- a/cognee-mcp/tests/test_tool_search.py
+++ b/cognee-mcp/tests/test_tool_search.py
@@ -123,6 +123,34 @@ async def test_result_window_is_not_the_binding_constraint():
     assert len(hidden) <= server.TOOL_SEARCH_MAX_RESULTS
 
 
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("what datasets do I have?", "list_datasets_json"),
+        ("list my datasets", "list_datasets_json"),
+        ("show me all the datasets", "list_datasets_json"),
+        ("show the data inside a dataset", "list_dataset_data_json"),
+        ("make a new dataset", "create_dataset_json"),
+        ("upload and ingest this file", "cognify_file"),
+        ("which client am I connected as", "get_client_info_json"),
+    ],
+)
+async def test_natural_language_queries_rank_their_tool_first(query, expected):
+    """The table in README.md's "Writing a tool so search can find it".
+
+    Lexical matching has real edges (see the next test), but the phrasings an
+    agent actually produces are multi-word and land at rank 1. Pinned here so a
+    description edit that breaks discoverability fails loudly, and so the README
+    claim stays honest.
+    """
+    server.apply_tool_mode("default")
+
+    async with Client(server.mcp) as client:
+        results = await search(client, query)
+
+    assert results and results[0] == expected, f"{query!r} -> {results}"
+
+
 async def test_search_matches_on_vocabulary_not_on_the_result_limit():
     """The window being wide enough does NOT mean every search returns everything.
 

--- a/cognee-mcp/tests/test_tool_search_benchmark.py
+++ b/cognee-mcp/tests/test_tool_search_benchmark.py
@@ -1,0 +1,359 @@
+"""Benchmark FastMCP's tool-search transforms against a hand-rolled alternative.
+
+Exists to answer "should we have written this ourselves?" with numbers rather
+than taste. Three things get measured over synthetic catalogs of mock tools:
+
+* **Context cost** — bytes/tokens of the ``tools/list`` payload an agent pays on
+  every turn. This is the entire reason for gating the surface.
+* **Latency** — index build plus per-query time, i.e. what gating costs at call
+  time.
+* **Retrieval quality** — recall@5 and MRR over labeled paraphrase queries,
+  comparing FastMCP's BM25 and regex transforms against ``NaiveSubstringSearch``
+  below, which is roughly the "v1 lexical scoring" a custom implementation would
+  have started from.
+
+Run with output:  pytest tests/test_tool_search_benchmark.py -s
+Assertions here are deliberately loose (order-of-magnitude, not thresholds) so
+the suite doesn't turn into a flaky performance gate. The printed tables are the
+deliverable.
+
+Measured conclusion (fastmcp 3.4.5, 500 mock tools, 10 paraphrase queries):
+
+* Gating cuts the ``tools/list`` payload by 67% at today's 11 tools, 92% at 50,
+  and 99% at 500 (1199 → 393 tokens, 47329 → 393). The gated payload is
+  *constant* in catalog size, which is the actual win.
+* On retrieval quality BM25 and the hand-rolled matcher are close, and **not
+  uniformly in FastMCP's favour**: naive substring wins recall@5 (70% vs 60% at
+  500 tools) while BM25 wins ranking (MRR 0.55 vs 0.51). Both are purely
+  lexical, so neither handles a true synonym; a real quality jump needs
+  embeddings, not a better hand-rolled scorer.
+* BM25 costs ~3 ms/query at 500 tools versus ~0.2 ms naive. Ten times slower in
+  relative terms, irrelevant next to an LLM round trip.
+
+So the case for FastMCP's transform is maintenance, not superiority: comparable
+quality and negligible latency for zero lines of our own search code. If we ever
+want a decisive quality win, the lever is semantic search over the catalog
+(cognee's own embeddings), not reimplementing lexical ranking.
+"""
+
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.server.transforms.search import BM25SearchTransform, RegexSearchTransform
+
+MCP_ROOT = Path(__file__).resolve().parents[1]  # cognee-mcp/
+if str(MCP_ROOT) not in sys.path:
+    sys.path.insert(0, str(MCP_ROOT))
+
+CATALOG_SIZES = (11, 50, 200, 500)
+PINNED = ["remember", "recall", "forget"]
+TOP_K = 5
+
+# Rough proxy: ~4 chars/token for JSON. Absolute values are indicative; the
+# flat-vs-gated ratio is the number that matters and is unit-independent.
+CHARS_PER_TOKEN = 4
+
+
+# --- synthetic catalog ---------------------------------------------------------
+
+ACTIONS = [
+    ("create", "Create a new {noun}"),
+    ("list", "List every {noun} visible to the current user"),
+    ("delete", "Permanently remove a {noun}"),
+    ("update", "Modify an existing {noun}"),
+    ("describe", "Return full details about a single {noun}"),
+]
+NOUNS = [
+    "dataset",
+    "permission",
+    "ontology",
+    "node_set",
+    "pipeline",
+    "user",
+    "role",
+    "credential",
+    "graph_projection",
+    "data_item",
+    "session",
+    "tenant",
+    "webhook",
+    "api_key",
+    "notebook",
+    "embedding_index",
+    "retriever",
+    "schedule",
+    "export_job",
+    "audit_log",
+]
+
+# (query, expected tool) — paraphrases that avoid the tool name's exact wording,
+# so a name-substring matcher cannot trivially win.
+LABELED_QUERIES = [
+    ("I want to make a brand new collection of documents", "create_dataset"),
+    ("show me everything the current user is allowed to see", "list_permission"),
+    ("get rid of a saved credential for good", "delete_credential"),
+    ("change the settings on an existing pipeline", "update_pipeline"),
+    ("full details about one particular ontology", "describe_ontology"),
+    ("wipe out a scheduled job", "delete_schedule"),
+    ("enumerate the tenants", "list_tenant"),
+    ("set up a fresh api key", "create_api_key"),
+    ("modify which nodes are in a group", "update_node_set"),
+    ("tell me about a specific audit record", "describe_audit_log"),
+]
+
+
+def mock_tool_specs(count: int) -> list[tuple[str, str, dict]]:
+    """Deterministic (name, description, params) triples for `count` mock tools."""
+    specs: list[tuple[str, str, dict]] = []
+    for noun in NOUNS:
+        for action, template in ACTIONS:
+            name = f"{action}_{noun}"
+            description = (
+                f"{template.format(noun=noun.replace('_', ' '))}. "
+                f"Operates on the {noun.replace('_', ' ')} resource in the Cognee API."
+            )
+            params = {"identifier": "The id of the target resource"}
+            if action in ("create", "update"):
+                params["payload"] = "Fields to write"
+            specs.append((name, description, params))
+    # Cycle with a suffix if more tools are requested than the vocabulary yields.
+    base = list(specs)
+    while len(specs) < count:
+        name, description, params = base[len(specs) % len(base)]
+        specs.append((f"{name}_v{len(specs) // len(base) + 1}", description, params))
+    return specs[:count]
+
+
+def build_server(count: int, transform=None) -> FastMCP:
+    """A FastMCP server with `count` mock tools plus the three pinned ones."""
+    mcp = FastMCP("benchmark")
+
+    for pinned in PINNED:
+
+        def handler(text: str = "", _name=pinned) -> str:
+            """Core memory operation."""
+            return _name
+
+        mcp.tool(name=pinned, description=f"Core memory tool {pinned}.")(handler)
+
+    for name, description, params in mock_tool_specs(count):
+
+        def handler(identifier: str = "", payload: str = "", _name=name) -> str:
+            return _name
+
+        mcp.tool(name=name, description=description)(handler)
+
+    if transform is not None:
+        mcp.add_transform(transform)
+    return mcp
+
+
+# --- the alternative we would have hand-rolled ---------------------------------
+
+
+class NaiveSubstringSearch:
+    """Substring/token-overlap ranking over name + description.
+
+    Stands in for the "v1: lexical scoring, zero deps" implementation the
+    original design proposed writing. Scores by how many query tokens appear in
+    the tool's text, ties broken by catalog order — no IDF, no length
+    normalization. Notably this is *not* enough of a handicap to lose on
+    recall@5 at these catalog sizes; see the module docstring.
+    """
+
+    def __init__(self, specs: list[tuple[str, str, dict]]):
+        self.docs = [(name, f"{name} {description}".lower()) for name, description, _ in specs]
+
+    def search(self, query: str, top_k: int = TOP_K) -> list[str]:
+        tokens = [t for t in query.lower().split() if len(t) > 2]
+        scored = []
+        for index, (name, text) in enumerate(self.docs):
+            score = sum(1 for token in tokens if token in text)
+            if score:
+                scored.append((-score, index, name))
+        scored.sort()
+        return [name for _, _, name in scored[:top_k]]
+
+
+# --- metrics ------------------------------------------------------------------
+
+
+def recall_and_mrr(results_by_query: dict[str, list[str]]) -> tuple[float, float]:
+    """recall@k (did the right tool appear at all) and mean reciprocal rank."""
+    hits, reciprocal_ranks = 0, []
+    for query, expected in LABELED_QUERIES:
+        found = results_by_query[query]
+        if expected in found:
+            hits += 1
+            reciprocal_ranks.append(1 / (found.index(expected) + 1))
+        else:
+            reciprocal_ranks.append(0.0)
+    return hits / len(LABELED_QUERIES), statistics.mean(reciprocal_ranks)
+
+
+async def list_tools_payload(mcp: FastMCP) -> tuple[int, int]:
+    """(tool count, serialized bytes) of what the client receives from tools/list."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+    payload = json.dumps(
+        [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "inputSchema": tool.inputSchema,
+            }
+            for tool in tools
+        ]
+    )
+    return len(tools), len(payload)
+
+
+async def run_search(mcp: FastMCP, argument: str, queries: list[str]) -> tuple[dict, list[float]]:
+    """Execute `queries` through the server's synthetic search tool.
+
+    `argument` is "query" for BM25 and "pattern" for the regex transform.
+    """
+    results, timings = {}, []
+    async with Client(mcp) as client:
+        for query in queries:
+            started = time.perf_counter()
+            result = await client.call_tool("search_tools", {argument: query})
+            timings.append((time.perf_counter() - started) * 1000)
+            if result.content:
+                results[query] = [tool["name"] for tool in json.loads(result.content[0].text)]
+            else:
+                results[query] = []
+    return results, timings
+
+
+# --- context cost -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("count", CATALOG_SIZES)
+async def test_context_cost_of_gating(count, capsys):
+    flat_count, flat_bytes = await list_tools_payload(build_server(count))
+    gated_count, gated_bytes = await list_tools_payload(
+        build_server(count, BM25SearchTransform(max_results=TOP_K, always_visible=PINNED))
+    )
+
+    with capsys.disabled():
+        if count == CATALOG_SIZES[0]:
+            print(
+                f"\n{'catalog':>8} | {'flat tools':>10} {'flat tokens':>12} | "
+                f"{'gated tools':>11} {'gated tokens':>12} | {'saved':>7}"
+            )
+            print("-" * 78)
+        print(
+            f"{count:>8} | {flat_count:>10} {flat_bytes // CHARS_PER_TOKEN:>12} | "
+            f"{gated_count:>11} {gated_bytes // CHARS_PER_TOKEN:>12} | "
+            f"{1 - gated_bytes / flat_bytes:>6.1%}"
+        )
+
+    # Gated listing is the pinned tools plus search_tools/call_tool, regardless
+    # of how large the catalog grows — that is the whole point.
+    assert gated_count == len(PINNED) + 2
+    assert gated_bytes < flat_bytes
+    if count >= 200:
+        # An order of magnitude smaller once the catalog is realistically large.
+        assert gated_bytes * 10 < flat_bytes
+
+
+# --- retrieval quality --------------------------------------------------------
+
+
+def as_regex_pattern(query: str) -> str:
+    """What a competent agent would send to RegexSearchTransform.
+
+    Feeding it raw prose scores 0% — it is a pattern matcher, not a ranker — so
+    comparing it fairly means giving it the query's content words as alternates.
+    """
+    tokens = [token for token in query.lower().split() if len(token) > 3]
+    return "|".join(tokens)
+
+
+@pytest.mark.parametrize("count", (50, 500))
+async def test_retrieval_quality_versus_hand_rolled(count, capsys):
+    queries = [query for query, _ in LABELED_QUERIES]
+
+    bm25_results, bm25_timings = await run_search(
+        build_server(count, BM25SearchTransform(max_results=TOP_K, always_visible=PINNED)),
+        "query",
+        queries,
+    )
+    regex_raw, regex_timings = await run_search(
+        build_server(count, RegexSearchTransform(max_results=TOP_K, always_visible=PINNED)),
+        "pattern",
+        [as_regex_pattern(query) for query in queries],
+    )
+    # Re-key by the original query so recall_and_mrr can line results up.
+    regex_results = {query: regex_raw[as_regex_pattern(query)] for query in queries}
+
+    naive = NaiveSubstringSearch(mock_tool_specs(count))
+    naive_timings = []
+    naive_results = {}
+    for query in queries:
+        started = time.perf_counter()
+        naive_results[query] = naive.search(query, TOP_K)
+        naive_timings.append((time.perf_counter() - started) * 1000)
+
+    rows = []
+    for label, results, timings in (
+        ("fastmcp BM25", bm25_results, bm25_timings),
+        ("fastmcp regex", regex_results, regex_timings),
+        ("hand-rolled", naive_results, naive_timings),
+    ):
+        recall, mrr = recall_and_mrr(results)
+        rows.append((label, recall, mrr, statistics.median(timings), max(timings)))
+
+    with capsys.disabled():
+        print(f"\ncatalog = {count} tools, top_k = {TOP_K}, {len(queries)} paraphrase queries")
+        print(f"{'strategy':>16} | {'recall@5':>9} {'MRR':>6} | {'p50 ms':>7} {'max ms':>7}")
+        print("-" * 60)
+        for label, recall, mrr, p50, worst in rows:
+            print(f"{label:>16} | {recall:>8.0%} {mrr:>6.2f} | {p50:>7.2f} {worst:>7.2f}")
+
+    bm25_recall, bm25_mrr = recall_and_mrr(bm25_results)
+    naive_recall, naive_mrr = recall_and_mrr(naive_results)
+
+    with capsys.disabled():
+        print(
+            f"{'':>16}   BM25 vs hand-rolled: "
+            f"recall {bm25_recall - naive_recall:+.0%}, MRR {bm25_mrr - naive_mrr:+.2f}"
+        )
+
+    # No comparative assertion on purpose: BM25 does *not* dominate the
+    # hand-rolled matcher here (see the module docstring), and encoding either
+    # direction as a requirement would be asserting an artifact of this fixed
+    # query set. What matters is that both clear a usable floor, so a genuine
+    # retrieval regression still fails the suite.
+    assert bm25_recall >= 0.5, "BM25 lost the target for most queries"
+    assert naive_recall >= 0.5, "labeled query set may no longer be solvable"
+
+    # Query cost stays interactive even at 500 tools (generous bound: CI is slow
+    # and the first call also builds the index).
+    assert statistics.median(bm25_timings) < 250
+
+
+async def test_bm25_index_is_built_once_and_reused(capsys):
+    """The index builds lazily on first search and is reused after, so only the
+    first query pays for it. Guards against a per-call rebuild regression."""
+    queries = [query for query, _ in LABELED_QUERIES] * 3
+    _, timings = await run_search(
+        build_server(500, BM25SearchTransform(max_results=TOP_K, always_visible=PINNED)),
+        "query",
+        queries,
+    )
+
+    first, rest = timings[0], timings[1:]
+    with capsys.disabled():
+        print(
+            f"\n500 tools: first query {first:.2f} ms (index build), "
+            f"subsequent p50 {statistics.median(rest):.2f} ms"
+        )
+
+    assert statistics.median(rest) <= first

--- a/cognee-mcp/tests/test_tool_search_benchmark.py
+++ b/cognee-mcp/tests/test_tool_search_benchmark.py
@@ -7,7 +7,7 @@ than taste. Three things get measured over synthetic catalogs of mock tools:
   every turn. This is the entire reason for gating the surface.
 * **Latency** — index build plus per-query time, i.e. what gating costs at call
   time.
-* **Retrieval quality** — recall@5 and MRR over labeled paraphrase queries,
+* **Retrieval quality** — recall@k and MRR over labeled paraphrase queries,
   comparing FastMCP's BM25 and regex transforms against ``NaiveSubstringSearch``
   below, which is roughly the "v1 lexical scoring" a custom implementation would
   have started from.
@@ -22,18 +22,29 @@ Measured conclusion (fastmcp 3.4.5, 500 mock tools, 10 paraphrase queries):
 * Gating cuts the ``tools/list`` payload by 67% at today's 11 tools, 92% at 50,
   and 99% at 500 (1199 → 393 tokens, 47329 → 393). The gated payload is
   *constant* in catalog size, which is the actual win.
-* On retrieval quality BM25 and the hand-rolled matcher are close, and **not
-  uniformly in FastMCP's favour**: naive substring wins recall@5 (70% vs 60% at
-  500 tools) while BM25 wins ranking (MRR 0.55 vs 0.51). Both are purely
-  lexical, so neither handles a true synonym; a real quality jump needs
-  embeddings, not a better hand-rolled scorer.
+* **max_results dominates the choice of ranker.** At k=5 the hand-rolled matcher
+  looks better on recall (70% vs 60%); at k=10 BM25 pulls ahead (80% vs 70%) and
+  both plateau by k=15. BM25's higher MRR (0.55 vs 0.51) was the tell: it was
+  placing the right tool just outside a 5-wide window. Any recall comparison at
+  a single k says more about the cutoff than about the ranker.
+* Recall, not ranking, is the metric to optimise: the agent receives every
+  returned schema and selects for itself, so a tool absent from the window is
+  unrecoverable while its rank inside the window costs almost nothing. Hence
+  ``server.TOOL_SEARCH_MAX_RESULTS = 10``, sitting at the knee of the sweep.
+* Both rankers are purely lexical and plateau near 80%. The residual misses are
+  vocabulary failures no ranker fixes — "wipe out" vs "permanently remove", and
+  plural/singular mismatches, since BM25's tokenizer does **no stemming** and it
+  drops zero-scoring tools outright ("tenants" never reaches ``list_tenant``).
+  So tool descriptions are the lever for recall, not k and not the ranker; a
+  decisive jump beyond that needs embeddings.
 * BM25 costs ~3 ms/query at 500 tools versus ~0.2 ms naive. Ten times slower in
   relative terms, irrelevant next to an LLM round trip.
 
-So the case for FastMCP's transform is maintenance, not superiority: comparable
-quality and negligible latency for zero lines of our own search code. If we ever
-want a decisive quality win, the lever is semantic search over the catalog
-(cognee's own embeddings), not reimplementing lexical ranking.
+So: use FastMCP's transform. It wins on the metric that matters once k is tuned,
+and costs zero lines of our own search code. If we later want semantic matching,
+``BaseSearchTransform`` leaves ``_search()`` abstract — we can swap the ranking
+function for cognee's embeddings and keep the synthetic tools, the call_tool
+proxy, and the visibility/auth composition.
 """
 
 import json
@@ -50,9 +61,14 @@ MCP_ROOT = Path(__file__).resolve().parents[1]  # cognee-mcp/
 if str(MCP_ROOT) not in sys.path:
     sys.path.insert(0, str(MCP_ROOT))
 
+from src.server import TOOL_SEARCH_MAX_RESULTS  # noqa: E402
+
 CATALOG_SIZES = (11, 50, 200, 500)
 PINNED = ["remember", "recall", "forget"]
-TOP_K = 5
+# The value the server actually ships, so the sweep below validates production
+# config rather than an arbitrary constant.
+TOP_K = TOOL_SEARCH_MAX_RESULTS
+K_SWEEP = (3, 5, 10, 15, 25)
 
 # Rough proxy: ~4 chars/token for JSON. Absolute values are indicative; the
 # flat-vs-gated ratio is the number that matters and is unit-independent.
@@ -162,8 +178,8 @@ class NaiveSubstringSearch:
     Stands in for the "v1: lexical scoring, zero deps" implementation the
     original design proposed writing. Scores by how many query tokens appear in
     the tool's text, ties broken by catalog order — no IDF, no length
-    normalization. Notably this is *not* enough of a handicap to lose on
-    recall@5 at these catalog sizes; see the module docstring.
+    normalization. Good enough to beat BM25 on recall at k=5, and beaten by it
+    at the k=10 we actually ship; see the module docstring.
     """
 
     def __init__(self, specs: list[tuple[str, str, dict]]):
@@ -312,7 +328,7 @@ async def test_retrieval_quality_versus_hand_rolled(count, capsys):
 
     with capsys.disabled():
         print(f"\ncatalog = {count} tools, top_k = {TOP_K}, {len(queries)} paraphrase queries")
-        print(f"{'strategy':>16} | {'recall@5':>9} {'MRR':>6} | {'p50 ms':>7} {'max ms':>7}")
+        print(f"{'strategy':>16} | {f'recall@{TOP_K}':>9} {'MRR':>6} | {'p50 ms':>7} {'max ms':>7}")
         print("-" * 60)
         for label, recall, mrr, p50, worst in rows:
             print(f"{label:>16} | {recall:>8.0%} {mrr:>6.2f} | {p50:>7.2f} {worst:>7.2f}")
@@ -337,6 +353,49 @@ async def test_retrieval_quality_versus_hand_rolled(count, capsys):
     # Query cost stays interactive even at 500 tools (generous bound: CI is slow
     # and the first call also builds the index).
     assert statistics.median(bm25_timings) < 250
+
+
+async def test_recall_versus_max_results(capsys):
+    """The sweep that sets TOOL_SEARCH_MAX_RESULTS.
+
+    Recall at a single k conflates the ranker with the window: BM25 trails the
+    hand-rolled matcher at k=5 and beats it at k=10, purely because its hits sat
+    just outside the narrower window. The shipped value must be at or past the
+    knee of this curve.
+    """
+    queries = [query for query, _ in LABELED_QUERIES]
+    naive = NaiveSubstringSearch(mock_tool_specs(500))
+
+    rows = []
+    for k in K_SWEEP:
+        bm25_results, _ = await run_search(
+            build_server(500, BM25SearchTransform(max_results=k, always_visible=PINNED)),
+            "query",
+            queries,
+        )
+        bm25_recall, bm25_mrr = recall_and_mrr(bm25_results)
+        naive_recall, _ = recall_and_mrr({q: naive.search(q, k) for q in queries})
+        rows.append((k, bm25_recall, bm25_mrr, naive_recall))
+
+    by_k = {k: bm25_recall for k, bm25_recall, _, _ in rows}
+
+    with capsys.disabled():
+        print(f"\ncatalog = 500 tools — recall@k sweep (shipping k={TOOL_SEARCH_MAX_RESULTS})")
+        print(f"{'k':>4} | {'BM25 recall':>11} {'BM25 MRR':>9} | {'hand-rolled':>11}")
+        print("-" * 46)
+        for k, bm25_recall, bm25_mrr, naive_recall in rows:
+            marker = "  <- shipping" if k == TOOL_SEARCH_MAX_RESULTS else ""
+            print(f"{k:>4} | {bm25_recall:>10.0%} {bm25_mrr:>9.2f} | {naive_recall:>10.0%}{marker}")
+
+    assert TOOL_SEARCH_MAX_RESULTS in by_k, "shipping k is not covered by the sweep"
+
+    # Recall is monotonic in k (a wider window can only add hits), so the knee is
+    # where it stops improving. The shipped k must be no worse than the plateau.
+    assert by_k[TOOL_SEARCH_MAX_RESULTS] == max(by_k.values()), (
+        f"k={TOOL_SEARCH_MAX_RESULTS} leaves recall on the table: {by_k}"
+    )
+    # ...and strictly better than the narrow window that made the ranker look bad.
+    assert by_k[TOOL_SEARCH_MAX_RESULTS] > by_k[3]
 
 
 async def test_bm25_index_is_built_once_and_reused(capsys):

--- a/cognee-mcp/uv.lock
+++ b/cognee-mcp/uv.lock
@@ -39,6 +39,39 @@ wheels = [
 ]
 
 [[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -412,6 +445,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -427,6 +473,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
 ]
 
 [[package]]
@@ -500,6 +555,15 @@ wheels = [
 ]
 
 [[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -561,7 +625,7 @@ name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
 wheels = [
@@ -600,6 +664,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/6c/671af79ee42bc4c968cae35c091ac89e8721c795bfa4639100670dc59139/blis-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e5a662c48cd4aad5dae1a950345df23957524f071315837a4c6feb7d3b288990", size = 3008771, upload-time = "2025-11-17T12:28:23.637Z" },
     { url = "https://files.pythonhosted.org/packages/be/92/7cd7f8490da7c98ee01557f2105885cc597217b0e7fd2eeb9e22cdd4ef23/blis-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9de26fbd72bac900c273b76d46f0b45b77a28eace2e01f6ac6c2239531a413bb", size = 14219213, upload-time = "2025-11-17T12:28:26.143Z" },
     { url = "https://files.pythonhosted.org/packages/0a/de/acae8e9f9a1f4bb393d41c8265898b0f29772e38eac14e9f69d191e2c006/blis-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:9e5fdf4211b1972400f8ff6dafe87cb689c5d84f046b4a76b207c0bd2270faaf", size = 6324695, upload-time = "2025-11-17T12:28:28.401Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/af/861ebc2e318a5c3300e3eb63bc4d30f3d70a46d13b360093728ac0705eed/cachetools-7.1.6.tar.gz", hash = "sha256:c7a79e7f30ba9943c1cefd08cc36f006aaae086e017af9166f1d59d6170c47e1", size = 40572, upload-time = "2026-07-23T22:47:53.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/f2/2086ba18a925a73586c4d4e61d25f4a6058e56fd00d77ce8f1d361ab4c9b/cachetools-7.1.6-py3-none-any.whl", hash = "sha256:2c12e255780330af28b91bb7fb96cce4c766f04e38396b9a24510190a5827096", size = 16954, upload-time = "2026-07-23T22:47:52.397Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -975,6 +1077,7 @@ version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "cognee", extra = ["docs", "neo4j", "postgres-binary"] },
+    { name = "fastmcp" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "uv" },
@@ -995,8 +1098,9 @@ postgres-binary = [
 [package.metadata]
 requires-dist = [
     { name = "cognee", extras = ["postgres-binary", "docs", "neo4j"], specifier = ">=1.1.0,<2.0.0" },
+    { name = "fastmcp", specifier = ">=3.4.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
-    { name = "mcp", specifier = ">=1.12.0,<2.0.0" },
+    { name = "mcp", specifier = ">=1.24.0,<2.0.0" },
     { name = "uv", specifier = ">=0.6.3,<1.0.0" },
 ]
 
@@ -1026,7 +1130,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.14'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -1050,7 +1154,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1123,7 +1227,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1297,43 +1401,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -1343,6 +1447,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/98/ca72a91d5c25a2ae1baf19d27b31f12288cb9d8a3168b65b3cd54d40d277/cyclopts-4.22.2.tar.gz", hash = "sha256:0721e90e7209885e78f7637cfba255c12e89206b633e35d185305e349ba20ecd", size = 194511, upload-time = "2026-07-24T20:53:08.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/75/a11bfb5045e58b4ef69337b848985918e829fe9a90572a761d17c1a992f5/cyclopts-4.22.2-py3-none-any.whl", hash = "sha256:9c2cdf6a621886cd0af631a67437eb7d0084f33f9e8fba2d2562a1aecf75f2ff", size = 233906, upload-time = "2026-07-24T20:53:07.064Z" },
 ]
 
 [[package]]
@@ -1414,8 +1535,8 @@ name = "dataclasses-json"
 version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "marshmallow", marker = "python_full_version < '3.13'" },
-    { name = "typing-inspect", marker = "python_full_version < '3.13'" },
+    { name = "marshmallow" },
+    { name = "typing-inspect" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
 wheels = [
@@ -1545,11 +1666,11 @@ name = "effdet"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "omegaconf", marker = "python_full_version < '3.13'" },
-    { name = "pycocotools", marker = "python_full_version < '3.13'" },
-    { name = "timm", marker = "python_full_version < '3.13'" },
-    { name = "torch", marker = "python_full_version < '3.13'" },
-    { name = "torchvision", marker = "python_full_version < '3.13'" },
+    { name = "omegaconf" },
+    { name = "pycocotools" },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "torchvision" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/c3/12d45167ec36f7f9a5ed80bc2128392b3f6207f760d437287d32a0e43f41/effdet-0.4.1.tar.gz", hash = "sha256:ac5589fd304a5650c201986b2ef5f8e10c111093a71b1c49fa6b8817710812b5", size = 110134, upload-time = "2023-05-21T22:18:01.039Z" }
 wheels = [
@@ -1592,7 +1713,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1676,6 +1797,69 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/14/c1ffb91b7d1fece86c81e1f9df5474f30fd97e4cdaa398814bbbeee88568/fastmcp-3.4.5.tar.gz", hash = "sha256:a95f2bc876bef42e8b50f7872f24f3f2fe3b1d37408c734e8b9d9e03014b72d3", size = 28800521, upload-time = "2026-07-27T19:20:01.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/1d/f3e271fbcd01ce01a4cf623b336d8e1305c192aa5d5e8e0223b7167462e9/fastmcp_slim-3.4.5.tar.gz", hash = "sha256:5badc3bceee61f61297eeb9494f499325f3ce1cafabf4611b31f6c3e9d7dff59", size = 591622, upload-time = "2026-07-27T19:15:19.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/3b/16d8aa8224094519f30b078138e725b8a731bf0a13f1f850e58b5f9b3cc4/fastmcp_slim-3.4.5-py3-none-any.whl", hash = "sha256:bc31217827c4999812543c83ee95ed9a47f3ed1e3fd0bd4f64371e375b748eca", size = 766478, upload-time = "2026-07-27T19:15:18.015Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "joserfc" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pyperclip" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "starlette" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 
 [[package]]
@@ -2113,6 +2297,15 @@ wheels = [
 ]
 
 [[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.82.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2315,7 +2508,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -2412,6 +2605,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -2533,6 +2771,27 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2546,6 +2805,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
 ]
 
 [[package]]
@@ -2571,6 +2845,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -3315,7 +3607,7 @@ name = "marshmallow"
 version = "3.26.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "python_full_version < '3.13'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
 wheels = [
@@ -3330,15 +3622,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -3409,15 +3701,15 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -4213,8 +4505,8 @@ name = "omegaconf"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "python_full_version < '3.13'" },
-    { name = "pyyaml", marker = "python_full_version < '3.13'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
 wheels = [
@@ -4270,13 +4562,13 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.14'" },
-    { name = "flatbuffers", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", marker = "python_full_version < '3.14'" },
-    { name = "sympy", marker = "python_full_version < '3.14'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -4311,10 +4603,10 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", marker = "python_full_version >= '3.14'" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
@@ -4355,6 +4647,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
 name = "opencv-python"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
@@ -4384,6 +4688,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -4464,6 +4780,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
     { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
     { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
 ]
 
 [[package]]
@@ -4745,8 +5070,8 @@ name = "preshed"
 version = "3.0.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cymem", marker = "python_full_version >= '3.13'" },
-    { name = "murmurhash", marker = "python_full_version >= '3.13'" },
+    { name = "cymem" },
+    { name = "murmurhash" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338, upload-time = "2026-03-23T08:57:31.378Z" }
 wheels = [
@@ -5064,6 +5389,32 @@ bcrypt = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "aiofile", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5146,7 +5497,7 @@ name = "pycocotools"
 version = "2.0.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/df/32354b5dda963ffdfc8f75c9acf8828ef7890723a4ed57bb3ff2dc1d6f7e/pycocotools-2.0.11.tar.gz", hash = "sha256:34254d76da85576fcaf5c1f3aa9aae16b8cb15418334ba4283b800796bd1993d", size = 25381, upload-time = "2025-12-15T22:31:46.148Z" }
@@ -5210,6 +5561,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -5472,6 +5828,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
 name = "pyreadline3"
 version = "3.5.6"
 source = { registry = "https://pypi.org/simple" }
@@ -5686,6 +6051,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
     { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
     { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -6044,6 +6418,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d6/d0b9fafc73b65767200da027acab1db1bdb1048f4fea5ebf659df01c700e/rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd", size = 302732, upload-time = "2026-07-05T02:59:44.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/68/1fc93dd759605b5d00fc98b50200739e41ed32bd22d6ba35ca6c3932371b/rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255", size = 272987, upload-time = "2026-07-05T02:59:42.792Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6329,7 +6716,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -6388,7 +6775,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -6464,7 +6851,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -6511,6 +6898,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6542,7 +6942,7 @@ name = "smart-open"
 version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt", marker = "python_full_version >= '3.13'" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/3e/79fd5fd2375a8a500b9ec2f6a0762fc1ac33e35582d4a87483a78d19408f/smart_open-8.0.0.tar.gz", hash = "sha256:5a2008d60688bd3b33c52e2ef666d3c60cf956e73e215de8c7b242cf56fdd1b2", size = 61520, upload-time = "2026-06-27T16:28:11.894Z" }
 wheels = [
@@ -6581,25 +6981,25 @@ name = "spacy"
 version = "3.8.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue", marker = "python_full_version >= '3.13'" },
-    { name = "confection", marker = "python_full_version >= '3.13'" },
-    { name = "cymem", marker = "python_full_version >= '3.13'" },
-    { name = "jinja2", marker = "python_full_version >= '3.13'" },
-    { name = "murmurhash", marker = "python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "packaging", marker = "python_full_version >= '3.13'" },
-    { name = "preshed", marker = "python_full_version >= '3.13'" },
-    { name = "pydantic", marker = "python_full_version >= '3.13'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
-    { name = "setuptools", marker = "python_full_version >= '3.13'" },
-    { name = "spacy-legacy", marker = "python_full_version >= '3.13'" },
-    { name = "spacy-loggers", marker = "python_full_version >= '3.13'" },
-    { name = "srsly", marker = "python_full_version >= '3.13'" },
-    { name = "thinc", marker = "python_full_version >= '3.13'" },
-    { name = "tqdm", marker = "python_full_version >= '3.13'" },
-    { name = "typer", marker = "python_full_version >= '3.13'" },
-    { name = "wasabi", marker = "python_full_version >= '3.13'" },
-    { name = "weasel", marker = "python_full_version >= '3.13'" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "jinja2" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "spacy-legacy" },
+    { name = "spacy-loggers" },
+    { name = "srsly" },
+    { name = "thinc" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wasabi" },
+    { name = "weasel" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/d5/9860449c9fbed97634fb974bbf7a128ae269f5e69f3d792a9679d2354141/spacy-3.8.14-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4a06e5cc029910eaa4a3c5a0a997f07fed6a41aba46b05da9f58643bc06fe8b9", size = 6625650, upload-time = "2026-03-29T10:40:07.13Z" },
@@ -6717,7 +7117,7 @@ name = "srsly"
 version = "2.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue", marker = "python_full_version >= '3.13'" },
+    { name = "catalogue" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881, upload-time = "2026-03-23T11:56:59.865Z" }
 wheels = [
@@ -6835,18 +7235,18 @@ name = "thinc"
 version = "8.3.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "blis", marker = "python_full_version >= '3.13'" },
-    { name = "catalogue", marker = "python_full_version >= '3.13'" },
-    { name = "confection", marker = "python_full_version >= '3.13'" },
-    { name = "cymem", marker = "python_full_version >= '3.13'" },
-    { name = "murmurhash", marker = "python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "packaging", marker = "python_full_version >= '3.13'" },
-    { name = "preshed", marker = "python_full_version >= '3.13'" },
-    { name = "pydantic", marker = "python_full_version >= '3.13'" },
-    { name = "setuptools", marker = "python_full_version >= '3.13'" },
-    { name = "srsly", marker = "python_full_version >= '3.13'" },
-    { name = "wasabi", marker = "python_full_version >= '3.13'" },
+    { name = "blis" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "setuptools" },
+    { name = "srsly" },
+    { name = "wasabi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640, upload-time = "2026-03-23T07:22:36.41Z" }
 wheels = [
@@ -7239,8 +7639,8 @@ name = "typing-inspect"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mypy-extensions", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
 wheels = [
@@ -7269,6 +7669,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
 name = "unstructured"
 version = "0.18.32"
 source = { registry = "https://pypi.org/simple" }
@@ -7278,30 +7687,30 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "backoff", marker = "python_full_version < '3.13'" },
-    { name = "beautifulsoup4", marker = "python_full_version < '3.13'" },
-    { name = "charset-normalizer", marker = "python_full_version < '3.13'" },
-    { name = "dataclasses-json", marker = "python_full_version < '3.13'" },
-    { name = "emoji", marker = "python_full_version < '3.13'" },
-    { name = "filetype", marker = "python_full_version < '3.13'" },
-    { name = "html5lib", marker = "python_full_version < '3.13'" },
-    { name = "langdetect", marker = "python_full_version < '3.13'" },
-    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "nltk", marker = "python_full_version < '3.13'" },
-    { name = "numba", marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "backoff" },
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "dataclasses-json" },
+    { name = "emoji" },
+    { name = "filetype" },
+    { name = "html5lib" },
+    { name = "langdetect" },
+    { name = "lxml", version = "4.9.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "nltk" },
+    { name = "numba" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "psutil", marker = "python_full_version < '3.13'" },
-    { name = "python-iso639", marker = "python_full_version < '3.13'" },
-    { name = "python-magic", marker = "python_full_version < '3.13'" },
-    { name = "python-oxmsg", marker = "python_full_version < '3.13'" },
-    { name = "rapidfuzz", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
-    { name = "tqdm", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "unstructured-client", version = "0.42.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "psutil" },
+    { name = "python-iso639" },
+    { name = "python-magic" },
+    { name = "python-oxmsg" },
+    { name = "rapidfuzz" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "unstructured-client", version = "0.42.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "wrapt", marker = "python_full_version < '3.13'" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/65/b73d84ede08fc2defe9c59d85ebf91f78210a424986586c6e39784890c8e/unstructured-0.18.32.tar.gz", hash = "sha256:40a7cf4a4a7590350bedb8a447e37029d6e74b924692576627b4edb92d70e39d", size = 1707730, upload-time = "2026-02-10T22:28:22.332Z" }
 wheels = [
@@ -7310,63 +7719,63 @@ wheels = [
 
 [package.optional-dependencies]
 csv = [
-    { name = "pandas", marker = "python_full_version < '3.13'" },
+    { name = "pandas" },
 ]
 doc = [
-    { name = "python-docx", marker = "python_full_version < '3.13'" },
+    { name = "python-docx" },
 ]
 docx = [
-    { name = "python-docx", marker = "python_full_version < '3.13'" },
+    { name = "python-docx" },
 ]
 epub = [
-    { name = "pypandoc", marker = "python_full_version < '3.13'" },
+    { name = "pypandoc" },
 ]
 md = [
-    { name = "markdown", marker = "python_full_version < '3.13'" },
+    { name = "markdown" },
 ]
 odt = [
-    { name = "pypandoc", marker = "python_full_version < '3.13'" },
-    { name = "python-docx", marker = "python_full_version < '3.13'" },
+    { name = "pypandoc" },
+    { name = "python-docx" },
 ]
 org = [
-    { name = "pypandoc", marker = "python_full_version < '3.13'" },
+    { name = "pypandoc" },
 ]
 pdf = [
-    { name = "effdet", marker = "python_full_version < '3.13'" },
-    { name = "google-cloud-vision", marker = "python_full_version < '3.13'" },
-    { name = "onnx", marker = "python_full_version < '3.13'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pdf2image", marker = "python_full_version < '3.13'" },
-    { name = "pdfminer-six", marker = "python_full_version < '3.13'" },
-    { name = "pi-heif", marker = "python_full_version < '3.13'" },
-    { name = "pikepdf", marker = "python_full_version < '3.13'" },
-    { name = "pypdf", marker = "python_full_version < '3.13'" },
-    { name = "unstructured-inference", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "effdet" },
+    { name = "google-cloud-vision" },
+    { name = "onnx" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pdf2image" },
+    { name = "pdfminer-six" },
+    { name = "pi-heif" },
+    { name = "pikepdf" },
+    { name = "pypdf" },
+    { name = "unstructured-inference", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "unstructured-inference", version = "1.6.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "unstructured-pytesseract", marker = "python_full_version < '3.13'" },
+    { name = "unstructured-pytesseract" },
 ]
 ppt = [
-    { name = "python-pptx", marker = "python_full_version < '3.13'" },
+    { name = "python-pptx" },
 ]
 pptx = [
-    { name = "python-pptx", marker = "python_full_version < '3.13'" },
+    { name = "python-pptx" },
 ]
 rst = [
-    { name = "pypandoc", marker = "python_full_version < '3.13'" },
+    { name = "pypandoc" },
 ]
 rtf = [
-    { name = "pypandoc", marker = "python_full_version < '3.13'" },
+    { name = "pypandoc" },
 ]
 tsv = [
-    { name = "pandas", marker = "python_full_version < '3.13'" },
+    { name = "pandas" },
 ]
 xlsx = [
-    { name = "msoffcrypto-tool", marker = "python_full_version < '3.13'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "msoffcrypto-tool" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "openpyxl", marker = "python_full_version < '3.13'" },
-    { name = "pandas", marker = "python_full_version < '3.13'" },
-    { name = "xlrd", marker = "python_full_version < '3.13'" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "xlrd" },
 ]
 
 [[package]]
@@ -7377,29 +7786,29 @@ resolution-markers = [
     "python_full_version == '3.13.*'",
 ]
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version == '3.13.*'" },
-    { name = "charset-normalizer", marker = "python_full_version == '3.13.*'" },
-    { name = "emoji", marker = "python_full_version == '3.13.*'" },
-    { name = "filelock", marker = "python_full_version == '3.13.*'" },
-    { name = "filetype", marker = "python_full_version == '3.13.*'" },
-    { name = "html5lib", marker = "python_full_version == '3.13.*'" },
-    { name = "installer", marker = "python_full_version == '3.13.*'" },
-    { name = "langdetect", marker = "python_full_version == '3.13.*'" },
-    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
-    { name = "numba", marker = "python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
-    { name = "psutil", marker = "python_full_version == '3.13.*'" },
-    { name = "python-iso639", marker = "python_full_version == '3.13.*'" },
-    { name = "python-magic", marker = "python_full_version == '3.13.*'" },
-    { name = "python-oxmsg", marker = "python_full_version == '3.13.*'" },
-    { name = "rapidfuzz", marker = "python_full_version == '3.13.*'" },
-    { name = "regex", marker = "python_full_version == '3.13.*'" },
-    { name = "requests", marker = "python_full_version == '3.13.*'" },
-    { name = "spacy", marker = "python_full_version == '3.13.*'" },
-    { name = "tqdm", marker = "python_full_version == '3.13.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.13.*'" },
-    { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
-    { name = "wrapt", marker = "python_full_version == '3.13.*'" },
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "emoji" },
+    { name = "filelock" },
+    { name = "filetype" },
+    { name = "html5lib" },
+    { name = "installer" },
+    { name = "langdetect" },
+    { name = "lxml", version = "5.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "psutil" },
+    { name = "python-iso639" },
+    { name = "python-magic" },
+    { name = "python-oxmsg" },
+    { name = "rapidfuzz" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "spacy" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/12/5960eb3d5fa2532ed5495c1c72442c022c2568c60f9c2f9fa020bac4007a/unstructured-0.22.23.tar.gz", hash = "sha256:75051c5a1dcfeca3c77149fc5e0ae5f1f0ee0fc31ec7f93bb259ce70dc4d5fb8", size = 1519424, upload-time = "2026-04-24T18:43:22.178Z" }
 wheels = [
@@ -7408,58 +7817,58 @@ wheels = [
 
 [package.optional-dependencies]
 csv = [
-    { name = "pandas", marker = "python_full_version == '3.13.*'" },
+    { name = "pandas" },
 ]
 doc = [
-    { name = "python-docx", marker = "python_full_version == '3.13.*'" },
+    { name = "python-docx" },
 ]
 docx = [
-    { name = "python-docx", marker = "python_full_version == '3.13.*'" },
+    { name = "python-docx" },
 ]
 epub = [
-    { name = "pypandoc-binary", marker = "python_full_version == '3.13.*' and sys_platform != 'win32'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 md = [
-    { name = "markdown", marker = "python_full_version == '3.13.*'" },
+    { name = "markdown" },
 ]
 odt = [
-    { name = "pypandoc-binary", marker = "python_full_version == '3.13.*' and sys_platform != 'win32'" },
-    { name = "python-docx", marker = "python_full_version == '3.13.*'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
+    { name = "python-docx" },
 ]
 org = [
-    { name = "pypandoc-binary", marker = "python_full_version == '3.13.*' and sys_platform != 'win32'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 pdf = [
-    { name = "google-cloud-vision", marker = "python_full_version == '3.13.*'" },
-    { name = "pdf2image", marker = "python_full_version == '3.13.*'" },
-    { name = "pdfminer-six", marker = "python_full_version == '3.13.*'" },
-    { name = "pi-heif", marker = "python_full_version == '3.13.*'" },
-    { name = "pikepdf", marker = "python_full_version == '3.13.*'" },
-    { name = "pypdf", marker = "python_full_version == '3.13.*'" },
-    { name = "unstructured-inference", version = "1.6.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*' and sys_platform != 'win32'" },
-    { name = "unstructured-pytesseract", marker = "python_full_version == '3.13.*'" },
+    { name = "google-cloud-vision" },
+    { name = "pdf2image" },
+    { name = "pdfminer-six" },
+    { name = "pi-heif" },
+    { name = "pikepdf" },
+    { name = "pypdf" },
+    { name = "unstructured-inference", version = "1.6.9", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "unstructured-pytesseract" },
 ]
 ppt = [
-    { name = "python-pptx", marker = "python_full_version == '3.13.*'" },
+    { name = "python-pptx" },
 ]
 pptx = [
-    { name = "python-pptx", marker = "python_full_version == '3.13.*'" },
+    { name = "python-pptx" },
 ]
 rst = [
-    { name = "pypandoc-binary", marker = "python_full_version == '3.13.*' and sys_platform != 'win32'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 rtf = [
-    { name = "pypandoc-binary", marker = "python_full_version == '3.13.*' and sys_platform != 'win32'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 tsv = [
-    { name = "pandas", marker = "python_full_version == '3.13.*'" },
+    { name = "pandas" },
 ]
 xlsx = [
-    { name = "msoffcrypto-tool", marker = "python_full_version == '3.13.*'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
-    { name = "openpyxl", marker = "python_full_version == '3.13.*'" },
-    { name = "pandas", marker = "python_full_version == '3.13.*'" },
-    { name = "xlrd", marker = "python_full_version == '3.13.*'" },
+    { name = "msoffcrypto-tool" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "xlrd" },
 ]
 
 [[package]]
@@ -7470,29 +7879,29 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version >= '3.14'" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.14'" },
-    { name = "emoji", marker = "python_full_version >= '3.14'" },
-    { name = "filelock", marker = "python_full_version >= '3.14'" },
-    { name = "filetype", marker = "python_full_version >= '3.14'" },
-    { name = "html5lib", marker = "python_full_version >= '3.14'" },
-    { name = "installer", marker = "python_full_version >= '3.14'" },
-    { name = "langdetect", marker = "python_full_version >= '3.14'" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "numba", marker = "python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "psutil", marker = "python_full_version >= '3.14'" },
-    { name = "python-iso639", marker = "python_full_version >= '3.14'" },
-    { name = "python-magic", marker = "python_full_version >= '3.14'" },
-    { name = "python-oxmsg", marker = "python_full_version >= '3.14'" },
-    { name = "rapidfuzz", marker = "python_full_version >= '3.14'" },
-    { name = "regex", marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
-    { name = "spacy", marker = "python_full_version >= '3.14'" },
-    { name = "tqdm", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
-    { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "wrapt", marker = "python_full_version >= '3.14'" },
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "emoji" },
+    { name = "filelock" },
+    { name = "filetype" },
+    { name = "html5lib" },
+    { name = "installer" },
+    { name = "langdetect" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "psutil" },
+    { name = "python-iso639" },
+    { name = "python-magic" },
+    { name = "python-oxmsg" },
+    { name = "rapidfuzz" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "spacy" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "unstructured-client", version = "0.45.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/a6/50f7dbc289bf617ae2850a7c16a3c4a8c5566599053a5cdabaeb6fd38a32/unstructured-0.24.0.tar.gz", hash = "sha256:23824fc1628109aa8c3fd03ac1423c5056e1d80e8357bfd76c03aa5b5b614837", size = 1535977, upload-time = "2026-07-06T22:43:07.724Z" }
 wheels = [
@@ -7501,58 +7910,58 @@ wheels = [
 
 [package.optional-dependencies]
 csv = [
-    { name = "pandas", marker = "python_full_version >= '3.14'" },
+    { name = "pandas" },
 ]
 doc = [
-    { name = "python-docx", marker = "python_full_version >= '3.14'" },
+    { name = "python-docx" },
 ]
 docx = [
-    { name = "python-docx", marker = "python_full_version >= '3.14'" },
+    { name = "python-docx" },
 ]
 epub = [
-    { name = "pypandoc-binary", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 md = [
-    { name = "markdown", marker = "python_full_version >= '3.14'" },
+    { name = "markdown" },
 ]
 odt = [
-    { name = "pypandoc-binary", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "python-docx", marker = "python_full_version >= '3.14'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
+    { name = "python-docx" },
 ]
 org = [
-    { name = "pypandoc-binary", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 pdf = [
-    { name = "google-cloud-vision", marker = "python_full_version >= '3.14'" },
-    { name = "pdf2image", marker = "python_full_version >= '3.14'" },
-    { name = "pdfminer-six", marker = "python_full_version >= '3.14'" },
-    { name = "pi-heif", marker = "python_full_version >= '3.14'" },
-    { name = "pikepdf", marker = "python_full_version >= '3.14'" },
-    { name = "pypdf", marker = "python_full_version >= '3.14'" },
-    { name = "unstructured-inference", version = "1.6.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "unstructured-pytesseract", marker = "python_full_version >= '3.14'" },
+    { name = "google-cloud-vision" },
+    { name = "pdf2image" },
+    { name = "pdfminer-six" },
+    { name = "pi-heif" },
+    { name = "pikepdf" },
+    { name = "pypdf" },
+    { name = "unstructured-inference", version = "1.6.13", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "unstructured-pytesseract" },
 ]
 ppt = [
-    { name = "python-pptx", marker = "python_full_version >= '3.14'" },
+    { name = "python-pptx" },
 ]
 pptx = [
-    { name = "python-pptx", marker = "python_full_version >= '3.14'" },
+    { name = "python-pptx" },
 ]
 rst = [
-    { name = "pypandoc-binary", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 rtf = [
-    { name = "pypandoc-binary", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "pypandoc-binary", marker = "sys_platform != 'win32'" },
 ]
 tsv = [
-    { name = "pandas", marker = "python_full_version >= '3.14'" },
+    { name = "pandas" },
 ]
 xlsx = [
-    { name = "msoffcrypto-tool", marker = "python_full_version >= '3.14'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "openpyxl", marker = "python_full_version >= '3.14'" },
-    { name = "pandas", marker = "python_full_version >= '3.14'" },
-    { name = "xlrd", marker = "python_full_version >= '3.14'" },
+    { name = "msoffcrypto-tool" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "xlrd" },
 ]
 
 [[package]]
@@ -7563,14 +7972,14 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "aiofiles", marker = "python_full_version < '3.11'" },
-    { name = "cryptography", marker = "python_full_version < '3.11'" },
-    { name = "httpcore", marker = "python_full_version < '3.11'" },
-    { name = "httpx", marker = "python_full_version < '3.11'" },
-    { name = "pydantic", marker = "python_full_version < '3.11'" },
-    { name = "pypdf", marker = "python_full_version < '3.11'" },
-    { name = "pypdfium2", marker = "python_full_version < '3.11'" },
-    { name = "requests-toolbelt", marker = "python_full_version < '3.11'" },
+    { name = "aiofiles" },
+    { name = "cryptography" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pypdf" },
+    { name = "pypdfium2" },
+    { name = "requests-toolbelt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/ca/73904d53e486af2f1d9d8baaf43d2a74b3d67e5f533834f5d51056471339/unstructured_client-0.42.12.tar.gz", hash = "sha256:50eb6717d8c6513b14b309fce8d6551354e433da982b7a9161a889d8e6a11166", size = 94714, upload-time = "2026-03-25T20:24:21.528Z" }
 wheels = [
@@ -7588,13 +7997,13 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "aiofiles", marker = "python_full_version >= '3.11'" },
-    { name = "httpcore", marker = "python_full_version >= '3.11'" },
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "pypdf", marker = "python_full_version >= '3.11'" },
-    { name = "pypdfium2", marker = "python_full_version >= '3.11'" },
-    { name = "requests-toolbelt", marker = "python_full_version >= '3.11'" },
+    { name = "aiofiles" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pypdf" },
+    { name = "pypdfium2" },
+    { name = "requests-toolbelt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/c6/bbc79efa9365fa8aecf353794a1253355eccf17468be3e6fb45a050e30d7/unstructured_client-0.45.0.tar.gz", hash = "sha256:3ffdaebdc27d2f043712dfeaee49cd38b990b480bed72e96255bf6245c0cc790", size = 94490, upload-time = "2026-06-05T21:36:51.635Z" }
 wheels = [
@@ -7609,22 +8018,22 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "accelerate", marker = "python_full_version < '3.11'" },
-    { name = "huggingface-hub", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "onnx", marker = "python_full_version < '3.11'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "opencv-python", marker = "python_full_version < '3.11'" },
-    { name = "pandas", marker = "python_full_version < '3.11'" },
-    { name = "pdfminer-six", marker = "python_full_version < '3.11'" },
-    { name = "pypdfium2", marker = "python_full_version < '3.11'" },
-    { name = "python-multipart", marker = "python_full_version < '3.11'" },
-    { name = "rapidfuzz", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "timm", marker = "python_full_version < '3.11'" },
-    { name = "torch", marker = "python_full_version < '3.11'" },
-    { name = "transformers", marker = "python_full_version < '3.11'" },
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnx" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "opencv-python" },
+    { name = "pandas" },
+    { name = "pdfminer-six" },
+    { name = "pypdfium2" },
+    { name = "python-multipart" },
+    { name = "rapidfuzz" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/10/8f3bccfa9f1e0101a402ae1f529e07876541c6b18004747f0e793ed41f9e/unstructured_inference-1.2.0.tar.gz", hash = "sha256:19ca28512f3649c70a759cf2a4e98663e942a1b83c1acdb9506b0445f4862f23", size = 45732, upload-time = "2026-01-30T20:57:58.019Z" }
 wheels = [
@@ -7641,21 +8050,21 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "accelerate", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "huggingface-hub", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "onnx", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "opencv-python", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pandas", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "pypdfium2", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "rapidfuzz", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnx" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "opencv-python" },
+    { name = "pandas" },
+    { name = "pypdfium2" },
+    { name = "rapidfuzz" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "timm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "torch", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "transformers", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/95/f5f629b6423bda2322de272366444acaeb07f0a02819638a2f19de07077e/unstructured_inference-1.6.9.tar.gz", hash = "sha256:7accd441c78033c6dce9a5f8020098daa44d75e65d95b100f3a5779866c27bc2", size = 47863, upload-time = "2026-04-26T19:03:29.998Z" }
 wheels = [
@@ -7670,21 +8079,21 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "accelerate", marker = "python_full_version >= '3.14'" },
-    { name = "huggingface-hub", marker = "python_full_version >= '3.14'" },
-    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "onnx", marker = "python_full_version >= '3.14'" },
-    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "opencv-python", marker = "python_full_version >= '3.14'" },
-    { name = "pandas", marker = "python_full_version >= '3.14'" },
-    { name = "pdfminer-six", marker = "python_full_version >= '3.14'" },
-    { name = "pypdfium2", marker = "python_full_version >= '3.14'" },
-    { name = "rapidfuzz", marker = "python_full_version >= '3.14'" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "timm", marker = "python_full_version >= '3.14'" },
-    { name = "torch", marker = "python_full_version >= '3.14'" },
-    { name = "transformers", marker = "python_full_version >= '3.14'" },
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnx" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "opencv-python" },
+    { name = "pandas" },
+    { name = "pdfminer-six" },
+    { name = "pypdfium2" },
+    { name = "rapidfuzz" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/ce/1e58008b8416884edfa6d18d65b635cde892189512d2e7531f91553b34d0/unstructured_inference-1.6.13.tar.gz", hash = "sha256:4efa2f3f517370aa09166c669cdc1addee71531e95bfbec7e6e3be66be90c147", size = 50137, upload-time = "2026-06-11T22:27:33.146Z" }
 wheels = [
@@ -7758,7 +8167,7 @@ name = "wasabi"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
 wheels = [
@@ -7766,19 +8175,136 @@ wheels = [
 ]
 
 [[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/5a/2bf22ecb24916983bf1cc0095e7dea2741d14d6553b0d6a2ac8bc96eca93/watchfiles-1.2.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bb68bf4df85abebe5efddc53cf2075520f243a59868d9b3973278b23e76962a9", size = 400471, upload-time = "2026-05-18T04:31:08.908Z" },
+    { url = "https://files.pythonhosted.org/packages/55/70/dea1f6a0e76607841a60fb51af150e70124864673f61704abb62b90cdcc7/watchfiles-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c16cb06dd17d43b9d185094268459eac92c9538356f050e55b54e82cf700e1d4", size = 394599, upload-time = "2026-05-18T04:30:19.845Z" },
+    { url = "https://files.pythonhosted.org/packages/18/52/752dcc7dc817baef5e89518732925795ce52e36a683a9a3c9fb68b21504e/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a0feab9af4c021c581f695258c642b3d10c5fd4c676e33a0d8606425d82631", size = 455458, upload-time = "2026-05-18T04:30:29.126Z" },
+    { url = "https://files.pythonhosted.org/packages/12/48/366ebbb22fcc504c2f72b45f0b7e72f40a18795cc01752c16066d597b67a/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a16ffe19bf5cf9f5edaa1ad1dd830c5a816e8feec430c522302ab55483a4b994", size = 460513, upload-time = "2026-05-18T04:31:40.85Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/44/1f9e1b15e7a729062e0d0c3d0d7225ea4ab98b2267ef87287153be2495fc/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204f299afcbd65918ab78dbc52626b0ae45e9d8cef403fdbf33ecf9e40eac66e", size = 493616, upload-time = "2026-05-18T04:30:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/55/8b1086dcc8a1d6a697a62767bd7ea368e74c61c6fd171683cfe24a3fe5d2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:11743adfa510bfffebe97659fb280182b5c9b238708f667e866f308c3430dc19", size = 573154, upload-time = "2026-05-18T04:30:37.903Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7a/242f400cc77fafa7b18d53d19d9cb64fc6a6f61f28c55913bae7c674d92a/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb72919d93e3a16fc451d3aa3d4b1698423daca1b382d3d959c9ac51297c12a8", size = 467046, upload-time = "2026-05-18T04:30:41.869Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c8/79eee650c62d2c186598489814468e389b5def0ebe755399ff645b35b1b2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62f042afde2dde21ec1d2c1a74361e804673df86f51e418a999c9acfe671b07", size = 457100, upload-time = "2026-05-18T04:31:13.064Z" },
+    { url = "https://files.pythonhosted.org/packages/81/36/519f6dbb7a95e4fe7c1513ed25b1520295ef9905a27f1f2226a73892bfb7/watchfiles-1.2.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:027ae72bfdfd254862065d8b3e2a815c6ab9b1853ce41e6648ece84afd34a551", size = 467038, upload-time = "2026-05-18T04:30:32.915Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/12/951af6b9f89097e02511122258402cb3578443021930b70cf968d6310dc0/watchfiles-1.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e1cfd51e97e13ff3bd047c140764d277fc9b95b7cb5da59e46a47d167adab310", size = 632563, upload-time = "2026-05-18T04:30:11.539Z" },
+    { url = "https://files.pythonhosted.org/packages/28/cc/0cba1f0a6117b7ec117271bdc3cb3a5a252005959755a2c09a745e0942cc/watchfiles-1.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:24b2405c0a46738dd9e1cf7135aa5dbdb9d42d024628651b3b13d5117e99f8df", size = 660851, upload-time = "2026-05-18T04:31:53.186Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/26347558cc8bf6877845e66b315f644d03c173906aa09e233a3f4fd23928/watchfiles-1.2.0-cp310-cp310-win32.whl", hash = "sha256:8c520725602756229f045b032a1ff33d7ef0f7404189d62f6c2438cb6d8ef6a1", size = 277023, upload-time = "2026-05-18T04:30:18.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/68/a5e67b6b68e94f4c1511d61c46c55eba0737583620b6febf194c7b9cc23f/watchfiles-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:03b14855c6f35539e2d95c442ae9530a75762f1e26567152b9ed05f96534a74d", size = 290107, upload-time = "2026-05-18T04:32:09.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3d/8024c801df84d1587740d0359e7fdd80afeae3d159011f3d5376dd82f18e/watchfiles-1.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:704fd259e332e01f9b9c178f4bce9e49027e5587cc2600eeeaf8e76e1c846201", size = 400242, upload-time = "2026-05-18T04:31:19.014Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/f4dfd45323e949984a3a7f9dc31d1cbb049921e7d98253488dda72ccdaa9/watchfiles-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6543cf55d170003296d185c0af981f3e1311564907e1f4e08671fc7693a890a5", size = 394562, upload-time = "2026-05-18T04:30:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/19483ef075d601c409bce8bcbb5c0f81a10876fff870400568f08ce484a1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d8c2394a065ca86f5d2910ff263ae67c127e1376ccc4f9fc35c71db879f80a", size = 456611, upload-time = "2026-05-18T04:30:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6a/cc81fbe7ee42f2f22e661a6e12def7807e01b14b2f39e0ff83fd373fd307/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:772b80df316480d894a0e3165fdd19cf77f5d17f9a787f94029465ad0e3529d1", size = 461379, upload-time = "2026-05-18T04:31:29.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/57/7e669002082c0a0f4fb5113bb70125f7110124b846b0a11bc5ae8e90eac1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d158cd89df6053823533e06fb1d73c549133bff5f0396170c0e53d9559340717", size = 493556, upload-time = "2026-05-18T04:30:05.44Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/f60a2b19807b21fe8281f3a8da4f59eef0d5f96825ac4680ba2d4f2ebf91/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d516b3283a758e087841aedb8031549fb41ced08f3db10aa6d2bf32dc042525b", size = 575255, upload-time = "2026-05-18T04:30:40.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/49/77f5b5e6efbcd57482f74948ebb1b97e5c0046d6b61475042d830c84b3ff/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53b2290c92e0506d102cd448fbc610d87079553f86caa39d67440856a8b8bba5", size = 467052, upload-time = "2026-05-18T04:31:17.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5a/73e2959af1b97fd5d556f9a8bdba017be23ceeef731869d5eaa0a753d5a3/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a711b51aec4370d0dcda5b6c09463206f133a5759341d7744b953a7b62e1100e", size = 456858, upload-time = "2026-05-18T04:30:30.182Z" },
+    { url = "https://files.pythonhosted.org/packages/50/57/1bc8c27fad7e6c19bddee15d276dbb6ab72480ec01c127afff1673aee417/watchfiles-1.2.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:e2ca07fa7d89195ec0865d3d285666286740bfa83d83e5cee204043a31ecc165", size = 467579, upload-time = "2026-05-18T04:32:15.897Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6c/3c2e44edba3553c5e3c3b8c8a2a6dee6b9e12ae2cf4bd2378bebf9dc3038/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e0618518f282c4ebff60f5e5b1247b6d91bb8b9f4476947563a1e74acc66f3c6", size = 633253, upload-time = "2026-05-18T04:31:37.123Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/d8c84a882ab39bbefcc4915ab3e91830b7a7e990c5570b0b69075aba3faf/watchfiles-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0d191c054d0715c3c95c99df9b8dbf6fd096d8c1e021e8f212e1bd8bc444ccb5", size = 660713, upload-time = "2026-05-18T04:31:24.62Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/07/f97736a5fc605364fe67b25e9fa4a6965dfd4840d50c406ada507e9d735f/watchfiles-1.2.0-cp311-cp311-win32.whl", hash = "sha256:9342472aff9b093c5acd4f6d8f70ae0937964ab56542502bcf5579782da69ae8", size = 277222, upload-time = "2026-05-18T04:31:21.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/99/2b04981977fc2608afd60360d928c6aecf6b950292ca221d98f4005f6694/watchfiles-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:dbd6c97045dad81227c8d040173da044c1de08de64a5ea8b555da4aee1d5fa22", size = 290274, upload-time = "2026-05-18T04:31:45.966Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/74/f7f58a7075ee9cf612b0cfcddb78b8cd8234f0742d6f0075cf0da2dde1c6/watchfiles-1.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:57a2d9fa4fb4c2ecae57b13dfff2c7ab53e21a2ba674fe9f05506680fcdcc0d7", size = 283460, upload-time = "2026-05-18T04:31:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f4/7513ef1e85fc4c6331b59479d6d72661fc391fbe543678052ac72c8b6c19/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4674d49eb94706dfe666c069fc0a1b646ffcf920473492e209f6d5f60d3f0cc2", size = 403050, upload-time = "2026-05-18T04:30:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
+]
+
+[[package]]
 name = "weasel"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpathlib", marker = "python_full_version >= '3.13'" },
-    { name = "confection", marker = "python_full_version >= '3.13'" },
-    { name = "httpx", marker = "python_full_version >= '3.13'" },
-    { name = "packaging", marker = "python_full_version >= '3.13'" },
-    { name = "pydantic", marker = "python_full_version >= '3.13'" },
-    { name = "smart-open", marker = "python_full_version >= '3.13'" },
-    { name = "srsly", marker = "python_full_version >= '3.13'" },
-    { name = "typer", marker = "python_full_version >= '3.13'" },
-    { name = "wasabi", marker = "python_full_version >= '3.13'" },
+    { name = "cloudpathlib" },
+    { name = "confection" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "smart-open" },
+    { name = "srsly" },
+    { name = "typer" },
+    { name = "wasabi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
 wheels = [

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -37,6 +37,8 @@ EXPECTED_TOOLS = PINNED_TOOLS | SEARCH_TRANSFORM_TOOLS
 
 # Registered but deliberately not advertised; reachable by name and via search.
 # The workspace UI calls these directly, so hiding them must not unreach them.
+# Not exhaustive on purpose — asserted as a subset, so the catalog can change
+# (e.g. cognify_file folding into remember) without touching this list.
 HIDDEN_TOOLS = {
     "list_datasets_json",
     "list_dataset_data_json",

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -2,7 +2,8 @@
 
 Drives the built ``cognee/cognee-mcp`` image through a real MCP session: boots it
 with ``TRANSPORT_MODE=http``, connects an MCP client at ``/mcp``, asserts the tool
-surface, exercises a ``remember`` -> ``recall`` round-trip, and validates
+surface (pinned + search transform, with unadvertised tools still callable),
+exercises a ``remember`` -> ``recall`` round-trip, and validates
 ``MCP_ALLOWED_HOSTS`` / DNS-rebinding behaviour on the ``0.0.0.0`` bind.
 """
 
@@ -17,15 +18,25 @@ from mcp_harness import mcp_client_session, run_mcp_http_container
 
 pytestmark = pytest.mark.deployment
 
-# Mirrors EXPECTED_TOOLS in cognee-mcp/tests/test_mcp_server_hardening.py and
-# cognee-mcp/src/test_client.py.
-EXPECTED_TOOLS = {
+# What the image advertises in COGNEE_MCP_TOOL_MODE=default: the pinned tools
+# plus the two synthetic tools FastMCP's search transform adds. Spelled out
+# rather than derived from cognee-mcp's registry because this suite tests the
+# container from the outside and its runner installs neither cognee-mcp nor
+# fastmcp — see .github/workflows/test_deployment_mcp.yml.
+PINNED_TOOLS = {
     "remember",
     "recall",
     "forget",
     "visualize_graph_ui",
     "upload_file_ui",
     "open_cognee_workspace",
+}
+SEARCH_TRANSFORM_TOOLS = {"search_tools", "call_tool"}
+EXPECTED_TOOLS = PINNED_TOOLS | SEARCH_TRANSFORM_TOOLS
+
+# Registered but deliberately not advertised; reachable by name and via search.
+# The workspace UI calls these directly, so hiding them must not unreach them.
+HIDDEN_TOOLS = {
     "list_datasets_json",
     "list_dataset_data_json",
     "create_dataset_json",
@@ -99,6 +110,30 @@ async def test_list_tools_over_http(mcp_http_container):
         f"Tool surface mismatch. "
         f"Missing: {sorted(EXPECTED_TOOLS - names)}. "
         f"Unexpected: {sorted(names - EXPECTED_TOOLS)}."
+    )
+
+
+@pytest.mark.asyncio
+async def test_hidden_tools_stay_reachable_over_http(mcp_http_container):
+    """Gating ``tools/list`` must not gate calling.
+
+    The workspace UI invokes these internals by name via app.callServerTool and
+    never sees them in ``tools/list``, so an unadvertised tool that stopped being
+    callable would break the UI without failing the surface assertion above.
+    """
+    async with mcp_client_session(mcp_http_container.mcp_url) as session:
+        listed = {tool.name for tool in (await session.list_tools()).tools}
+        assert not (HIDDEN_TOOLS & listed), "hidden tools should not be advertised"
+
+        direct = await session.call_tool("list_datasets_json", arguments={})
+        assert not direct.isError, _text_of(direct)
+
+        found = await session.call_tool(
+            "search_tools", arguments={"query": "list all of my datasets"}
+        )
+
+    assert "list_datasets_json" in _text_of(found), (
+        f"search_tools did not surface the hidden tool: {_text_of(found)!r}"
     )
 
 

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -26,7 +26,6 @@ EXPECTED_TOOLS = {
     "visualize_graph_ui",
     "upload_file_ui",
     "open_cognee_workspace",
-    "cognify_file",
     "list_datasets_json",
     "list_dataset_data_json",
     "create_dataset_json",

--- a/cognee/tests/deployment/test_mcp_http_direct.py
+++ b/cognee/tests/deployment/test_mcp_http_direct.py
@@ -18,6 +18,7 @@ from mcp_harness import mcp_client_session, run_mcp_http_container
 
 pytestmark = pytest.mark.deployment
 
+# DANGER: IF THE MCP TOOLING CHANGES, UPDATE THIS LIST OR ELSE IT WILL FAIL!
 # What the image advertises in COGNEE_MCP_TOOL_MODE=default: the pinned tools
 # plus the two synthetic tools FastMCP's search transform adds. Spelled out
 # rather than derived from cognee-mcp's registry because this suite tests the


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
There are presently 11 tools registered with an old fastMCP version for Cognee's MCP. They pollute far too much agent context, and ought to be shrunk into a smaller agent-facing interface, where some tools are exposed as default and others are gated behind a tool loader. Thankfully, fastMCP already implements this lazy-loading mechanism, but only in a newer version. This PR minimally migrates the existing codebase to a loader-compatible version of fastMCP, decorates cognee’s MCP tools as default or gated (along with meta categories for the agent to understand), and adds various tests to check the efficacy & functionality of fastMCP's tool loader (reusable design pattern for exploring alternative implementations if fastMCP's lazy-loader is not cutting it as we expand our MCP tooling.) Altered tests to use decorators as a single source of truth for getting a tool list + warn if certain tools have no test coverage.  
NOTE: Depends on #4258 which was the first step of this overall update

## Acceptance Criteria
Agents no longer receive the whole catalog. tools/list returns 8 of 10 registered tools by default: remember, recall, forget, the three workspace UI entry points, plus search_tools and call_tool — with the rest reachable through natural-language search. Covered by test_default_mode_advertises_pinned_plus_synthetic, test_hidden_tools_are_discoverable_by_search, and six test_natural_language_queries_rank_their_tool_first cases.

Hiding a tool never makes it unreachable, which is what keeps the workspace UI working. It calls internals by name and never discovers them through listing. Unadvertised tools stay callable directly and via the call_tool proxy, search results carry full inputSchema and _meta.ui, and pinned tools are excluded from results. See test_hidden_tool_is_callable_directly, test_hidden_tool_is_callable_through_the_proxy, test_hidden_tools_keep_their_schemas_and_ui_metadata, test_search_never_returns_pinned_tools.

The core set is declared at each definition site via @registry.tool(tags={DEFAULT_TAG, ...}) and derived with names_with_tag(), so retiering a tool needs no edit elsewhere, and this retired three separate duplicated copies of the expected tool names. test_every_tool_declares_a_tier compares the registry against the live catalog, so a bare @mcp.tool fails the build.

The change is reversible without a revert. COGNEE_MCP_TOOL_MODE selects default (8 advertised), minimal (5), or all (10, the previous flat surface); unknown values warn and fall back, and re-applying a mode replaces the transform rather than stacking one. See test_all_mode_restores_the_flat_surface, test_unknown_mode_falls_back_to_default, test_apply_tool_mode_is_idempotent.

Nothing regressed and new tools can't go silently untested. @log_usage is folded into the registry decorator and still logs MCP <tool_name>, the suite is green at 86 tests, and a conftest hook reports registered tools no test invoked (warn-only, or failing under COGNEE_MCP_STRICT_TOOL_COVERAGE=1.)

Routing parameters are measured, not guessed. Over synthetic catalogs of 11–500 tools the gated payload stays constant at ~393 tokens (99% smaller at 500), and max_results=10 comes from a recall sweep rising 60% at k=5 to 80% at k=10 before plateauing. tests/test_tool_search_benchmark.py also compares BM25 against a hand-rolled matcher and records that the case for the built-in is maintenance, not superiority.

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
Unit/bevhaior tests for MCP (python -m pytest tests/ -q):
<img width="587" height="202" alt="Screenshot 2026-07-30 at 10 42 22 PM" src="https://github.com/user-attachments/assets/919b02ab-b53f-4b8d-bf98-3b44e9bc36d4" />

Server tests (python src/test_client.py)
<img width="362" height="214" alt="Screenshot 2026-07-30 at 10 46 49 PM" src="https://github.com/user-attachments/assets/58b81501-9e3f-40b8-97ad-db88aaaa9655" />

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [X] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [X] **This PR contains minimal changes necessary to address the issue/feature**
- [X] My code follows the project's coding standards and style guidelines
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if applicable)
- [X] All new and existing tests pass
- [X] I have searched existing PRs to ensure this change hasn't been submitted already
- [X] I have linked any relevant issues in the description
- [X]  My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.