### PR TITLE
ci: Backport nightly perf suite to main (v1.4.1 follow-up)

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - '.github/workflows/nightly_tests.yml'
       - '.github/workflows/performance_report.yml'
+      - '.github/workflows/performance_report_cloud.yml'
 
 
 concurrency:
@@ -78,6 +79,27 @@ jobs:
       mock_memories_key: nightly_ci_artifacts/performance_test_artifacts/mock_war_and_peace.json
     secrets: inherit
 
+  # ══ Performance: Cognee Cloud tenant. No mock variants — the LLM runs ══════
+  # server-side on the tenant, so there is nothing to mock client-side.
+  perf-small-cloud:
+    name: Performance — 50 Small Documents (cloud)
+    uses: ./.github/workflows/performance_report_cloud.yml
+    with:
+      label: 50_small_documents
+      runs: '3'
+      num_memories: '50'
+      memories_key: nightly_ci_artifacts/performance_test_artifacts/memories.json
+    secrets: inherit
+
+  perf-wap-cloud:
+    name: Performance — War and Peace (cloud)
+    uses: ./.github/workflows/performance_report_cloud.yml
+    with:
+      label: war_and_peace
+      runs: '3'
+      memories_key: nightly_ci_artifacts/performance_test_artifacts/war_and_peace.json
+    secrets: inherit
+
   notify:
     name: Test Completion Status
     needs: [
@@ -87,6 +109,8 @@ jobs:
       perf-small-mock,
       perf-wap-llm,
       perf-wap-mock,
+      perf-small-cloud,
+      perf-wap-cloud,
     ]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
@@ -99,7 +123,9 @@ jobs:
                 "${{ needs.perf-small-llm.result }}" == "success" &&
                 "${{ needs.perf-small-mock.result }}" == "success" &&
                 "${{ needs.perf-wap-llm.result }}" == "success" &&
-                "${{ needs.perf-wap-mock.result }}" == "success" ]]; then
+                "${{ needs.perf-wap-mock.result }}" == "success" &&
+                "${{ needs.perf-small-cloud.result }}" == "success" &&
+                "${{ needs.perf-wap-cloud.result }}" == "success" ]]; then
             echo "passed=true" >> "$GITHUB_OUTPUT"
             echo "emoji=✅" >> "$GITHUB_OUTPUT"
             echo "summary=All nightly test suites completed successfully!" >> "$GITHUB_OUTPUT"
@@ -128,6 +154,8 @@ jobs:
             url_pg_small_mock ${{ needs.perf-small-mock.outputs.postgres_html_key }}
             url_pg_wap_llm ${{ needs.perf-wap-llm.outputs.postgres_html_key }}
             url_pg_wap_mock ${{ needs.perf-wap-mock.outputs.postgres_html_key }}
+            url_cloud_small ${{ needs.perf-small-cloud.outputs.cloud_html_key }}
+            url_cloud_wap ${{ needs.perf-wap-cloud.outputs.cloud_html_key }}
         run: |
           set -euo pipefail
           # 7 days = 604800s is the maximum lifetime for an IAM-user presigned URL.
@@ -233,6 +261,28 @@ jobs:
                     search     p50 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').search.p99 }}s`
                     total      p50 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').total.p99 }}s`
                     <${{ steps.presign.outputs.url_pg_wap_mock }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *📊 Cognee Cloud — 50 Small Documents* (`${{ needs.perf-small-cloud.result }}`)  •  runs `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').success }}`
+                    tenant   p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').tenant_create.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').tenant_create.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').tenant_create.p99 }}s`
+                    add      p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_cloud_small }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *📚 Cognee Cloud — War and Peace* (`${{ needs.perf-wap-cloud.result }}`)  •  runs `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').success }}`
+                    tenant   p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').tenant_create.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').tenant_create.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').tenant_create.p99 }}s`
+                    add      p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_cloud_wap }}|HTML report>
               - type: "section"
                 text:
                   type: "mrkdwn"

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/nightly_tests.yml'
       - '.github/workflows/performance_report.yml'
       - '.github/workflows/performance_report_cloud.yml'
+      - '.github/workflows/performance_report_rust.yml'
 
 
 concurrency:
@@ -100,6 +101,50 @@ jobs:
       memories_key: nightly_ci_artifacts/performance_test_artifacts/war_and_peace.json
     secrets: inherit
 
+  # ══ Performance (Rust SDK): builds latest cognee-rs and drives the SAME ═════
+  # ══ orchestrator via cognee-cli bench (file_based, mock LLM, offline). ══════
+  perf-rust:
+    name: Performance — Rust SDK — 50 Small Documents (mock LLM)
+    uses: ./.github/workflows/performance_report_rust.yml
+    with:
+      runs: '3'
+      mode: mock_llm
+      label: 50_small_documents
+      memories: scripts/perf/fixtures/memories.json
+      cassette: scripts/perf/fixtures/cassette.json
+    secrets: inherit
+
+  perf-rust-wap:
+    name: Performance — Rust SDK — War and Peace (mock LLM)
+    uses: ./.github/workflows/performance_report_rust.yml
+    with:
+      runs: '3'
+      mode: mock_llm
+      label: war_and_peace
+      memories: scripts/perf/fixtures/war_and_peace/memories.json
+      cassette: scripts/perf/fixtures/war_and_peace/cassette.json
+    secrets: inherit
+
+  perf-rust-llm:
+    name: Performance — Rust SDK — 50 Small Documents (real LLM)
+    uses: ./.github/workflows/performance_report_rust.yml
+    with:
+      runs: '3'
+      mode: llm
+      label: 50_small_documents
+      memories: scripts/perf/fixtures/memories.json
+    secrets: inherit
+
+  perf-rust-wap-llm:
+    name: Performance — Rust SDK — War and Peace (real LLM)
+    uses: ./.github/workflows/performance_report_rust.yml
+    with:
+      runs: '3'
+      mode: llm
+      label: war_and_peace
+      memories: scripts/perf/fixtures/war_and_peace/memories.json
+    secrets: inherit
+
   notify:
     name: Test Completion Status
     needs: [
@@ -111,6 +156,10 @@ jobs:
       perf-wap-mock,
       perf-small-cloud,
       perf-wap-cloud,
+      perf-rust,
+      perf-rust-wap,
+      perf-rust-llm,
+      perf-rust-wap-llm,
     ]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
@@ -125,7 +174,11 @@ jobs:
                 "${{ needs.perf-wap-llm.result }}" == "success" &&
                 "${{ needs.perf-wap-mock.result }}" == "success" &&
                 "${{ needs.perf-small-cloud.result }}" == "success" &&
-                "${{ needs.perf-wap-cloud.result }}" == "success" ]]; then
+                "${{ needs.perf-wap-cloud.result }}" == "success" &&
+                "${{ needs.perf-rust.result }}" == "success" &&
+                "${{ needs.perf-rust-wap.result }}" == "success" &&
+                "${{ needs.perf-rust-llm.result }}" == "success" &&
+                "${{ needs.perf-rust-wap-llm.result }}" == "success" ]]; then
             echo "passed=true" >> "$GITHUB_OUTPUT"
             echo "emoji=✅" >> "$GITHUB_OUTPUT"
             echo "summary=All nightly test suites completed successfully!" >> "$GITHUB_OUTPUT"
@@ -156,6 +209,10 @@ jobs:
             url_pg_wap_mock ${{ needs.perf-wap-mock.outputs.postgres_html_key }}
             url_cloud_small ${{ needs.perf-small-cloud.outputs.cloud_html_key }}
             url_cloud_wap ${{ needs.perf-wap-cloud.outputs.cloud_html_key }}
+            url_rust ${{ needs.perf-rust.outputs.html_key }}
+            url_rust_wap ${{ needs.perf-rust-wap.outputs.html_key }}
+            url_rust_llm ${{ needs.perf-rust-llm.outputs.html_key }}
+            url_rust_wap_llm ${{ needs.perf-rust-wap-llm.outputs.html_key }}
         run: |
           set -euo pipefail
           # 7 days = 604800s is the maximum lifetime for an IAM-user presigned URL.
@@ -166,6 +223,10 @@ jobs:
           done <<< "$REPORT_KEYS"
 
       - name: Post status to Slack
+        # Only post on the real scheduled/manual runs. The pull_request trigger
+        # (which fires when this workflow file itself changes) validates the
+        # pipeline without spamming the nightly Slack channel.
+        if: ${{ github.event_name != 'pull_request' }}
         uses: slackapi/slack-github-action@v2.1.0
         with:
           method: chat.postMessage
@@ -283,6 +344,46 @@ jobs:
                     search     p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p99 }}s`
                     total      p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p99 }}s`
                     <${{ steps.presign.outputs.url_cloud_wap }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *🦀 Rust SDK (file_based) — 50 Small Documents — Mock LLM* (`${{ needs.perf-rust.result }}`)  •  runs `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').success }}`
+                    add      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_rust }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *🦀 Rust SDK (file_based) — War and Peace — Mock LLM* (`${{ needs.perf-rust-wap.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').success }}`
+                    add      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_rust_wap }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *🦀 Rust SDK (file_based) — 50 Small Documents — Real LLM* (`${{ needs.perf-rust-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').success }}`
+                    add      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_rust_llm }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *🦀 Rust SDK (file_based) — War and Peace — Real LLM* (`${{ needs.perf-rust-wap-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').success }}`
+                    add      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_rust_wap_llm }}|HTML report>
               - type: "section"
                 text:
                   type: "mrkdwn"

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -348,42 +348,11 @@ jobs:
                 text:
                   type: "mrkdwn"
                   text: |
