### PR TITLE
fix(skills): make ingest idempotent by name and add delete endpoint

### DIFF
--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from pathlib import Path
 from uuid import UUID
 from typing import Union, BinaryIO, List, Optional, Any, Literal, TYPE_CHECKING
 
@@ -875,26 +876,42 @@ async def remember(
         )
 
 
-def _materialize_inline_skill(skills_text, skill_name):
-    """Write inline SKILL.md markdown into a temporary ``<slug>/SKILL.md`` folder.
+def _skill_materialize_root(dataset_id: UUID) -> Path:
+    """Stable on-disk base for materialized skills, per dataset.
+
+    Inline text and uploaded SKILL.md files are staged here so that
+    ``skill.source_dir`` (which feeds ``_scoped_skill_id``) is deterministic
+    across re-ingests. A fresh random tempdir would mint a new skill id on every
+    call and duplicate the Skill node in the graph. The system temp dir is always
+    an allowed skill source root (see ``_configured_skill_source_roots``).
+    """
+    import hashlib
+    import tempfile
+    from pathlib import Path as _Path
+
+    key = hashlib.sha256(str(dataset_id).encode("utf-8")).hexdigest()[:16]
+    return _Path(tempfile.gettempdir()) / f"cognee-skills-{key}"
+
+
+def _materialize_inline_skill(skills_text, skill_name, materialize_root):
+    """Write inline SKILL.md markdown into a deterministic ``<slug>/SKILL.md`` folder.
 
     The no-code companion to the file-upload skills path: callers can pass the
     SKILL.md body as a string (e.g. from an n8n field) instead of uploading a
     file. The parser derives the skill name from the parent directory, so the
