### PR TITLE
docs: fix htpps typo in website link (htpps -> https)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Graph memory traditionally means operating a stack — a graph database for rela
 > **⚠️ Warning:** Using Postgres as a graph store is currently a released as a demo feature. The production ready feature is available as a licenced product. Use it to demo keeping relational metadata, PGVector, and graph
 > state in a single Postgres service.
 >
-> Interested in production use of Postgres as a graph database? Book a call with our sales team at our [website](htpps://www.cognee.ai)
+> Interested in production use of Postgres as a graph database? Book a call with our sales team at our [website](https://www.cognee.ai)
 >
 | Memory layer | Traditional stack | cognee on Postgres |
 | --- | --- | --- |


### PR DESCRIPTION
The sales-team website link in the README uses the scheme `htpps://www.cognee.ai`:

```
Book a call with our sales team at our [website](htpps://www.cognee.ai)
```

`htpps` is not a valid URI scheme, so the link is dead. The same URL appears correctly as `https://www.cognee.ai` elsewhere in the README (the Cognee Cloud links at lines 366 and 370). This corrects the scheme to `https`.

Docs-only, no functional change.

---

I have read the DCO and I sign off on the commit:
Signed-off-by: latent-9 <296084221+latent-9@users.noreply.github.com>
