### PR TITLE
feat: Add opt-in per-operation activity log (COG-6037)

### DIFF
--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -10,10 +10,12 @@ from cognee.modules.observability import (
     COGNEE_FORGET_TARGET,
     COGNEE_RESULT_COUNT,
 )
+from cognee.modules.session_lifecycle.usage_tracking import log_activity
 
 logger = get_logger("forget")
 
 
+@log_activity("forget")
 async def forget(
     *,
     data_id: Optional[UUID] = None,

--- a/cognee/api/v1/remember/remember.py
+++ b/cognee/api/v1/remember/remember.py
@@ -171,6 +171,20 @@ async def _add_to_session(session_id: str, data, user):
         context="",
         answer=text,
     )
+
+    # Activity log: record the session write (no LLM cost). Inert without a sink.
+    from cognee.modules.session_lifecycle.usage_tracking import begin_operation, end_operation
+
+    await end_operation(
+        begin_operation(
+            "remember",
+            user_id=getattr(user, "id", None),
+            tenant_id=getattr(user, "tenant_id", None),
+            session_id=session_id,
+            origin="session",
+        )
+    )
+
     logger.info("remember: added entry to session '%s'", session_id)
 
 

--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -34,17 +34,26 @@ async def _record_session_usage_after(
     """
     result = await coro
     try:
-        from cognee.modules.session_lifecycle.usage_tracking import record_llm_call
+        from cognee.modules.session_lifecycle.usage_tracking import (
+            consume_last_usage,
+            record_llm_call,
+        )
 
         if isinstance(result, BaseModel):
             output_repr = result.model_dump_json()
         else:
             output_repr = str(result)
         model = get_llm_context_config().llm_model
+        # Prefer exact counts an adapter reported via report_llm_usage; fall
+        # back to the char estimate inside record_llm_call when unavailable.
+        usage = consume_last_usage()
+        tokens_in_override, tokens_out_override = usage if usage else (None, None)
         await record_llm_call(
             input_text=text_input,
             output_text=output_repr,
             model=model,
+            tokens_in_override=tokens_in_override,
+            tokens_out_override=tokens_out_override,
         )
     except Exception:
         pass

--- a/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
+++ b/cognee/infrastructure/llm/structured_output_framework/litellm_native/native_adapter.py
@@ -51,6 +51,25 @@ observe = get_observe()
 _MAX_VALIDATION_RETRIES: int = 3
 
 
+def _report_usage(response: Any) -> None:
+    """Report a litellm response's token usage to the usage tracker (best-effort).
+
+    Feeds exact counts to the gateway's usage hook so the session/activity
+    trackers record real tokens instead of the char estimate. Never raises.
+    """
+    try:
+        from cognee.modules.session_lifecycle.usage_tracking import report_llm_usage
+
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            report_llm_usage(
+                getattr(usage, "prompt_tokens", None),
+                getattr(usage, "completion_tokens", None),
+            )
+    except Exception:
+        pass
+
+
 def _supports_native_schema(model_name: str) -> bool:
     """Whether *model_name* can enforce a Pydantic schema via ``response_format``.
 
@@ -156,6 +175,7 @@ class NativeLiteLLMAdapter:
                 api_version=api_version,
                 **merged_kwargs,
             )
+        _report_usage(response)
         return response.choices[0].message.content or ""
 
     async def _acreate_schema_native(
@@ -184,6 +204,7 @@ class NativeLiteLLMAdapter:
                 api_version=api_version,
                 **merged_kwargs,
             )
+        _report_usage(response)
         raw_content = response.choices[0].message.content or "{}"
         return response_model.model_validate_json(raw_content)
 
@@ -237,6 +258,7 @@ class NativeLiteLLMAdapter:
                     **merged_kwargs,
                 )
 
