### PR TITLE
[SDK-255] SessionManager rejects non-UUID user ids

### DIFF
--- a/cognee/infrastructure/session/session_manager.py
+++ b/cognee/infrastructure/session/session_manager.py
@@ -30,7 +30,7 @@ from cognee.modules.observability import (
 from cognee.modules.retrieval.utils.completion import generate_completion
 from cognee.modules.session_lifecycle.metrics import record_session_activity
 from cognee.shared.logging_utils import get_logger
-from cognee.shared.utils import send_telemetry
+from cognee.shared.utils import as_uuid, send_telemetry
 
 logger = get_logger("SessionManager")
 
@@ -52,7 +52,8 @@ class SessionManager:
         Validate session parameters. Raises SessionParameterValidationError if any
         provided parameter is invalid.
 
-        - user_id, session_id, qa_id: must be non-empty strings when provided.
+        - user_id: must be a UUID (or UUID string) when provided.
+        - session_id, qa_id: must be non-empty strings when provided.
         - last_n: when provided, must be a positive integer.
         """
         checks = (
@@ -63,6 +64,11 @@ class SessionManager:
         for value, name in checks:
             if value is not None and (not str(value).strip()):
                 raise SessionParameterValidationError(message=f"{name} must be a non-empty string")
+        if user_id is not None and as_uuid(user_id) is None:
+            raise SessionParameterValidationError(
+                message=f"user_id must be a UUID, got {user_id!r}. Non-UUID user ids create "
+                "sessions invisible to lifecycle tracking, attribution, and cleanup."
+            )
         if last_n is not None and (not isinstance(last_n, int) or last_n < 1):
             raise SessionParameterValidationError(message="last_n must be a positive integer")
 

--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -27,6 +27,19 @@ _DEFAULT_TELEMETRY_API_KEY_TRACKING_SALT = b"cognee.telemetry.api-key-tracking.v
 _TELEMETRY_API_KEY_TRACKING_ITERATIONS = 100_000
 
 
+def as_uuid(value) -> UUID | None:
+    """Coerce ``value`` to a UUID, or return None when it is not one.
+
+    The tolerant counterpart to ``UUID(str(value))`` for identifiers that
+    arrive as UUIDs, strings, or context values that may legitimately hold
+    something else (e.g. a dataset *name* in ``current_dataset_id``).
+    """
+    try:
+        return UUID(str(value))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
 def create_secure_ssl_context() -> ssl.SSLContext:
     """
     Create a secure SSL context.

--- a/cognee/tests/integration/infrastructure/session/test_feedback_weights_memify_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_feedback_weights_memify_integration.py
@@ -121,7 +121,7 @@ def session_manager_with_backend(request):
 
 def _make_user():
     user = MagicMock()
-    user.id = "u1"
+    user.id = "00000000-0000-0000-0000-000000000001"
     return user
 
 
@@ -131,7 +131,7 @@ async def test_feedback_weights_first_run_then_idempotent(session_manager_with_b
     user = _make_user()
 
     await sm.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q",
         context="C",
         answer="A",
@@ -175,7 +175,7 @@ async def test_feedback_weights_mixed_success_keeps_false(session_manager_with_b
     user = _make_user()
 
     await sm.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q",
         context="C",
         answer="A",
@@ -206,5 +206,7 @@ async def test_feedback_weights_mixed_success_keeps_false(session_manager_with_b
     assert result["processed"] == 1
     assert result["applied"] == 0
 
-    entries = await sm.get_session(user_id="u1", session_id="s1", formatted=False)
+    entries = await sm.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1", formatted=False
+    )
     assert entries[0].memify_metadata[MEMIFY_METADATA_FEEDBACK_WEIGHTS_APPLIED_KEY] is False

--- a/cognee/tests/integration/infrastructure/session/test_session_context_fs.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_context_fs.py
@@ -33,7 +33,7 @@ def session_manager(fs_adapter) -> SessionManager:
 async def test_add_qa_with_used_session_context_ids_round_trip(session_manager: SessionManager):
     """add_qa with used_session_context_ids stores and returns it via get_session."""
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q?",
         context="C",
         answer="A",
@@ -41,7 +41,9 @@ async def test_add_qa_with_used_session_context_ids_round_trip(session_manager: 
         used_session_context_ids=["c1", "c2"],
     )
     assert qa_id is not None
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].used_session_context_ids == ["c1", "c2"]
 
@@ -50,16 +52,22 @@ async def test_add_qa_with_used_session_context_ids_round_trip(session_manager: 
 async def test_update_qa_with_used_session_context_ids(session_manager: SessionManager):
     """update_qa can set used_session_context_ids on an existing entry."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     ok = await session_manager.update_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         qa_id=qa_id,
         used_session_context_ids=["c9"],
         session_id="s1",
     )
     assert ok
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].used_session_context_ids == ["c9"]
 
 
@@ -68,10 +76,12 @@ async def test_session_context_create_get_round_trip(session_manager: SessionMan
     """create_session_context_entry then get_session_context_entries returns it."""
     entry = {"id": "c1", "kind": "context", "section": "rules", "content": "Use tabs."}
     ok = await session_manager.create_session_context_entry(
-        user_id="u1", entry_dump=entry, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001", entry_dump=entry, session_id="s1"
     )
     assert ok
-    entries = await session_manager.get_session_context_entries(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session_context_entries(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0]["id"] == "c1"
     assert entries[0]["kind"] == "context"
@@ -82,16 +92,18 @@ async def test_session_context_create_get_round_trip(session_manager: SessionMan
 async def test_session_context_mixed_kinds(session_manager: SessionManager):
     """Both context and feedback kinds are stored in the same list and returned together."""
     await session_manager.create_session_context_entry(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         entry_dump={"id": "c1", "kind": "context", "content": "x"},
         session_id="s1",
     )
     await session_manager.create_session_context_entry(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         entry_dump={"id": "f1", "kind": "feedback", "raw_text": "thanks"},
         session_id="s1",
     )
-    entries = await session_manager.get_session_context_entries(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session_context_entries(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     kinds = sorted(e["kind"] for e in entries)
     assert kinds == ["context", "feedback"]
 
@@ -100,18 +112,20 @@ async def test_session_context_mixed_kinds(session_manager: SessionManager):
 async def test_session_context_update(session_manager: SessionManager):
     """update_session_context_entry shallow-merges by entry id."""
     await session_manager.create_session_context_entry(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         entry_dump={"id": "c1", "kind": "context", "helpful_count": 0},
         session_id="s1",
     )
     ok = await session_manager.update_session_context_entry(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         entry_id="c1",
         merge={"helpful_count": 3, "last_served_at": "now"},
         session_id="s1",
     )
     assert ok
-    entries = await session_manager.get_session_context_entries(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session_context_entries(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0]["helpful_count"] == 3
     assert entries[0]["last_served_at"] == "now"
     assert entries[0]["kind"] == "context"
@@ -121,10 +135,15 @@ async def test_session_context_update(session_manager: SessionManager):
 async def test_session_context_update_missing_id(session_manager: SessionManager):
     """update_session_context_entry returns False when entry id not found."""
     await session_manager.create_session_context_entry(
-        user_id="u1", entry_dump={"id": "c1", "kind": "context"}, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        entry_dump={"id": "c1", "kind": "context"},
+        session_id="s1",
     )
     ok = await session_manager.update_session_context_entry(
-        user_id="u1", entry_id="missing", merge={"x": 1}, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        entry_id="missing",
+        merge={"x": 1},
+        session_id="s1",
     )
     assert ok is False
 
@@ -133,11 +152,17 @@ async def test_session_context_update_missing_id(session_manager: SessionManager
 async def test_session_context_delete(session_manager: SessionManager):
     """delete_session_context removes all context entries."""
     await session_manager.create_session_context_entry(
-        user_id="u1", entry_dump={"id": "c1", "kind": "context"}, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        entry_dump={"id": "c1", "kind": "context"},
+        session_id="s1",
     )
-    ok = await session_manager.delete_session_context(user_id="u1", session_id="s1")
+    ok = await session_manager.delete_session_context(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert ok
-    entries = await session_manager.get_session_context_entries(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session_context_entries(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries == []
 
 
@@ -145,17 +170,29 @@ async def test_session_context_delete(session_manager: SessionManager):
 async def test_session_context_isolated_by_user_and_session(session_manager: SessionManager):
     """Session-context entries remain isolated by user_id and session_id."""
     await session_manager.create_session_context_entry(
-        user_id="u1", entry_dump={"id": "a", "kind": "context"}, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        entry_dump={"id": "a", "kind": "context"},
+        session_id="s1",
     )
     await session_manager.create_session_context_entry(
-        user_id="u1", entry_dump={"id": "b", "kind": "context"}, session_id="s2"
+        user_id="00000000-0000-0000-0000-000000000001",
+        entry_dump={"id": "b", "kind": "context"},
+        session_id="s2",
     )
     await session_manager.create_session_context_entry(
-        user_id="u2", entry_dump={"id": "c", "kind": "context"}, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000002",
+        entry_dump={"id": "c", "kind": "context"},
+        session_id="s1",
     )
-    u1s1 = await session_manager.get_session_context_entries(user_id="u1", session_id="s1")
-    u1s2 = await session_manager.get_session_context_entries(user_id="u1", session_id="s2")
-    u2s1 = await session_manager.get_session_context_entries(user_id="u2", session_id="s1")
+    u1s1 = await session_manager.get_session_context_entries(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
+    u1s2 = await session_manager.get_session_context_entries(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s2"
+    )
+    u2s1 = await session_manager.get_session_context_entries(
+        user_id="00000000-0000-0000-0000-000000000002", session_id="s1"
+    )
     assert [e["id"] for e in u1s1] == ["a"]
     assert [e["id"] for e in u1s2] == ["b"]
     assert [e["id"] for e in u2s1] == ["c"]
@@ -165,18 +202,28 @@ async def test_session_context_isolated_by_user_and_session(session_manager: Ses
 async def test_delete_session_clears_context(session_manager: SessionManager):
     """delete_session also clears the session-context list."""
     await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     await session_manager.create_session_context_entry(
-        user_id="u1", entry_dump={"id": "c1", "kind": "context"}, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        entry_dump={"id": "c1", "kind": "context"},
+        session_id="s1",
     )
-    ok = await session_manager.delete_session(user_id="u1", session_id="s1")
+    ok = await session_manager.delete_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert ok
 
-    qa_entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    qa_entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert qa_entries == []
     context_entries = await session_manager.get_session_context_entries(
-        user_id="u1", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
     )
     assert context_entries == []
 
@@ -187,15 +234,30 @@ async def test_session_context_wrappers_fail_open_when_unavailable():
     sm = SessionManager(cache_engine=None)
     assert (
         await sm.create_session_context_entry(
-            user_id="u1", entry_dump={"id": "c1", "kind": "context"}, session_id="s1"
+            user_id="00000000-0000-0000-0000-000000000001",
+            entry_dump={"id": "c1", "kind": "context"},
+            session_id="s1",
         )
         is False
     )
-    assert await sm.get_session_context_entries(user_id="u1", session_id="s1") == []
+    assert (
+        await sm.get_session_context_entries(
+            user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+        )
+        == []
+    )
     assert (
         await sm.update_session_context_entry(
-            user_id="u1", entry_id="c1", merge={"x": 1}, session_id="s1"
+            user_id="00000000-0000-0000-0000-000000000001",
+            entry_id="c1",
+            merge={"x": 1},
+            session_id="s1",
         )
         is False
     )
-    assert await sm.delete_session_context(user_id="u1", session_id="s1") is False
+    assert (
+        await sm.delete_session_context(
+            user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+        )
+        is False
+    )

--- a/cognee/tests/integration/infrastructure/session/test_session_context_turn_flow.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_context_turn_flow.py
@@ -75,7 +75,7 @@ def _config(*, auto_feedback: bool = True):
 def _patches(completion_return, analysis_return=None):
     """Patch session_user, CacheConfig, turn analysis, and completion."""
     user = MagicMock()
-    user.id = "owner-1"  # non-UUID -> skips track_session_usage + session_records side effects
+    user.id = "00000000-0000-0000-0000-0000000000a1"
 
     mock_user = patch("cognee.infrastructure.session.session_manager.session_user")
     mock_cfg = patch("cognee.infrastructure.session.session_manager.CacheConfig")
@@ -94,7 +94,7 @@ def _patches(completion_return, analysis_return=None):
 
 async def _seed_context_entry(sm, entry_id, section, content):
     await sm.create_session_context_entry(
-        user_id="owner-1",
+        user_id="00000000-0000-0000-0000-0000000000a1",
         entry_dump={
             "id": entry_id,
             "kind": "context",
@@ -132,7 +132,9 @@ async def test_first_turn_no_block_empty_served_ids(session_manager):
     history = mg.call_args.kwargs["conversation_history"]
     assert "## Active session guidance" not in history
 
-    entries = await session_manager.get_session(user_id="owner-1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].used_session_context_ids is None
 
@@ -164,7 +166,9 @@ async def test_non_feedback_block_prepended_and_served_ids_recorded(session_mana
     assert "Background knowledge from the knowledge graph" not in history
     assert "Always answer in metric units." in history
 
-    entries = await session_manager.get_session(user_id="owner-1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
+    )
     new_qa = entries[-1]
     assert new_qa.question == "Give me the distance."
     assert new_qa.used_session_context_ids == ["c-rule"]
@@ -176,7 +180,7 @@ async def test_feedback_only_returns_thanks_records_qa_and_applies_candidate(ses
     await _seed_context_entry(session_manager, "c-served", "rules", "Be concise.")
     # A previous QA that served c-served, so it can be rated this turn.
     await session_manager.add_qa(
-        user_id="owner-1",
+        user_id="00000000-0000-0000-0000-0000000000a1",
         question="prev?",
         context="",
         answer="prev answer",
@@ -219,14 +223,16 @@ async def test_feedback_only_returns_thanks_records_qa_and_applies_candidate(ses
     assert result == "Glad it helped!"
     mock_add_feedback.assert_not_called()
 
-    entries = await session_manager.get_session(user_id="owner-1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
+    )
     assert len(entries) == 2
     assert entries[-1].question == "that was great"
     assert entries[-1].answer == "Glad it helped!"
     assert entries[-1].used_session_context_ids is None
 
     ctx_entries = await session_manager.get_session_context_entries(
-        user_id="owner-1", session_id="s1"
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
     )
     served = next(e for e in ctx_entries if e.get("id") == "c-served")
     assert served["helpful_count"] == 1
@@ -252,7 +258,7 @@ async def test_duplicate_served_context_ratings_accumulate(session_manager):
 
     await apply_served_context_ratings(
         session_manager,
-        user_id="owner-1",
+        user_id="00000000-0000-0000-0000-0000000000a1",
         session_id="s1",
         ratings=[
             ServedContextRating(entry_id="c-served", rating="helpful"),
@@ -262,7 +268,7 @@ async def test_duplicate_served_context_ratings_accumulate(session_manager):
     )
 
     ctx_entries = await session_manager.get_session_context_entries(
-        user_id="owner-1", session_id="s1"
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
     )
     served = next(e for e in ctx_entries if e.get("id") == "c-served")
     assert served["helpful_count"] == 2
@@ -273,7 +279,7 @@ async def test_duplicate_served_context_ratings_accumulate(session_manager):
 async def test_preference_only_turn_applies_candidate_without_answering(session_manager):
     """Instruction-only turn: preference is stored, acknowledgement is recorded."""
     await session_manager.add_qa(
-        user_id="owner-1",
+        user_id="00000000-0000-0000-0000-0000000000a1",
         question="prev?",
         context="",
         answer="prev answer",
@@ -310,14 +316,16 @@ async def test_preference_only_turn_applies_candidate_without_answering(session_
     assert result == "Got it."
     mg.assert_not_called()
 
-    entries = await session_manager.get_session(user_id="owner-1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
+    )
     assert len(entries) == 2
     assert entries[-1].question == "For now, answer with 2 informative bullet points."
     assert entries[-1].answer == "Got it."
     assert entries[-1].used_session_context_ids is None
 
     ctx_entries = await session_manager.get_session_context_entries(
-        user_id="owner-1", session_id="s1"
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
     )
     preferences = [
         e
@@ -335,7 +343,7 @@ async def test_feedback_followup_prepends_thanks_and_stores_qa(session_manager):
     """Feedback+follow-up: thanks prepended to answer, new QA stored with served_ids."""
     await _seed_context_entry(session_manager, "c-goal", "goals", "Help the user ship faster.")
     await session_manager.add_qa(
-        user_id="owner-1",
+        user_id="00000000-0000-0000-0000-0000000000a1",
         question="prev?",
         context="",
         answer="prev answer",
@@ -378,14 +386,16 @@ async def test_feedback_followup_prepends_thanks_and_stores_qa(session_manager):
 
     # A new QA was added with this turn's served_ids. The previous goal and the newly accepted
     # lesson are both available to the follow-up answer.
-    entries = await session_manager.get_session(user_id="owner-1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
+    )
     assert len(entries) == 2
     new_qa = entries[-1]
     assert new_qa.question == "that was wrong, now what about Y?"
     assert "c-goal" in new_qa.used_session_context_ids
 
     ctx_entries = await session_manager.get_session_context_entries(
-        user_id="owner-1", session_id="s1"
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
     )
     served = next(e for e in ctx_entries if e.get("id") == "c-goal")
     assert served["harmful_count"] == 1
@@ -421,5 +431,7 @@ async def test_layer_disabled_when_auto_feedback_off(session_manager):
     assert "## Active session guidance" not in history
     ma.assert_not_called()
 
-    entries = await session_manager.get_session(user_id="owner-1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-0000000000a1", session_id="s1"
+    )
     assert entries[-1].used_session_context_ids is None

--- a/cognee/tests/integration/infrastructure/session/test_session_manager_fs.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_manager_fs.py
@@ -60,11 +60,17 @@ def session_vector_mocks():
 async def test_add_qa_and_get_session(session_manager: SessionManager):
     """Add QA via SessionManager and retrieve via get_session."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1?",
+        context="ctx1",
+        answer="A1.",
+        session_id="s1",
     )
     assert qa_id is not None
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "Q1?"
     assert entries[0].answer == "A1."
@@ -76,7 +82,7 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager: Se
     """add_qa with used_graph_element_ids stores and returns it via get_session."""
     used_ids = {"node_ids": ["n1"], "edge_ids": ["e1"]}
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q?",
         context="C",
         answer="A",
@@ -84,7 +90,9 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager: Se
         used_graph_element_ids=used_ids,
     )
     assert qa_id is not None
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].used_graph_element_ids == used_ids
 