-    file is nested under ``<slug>/``. Returns ``(cleanup_handle, source_root)``.
+    file is nested under ``<slug>/`` under the given materialization root.
+    Returns the materialization root.
     """
-    import tempfile
     from pathlib import Path as _Path
 
     slug = _Path((skill_name or "skill").strip() or "skill").name
-    tmp = tempfile.TemporaryDirectory(prefix="cognee-skills-")
-    skill_dir = _Path(tmp.name) / slug
+    skill_dir = _Path(materialize_root) / slug
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
         skills_text if isinstance(skills_text, str) else str(skills_text),
         encoding="utf-8",
     )
-    return tmp, _Path(tmp.name)
+    return _Path(materialize_root)
 
 
 async def _remember_inner(
@@ -1026,7 +1043,6 @@ async def _remember_inner(
 
     if content_type == "skills":
         import shutil
-        import tempfile
         from pathlib import Path as _Path
 
         from cognee.context_global_variables import set_database_global_context_variables
@@ -1047,11 +1063,10 @@ async def _remember_inner(
 
         # HTTP callers (CloudClient + Swagger) deliver SKILL.md content as
         # UploadFile/file-like objects, not paths. add_skills reads paths from
-        # the local filesystem, so materialize the uploads into a tempdir
-        # under cwd (which is always allowed by _configured_skill_source_roots)
-        # before handing off. Local SDK callers continue to pass a path.
+        # the local filesystem, so materialize the uploads into a stable
+        # per-dataset temp dir before handing off. Local SDK callers continue to
+        # pass a path.
         skill_source: Any = data
-        tmp_dir: Optional[tempfile.TemporaryDirectory] = None
         normalized_uploads: list = []
         if isinstance(data, list):
             for item in data:
@@ -1060,44 +1075,56 @@ async def _remember_inner(
         elif data is not None and not isinstance(data, (str, _Path)) and hasattr(data, "read"):
             normalized_uploads.append(data)
 
-        if normalized_uploads:
-            tmp_dir = tempfile.TemporaryDirectory(prefix="cognee-skills-", dir=_Path.cwd())
-            tmp_root = _Path(tmp_dir.name)
-            for upload in normalized_uploads:
-                rel_name = (
-                    getattr(upload, "filename", None) or getattr(upload, "name", None) or "SKILL.md"
-                )
-                # Defensive: reject absolute paths / traversal in client-sent names.
-                safe_rel = _Path(rel_name).as_posix().lstrip("/")
-                if ".." in _Path(safe_rel).parts:
-                    raise ValueError(f"Invalid skill filename: {rel_name}")
-                dest = tmp_root / safe_rel
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                # UploadFile.read() is async; plain file-like .read() is sync.
-                read_result = upload.read()
-                payload = await read_result if hasattr(read_result, "__await__") else read_result
-                if isinstance(payload, str):
-                    payload = payload.encode("utf-8")
-                dest.write_bytes(payload or b"")
-            skill_files = list(tmp_root.rglob("SKILL.md"))
-            if skill_files:
-                skill_source = tmp_root
-            else:
-                raw_files = [path for path in tmp_root.rglob("*") if path.is_file()]
-                if raw_files:
-                    canonical_root = tmp_root / "__canonical_skills__"
-                    for index, raw_file in enumerate(raw_files):
-                        target_dir = canonical_root / f"skill-{index:04d}"
-                        target_dir.mkdir(parents=True, exist_ok=True)
-                        shutil.copy2(raw_file, target_dir / "SKILL.md")
-                    skill_source = canonical_root
-                else:
-                    skill_source = tmp_root
+        # A deterministic root keeps skill.source_dir (and therefore the
+        # _scoped_skill_id uuid5) stable across re-ingests, so re-ingesting an
+        # edited SKILL.md upserts the existing Skill node instead of creating a
+        # duplicate.
+        materialize_root: Optional[_Path] = None
+        if normalized_uploads or skills_text:
+            root = _skill_materialize_root(dataset.id)
+            root.mkdir(parents=True, exist_ok=True)
+            materialize_root = root
 
-        # No-code path: inline SKILL.md markdown supplied as a string instead of
-        # an uploaded file. Reuses the same add_skills pipeline as the upload path.
-        if not normalized_uploads and skills_text:
-            tmp_dir, skill_source = _materialize_inline_skill(skills_text, skill_name)
+            if normalized_uploads:
+                for upload in normalized_uploads:
+                    rel_name = (
+                        getattr(upload, "filename", None)
+                        or getattr(upload, "name", None)
+                        or "SKILL.md"
+                    )
+                    # Defensive: reject absolute paths / traversal in client-sent names.
+                    safe_rel = _Path(rel_name).as_posix().lstrip("/")
+                    if ".." in _Path(safe_rel).parts:
+                        raise ValueError(f"Invalid skill filename: {rel_name}")
+                    dest = root / safe_rel
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    # UploadFile.read() is async; plain file-like .read() is sync.
+                    read_result = upload.read()
+                    payload = (
+                        await read_result if hasattr(read_result, "__await__") else read_result
+                    )
+                    if isinstance(payload, str):
+                        payload = payload.encode("utf-8")
+                    dest.write_bytes(payload or b"")
+                skill_files = list(root.rglob("SKILL.md"))
+                if skill_files:
+                    skill_source = root
+                else:
+                    raw_files = [path for path in root.rglob("*") if path.is_file()]
+                    if raw_files:
+                        canonical_root = root / "__canonical_skills__"
+                        for index, raw_file in enumerate(raw_files):
+                            target_dir = canonical_root / f"skill-{index:04d}"
+                            target_dir.mkdir(parents=True, exist_ok=True)
+                            shutil.copy2(raw_file, target_dir / "SKILL.md")
+                        skill_source = canonical_root
+                    else:
+                        skill_source = root
+            else:
+                # No-code path: inline SKILL.md markdown supplied as a string
+                # instead of an uploaded file. Reuses the same add_skills
+                # pipeline as the upload path.
+                skill_source = _materialize_inline_skill(skills_text, skill_name, root)
 
         try:
             async with set_database_global_context_variables(dataset.id, owner_id):
@@ -1108,8 +1135,8 @@ async def _remember_inner(
                     dataset=dataset,
                 )
         finally:
-            if tmp_dir is not None:
-                tmp_dir.cleanup()
+            if materialize_root is not None:
+                shutil.rmtree(materialize_root, ignore_errors=True)
         result = RememberResult(
             status="completed",
             dataset_name=dataset.name,

--- a/cognee/api/v1/skills/list_skills.py
+++ b/cognee/api/v1/skills/list_skills.py
@@ -17,6 +17,9 @@ from cognee.modules.tools.resolve_skills import (
     _load_skill_nodes,
     find_skill_by_id,
 )
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("list_skills")
 
 
 def _skill_to_dict(skill: Skill, *, include_procedure: bool = False) -> dict[str, Any]:
@@ -85,6 +88,48 @@ async def get_skill(skill_id: str, dataset: str | UUID) -> dict[str, Any] | None
     else:
         skill = await find_skill_by_id(skill_id, dataset_id=dataset)
     return _skill_to_dict(skill, include_procedure=True) if skill else None
+
+
+async def delete_skill(skill_id: str, dataset: str | UUID) -> bool:
+    """Hard-delete a single dataset-scoped Skill node (graph node + embeddings).
+
+    Returns True when a matching active Skill was found and removed, False when
+    no such skill exists (so callers can surface a 404).
+    """
+    if not isinstance(dataset, UUID):
+        try:
+            dataset = UUID(str(dataset))
+        except (ValueError, TypeError):
+            return False
+    owner_id = await _resolve_dataset_owner(dataset)
+    if owner_id is not None:
+        async with set_database_global_context_variables(dataset, owner_id):
+            return await _delete_skill_in_context(skill_id, dataset)
+    return await _delete_skill_in_context(skill_id, dataset)
+
+
+async def _delete_skill_in_context(skill_id: str, dataset: UUID) -> bool:
+    skill = await find_skill_by_id(skill_id, dataset_id=dataset)
+    if skill is None:
+        return False
+
+    from cognee.infrastructure.databases.graph import get_graph_engine
+
+    graph_engine = await get_graph_engine()
+    # delete_nodes cascades connected edges on every graph backend (DETACH
+    # DELETE on ladybug/neo4j/neptune; ON DELETE CASCADE FKs on postgres/turso).
+    await graph_engine.delete_nodes([str(skill.id)])
+
+    # Remove the Skill's embeddings. index_fields=["search_text"] maps to the
+    # ``Skill_search_text`` collection on every vector adapter.
+    try:
+        from cognee.infrastructure.databases.vector import get_vector_engine_async
+
+        vector_engine = await get_vector_engine_async()
+        await vector_engine.delete_data_points("Skill_search_text", [str(skill.id)])
+    except Exception as exc:
+        logger.warning("Skill vector cleanup skipped (non-fatal): %s", exc)
+    return True
 
 
 async def _resolve_dataset_owner(dataset: str | UUID) -> UUID | None:

--- a/cognee/api/v1/skills/routers/get_skills_router.py
+++ b/cognee/api/v1/skills/routers/get_skills_router.py
@@ -213,4 +213,35 @@ def get_skills_router() -> APIRouter:
             logger.error("get skill failed: %s", exc, exc_info=True)
             return JSONResponse(status_code=409, content={"error": "Failed to fetch skill"})
 
+    @router.delete(
+        "/{skill_id}",
+        response_model=dict,
+        responses={
+            403: {"model": ErrorResponse},
+            404: {"model": ErrorResponse},
+            409: {"model": ErrorResponse},
+        },
+    )
+    async def delete_dataset_skill(
+        skill_id: str,
+        dataset_id: UUID = Query(..., description="Dataset UUID the skill belongs to."),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """Delete one skill (graph node + embeddings) from an authorized dataset."""
+        from cognee.api.v1.skills.list_skills import delete_skill
+
+        try:
+            dataset = await _authorized_dataset(dataset_id, user, "delete")
+            deleted = await delete_skill(skill_id, dataset.id)
+            if not deleted:
+                return JSONResponse(status_code=404, content={"error": "Skill not found"})
+            return {"status": "deleted", "id": skill_id, "dataset_id": str(dataset_id)}
+        except PermissionDeniedError:
+            return JSONResponse(
+                status_code=403, content={"error": "Not authorized for this dataset"}
+            )
+        except Exception as exc:
+            logger.error("delete skill failed: %s", exc, exc_info=True)
+            return JSONResponse(status_code=409, content={"error": "Failed to delete skill"})
+
     return router

--- a/cognee/tests/unit/api/test_skills_router.py
+++ b/cognee/tests/unit/api/test_skills_router.py
@@ -1,0 +1,94 @@
+"""Tests for the dataset-scoped skills router (DELETE /api/v1/skills/{skill_id})."""
+
+from types import SimpleNamespace
+from importlib import import_module
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+router_module = import_module("cognee.api.v1.skills.routers.get_skills_router")
+list_module = import_module("cognee.api.v1.skills.list_skills")
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router_module.get_skills_router(), prefix="/api/v1/skills")
+    return app
+
+
+def _delete_client(monkeypatch, *, authorized=True, delete_result=True) -> TestClient:
+    app = _app()
+    user_id = uuid4()
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=user_id,
+        tenant_id=None,
+    )
+
+    async def fake_authorized_datasets(dataset_ids, _permission, _user):
+        if not authorized:
+            return []
+        return [SimpleNamespace(id=dataset_ids[0])]
+
+    monkeypatch.setattr(router_module, "send_telemetry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        router_module,
+        "get_authorized_existing_datasets",
+        fake_authorized_datasets,
+    )
+
+    async def fake_delete_skill(skill_id, dataset):
+        return delete_result
+
+    monkeypatch.setattr(list_module, "delete_skill", fake_delete_skill)
+    return TestClient(app)
+
+
+def test_delete_skill_success(monkeypatch):
+    client = _delete_client(monkeypatch)
+    skill_id = str(uuid4())
+    dataset_id = str(uuid4())
+
+    response = client.delete(
+        f"/api/v1/skills/{skill_id}",
+        params={"dataset_id": dataset_id},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "deleted",
+        "id": skill_id,
+        "dataset_id": dataset_id,
+    }
+
+
+def test_delete_skill_forbidden(monkeypatch):
+    client = _delete_client(monkeypatch, authorized=False)
+
+    response = client.delete(
+        f"/api/v1/skills/{uuid4()}",
+        params={"dataset_id": str(uuid4())},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"error": "Not authorized for this dataset"}
+
+
+def test_delete_skill_not_found(monkeypatch):
+    client = _delete_client(monkeypatch, delete_result=False)
+
+    response = client.delete(
+        f"/api/v1/skills/{uuid4()}",
+        params={"dataset_id": str(uuid4())},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "Skill not found"}
+
+
+def test_delete_skill_requires_dataset_query_param(monkeypatch):
+    client = _delete_client(monkeypatch)
+
+    response = client.delete(f"/api/v1/skills/{uuid4()}")
+
+    assert response.status_code == 422

--- a/cognee/tests/unit/modules/tools/test_skill_ingest.py
+++ b/cognee/tests/unit/modules/tools/test_skill_ingest.py
@@ -535,26 +535,81 @@ class TestSkillContract(unittest.TestCase):
     def test_materialize_inline_skill_writes_slug_dir(self):
         from cognee.api.v1.remember.remember import _materialize_inline_skill
 
-        tmp_dir, source = _materialize_inline_skill(_SKILL, "code-review")
+        root = Path(tempfile.mkdtemp())
         try:
+            source = _materialize_inline_skill(_SKILL, "code-review", root)
             md = source / "code-review" / "SKILL.md"
             assert md.is_file()
             assert "Review code changes" in md.read_text()
         finally:
-            tmp_dir.cleanup()
+            import shutil
+
+            shutil.rmtree(root)
 
     def test_materialize_inline_skill_defaults_and_sanitizes_slug(self):
         from cognee.api.v1.remember.remember import _materialize_inline_skill
 
-        tmp_dir, source = _materialize_inline_skill("# x", None)
+        root = Path(tempfile.mkdtemp())
         try:
+            source = _materialize_inline_skill("# x", None, root)
             assert (source / "skill" / "SKILL.md").is_file()
-        finally:
-            tmp_dir.cleanup()
 
-        # A traversal-y name collapses to a single safe path segment.
-        tmp_dir2, source2 = _materialize_inline_skill("# x", "../../etc/evil")
-        try:
+            # A traversal-y name collapses to a single safe path segment.
+            source2 = _materialize_inline_skill("# x", "../../etc/evil", root)
             assert (source2 / "evil" / "SKILL.md").is_file()
         finally:
-            tmp_dir2.cleanup()
+            import shutil
+
+            shutil.rmtree(root)
+
+    def test_reingest_inline_skill_keeps_same_node_id(self):
+        """Re-ingesting the same skill_name into the same dataset reuses the id.
+
+        Regression for the duplicate-skill bug: inline materialization used a
+        fresh random tempdir per call, so skill.source_dir (which feeds
+        _scoped_skill_id) changed every POST /api/v1/skills and minted a new
+        Skill node. The deterministic materialize root keeps the id stable, so
+        the storage layer's upsert replaces the existing node instead.
+        """
+        from cognee.api.v1.remember.remember import (
+            _materialize_inline_skill,
+            _skill_materialize_root,
+        )
+        from cognee.modules.tools.ingest_skills import add_skills
+
+        dataset = SimpleNamespace(id=uuid4(), name="project")
+        user = SimpleNamespace(id=uuid4(), tenant_id=uuid4())
+        root = _skill_materialize_root(dataset.id)
+        edited = _SKILL.replace(
+            "Read the diff, identify concrete bugs, and cite file paths.",
+            "Read the diff, identify concrete bugs, cite file paths, and add tests.",
+        )
+
+        try:
+            with patch(
+                "cognee.modules.tools.ingest_skills.add_data_points",
+                new_callable=AsyncMock,
+            ):
+                first_source = _materialize_inline_skill(_SKILL, "code-review", root)
+                first = _run(add_skills(first_source, user=user, dataset=dataset))[0]
+
+                second_source = _materialize_inline_skill(edited, "code-review", root)
+                second = _run(add_skills(second_source, user=user, dataset=dataset))[0]
+
+            assert first.id == second.id
+            assert second.procedure != first.procedure  # edited body picked up
+
+            # Same name in a different dataset gets a distinct id.
+            other_dataset = SimpleNamespace(id=uuid4(), name="other")
+            with patch(
+                "cognee.modules.tools.ingest_skills.add_data_points",
+                new_callable=AsyncMock,
+            ):
+                other_source = _materialize_inline_skill(_SKILL, "code-review", root)
+                other = _run(add_skills(other_source, user=user, dataset=other_dataset))[0]
+
+            assert other.id != first.id
+        finally:
+            import shutil
+
+            shutil.rmtree(root, ignore_errors=True)


### PR DESCRIPTION
## Description

Re-ingesting a skill through `POST /api/v1/skills` was creating a duplicate
Skill node instead of updating the existing one. Traced it down: skill IDs
are supposed to be deterministic (`_scoped_skill_id` hashes
`dataset_id + source_dir + skill.name`), and `add_data_points` already
upserts by node id — so the storage layer was never the problem. The actual
bug was that both the inline-text and file-upload ingestion paths in
`remember.py` materialized the skill into a fresh `TemporaryDirectory()` on
every single call. That randomized `source_dir` each time, which meant the
"deterministic" id was actually different on every POST for the same skill —
hence the duplicates.

Fix: stage materialized skills under a deterministic per-dataset root
(`cognee-skills-<sha256(dataset_id)[:16]>`) instead of a random tempdir, with
the skill's slug as a subfolder under it. That keeps `source_dir` stable per
`(dataset_id, skill_name)` so re-ingesting the same skill now upserts in
place — same node, refreshed content/embedding — instead of minting a new
one. Both the inline and upload paths had the bug, so both are fixed.

Also added the missing `DELETE /api/v1/skills/{skill_id}` endpoint (the
issue points out there was no way to remove a skill at all). It's
dataset-scoped, requires `delete` permission (matching how the other
dataset/data deletion endpoints are gated — the ingest path only needs
`write`, but deletion is a more destructive action and deserves its own
permission tier). It hard-deletes the graph node plus its
`Skill_search_text` vector embedding rather than soft-deleting via
`is_active=False` — soft delete would leave a resident node that a
re-ingest (now that ids are stable) would silently resurrect, which seemed
like a worse footgun than an irreversible delete.

Left untouched: the skills-router pagination bug (#4279) and the generic
409-on-ingest-failure issue (#4281) — same file, different bugs, out of
scope here.

## Acceptance Criteria

- Re-ingesting a skill with the same `skill_name` into the same dataset
  updates the existing Skill node (same id) instead of creating a duplicate.
- Re-ingesting the same `skill_name` into a *different* dataset produces a
  distinct id (no cross-dataset collision).
- `DELETE /api/v1/skills/{skill_id}` removes the graph node and its
  embedding; returns 403 for a dataset the caller doesn't have `delete`
  access to, 404 for an unknown skill id.
- No behavior change to path-based (folder) skill ingestion.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<!-- attach local test run screenshot -->

## Pre-submission Checklist

- [x] I have tested my changes thoroughly before submitting this PR
- [x] This PR contains minimal changes necessary to address the issue/feature
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.