### PR TITLE
COG-5970 fix: cognee-cli config get/set/unset persistence

### DIFF
--- a/.claude/skills/cognee-cli/SKILL.md
+++ b/.claude/skills/cognee-cli/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cognee-cli
+description: Use when the user wants to drive cognee from the terminal with cognee-cli — ingesting data, building and searching the knowledge graph, managing datasets and config, memory commands, or database migrations.
+---
+
+# Use the cognee CLI
+
+`cognee-cli` ships with the package (entry point in `cognee/cli/_cognee.py`;
+each command lives in `cognee/cli/commands/`). Every command has
+`--help` with examples — prefer that over guessing flags. Needs
+`LLM_API_KEY` configured, same as the SDK.
+
+## Core flow
+
+```bash
+cognee-cli add "Your text here"              # also accepts file paths / URLs
+cognee-cli add ./docs --dataset-name my_project
+cognee-cli cognify                           # build the knowledge graph
+cognee-cli search "Your question"            # GRAPH_COMPLETION by default
+cognee-cli search "keyword" --query-type CHUNKS
+cognee-cli delete --all                      # wipe local state
+```
+
+Search types match the SDK's `SearchType` enum (`cognee/modules/search/types/SearchType.py`):
+GRAPH_COMPLETION, RAG_COMPLETION, CHUNKS, SUMMARIES, TEMPORAL, FEELING_LUCKY, …
+
+## Management
+
+```bash
+cognee-cli datasets list                     # dataset operations
+cognee-cli config get|set|list               # configuration management
+cognee-cli -ui                               # launch API server + UI (see cognee-server skill)
+cognee-cli serve --url http://localhost:8000 # connect CLI/SDK to a running instance
+```
+
+## Memory commands
+
+Higher-level agent-memory surface on top of the core flow:
+
+```bash
+cognee-cli remember "fact to keep"           # store into permanent memory
+cognee-cli recall "what do I know about X"   # retrieve
+cognee-cli memify                            # enrich the graph
+cognee-cli forget ...                        # remove memories
+cognee-cli improve                           # bridge session memory into the graph
+cognee-cli sessions get                      # retrieve session Q&A history
+cognee-cli feedback ...                      # attach feedback to results
+```
+
+`remember`/`improve` build their graphs through `cognify()`, so cognify-level
+settings (e.g. `CONTRADICTION_DETECTION=true`) apply to them too.
+
+## Relational DB migrations (Alembic)
+
+```bash
+cognee-cli upgrade        # apply migrations
+cognee-cli downgrade
+cognee-cli history
+cognee-cli current
+```
+
+Typically needed after version upgrades when the server refuses to start on
+an old schema.
+
+## Gotchas
+
+- The CLI initializes cognee lazily; the first command in a fresh environment
+  is slow (DB + model setup), later ones are fast.
+- `add` without `--dataset-name` targets the default dataset `main_dataset`;
+  cognify/search operate across your accessible datasets unless a dataset is
+  given.

--- a/.claude/skills/cognee-cli/SKILL.md
+++ b/.claude/skills/cognee-cli/SKILL.md
@@ -29,7 +29,9 @@ Others must be reached from the SDK, not CLI; e.g. call cognee.search with `quer
 
 ```bash
 cognee-cli datasets list                     # dataset operations
-cognee-cli config get|set|list               # configuration management
+cognee-cli config get [key] [--show-secrets] # view one/all settings (API keys masked by default)
+cognee-cli config set <key> <value>          # set + persist to ./.env in the cwd
+cognee-cli config unset <key>                # reset a key to its default (also persisted)
 cognee-cli -ui                               # launch API server + UI (see cognee-server skill)
 cognee-cli serve --url http://localhost:8000 # connect CLI/SDK to a running instance
 ```
@@ -71,4 +73,8 @@ an old schema.
   cognify/search operate across your accessible datasets unless a dataset is
   given.
 - `memify` requires one of the arguments -d/--dataset-name --dataset-id
-- `cognee-cli get` is not implemented presently; `cognee-cli set` is not working. The user must presently rely on .env and environment variables for config
+- `config set`/`config unset` write to the `.env` file in whatever directory
+  you run the command from (creating it if missing) — run later
+  `cognee-cli`/SDK commands from that same directory to see the change take
+  effect, same as editing `.env` by hand. `config reset` (reset *all* keys)
+  is still not implemented.

--- a/.claude/skills/cognee-cli/SKILL.md
+++ b/.claude/skills/cognee-cli/SKILL.md
@@ -21,8 +21,9 @@ cognee-cli search "keyword" --query-type CHUNKS
 cognee-cli delete --all                      # wipe local state
 ```
 
-Search types match the SDK's `SearchType` enum (`cognee/modules/search/types/SearchType.py`):
-GRAPH_COMPLETION, RAG_COMPLETION, CHUNKS, SUMMARIES, TEMPORAL, FEELING_LUCKY, …
+Search types match exactly 7 of the SDK's `SearchType` enum (`cognee/modules/search/types/SearchType.py`), those 7 being chosen in (`cognee/cli/config.py:SEARCH_TYPE_CHOICES`):
+GRAPH_COMPLETION, RAG_COMPLETION, CHUNKS, SUMMARIES, CODE, CYPHER, GRAPH_REPORT
+Others must be reached from the SDK, not CLI; e.g. call cognee.search with `query_type=SearchType.TEMPORAL`
 
 ## Management
 
@@ -69,3 +70,5 @@ an old schema.
 - `add` without `--dataset-name` targets the default dataset `main_dataset`;
   cognify/search operate across your accessible datasets unless a dataset is
   given.
+- `memify` requires one of the arguments -d/--dataset-name --dataset-id
+- `cognee-cli get` is not implemented presently; `cognee-cli set` is not working. The user must presently rely on .env and environment variables for config

