### PR TITLE
[SDK-255] Groundwork: DEFAULT_DATASET_NAME constant + as_uuid/warn_once helpers

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -18,6 +18,7 @@ from cognee.tasks.ingestion.data_item import DataItem
 from cognee.tasks.ingestion.resolve_dlt_sources import resolve_dlt_sources
 from cognee.tasks.ingestion.utils import materialize_stream_for_background
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger()
 
@@ -32,7 +33,7 @@ async def add(
         list[DataItem],
         Any,  # DltResource, SourceFactory, or other dlt types
     ],
-    dataset_name: str = "main_dataset",
+    dataset_name: str = DEFAULT_DATASET_NAME,
     user: User = None,
     node_set: Optional[List[str]] = None,
     vector_db_config: dict = None,

--- a/cognee/api/v1/export/export.py
+++ b/cognee/api/v1/export/export.py
@@ -7,13 +7,14 @@ from uuid import UUID
 from cognee.modules.migration.export import ExportResult, export_dataset
 from cognee.modules.migration.snapshot import GraphSnapshot
 from cognee.modules.observability import new_span, COGNEE_DATASET_NAME
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 _FileFormat = Literal["cogx", "json", "graphml", "cypher"]
 
 
 @overload
 async def export(
-    dataset: Union[str, UUID] = "main_dataset",
+    dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     format: Literal["pydantic"] = "pydantic",
     destination: Optional[Union[str, Path]] = None,
     user=None,
@@ -35,7 +36,7 @@ async def export(
 
 @overload
 async def export(
-    dataset: Union[str, UUID] = "main_dataset",
+    dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     *,
     format: _FileFormat,
     destination: Optional[Union[str, Path]] = None,
@@ -46,7 +47,7 @@ async def export(
 
 
 async def export(
-    dataset: Union[str, UUID] = "main_dataset",
+    dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     format: str = "pydantic",
     destination: Optional[Union[str, Path]] = None,
     user=None,

--- a/cognee/api/v1/push/push.py
+++ b/cognee/api/v1/push/push.py
@@ -18,6 +18,7 @@ from typing import Optional, Union
 from uuid import UUID
 
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger("push")
 
@@ -94,7 +95,7 @@ def _verify_migration_import(response: dict) -> None:
 
 
 async def push(
-    dataset: Union[str, UUID] = "main_dataset",
+    dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     *,
     target_dataset: Optional[str] = None,
     mode: str = "preserve",

--- a/cognee/api/v1/report/report.py
+++ b/cognee/api/v1/report/report.py
@@ -6,12 +6,13 @@ from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.users.methods import get_default_user
 from cognee.modules.users.models.User import User
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger("report")
 
 
 async def report(
-    datasets: Optional[Union[str, List[str]]] = "main_dataset",
+    datasets: Optional[Union[str, List[str]]] = DEFAULT_DATASET_NAME,
     output_path: Optional[str] = "graph_report.md",
     top_n: int = 10,
     user: Optional[User] = None,

--- a/cognee/api/v1/skills/routers/get_skills_router.py
+++ b/cognee/api/v1/skills/routers/get_skills_router.py
@@ -19,6 +19,7 @@ from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
 from cognee.shared.utils import send_telemetry
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger()
 
@@ -119,7 +120,7 @@ def get_skills_router() -> APIRouter:
         try:
             result = await cognee_remember(
                 "",
-                dataset_name=payload.dataset_name or "main_dataset",
+                dataset_name=payload.dataset_name or DEFAULT_DATASET_NAME,
                 content_type="skills",
                 skills_text=payload.skills_text,
                 skill_name=payload.skill_name,

--- a/cognee/api/v1/visualize/visualize.py
+++ b/cognee/api/v1/visualize/visualize.py
@@ -20,6 +20,7 @@ from cognee.shared.logging_utils import get_logger, setup_logging, ERROR
 
 
 import asyncio
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 logger = get_logger()
@@ -30,7 +31,7 @@ async def visualize_graph(
     include_session_events: bool = True,
     session_ids: list = None,
     user: Optional[User] = None,
-    dataset: Optional[Union[str, UUID]] = "main_dataset",
+    dataset: Optional[Union[str, UUID]] = DEFAULT_DATASET_NAME,
     *,
     full: bool = False,
     query: Optional[str] = None,

--- a/cognee/cli/api_client.py
+++ b/cognee/cli/api_client.py
@@ -17,6 +17,7 @@ import mimetypes
 import os
 from typing import Any, Optional
 from urllib.parse import urljoin
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 def _import_httpx():
@@ -122,7 +123,7 @@ class CogneeApiClient:
     def add(
         self,
         data_items: list[str],
-        dataset_name: str = "main_dataset",
+        dataset_name: str = DEFAULT_DATASET_NAME,
     ) -> dict:
         files = []
         opened = []
@@ -255,7 +256,7 @@ class CogneeApiClient:
     def remember(
         self,
         data_items: list[str],
-        dataset_name: str = "main_dataset",
+        dataset_name: str = DEFAULT_DATASET_NAME,
         session_id: Optional[str] = None,
         node_set: Optional[list[str]] = None,
         run_in_background: bool = False,

--- a/cognee/cli/commands/add_command.py
+++ b/cognee/cli/commands/add_command.py
@@ -6,6 +6,7 @@ from cognee.cli.reference import SupportsCliCommand
 from cognee.cli import DEFAULT_DOCS_URL
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 class AddCommand(SupportsCliCommand):
@@ -46,7 +47,7 @@ After adding data, use `cognee cognify` to process it into knowledge graphs.
         parser.add_argument(
             "--dataset-name",
             "-d",
-            default="main_dataset",
+            default=DEFAULT_DATASET_NAME,
             help="Dataset name to organize your data (default: main_dataset)",
         )
 

--- a/cognee/cli/commands/improve_command.py
+++ b/cognee/cli/commands/improve_command.py
@@ -5,6 +5,7 @@ from cognee.cli.reference import SupportsCliCommand
 from cognee.cli import DEFAULT_DOCS_URL
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 class ImproveCommand(SupportsCliCommand):
@@ -22,7 +23,7 @@ tasks on an existing knowledge graph to add context, rules, and connections.
         parser.add_argument(
             "--dataset-name",
             "-d",
-            default="main_dataset",
+            default=DEFAULT_DATASET_NAME,
             help="Dataset name (default: main_dataset)",
         )
         parser.add_argument(

--- a/cognee/cli/commands/push_command.py
+++ b/cognee/cli/commands/push_command.py
@@ -8,6 +8,7 @@ from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
 
 # Tiny constants-only import; the cognee package is already loaded by the CLI.
 from cognee.modules.migration.sources.base import IMPORT_MODES
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 class PushCommand(SupportsCliCommand):
@@ -42,7 +43,7 @@ Examples:
         parser.add_argument(
             "dataset",
             nargs="?",
-            default="main_dataset",
+            default=DEFAULT_DATASET_NAME,
             help="Local dataset name to push (default: main_dataset)",
         )
         parser.add_argument(

--- a/cognee/cli/commands/remember_command.py
+++ b/cognee/cli/commands/remember_command.py
@@ -6,6 +6,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.config import CHUNKER_CHOICES
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 class RememberCommand(SupportsCliCommand):
@@ -30,7 +31,7 @@ After completion, use `cognee recall` (or `cognee search`) to query the graph.
         parser.add_argument(
             "--dataset-name",
             "-d",
-            default="main_dataset",
+            default=DEFAULT_DATASET_NAME,
             help="Dataset name (default: main_dataset)",
         )
         parser.add_argument(

--- a/cognee/cli/commands/report_command.py
+++ b/cognee/cli/commands/report_command.py
@@ -5,6 +5,7 @@ from cognee.cli import DEFAULT_DOCS_URL
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
 from cognee.cli.reference import SupportsCliCommand
 import cognee.cli.echo as fmt
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 class ReportCommand(SupportsCliCommand):
@@ -22,7 +23,7 @@ class ReportCommand(SupportsCliCommand):
             "--datasets",
             "-d",
             nargs="*",
-            default=["main_dataset"],
+            default=[DEFAULT_DATASET_NAME],
             help="Dataset name(s) to analyse (default: main_dataset)",
         )
         parser.add_argument(
@@ -48,7 +49,7 @@ class ReportCommand(SupportsCliCommand):
                     from cognee.cli.user_resolution import resolve_cli_user
 
                     user = await resolve_cli_user(getattr(args, "user_id", None))
-                    datasets = args.datasets or ["main_dataset"]
+                    datasets = args.datasets or [DEFAULT_DATASET_NAME]
                     return await report(
                         datasets=datasets,
                         output_path=args.output,

--- a/cognee/memify_pipelines/apply_feedback_weights.py
+++ b/cognee/memify_pipelines/apply_feedback_weights.py
@@ -12,6 +12,7 @@ from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.memify.apply_feedback_weights import apply_feedback_weights
 from cognee.tasks.memify.extract_feedback_qas import extract_feedback_qas
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger("apply_feedback_weights_pipeline")
 
@@ -19,7 +20,7 @@ logger = get_logger("apply_feedback_weights_pipeline")
 async def apply_feedback_weights_pipeline(
     user: User,
     session_ids: List[str],
-    dataset: str = "main_dataset",
+    dataset: str = DEFAULT_DATASET_NAME,
     alpha: float = 0.1,
     batch_size: int = 100,
     run_in_background: bool = False,

--- a/cognee/memify_pipelines/apply_frequency_weights.py
+++ b/cognee/memify_pipelines/apply_frequency_weights.py
@@ -12,6 +12,7 @@ from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.memify.apply_frequency_weights import apply_frequency_weights
 from cognee.tasks.memify.extract_feedback_qas import extract_feedback_qas
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger("apply_frequency_weights_pipeline")
 
@@ -19,7 +20,7 @@ logger = get_logger("apply_frequency_weights_pipeline")
 async def apply_frequency_weights_pipeline(
     user: User,
     session_ids: List[str],
-    dataset: str = "main_dataset",
+    dataset: str = DEFAULT_DATASET_NAME,
     batch_size: int = 100,
     run_in_background: bool = False,
 ):

--- a/cognee/memify_pipelines/consolidate_entities.py
+++ b/cognee/memify_pipelines/consolidate_entities.py
@@ -21,6 +21,7 @@ from cognee.tasks.memify.consolidate_entities import (
     detect_entity_duplicates,
     merge_entity_duplicates,
 )
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger("consolidate_entities_pipeline")
 
@@ -33,7 +34,7 @@ async def consolidate_entities_pipeline(
     top_k: int = 10,
     allow_cross_type: bool = False,
     user: Optional[User] = None,
-    dataset: str = "main_dataset",
+    dataset: str = DEFAULT_DATASET_NAME,
     run_in_background: bool = False,
 ):
     """Merge near-duplicate ``Entity`` nodes in an existing graph.

--- a/cognee/memify_pipelines/create_triplet_embeddings.py
+++ b/cognee/memify_pipelines/create_triplet_embeddings.py
@@ -11,13 +11,14 @@ from cognee.modules.pipelines.tasks.task import Task
 from cognee.modules.users.models import User
 from cognee.tasks.memify.get_triplet_datapoints import get_triplet_datapoints
 from cognee.tasks.storage import index_data_points
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger("create_triplet_embeddings")
 
 
 async def create_triplet_embeddings(
     user: User,
-    dataset: str = "main_dataset",
+    dataset: str = DEFAULT_DATASET_NAME,
     run_in_background: bool = False,
     triplets_batch_size: int = 100,
 ) -> dict[str, Any]:

--- a/cognee/memify_pipelines/global_context_index.py
+++ b/cognee/memify_pipelines/global_context_index.py
@@ -9,6 +9,7 @@ from cognee.tasks.memify.global_context_index import (
     update_global_context_index,
 )
 from cognee.tasks.memify.global_context_index.bucketing_strategy import BucketingStrategyName
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 def get_global_context_index_memify_tasks(
@@ -45,7 +46,7 @@ def get_global_context_index_memify_tasks(
 
 async def global_context_index_pipeline(
     user: User,
-    dataset: Union[str, UUID] = "main_dataset",
+    dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     run_in_background: bool = False,
     max_bucket_size: int = 20,
     placement_distance_threshold: float = 0.5,

--- a/cognee/memify_pipelines/persist_agent_trace_feedbacks_in_knowledge_graph.py
+++ b/cognee/memify_pipelines/persist_agent_trace_feedbacks_in_knowledge_graph.py
@@ -14,6 +14,7 @@ from cognee.tasks.memify import (
     cognify_agent_trace_feedback,
     extract_agent_trace_feedbacks,
 )
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger("persist_agent_trace_feedbacks_in_knowledge_graph")
 
@@ -21,7 +22,7 @@ logger = get_logger("persist_agent_trace_feedbacks_in_knowledge_graph")
 async def persist_agent_trace_feedbacks_in_knowledge_graph_pipeline(
     user: User,
     session_ids: Optional[list[str]] = None,
-    dataset: str = "main_dataset",
+    dataset: str = DEFAULT_DATASET_NAME,
     node_set_name: str = "agent_trace_feedbacks",
     raw_trace_content: bool = False,
     last_n_steps: Optional[int] = None,

--- a/cognee/memify_pipelines/persist_sessions_in_knowledge_graph.py
+++ b/cognee/memify_pipelines/persist_sessions_in_knowledge_graph.py
@@ -11,6 +11,7 @@ from cognee.shared.logging_utils import get_logger
 from cognee.modules.pipelines.tasks.task import Task
 from cognee.modules.users.models import User
 from cognee.tasks.memify import extract_user_sessions, cognify_session
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 logger = get_logger("persist_sessions_in_knowledge_graph")
@@ -19,7 +20,7 @@ logger = get_logger("persist_sessions_in_knowledge_graph")
 async def persist_sessions_in_knowledge_graph_pipeline(
     user: User,
     session_ids: Optional[List[str]] = None,
-    dataset: str = "main_dataset",
+    dataset: str = DEFAULT_DATASET_NAME,
     run_in_background: bool = False,
 ):
     """

--- a/cognee/modules/data/constants.py
+++ b/cognee/modules/data/constants.py
@@ -1,0 +1,8 @@
+"""Shared constants for the data/dataset layer."""
+
+# The dataset used whenever a caller states no dataset at all. Cognee's
+# convention across add/cognify/remember/improve/memify is "no dataset
+# stated -> main_dataset"; session scoping follows the same rule so an
+# omitted dataset still produces a dataset-scoped session rather than an
+# unscoped, unenforceable one.
+DEFAULT_DATASET_NAME = "main_dataset"

--- a/cognee/modules/memify/memify.py
+++ b/cognee/modules/memify/memify.py
@@ -2,6 +2,7 @@ from typing import Union, Optional, List, Type, Any
 from uuid import UUID
 
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 from cognee.modules.retrieval.utils.brute_force_triplet_search import get_memory_fragment
 from cognee.context_global_variables import set_database_global_context_variables
@@ -26,7 +27,7 @@ async def memify(
     extraction_tasks: Union[List[Task], List[str]] = None,
     enrichment_tasks: Union[List[Task], List[str]] = None,
     data: Optional[Any] = None,
-    dataset: Union[str, UUID] = "main_dataset",
+    dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     user: User = None,
     node_type: Optional[Type] = NodeSet,
     node_name: Optional[List[str]] = None,

--- a/cognee/modules/migration/export.py
+++ b/cognee/modules/migration/export.py
@@ -28,6 +28,7 @@ from cognee.modules.migration.cogx import (
 from cognee.modules.migration.formats import write_cypher, write_graphml, write_json
 from cognee.modules.migration.snapshot import GraphSnapshot, build_snapshot
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger("migration.export")
 
@@ -193,7 +194,7 @@ def _write_cogx(
 
 
 async def export_dataset(
-    dataset: Union[str, UUID] = "main_dataset",
+    dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     format: str = "pydantic",
     destination: Optional[Union[str, Path]] = None,
     user=None,

--- a/cognee/modules/migration/import_source.py
+++ b/cognee/modules/migration/import_source.py
@@ -29,6 +29,7 @@ from cognee.modules.migration.loader import (
 from cognee.modules.migration.sources.base import MemorySource
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.ingestion.data_item import DataItem
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 if TYPE_CHECKING:
     from cognee.api.v1.remember.remember import RememberResult
@@ -265,7 +266,7 @@ def _pipeline_run_id(pipeline_result: Any) -> Optional[str]:
 
 async def import_memory_source(
     source: MemorySource,
-    dataset_name: str = "main_dataset",
+    dataset_name: str = DEFAULT_DATASET_NAME,
     user=None,
     run_in_background: bool = False,
     node_set: Optional[list] = None,

--- a/cognee/modules/run_custom_pipeline/run_custom_pipeline.py
+++ b/cognee/modules/run_custom_pipeline/run_custom_pipeline.py
@@ -7,6 +7,7 @@ from cognee.modules.pipelines import run_pipeline
 from cognee.modules.pipelines.tasks.task import Task
 from cognee.modules.users.models import User
 from cognee.modules.pipelines.layers.pipeline_execution_mode import get_pipeline_executor
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 logger = get_logger()
 
@@ -14,7 +15,7 @@ logger = get_logger()
 async def run_custom_pipeline(
     tasks: Union[List[Task], List[str]] = None,
     data: Any = None,
-    dataset: Union[str, UUID] = "main_dataset",
+    dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     user: User = None,
     vector_db_config: Optional[dict] = None,
     graph_db_config: Optional[dict] = None,

--- a/cognee/shared/logging_utils.py
+++ b/cognee/shared/logging_utils.py
@@ -247,6 +247,23 @@ def get_logger(name=None, level=None) -> logging.Logger:
         return logger
 
 
+_warned_once_keys: set = set()
+
+
+def warn_once(logger, key: str, message: str, *args) -> None:
+    """Log ``message`` at WARNING the first time ``key`` is seen this process,
+    then at DEBUG.
+
+    For failure paths that fire on every write (lifecycle heartbeats, binding
+    lookups): silent breakage stays visible in ops without spamming the log.
+    """
+    if key in _warned_once_keys:
+        logger.debug(message, *args)
+    else:
+        _warned_once_keys.add(key)
+        logger.warning(message, *args)
+
+
 def log_database_configuration(logger) -> None:
     """Log the current database configuration for all database types"""
     # NOTE: Has to be imporated at runtime to avoid circular import

--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -27,6 +27,19 @@ _DEFAULT_TELEMETRY_API_KEY_TRACKING_SALT = b"cognee.telemetry.api-key-tracking.v
 _TELEMETRY_API_KEY_TRACKING_ITERATIONS = 100_000
 
 
+def as_uuid(value) -> UUID | None:
+    """Coerce ``value`` to a UUID, or return None when it is not one.
+
+    The tolerant counterpart to ``UUID(str(value))`` for identifiers that
+    arrive as UUIDs, strings, or context values that may legitimately hold
+    something else (e.g. a dataset *name* in ``current_dataset_id``).
+    """
+    try:
+        return UUID(str(value))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
 def create_secure_ssl_context() -> ssl.SSLContext:
     """
     Create a secure SSL context.


### PR DESCRIPTION
Extracted from #4209 (Simple dataset bound sessions) as standalone, zero-behavior-change groundwork so the core binding PR can be reviewed without mechanical noise.

## What
- **`DEFAULT_DATASET_NAME`** (`cognee/modules/data/constants.py`) replaces the `"main_dataset"` string literal at every code default — 26 files across api, cli, memify_pipelines, and modules. One definition instead of dozens of copies.
- **`as_uuid()`** (`cognee/shared/utils.py`) — tolerant UUID coercion for identifiers that may legitimately hold something else (e.g. a dataset *name* travelling through `current_dataset_id`).
- **`warn_once()`** (`cognee/shared/logging_utils.py`) — logs WARNING the first time a key is seen, DEBUG afterwards, for failure paths that fire on every write.

## Why now
These are prerequisites of the session-dataset-binding work (#4209). The two helpers have no callers yet in this PR — they gain them in the follow-up binding PR. Landing this first shrinks that PR's diff by ~30 files.

## Testing
- All 26 files compile and import; ruff clean.
- CLI unit tests: 128 pass (the 2 failures in `TestDeleteCommand` reproduce identically on plain `dev` — pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)