### PR TITLE
[SDK-255] improve: resolve the write dataset once, with write permission, as a UUID

### DIFF
--- a/cognee/api/v1/improve/improve.py
+++ b/cognee/api/v1/improve/improve.py
@@ -9,6 +9,9 @@ except ImportError:
 from typing_extensions import TypedDict
 
 from cognee.shared.logging_utils import get_logger
+from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
+    resolve_authorized_user_datasets,
+)
 from cognee.modules.observability import (
     new_span,
     COGNEE_DATASET_NAME,
@@ -135,6 +138,18 @@ async def improve(
         if user is None:
             user = await get_default_user()
 
+        # One write-level resolution, shared by every stage below — the same
+        # resolver remember/memify use: names resolve
+        # or are created for the caller; a missing or unauthorized UUID raises
+        # DatasetNotFoundError instead of being silently retargeted. Downstream
+        # always receives the resolved UUID, never a name: names are
+        # owner-scoped, so a name collapsed from a *shared* dataset's UUID
+        # would re-resolve to the caller's own same-named dataset inside the
+        # pipelines.
+        user, authorized_datasets = await resolve_authorized_user_datasets(dataset, user)
+        resolved_dataset = authorized_datasets[0]
+        write_dataset_ref = resolved_dataset.id
+
         feedback_alpha = kwargs.pop("feedback_alpha", 0.1)
 
         # Mutex: single-session improves serialize on the session's
@@ -161,7 +176,7 @@ async def improve(
             # Stage 1 & 2: bridge sessions into the permanent graph
             if session_ids:
                 await _bridge_sessions(
-                    dataset=dataset,
+                    dataset=write_dataset_ref,
                     session_ids=session_ids,
                     user=user,
                     feedback_alpha=feedback_alpha,
@@ -174,7 +189,7 @@ async def improve(
                 # plugin's trace activity never reaches permanent
                 # memory — only QA entries do.
                 await _persist_session_traces(
-                    dataset=dataset,
+                    dataset=write_dataset_ref,
                     session_ids=session_ids,
                     user=user,
                     run_in_background=run_in_background,
@@ -282,16 +297,6 @@ async def _build_global_context_index(
         return False
 
 
-async def _resolve_dataset_name(dataset: Union[str, UUID], user) -> str:
-    """Resolve a dataset reference to its name string."""
-    if isinstance(dataset, str):
-        return dataset
-    from cognee.modules.data.methods.get_authorized_dataset import get_authorized_dataset
-
-    ds = await get_authorized_dataset(user, dataset, "write")
-    return ds.name if ds else "main_dataset"
-
-
 async def _bridge_sessions(
     dataset: Union[str, UUID],
     session_ids: List[str],
@@ -315,13 +320,11 @@ async def _bridge_sessions(
     # Stage 1: apply feedback weights from session retrieval traces
     from cognee.memify_pipelines.apply_feedback_weights import apply_feedback_weights_pipeline
 
-    dataset_name = await _resolve_dataset_name(dataset, user)
-
     try:
         await apply_feedback_weights_pipeline(
             user=user,
             session_ids=session_ids,
-            dataset=dataset_name,
+            dataset=dataset,
             alpha=feedback_alpha,
             run_in_background=run_in_background,
         )
@@ -337,7 +340,7 @@ async def _bridge_sessions(
     await persist_sessions_in_knowledge_graph_pipeline(
         user=user,
         session_ids=session_ids,
-        dataset=dataset_name,
+        dataset=dataset,
         run_in_background=run_in_background,
     )
     logger.info("improve: session Q&A persisted from %d session(s)", len(session_ids))
@@ -443,8 +446,6 @@ async def _persist_session_traces(
     that extracts per-step ``session_feedback`` from the cache and
     cognifies it into the ``agent_trace_feedbacks`` node-set.
     """
-    dataset_name = await _resolve_dataset_name(dataset, user)
-
     try:
         from cognee.memify_pipelines.persist_agent_trace_feedbacks_in_knowledge_graph import (
             persist_agent_trace_feedbacks_in_knowledge_graph_pipeline,
@@ -453,7 +454,7 @@ async def _persist_session_traces(
         await persist_agent_trace_feedbacks_in_knowledge_graph_pipeline(
             user=user,
             session_ids=session_ids,
-            dataset=dataset_name,
+            dataset=dataset,
             node_set_name="agent_trace_feedbacks",
             raw_trace_content=False,
             last_n_steps=None,  # persist all stored steps on demand

--- a/cognee/tests/test_permissions.py
+++ b/cognee/tests/test_permissions.py
@@ -280,3 +280,79 @@ async def test_remove_user_from_tenant_user_not_in_tenant_404(permissions_exampl
         await remove_user_from_tenant(user_id=other_user.id, tenant_id=tenant_id, owner_id=owner.id)
 
     assert "User not found in this tenant" in exc_info.value.message
+
+
+async def test_improve_permission_matrix(permissions_example_env):
+    """Write-side pipelines (improve + its memify engine) enforce dataset permissions.
+
+    improve() mutates the dataset in every stage, so it requires *write*
+    permission. The matrix, with real users and ACLs:
+
+    1. no grant, by UUID        -> PermissionDeniedError (403)
+    1b. nonexistent UUID        -> PermissionDeniedError too — existence is
+                                   never confirmed to an unauthorized caller
+    2. read grant only, by UUID -> PermissionDeniedError (read is not enough)
+    3. write grant, by UUID     -> allowed, and the stage receives exactly the
+                                   authorized dataset (no retargeting)
+    4. by another owner's NAME  -> never touches their dataset (names are
+                                   owner-scoped; shared datasets are only
+                                   addressable by UUID)
+    5. memify directly          -> same write requirement as improve
+
+    No LLM involved: denials raise before any stage runs, and the success
+    paths patch the memify engine.
+    """
+    from importlib import import_module
+
+    from uuid import uuid4
+
+    from cognee.modules.data.methods import get_datasets_by_name
+
+    import_module("cognee.api.v1.improve.improve")
+
+    owner = await create_user("improve_owner@example.com", "example")
+    other = await create_user("improve_other@example.com", "example")
+
+    # add() creates the dataset and the owner's ACLs without any LLM work.
+    await cognee.add(["improve permission fixture text"], dataset_name="IMPROVE_PERMS", user=owner)
+    dataset_id = (await get_datasets_by_name(["IMPROVE_PERMS"], owner.id))[0].id
+
+    def memify_patch():
+        return patch("cognee.modules.memify.memify", new_callable=AsyncMock, return_value={})
+
+    # 1. No grant on an existing dataset: refused with 403.
+    with pytest.raises(PermissionDeniedError):
+        await cognee.improve(dataset=dataset_id, user=other)
+
+    # 1b. A UUID that exists nowhere gets the same 403 — the permission layer
+    #     never confirms dataset existence to an unauthorized caller.
+    with pytest.raises(PermissionDeniedError):
+        await cognee.improve(dataset=uuid4(), user=other)
+
+    # 2. Read grant is not enough — every improve stage writes.
+    await authorized_give_permission_on_datasets(other.id, [dataset_id], "read", owner.id)
+    with pytest.raises(PermissionDeniedError):
+        await cognee.improve(dataset=dataset_id, user=other)
+
+    # 3. Write grant allows it, and the engine receives the authorized dataset.
+    await authorized_give_permission_on_datasets(other.id, [dataset_id], "write", owner.id)
+    with memify_patch() as memify_mock:
+        await cognee.improve(dataset=dataset_id, user=other)
+    memify_mock.assert_awaited_once()
+    assert memify_mock.await_args.kwargs["dataset"] == dataset_id
+
+    # 4. Names are owner-scoped: improving the owner's dataset *name* as another
+    #    user creates that user's own dataset and never touches the owner's.
+    with memify_patch():
+        await cognee.improve(dataset="IMPROVE_PERMS", user=other)
+    others_datasets = await get_datasets_by_name(["IMPROVE_PERMS"], other.id)
+    assert len(others_datasets) == 1
+    assert others_datasets[0].id != dataset_id
+
+    # 5. memify (improve's engine) enforces the same write requirement directly.
+    from cognee.modules.memify import memify as real_memify
+
+    await cognee.add(["second fixture"], dataset_name="IMPROVE_PERMS_2", user=owner)
+    dataset_2_id = (await get_datasets_by_name(["IMPROVE_PERMS_2"], owner.id))[0].id
+    with pytest.raises(PermissionDeniedError):
+        await real_memify(dataset=dataset_2_id, user=other)

--- a/cognee/tests/unit/api/test_improve_global_context_index.py
+++ b/cognee/tests/unit/api/test_improve_global_context_index.py
@@ -1,6 +1,7 @@
 from importlib import import_module
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
@@ -69,6 +70,13 @@ async def test_improve_global_context_index_opt_in(monkeypatch, build_global_con
     global_context_mock = AsyncMock(return_value={"status": "global-context-ok"})
     monkeypatch.setattr(memify_module, "memify", memify_mock)
     monkeypatch.setattr(pipeline_module, "global_context_index_pipeline", global_context_mock)
+    # Write-level dataset resolution hits the relational DB — stub it out.
+    resolved = SimpleNamespace(id=uuid4(), name="docs")
+    monkeypatch.setattr(
+        improve_module,
+        "resolve_authorized_user_datasets",
+        AsyncMock(side_effect=lambda dataset, user: (user, [resolved])),
+    )
 
     user = SimpleNamespace(id="user-id")
 
@@ -108,6 +116,13 @@ async def test_improve_skips_global_context_index_in_background(monkeypatch):
     global_context_mock = AsyncMock(return_value={"status": "global-context-ok"})
     monkeypatch.setattr(memify_module, "memify", memify_mock)
     monkeypatch.setattr(pipeline_module, "global_context_index_pipeline", global_context_mock)
+    # Write-level dataset resolution hits the relational DB — stub it out.
+    resolved = SimpleNamespace(id=uuid4(), name="docs")
+    monkeypatch.setattr(
+        improve_module,
+        "resolve_authorized_user_datasets",
+        AsyncMock(side_effect=lambda dataset, user: (user, [resolved])),
+    )
 
     result = await improve_module.improve(
         dataset="docs",


### PR DESCRIPTION
Extracted from #4209 as a standalone permission fix (independent of the abandoned session-binding approach).

## Problem
`improve()` had a silent fallback: whenever its dataset reference could not be resolved, `_resolve_dataset_name` returned `"main_dataset"` — so an unauthorized or mistyped dataset id quietly enriched the caller's default dataset instead of failing. It also collapsed dataset UUIDs to *names* before handing them to the session pipelines; names are owner-scoped, so a **shared** dataset's UUID would re-resolve to the caller's own same-named dataset inside the stages — writes landing in the wrong dataset.

## Fix
One write-level resolution up front via the existing `resolve_authorized_user_datasets` (the same resolver remember/memify use — no new duplicate):

- names resolve or are created for the caller (unchanged convention)
- a missing or unauthorized UUID **raises** instead of retargeting
- every stage receives the resolved **UUID**, never a name
- the `_resolve_dataset_name` fallback is deleted (−10 lines)

## Testing
`test_improve_permission_matrix` with real users and ACLs, no LLM (denials raise before any stage; success paths patch the memify engine):

1. no grant, by UUID → `PermissionDeniedError`
2. nonexistent UUID → `PermissionDeniedError` (existence never confirmed to an unauthorized caller)
3. read grant only → `PermissionDeniedError` (every improve stage writes)
4. write grant → allowed, and the engine receives exactly the authorized dataset id
5. another owner's dataset *name* → never touches their dataset (names are owner-scoped)
6. `memify` directly → same write requirement

Passes solo (~5s) against a real environment; the global-context-index unit tests stub the resolver (5 pass); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)