--- a/.claude/skills/cognee-docker/SKILL.md
+++ b/.claude/skills/cognee-docker/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cognee-docker
+description: Use when the user wants to run cognee with Docker or docker compose — trying it out from the prebuilt image, starting the API server in a container, or bringing up the full stack (UI, MCP, Postgres, Neo4j) with compose profiles.
+---
+
+# Start cognee from the Docker image
+
+## Fastest path: prebuilt image, one file
+
+For a local try-out, do NOT clone or build anything. Follow
+`docs/minimal-docker-compose.md`: save this as `docker-compose.yml` in an
+empty directory:
+
+```yaml
+services:
+  cognee:
+    image: cognee/cognee:main
+    ports:
+      - "8000:8000"
+    environment:
+      LLM_API_KEY: ${LLM_API_KEY:?set LLM_API_KEY to your OpenAI API key}
+      # Single-user try-out: no auth, shared local databases.
+      ENABLE_BACKEND_ACCESS_CONTROL: "false"
+```
+
+Then:
+
+```bash
+export LLM_API_KEY="sk-..."   # OpenAI key (default LLM + embedding provider)
+docker compose up
+curl http://localhost:8000/health
+```
+
+Interactive API reference: http://localhost:8000/docs. First requests:
+
+```bash
+echo "Cognee turns documents into AI memory." > note.txt
+curl -X POST http://localhost:8000/api/v1/add -F "data=@note.txt" -F "datasetName=main_dataset"
+curl -X POST http://localhost:8000/api/v1/cognify -H "Content-Type: application/json" -d '{"datasets": ["main_dataset"]}'
+curl -X POST http://localhost:8000/api/v1/search -H "Content-Type: application/json" -d '{"searchType": "GRAPH_COMPLETION", "query": "What does Cognee do?", "datasets": ["main_dataset"]}'
+```
+
+Data lives inside the container by default. To persist it, set
+`DATA_ROOT_DIRECTORY=/cognee-data/data` and
+`SYSTEM_ROOT_DIRECTORY=/cognee-data/system` and mount a named volume at
+`/cognee-data` (full example in `docs/minimal-docker-compose.md`).
+
+## Full stack from the repo
+
+The repository's `docker-compose.yml` builds from source and adds opt-in
+profiles. From the repo root (needs a `.env` with at least `LLM_API_KEY`;
+copy `.env.template`):
+
+```bash
+docker compose up                                  # API server only, port 8000
+docker compose --profile ui up                     # + frontend on port 3000
+docker compose --profile mcp up                    # + MCP server on port 8001
+docker compose --profile postgres --profile neo4j up   # + databases
+```
+
+Postgres profile: pgvector/pg17, user/password/db `cognee`/`cognee`/`cognee_db`
+on 5432. Neo4j profile: `neo4j`/`pleaseletmein` on 7474/7687. When cognee runs
+in a container and the database on the host, use `DB_HOST=host.docker.internal`.
+
+## Gotchas
+
+- With `ENABLE_BACKEND_ACCESS_CONTROL` unset (defaults to true), every API
+  call requires authentication — the single-user try-out sets it to `false`.
+- The image defaults to OpenAI for both LLM and embeddings; configuring only
+  one of them leaves the other on OpenAI, so keep a valid OpenAI key or
+  configure both (see the cognee-integrations skill).

--- a/.claude/skills/cognee-install/SKILL.md
+++ b/.claude/skills/cognee-install/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: cognee-install
+description: Use when the user wants to install cognee and run their first add → cognify → search flow with the Python SDK — fresh setup, virtual env, extras selection, or a minimal working example.
+---
+
+# Install and run cognee
+
+## Install
+
+Requires Python 3.10–3.14. Prefer uv:
+
+```bash
+uv venv && source .venv/bin/activate
+uv pip install cognee            # from PyPI
+# or, working inside this repo:
+uv pip install -e .
+```
+
+Add extras only when needed — examples: `cognee[postgres]`, `cognee[neo4j]`,
+`cognee[docling]` (office/HTML document parsing, slim), `cognee[docs]`
+(unstructured), `cognee[anthropic]`, `cognee[ollama]`, `cognee[aws]`. The full
+list is in `pyproject.toml` under `[project.optional-dependencies]`.
+
+## Configure
+
+The only required setting is an LLM API key. Create `.env` in the working
+directory (or export the variable):
+
+```bash
+LLM_API_KEY="your_openai_api_key"
+```
+
+Defaults need no services: SQLite (relational), LanceDB (vector), and Ladybug
+(graph), all stored locally. OpenAI is the default LLM and embedding provider —
+if you configure a different LLM but not embeddings (or vice versa), the other
+silently stays on OpenAI. For other providers and databases use the
+cognee-integrations skill.
+
+## First run
+
+All SDK functions are async. Minimal end-to-end script:
+
+```python
+import asyncio
+import cognee
+
+async def main():
+    await cognee.add("Cognee turns documents into AI memory.")
+    await cognee.cognify()
+    results = await cognee.search("What does cognee do?")
+    print(results)
+
+asyncio.run(main())
+```
+
+`add()` accepts text, file paths, and URLs, with an optional
+`dataset_name="my_project"`; pass `datasets=["my_project"]` to `cognify()` and
+`search()` to stay inside one dataset. More runnable examples live in
+`examples/` (start with `examples/demos/simple_cognee_example.py`).
+
+## Verify / troubleshoot
+
+- `cognee-cli add "hello" && cognee-cli cognify && cognee-cli search "hello"`
+  exercises the same flow from the shell.
+- To wipe local state during experiments: `cognee-cli delete --all`.
+- Structured LLM output errors usually mean the model/provider needs an
+  explicit instructor mode: `LLM_INSTRUCTOR_MODE="json_schema_mode"`.

--- a/.claude/skills/cognee-integrations/SKILL.md
+++ b/.claude/skills/cognee-integrations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cognee-integrations
-description: Use when the user wants to connect cognee to external services — switching LLM or embedding providers (OpenAI, Azure, Gemini, Anthropic, Ollama, OpenRouter), changing databases (Postgres, PGVector, ChromaDB, Neo4j, Neptune), S3 storage, or the MCP server for IDE integration.
+description: Use when the user wants to connect cognee to external services — switching LLM or embedding providers (OpenAI, Azure, Gemini, Anthropic, Ollama, OpenRouter), changing databases (Postgres, PGVector, Neo4j, Neptune, Turso), S3 storage, or the MCP server for IDE integration.
 ---
 
 # Set up cognee integrations
@@ -17,7 +17,7 @@ Default is OpenAI (`LLM_API_KEY` is all you need). To switch, set
 `LLM_ENDPOINT` / `LLM_API_VERSION`:
 
 - **Azure OpenAI**: `LLM_PROVIDER=azure`, `LLM_MODEL=azure/gpt-4o-mini`, endpoint + api version required.
-- **Gemini** (`cognee[gemini]`): `LLM_PROVIDER=gemini`, `LLM_MODEL=gemini/gemini-2.0-flash-exp`.
+- **Gemini** (no extra needed): `LLM_PROVIDER=gemini`, `LLM_MODEL=gemini/gemini-2.0-flash-exp`.
 - **Anthropic** (`cognee[anthropic]`): `LLM_PROVIDER=anthropic`, model e.g. `claude-3-5-sonnet-20241022`.
 - **Ollama, local** (`cognee[ollama]`): `LLM_PROVIDER=ollama`, `LLM_ENDPOINT=http://localhost:11434/v1`, and set the embedding block + `HUGGINGFACE_TOKENIZER` too.
 - **Custom / OpenRouter / vLLM**: `LLM_PROVIDER=custom` with the provider's OpenAI-compatible endpoint.