@@ -93,9 +101,15 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager: Se
 async def test_get_session_formatted(session_manager: SessionManager):
     """get_session with formatted=True returns prompt string."""
     await session_manager.add_qa(
-        user_id="u1", question="Q?", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q?",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
-    formatted = await session_manager.get_session(user_id="u1", formatted=True, session_id="s1")
+    formatted = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", formatted=True, session_id="s1"
+    )
     assert isinstance(formatted, str)
     assert "Previous conversation" in formatted and "Q?" in formatted
 
@@ -115,7 +129,7 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager: Sessi
         ),
     ):
         trace_id_1 = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="plan_trip",
             status="success",
@@ -125,7 +139,7 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager: Sessi
             method_return_value="Plan created",
         )
         trace_id_2 = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="book_hotel",
             status="error",
@@ -133,8 +147,12 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager: Sessi
             error_message="No availability",
         )
 
-    entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
-    feedback = await session_manager.get_agent_trace_feedback(user_id="u1", session_id="s1")
+    entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
+    feedback = await session_manager.get_agent_trace_feedback(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
 
     assert [entry.trace_id for entry in entries] == [trace_id_1, trace_id_2]
     assert entries[0].origin_function == "plan_trip"
@@ -155,7 +173,7 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(
         new_callable=AsyncMock,
     ) as mock_llm:
         trace_id = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="plan_trip",
             status="success",
@@ -165,7 +183,9 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(
 
     assert trace_id is not None
     mock_llm.assert_not_awaited()
-    entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].session_feedback == "plan_trip succeeded."
 
@@ -174,28 +194,34 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(
 async def test_agent_trace_session_isolated_by_user_and_session(session_manager: SessionManager):
     """Agent trace sessions remain isolated by user_id and session_id."""
     await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s1",
         origin_function="plan_trip",
         status="success",
     )
     await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s2",
         origin_function="book_hotel",
         status="error",
         error_message="No availability",
     )
     await session_manager.add_agent_trace_step(
-        user_id="u2",
+        user_id="00000000-0000-0000-0000-000000000002",
         session_id="s1",
         origin_function="book_flight",
         status="success",
     )
 