-                    *🦀 Rust SDK (file_based) — 50 Small Documents — Mock LLM* (`${{ needs.perf-rust.result }}`)  •  runs `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *🦀 Rust SDK (file_based) — War and Peace — Mock LLM* (`${{ needs.perf-rust-wap.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_wap }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *🦀 Rust SDK (file_based) — 50 Small Documents — Real LLM* (`${{ needs.perf-rust-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_llm }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *🦀 Rust SDK (file_based) — War and Peace — Real LLM* (`${{ needs.perf-rust-wap-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_wap_llm }}|HTML report>
+                    *🦀 Rust SDK (file_based)* — total-latency percentiles; per-stage detail is in each HTML report
+                    50 small documents — mock LLM  (`${{ needs.perf-rust.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust }}|HTML report>
+                    War and Peace — mock LLM  (`${{ needs.perf-rust-wap.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_wap }}|HTML report>
+                    50 small documents — real LLM  (`${{ needs.perf-rust-llm.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_llm }}|HTML report>
+                    War and Peace — real LLM  (`${{ needs.perf-rust-wap-llm.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_wap_llm }}|HTML report>
               - type: "section"
                 text:
                   type: "mrkdwn"

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -223,10 +223,9 @@ jobs:
           done <<< "$REPORT_KEYS"
 
       - name: Post status to Slack
-        # Only post on the real scheduled/manual runs. The pull_request trigger
-        # (which fires when this workflow file itself changes) validates the
-        # pipeline without spamming the nightly Slack channel.
-        if: ${{ github.event_name != 'pull_request' }}
+        # Posts on scheduled/manual runs AND on pull_request validation runs
+        # (which fire when the nightly workflow files themselves change), so
+        # workflow changes surface their reports in the channel too.
         uses: slackapi/slack-github-action@v2.1.0
         with:
           method: chat.postMessage

--- a/.github/workflows/performance_report.yml
+++ b/.github/workflows/performance_report.yml
@@ -125,10 +125,17 @@ jobs:
             ARGS+=(--num-memories "${{ inputs.num_memories }}")
           fi
 
+          # Capture the exit code instead of failing here: the report writes
+          # its JSON/HTML even when runs fail, and the upload + metrics steps
+          # must still run. The job fails at the end via REPORT_RC.
+          set +e
           uv run python cognee/tests/performance/statistics_percentile_report.py \
             "${ARGS[@]}" \
             --output "$JSON_PATH" \
             --html "$HTML_PATH"
+          REPORT_RC=$?
+          set -e
+          echo "REPORT_RC=$REPORT_RC" >> "$GITHUB_ENV"
 
       - name: Upload reports to S3
         id: upload
@@ -158,6 +165,12 @@ jobs:
             total:   {p50: .stats.total_ingest_time_s.p50, p90: .stats.total_ingest_time_s.p90, p99: .stats.total_ingest_time_s.p99}
           }' "$JSON_PATH")"
           echo "metrics=$METRICS" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if any benchmark run failed
+        if: ${{ env.REPORT_RC != '0' }}
+        run: |
+          echo "Performance report exited with code $REPORT_RC — one or more benchmark runs failed."
+          exit 1
 
   # ── Postgres backend: Postgres relational + PGVector + Postgres graph ────────
   postgres:
@@ -263,10 +276,17 @@ jobs:
             ARGS+=(--num-memories "${{ inputs.num_memories }}")
           fi
 
+          # Capture the exit code instead of failing here: the report writes
+          # its JSON/HTML even when runs fail, and the upload + metrics steps
+          # must still run. The job fails at the end via REPORT_RC.
+          set +e
           uv run python cognee/tests/performance/statistics_percentile_report.py \
             "${ARGS[@]}" \
             --output "$JSON_PATH" \
             --html "$HTML_PATH"
+          REPORT_RC=$?
+          set -e
+          echo "REPORT_RC=$REPORT_RC" >> "$GITHUB_ENV"
 
       - name: Upload reports to S3
         id: upload
@@ -296,3 +316,9 @@ jobs:
             total:   {p50: .stats.total_ingest_time_s.p50, p90: .stats.total_ingest_time_s.p90, p99: .stats.total_ingest_time_s.p99}
           }' "$JSON_PATH")"
           echo "metrics=$METRICS" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if any benchmark run failed
+        if: ${{ env.REPORT_RC != '0' }}
+        run: |
+          echo "Performance report exited with code $REPORT_RC — one or more benchmark runs failed."
+          exit 1

--- a/.github/workflows/performance_report_cloud.yml
+++ b/.github/workflows/performance_report_cloud.yml
@@ -1,0 +1,160 @@
+name: performance report (cloud)
+
+# Reusable workflow: runs the percentile performance report against Cognee
+# Cloud (all processing server-side via cognee.serve()), uploads the JSON +
+# HTML artifacts to S3, and exposes the headline metrics + HTML object key as
+# outputs for the caller (the Slack bot in nightly_tests.yml).
+#
+# Every benchmark run CREATES its own tenant through the tenant-controller
+# API, measures creation time as its own metric (tenant_create_time_s), runs
+# the full add/cognify/search cycle on that fresh tenant, and deletes it
+# afterwards — so suites never share tenant state.
+#
+# Mock mode is NOT supported here: the LLM and embedding configuration live on
+# the tenant, so there is nothing to mock client-side (bench_cognee.py rejects
+# --mock-llm in cloud mode).
+#
+# Required repository secret:
+#   COGNEE_CLOUD_API_KEY — API key authorized on the tenant-controller API
+#                          (https://api.aws.cognee.ai)
+on:
+  workflow_call:
+    inputs:
+      label:
+        description: "Dataset label, used in the S3 output path and display name."
+        required: true
+        type: string
+      runs:
+        description: "Number of sequential benchmark runs."
+        required: false
+        type: string
+        default: '3'
+      num_memories:
+        description: "If set, forwarded as --num-memories (limit input documents)."
+        required: false
+        type: string
+        default: ''
+      memories_key:
+        description: "S3 object key (under the bucket) downloaded and used as --memories."
+        required: true
+        type: string
+    outputs:
+      cloud_metrics:
+        description: "Cloud run: success + add/cognify/search/total p50/p90/p99."
+        value: ${{ jobs.cloud.outputs.metrics }}
+      cloud_html_key:
+        description: "Cloud run: S3 object key of the HTML report."
+        value: ${{ jobs.cloud.outputs.html_key }}
+
+env:
+  ENV: 'dev'
+  COGNEE_SKIP_CONNECTION_TEST: 'true'
+  RUNTIME__LOG_LEVEL: ERROR
+  BUCKET: github-runner-cognee-tests
+
+jobs:
+  # ── Cloud tenant: all cognee operations run remotely via cognee.serve() ──────
+  cloud:
+    name: cloud — ${{ inputs.label }}
+    runs-on: ubuntu-22.04
+    outputs:
+      metrics: ${{ steps.parse.outputs.metrics }}
+      html_key: ${{ steps.upload.outputs.html_key }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Cognee Setup
+        uses: ./.github/actions/cognee_setup
+        with:
+          python-version: '3.11.x'
+
+      - name: Download dataset from S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_DEV_USER_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_DEV_USER_SECRET_KEY }}
+          AWS_DEFAULT_REGION: eu-west-1
+          MEMORIES_KEY: ${{ inputs.memories_key }}
+        run: |
+          set -euo pipefail
+          mkdir -p performance_datasets
+          aws s3 cp "s3://$BUCKET/$MEMORIES_KEY" performance_datasets/memories.json
+          echo "MEMORIES_FILE=$PWD/performance_datasets/memories.json" >> "$GITHUB_ENV"
+
+      - name: Run performance report
+        id: run
+        env:
+          PYTHONFAULTHANDLER: 1
+          # bench_cognee.py picks the key up from COGNEE_API_KEY, keeping it
+          # out of the process argument list.
+          COGNEE_API_KEY: ${{ secrets.COGNEE_CLOUD_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${COGNEE_API_KEY:-}" ]; then
+            echo "COGNEE_CLOUD_API_KEY secret is not set." >&2
+            exit 1
+          fi
+          TS="$(date -u '+%Y-%m-%d_%H-%M-%SZ')"
+          JSON_PATH="performance_results/cloud/${{ inputs.label }}/cloud_${TS}.json"
+          HTML_PATH="performance_results/cloud/${{ inputs.label }}/cloud_${TS}.html"
+          mkdir -p "$(dirname "$JSON_PATH")"
+          echo "JSON_PATH=$JSON_PATH" >> "$GITHUB_ENV"
+          echo "HTML_PATH=$HTML_PATH" >> "$GITHUB_ENV"
+
+          ARGS=(--runs "${{ inputs.runs }}" --memories "$MEMORIES_FILE")
+          # Fresh tenant per run: creation time is measured as its own metric
+          # and the tenant is deleted after the run, so suites never collide.
+          ARGS+=(--create-tenant)
+          # Dataset-scoped naming/cleanup stays as belt-and-braces isolation.
+          ARGS+=(--dataset-name "bench_${{ inputs.label }}")
+          if [ -n "${{ inputs.num_memories }}" ]; then
+            ARGS+=(--num-memories "${{ inputs.num_memories }}")
+          fi
+
+          # Capture the exit code instead of failing here: the report writes
+          # its JSON/HTML even when runs fail, and the upload + metrics steps
+          # must still run. The job fails at the end via REPORT_RC.
+          set +e
+          uv run python cognee/tests/performance/statistics_percentile_report.py \
+            "${ARGS[@]}" \
+            --output "$JSON_PATH" \
+            --html "$HTML_PATH"
+          REPORT_RC=$?
+          set -e
+          echo "REPORT_RC=$REPORT_RC" >> "$GITHUB_ENV"
+
+      - name: Upload reports to S3
+        id: upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_DEV_USER_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_DEV_USER_SECRET_KEY }}
+          AWS_DEFAULT_REGION: eu-west-1
+        run: |
+          set -euo pipefail
+          aws s3 cp "$JSON_PATH" "s3://$BUCKET/$JSON_PATH" --content-type application/json
+          aws s3 cp "$HTML_PATH" "s3://$BUCKET/$HTML_PATH" --content-type text/html
+          # Presigning is done by the caller (the Slack job), NOT here: a presigned URL
+          # embeds the AWS access key id, and GitHub scrubs registered secrets from
+          # reusable-workflow outputs — which would blank the link. Pass only the
+          # (non-secret) object key across the boundary.
+          echo "html_key=$HTML_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Parse headline metrics
+        id: parse
+        run: |
+          set -euo pipefail
+          METRICS="$(jq -c '{
+            success: "\(.succeeded)/\(.num_runs)",
+            tenant_create: {p50: .stats.tenant_create_time_s.p50, p90: .stats.tenant_create_time_s.p90, p99: .stats.tenant_create_time_s.p99},
+            add:     {p50: .stats.add_time_s.p50,          p90: .stats.add_time_s.p90,          p99: .stats.add_time_s.p99},
+            cognify: {p50: .stats.cognify_time_s.p50,      p90: .stats.cognify_time_s.p90,      p99: .stats.cognify_time_s.p99},
+            search:  {p50: .stats.search_time.p50,         p90: .stats.search_time.p90,         p99: .stats.search_time.p99},
+            total:   {p50: .stats.total_ingest_time_s.p50, p90: .stats.total_ingest_time_s.p90, p99: .stats.total_ingest_time_s.p99}
+          }' "$JSON_PATH")"
+          echo "metrics=$METRICS" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if any benchmark run failed
+        if: ${{ env.REPORT_RC != '0' }}
+        run: |
+          echo "Performance report exited with code $REPORT_RC — one or more benchmark runs failed."
+          exit 1