@@ -33,8 +33,12 @@ either keep a valid OpenAI key or configure both.
 - **Relational** (`DB_PROVIDER`): sqlite (default) or postgres
   (`cognee[postgres]`; host/port/user/password/name via `DB_*` vars).
 - **Vector** (`VECTOR_DB_PROVIDER`): lancedb (default), pgvector
-  (`cognee[postgres]`, needs `VECTOR_DB_URL`), chromadb (`cognee[chromadb]`),
-  qdrant, weaviate, milvus.
+  (`cognee[postgres]`, needs `VECTOR_DB_URL`), neptune_analytics
+  (`cognee[neptune]`), turso (`cognee[turso]`). Anything else (ChromaDB,
+  Qdrant, Weaviate, Milvus, …) lives in community adapters — install from
+  https://github.com/topoteretes/cognee-community and register with
+  `use_vector_adapter` before use; setting `VECTOR_DB_PROVIDER` alone raises
+  "Unsupported vector database provider".
 - **Graph** (`GRAPH_DATABASE_PROVIDER`): ladybug (default), neo4j
   (`cognee[neo4j]`, bolt URL + credentials), neptune (`cognee[neptune]`),
   ladybug-remote, postgres (no raw Cypher / natural-language search).
@@ -47,7 +51,7 @@ host services with `DB_HOST=host.docker.internal`.
 
 - **S3 storage** (`cognee[aws]`): `STORAGE_BACKEND=s3` + bucket/credentials,
   and point `DATA_ROOT_DIRECTORY`/`SYSTEM_ROOT_DIRECTORY` at `s3://` paths.
-- **Session cache**: `CACHE_BACKEND` = sqlite (default) | postgres | redis | fs.
+- **Session cache**: `CACHE_BACKEND` = sqlite (default) | postgres | redis | fs | tapes.
 - **Ontologies**: `ONTOLOGY_FILE_PATH` to an OWL file, resolver/matching via
   `ONTOLOGY_RESOLVER` / `MATCHING_STRATEGY`.
 

