### PR TITLE
fix(migration): read the session_id alias on Zep entities and facts

### DIFF
--- a/cognee/modules/migration/sources/zep.py
+++ b/cognee/modules/migration/sources/zep.py
@@ -109,7 +109,7 @@ class ZepSource(MemorySource):
                 description=node.get("summary") or node.get("description"),
                 attributes=node.get("attributes") or {},
                 created_at=parse_timestamp(node.get("created_at")),
-                scope=COGXScope(session_id=node.get("group_id")),
+                scope=COGXScope(session_id=node.get("group_id") or node.get("session_id")),
             )
 
         for index, edge in enumerate(_first_list(data, "facts", "edges", "entity_edges")):
@@ -128,7 +128,7 @@ class ZepSource(MemorySource):
                 invalid_at=parse_timestamp(edge.get("invalid_at") or edge.get("expired_at")),
                 created_at=parse_timestamp(edge.get("created_at")),
                 provenance=[str(episode) for episode in edge.get("episodes") or []],
-                scope=COGXScope(session_id=edge.get("group_id")),
+                scope=COGXScope(session_id=edge.get("group_id") or edge.get("session_id")),
             )
 
 

--- a/cognee/tests/unit/migration/test_migration.py
+++ b/cognee/tests/unit/migration/test_migration.py
@@ -364,6 +364,50 @@ class TestZepSource:
         records = collect(GraphitiSource(export))
         assert [record.kind for record in records] == ["episode", "entity", "entity", "fact"]
 
+    def test_session_id_alias_is_read_on_every_record_kind(self):
+        # The episode branch already treats "session_id" as an alias for
+        # "group_id", so an export that spells it that way must keep its scope
+        # on entities and facts too, not just on episodes.
+        export = {
+            "episodes": [
+                {"uuid": "ep1", "content": "Alice moved to Berlin", "session_id": "tenant-a"}
+            ],
+            "nodes": [
+                {"uuid": "n1", "name": "Alice", "session_id": "tenant-a"},
+                {"uuid": "n2", "name": "Berlin", "session_id": "tenant-a"},
+            ],
+            "edges": [
+                {
+                    "uuid": "f1",
+                    "source_node_uuid": "n1",
+                    "target_node_uuid": "n2",
+                    "session_id": "tenant-a",
+                }
+            ],
+        }
+        records = collect(GraphitiSource(export))
+
+        assert [record.scope.session_id for record in records] == ["tenant-a"] * 4
+
+    def test_group_id_still_wins_over_session_id(self):
+        # Both spellings present: "group_id" is the canonical one and keeps
+        # precedence, matching how the episode branch resolves the pair.
+        export = {
+            "nodes": [{"uuid": "n1", "name": "Alice", "group_id": "g1", "session_id": "s1"}],
+            "edges": [
+                {
+                    "uuid": "f1",
+                    "source_node_uuid": "n1",
+                    "target_node_uuid": "n2",
+                    "group_id": "g1",
+                    "session_id": "s1",
+                }
+            ],
+        }
+        records = collect(GraphitiSource(export))
+
+        assert [record.scope.session_id for record in records] == ["g1", "g1"]
+
     def test_default_mode_is_hybrid(self):
         assert GraphitiSource({"nodes": []}).mode == "hybrid"
 


### PR DESCRIPTION
## Description

I was reading `zep.py` top to bottom after my last two migration fixes and noticed the three record branches disagree about how to read scope out of the same export.

Episodes resolve it as `group_id` or `session_id`:

```python
scope=COGXScope(
    user_id=episode.get("user_id"),
    session_id=episode.get("group_id") or episode.get("session_id"),
),
```

Entities and facts read only `group_id`:

```python
scope=COGXScope(session_id=node.get("group_id")),   # entities
scope=COGXScope(session_id=edge.get("group_id")),   # facts
```

So one export, one file, two different answers about the same key. If a Zep or Graphiti export spells the scope key `session_id`, the episodes keep their scope and **every entity and every fact silently loses it**. Nothing raises — the records still import, they just arrive with `scope.session_id = None`. For a multi-tenant graph that means tenant attribution is intact on the episodes and gone from every node and edge, which is worse than a hard failure because the import looks like it worked.

The reason I'm treating this as a bug rather than a deliberate difference is that the file already tells you which behaviour is intended. The module docstring says the reader is "tolerant of key-name variants", and the episode branch is where that tolerance is actually implemented. It just never made it to the other two call sites. That is the same shape as #4253, where `_first_list` advertised alias tolerance in its docstring and the helper inverted it — the intent was stated in one place and not carried through to the rest.

The fix is the alias the episode branch already uses, applied to the two branches that were missing it:

```python
scope=COGXScope(session_id=node.get("group_id") or node.get("session_id")),
scope=COGXScope(session_id=edge.get("group_id") or edge.get("session_id")),
```

`group_id` keeps precedence when both keys are present, so nothing changes for any export that already worked. Only the case that was silently dropping scope moves.

**What I deliberately left out.** Episodes also read `user_id`, and entities and facts do not. That is a real asymmetry and I considered fixing it in the same diff, but I could not confirm that Zep or Graphiti ever emits `user_id` on nodes and edges — `group_id` is the scope key those exporters actually write. Adding a read for a key I have not seen in a real export is speculation, not a fix, so I left it alone rather than pad the diff. Happy to add it if you know of an export shape that carries it.

## Acceptance Criteria

- A Zep/Graphiti export using `session_id` instead of `group_id` keeps its scope on episodes, entities and facts alike.
- An export using `group_id` is completely unaffected, including when both keys are present.
- Two new tests in `TestZepSource`, and the first of them fails on `dev`.

I ran the new tests against unpatched code before trusting them. `test_session_id_alias_is_read_on_every_record_kind` fails on `dev` and passes with the fix; `test_group_id_still_wins_over_session_id` passes both ways by design, since it exists to prove the precedence I did *not* change. The full migration suite is 142 passed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="2084" height="486" alt="PR4-cognee-tests" src="https://github.com/user-attachments/assets/df303fe0-bafa-4456-9246-657b2bda9df1" />

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature** — two lines of source, one alias each
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable) — behaviour now matches the existing module docstring, so no doc change was needed
- [x] All new and existing tests pass — 142 passed in `cognee/tests/unit/migration/`
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

I left the pre-existing ruff findings in both files alone (`typing.Dict` deprecations, import ordering) — they are unrelated to this change and unchanged in count before and after.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