+            _report_usage(response)
             raw_content = response.choices[0].message.content or "{}"
             try:
                 return response_model.model_validate_json(raw_content)

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -81,6 +81,23 @@ async def run_tasks(
     pipeline_run = await log_pipeline_run_start(pipeline_id, pipeline_name, dataset.id, data)
     pipeline_run_id = pipeline_run.pipeline_run_id
 
+    from cognee.modules.session_lifecycle.usage_tracking import (
+        begin_operation,
+        end_operation,
+        mark_active_operation_errored,
+    )
+
+    # Open an activity-log scope for this run (inert unless a sink is registered).
+    # Set before the per-item tasks are created so their LLM usage accrues here.
+    activity_token = begin_operation(
+        pipeline_name,
+        user_id=user.id,
+        tenant_id=getattr(user, "tenant_id", None),
+        dataset_id=dataset.id,
+        dataset_name=dataset.name,
+        pipeline_run_id=pipeline_run_id,
+    )
+
     yield PipelineRunStarted(
         pipeline_run_id=pipeline_run_id,
         dataset_id=dataset.id,
@@ -177,6 +194,8 @@ async def run_tasks(
                 pipeline_run_id, pipeline_id, pipeline_name, dataset.id, data
             )
 
+            await end_operation(activity_token)
+
             yield PipelineRunCompleted(
                 pipeline_run_id=pipeline_run_id,
                 dataset_id=dataset.id,
@@ -203,6 +222,9 @@ async def run_tasks(
             await log_pipeline_run_error(
                 pipeline_run_id, pipeline_id, pipeline_name, dataset.id, data, error
             )
+
+            mark_active_operation_errored(repr(error))
+            await end_operation(activity_token)
 
             yield PipelineRunErrored(
                 pipeline_run_id=pipeline_run_id,

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -77,6 +77,20 @@ async def search(
         Searching by dataset is only available in ENABLE_BACKEND_ACCESS_CONTROL mode
     """
     query = await log_query(query_text, query_type.value, user.id)
+
+    # Activity log: scope the search so its LLM usage accrues to one event
+    # (inert unless a sink is registered). Single return below closes it.
+    from cognee.modules.session_lifecycle.usage_tracking import begin_operation, end_operation
+
+    _activity_token = begin_operation(
+        "search",
+        user_id=user.id,
+        tenant_id=getattr(user, "tenant_id", None),
+        dataset_id=dataset_ids[0] if dataset_ids and len(dataset_ids) == 1 else None,
+        session_id=session_id,
+        origin="session" if session_id else "api",
+    )
+
     send_telemetry(
         "cognee.search EXECUTION STARTED",
         user.id,
@@ -146,6 +160,8 @@ async def search(
         json.dumps(completions) if completions else "[]",
         user.id,
     )
+
+    await end_operation(_activity_token)
 
     return _backwards_compatible_search_results(search_results, verbose)
 

--- a/cognee/modules/session_lifecycle/usage_tracking.py
+++ b/cognee/modules/session_lifecycle/usage_tracking.py
@@ -132,6 +132,45 @@ async def track_operation_usage(operation: str, **context):
                 logger.debug("activity sink failed (%s)", exc)
 
 
+# Exact per-call token usage, reported by an adapter right after a completion
+# so the gateway's usage hook can use real counts instead of the char estimate.
+# One-shot: consumed (and cleared) by the very next record_llm_call.
+_last_call_usage: ContextVar[Optional[tuple[int, int]]] = ContextVar(
+    "cognee_last_llm_usage", default=None
+)
+
+
+def report_llm_usage(prompt_tokens: Optional[int], completion_tokens: Optional[int]) -> None:
+    """Report exact token counts for the just-completed LLM call.
+
+    Adapters call this immediately after a completion (from ``response.usage``)
+    so the gateway records real tokens rather than the char estimate. Inert if
+    either count is missing (falls back to the estimate).
+    """
+    if prompt_tokens is None or completion_tokens is None:
+        return
+    # Accumulate within a public call: one acreate_structured_output may make
+    # several internal completions (e.g. the JSON-fallback validation retries),
+    # and the gateway consumes the total exactly once. Cleared by consume.
+    prev = _last_call_usage.get()
+    if prev is None:
+        _last_call_usage.set((int(prompt_tokens), int(completion_tokens)))
+    else:
+        _last_call_usage.set((prev[0] + int(prompt_tokens), prev[1] + int(completion_tokens)))
+
+
+def consume_last_usage() -> Optional[tuple[int, int]]:
+    """Return and clear the last reported ``(prompt, completion)`` token counts.
+
+    Cleared on read so a later call that reports nothing can't reuse stale
+    counts.
+    """
+    usage = _last_call_usage.get()
+    if usage is not None:
+        _last_call_usage.set(None)
+    return usage
+
+
 def _estimate_tokens(text: str) -> int:
     """Very rough char-based estimate. Good enough for dashboard aggregates."""
     if not text:

--- a/cognee/modules/session_lifecycle/usage_tracking.py
+++ b/cognee/modules/session_lifecycle/usage_tracking.py
@@ -175,6 +175,45 @@ async def end_operation(token) -> None:
             logger.debug("activity sink failed (%s)", exc)
 
 
+def log_activity(operation: str):
+    """Decorator: wrap a **keyword-only** async entry point in an activity scope.
+
+    Reads ``user``/``dataset``/``dataset_id``/``session_id`` from kwargs
+    (best-effort), opens an operation scope so any LLM usage inside accrues, and
+    emits the finished event on return or error. Inert when no sink is
+    registered. For functions with positional args, use ``begin_operation`` /
+    ``end_operation`` directly instead (kwargs extraction won't see positionals).
+    """
+    import functools
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            user = kwargs.get("user")
+            dataset = kwargs.get("dataset")
+            session_id = kwargs.get("session_id")
+            token = begin_operation(
+                operation,
+                user_id=getattr(user, "id", None),
+                tenant_id=getattr(user, "tenant_id", None),
+                dataset_id=kwargs.get("dataset_id"),
+                dataset_name=dataset if isinstance(dataset, str) else None,
+                session_id=session_id,
+                origin="session" if session_id else "api",
+            )
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as exc:
+                mark_active_operation_errored(repr(exc))
+                raise
+            finally:
+                await end_operation(token)
+
+        return wrapper
+
+    return decorator
+
+
 # Exact per-call token usage, reported by an adapter right after a completion
 # so the gateway's usage hook can use real counts instead of the char estimate.
 # One-shot: consumed (and cleared) by the very next record_llm_call.

--- a/cognee/modules/session_lifecycle/usage_tracking.py
+++ b/cognee/modules/session_lifecycle/usage_tracking.py
@@ -132,6 +132,49 @@ async def track_operation_usage(operation: str, **context):
                 logger.debug("activity sink failed (%s)", exc)
 
 
+def begin_operation(operation: str, **context) -> Optional[object]:
+    """Open an operation scope without a context manager (for async generators
+    like ``run_tasks`` where wrapping in ``async with`` is awkward).
+
+    Returns a reset token to hand to ``end_operation``, or ``None`` when no sink
+    is registered (inert — the caller's ``end_operation``/``mark_*`` become
+    no-ops).
+    """
+    if _activity_sink is None:
+        return None
+    event = ActivityEvent(operation=operation, **context)
+    return _active_operation.set(event)
+
+
+def mark_active_operation_errored(error: str) -> None:
+    """Mark the active operation (if any) errored, before ``end_operation``."""
+    event = _active_operation.get()
+    if event is not None:
+        event.status = "errored"
+        event.error = error
+
+
+async def end_operation(token) -> None:
+    """Close a scope opened by ``begin_operation``: emit the event, then reset.
+
+    ``token is None`` (no sink) is a no-op. Sink failures are swallowed so
+    activity logging can never break the operation it observes.
+    """
+    if token is None:
+        return
+    event = _active_operation.get()
+    _active_operation.reset(token)
+    if event is None:
+        return
+    event.ended_at = datetime.now(timezone.utc)
+    sink = _activity_sink
+    if sink is not None:
+        try:
+            await sink(event)
+        except Exception as exc:
+            logger.debug("activity sink failed (%s)", exc)
+
+
 # Exact per-call token usage, reported by an adapter right after a completion
 # so the gateway's usage hook can use real counts instead of the char estimate.
 # One-shot: consumed (and cleared) by the very next record_llm_call.

--- a/cognee/modules/session_lifecycle/usage_tracking.py
+++ b/cognee/modules/session_lifecycle/usage_tracking.py
@@ -15,7 +15,9 @@ upstream.
 
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
-from typing import Optional
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Optional
 from uuid import UUID as UUIDType
 
 from cognee.shared.logging_utils import get_logger
@@ -40,6 +42,94 @@ async def track_session_usage(session_id: str, user_id: UUIDType):
         yield
     finally:
         _active_session.reset(token)
+
+
+# ── Activity log (opt-in; inert unless a sink is registered) ─────────────────
+#
+# A parallel, operation-scoped accumulator alongside the session tracker above,
+# for consumers (e.g. the Cognee Cloud control plane) that want a per-operation
+# activity log — one record per add/cognify/improve/remember/forget/recall/
+# search run, carrying who/what/when + token usage.
+#
+# Inert by default: with no sink registered, ``track_operation_usage`` is a
+# passthrough and ``record_llm_call`` skips the operation branch, so open-source
+# users incur zero overhead and nothing is stored anywhere. A deployment opts in
+# by calling ``register_activity_sink`` once at startup; the sink receives each
+# finished ``ActivityEvent`` and is responsible for persisting it.
+
+
+@dataclass
+class ActivityEvent:
+    """One completed user-facing operation, handed to the registered sink."""
+
+    operation: str
+    user_id: Optional[UUIDType] = None
+    tenant_id: Optional[UUIDType] = None
+    dataset_id: Optional[UUIDType] = None
+    dataset_name: Optional[str] = None
+    session_id: Optional[str] = None
+    origin: str = "api"
+    pipeline_run_id: Optional[UUIDType] = None
+    tokens_in: int = 0
+    tokens_out: int = 0
+    status: str = "completed"
+    error: Optional[str] = None
+    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    ended_at: Optional[datetime] = None
+
+
+ActivitySink = Callable[[ActivityEvent], Awaitable[None]]
+
+_activity_sink: Optional[ActivitySink] = None
+
+_active_operation: ContextVar[Optional[ActivityEvent]] = ContextVar(
+    "cognee_activity_operation", default=None
+)
+
+
+def register_activity_sink(sink: Optional[ActivitySink]) -> None:
+    """Install (or clear, with ``None``) the process-wide activity-log sink.
+
+    Only one sink is supported; the last registration wins. Deployments that
+    persist an activity log call this once at startup; open-source leaves it
+    unset, keeping the whole mechanism inert.
+    """
+    global _activity_sink
+    _activity_sink = sink
+
+
+@asynccontextmanager
+async def track_operation_usage(operation: str, **context):
+    """Accumulate token usage for one user-facing operation, then emit it to the
+    registered activity sink on exit. No-op when no sink is registered.
+
+    Any LLM call made inside this scope adds its tokens to the event via
+    ``record_llm_call``. The finished event (with status/error/duration) is
+    handed to the sink; sink failures are swallowed so activity logging can
+    never break the operation it observes.
+    """
+    if _activity_sink is None:
+        # Open-source default: nothing consumes activity — add zero overhead.
+        yield
+        return
+
+    event = ActivityEvent(operation=operation, **context)
+    token = _active_operation.set(event)
+    try:
+        yield
+    except Exception as exc:
+        event.status = "errored"
+        event.error = str(exc)
+        raise
+    finally:
+        _active_operation.reset(token)
+        event.ended_at = datetime.now(timezone.utc)
+        sink = _activity_sink
+        if sink is not None:
+            try:
+                await sink(event)
+            except Exception as exc:
+                logger.debug("activity sink failed (%s)", exc)
 
 
 def _estimate_tokens(text: str) -> int:
@@ -141,17 +231,25 @@ async def record_llm_call(
     caller has exact counts from ``response.usage``; otherwise the
     char-based estimate is used.
     """
-    target = _active_session.get()
-    if target is None:
-        return
-    session_id, user_id = target
-
     tokens_in = (
         tokens_in_override if tokens_in_override is not None else _estimate_tokens(input_text)
     )
     tokens_out = (
         tokens_out_override if tokens_out_override is not None else _estimate_tokens(output_text)
     )
+
+    # Activity log (operation scope): accumulate independently of any session,
+    # so an operation's per-run tokens are captured even when no session is active.
+    operation = _active_operation.get()
+    if operation is not None:
+        operation.tokens_in += tokens_in
+        operation.tokens_out += tokens_out
+
+    # Session usage accumulation (unchanged): only when a session is active.
+    target = _active_session.get()
+    if target is None:
+        return
+    session_id, user_id = target
     cost = _estimate_cost_usd(model, tokens_in, tokens_out)
 
     try:


### PR DESCRIPTION
## What
Adds an **opt-in, per-operation activity log**: one event per pipeline run (`add`/`cognify`/`improve`/`remember`) carrying the acting **user + tenant**, **dataset** (id + name), **pipeline run id**, **token usage**, **status**, and **duration**. Powers a per-operation activity view for consumers like Cognee Cloud.

**Inert for open-source:** nothing is stored and there is zero overhead unless a consumer registers a sink via `register_activity_sink`. No table is added to core — persistence is the sink's responsibility.

## How (3 commits)
1. **Opt-in activity sink** (`session_lifecycle/usage_tracking.py`) — `ActivityEvent`, `register_activity_sink`, `track_operation_usage` / `begin_operation`+`end_operation` scope primitives. `record_llm_call` feeds the per-operation token accumulator independently of the session tracker.
2. **Real `response.usage`** — adapters call `report_llm_usage(prompt, completion)`; the gateway's usage hook consumes the total (accumulated across a call's internal retries) and passes it as the `record_llm_call` token overrides. **litellm-native** fully wired; falls back to the char estimate when unreported.
3. **Emit from `run_tasks`** — open an activity scope around each pipeline run (before the per-item tasks are created, so their LLM usage accrues), emitting the finished event on completion/error. No restructuring of the async generator.

## Follow-ups (noted, not in this PR)
- **instructor** (`generic_llm_api` is the OpenAI-compatible/`custom` path) + **BAML** real-usage capture (`create_with_completion` / a `Collector`) — until then those frameworks use the char estimate.
- Instrument non-pipeline ops: `forget`, `recall`/`search`, session-`remember`.

## Notes
- Cost is intentionally left to the consumer (tokens × rate); this PR stores tokens.
- Verified `py_compile` + `ruff format`; relies on CI for the full suite (local env can't build `ladybug`).

Part of COG-6037.