--- a/.github/workflows/performance_report_rust.yml
+++ b/.github/workflows/performance_report_rust.yml
@@ -1,0 +1,254 @@
+name: performance report (rust)
+
+# Reusable workflow: runs the SAME percentile performance report as
+# performance_report.yml, but drives the Rust SDK (`cognee-rs`) instead of the
+# Python one. It checks out the latest cognee-rs, builds the `cognee-cli bench`
+# subcommand, and feeds it to the shared Python orchestrator
+# (cognee/tests/performance/statistics_percentile_report.py) via the BENCH_CMD
+# hook — so the identical percentile table + JSON + HTML report are produced and
+# uploaded to S3, and the headline metrics are exposed as outputs for the Slack
+# bot in nightly_tests.yml.
+#
+# Scope: file_based backend (SQLite + Ladybug + LanceDB), mock LLM only. The run
+# is fully offline — deterministic mock embeddings + a committed record/replay
+# cassette (cognee-rs scripts/perf/fixtures/) — so it needs no LLM API key. Real
+# LLM and the postgres backend are future extensions (the latter needs bench.rs
+# to honour DB_PROVIDER instead of hardcoding on-disk backends).
+
+on:
+  workflow_call:
+    inputs:
+      runs:
+        description: "Number of sequential benchmark runs."
+        required: false
+        type: string
+        default: '3'
+      mode:
+        description: "'mock_llm' (offline cassette) or 'llm' (real LLM + embeddings)."
+        required: false
+        type: string
+        default: 'mock_llm'
+      cognee_rs_ref:
+        description: "cognee-rs git ref to check out (blank = default branch)."
+        required: false
+        type: string
+        default: ''
+      label:
+        description: "Dataset label — display name + S3 output path segment."
+        required: false
+        type: string
+        default: '50_small_documents'
+      memories:
+        description: "Corpus path inside the cognee-rs checkout."
+        required: false
+        type: string
+        default: 'scripts/perf/fixtures/memories.json'
+      cassette:
+        description: "Replay cassette path inside the cognee-rs checkout."
+        required: false
+        type: string
+        default: 'scripts/perf/fixtures/cassette.json'
+    outputs:
+      metrics:
+        description: "success + add/cognify/search/total p50/p90/p99."
+        value: ${{ jobs.rust_file_based.outputs.metrics }}
+      html_key:
+        description: "S3 object key of the HTML report."
+        value: ${{ jobs.rust_file_based.outputs.html_key }}
+
+permissions:
+  contents: read
+
+env:
+  BUCKET: github-runner-cognee-tests
+  # ort-sys caches the ONNX Runtime static lib here (mirrors cognee-rs ci.yml).
+  ORT_CACHE_DIR: ${{ github.workspace }}/cognee-rs/target/ort-cache
+  CARGO_INCREMENTAL: '0'
+
+jobs:
+  rust_file_based:
+    name: rust file_based — ${{ inputs.label }} (${{ inputs.mode }})
+    # ubuntu-latest (not 22.04): lbug's bundled simsimd needs a C compiler with
+    # avx512fp16 / _Float16 support (GCC >= 12). This matches cognee-rs's own CI.
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    outputs:
+      metrics: ${{ steps.parse.outputs.metrics }}
+      html_key: ${{ steps.upload.outputs.html_key }}
+    steps:
+      # cognee (this repo) supplies the shared orchestrator + reporter.
+      - name: Checkout cognee (orchestrator)
+        uses: actions/checkout@v6
+
+      # cognee-rs supplies the CLI, the perf harness, and the committed cassette.
+      - name: Checkout cognee-rs (latest)
+        uses: actions/checkout@v6
+        with:
+          repository: topoteretes/cognee-rs
+          ref: ${{ inputs.cognee_rs_ref }}
+          path: cognee-rs
+
+      # Toolchain pin comes from cognee-rs/rust-toolchain.toml (rustup honours it).
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install mold linker
+        uses: rui314/setup-mold@v1
+        with:
+          make-default: true
+
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          # large-packages removes ^llvm-.* (libclang) which litert bindgen needs.
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cognee-rs
+          shared-key: perf-rust
+
+      - name: Cache ORT binary
+        uses: actions/cache@v4
+        with:
+          path: cognee-rs/target/ort-cache
+          key: ort-perf-rust-linux-x86_64
+
+      - name: Build cognee-cli (release, bench)
+        working-directory: cognee-rs
+        run: cargo build --release -p cognee-cli --features bench
+
+      # Cassette-freshness guard. The committed cassette is a static fixture with
+      # no auto-refresh (record-cassettes.yml does not cover scripts/perf). When
+      # cognify prompts, the KnowledgeGraph/SummarizedContent schemas, chunking,
+      # or the model drift, replay silently falls back to EmptyGraph — no
+      # entity-type nodes get created and the benchmark keeps reporting "success"
+      # with meaningless timings. A cassette HIT replays the recorded graph and
+      # logs "Stored N entity types as graph nodes".
+      #
+      # On drift this WARNS rather than fails: the perf run still completes and
+      # reports (empty-graph timings are cheap but not representative), and the
+      # nightly stays green. The warning surfaces as a GitHub annotation + step
+      # summary so it is visible without red-failing the whole nightly. Re-record
+      # cognee-rs/scripts/perf/fixtures/cassette.json to clear it (see its README).
+      #
+      # LOG_LEVEL=info is pinned so the log-scraping check is deterministic
+      # regardless of any RUST_LOG/LOG_LEVEL inherited by the runner.
+      - name: Verify cassette freshness (warn on drift)
+        # Cassette only exists / matters in mock mode; real-LLM mode calls the API.
+        if: ${{ inputs.mode == 'mock_llm' }}
+        working-directory: cognee-rs
+        env:
+          LOG_LEVEL: info
+        run: |
+          set -euo pipefail
+          log="$(mktemp)"
+          MOCK_EMBEDDING=deterministic ./target/release/cognee-cli bench \
+            --mock-llm \
+            --mock-memories "${{ inputs.cassette }}" \
+            --memories "${{ inputs.memories }}" \
+            --num-memories 8 \
+            --output /tmp/freshness.json >"$log" 2>&1 || { cat "$log"; }
+          entities="$(grep -oE 'Stored [0-9]+ entity types as graph nodes' "$log" \
+                      | grep -oE '[0-9]+' | head -1 || true)"
+          echo "entity-type nodes created on replay: ${entities:-0}"
+          if [ -z "${entities:-}" ] || [ "${entities:-0}" -lt 1 ]; then
+            msg="cognee-rs perf cassette looks STALE — replay produced no entity-type nodes (EmptyGraph fallback). Timings below are NOT representative. Re-record cognee-rs/scripts/perf/fixtures/cassette.json (see its README)."
+            echo "::warning::$msg"
+            echo "⚠️ $msg" >> "$GITHUB_STEP_SUMMARY"
+            cat "$log" >&2
+          else
+            echo "✅ Cassette fresh — replay created ${entities} entity-type nodes." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # ── Mock mode: offline, via the committed harness ────────────────────────
+      # run_mock_bench.sh forwards --mock-llm/--mock-memories to the orchestrator
+      # (which passes them through to the bench subcommand) and puts --memories in
+      # BENCH_CMD, so --memories is never duplicated.
+      - name: Run performance report (mock LLM)
+        if: ${{ inputs.mode == 'mock_llm' }}
+        env:
+          PYTHONFAULTHANDLER: 1
+          COGNEE_SKIP_CONNECTION_TEST: 'true'
+        run: |
+          set -euo pipefail
+          COGNEE_PY="$GITHUB_WORKSPACE" \
+          BENCH_BIN="$GITHUB_WORKSPACE/cognee-rs/target/release/cognee-cli" \
+          RUNS="${{ inputs.runs }}" \
+          OUT_DIR="$GITHUB_WORKSPACE/perf-out" \
+          CASSETTE="$GITHUB_WORKSPACE/cognee-rs/${{ inputs.cassette }}" \
+          MEMORIES="$GITHUB_WORKSPACE/cognee-rs/${{ inputs.memories }}" \
+            bash "$GITHUB_WORKSPACE/cognee-rs/scripts/perf/run_mock_bench.sh"
+
+      # ── Real-LLM mode: drive the orchestrator directly (no --mock-llm) ───────
+      # BENCH_CMD holds the bench invocation + corpus; the orchestrator adds
+      # --output and (real mode) sleeps 60s between runs. LLM + embeddings both go
+      # to OpenAI via the inherited OPENAI_API_KEY. gpt-4o-mini / text-embedding-3-
+      # small match the mock cassette's model, so mock vs real stay comparable.
+      - name: Run performance report (real LLM)
+        if: ${{ inputs.mode == 'llm' }}
+        env:
+          PYTHONFAULTHANDLER: 1
+          COGNEE_SKIP_CONNECTION_TEST: 'true'
+          LLM_PROVIDER: openai
+          LLM_ENDPOINT: https://api.openai.com/v1
+          LLM_MODEL: gpt-4o-mini
+          LLM_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          EMBEDDING_PROVIDER: openai
+          EMBEDDING_MODEL: text-embedding-3-small
+          EMBEDDING_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/perf-out"
+          BENCH_CMD="$GITHUB_WORKSPACE/cognee-rs/target/release/cognee-cli bench --memories $GITHUB_WORKSPACE/cognee-rs/${{ inputs.memories }}" \
+            python3 "$GITHUB_WORKSPACE/cognee/tests/performance/statistics_percentile_report.py" \
+              --runs "${{ inputs.runs }}" \
+              --output "$GITHUB_WORKSPACE/perf-out/report.json" \
+              --html "$GITHUB_WORKSPACE/perf-out/report.html"
+
+      # ── Stage the report (common to both modes) for S3 upload ────────────────
+      - name: Stage report
+        run: |
+          set -euo pipefail
+          TS="$(date -u '+%Y-%m-%d_%H-%M-%SZ')"
+          JSON_PATH="performance_results/rust_file_based/${{ inputs.label }}/${{ inputs.mode }}_${TS}.json"
+          HTML_PATH="performance_results/rust_file_based/${{ inputs.label }}/${{ inputs.mode }}_${TS}.html"
+          mkdir -p "$(dirname "$JSON_PATH")"
+          cp "$GITHUB_WORKSPACE/perf-out/report.json" "$JSON_PATH"
+          cp "$GITHUB_WORKSPACE/perf-out/report.html" "$HTML_PATH"
+          echo "JSON_PATH=$JSON_PATH" >> "$GITHUB_ENV"
+          echo "HTML_PATH=$HTML_PATH" >> "$GITHUB_ENV"
+
+      - name: Upload reports to S3
+        id: upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_DEV_USER_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_DEV_USER_SECRET_KEY }}
+          AWS_DEFAULT_REGION: eu-west-1
+        run: |
+          set -euo pipefail
+          aws s3 cp "$JSON_PATH" "s3://$BUCKET/$JSON_PATH" --content-type application/json
+          aws s3 cp "$HTML_PATH" "s3://$BUCKET/$HTML_PATH" --content-type text/html
+          # Presigning is done by the caller (the Slack job), NOT here — see the
+          # note in performance_report.yml. Pass only the (non-secret) object key.
+          echo "html_key=$HTML_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Parse headline metrics
+        id: parse
+        run: |
+          set -euo pipefail
+          METRICS="$(jq -c '{
+            success: "\(.succeeded)/\(.num_runs)",
+            add:     {p50: .stats.add_time_s.p50,          p90: .stats.add_time_s.p90,          p99: .stats.add_time_s.p99},
+            cognify: {p50: .stats.cognify_time_s.p50,      p90: .stats.cognify_time_s.p90,      p99: .stats.cognify_time_s.p99},
+            search:  {p50: .stats.search_time.p50,         p90: .stats.search_time.p90,         p99: .stats.search_time.p99},
+            total:   {p50: .stats.total_ingest_time_s.p50, p90: .stats.total_ingest_time_s.p90, p99: .stats.total_ingest_time_s.p99}
+          }' "$JSON_PATH")"
+          echo "metrics=$METRICS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/performance_report_rust.yml
+++ b/.github/workflows/performance_report_rust.yml
@@ -202,10 +202,20 @@ jobs:
           LLM_MODEL: ${{ secrets.LLM_MODEL }}
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LLM_ARGS: ${{ secrets.LLM_ARGS }}
-          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_MODEL_RAW: ${{ secrets.EMBEDDING_MODEL }}
           EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
         run: |
           set -euo pipefail