--- a/.claude/skills/cognee-integrations/SKILL.md
+++ b/.claude/skills/cognee-integrations/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: cognee-integrations
+description: Use when the user wants to connect cognee to external services — switching LLM or embedding providers (OpenAI, Azure, Gemini, Anthropic, Ollama, OpenRouter), changing databases (Postgres, PGVector, ChromaDB, Neo4j, Neptune), S3 storage, or the MCP server for IDE integration.
+---
+
+# Set up cognee integrations
+
+All integration config is environment variables (`.env`). The authoritative,
+always-current list with commented examples is `.env.template` at the repo
+root — check it before inventing variable names. Install the matching extra
+before switching a backend (e.g. `pip install cognee[postgres]`).
+
+## LLM providers
+
+Default is OpenAI (`LLM_API_KEY` is all you need). To switch, set
+`LLM_PROVIDER`, `LLM_MODEL`, `LLM_API_KEY`, and (where relevant)
+`LLM_ENDPOINT` / `LLM_API_VERSION`:
+
+- **Azure OpenAI**: `LLM_PROVIDER=azure`, `LLM_MODEL=azure/gpt-4o-mini`, endpoint + api version required.
+- **Gemini** (`cognee[gemini]`): `LLM_PROVIDER=gemini`, `LLM_MODEL=gemini/gemini-2.0-flash-exp`.
+- **Anthropic** (`cognee[anthropic]`): `LLM_PROVIDER=anthropic`, model e.g. `claude-3-5-sonnet-20241022`.
+- **Ollama, local** (`cognee[ollama]`): `LLM_PROVIDER=ollama`, `LLM_ENDPOINT=http://localhost:11434/v1`, and set the embedding block + `HUGGINGFACE_TOKENIZER` too.
+- **Custom / OpenRouter / vLLM**: `LLM_PROVIDER=custom` with the provider's OpenAI-compatible endpoint.
+- **AWS Bedrock** (`cognee[aws]`): `LLM_PROVIDER=bedrock` + AWS credentials/region.
+
+**The classic trap**: LLM and embeddings are configured independently
+(`EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, `EMBEDDING_ENDPOINT`,
+`EMBEDDING_API_KEY`). Configuring only one leaves the other on OpenAI —
+either keep a valid OpenAI key or configure both.
+
+## Databases
+
+- **Relational** (`DB_PROVIDER`): sqlite (default) or postgres
+  (`cognee[postgres]`; host/port/user/password/name via `DB_*` vars).
+- **Vector** (`VECTOR_DB_PROVIDER`): lancedb (default), pgvector
+  (`cognee[postgres]`, needs `VECTOR_DB_URL`), chromadb (`cognee[chromadb]`),
+  qdrant, weaviate, milvus.
+- **Graph** (`GRAPH_DATABASE_PROVIDER`): ladybug (default), neo4j
+  (`cognee[neo4j]`, bolt URL + credentials), neptune (`cognee[neptune]`),
+  ladybug-remote, postgres (no raw Cypher / natural-language search).
+
+The repo `docker-compose.yml` ships ready-to-use `postgres` (pgvector) and
+`neo4j` profiles with matching default credentials. From a container, reach
+host services with `DB_HOST=host.docker.internal`.
+
+## Storage, cache, and the rest
+
+- **S3 storage** (`cognee[aws]`): `STORAGE_BACKEND=s3` + bucket/credentials,
+  and point `DATA_ROOT_DIRECTORY`/`SYSTEM_ROOT_DIRECTORY` at `s3://` paths.
+- **Session cache**: `CACHE_BACKEND` = sqlite (default) | postgres | redis | fs.
+- **Ontologies**: `ONTOLOGY_FILE_PATH` to an OWL file, resolver/matching via
+  `ONTOLOGY_RESOLVER` / `MATCHING_STRATEGY`.
+
+## MCP server (IDE integration)
+
+`docker compose --profile mcp up` starts the MCP server on port 8001
+(SSE transport), built from `cognee-mcp/`. Point Cursor / Claude Desktop /
+Claude Code at it to use cognee memory from the IDE. Configure its `DB_*` env
+to match the main service so both see the same data.
+
+## After changing providers mid-project
+
+Embeddings from different models are not comparable — after switching the
+embedding provider or model, reset local state (`cognee-cli delete --all` or
+`cognee.prune`) and re-cognify.

--- a/.claude/skills/cognee-server/SKILL.md
+++ b/.claude/skills/cognee-server/SKILL.md
@@ -49,8 +49,9 @@ auth off you must set `ENABLE_BACKEND_ACCESS_CONTROL=false`.
 ## Graph visualization without the full UI
 
 ```python
-from cognee.api.v1.visualize import start_visualization_server
-await start_visualization_server(port=8080)
+from cognee.api.v1.visualize import visualization_server
+
+shutdown = visualization_server(port=8080)  # synchronous; returns a shutdown callable
 ```
 
 ## Troubleshooting

--- a/.claude/skills/cognee-server/SKILL.md
+++ b/.claude/skills/cognee-server/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: cognee-server
+description: Use when the user wants to run the cognee API server (and optional UI) on their own machine — starting it, checking it's healthy, connecting the SDK or other clients to it, and choosing the right auth posture.
+---
+
+# Start the cognee server locally
+
+## From an installed cognee (no Docker)
+
+```bash
+cognee-cli -ui
+```
+
+launches the full local stack: FastAPI backend on **http://localhost:8000**
+and the UI on **http://localhost:3000**. Needs `LLM_API_KEY` in the
+environment or `.env`. The interactive API reference is at
+http://localhost:8000/docs, health at `/health`.
+
+For API-only serving via Docker instead, use the cognee-docker skill (the
+prebuilt `cognee/cognee:main` image or `docker compose up` from the repo).
+
+## Auth posture
+
+`ENABLE_BACKEND_ACCESS_CONTROL` decides everything:
+
+- `true` (default): multi-tenant — auth required on every API call, per
+  user+dataset database isolation.
+- `false`: single-user local mode — no auth, shared local databases. Right
+  choice for a personal dev server; never for anything exposed.
+
+`REQUIRE_AUTHENTICATION=false` is ignored while access control is on; to turn
+auth off you must set `ENABLE_BACKEND_ACCESS_CONTROL=false`.
+
+## Connecting clients to the running server
+
+- **SDK / CLI against the server** (instead of embedded local mode):
+
+  ```bash
+  cognee-cli serve --url http://localhost:8000        # local instance
+  cognee-cli serve                                    # cognee cloud (device flow)
+  cognee-cli serve --logout                           # disconnect
+  ```
+
+  In Python: `await cognee.serve(url="http://localhost:8000")`.
+
+- **HTTP**: main routes live under `/api/v1/` — `add`, `cognify`, `search`,
+  `memify`, `datasets`, `users`, `visualize` (see `cognee/api/v1/`).
+
+## Graph visualization without the full UI
+
+```python
+from cognee.api.v1.visualize import start_visualization_server
+await start_visualization_server(port=8080)
+```
+
+## Troubleshooting
+
+- Port 8000 already taken → stop the other service or remap (compose:
+  `"8080:8000"`).
+- 401/403 on every call → you're in multi-tenant mode; either authenticate or
+  set `ENABLE_BACKEND_ACCESS_CONTROL=false` and restart.
+- Search returns `[]` instead of erroring → permission-filtered result;
+  check dataset access rights for the calling user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ uv pip install -e .
 uv pip install -e ".[dev]"
 
 # Install with specific extras
-uv pip install -e ".[postgres,neo4j,docs,chromadb]"
+uv pip install -e ".[postgres,neo4j,docs]"
 
 # Set up pre-commit hooks
 pre-commit install
@@ -32,13 +32,12 @@ pre-commit install
 - **postgres** / **postgres-binary** - PostgreSQL + PGVector support (also enables the Postgres session-cache backend, `CACHE_BACKEND=postgres`)
 - **neo4j** - Neo4j graph database support
 - **neptune** - AWS Neptune support
-- **chromadb** - ChromaDB vector database
+- **turso** - Turso vector database support
 - **docs** - Document processing (unstructured library)
 - **scraping** - Web scraping (Tavily, BeautifulSoup, Playwright)
 - **langchain** - LangChain integration
 - **llama-index** - LlamaIndex integration
 - **anthropic** - Anthropic Claude models
-- **gemini** - Google Gemini models
 - **ollama** - Ollama local models
 - **mistral** - Mistral AI models
 - **groq** - Groq API support
@@ -130,7 +129,7 @@ All data flows through task-based pipelines (`cognee/modules/pipelines/`). Tasks
 #### 2. Interface-Based Database Adapters
 Multiple backends are supported through adapter interfaces:
 - **Graph**: Ladybug (default), Neo4j, Neptune, Postgres via `GraphDBInterface`
-- **Vector**: LanceDB (default), ChromaDB, PGVector via `VectorDBInterface`
+- **Vector**: LanceDB (default), PGVector, Neptune Analytics, Turso via `VectorDBInterface` (ChromaDB/Qdrant/Weaviate/Milvus via community adapters)
 - **Relational**: SQLite (default), PostgreSQL
 
 Key files:
@@ -254,11 +253,12 @@ DB_NAME=cognee_db
 ```
 
 #### Vector Databases
-Supported: lancedb (default), pgvector, chromadb, qdrant, weaviate, milvus
+Supported in-tree: lancedb (default), pgvector, neptune_analytics, turso.
+Others (ChromaDB, Qdrant, Weaviate, Milvus, …) are community adapters — install from
+https://github.com/topoteretes/cognee-community and register via `use_vector_adapter`
+before setting `VECTOR_DB_PROVIDER`, otherwise cognee raises
+"Unsupported vector database provider".
 ```bash
-# ChromaDB (requires chromadb extra)
-VECTOR_DB_PROVIDER=chromadb
-
 # PGVector (requires postgres extra)
 VECTOR_DB_PROVIDER=pgvector
 VECTOR_DB_URL=postgresql://cognee:cognee@localhost:5432/cognee_db
@@ -314,7 +314,7 @@ LLM_API_KEY="your_azure_api_key"
 LLM_API_VERSION="2024-12-01-preview"
 ```
 
-#### Google Gemini (requires gemini extra)
+#### Google Gemini (no extra required)
 ```bash
 LLM_PROVIDER="gemini"
 LLM_MODEL="gemini/gemini-2.0-flash-exp"
@@ -578,8 +578,8 @@ Launch visualization server:
 cognee-cli -ui  # Launches full stack with UI at http://localhost:3000
 
 # Via Python
-from cognee.api.v1.visualize import start_visualization_server
-await start_visualization_server(port=8080)
+from cognee.api.v1.visualize import visualization_server
+shutdown = visualization_server(port=8080)  # synchronous; returns a shutdown callable
 ```
 
 ## Debugging & Troubleshooting

--- a/cognee/api/v1/config/config.py
+++ b/cognee/api/v1/config/config.py
@@ -59,6 +59,55 @@ def _coerce_int(value, name: str, *, min_value: int | None = None) -> int:
     return result
 
 
+def _resolve_env_var_name(config_obj, key: str) -> str:
+    """Resolve the env var name pydantic-settings will read ``key`` back from.
+
+    Most fields have no alias, so the env var name is just ``key.upper()``.
+    A few (e.g. ``TranslationConfig.batch_size`` -> ``TRANSLATION_BATCH_SIZE``)
+    declare an explicit ``validation_alias``/``Field(..., env=...)`` that
+    diverges from that default — check for one before falling back.
+    """
+    fields = getattr(type(config_obj), "model_fields", None)
+    info = fields.get(key) if fields else None
+    alias = getattr(info, "validation_alias", None) if info else None
+    if isinstance(alias, str):
+        return alias
+    choices = getattr(alias, "choices", None)
+    if choices:
+        first = choices[0]
+        if isinstance(first, str):
+            return first
+    return key.upper()
+
+
+def _mask_secret(value: str) -> str:
+    """Mask a secret value for display, keeping a few edge characters as a hint."""
+    if not value:
+        return value
+    if len(value) <= 8:
+        return "*" * len(value)
+    return f"{value[:3]}...{value[-4:]}"
+
+
+def _persist_env_var(env_var_name: str, value) -> tuple[str, bool]:
+    """Write ``env_var_name=value`` into the ``.env`` file in the current
+    working directory, creating it if it doesn't exist yet.
+
+    This is the same file every config class resolves via
+    ``SettingsConfigDict(env_file=".env")``, so a value persisted here is
+    picked up by the next process (CLI invocation or script) started from
+    the same directory. Returns ``(path, created)``.
+    """
+    import dotenv
+
+    path = os.path.join(os.getcwd(), ".env")
+    created = not os.path.exists(path)
+    if created:
+        open(path, "a").close()
+    dotenv.set_key(path, env_var_name, "" if value is None else str(value))
+    return path, created
+
+
 def _coerce_for_field(config_obj, key: str, value):
     """Coerce ``value`` to the declared type of ``config_obj.<key>`` for the
     common ``bool`` and ``int`` cases. Used by ``_update_config`` so bulk
@@ -656,8 +705,123 @@ class config:
         """
         config._update_config(get_translation_config(), config_dict)
 
+    # Map configuration keys to their setter methods. Used by ``set()``.
+    _setter_mapping = {
+        "llm_provider": "set_llm_provider",
+        "llm_model": "set_llm_model",
+        "llm_api_key": "set_llm_api_key",
+        "llm_endpoint": "set_llm_endpoint",
+        "embedding_provider": "set_embedding_provider",
+        "embedding_model": "set_embedding_model",
+        "embedding_dimensions": "set_embedding_dimensions",
+        "embedding_endpoint": "set_embedding_endpoint",
+        "embedding_api_key": "set_embedding_api_key",
+        "graph_database_provider": "set_graph_database_provider",
+        "graph_database_subprocess_enabled": "set_graph_database_subprocess_enabled",
+        "kuzu_num_threads": "set_kuzu_num_threads",
+        "kuzu_buffer_pool_size": "set_kuzu_buffer_pool_size",
+        "kuzu_max_db_size": "set_kuzu_max_db_size",
+        "vector_db_provider": "set_vector_db_provider",
+        "vector_db_subprocess_enabled": "set_vector_db_subprocess_enabled",
+        "vector_db_url": "set_vector_db_url",
+        "vector_db_key": "set_vector_db_key",
+        "chunk_size": "set_chunk_size",
+        "chunk_overlap": "set_chunk_overlap",
+        "chunk_strategy": "set_chunk_strategy",
+        "chunk_engine": "set_chunk_engine",
+        "classification_model": "set_classification_model",
+        "summarization_model": "set_summarization_model",
+        "graph_model": "set_graph_model",
+        "system_root_directory": "system_root_directory",
+        "data_root_directory": "data_root_directory",
+    }
+
+    # Mirrors ``_setter_mapping`` for reads: key -> (config getter, attribute name).
+    # Used by ``get()``/``get_all()``.
+    _getter_mapping = {
+        "llm_provider": (get_llm_config, "llm_provider"),
+        "llm_model": (get_llm_config, "llm_model"),
+        "llm_api_key": (get_llm_config, "llm_api_key"),
+        "llm_endpoint": (get_llm_config, "llm_endpoint"),
+        "embedding_provider": (get_embedding_config, "embedding_provider"),
+        "embedding_model": (get_embedding_config, "embedding_model"),
+        "embedding_dimensions": (get_embedding_config, "embedding_dimensions"),
+        "embedding_endpoint": (get_embedding_config, "embedding_endpoint"),
+        "embedding_api_key": (get_embedding_config, "embedding_api_key"),
+        "graph_database_provider": (get_graph_config, "graph_database_provider"),
+        "graph_database_subprocess_enabled": (
+            get_graph_config,
+            "graph_database_subprocess_enabled",
+        ),
+        "kuzu_num_threads": (get_graph_config, "kuzu_num_threads"),
+        "kuzu_buffer_pool_size": (get_graph_config, "kuzu_buffer_pool_size"),
+        "kuzu_max_db_size": (get_graph_config, "kuzu_max_db_size"),
+        "vector_db_provider": (get_vectordb_config, "vector_db_provider"),
+        "vector_db_subprocess_enabled": (get_vectordb_config, "vector_db_subprocess_enabled"),
+        "vector_db_url": (get_vectordb_config, "vector_db_url"),
+        "vector_db_key": (get_vectordb_config, "vector_db_key"),
+        "chunk_size": (get_chunk_config, "chunk_size"),
+        "chunk_overlap": (get_chunk_config, "chunk_overlap"),
+        "chunk_strategy": (get_chunk_config, "chunk_strategy"),
+        "chunk_engine": (get_chunk_config, "chunk_engine"),
+        "classification_model": (get_cognify_config, "classification_model"),
+        "summarization_model": (get_cognify_config, "summarization_model"),
+        "graph_model": (get_graph_config, "graph_model"),
+        "system_root_directory": (get_base_config, "system_root_directory"),
+        "data_root_directory": (get_base_config, "data_root_directory"),
+    }
+
+    # Keys whose value is a secret and should be masked by ``get``/``get_all``
+    # unless the caller explicitly asks to reveal it.
+    _secret_keys = {"llm_api_key", "embedding_api_key", "vector_db_key"}
+
     @staticmethod
-    def set(key: str, value):
+    def get(key: str, reveal_secrets: bool = False):
+        """Get a configuration value by key name.
+
+        Parameters
+        ----------
+        key : str
+            The configuration key name (same names accepted by ``set()``).
+        reveal_secrets : bool
+            If False (default), secret values (API keys) are masked.
+
+        Raises
+        ------
+        InvalidConfigAttributeError
+            If the key is not a recognized configuration attribute.
+        """
+        if key in config._getter_mapping:
+            getter, attribute = config._getter_mapping[key]
+            value = getattr(getter(), attribute)
+        else:
+            embedding_config = get_embedding_config()
+            if not hasattr(embedding_config, key):
+                raise InvalidConfigAttributeError(attribute=key)
+            value = getattr(embedding_config, key)
+
+        if key in config._secret_keys and value and not reveal_secrets:
+            return _mask_secret(str(value))
+        return value
+
+    @staticmethod
+    def get_all(reveal_secrets: bool = False) -> dict:
+        """Get all known configuration values.
+
+        Parameters
+        ----------
+        reveal_secrets : bool
+            If False (default), secret values (API keys) are masked.
+        """
+        keys = list(config._getter_mapping.keys())
+        for field_name in type(get_embedding_config()).model_fields:
+            if field_name not in config._getter_mapping:
+                keys.append(field_name)
+
+        return {key: config.get(key, reveal_secrets=reveal_secrets) for key in keys}
+
+    @staticmethod
+    def set(key: str, value, persist: bool = False):
         """Set a configuration value by key name.
 
         Generic setter that maps configuration keys to their specific setter methods.
@@ -673,52 +837,44 @@ class config:
             The configuration key name.
         value : any
             The value to set.
+        persist : bool
+            If True, also write the resulting value to the ``.env`` file in the
+            current working directory, so it survives past the current process
+            (used by the CLI; SDK callers default to the previous in-memory-only
+            behavior).
+
+        Returns
+        -------
+        dict or None
+            When ``persist`` is True, ``{"path": ..., "created": ..., "env_var": ...}``
+            describing where the value was written. ``None`` otherwise.
 
         Raises
         ------
         InvalidConfigAttributeError
             If the key is not a recognized configuration attribute.
         """
-        # Map configuration keys to their setter methods
-        setter_mapping = {
-            "llm_provider": "set_llm_provider",
-            "llm_model": "set_llm_model",
-            "llm_api_key": "set_llm_api_key",
-            "llm_endpoint": "set_llm_endpoint",
-            "embedding_provider": "set_embedding_provider",
-            "embedding_model": "set_embedding_model",
-            "embedding_dimensions": "set_embedding_dimensions",
-            "embedding_endpoint": "set_embedding_endpoint",
-            "embedding_api_key": "set_embedding_api_key",
-            "graph_database_provider": "set_graph_database_provider",
-            "graph_database_subprocess_enabled": "set_graph_database_subprocess_enabled",
-            "kuzu_num_threads": "set_kuzu_num_threads",
-            "kuzu_buffer_pool_size": "set_kuzu_buffer_pool_size",
-            "kuzu_max_db_size": "set_kuzu_max_db_size",
-            "vector_db_provider": "set_vector_db_provider",
-            "vector_db_subprocess_enabled": "set_vector_db_subprocess_enabled",
-            "vector_db_url": "set_vector_db_url",
-            "vector_db_key": "set_vector_db_key",
-            "chunk_size": "set_chunk_size",
-            "chunk_overlap": "set_chunk_overlap",
-            "chunk_strategy": "set_chunk_strategy",
-            "chunk_engine": "set_chunk_engine",
-            "classification_model": "set_classification_model",
-            "summarization_model": "set_summarization_model",
-            "graph_model": "set_graph_model",
-            "system_root_directory": "system_root_directory",
-            "data_root_directory": "data_root_directory",
-        }
-
-        if key in setter_mapping:
-            method_name = setter_mapping[key]
+        if key in config._setter_mapping:
+            method_name = config._setter_mapping[key]
             method = getattr(config, method_name)
             method(value)
-            return
-
-        embedding_config = get_embedding_config()
-        if hasattr(embedding_config, key):
+        else:
+            embedding_config = get_embedding_config()
+            if not hasattr(embedding_config, key):
+                raise InvalidConfigAttributeError(attribute=key)
             config.set_embedding_config({key: value})
-            return
 
-        raise InvalidConfigAttributeError(attribute=key)
+        if not persist:
+            return None
+
+        if key in config._getter_mapping:
+            getter, attribute = config._getter_mapping[key]
+            config_obj = getter()
+        else:
+            config_obj = get_embedding_config()
+            attribute = key
+        final_value = getattr(config_obj, attribute)
+
+        env_var_name = _resolve_env_var_name(config_obj, attribute)
+        path, created = _persist_env_var(env_var_name, final_value)
+        return {"path": path, "created": created, "env_var": env_var_name}

--- a/cognee/cli/commands/config_command.py
+++ b/cognee/cli/commands/config_command.py
@@ -6,6 +6,7 @@ from cognee.cli.reference import SupportsCliCommand
 from cognee.cli import DEFAULT_DOCS_URL
 import cognee.cli.echo as fmt
 from cognee.cli.exceptions import CliCommandException, CliCommandInnerException
+from cognee.api.v1.exceptions.exceptions import InvalidConfigAttributeError
 
 
 class ConfigCommand(SupportsCliCommand):
@@ -32,6 +33,11 @@ Configuration changes will affect how cognee processes and stores data.
         get_parser = subparsers.add_parser("get", help="Get configuration value(s)")
         get_parser.add_argument(
             "key", nargs="?", help="Configuration key to retrieve (shows all if not specified)"
+        )
+        get_parser.add_argument(
+            "--show-secrets",
+            action="store_true",
+            help="Show secret values (API keys) in plaintext instead of masked",
         )
 
         # Set command
@@ -88,40 +94,27 @@ Configuration changes will affect how cognee processes and stores data.
         try:
             import cognee
 
+            reveal_secrets = getattr(args, "show_secrets", False)
+
             if args.key:
                 # Get specific key
                 try:
-                    if hasattr(cognee.config, "get"):
-                        value = cognee.config.get(args.key)
-                        fmt.echo(f"{args.key}: {value}")
-                    else:
-                        fmt.error("Configuration retrieval not implemented yet")
-                        fmt.note(
-                            "The config system currently only supports setting values, not retrieving them"
-                        )
-                        fmt.note(f"To set this value: 'cognee config set {args.key} <value>'")
+                    value = cognee.config.get(args.key, reveal_secrets=reveal_secrets)
+                    fmt.echo(f"{args.key}: {value}")
+                except InvalidConfigAttributeError:
+                    fmt.error(f"Configuration key '{args.key}' not found")
+                    fmt.note("Use 'cognee config get' to see all available keys")
                 except Exception:
                     fmt.error(f"Configuration key '{args.key}' not found or retrieval failed")
             else:
                 # Get all configuration
-                try:
-                    if hasattr(cognee.config, "get_all"):
-                        config_dict = cognee.config.get_all()
-                        if config_dict:
-                            fmt.echo("Current configuration:")
-                            for key, value in config_dict.items():
-                                fmt.echo(f"  {key}: {value}")
-                        else:
-                            fmt.echo("No configuration settings found")
-                    else:
-                        fmt.error("Configuration viewing not implemented yet")
-                        fmt.note(
-                            "The config system currently only supports setting values, not retrieving them"
-                        )
-                        fmt.note("Available commands: 'cognee config set <key> <value>'")
-                except Exception:
-                    fmt.error("Failed to retrieve configuration")
-                    fmt.note("Configuration viewing not fully implemented yet")
+                config_dict = cognee.config.get_all(reveal_secrets=reveal_secrets)
+                if config_dict:
+                    fmt.echo("Current configuration:")
+                    for key, value in config_dict.items():
+                        fmt.echo(f"  {key}: {value}")
+                else:
+                    fmt.echo("No configuration settings found")
 
         except Exception as e:
             raise CliCommandInnerException(f"Failed to get configuration: {str(e)}") from e
@@ -137,8 +130,12 @@ Configuration changes will affect how cognee processes and stores data.
                 value = args.value
 
             try:
-                cognee.config.set(args.key, value)
+                persist_info = cognee.config.set(args.key, value, persist=True)
                 fmt.success(f"Set {args.key} = {value}")
+                if persist_info:
+                    if persist_info["created"]:
+                        fmt.note(f"Created new .env file at {persist_info['path']}")
+                    fmt.note(f"Persisted {persist_info['env_var']} to {persist_info['path']}")
             except Exception:
                 fmt.error(f"Failed to set configuration key '{args.key}'")
 
@@ -155,39 +152,36 @@ Configuration changes will affect how cognee processes and stores data.
                     fmt.echo("Unset cancelled.")
                     return
 
-            # Since the config system doesn't have explicit unset methods,
-            # we need to map config keys to their reset/default behaviors
-            config_key_mappings = {
+            # Since the config system doesn't have explicit unset methods, we
+            # map config keys to their default values and reuse the generic
+            # setter (persisted, so the reset survives past this process).
+            config_key_defaults = {
                 # LLM configuration
-                "llm_provider": ("set_llm_provider", "openai"),
-                "llm_model": ("set_llm_model", "gpt-5-mini"),
-                "llm_api_key": ("set_llm_api_key", ""),
-                "llm_endpoint": ("set_llm_endpoint", ""),
+                "llm_provider": "openai",
+                "llm_model": "gpt-5-mini",
+                "llm_api_key": "",
+                "llm_endpoint": "",
                 # Database configuration
-                "graph_database_provider": ("set_graph_database_provider", "ladybug"),
-                "vector_db_provider": ("set_vector_db_provider", "lancedb"),
-                "vector_db_url": ("set_vector_db_url", ""),
-                "vector_db_key": ("set_vector_db_key", ""),
+                "graph_database_provider": "ladybug",
+                "vector_db_provider": "lancedb",
+                "vector_db_url": "",
+                "vector_db_key": "",
                 # Chunking configuration
-                "chunk_size": ("set_chunk_size", 1500),
-                "chunk_overlap": ("set_chunk_overlap", 10),
+                "chunk_size": 1500,
+                "chunk_overlap": 10,
             }
 
-            if args.key in config_key_mappings:
-                method_name, default_value = config_key_mappings[args.key]
+            if args.key in config_key_defaults:
+                default_value = config_key_defaults[args.key]
 
                 try:
-                    # Get the method and call it with the default value
-                    method = getattr(cognee.config, method_name)
-                    method(default_value)
+                    cognee.config.set(args.key, default_value, persist=True)
                     fmt.success(f"Unset {args.key} (reset to default: {default_value})")
-                except AttributeError:
-                    fmt.error(f"Configuration method '{method_name}' not found")
                 except Exception as e:
                     fmt.error(f"Failed to unset '{args.key}': {str(e)}")
             else:
                 fmt.error(f"Unknown configuration key '{args.key}'")
-                fmt.note("Available keys: " + ", ".join(config_key_mappings.keys()))
+                fmt.note("Available keys: " + ", ".join(config_key_defaults.keys()))
                 fmt.note("Use 'cognee config list' to see all available configuration options")
 
         except Exception as e:
@@ -197,7 +191,6 @@ Configuration changes will affect how cognee processes and stores data.
         try:
             import cognee
 
-            # This would need to be implemented in cognee.config
             fmt.note("Available configuration keys:")
             fmt.echo("  llm_provider, llm_model, llm_api_key, llm_endpoint")
             fmt.echo("  graph_database_provider, vector_db_provider")

--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
@@ -659,3 +659,85 @@ class TestConfigCommand:
         # This should not raise CliCommandException, just handle it gracefully
         # The config command handles unknown actions by showing an error message
         command.execute(args)
+
+
+class TestConfigGetSetPersistence:
+    """Exercise the real (unmocked) cognee.config.get/get_all/set behavior.
+
+    These reproduce the originally reported bugs directly against
+    cognee.config rather than through ConfigCommand, since that's where the
+    actual get/get_all/persistence logic lives.
+    """
+
+    def test_get_unknown_key_raises(self):
+        from cognee.api.v1.exceptions.exceptions import InvalidConfigAttributeError
+
+        with pytest.raises(InvalidConfigAttributeError):
+            cognee.config.get("not_a_real_config_key")
+
+    def test_get_reflects_in_process_set(self):
+        from cognee.infrastructure.data.chunking.config import get_chunk_config
+
+        original = get_chunk_config().chunk_size
+        try:
+            cognee.config.set("chunk_size", 777)
+            assert cognee.config.get("chunk_size") == 777
+        finally:
+            cognee.config.set_chunk_size(original)
+
+    def test_get_masks_secret_by_default(self):
+        from cognee.infrastructure.llm.config import get_llm_config
+
+        original = get_llm_config().llm_api_key
+        try:
+            cognee.config.set_llm_api_key("sk-1234567890abcdef")
+
+            masked = cognee.config.get("llm_api_key")
+            assert masked != "sk-1234567890abcdef"
+            assert masked.startswith("sk-")
+
+            full = cognee.config.get("llm_api_key", reveal_secrets=True)
+            assert full == "sk-1234567890abcdef"
+        finally:
+            cognee.config.set_llm_api_key(original)
+
+    def test_get_all_covers_documented_keys(self):
+        config_dict = cognee.config.get_all()
+
+        for key in (
+            "llm_provider",
+            "llm_model",
+            "chunk_size",
+            "chunk_overlap",
+            "vector_db_provider",
+            "graph_database_provider",
+        ):
+            assert key in config_dict
+
+    def test_set_persists_across_process_boundary(self, tmp_path):
+        """Reproduces the originally reported bug: `config set` must survive
+        past the current process, since each `cognee-cli` invocation is a
+        fresh process re-reading config from scratch."""
+        from cognee.infrastructure.data.chunking.config import get_chunk_config
+
+        original_cwd = os.getcwd()
+        original_chunk_size = get_chunk_config().chunk_size
+        try:
+            os.chdir(tmp_path)
+
+            result = cognee.config.set("chunk_size", "999", persist=True)
+
+            assert result["created"] is True
+            env_path = tmp_path / ".env"
+            assert env_path.exists()
+            # dotenv.set_key quotes values, e.g. CHUNK_SIZE='999'.
+            assert "CHUNK_SIZE=" in env_path.read_text()
+            assert "999" in env_path.read_text()
+
+            # Simulate a fresh process re-reading config from the persisted .env.
+            get_chunk_config.cache_clear()
+            assert get_chunk_config().chunk_size == 999
+        finally:
+            os.chdir(original_cwd)
+            get_chunk_config.cache_clear()
+            get_chunk_config().chunk_size = original_chunk_size

--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_commands.py
@@ -714,11 +714,17 @@ class TestConfigGetSetPersistence:
         ):
             assert key in config_dict
 
-    def test_set_persists_across_process_boundary(self, tmp_path):
+    def test_set_persists_across_process_boundary(self, tmp_path, monkeypatch):
         """Reproduces the originally reported bug: `config set` must survive
         past the current process, since each `cognee-cli` invocation is a
         fresh process re-reading config from scratch."""
         from cognee.infrastructure.data.chunking.config import get_chunk_config
+
+        # A real CHUNK_SIZE env var (e.g. leftover from `dotenv.load_dotenv`
+        # picking up a developer's own .env at cognee import time) would
+        # outrank the .env file this test writes below, since pydantic-settings
+        # prioritizes real environment variables over dotenv-file values.
+        monkeypatch.delenv("CHUNK_SIZE", raising=False)
 
         original_cwd = os.getcwd()
         original_chunk_size = get_chunk_config().chunk_size

--- a/cognee/tests/cli_tests/cli_unit_tests/test_cli_edge_cases.py
+++ b/cognee/tests/cli_tests/cli_unit_tests/test_cli_edge_cases.py
@@ -511,7 +511,7 @@ class TestConfigCommandEdgeCases:
 
         # Should handle the exception gracefully
         command.execute(args)
-        mock_cognee.config.get.assert_called_once_with("nonexistent_key")
+        mock_cognee.config.get.assert_called_once_with("nonexistent_key", reveal_secrets=False)
 
     @patch("builtins.__import__")
     def test_config_set_complex_json_value(self, mock_import):
@@ -528,7 +528,7 @@ class TestConfigCommandEdgeCases:
 
         command.execute(args)
         mock_cognee.config.set.assert_called_once_with(
-            "complex_config", complex_json_expected_value
+            "complex_config", complex_json_expected_value, persist=True
         )
 
     @patch("builtins.__import__")
@@ -544,7 +544,7 @@ class TestConfigCommandEdgeCases:
         args = argparse.Namespace(config_action="set", key="test_key", value=invalid_json)
 
         command.execute(args)
-        mock_cognee.config.set.assert_called_once_with("test_key", invalid_json)
+        mock_cognee.config.set.assert_called_once_with("test_key", invalid_json, persist=True)
 
     @patch("cognee.cli.commands.config_command.fmt.confirm")
     def test_config_unset_unknown_key(self, mock_confirm):

--- a/cognee/tests/unit/api/v1/config/test_config_set_method.py
+++ b/cognee/tests/unit/api/v1/config/test_config_set_method.py
@@ -67,7 +67,8 @@ class TestConfigSetMethod:
         params = list(sig.parameters.keys())
         assert "key" in params
         assert "value" in params
-        assert len(params) == 2
+        assert "persist" in params
+        assert len(params) == 3
 
     def test_set_can_be_called_without_instance(self):
         """Test that set can be called as a static method without instantiation."""


### PR DESCRIPTION
## Summary
Decided to investigate some of the issues uncovered while reviewing #4224 for QA checking. This PR updates the behavior of CLI - getter and setter were broken, and now they can write to/read from an .env file as expected.
- `cognee-cli config get`/`get_all` were dead code (gated on `hasattr` checks for methods that never existed on `cognee.config`) — implemented them, with API-key-style secrets masked by default (`--show-secrets` to reveal).
- `cognee-cli config set`/`unset` only ever mutated an in-process `@lru_cache`d config singleton, so changes vanished the instant the CLI process exited. Added an opt-in `persist=True` path that writes the resolved value to the `.env` file in the current working directory (the same file every config class already reads via `env_file=".env"`), so values survive across separate CLI invocations. `unset` now goes through the same persisted path instead of a dead-ended direct setter call.
- Updated the `cognee-cli` skill doc to describe the real (now-working) behavior instead of the previous "not implemented" caveat.
- Fixed a stale signature assertion in `test_config_set_method.py` that hard-coded `config.set()`'s old 2-parameter signature.

**Note: this branch stacks on `feature/cog-5964-onboarding-skills` (PR #4224, still open), so this diff includes that work until #4224 merges to `dev` first. Ready to merge with dev, has been rebased for the latest version.**

## Tests:
Setter callable
<img width="553" height="76" alt="Screenshot 2026-07-31 at 12 38 16 PM" src="https://github.com/user-attachments/assets/36437ac6-6e77-4456-be1f-1ba517d404c6" />

Setter sets correct value
<img width="551" height="73" alt="Screenshot 2026-07-31 at 12 38 25 PM" src="https://github.com/user-attachments/assets/ba7337db-a818-4f6d-96c6-00ef4b5719a6" />

Getter retrieves correct value
<img width="555" height="79" alt="Screenshot 2026-07-31 at 12 39 19 PM" src="https://github.com/user-attachments/assets/55b5f21c-b190-4f3a-8ed0-780fb6830379" />

Getter doesn't expose sensitive info unless argument checked
<img width="783" height="612" alt="Screenshot 2026-07-31 at 12 39 50 PM" src="https://github.com/user-attachments/assets/6dc4404a-d3af-4fb1-8263-8e0a50d43193" />

Sensitive info flag works
<img width="836" height="76" alt="Screenshot 2026-07-31 at 12 40 14 PM" src="https://github.com/user-attachments/assets/70e09ec1-5a35-44ae-8faa-eb4d608b5287" />

Hard reset of value works (from 999 back to 1500)
<img width="828" height="66" alt="Screenshot 2026-07-31 at 12 42 07 PM" src="https://github.com/user-attachments/assets/8d13b27f-6e33-4415-924f-fd22453beeb1" />

CLI unit tests (pytest cognee/tests/cli_tests/cli_unit_tests/ -k "Config" -v)
<img width="831" height="40" alt="Screenshot 2026-07-31 at 12 48 49 PM" src="https://github.com/user-attachments/assets/85f89f7c-9451-4a78-b661-d11a89fb6fe9" />

Config unit tests (pytest cognee/tests/unit/api/v1/config/ -v)
<img width="823" height="46" alt="Screenshot 2026-07-31 at 1 47 58 PM" src="https://github.com/user-attachments/assets/0b9d8c6c-6f08-4164-9c87-1f732476f168" />

## Type of change
[X] Bug fix

🤖 Generated partially with [Claude Code](https://claude.com/claude-code)