-    u1s1 = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
-    u1s2 = await session_manager.get_agent_trace_session(user_id="u1", session_id="s2")
-    u2s1 = await session_manager.get_agent_trace_session(user_id="u2", session_id="s1")
+    u1s1 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
+    u1s2 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s2"
+    )
+    u2s1 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000002", session_id="s1"
+    )
 
     assert len(u1s1) == 1
     assert u1s1[0].origin_function == "plan_trip"
@@ -209,14 +235,23 @@ async def test_agent_trace_session_isolated_by_user_and_session(session_manager:
 async def test_update_qa(session_manager: SessionManager):
     """update_qa updates entry via FsCacheAdapter."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     ok = await session_manager.update_qa(
-        user_id="u1", qa_id=qa_id, question="Q updated?", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        qa_id=qa_id,
+        question="Q updated?",
+        session_id="s1",
     )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].question == "Q updated?"
 
 
@@ -224,14 +259,23 @@ async def test_update_qa(session_manager: SessionManager):
 async def test_add_feedback(session_manager: SessionManager):
     """add_feedback sets feedback on entry."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     ok = await session_manager.add_feedback(
-        user_id="u1", qa_id=qa_id, feedback_score=5, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        qa_id=qa_id,
+        feedback_score=5,
+        session_id="s1",
     )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].feedback_score == 5
 
 
@@ -239,7 +283,7 @@ async def test_add_feedback(session_manager: SessionManager):
 async def test_delete_feedback(session_manager: SessionManager):
     """delete_feedback clears feedback."""
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q",
         context="C",
         answer="A",
@@ -247,10 +291,14 @@ async def test_delete_feedback(session_manager: SessionManager):
         feedback_text="good",
         feedback_score=4,
     )
-    ok = await session_manager.delete_feedback(user_id="u1", qa_id=qa_id, session_id="s1")
+    ok = await session_manager.delete_feedback(
+        user_id="00000000-0000-0000-0000-000000000001", qa_id=qa_id, session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].feedback_score is None
     assert entries[0].feedback_text is None
 
@@ -259,15 +307,27 @@ async def test_delete_feedback(session_manager: SessionManager):
 async def test_delete_qa(session_manager: SessionManager):
     """delete_qa removes single entry."""
     qa1 = await session_manager.add_qa(
-        user_id="u1", question="Q1", context="C1", answer="A1", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1",
+        context="C1",
+        answer="A1",
+        session_id="s1",
     )
     await session_manager.add_qa(
-        user_id="u1", question="Q2", context="C2", answer="A2", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q2",
+        context="C2",
+        answer="A2",
+        session_id="s1",
     )
-    ok = await session_manager.delete_qa(user_id="u1", qa_id=qa1, session_id="s1")
+    ok = await session_manager.delete_qa(
+        user_id="00000000-0000-0000-0000-000000000001", qa_id=qa1, session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "Q2"
 
@@ -276,21 +336,31 @@ async def test_delete_qa(session_manager: SessionManager):
 async def test_delete_session(session_manager):
     """delete_session clears both QA and trace session entries."""
     await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     trace_id = await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s1",
         origin_function="plan_trip",
         status="success",
     )
     assert trace_id is not None
-    ok = await session_manager.delete_session(user_id="u1", session_id="s1")
+    ok = await session_manager.delete_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries == []
-    trace_entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    trace_entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert trace_entries == []
 
 
@@ -298,7 +368,7 @@ async def test_delete_session(session_manager):
 async def test_generate_completion_with_session_saves_qa(session_manager: SessionManager):
     """generate_completion_with_session runs completion and saves QA to session (LLM mocked)."""
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -324,7 +394,9 @@ async def test_generate_completion_with_session_saves_qa(session_manager: Sessio
         )
 
     assert result == "Integration test answer"
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "What is X?"
     assert entries[0].answer == "Integration test answer"
@@ -337,7 +409,7 @@ async def test_generate_completion_with_session_feedback_only_records_qa(
 ):
     """When no query_to_answer is detected: acknowledgement returned and recorded."""
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="What is X?",
         context="Context about X.",
         answer="X is something.",
@@ -346,7 +418,7 @@ async def test_generate_completion_with_session_feedback_only_records_qa(
     assert qa_id is not None
 
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -376,7 +448,9 @@ async def test_generate_completion_with_session_feedback_only_records_qa(
         )
 
     assert result == "Thanks for your feedback!"
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 2
     assert entries[0].qa_id == qa_id
     assert entries[0].question == "What is X?"
@@ -393,7 +467,7 @@ async def test_generate_completion_with_session_feedback_and_followup_adds_qa(
 ):
     """When query_to_answer is present: new QA is added with answer."""
     qa_id_first = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="What is X?",
         context="Context about X.",
         answer="X is something.",
@@ -402,7 +476,7 @@ async def test_generate_completion_with_session_feedback_and_followup_adds_qa(
     assert qa_id_first is not None
 
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -435,7 +509,9 @@ async def test_generate_completion_with_session_feedback_and_followup_adds_qa(
         )
 
     assert result == "Paris is the capital of France."
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 2
     first_qa = next((e for e in entries if e.qa_id == qa_id_first), None)
     followup_qa = next(

--- a/cognee/tests/integration/infrastructure/session/test_session_manager_redis.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_manager_redis.py
@@ -100,11 +100,17 @@ def session_vector_mocks():
 async def test_add_qa_and_get_session(session_manager):
     """Add QA via SessionManager and retrieve via get_session."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1?",
+        context="ctx1",
+        answer="A1.",
+        session_id="s1",
     )
     assert qa_id is not None
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "Q1?"
     assert entries[0].answer == "A1."
@@ -115,21 +121,36 @@ async def test_add_qa_and_get_session(session_manager):
 async def test_add_qa_sets_session_ttl(session_manager, redis_adapter):
     """Session writes through SessionManager apply Redis TTL to the session key."""
     await session_manager.add_qa(
-        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1?",
+        context="ctx1",
+        answer="A1.",
+        session_id="s1",
     )
 
-    assert await redis_adapter.async_redis.ttl("agent_sessions:u1:s1") == 604800
+    assert (
+        await redis_adapter.async_redis.ttl(
+            "agent_sessions:00000000-0000-0000-0000-000000000001:s1"
+        )
+        == 604800
+    )
 
 
 @pytest.mark.asyncio
 async def test_get_session_does_not_refresh_session_ttl(session_manager, redis_adapter):
     """Read-only session access should not refresh TTL."""
     await session_manager.add_qa(
-        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1?",
+        context="ctx1",
+        answer="A1.",
+        session_id="s1",
     )
     redis_adapter.async_redis.expire_calls.clear()
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
 
     assert len(entries) == 1
     assert redis_adapter.async_redis.expire_calls == []
@@ -150,7 +171,7 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager):
         ),
     ):
         trace_id_1 = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="plan_trip",
             status="success",
@@ -160,7 +181,7 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager):
             method_return_value="Plan created",
         )
         trace_id_2 = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="book_hotel",
             status="error",
@@ -168,8 +189,12 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager):
             error_message="No availability",
         )
 
-    entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
-    feedback = await session_manager.get_agent_trace_feedback(user_id="u1", session_id="s1")
+    entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
+    feedback = await session_manager.get_agent_trace_feedback(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
 
     assert [entry.trace_id for entry in entries] == [trace_id_1, trace_id_2]
     assert entries[0].origin_function == "plan_trip"
@@ -188,7 +213,7 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(session_
         new_callable=AsyncMock,
     ) as mock_llm:
         trace_id = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="plan_trip",
             status="success",
@@ -198,7 +223,9 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(session_
 
     assert trace_id is not None
     mock_llm.assert_not_awaited()
-    entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].session_feedback == "plan_trip succeeded."
 
@@ -207,28 +234,34 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(session_
 async def test_agent_trace_session_isolated_by_user_and_session(session_manager):
     """Agent trace sessions remain isolated by user_id and session_id."""
     await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s1",
         origin_function="plan_trip",
         status="success",
     )
     await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s2",
         origin_function="book_hotel",
         status="error",
         error_message="No availability",
     )
     await session_manager.add_agent_trace_step(
-        user_id="u2",
+        user_id="00000000-0000-0000-0000-000000000002",
         session_id="s1",
         origin_function="book_flight",
         status="success",
     )
 
-    u1s1 = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
-    u1s2 = await session_manager.get_agent_trace_session(user_id="u1", session_id="s2")
-    u2s1 = await session_manager.get_agent_trace_session(user_id="u2", session_id="s1")
+    u1s1 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
+    u1s2 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s2"
+    )
+    u2s1 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000002", session_id="s1"
+    )
 
     assert len(u1s1) == 1
     assert u1s1[0].origin_function == "plan_trip"
@@ -243,7 +276,7 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager):
     """add_qa with used_graph_element_ids stores and returns it via get_session."""
     used_ids = {"node_ids": ["n1"], "edge_ids": ["e1"]}
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q?",
         context="C",
         answer="A",
@@ -251,7 +284,9 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager):
         used_graph_element_ids=used_ids,
     )
     assert qa_id is not None
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].used_graph_element_ids == used_ids
 
@@ -260,9 +295,15 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager):
 async def test_get_session_formatted(session_manager):
     """get_session with formatted=True returns prompt string."""
     await session_manager.add_qa(
-        user_id="u1", question="Q?", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q?",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
-    formatted = await session_manager.get_session(user_id="u1", formatted=True, session_id="s1")
+    formatted = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", formatted=True, session_id="s1"
+    )
     assert isinstance(formatted, str)
     assert "Previous conversation" in formatted and "Q?" in formatted
 
@@ -271,14 +312,23 @@ async def test_get_session_formatted(session_manager):
 async def test_update_qa(session_manager):
     """update_qa updates entry via RedisAdapter."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     ok = await session_manager.update_qa(
-        user_id="u1", qa_id=qa_id, question="Q updated?", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        qa_id=qa_id,
+        question="Q updated?",
+        session_id="s1",
     )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].question == "Q updated?"
 
 
@@ -286,14 +336,23 @@ async def test_update_qa(session_manager):
 async def test_add_feedback(session_manager):
     """add_feedback sets feedback on entry."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     ok = await session_manager.add_feedback(
-        user_id="u1", qa_id=qa_id, feedback_score=5, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        qa_id=qa_id,
+        feedback_score=5,
+        session_id="s1",
     )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].feedback_score == 5
 
 
@@ -301,7 +360,7 @@ async def test_add_feedback(session_manager):
 async def test_delete_feedback(session_manager):
     """delete_feedback clears feedback."""
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q",
         context="C",
         answer="A",
@@ -309,10 +368,14 @@ async def test_delete_feedback(session_manager):
         feedback_text="good",
         feedback_score=4,
     )
-    ok = await session_manager.delete_feedback(user_id="u1", qa_id=qa_id, session_id="s1")
+    ok = await session_manager.delete_feedback(
+        user_id="00000000-0000-0000-0000-000000000001", qa_id=qa_id, session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].feedback_score is None
     assert entries[0].feedback_text is None
 
@@ -321,15 +384,27 @@ async def test_delete_feedback(session_manager):
 async def test_delete_qa(session_manager):
     """delete_qa removes single entry."""
     qa1 = await session_manager.add_qa(
-        user_id="u1", question="Q1", context="C1", answer="A1", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1",
+        context="C1",
+        answer="A1",
+        session_id="s1",
     )
     await session_manager.add_qa(
-        user_id="u1", question="Q2", context="C2", answer="A2", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q2",
+        context="C2",
+        answer="A2",
+        session_id="s1",
     )
-    ok = await session_manager.delete_qa(user_id="u1", qa_id=qa1, session_id="s1")
+    ok = await session_manager.delete_qa(
+        user_id="00000000-0000-0000-0000-000000000001", qa_id=qa1, session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "Q2"
 
@@ -338,21 +413,31 @@ async def test_delete_qa(session_manager):
 async def test_delete_session(session_manager):
     """delete_session clears both QA and trace session entries."""
     await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     trace_id = await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s1",
         origin_function="plan_trip",
         status="success",
     )
     assert trace_id is not None
-    ok = await session_manager.delete_session(user_id="u1", session_id="s1")
+    ok = await session_manager.delete_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries == []
-    trace_entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    trace_entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert trace_entries == []
 
 
@@ -360,7 +445,7 @@ async def test_delete_session(session_manager):
 async def test_generate_completion_with_session_saves_qa(session_manager):
     """generate_completion_with_session runs completion and saves QA to session (LLM mocked)."""
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -386,7 +471,9 @@ async def test_generate_completion_with_session_saves_qa(session_manager):
         )
 
     assert result == "Integration test answer"
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "What is X?"
     assert entries[0].answer == "Integration test answer"
@@ -397,7 +484,7 @@ async def test_generate_completion_with_session_saves_qa(session_manager):
 async def test_generate_completion_with_session_feedback_only_records_qa(session_manager):
     """When feedback only is detected: acknowledgement returned and recorded."""
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="What is X?",
         context="Context about X.",
         answer="X is something.",
@@ -406,7 +493,7 @@ async def test_generate_completion_with_session_feedback_only_records_qa(session
     assert qa_id is not None
 
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -436,7 +523,9 @@ async def test_generate_completion_with_session_feedback_only_records_qa(session
         )
 
     assert result == "Thanks for your feedback!"
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 2
     assert entries[0].qa_id == qa_id
     assert entries[0].question == "What is X?"
@@ -451,7 +540,7 @@ async def test_generate_completion_with_session_feedback_only_records_qa(session
 async def test_generate_completion_with_session_feedback_and_followup_adds_qa(session_manager):
     """When query_to_answer is present: new QA is added with answer."""
     qa_id_first = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="What is X?",
         context="Context about X.",
         answer="X is something.",
@@ -460,7 +549,7 @@ async def test_generate_completion_with_session_feedback_and_followup_adds_qa(se
     assert qa_id_first is not None
 
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -493,7 +582,9 @@ async def test_generate_completion_with_session_feedback_and_followup_adds_qa(se
         )
 
     assert result == "Paris is the capital of France."
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 2
     first_qa = next((e for e in entries if e.qa_id == qa_id_first), None)
     followup_qa = next(

--- a/cognee/tests/integration/infrastructure/session/test_session_manager_sql.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_manager_sql.py
@@ -71,11 +71,17 @@ async def _qa_expirations(adapter, user_id: str, session_id: str):
 async def test_add_qa_and_get_session(session_manager):
     """Add QA via SessionManager and retrieve via get_session."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1?",
+        context="ctx1",
+        answer="A1.",
+        session_id="s1",
     )
     assert qa_id is not None
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "Q1?"
     assert entries[0].answer == "A1."