+          # The Rust embedding client sends the model id verbatim to the API,
+          # so a litellm-style prefixed secret ("openai/text-embedding-3-small")
+          # 400s with "invalid model ID". Split the secret into the bare model
+          # and a provider the Rust client understands.
+          if [[ "$EMBEDDING_MODEL_RAW" == */* ]]; then
+            export EMBEDDING_PROVIDER="${EMBEDDING_MODEL_RAW%%/*}"
+          else
+            export EMBEDDING_PROVIDER="openai"
+          fi
+          export EMBEDDING_MODEL="${EMBEDDING_MODEL_RAW##*/}"
           mkdir -p "$GITHUB_WORKSPACE/perf-out"
           BENCH_CMD="$GITHUB_WORKSPACE/cognee-rs/target/release/cognee-cli bench --memories $GITHUB_WORKSPACE/cognee-rs/${{ inputs.memories }}" \
             python3 "$GITHUB_WORKSPACE/cognee/tests/performance/statistics_percentile_report.py" \

--- a/.github/workflows/performance_report_rust.yml
+++ b/.github/workflows/performance_report_rust.yml
@@ -216,6 +216,14 @@ jobs:
             export EMBEDDING_PROVIDER="openai"
           fi
           export EMBEDDING_MODEL="${EMBEDDING_MODEL_RAW##*/}"
+          # The Rust client also does not send OpenAI's `dimensions` truncation
+          # parameter (the Python arms get 1536-d vectors that way), so size the
+          # vector store to the model's NATIVE output or every insert fails with
+          # a dimension mismatch. Unknown models keep the client default.
+          case "$EMBEDDING_MODEL" in
+            text-embedding-3-large) export EMBEDDING_DIMENSIONS=3072 ;;
+            text-embedding-3-small | text-embedding-ada-002) export EMBEDDING_DIMENSIONS=1536 ;;
+          esac
           mkdir -p "$GITHUB_WORKSPACE/perf-out"
           BENCH_CMD="$GITHUB_WORKSPACE/cognee-rs/target/release/cognee-cli bench --memories $GITHUB_WORKSPACE/cognee-rs/${{ inputs.memories }}" \
             python3 "$GITHUB_WORKSPACE/cognee/tests/performance/statistics_percentile_report.py" \

--- a/.github/workflows/performance_report_rust.yml
+++ b/.github/workflows/performance_report_rust.yml
@@ -189,21 +189,21 @@ jobs:
 
       # ── Real-LLM mode: drive the orchestrator directly (no --mock-llm) ───────
       # BENCH_CMD holds the bench invocation + corpus; the orchestrator adds
-      # --output and (real mode) sleeps 60s between runs. LLM + embeddings both go
-      # to OpenAI via the inherited OPENAI_API_KEY. gpt-4o-mini / text-embedding-3-
-      # small match the mock cassette's model, so mock vs real stay comparable.
+      # --output and (real mode) sleeps 60s between runs. LLM + embedding config
+      # comes from the same standard CI secrets as the Python perf arms
+      # (performance_report.yml), so all nightly benchmarks measure one model
+      # fleet. Note: the mock cassette was recorded with gpt-4o-mini — mock vs
+      # real comparability now depends on the org secrets matching the cassette.
       - name: Run performance report (real LLM)
         if: ${{ inputs.mode == 'llm' }}
         env:
           PYTHONFAULTHANDLER: 1
           COGNEE_SKIP_CONNECTION_TEST: 'true'
-          LLM_PROVIDER: openai
-          LLM_ENDPOINT: https://api.openai.com/v1
-          LLM_MODEL: gpt-4o-mini
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
           LLM_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          EMBEDDING_PROVIDER: openai
