### PR TITLE
fix(serve): Name raw-text cloud uploads by content hash

### DIFF
--- a/cognee/api/v1/serve/cloud_client.py
+++ b/cognee/api/v1/serve/cloud_client.py
@@ -7,9 +7,22 @@ from uuid import UUID
 
 import aiohttp
 
+from cognee.modules.ingestion.data_types.TextData import create_text_data
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("serve.cloud_client")
+
+
+def _text_upload_filename(text: str) -> str:
+    """Content-hash filename for raw-text uploads, via local ingestion's namer.
+
+    Delegates to ``TextData`` — the same source ``save_data_to_file`` uses for
+    nameless text (``text_<md5>.txt``). A fixed placeholder here instead makes
+    every text upload for a tenant collide on one remote object, racing
+    concurrent adds against the server's content-hash read-back
+    (FileContentHashingError 409s).
+    """
+    return create_text_data(text).get_metadata()["name"]
 
 
 class CloudClient:
@@ -109,7 +122,7 @@ class CloudClient:
             form.add_field(
                 "data",
                 io.BytesIO(data.encode("utf-8")),
-                filename="data.txt",
+                filename=_text_upload_filename(data),
                 content_type="text/plain",
             )
         elif isinstance(data, list):
@@ -118,7 +131,7 @@ class CloudClient:
                     form.add_field(
                         "data",
                         io.BytesIO(item.encode("utf-8")),
-                        filename="data.txt",
+                        filename=_text_upload_filename(item),
                         content_type="text/plain",
                     )
                 elif hasattr(item, "read"):
@@ -248,7 +261,7 @@ class CloudClient:
             form.add_field(
                 "data",
                 io.BytesIO(data.encode("utf-8")),
-                filename="data.txt",
+                filename=_text_upload_filename(data),
                 content_type="text/plain",
             )
         elif isinstance(data, list):
@@ -257,7 +270,7 @@ class CloudClient:
                     form.add_field(
                         "data",
                         io.BytesIO(item.encode("utf-8")),
-                        filename="data.txt",
+                        filename=_text_upload_filename(item),
                         content_type="text/plain",
                     )
                 elif hasattr(item, "read"):

--- a/cognee/tests/unit/api/v1/serve/test_cloud_client_text_filename.py
+++ b/cognee/tests/unit/api/v1/serve/test_cloud_client_text_filename.py
@@ -1,0 +1,42 @@
+"""Raw-text cloud uploads must be named by content hash, not a shared placeholder.
+
+A fixed ``data.txt`` made every text upload for a tenant land on one remote
+object; rapid adds then raced the server's content-hash read-back into
+FileContentHashingError 409s (first surfaced by the nightly cloud 50-small-
+documents benchmark). The name must mirror local ingestion's
+``save_data_to_file`` convention (``text_<md5>.txt``) so identical content
+dedupes to the same key and distinct content never collides.
+"""
+
+import hashlib
+
+from cognee.api.v1.serve.cloud_client import _text_upload_filename
+from cognee.modules.ingestion.data_types.TextData import create_text_data
+
+
+def test_filename_is_content_hash_in_local_ingestion_format():
+    text = "a small memory"
+    expected_hash = hashlib.md5(text.encode("utf-8")).hexdigest()
+    assert _text_upload_filename(text) == f"text_{expected_hash}.txt"
+
+
+def test_filename_matches_local_ingestion_namer_exactly():
+    # The contract: cloud uploads and save_data_to_file use ONE naming source
+    # (TextData), so remote and local names can never drift apart.
+    text = "shared naming contract"
+    assert _text_upload_filename(text) == create_text_data(text).get_metadata()["name"]
+
+
+def test_distinct_texts_get_distinct_filenames():
+    names = {_text_upload_filename(f"memory number {i}") for i in range(50)}
+    assert len(names) == 50
+
+
+def test_identical_texts_share_a_filename():
+    assert _text_upload_filename("same") == _text_upload_filename("same")
+
+
+def test_unicode_text_hashes_utf8_bytes():
+    text = "café ☕ разговор"
+    expected_hash = hashlib.md5(text.encode("utf-8")).hexdigest()
+    assert _text_upload_filename(text) == f"text_{expected_hash}.txt"


### PR DESCRIPTION
## Description

Every raw-text `add()`/`remember()` through `CloudClient` uploads its payload with the fixed multipart filename `data.txt`, and the server stores uploads under the client-supplied name — so **all text memories of a tenant collide on a single remote object** (`…/data/<tenant-id>/data.txt`). Rapid consecutive adds then race the server's content-hash read-back: the hasher pins the old Etag, the next add has already overwritten the object, and S3's "no longer exists" surfaces as `FileContentHashingError` 409s.

First surfaced by the nightly **cloud — 50 small documents** benchmark (3/3 runs failing at the add stage on three fresh tenants, while the single-document War-and-Peace cloud arm passed — no key collision with one document). Any real workload doing rapid small text adds to a cloud tenant hits the same failure.

## Fix

Name text uploads through `TextData` — the **same namer** local ingestion's `save_data_to_file` uses for nameless text (`text_<md5>.txt`) — rather than a placeholder. One naming source, so remote and local names can't drift: distinct content never collides, identical content dedupes to the same key.

- `_text_upload_filename()` delegates to `create_text_data(text).get_metadata()["name"]`
- All four upload sites (remember + add, single string + list) switched from `data.txt`
- Unit tests cover the format, distinctness across 50 texts, dedup of identical text, UTF-8 hashing, and exact equality with the `TextData` namer

Related: #4231 reworks filename preservation for file uploads; this PR covers the raw-text path. The server-side "trust client filename" behavior may still deserve hardening independently (a malicious/old client can still collide keys).

## Verification

- `cognee/tests/unit/api/v1/serve/` — 5 passed
- Import chain verified; pre-commit (ruff lint + format) green
- After merge, the nightly `cloud — 50_small_documents` arm (currently red on every run) is the live regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)