@@ -86,10 +92,14 @@ async def test_add_qa_and_get_session(session_manager):
 async def test_add_qa_sets_session_ttl(session_manager, sql_adapter):
     """Session writes through SessionManager stamp expires_at on the session rows."""
     await session_manager.add_qa(
-        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1?",
+        context="ctx1",
+        answer="A1.",
+        session_id="s1",
     )
 
-    expirations = await _qa_expirations(sql_adapter, "u1", "s1")
+    expirations = await _qa_expirations(sql_adapter, "00000000-0000-0000-0000-000000000001", "s1")
     assert len(expirations) == 1
     assert expirations[0] is not None
 
@@ -98,13 +108,19 @@ async def test_add_qa_sets_session_ttl(session_manager, sql_adapter):
 async def test_get_session_does_not_refresh_session_ttl(session_manager, sql_adapter):
     """Read-only session access should not refresh expires_at."""
     await session_manager.add_qa(
-        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1?",
+        context="ctx1",
+        answer="A1.",
+        session_id="s1",
     )
-    before = await _qa_expirations(sql_adapter, "u1", "s1")
+    before = await _qa_expirations(sql_adapter, "00000000-0000-0000-0000-000000000001", "s1")
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
 
-    after = await _qa_expirations(sql_adapter, "u1", "s1")
+    after = await _qa_expirations(sql_adapter, "00000000-0000-0000-0000-000000000001", "s1")
     assert len(entries) == 1
     assert before == after
 
@@ -124,7 +140,7 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager):
         ),
     ):
         trace_id_1 = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="plan_trip",
             status="success",
@@ -134,7 +150,7 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager):
             method_return_value="Plan created",
         )
         trace_id_2 = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="book_hotel",
             status="error",
@@ -142,8 +158,12 @@ async def test_add_agent_trace_step_and_get_trace_session(session_manager):
             error_message="No availability",
         )
 
-    entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
-    feedback = await session_manager.get_agent_trace_feedback(user_id="u1", session_id="s1")
+    entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
+    feedback = await session_manager.get_agent_trace_feedback(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
 
     assert [entry.trace_id for entry in entries] == [trace_id_1, trace_id_2]
     assert entries[0].origin_function == "plan_trip"
@@ -162,7 +182,7 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(session_
         new_callable=AsyncMock,
     ) as mock_llm:
         trace_id = await session_manager.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             origin_function="plan_trip",
             status="success",
@@ -172,7 +192,9 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(session_
 
     assert trace_id is not None
     mock_llm.assert_not_awaited()
-    entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].session_feedback == "plan_trip succeeded."
 
@@ -181,28 +203,34 @@ async def test_add_agent_trace_step_can_disable_llm_feedback_generation(session_
 async def test_agent_trace_session_isolated_by_user_and_session(session_manager):
     """Agent trace sessions remain isolated by user_id and session_id."""
     await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s1",
         origin_function="plan_trip",
         status="success",
     )
     await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s2",
         origin_function="book_hotel",
         status="error",
         error_message="No availability",
     )
     await session_manager.add_agent_trace_step(
-        user_id="u2",
+        user_id="00000000-0000-0000-0000-000000000002",
         session_id="s1",
         origin_function="book_flight",
         status="success",
     )
 
-    u1s1 = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
-    u1s2 = await session_manager.get_agent_trace_session(user_id="u1", session_id="s2")
-    u2s1 = await session_manager.get_agent_trace_session(user_id="u2", session_id="s1")
+    u1s1 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
+    u1s2 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s2"
+    )
+    u2s1 = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000002", session_id="s1"
+    )
 
     assert len(u1s1) == 1
     assert u1s1[0].origin_function == "plan_trip"
@@ -217,7 +245,7 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager):
     """add_qa with used_graph_element_ids stores and returns it via get_session."""
     used_ids = {"node_ids": ["n1"], "edge_ids": ["e1"]}
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q?",
         context="C",
         answer="A",
@@ -225,7 +253,9 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager):
         used_graph_element_ids=used_ids,
     )
     assert qa_id is not None
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].used_graph_element_ids == used_ids
 
@@ -234,9 +264,15 @@ async def test_add_qa_with_used_graph_element_ids_round_trip(session_manager):
 async def test_get_session_formatted(session_manager):
     """get_session with formatted=True returns prompt string."""
     await session_manager.add_qa(
-        user_id="u1", question="Q?", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q?",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
-    formatted = await session_manager.get_session(user_id="u1", formatted=True, session_id="s1")
+    formatted = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", formatted=True, session_id="s1"
+    )
     assert isinstance(formatted, str)
     assert "Previous conversation" in formatted and "Q?" in formatted
 