-          EMBEDDING_MODEL: text-embedding-3-small
-          EMBEDDING_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          LLM_ARGS: ${{ secrets.LLM_ARGS }}
+          EMBEDDING_MODEL: ${{ secrets.EMBEDDING_MODEL }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/perf-out"

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -26,11 +26,13 @@ class CloudClient:
 
     # Default for ordinary API calls: aiohttp's standard 5-minute total,
     # with connect failures surfacing quickly.
-    DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=300, sock_connect=30)
+    # 600s: long-running blocking operations (e.g. cognify over a large
+    # dataset) can legitimately take many minutes server-side
+    DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=600, sock_connect=30)
     # Archive uploads (cognee.push) plus the synchronous server-side import
     # can legitimately exceed any fixed total; per-read inactivity stays
     # bounded instead. Applied per-request, only to archive uploads.
-    UPLOAD_TIMEOUT = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=300)
+    UPLOAD_TIMEOUT = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=600)
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:

--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -7,9 +7,22 @@ from uuid import UUID
 
 import aiohttp
 
+from cognee.modules.ingestion.data_types.TextData import create_text_data
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("serve.cloud_client")
+
+
+def _text_upload_filename(text: str) -> str:
+    """Content-hash filename for raw-text uploads, via local ingestion's namer.
+
+    Delegates to ``TextData`` — the same source ``save_data_to_file`` uses for
+    nameless text (``text_<md5>.txt``). A fixed placeholder here instead makes
+    every text upload for a tenant collide on one remote object, racing
+    concurrent adds against the server's content-hash read-back
+    (FileContentHashingError 409s).
+    """
+    return create_text_data(text).get_metadata()["name"]
 
 
 class CloudClient:
@@ -109,7 +122,7 @@ class CloudClient:
             form.add_field(
                 "data",
                 io.BytesIO(data.encode("utf-8")),
-                filename="data.txt",
+                filename=_text_upload_filename(data),
                 content_type="text/plain",
             )
         elif isinstance(data, list):
@@ -118,7 +131,7 @@ class CloudClient:
                     form.add_field(
                         "data",
                         io.BytesIO(item.encode("utf-8")),
-                        filename="data.txt",
+                        filename=_text_upload_filename(item),
                         content_type="text/plain",
                     )
                 elif hasattr(item, "read"):
@@ -248,7 +261,7 @@ class CloudClient:
             form.add_field(
                 "data",
                 io.BytesIO(data.encode("utf-8")),
-                filename="data.txt",
+                filename=_text_upload_filename(data),
                 content_type="text/plain",
             )
         elif isinstance(data, list):
@@ -257,7 +270,7 @@ class CloudClient:
                     form.add_field(
                         "data",
                         io.BytesIO(item.encode("utf-8")),
-                        filename="data.txt",
+                        filename=_text_upload_filename(item),
                         content_type="text/plain",
                     )
                 elif hasattr(item, "read"):

--- a/cognee/tests/performance/statistics_percentile/bench_cognee.py
+++ b/cognee/tests/performance/statistics_percentile/bench_cognee.py
@@ -8,6 +8,8 @@ Usage:
     python bench_cognee.py                     # default settings
     python bench_cognee.py --memories data.json # custom memories file
     python bench_cognee.py --llm-model gpt-4o  # override LLM model
+    python bench_cognee.py --tenant-url https://tenant-x.aws.cognee.ai --tenant-api-key ck_...
+                                               # run against a Cognee Cloud tenant
 
 The memories file should be a JSON array of objects with "title" and "content"
 keys (see the bundled memories.json).
@@ -74,6 +76,26 @@ def _resolve_config(args: argparse.Namespace) -> dict:
         "embedding_model": pick(args.embedding_model, "EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL),
         "embedding_dims": pick(args.embedding_dims, "EMBEDDING_DIMENSIONS", DEFAULT_EMBEDDING_DIMS),
         "mock_llm": mock_llm,
+    }
+
+
+def _resolve_cloud_config(args: argparse.Namespace) -> dict:
+    """Resolve config for cloud mode (--tenant-url / --create-tenant):
+    all processing is server-side."""
+    if args.mock_llm:
+        sys.exit("Error: --mock-llm is not supported in cloud mode (LLM runs server-side)")
+    api_key = args.tenant_api_key or os.environ.get("COGNEE_API_KEY", "")
+    if not api_key:
+        sys.exit("Error: --tenant-api-key (or COGNEE_API_KEY env var) is required in cloud mode")
+    if not args.tenant_url and not args.create_tenant:
+        sys.exit("Error: cloud mode needs --tenant-url or --create-tenant")
+    return {
+        "tenant_url": args.tenant_url.rstrip("/") if args.tenant_url else None,
+        "tenant_api_key": api_key,
+        "dataset_name": args.dataset_name or DATASET_NAME,
+        "create_tenant": bool(args.create_tenant),
+        "management_url": args.management_url.rstrip("/"),
+        "mock_llm": False,
     }
 
 
@@ -212,12 +234,14 @@ async def run_benchmark(
         "add": "success",
         "cognify": "success",
         "search": "success",
+        "dataset_delete": "success",
     }
     t_prune = 0.0
     t_db_setup = 0.0
     t_add = 0.0
     t_cognify = 0.0
     t_search = 0.0
+    t_dataset_delete = 0.0
 
     # ── Prune (clean slate) ──────────────────────────────────────────────
     print("Pruning previous data...")
