### PR TITLE
fix(datasets): guard against empty list from get_authorized_existing_datasets

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -380,10 +380,10 @@ def get_datasets_router() -> APIRouter:
         # Verify user has permission to read dataset
         dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
 
-        if dataset is None:
+        if not dataset:
             return JSONResponse(
                 status_code=404,
-                content=ErrorResponseDTO(f"Dataset ({str(dataset_id)}) not found."),
+                content=ErrorResponseDTO(message=f"Dataset ({str(dataset_id)}) not found.").model_dump(),
             )
 
         dataset_id = dataset[0].id
@@ -691,7 +691,7 @@ def get_datasets_router() -> APIRouter:
         # Verify user has permission to read dataset
         dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
 
-        if dataset is None:
+        if not dataset:
             return JSONResponse(
                 status_code=404, content={"detail": f"Dataset ({dataset_id}) not found."}
             )


### PR DESCRIPTION
`get_authorized_existing_datasets()` always returns `list[Dataset]`, never `None`, so the two `if dataset is None` checks in `GET /{dataset_id}/data` and `GET /{dataset_id}/data/{data_id}/raw` were dead code. When the dataset is absent or the user lacks permission the function returns `[]`, which then falls through to `dataset[0]` and raises `IndexError` → HTTP 500 instead of the intended 404.

**Root cause:** the return type is `list[Dataset]` (confirmed in `get_authorized_existing_datasets.py`), never `Optional`. The correct guard is `if not dataset`, already used in the proposals and skills routers.

**Changes:**
- Replace both `if dataset is None` guards with `if not dataset`
- Fix `ErrorResponseDTO(f"...")` positional-arg call → `ErrorResponseDTO(message=f"...").model_dump()` (Pydantic v2 requires keyword args on BaseModel)

Fixes #4304