@@ -245,14 +281,23 @@ async def test_get_session_formatted(session_manager):
 async def test_update_qa(session_manager):
     """update_qa updates entry via SqlCacheAdapter."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     ok = await session_manager.update_qa(
-        user_id="u1", qa_id=qa_id, question="Q updated?", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        qa_id=qa_id,
+        question="Q updated?",
+        session_id="s1",
     )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].question == "Q updated?"
 
 
@@ -260,14 +305,23 @@ async def test_update_qa(session_manager):
 async def test_add_feedback(session_manager):
     """add_feedback sets feedback on entry."""
     qa_id = await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     ok = await session_manager.add_feedback(
-        user_id="u1", qa_id=qa_id, feedback_score=5, session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        qa_id=qa_id,
+        feedback_score=5,
+        session_id="s1",
     )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].feedback_score == 5
 
 
@@ -275,7 +329,7 @@ async def test_add_feedback(session_manager):
 async def test_delete_feedback(session_manager):
     """delete_feedback clears feedback."""
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q",
         context="C",
         answer="A",
@@ -283,10 +337,14 @@ async def test_delete_feedback(session_manager):
         feedback_text="good",
         feedback_score=4,
     )
-    ok = await session_manager.delete_feedback(user_id="u1", qa_id=qa_id, session_id="s1")
+    ok = await session_manager.delete_feedback(
+        user_id="00000000-0000-0000-0000-000000000001", qa_id=qa_id, session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries[0].feedback_score is None
     assert entries[0].feedback_text is None
 
@@ -295,15 +353,27 @@ async def test_delete_feedback(session_manager):
 async def test_delete_qa(session_manager):
     """delete_qa removes single entry."""
     qa1 = await session_manager.add_qa(
-        user_id="u1", question="Q1", context="C1", answer="A1", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1",
+        context="C1",
+        answer="A1",
+        session_id="s1",
     )
     await session_manager.add_qa(
-        user_id="u1", question="Q2", context="C2", answer="A2", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q2",
+        context="C2",
+        answer="A2",
+        session_id="s1",
     )
-    ok = await session_manager.delete_qa(user_id="u1", qa_id=qa1, session_id="s1")
+    ok = await session_manager.delete_qa(
+        user_id="00000000-0000-0000-0000-000000000001", qa_id=qa1, session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "Q2"
 
@@ -312,39 +382,59 @@ async def test_delete_qa(session_manager):
 async def test_delete_session(session_manager):
     """delete_session clears both QA and trace session entries."""
     await session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
     trace_id = await session_manager.add_agent_trace_step(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         session_id="s1",
         origin_function="plan_trip",
         status="success",
     )
     assert trace_id is not None
-    ok = await session_manager.delete_session(user_id="u1", session_id="s1")
+    ok = await session_manager.delete_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert ok
 
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert entries == []
-    trace_entries = await session_manager.get_agent_trace_session(user_id="u1", session_id="s1")
+    trace_entries = await session_manager.get_agent_trace_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert trace_entries == []
 
 
 @pytest.mark.asyncio
 async def test_delete_session_removes_legacy_graph_snapshot_key(session_manager, sql_adapter):
     """delete_session clears graph snapshots left by the removed graph-to-session sync."""
-    await sql_adapter.set_value("graph_knowledge:u1:s1", "legacy snapshot")
-    assert await sql_adapter.get_value("graph_knowledge:u1:s1") == "legacy snapshot"
+    await sql_adapter.set_value(
+        "graph_knowledge:00000000-0000-0000-0000-000000000001:s1", "legacy snapshot"
+    )
+    assert (
+        await sql_adapter.get_value("graph_knowledge:00000000-0000-0000-0000-000000000001:s1")
+        == "legacy snapshot"
+    )
 
-    await session_manager.delete_session(user_id="u1", session_id="s1")
-    assert await sql_adapter.get_value("graph_knowledge:u1:s1") is None
+    await session_manager.delete_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
+    assert (
+        await sql_adapter.get_value("graph_knowledge:00000000-0000-0000-0000-000000000001:s1")
+        is None
+    )
 
 
 @pytest.mark.asyncio
 async def test_generate_completion_with_session_saves_qa(session_manager):
     """generate_completion_with_session runs completion and saves QA to session (LLM mocked)."""
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -374,7 +464,9 @@ async def test_generate_completion_with_session_saves_qa(session_manager):
         )
 
     assert result == "Integration test answer"
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 1
     assert entries[0].question == "What is X?"
     assert entries[0].answer == "Integration test answer"
@@ -392,7 +484,7 @@ async def test_generate_completion_with_session_feedback_only_records_acknowledg
     skipped but the acknowledgement turn remains recallable in the session history.
     """
     qa_id = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="What is X?",
         context="Context about X.",
         answer="X is something.",
@@ -401,7 +493,7 @@ async def test_generate_completion_with_session_feedback_only_records_acknowledg
     assert qa_id is not None
 
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -431,7 +523,9 @@ async def test_generate_completion_with_session_feedback_only_records_acknowledg
         )
 
     assert result == "Thanks for your feedback!"
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 2
     assert entries[0].qa_id == qa_id
     assert entries[0].question == "What is X?"