@@ -281,6 +305,28 @@ async def run_benchmark(
         status["search"] = f"failed: {e}"
         print(f"  Search FAILED: {e}")
 
+    # ── Phase 4: dataset delete (populated) ──────────────────────────────
+    # Deleting the dataset AFTER the graph is built measures the meaningful
+    # case (nodes, edges, and vectors all present) — mirrors the cloud mode's
+    # dataset_delete_time_s metric.
+    print("\nPhase 4: Deleting the populated dataset...")
+    t_dataset_delete_start = time.time()
+    try:
+        from cognee.api.v1.datasets.datasets import datasets as datasets_api
+        from cognee.modules.data.methods import get_datasets_by_name
+        from cognee.modules.users.methods import get_default_user
+
+        user = await get_default_user()
+        found = await get_datasets_by_name([DATASET_NAME], user.id)
+        if found:
+            await datasets_api.empty_dataset(found[0].id, user)
+        t_dataset_delete = time.time() - t_dataset_delete_start
+        print(f"  Dataset deleted in {t_dataset_delete:.2f}s")
+    except Exception as e:
+        t_dataset_delete = time.time() - t_dataset_delete_start
+        status["dataset_delete"] = f"failed: {e}"
+        print(f"  Dataset delete FAILED: {e}")
+
     all_ok = all(v == "success" for v in status.values())
 
     # ── Report ───────────────────────────────────────────────────────────
@@ -292,6 +338,7 @@ async def run_benchmark(
         "prune_time_s": round(t_prune, 3),
         "db_setup_time_s": round(t_db_setup, 3),
         "search_time": t_search,
+        "dataset_delete_time_s": round(t_dataset_delete, 3),
         "status": status,
         "success": all_ok,
         "config": {
@@ -313,10 +360,346 @@ async def run_benchmark(
     print(f"  Search total      : {t_search:.2f}s  [{status['search']}]")
     print(f"  DB setup time     : {t_db_setup:.2f}s  [{status['db_setup']}]")
     print(f"  Prune time        : {t_prune:.2f}s  [{status['prune']}]")
+    print(f"  Dataset delete    : {t_dataset_delete:.2f}s  [{status['dataset_delete']}]")
     print(f"  LLM model         : {llm_model}")
     print(f"  Embedding model   : {embedding_model} ({embedding_dims}d)")
     if config.get("mock_llm"):
         print("  Mock mode         : ON")
+    print(f"  Overall           : {'ALL OK' if all_ok else 'SOME FAILURES'}")
+    print("=" * 60)
+
+    return results
+
+
+def _err(e: Exception) -> str:
+    """Readable error text: timeout-class exceptions stringify to '' (the
+    infamous blank 'cognify: failed: ' in CI logs), so fall back to repr."""
+    return str(e) or repr(e)
+
+
+async def _create_cloud_tenant(
+    management_url: str, api_key: str, tenant_name: str, ready_timeout_s: float = 600.0
+) -> tuple[str, str, float]:
+    """Create a tenant via the tenant-controller API and wait until healthy.
+
+    Returns (tenant_id, service_url, seconds) where seconds covers the create
+    call PLUS the wait until the tenant reports healthy — the number that
+    matters is "time until a usable tenant", not just the POST round trip.
+    """
+    import aiohttp
+    from urllib.parse import urlsplit
+
+    t0 = time.time()
+    async with aiohttp.ClientSession(headers={"X-Api-Key": api_key}) as session:
+        async with session.post(
+            f"{management_url}/api/v1/tenants", params={"tenant_name": tenant_name}
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise RuntimeError(f"Tenant creation failed ({resp.status}): {body}")
+            tenant_id = (await resp.json())["tenant_id"]
+
+        deadline = time.time() + ready_timeout_s
+        while True:
+            async with session.get(f"{management_url}/api/v1/tenants/{tenant_id}/status") as resp:
+                if resp.status < 400 and (await resp.json()).get("status") == "healthy":
+                    break
+            if time.time() > deadline:
+                raise TimeoutError(f"Tenant {tenant_id} not healthy after {ready_timeout_s:.0f}s")
+            await asyncio.sleep(2)
+
+    # Service URL convention: api.<domain> hosts the controller and
+    # tenant-<id>.<domain> hosts the tenant (e.g. https://tenant-<id>.aws.cognee.ai).
+    management_host = urlsplit(management_url).netloc
+    service_host = management_host.replace("api.", f"tenant-{tenant_id}.", 1)
+    return tenant_id, f"https://{service_host}", time.time() - t0
+
+
+async def _delete_cloud_tenant(management_url: str, api_key: str, tenant_id: str) -> float:
+    """Delete a benchmark-created tenant; returns seconds taken."""
+    import aiohttp
+
+    t0 = time.time()
+    async with aiohttp.ClientSession(headers={"X-Api-Key": api_key}) as session:
+        async with session.delete(
+            f"{management_url}/api/v1/tenants", params={"tenant_id": tenant_id}
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise RuntimeError(f"Tenant deletion failed ({resp.status}): {body}")
+    return time.time() - t0
+
+
+async def _delete_cloud_dataset_if_exists(client, dataset_name: str) -> None:
+    """Dataset-scoped clean slate for cloud runs.
+
+    Multiple benchmark suites share one tenant in nightly CI, so a global
+    ``forget(everything=True)`` would wipe a concurrently-running suite's
+    data. Delete ONLY this suite's dataset — and only when it exists (the
+    first run on a fresh tenant has nothing to delete).
+    """
+    session = await client._get_session()
+    async with session.get(f"{client.service_url}/api/v1/datasets") as resp:
+        if resp.status >= 400:
+            body = await resp.text()
+            raise RuntimeError(f"Listing datasets failed ({resp.status}): {body}")
+        datasets = await resp.json()
+    existing_names = {record.get("name") for record in datasets if isinstance(record, dict)}
+    if dataset_name not in existing_names:
+        print(f"  Dataset '{dataset_name}' not present on tenant; nothing to delete")
+        return
+    await client.forget(dataset=dataset_name)
+    print(f"  Deleted dataset '{dataset_name}'")
+
+
+async def _wait_for_cloud_cognify(
+    client, cognify_response: dict, poll_interval_s: float = 5.0, timeout_s: float = 7200.0
+) -> None:
+    """Block until every dataset in a cognify response finishes building.
+
+    Cloud tenants run cognify in the background and return
+    ``PipelineRunStarted`` immediately, so the POST duration alone measures
+    only the API round trip. Poll ``GET /v1/datasets/status`` until each
+    started dataset reports COMPLETED (raising on ERRORED/timeout) so the
+    benchmarked cognify time covers the actual knowledge-graph build.
+    """
+    pending = {
+        str(dataset_id)
+        for dataset_id, info in (cognify_response or {}).items()
+        if isinstance(info, dict) and info.get("status") == "PipelineRunStarted"
+    }
+    if not pending:
+        return  # the tenant processed synchronously; nothing to wait for
+
+    session = await client._get_session()
+    deadline = time.time() + timeout_s
+    while pending:
+        if time.time() > deadline:
+            raise TimeoutError(f"cognify still running after {timeout_s:.0f}s: {sorted(pending)}")
+        await asyncio.sleep(poll_interval_s)
+        params = [("dataset", dataset_id) for dataset_id in sorted(pending)]
+        params.append(("pipeline", "cognify_pipeline"))
+        async with session.get(
+            f"{client.service_url}/api/v1/datasets/status", params=params
+        ) as resp:
+            if resp.status >= 400:
+                continue  # transient status-endpoint hiccup; keep polling
+            statuses = await resp.json()
+        for dataset_id in list(pending):
+            value = statuses.get(dataset_id)
+            if isinstance(value, dict):  # nested {pipeline_name: status} shape
+                value = value.get("cognify_pipeline")
+            if value == "DATASET_PROCESSING_COMPLETED":
+                pending.discard(dataset_id)
+            elif value == "DATASET_PROCESSING_ERRORED":
+                raise RuntimeError(f"cognify errored on the tenant for dataset {dataset_id}")
+
+
+async def run_benchmark_cloud(
+    memories: list[dict],
+    *,
+    config: dict,
+) -> dict:
+    """Run the same phases against a remote Cognee tenant via cognee.serve().
+
+    Timings include network latency; LLM/embedding config lives server-side.
+    """
+    import cognee
+
+    n = len(memories)
+    status = {
+        "prune": "success",
+        "db_setup": "success",  # server-side, nothing to set up from the client
+        "add": "success",
+        "cognify": "success",
+        "search": "success",
+    }
+    t_prune = 0.0
+    t_add = 0.0
+    t_cognify = 0.0
+    t_search = 0.0
+    t_tenant_create = 0.0
+    t_tenant_delete = 0.0
+    t_dataset_delete = 0.0
+
+    dataset_name = config.get("dataset_name", DATASET_NAME)
+
+    # ── Phase 0 (cloud-only metric): tenant creation ─────────────────────
+    # With --create-tenant, the whole benchmark runs on a tenant provisioned
+    # here, and tenant creation time (create call + wait-until-healthy) is
+    # measured as its own metric. The tenant is deleted after the run.
+    tenant_id = None
+    tenant_url = config["tenant_url"]
+    tenant_ready = True
+    if config.get("create_tenant"):
+        status["tenant_create"] = "success"
+        status["tenant_delete"] = "success"
+        # DNS-safe, unique per run: labels use underscores, hostnames cannot.
+        tenant_name = f"bench-{dataset_name}-{int(time.time())}".replace("_", "-")
+        print(f"Phase 0: Creating tenant '{tenant_name}'...")
+        t_tenant_create_start = time.time()
+        try:
+            tenant_id, tenant_url, t_tenant_create = await _create_cloud_tenant(
+                config["management_url"], config["tenant_api_key"], tenant_name
+            )
+            print(f"  Tenant {tenant_id} ready in {t_tenant_create:.2f}s at {tenant_url}")
+        except Exception as e:
+            # Record elapsed-until-failure like every other phase (0.0 would
+            # skew failed-run percentiles low).
+            t_tenant_create = time.time() - t_tenant_create_start
+            status["tenant_create"] = f"failed: {_err(e)}"
+            for phase in ("prune", "add", "cognify", "search"):
+                status[phase] = "skipped"
+            tenant_ready = False
+            print(f"  Tenant creation FAILED: {_err(e)}")
+
+    if tenant_ready:
+        client = await cognee.serve(url=tenant_url, api_key=config["tenant_api_key"])
+
+        # ── Prune (dataset-scoped clean slate on the tenant) ─────────────
+        # Suites share the tenant, so never forget(everything=True) here.
+        # On a just-created tenant the dataset cannot exist, so the pre-run
+        # prune is skipped; dataset deletion is instead measured AFTER the
+        # graph is built (dataset_delete_time_s), which is the meaningful
+        # number — deleting a populated dataset.
+        if config.get("create_tenant"):
+            status["prune"] = "skipped"
+            print("Skipping pre-run prune (fresh tenant, nothing to delete)")
+        else:
+            print(f"Deleting previous '{dataset_name}' dataset on tenant (if it exists)...")
+            t_prune_start = time.time()
+            try:
+                await _delete_cloud_dataset_if_exists(client, dataset_name)
+                t_prune = time.time() - t_prune_start
+                print(f"  Prune completed in {t_prune:.2f}s")
+            except Exception as e:
+                t_prune = time.time() - t_prune_start
+                status["prune"] = f"failed: {_err(e)}"
+                print(f"  Prune FAILED: {_err(e)}")
+
+        # ── Phase 1: add ─────────────────────────────────────────────────
+        print(f"\nPhase 1: Adding {n} memories via remote add...")
+        text_list = [memory_to_text(mem) for mem in memories]
+        t_add_start = time.time()
+        try:
+            await client.add(text_list, dataset_name=dataset_name)
+            t_add = time.time() - t_add_start
+        except Exception as e:
+            t_add = time.time() - t_add_start
+            status["add"] = f"failed: {_err(e)}"
+            print(f"  Add FAILED: {_err(e)}")
+
+        # ── Phase 2: cognify ─────────────────────────────────────────────
+        print("\nPhase 2: Running remote cognify (knowledge graph build)...")
+        t_cognify_start = time.time()
+        try:
+            cognify_response = await client.cognify(datasets=[dataset_name])
+            # The tenant builds the graph in the background — wait for
+            # completion so t_cognify measures the build, not the round trip.
+            await _wait_for_cloud_cognify(client, cognify_response)
+            t_cognify = time.time() - t_cognify_start
+        except Exception as e:
+            t_cognify = time.time() - t_cognify_start
+            status["cognify"] = f"failed: {_err(e)}"
+            print(f"  Cognify FAILED: {_err(e)}")
+
+        # ── Phase 3: search ──────────────────────────────────────────────
+        # Scoped to this suite's dataset so a concurrently-running suite on
+        # the same tenant cannot contaminate the search timing or results.
+        print("\nPhase 3: Running remote search query...")
+        t_q_start = time.time()
+        try:
+            await client.search(
+                "What is in the document", datasets=[dataset_name], only_context=True
+            )
+            t_search = time.time() - t_q_start
+        except Exception as e:
+            t_search = time.time() - t_q_start
+            status["search"] = f"failed: {_err(e)}"
+            print(f"  Search FAILED: {_err(e)}")
+
+        # ── Phase 4 (cloud-only metric): delete the POPULATED dataset ────
+        # Only meaningful with a graph in it, hence after cognify/search and
+        # before tenant teardown.
+        if config.get("create_tenant"):
+            status["dataset_delete"] = "success"
+            print(f"\nPhase 4: Deleting populated dataset '{dataset_name}'...")
+            t_dataset_delete_start = time.time()
+            try:
+                await client.forget(dataset=dataset_name)
+                t_dataset_delete = time.time() - t_dataset_delete_start
+                print(f"  Dataset deleted in {t_dataset_delete:.2f}s")
+            except Exception as e:
+                t_dataset_delete = time.time() - t_dataset_delete_start
+                status["dataset_delete"] = f"failed: {_err(e)}"
+                print(f"  Dataset deletion FAILED: {_err(e)}")
+
+        await client.close()
+
+    t_total = t_add + t_cognify
+
+    # ── Tenant teardown (only for tenants this run created) ──────────────
+    if tenant_id is not None:
+        print(f"\nDeleting benchmark tenant {tenant_id}...")
+        t_tenant_delete_start = time.time()
+        try:
+            t_tenant_delete = await _delete_cloud_tenant(
+                config["management_url"], config["tenant_api_key"], tenant_id
+            )
+            print(f"  Tenant deleted in {t_tenant_delete:.2f}s")
+        except Exception as e:
+            t_tenant_delete = time.time() - t_tenant_delete_start
+            status["tenant_delete"] = f"failed: {_err(e)}"
+            print(f"  Tenant deletion FAILED (manual cleanup needed for {tenant_id}): {e}")
+
+    all_ok = all(v in ("success", "skipped") for v in status.values())
+
+    # ── Report ───────────────────────────────────────────────────────────
+    results = {
+        "memories_count": n,
+        "add_time_s": round(t_add, 3),
+        "cognify_time_s": round(t_cognify, 3),
+        "total_ingest_time_s": round(t_total, 3),
+        "prune_time_s": round(t_prune, 3),
+        "db_setup_time_s": 0.0,
+        "search_time": t_search,
+        "status": status,
+        "success": all_ok,
+        "config": {
+            "llm_model": "cloud (server-side)",
+            "embedding_model": "cloud (server-side)",
+            "embedding_dimensions": "server",
+            "dataset_name": dataset_name,
+            "mock_llm": False,
+            "tenant_url": tenant_url,
+            "created_tenant": bool(config.get("create_tenant")),
+        },
+    }
+    if config.get("create_tenant"):
+        results["tenant_create_time_s"] = round(t_tenant_create, 3)
+        results["dataset_delete_time_s"] = round(t_dataset_delete, 3)
+        results["tenant_delete_time_s"] = round(t_tenant_delete, 3)
+        # Pre-run prune is skipped on a fresh tenant; drop the meaningless
+        # zero so the report only shows metrics that were actually measured.
+        results.pop("prune_time_s", None)
+
+    print("\n" + "=" * 60)
+    print("RESULTS (cloud)")
+    print("=" * 60)
+    print(f"  Tenant            : {tenant_url}")
+    if config.get("create_tenant"):
+        print(f"  Tenant create     : {t_tenant_create:.2f}s  [{status['tenant_create']}]")
+        print(
+            f"  Dataset delete    : {t_dataset_delete:.2f}s  "
+            f"[{status.get('dataset_delete', 'skipped')}]"
+        )
+        print(f"  Tenant delete     : {t_tenant_delete:.2f}s  [{status['tenant_delete']}]")
+    print(f"  Memories inserted : {n}")
+    print(f"  add time          : {t_add:.2f}s  ({t_add / n:.2f}s per memory)  [{status['add']}]")
+    print(f"  cognify time      : {t_cognify:.2f}s  [{status['cognify']}]")
+    print(f"  Total ingest time : {t_total:.2f}s  ({t_total / n:.2f}s per memory)")
+    print(f"  Search total      : {t_search:.2f}s  [{status['search']}]")
+    print(f"  Prune time        : {t_prune:.2f}s  [{status['prune']}]")
     print(f"  Overall           : {'ALL OK' if all_ok else 'SOME FAILURES'}")
     print("=" * 60)
 
@@ -381,6 +764,39 @@ def main():
         help=f"Mock responses JSON file (default: {DEFAULT_MOCK_MEMORIES_FILE.name})",
     )
     parser.add_argument(
+        "--tenant-url",
+        default=None,
+        help="Cognee Cloud tenant URL; runs all operations remotely via cognee.serve()",
+    )
+    parser.add_argument(
+        "--tenant-api-key",
+        default=None,
+        help="API key for the cloud tenant (or set COGNEE_API_KEY)",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        default=None,
+        help=(
+            "Dataset name for cloud mode (default: bench_memories). Give each "
+            "suite sharing a tenant its own name — cloud cleanup is dataset-scoped."
+        ),
+    )
+    parser.add_argument(
+        "--create-tenant",
+        action="store_true",
+        default=False,
+        help=(
+            "Cloud mode: create a fresh tenant via the tenant-controller API, "
+            "measure creation time as its own metric, run the whole benchmark "
+            "on it, and delete it afterwards. Replaces --tenant-url."
+        ),
+    )
+    parser.add_argument(
+        "--management-url",
+        default="https://api.aws.cognee.ai",
+        help="Tenant-controller API base URL for --create-tenant (default: %(default)s)",
+    )
+    parser.add_argument(
         "--output",
         "-o",
         type=Path,
@@ -389,25 +805,40 @@ def main():
     )
     args = parser.parse_args()
 
-    config = _resolve_config(args)
-    if config["mock_llm"]:
-        config["mock_memories_file"] = args.mock_memories
+    cloud_mode = bool(args.tenant_url or args.create_tenant)
+    if cloud_mode:
+        config = _resolve_cloud_config(args)
+    else:
+        config = _resolve_config(args)
+        if config["mock_llm"]:
+            config["mock_memories_file"] = args.mock_memories
 
     memories = load_memories(args.memories)
     if args.num_memories is not None:
         memories = memories[: args.num_memories]
     print(f"Loaded {len(memories)} memories from {args.memories}")
-    mock_label = " [MOCK]" if config["mock_llm"] else ""
-    print(
-        f"Config: llm={config['llm_model']}, embeddings={config['embedding_model']} ({config['embedding_dims']}d){mock_label}\n"
-    )
 
-    results = asyncio.run(run_benchmark(memories, config=config))
+    if cloud_mode:
+        tenant_label = config["tenant_url"] or f"fresh tenant via {config['management_url']}"
+        print(f"Config: cloud tenant {tenant_label}\n")
+        results = asyncio.run(run_benchmark_cloud(memories, config=config))
+    else:
+        mock_label = " [MOCK]" if config["mock_llm"] else ""
+        print(
+            f"Config: llm={config['llm_model']}, embeddings={config['embedding_model']} ({config['embedding_dims']}d){mock_label}\n"
+        )
+        results = asyncio.run(run_benchmark(memories, config=config))
 
     if args.output:
         with open(args.output, "w") as f:
             json.dump(results, f, indent=2)
         print(f"\nResults written to {args.output}")
+
+    # Propagate failures via the exit code so CI can gate on run outcomes.
+    # The results JSON is already written above — orchestrators (the
+    # percentile report) still collect the failed run's data.
+    if not results.get("success", True):
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/cognee/tests/performance/statistics_percentile_report.py
+++ b/cognee/tests/performance/statistics_percentile_report.py
@@ -34,6 +34,12 @@ METRICS = [
     "search_time",
     "prune_time_s",
     "db_setup_time_s",
+    # Local + cloud --create-tenant modes (populated-dataset deletion).
+    "dataset_delete_time_s",
+    # Cloud --create-tenant runs only; build_report skips metrics absent
+    # from the run results, so local/fixed-tenant runs are unaffected.
+    "tenant_create_time_s",
+    "tenant_delete_time_s",
 ]
 PERCENTILES = [50, 75, 90, 95, 99]
 LABELS = {
@@ -43,6 +49,9 @@ LABELS = {
     "search_time": "Search",
     "prune_time_s": "Prune",
     "db_setup_time_s": "DB setup",
+    "tenant_create_time_s": "Tenant create (cloud)",
+    "dataset_delete_time_s": "Dataset delete",
+    "tenant_delete_time_s": "Tenant delete (cloud)",
     "wall_time_s": "Wall clock (e2e)",
 }
 
@@ -75,11 +84,18 @@ def run_single(run_num: int, total: int, extra_args: list[str]) -> dict:
     result = subprocess.run(cmd, text=True, cwd=str(COGNEE_DIR))
     wall = time.time() - t0
 
-    if result.returncode != 0:
-        raise RuntimeError(f"Run {run_num} failed with exit code {result.returncode}")
-
-    with open(tmp_path) as f:
-        data = json.load(f)
+    # A non-zero exit with results present is a FAILED RUN (the bench exits 1
+    # after writing its JSON when any phase failed) — keep it as data so the
+    # percentile report covers it; the report itself exits non-zero at the
+    # end. Only a crash that produced no parseable results aborts the report.
+    try:
+        with open(tmp_path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        Path(tmp_path).unlink(missing_ok=True)
+        raise RuntimeError(
+            f"Run {run_num} crashed with exit code {result.returncode} and produced no results"
+        )
 
     Path(tmp_path).unlink(missing_ok=True)
     data["wall_time_s"] = round(wall, 3)
@@ -88,7 +104,9 @@ def run_single(run_num: int, total: int, extra_args: list[str]) -> dict:
 
 def build_report(runs: list[dict]) -> dict:
     stats = {}
-    all_metrics = METRICS + ["wall_time_s"]
+    # Only report metrics the runs actually produced: cloud runs carry
+    # tenant metrics, local runs don't, and vice versa for local-only ones.
+    all_metrics = [m for m in METRICS + ["wall_time_s"] if m in runs[0]]
     for metric in all_metrics:
         values = sorted(r[metric] for r in runs)
         entry = {
@@ -153,12 +171,17 @@ def generate_html(stats: dict, num_runs: int, config: dict, runs: list[dict], pa
         cells = "".join(f"<td>{entry[k]:.3f}s</td>" for k in pct_keys)
         table_rows += f"<tr><td class='metric-name'>{label}</td>{cells}</tr>\n"
 
+    # Metrics actually present in this report (build_report filters by what
+    # the runs produced — cloud and local runs carry different sets).
+    all_metrics = list(stats.keys())
+    run_header_cells = "".join(f"<th>{LABELS.get(m, m)}</th>" for m in all_metrics)
+
     # Per-run breakdown rows
     succeeded = sum(1 for r in runs if r.get("success", True))
     failed = num_runs - succeeded
     run_rows = ""
     for i, r in enumerate(runs, 1):
-        cells = "".join(f"<td>{r.get(m, 0):.3f}s</td>" for m in METRICS + ["wall_time_s"])
+        cells = "".join(f"<td>{r.get(m, 0):.3f}s</td>" for m in all_metrics)
         ok = r.get("success", True)
         status_style = "color: var(--green)" if ok else "color: var(--red)"
         status_label = "OK" if ok else "FAIL"
@@ -170,7 +193,6 @@ def generate_html(stats: dict, num_runs: int, config: dict, runs: list[dict], pa
         run_rows += f"<tr><td>Run {i}</td>{cells}</tr>\n"
 
     # Chart data
-    all_metrics = METRICS + ["wall_time_s"]
     chart_labels = json.dumps([LABELS.get(m, m) for m in all_metrics])
     chart_p50 = json.dumps([stats[m]["p50"] for m in all_metrics])
     chart_p90 = json.dumps([stats[m]["p90"] for m in all_metrics])
@@ -248,7 +270,7 @@ def generate_html(stats: dict, num_runs: int, config: dict, runs: list[dict], pa
 
 <h2 class="section-title">Individual Runs</h2>
 <table>
-  <thead><tr><th>Run</th><th>add()</th><th>cognify()</th><th>Total Ingest</th><th>Search</th><th>Prune</th><th>DB Setup</th><th>Wall Clock</th><th>Status</th></tr></thead>
+  <thead><tr><th>Run</th>{run_header_cells}<th>Status</th></tr></thead>
   <tbody>{run_rows}</tbody>
 </table>
 
@@ -337,6 +359,32 @@ def main():
     parser.add_argument(
         "--mock-memories", type=Path, default=None, help="Forward to bench_cognee.py"
     )
+    parser.add_argument(
+        "--tenant-url",
+        default=None,
+        help="Cognee Cloud tenant URL; benchmark runs remotely via cognee.serve()",
+    )
+    parser.add_argument(
+        "--tenant-api-key",
+        default=None,
+        help="API key for the cloud tenant (or set COGNEE_API_KEY)",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        default=None,
+        help="Forward to bench_cognee.py: per-suite dataset name for cloud mode",
+    )
+    parser.add_argument(
+        "--create-tenant",
+        action="store_true",
+        default=False,
+        help="Forward to bench_cognee.py: create+measure+delete a tenant per run",
+    )
+    parser.add_argument(
+        "--management-url",
+        default=None,
+        help="Forward to bench_cognee.py: tenant-controller API base URL",
+    )
     args = parser.parse_args()
 
     extra_args = []
@@ -358,8 +406,24 @@ def main():
         extra_args += ["--mock-llm"]
     if args.mock_memories:
         extra_args += ["--mock-memories", str(args.mock_memories)]
+    if args.tenant_url:
+        extra_args += ["--tenant-url", args.tenant_url]
+    if args.tenant_api_key:
+        extra_args += ["--tenant-api-key", args.tenant_api_key]
+    if args.dataset_name:
+        extra_args += ["--dataset-name", args.dataset_name]
+    if args.create_tenant:
+        extra_args += ["--create-tenant"]
+    if args.management_url:
+        extra_args += ["--management-url", args.management_url]
 
-    mode = " [MOCK LLM]" if args.mock_llm else ""
+    mode = (
+        " [MOCK LLM]"
+        if args.mock_llm
+        else " [CLOUD]"
+        if (args.tenant_url or args.create_tenant)
+        else ""
+    )
     print(f"Starting {args.runs} sequential run(s) of bench_cognee.py...{mode}")
 
     runs = []
@@ -393,6 +457,12 @@ def main():
         print(f"Full report saved to {args.output}")
 
     generate_html(stats, args.runs, config, runs, args.html)
+
+    # Propagate run failures via the exit code AFTER all artifacts are
+    # written, so CI both keeps the report and fails the job.
+    failed = args.runs - sum(1 for r in runs if r.get("success", True))
+    if failed:
+        sys.exit(f"{failed}/{args.runs} benchmark runs failed (report artifacts were written).")
 
 
 if __name__ == "__main__":

--- a/cognee/tests/unit/api/v1/serve/test_cloud_client_text_filename.py
+++ b/cognee/tests/unit/api/v1/serve/test_cloud_client_text_filename.py
@@ -1,0 +1,42 @@
+"""Raw-text cloud uploads must be named by content hash, not a shared placeholder.
+
+A fixed ``data.txt`` made every text upload for a tenant land on one remote
+object; rapid adds then raced the server's content-hash read-back into
+FileContentHashingError 409s (first surfaced by the nightly cloud 50-small-
+documents benchmark). The name must mirror local ingestion's
+``save_data_to_file`` convention (``text_<md5>.txt``) so identical content
+dedupes to the same key and distinct content never collides.
+"""
+
+import hashlib
+
+from cognee.api.v1.serve.cloud_client import _text_upload_filename
+from cognee.modules.ingestion.data_types.TextData import create_text_data
+
+
+def test_filename_is_content_hash_in_local_ingestion_format():
+    text = "a small memory"
+    expected_hash = hashlib.md5(text.encode("utf-8")).hexdigest()
+    assert _text_upload_filename(text) == f"text_{expected_hash}.txt"
+
+
+def test_filename_matches_local_ingestion_namer_exactly():
+    # The contract: cloud uploads and save_data_to_file use ONE naming source
+    # (TextData), so remote and local names can never drift apart.
+    text = "shared naming contract"
+    assert _text_upload_filename(text) == create_text_data(text).get_metadata()["name"]
+
+
+def test_distinct_texts_get_distinct_filenames():
+    names = {_text_upload_filename(f"memory number {i}") for i in range(50)}
+    assert len(names) == 50
+
+
+def test_identical_texts_share_a_filename():
+    assert _text_upload_filename("same") == _text_upload_filename("same")
+
+
+def test_unicode_text_hashes_utf8_bytes():
+    text = "café ☕ разговор"
+    expected_hash = hashlib.md5(text.encode("utf-8")).hexdigest()
+    assert _text_upload_filename(text) == f"text_{expected_hash}.txt"

--- a/cognee/tests/unit/migration/test_push.py
+++ b/cognee/tests/unit/migration/test_push.py
@@ -427,7 +427,7 @@ class TestCloudClientTimeout:
 
         timeout = asyncio.run(get_timeout())
         assert isinstance(timeout, aiohttp.ClientTimeout)
-        assert timeout.total == 300
+        assert timeout.total == 600
         assert timeout.sock_connect == 30
 
     def test_upload_timeout_is_unbounded_and_scoped_to_archives(self):
@@ -436,5 +436,5 @@ class TestCloudClientTimeout:
 
         assert CloudClient.UPLOAD_TIMEOUT.total is None
         assert CloudClient.UPLOAD_TIMEOUT.sock_connect == 30
-        assert CloudClient.UPLOAD_TIMEOUT.sock_read == 300
-        assert CloudClient.DEFAULT_TIMEOUT.total == 300
+        assert CloudClient.UPLOAD_TIMEOUT.sock_read == 600
+        assert CloudClient.DEFAULT_TIMEOUT.total == 600


### PR DESCRIPTION
## Description

Follow-up to the merged v1.4.1 release PR #4282: cherry-picks the nightly-CI / performance-suite PRs from `dev` onto `main`. These were requested for the release but #4282 merged while they were being prepared, so they ride separately.

| PR | Change |
|---|---|
| #4145 | SDK-284: nightly cloud arm — cloud tenant support in the statistics analysis benchmark, plus `performance_report_cloud.yml` |
| #3981 | Nightly cognee-rs SDK performance benchmark (`performance_report_rust.yml`) |
| #4242 | Compact the Rust Slack notification blocks under GitHub's 21k template size limit — without this `nightly_tests.yml` fails to load at all |
| — | fix(serve): name raw-text cloud uploads by content hash (`text_<md5>.txt` via `TextData`, replacing the shared `data.txt` placeholder) — fixes the `cloud — 50_small_documents` arm's FileContentHashingError 409s that the backported nightly surfaced on its first run |

Picked in dev merge order; the resulting workflow files are byte-identical to `dev`'s. Verified: all three workflows YAML-parse, pre-commit passes, and the touched `test_push.py` suite passes (24 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Also included

- **Slack posting on `pull_request` runs**: the notify job's Slack step previously only fired on scheduled/manual runs; PR-triggered validation runs of the nightly suite now post their reports too.