@@ -448,7 +542,7 @@ async def test_generate_completion_with_session_feedback_and_followup_adds_qa(se
     and the answer is persisted as a new QA.
     """
     qa_id_first = await session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="What is X?",
         context="Context about X.",
         answer="X is something.",
@@ -457,7 +551,7 @@ async def test_generate_completion_with_session_feedback_and_followup_adds_qa(se
     assert qa_id_first is not None
 
     mock_user = MagicMock()
-    mock_user.id = "u1"
+    mock_user.id = "00000000-0000-0000-0000-000000000001"
     with (
         patch("cognee.infrastructure.session.session_manager.session_user") as mock_session_user,
         patch("cognee.infrastructure.session.session_manager.CacheConfig") as mock_config_cls,
@@ -490,7 +584,9 @@ async def test_generate_completion_with_session_feedback_and_followup_adds_qa(se
         )
 
     assert result == "Paris is the capital of France."
-    entries = await session_manager.get_session(user_id="u1", session_id="s1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="s1"
+    )
     assert len(entries) == 2
     first_qa = next((e for e in entries if e.qa_id == qa_id_first), None)
     followup_qa = next(

--- a/cognee/tests/integration/infrastructure/session/test_session_sdk_integration.py
+++ b/cognee/tests/integration/infrastructure/session/test_session_sdk_integration.py
@@ -121,7 +121,7 @@ def sdk_uses_session_manager(request):
 @pytest.mark.asyncio
 async def test_sdk_get_session_returns_empty_when_no_data(sdk_uses_session_manager):
     """cognee.session.get_session returns [] when session has no QAs."""
-    user = _user("u1")
+    user = _user("00000000-0000-0000-0000-000000000001")
     result = await cognee.session.get_session(session_id="s1", user=user)
     assert result == []
 
@@ -129,9 +129,13 @@ async def test_sdk_get_session_returns_empty_when_no_data(sdk_uses_session_manag
 @pytest.mark.asyncio
 async def test_sdk_get_session_returns_entries_after_add_qa(sdk_uses_session_manager):
     """Add QA via SessionManager, then retrieve via cognee.session.get_session."""
-    user = _user("u1")
+    user = _user("00000000-0000-0000-0000-000000000001")
     qa_id = await sdk_uses_session_manager.add_qa(
-        user_id="u1", question="Q1?", context="ctx1", answer="A1.", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q1?",
+        context="ctx1",
+        answer="A1.",
+        session_id="s1",
     )
     assert qa_id is not None
 
@@ -194,10 +198,10 @@ async def test_sdk_get_session_without_main_dataset_raises(sdk_uses_session_mana
 @pytest.mark.asyncio
 async def test_sdk_get_session_last_n(sdk_uses_session_manager):
     """get_session(last_n=N) returns only last N entries."""
-    user = _user("u1")
+    user = _user("00000000-0000-0000-0000-000000000001")
     for i in range(3):
         await sdk_uses_session_manager.add_qa(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             question=f"Q{i}?",
             context=f"C{i}",
             answer=f"A{i}.",
@@ -213,9 +217,13 @@ async def test_sdk_get_session_last_n(sdk_uses_session_manager):
 @pytest.mark.asyncio
 async def test_sdk_add_feedback_roundtrip(sdk_uses_session_manager):
     """add_feedback via SDK updates entry; get_session returns updated feedback."""
-    user = _user("u1")
+    user = _user("00000000-0000-0000-0000-000000000001")
     qa_id = await sdk_uses_session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
 
     ok = await cognee.session.add_feedback(
@@ -236,9 +244,9 @@ async def test_sdk_add_feedback_roundtrip(sdk_uses_session_manager):
 @pytest.mark.asyncio
 async def test_sdk_delete_feedback_roundtrip(sdk_uses_session_manager):
     """delete_feedback via SDK clears feedback on entry."""
-    user = _user("u1")
+    user = _user("00000000-0000-0000-0000-000000000001")
     qa_id = await sdk_uses_session_manager.add_qa(
-        user_id="u1",
+        user_id="00000000-0000-0000-0000-000000000001",
         question="Q",
         context="C",
         answer="A",
@@ -259,9 +267,13 @@ async def test_sdk_delete_feedback_roundtrip(sdk_uses_session_manager):
 @pytest.mark.asyncio
 async def test_sdk_add_feedback_returns_false_when_qa_not_found(sdk_uses_session_manager):
     """add_feedback returns False when qa_id does not exist."""
-    user = _user("u1")
+    user = _user("00000000-0000-0000-0000-000000000001")
     await sdk_uses_session_manager.add_qa(
-        user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+        user_id="00000000-0000-0000-0000-000000000001",
+        question="Q",
+        context="C",
+        answer="A",
+        session_id="s1",
     )
 
     ok = await cognee.session.add_feedback(
@@ -273,7 +285,7 @@ async def test_sdk_add_feedback_returns_false_when_qa_not_found(sdk_uses_session
 @pytest.mark.asyncio
 async def test_sdk_delete_feedback_returns_false_when_qa_not_found(sdk_uses_session_manager):
     """delete_feedback returns False when qa_id does not exist."""
-    user = _user("u1")
+    user = _user("00000000-0000-0000-0000-000000000001")
     ok = await cognee.session.delete_feedback(session_id="s1", qa_id="nonexistent-qa-id", user=user)
     assert ok is False
 
@@ -281,13 +293,21 @@ async def test_sdk_delete_feedback_returns_false_when_qa_not_found(sdk_uses_sess
 @pytest.mark.asyncio
 async def test_sdk_explicit_user_id_passed_to_cache(sdk_uses_session_manager):
     """Session SDK passes resolved user id to SessionManager (isolation by user)."""
-    user1 = _user("user-one")
-    user2 = _user("user-two")
+    user1 = _user("00000000-0000-0000-0000-000000000011")
+    user2 = _user("00000000-0000-0000-0000-000000000012")
     await sdk_uses_session_manager.add_qa(
-        user_id="user-one", question="Q1", context="C1", answer="A1", session_id="shared"
+        user_id="00000000-0000-0000-0000-000000000011",
+        question="Q1",
+        context="C1",
+        answer="A1",
+        session_id="shared",
     )
     await sdk_uses_session_manager.add_qa(
-        user_id="user-two", question="Q2", context="C2", answer="A2", session_id="shared"
+        user_id="00000000-0000-0000-0000-000000000012",
+        question="Q2",
+        context="C2",
+        answer="A2",
+        session_id="shared",
     )
 
     entries1 = await cognee.session.get_session(session_id="shared", user=user1)

--- a/cognee/tests/integration/infrastructure/session/test_tapes_cache_adapter.py
+++ b/cognee/tests/integration/infrastructure/session/test_tapes_cache_adapter.py
@@ -38,7 +38,7 @@ async def test_create_qa_entry_writes_fs_and_mirrors_to_tapes(tapes_adapter):
     mock_post = _patched_post_returning(202)
     with patch("httpx.AsyncClient.post", mock_post):
         await tapes_adapter.create_qa_entry(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             question="What is cognee?",
             context="Background context here.",
@@ -46,7 +46,7 @@ async def test_create_qa_entry_writes_fs_and_mirrors_to_tapes(tapes_adapter):
             qa_id="qa-1",
         )
 
-    entries = await tapes_adapter.get_all_qa_entries("u1", "s1")
+    entries = await tapes_adapter.get_all_qa_entries("00000000-0000-0000-0000-000000000001", "s1")
     assert len(entries) == 1
     assert entries[0].qa_id == "qa-1"
     assert entries[0].answer == "An AI memory platform."
@@ -71,7 +71,7 @@ async def test_ingest_failure_does_not_break_fs_write(tapes_adapter):
     mock_post = AsyncMock(side_effect=RuntimeError("tapes unreachable"))
     with patch("httpx.AsyncClient.post", mock_post):
         await tapes_adapter.create_qa_entry(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             question="Q?",
             context="",
@@ -79,7 +79,7 @@ async def test_ingest_failure_does_not_break_fs_write(tapes_adapter):
             qa_id="qa-2",
         )
 
-    entries = await tapes_adapter.get_all_qa_entries("u1", "s1")
+    entries = await tapes_adapter.get_all_qa_entries("00000000-0000-0000-0000-000000000001", "s1")
     assert len(entries) == 1
     assert entries[0].qa_id == "qa-2"
 
@@ -90,7 +90,7 @@ async def test_anthropic_provider_shape(tapes_adapter):
     mock_post = _patched_post_returning(202)
     with patch("httpx.AsyncClient.post", mock_post):
         await tapes_adapter.create_qa_entry(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             question="Hi?",
             context="sys",
@@ -111,7 +111,7 @@ async def test_update_and_delete_are_not_mirrored(tapes_adapter):
     mock_post = _patched_post_returning(202)
     with patch("httpx.AsyncClient.post", mock_post):
         await tapes_adapter.create_qa_entry(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             question="Q?",
             context="",
@@ -121,14 +121,16 @@ async def test_update_and_delete_are_not_mirrored(tapes_adapter):
         assert mock_post.await_count == 1
 
         updated = await tapes_adapter.update_qa_entry(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             qa_id="qa-4",
             feedback_score=5,
         )
         assert updated is True
 
-        deleted = await tapes_adapter.delete_qa_entry("u1", "s1", "qa-4")
+        deleted = await tapes_adapter.delete_qa_entry(
+            "00000000-0000-0000-0000-000000000001", "s1", "qa-4"
+        )
         assert deleted is True
 
     # Only the initial create_qa_entry should have reached tapes.

--- a/cognee/tests/integration/retrieval/test_graph_completion_decomposition_retriever.py
+++ b/cognee/tests/integration/retrieval/test_graph_completion_decomposition_retriever.py
@@ -252,7 +252,7 @@ async def test_graph_completion_decomposition_combined_mode_session_stores_only_
         top_k=20,
         session_id="session-1",
     )
-    user = SimpleNamespace(id="user-1")
+    user = SimpleNamespace(id="00000000-0000-0000-0000-000000000001")
 
     with (
         patch(
@@ -302,7 +302,9 @@ async def test_graph_completion_decomposition_combined_mode_session_stores_only_
 
     assert answer == ["Combined answer for both companies."]
 
-    entries = await session_manager.get_session(user_id="user-1", session_id="session-1")
+    entries = await session_manager.get_session(
+        user_id="00000000-0000-0000-0000-000000000001", session_id="session-1"
+    )
     assert len(entries) == 1
     assert entries[0].question == ORIGINAL_QUERY
     assert entries[0].answer == "Combined answer for both companies."

--- a/cognee/tests/unit/infrastructure/session/test_session_manager.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_manager.py
@@ -37,8 +37,8 @@ class TestValidateSessionParams:
 
     def test_valid_params(self):
         """Valid user_id and session_id do not raise."""
-        SessionManager._validate_session_params(user_id="u1", session_id="s1")
-        SessionManager._validate_session_params(user_id="u1", session_id="s1", qa_id="q1")
+        SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
+        SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="s1", qa_id="q1")
 
     def test_empty_user_id_raises(self):
         """Empty user_id raises SessionParameterValidationError."""
@@ -49,7 +49,7 @@ class TestValidateSessionParams:
     def test_empty_session_id_raises(self):
         """Empty session_id raises SessionParameterValidationError."""
         with pytest.raises(SessionParameterValidationError) as exc_info:
-            SessionManager._validate_session_params(user_id="u1", session_id="")
+            SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="")
         assert "session_id" in exc_info.value.message
 
     def test_whitespace_user_id_raises(self):
@@ -60,30 +60,30 @@ class TestValidateSessionParams:
     def test_empty_qa_id_raises(self):
         """Empty qa_id raises when provided."""
         with pytest.raises(SessionParameterValidationError) as exc_info:
-            SessionManager._validate_session_params(user_id="u1", session_id="s1", qa_id="")
+            SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="s1", qa_id="")
         assert "qa_id" in exc_info.value.message
 
     def test_valid_last_n(self):
         """Valid last_n (positive int or None) does not raise."""
-        SessionManager._validate_session_params(user_id="u1", session_id="s1", last_n=5)
-        SessionManager._validate_session_params(user_id="u1", session_id="s1", last_n=1)
+        SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="s1", last_n=5)
+        SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="s1", last_n=1)
 
     def test_invalid_last_n_zero_raises(self):
         """last_n=0 raises SessionParameterValidationError."""
         with pytest.raises(SessionParameterValidationError) as exc_info:
-            SessionManager._validate_session_params(user_id="u1", session_id="s1", last_n=0)
+            SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="s1", last_n=0)
         assert "last_n" in exc_info.value.message
 
     def test_invalid_last_n_negative_raises(self):
         """last_n negative raises."""
         with pytest.raises(SessionParameterValidationError) as exc_info:
-            SessionManager._validate_session_params(user_id="u1", session_id="s1", last_n=-1)
+            SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="s1", last_n=-1)
         assert "last_n" in exc_info.value.message
 
     def test_invalid_last_n_not_int_raises(self):
         """last_n not an int raises."""
         with pytest.raises(SessionParameterValidationError) as exc_info:
-            SessionManager._validate_session_params(user_id="u1", session_id="s1", last_n="5")
+            SessionManager._validate_session_params(user_id="00000000-0000-0000-0000-000000000001", session_id="s1", last_n="5")
         assert "last_n" in exc_info.value.message
 
 
@@ -157,7 +157,7 @@ class TestSessionManager:
     @pytest.mark.asyncio
     async def test_add_qa_session_id_none_uses_default(self, sm, mock_cache):
         """add_qa with session_id=None uses default_session_id."""
-        qa_id = await sm.add_qa(user_id="u1", question="Q", context="C", answer="A")
+        qa_id = await sm.add_qa(user_id="00000000-0000-0000-0000-000000000001", question="Q", context="C", answer="A")
         assert qa_id is not None
         call_kw = mock_cache.create_qa_entry.call_args.kwargs
         assert call_kw["session_id"] == "default_session"
@@ -167,7 +167,7 @@ class TestSessionManager:
         """add_qa returns generated qa_id and calls cache."""
         used_ids = {"node_ids": ["n1"], "edge_ids": ["e1"]}
         qa_id = await sm.add_qa(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             question="Q",
             context="C",
             answer="A",
@@ -177,7 +177,7 @@ class TestSessionManager:
         assert qa_id is not None
         mock_cache.create_qa_entry.assert_called_once()
         call_kw = mock_cache.create_qa_entry.call_args.kwargs
-        assert call_kw["user_id"] == "u1"
+        assert call_kw["user_id"] == "00000000-0000-0000-0000-000000000001"
         assert call_kw["session_id"] == "s1"
         assert call_kw["question"] == "Q"
         assert call_kw["answer"] == "A"
@@ -185,7 +185,7 @@ class TestSessionManager:
         assert call_kw["used_graph_element_ids"] == used_ids
         assert "embedding" not in call_kw
         session_vector_mocks["index"].assert_awaited_once_with(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             qa_id=qa_id,
             question="Q",
@@ -197,7 +197,7 @@ class TestSessionManager:
         """add_qa returns None when cache unavailable."""
         assert (
             await sm_unavailable.add_qa(
-                user_id="u1", question="Q", context="C", answer="A", session_id="s1"
+                user_id="00000000-0000-0000-0000-000000000001", question="Q", context="C", answer="A", session_id="s1"
             )
             is None
         )
@@ -208,13 +208,13 @@ class TestSessionManager:
         with pytest.raises(SessionParameterValidationError):
             await sm.add_qa(user_id="", question="Q", context="C", answer="A", session_id="s1")
         with pytest.raises(SessionParameterValidationError):
-            await sm.add_qa(user_id="u1", question="Q", context="C", answer="A", session_id="")
+            await sm.add_qa(user_id="00000000-0000-0000-0000-000000000001", question="Q", context="C", answer="A", session_id="")
 
     @pytest.mark.asyncio
     async def test_add_agent_trace_step_session_id_none_uses_default(self, sm, mock_cache):
         """add_agent_trace_step with session_id=None uses default_session_id."""
         trace_id = await sm.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             origin_function="plan_trip",
             status="success",
         )
@@ -236,7 +236,7 @@ class TestSessionManager:
         monkeypatch.setattr(sm, "is_auto_feedback_enabled", lambda: True)
 
         trace_id = await sm.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             origin_function="run_tests",
             status="error",
             session_id="s1",
@@ -252,7 +252,7 @@ class TestSessionManager:
         assert call_kw["session_id"] == "s1"
         pending_spy.assert_awaited_once_with(
             session_manager=sm,
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
         )
 
@@ -270,7 +270,7 @@ class TestSessionManager:
         monkeypatch.setattr(sm, "is_auto_feedback_enabled", lambda: False)
 
         await sm.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             origin_function="run_tests",
             status="error",
             session_id="s1",
@@ -298,7 +298,7 @@ class TestSessionManager:
             ),
         ):
             trace_id = await sm.add_agent_trace_step(
-                user_id="u1",
+                user_id="00000000-0000-0000-0000-000000000001",
                 origin_function="plan_trip",
                 status="success",
                 session_id="s1",
@@ -334,7 +334,7 @@ class TestSessionManager:
             ),
         ):
             trace_id = await sm.add_agent_trace_step(
-                user_id="u1",
+                user_id="00000000-0000-0000-0000-000000000001",
                 origin_function="book_hotel",
                 status="error",
                 session_id="s1",
@@ -360,7 +360,7 @@ class TestSessionManager:
             ),
         ):
             trace_id = await sm.add_agent_trace_step(
-                user_id="u1",
+                user_id="00000000-0000-0000-0000-000000000001",
                 origin_function="book_hotel",
                 status="error",
                 session_id="s1",
@@ -385,7 +385,7 @@ class TestSessionManager:
             ) as mock_llm,
         ):
             trace_id = await sm.add_agent_trace_step(
-                user_id="u1",
+                user_id="00000000-0000-0000-0000-000000000001",
                 origin_function="plan_trip",
                 status="success",
                 session_id="s1",
@@ -414,7 +414,7 @@ class TestSessionManager:
             ),
         ):
             trace_id = await sm.add_agent_trace_step(
-                user_id="u1",
+                user_id="00000000-0000-0000-0000-000000000001",
                 origin_function="plan_trip",
                 status="success",
                 session_id="s1",
@@ -435,7 +435,7 @@ class TestSessionManager:
             new_callable=AsyncMock,
         ) as mock_llm:
             trace_id = await sm.add_agent_trace_step(
-                user_id="u1",
+                user_id="00000000-0000-0000-0000-000000000001",
                 origin_function="plan_trip",
                 status="success",
                 session_id="s1",
@@ -455,7 +455,7 @@ class TestSessionManager:
             new_callable=AsyncMock,
         ) as mock_llm:
             trace_id = await sm.add_agent_trace_step(
-                user_id="u1",
+                user_id="00000000-0000-0000-0000-000000000001",
                 origin_function="plan_trip",
                 status="success",
                 session_id="s1",
@@ -472,7 +472,7 @@ class TestSessionManager:
     async def test_add_agent_trace_step_unavailable_returns_none(self, sm_unavailable):
         """add_agent_trace_step returns None when cache unavailable."""
         result = await sm_unavailable.add_agent_trace_step(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             origin_function="plan_trip",
             status="success",
             session_id="s1",
@@ -483,9 +483,9 @@ class TestSessionManager:
     async def test_get_session_invalid_last_n_raises(self, sm):
         """get_session raises on invalid last_n."""
         with pytest.raises(SessionParameterValidationError):
-            await sm.get_session(user_id="u1", last_n=0, session_id="s1")
+            await sm.get_session(user_id="00000000-0000-0000-0000-000000000001", last_n=0, session_id="s1")
         with pytest.raises(SessionParameterValidationError):
-            await sm.get_session(user_id="u1", last_n=-1, session_id="s1")
+            await sm.get_session(user_id="00000000-0000-0000-0000-000000000001", last_n=-1, session_id="s1")
 
     def test_format_entries_empty(self):
         """format_entries returns empty string for empty list."""
@@ -506,10 +506,10 @@ class TestSessionManager:
         mock_cache.get_all_qa_entries.return_value = [
             {"qa_id": "1", "question": "Q", "context": "C", "answer": "A", "time": "t"}
         ]
-        entries = await sm.get_session(user_id="u1", session_id="s1")
+        entries = await sm.get_session(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
         assert len(entries) == 1
         assert entries[0]["question"] == "Q"
-        mock_cache.get_all_qa_entries.assert_called_once_with("u1", "s1")
+        mock_cache.get_all_qa_entries.assert_called_once_with("00000000-0000-0000-0000-000000000001", "s1")
 
     @pytest.mark.asyncio
     async def test_get_session_formatted(self, sm, mock_cache):
@@ -517,15 +517,15 @@ class TestSessionManager:
         mock_cache.get_all_qa_entries.return_value = [
             SessionQAEntry(qa_id="1", question="Q", context="C", answer="A", time="t")
         ]
-        out = await sm.get_session(user_id="u1", formatted=True, session_id="s1")
+        out = await sm.get_session(user_id="00000000-0000-0000-0000-000000000001", formatted=True, session_id="s1")
         assert isinstance(out, str)
         assert "Previous conversation" in out and "Q" in out
 
     @pytest.mark.asyncio
     async def test_get_session_unavailable_returns_empty(self, sm_unavailable):
         """get_session returns empty list when cache unavailable."""
-        assert await sm_unavailable.get_session(user_id="u1", session_id="s1") == []
-        assert await sm_unavailable.get_session(user_id="u1", formatted=True, session_id="s1") == ""
+        assert await sm_unavailable.get_session(user_id="00000000-0000-0000-0000-000000000001", session_id="s1") == []
+        assert await sm_unavailable.get_session(user_id="00000000-0000-0000-0000-000000000001", formatted=True, session_id="s1") == ""
 
     @pytest.mark.asyncio
     async def test_get_agent_trace_session_calls_cache(self, sm, mock_cache):
@@ -538,15 +538,15 @@ class TestSessionManager:
                 "session_feedback": "plan_trip succeeded.",
             }
         ]
-        entries = await sm.get_agent_trace_session(user_id="u1", session_id="s1")
+        entries = await sm.get_agent_trace_session(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
         assert len(entries) == 1
         assert entries[0]["trace_id"] == "t1"
-        mock_cache.get_agent_trace_session.assert_called_once_with("u1", "s1", last_n=None)
+        mock_cache.get_agent_trace_session.assert_called_once_with("00000000-0000-0000-0000-000000000001", "s1", last_n=None)
 
     @pytest.mark.asyncio
     async def test_get_agent_trace_session_unavailable_returns_empty(self, sm_unavailable):
         """get_agent_trace_session returns empty list when cache unavailable."""
-        assert await sm_unavailable.get_agent_trace_session(user_id="u1", session_id="s1") == []
+        assert await sm_unavailable.get_agent_trace_session(user_id="00000000-0000-0000-0000-000000000001", session_id="s1") == []
 
     @pytest.mark.asyncio
     async def test_get_agent_trace_feedback_calls_cache(self, sm, mock_cache):
@@ -555,42 +555,42 @@ class TestSessionManager:
             "plan_trip succeeded.",
             "book_hotel failed. Reason: No availability.",
         ]
-        feedback = await sm.get_agent_trace_feedback(user_id="u1", session_id="s1")
+        feedback = await sm.get_agent_trace_feedback(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
         assert feedback == [
             "plan_trip succeeded.",
             "book_hotel failed. Reason: No availability.",
         ]
-        mock_cache.get_agent_trace_feedback.assert_called_once_with("u1", "s1", last_n=None)
+        mock_cache.get_agent_trace_feedback.assert_called_once_with("00000000-0000-0000-0000-000000000001", "s1", last_n=None)
 
     @pytest.mark.asyncio
     async def test_get_agent_trace_feedback_passes_last_n_to_cache(self, sm, mock_cache):
         """get_agent_trace_feedback forwards last_n to cache."""
         mock_cache.get_agent_trace_feedback.return_value = ["book_hotel failed."]
 
-        feedback = await sm.get_agent_trace_feedback(user_id="u1", session_id="s1", last_n=1)
+        feedback = await sm.get_agent_trace_feedback(user_id="00000000-0000-0000-0000-000000000001", session_id="s1", last_n=1)
 
         assert feedback == ["book_hotel failed."]
-        mock_cache.get_agent_trace_feedback.assert_called_once_with("u1", "s1", last_n=1)
+        mock_cache.get_agent_trace_feedback.assert_called_once_with("00000000-0000-0000-0000-000000000001", "s1", last_n=1)
 
     @pytest.mark.asyncio
     async def test_get_agent_trace_feedback_unavailable_returns_empty(self, sm_unavailable):
         """get_agent_trace_feedback returns empty list when cache unavailable."""
-        assert await sm_unavailable.get_agent_trace_feedback(user_id="u1", session_id="s1") == []
+        assert await sm_unavailable.get_agent_trace_feedback(user_id="00000000-0000-0000-0000-000000000001", session_id="s1") == []
 
     @pytest.mark.asyncio
     async def test_get_agent_trace_count_calls_cache(self, sm, mock_cache):
         """get_agent_trace_count delegates to cache."""
         mock_cache.get_agent_trace_count.return_value = 3
 
-        count = await sm.get_agent_trace_count(user_id="u1", session_id="s1")
+        count = await sm.get_agent_trace_count(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
 
         assert count == 3
-        mock_cache.get_agent_trace_count.assert_called_once_with("u1", "s1")
+        mock_cache.get_agent_trace_count.assert_called_once_with("00000000-0000-0000-0000-000000000001", "s1")
 
     @pytest.mark.asyncio
     async def test_get_agent_trace_count_unavailable_returns_zero(self, sm_unavailable):
         """get_agent_trace_count returns zero when cache unavailable."""
-        assert await sm_unavailable.get_agent_trace_count(user_id="u1", session_id="s1") == 0
+        assert await sm_unavailable.get_agent_trace_count(user_id="00000000-0000-0000-0000-000000000001", session_id="s1") == 0
 
     @pytest.mark.asyncio
     async def test_update_qa_calls_cache_and_reindexes_when_text_changes(
@@ -601,11 +601,11 @@ class TestSessionManager:
             SessionQAEntry(qa_id="q1", question="Q2", context="C", answer="A", time="t")
         ]
 
-        ok = await sm.update_qa(user_id="u1", qa_id="q1", question="Q2", session_id="s1")
+        ok = await sm.update_qa(user_id="00000000-0000-0000-0000-000000000001", qa_id="q1", question="Q2", session_id="s1")
 
         assert ok is True
         mock_cache.update_qa_entry.assert_called_once_with(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             qa_id="q1",
             question="Q2",
@@ -617,10 +617,10 @@ class TestSessionManager:
             memify_metadata=None,
             used_session_context_ids=None,
         )
-        mock_cache.get_qa_entries_by_ids.assert_awaited_once_with("u1", "s1", ["q1"])
+        mock_cache.get_qa_entries_by_ids.assert_awaited_once_with("00000000-0000-0000-0000-000000000001", "s1", ["q1"])
         session_vector_mocks["delete_qa"].assert_awaited_once_with(qa_id="q1")
         session_vector_mocks["index"].assert_awaited_once_with(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
             qa_id="q1",
             question="Q2",
@@ -633,7 +633,7 @@ class TestSessionManager:
     ):
         """Feedback-only updates leave QA vector rows unchanged."""
         ok = await sm.update_qa(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             qa_id="q1",
             feedback_text="useful",
             feedback_score=5,
@@ -648,10 +648,10 @@ class TestSessionManager:
     @pytest.mark.asyncio
     async def test_delete_feedback_calls_cache(self, sm, mock_cache):
         """delete_feedback delegates to cache."""
-        ok = await sm.delete_feedback(user_id="u1", qa_id="q1", session_id="s1")
+        ok = await sm.delete_feedback(user_id="00000000-0000-0000-0000-000000000001", qa_id="q1", session_id="s1")
         assert ok is True
         mock_cache.delete_feedback.assert_called_once_with(
-            user_id="u1", session_id="s1", qa_id="q1"
+            user_id="00000000-0000-0000-0000-000000000001", session_id="s1", qa_id="q1"
         )
 
     @pytest.mark.asyncio
@@ -659,10 +659,10 @@ class TestSessionManager:
         self, sm, mock_cache, session_vector_mocks
     ):
         """delete_qa delegates to cache and removes its vector row."""
-        ok = await sm.delete_qa(user_id="u1", qa_id="q1", session_id="s1")
+        ok = await sm.delete_qa(user_id="00000000-0000-0000-0000-000000000001", qa_id="q1", session_id="s1")
         assert ok is True
         mock_cache.delete_qa_entry.assert_called_once_with(
-            user_id="u1", session_id="s1", qa_id="q1"
+            user_id="00000000-0000-0000-0000-000000000001", session_id="s1", qa_id="q1"
         )
         session_vector_mocks["delete_qa"].assert_awaited_once_with(qa_id="q1")
 
@@ -673,7 +673,7 @@ class TestSessionManager:
         """delete_qa leaves vectors alone when the cache row was not deleted."""
         mock_cache.delete_qa_entry.return_value = False
 
-        ok = await sm.delete_qa(user_id="u1", qa_id="q1", session_id="s1")
+        ok = await sm.delete_qa(user_id="00000000-0000-0000-0000-000000000001", qa_id="q1", session_id="s1")
 
         assert ok is False
         session_vector_mocks["delete_qa"].assert_not_awaited()
@@ -683,11 +683,11 @@ class TestSessionManager:
         self, sm, mock_cache, session_vector_mocks
     ):
         """delete_session delegates to cache and removes its scoped vector rows."""
-        ok = await sm.delete_session(user_id="u1", session_id="s1")
+        ok = await sm.delete_session(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
         assert ok is True
-        mock_cache.delete_session.assert_called_once_with(user_id="u1", session_id="s1")
+        mock_cache.delete_session.assert_called_once_with(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
         session_vector_mocks["delete_session"].assert_awaited_once_with(
-            user_id="u1",
+            user_id="00000000-0000-0000-0000-000000000001",
             session_id="s1",
         )
 
@@ -698,7 +698,7 @@ class TestSessionManager:
         """delete_session leaves vectors alone when the cache session was not deleted."""
         mock_cache.delete_session.return_value = False
 
-        ok = await sm.delete_session(user_id="u1", session_id="s1")
+        ok = await sm.delete_session(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
 
         assert ok is False
         session_vector_mocks["delete_session"].assert_not_awaited()
@@ -748,7 +748,7 @@ class TestSessionManager:
             ) as mock_generate,
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = False
@@ -780,7 +780,7 @@ class TestSessionManager:
             ) as mock_generate,
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -801,7 +801,7 @@ class TestSessionManager:
         mock_generate.assert_awaited_once()
         mock_cache.create_qa_entry.assert_called_once()
         call_kw = mock_cache.create_qa_entry.call_args.kwargs
-        assert call_kw["user_id"] == "u1"
+        assert call_kw["user_id"] == "00000000-0000-0000-0000-000000000001"
         assert call_kw["session_id"] == "s1"
         assert call_kw["question"] == "Q?"
         assert call_kw["answer"] == "Generated answer"
@@ -824,7 +824,7 @@ class TestSessionManager:
             ) as mock_generate,
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
 
             result = await sm_unavailable.generate_completion_with_session(
@@ -855,7 +855,7 @@ class TestSessionManager:
             ),
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -906,7 +906,7 @@ class TestSessionManager:
             ),
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -948,7 +948,7 @@ class TestSessionManager:
             ),
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -992,7 +992,7 @@ class TestSessionManager:
             ),
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -1034,7 +1034,7 @@ class TestSessionManager:
             ),
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -1079,7 +1079,7 @@ class TestSessionManager:
             ),
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -1128,7 +1128,7 @@ class TestSessionManager:
             ),
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -1169,7 +1169,7 @@ class TestSessionManager:
             ),
         ):
             mock_user = MagicMock()
-            mock_user.id = "u1"
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
             mock_session_user.get.return_value = mock_user
             mock_config = MagicMock()
             mock_config.caching = True
@@ -1232,7 +1232,7 @@ class TestSessionContextEntryValidation:
             )
         with pytest.raises(SessionParameterValidationError):
             await sm.create_session_context_entry(
-                user_id="u1", entry_dump={"kind": "context"}, session_id="  "
+                user_id="00000000-0000-0000-0000-000000000001", entry_dump={"kind": "context"}, session_id="  "
             )
         mock_cache.create_session_context_entry.assert_not_called()
 
@@ -1242,7 +1242,7 @@ class TestSessionContextEntryValidation:
         with pytest.raises(SessionParameterValidationError):
             await sm.get_session_context_entries(user_id="", session_id="s1")
         with pytest.raises(SessionParameterValidationError):
-            await sm.get_session_context_entries(user_id="u1", session_id="  ")
+            await sm.get_session_context_entries(user_id="00000000-0000-0000-0000-000000000001", session_id="  ")
         mock_cache.get_session_context_entries.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1254,7 +1254,7 @@ class TestSessionContextEntryValidation:
             )
         with pytest.raises(SessionParameterValidationError):
             await sm.update_session_context_entry(
-                user_id="u1", entry_id="e1", merge={}, session_id="  "
+                user_id="00000000-0000-0000-0000-000000000001", entry_id="e1", merge={}, session_id="  "
             )
         mock_cache.update_session_context_entry.assert_not_called()
 
@@ -1264,7 +1264,7 @@ class TestSessionContextEntryValidation:
         with pytest.raises(SessionParameterValidationError):
             await sm.delete_session_context(user_id="", session_id="s1")
         with pytest.raises(SessionParameterValidationError):
-            await sm.delete_session_context(user_id="u1", session_id="  ")
+            await sm.delete_session_context(user_id="00000000-0000-0000-0000-000000000001", session_id="  ")
         mock_cache.delete_session_context.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1282,28 +1282,28 @@ class TestSessionContextEntryValidation:
     async def test_create_session_context_entry_fail_open_on_cache_error(self, sm_failing_cache):
         """Cache runtime failures stay fail-open: returns False, never raises."""
         result = await sm_failing_cache.create_session_context_entry(
-            user_id="u1", entry_dump={"kind": "context"}, session_id="s1"
+            user_id="00000000-0000-0000-0000-000000000001", entry_dump={"kind": "context"}, session_id="s1"
         )
         assert result is False
 
     @pytest.mark.asyncio
     async def test_get_session_context_entries_fail_open_on_cache_error(self, sm_failing_cache):
         """Cache runtime failures stay fail-open: returns [], never raises."""
-        result = await sm_failing_cache.get_session_context_entries(user_id="u1", session_id="s1")
+        result = await sm_failing_cache.get_session_context_entries(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
         assert result == []
 
     @pytest.mark.asyncio
     async def test_update_session_context_entry_fail_open_on_cache_error(self, sm_failing_cache):
         """Cache runtime failures stay fail-open: returns False, never raises."""
         result = await sm_failing_cache.update_session_context_entry(
-            user_id="u1", entry_id="e1", merge={"content": "x"}, session_id="s1"
+            user_id="00000000-0000-0000-0000-000000000001", entry_id="e1", merge={"content": "x"}, session_id="s1"
         )
         assert result is False
 
     @pytest.mark.asyncio
     async def test_delete_session_context_fail_open_on_cache_error(self, sm_failing_cache):
         """Cache runtime failures stay fail-open: returns False, never raises."""
-        result = await sm_failing_cache.delete_session_context(user_id="u1", session_id="s1")
+        result = await sm_failing_cache.delete_session_context(user_id="00000000-0000-0000-0000-000000000001", session_id="s1")
         assert result is False
 
     @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/memify_tasks/test_extract_feedback_qas.py
+++ b/cognee/tests/unit/modules/memify_tasks/test_extract_feedback_qas.py
@@ -1,5 +1,6 @@
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
 
 import pytest
 
@@ -27,7 +28,7 @@ def _make_entry(**kwargs) -> SessionQAEntry:
 @pytest.fixture
 def mock_user():
     user = MagicMock()
-    user.id = "u1"
+    user.id = UUID("00000000-0000-0000-0000-000000000001")
     return user
 
 


### PR DESCRIPTION
Extracted from #4209 as a standalone hygiene fix (independent of the abandoned session-binding approach).

## Problem
A non-UUID `user_id` (`"u1"`, a username, any string) silently created **ghost sessions**: stored under an arbitrary string key in the cache, invisible to lifecycle tracking, dataset attribution, the sessions dashboard, and cleanup — and unreachable from any real user's session listing. Nothing failed; the data just leaked into unreachable keys.

## Fix
`_validate_session_params` — the guard every SessionManager entry point already runs — now rejects non-UUID user ids with `SessionParameterValidationError` (UUID objects and UUID strings both accepted, same posture as the dataset-id validation that landed with #4286):

```python
if user_id is not None and as_uuid(user_id) is None:
    raise SessionParameterValidationError(
        message=f"user_id must be a UUID, got {user_id!r}. Non-UUID user ids create "
        "sessions invisible to lifecycle tracking, attribution, and cleanup."
    )
```

Includes `as_uuid` in `shared/utils` (also in #4284, byte-identical — whichever merges first, the other shrinks).

## Test sweep
The suites used `"u1"`-style user ids throughout — which is exactly the input class that now breaks. Mechanically replaced with real UUID strings: 80 sites in the unit suites, 225 in the session integration suites, including two composite legacy cache keys that embed the id, and one mock-user fixture.

## Testing
- 320 unit tests (session infrastructure, session API, memify tasks) pass
- 102 integration tests across fs / redis / sqlite cache backends pass
- Ruff and ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)