### PR TITLE
fix(api): guard unguarded dataset[0] access in export and visualize endpoints

### DIFF
--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -279,6 +279,8 @@ def get_activity_router() -> APIRouter:
         from datetime import datetime, timezone
 
         dataset_ids = await get_specific_user_permission_datasets(user.id, "read", [dataset_id])
+        if not dataset_ids:
+            return Response(content="Dataset not found or access denied", status_code=403)
         dataset_id = dataset_ids[0].id
 
         db_engine = get_relational_engine()

--- a/cognee/api/v1/users/routers/get_visualize_router.py
+++ b/cognee/api/v1/users/routers/get_visualize_router.py
@@ -123,10 +123,15 @@ def get_visualize_router() -> APIRouter:
 
         from cognee.api.v1.visualize import visualize_graph
 
-        try:
-            # Verify user has permission to read dataset
-            dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
+        # Verify user has permission to read dataset
+        dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
+        if not dataset:
+            return JSONResponse(
+                status_code=403,
+                content={"error": "Dataset not found or access denied"},
+            )
 
+        try:
             html_visualization = await visualize_graph(
                 dataset=dataset[0].id,
                 user=user,
@@ -141,7 +146,7 @@ def get_visualize_router() -> APIRouter:
 
         except Exception as error:
             logger.exception("Visualization failed for dataset %s", dataset_id)
-            return JSONResponse(status_code=409, content={"error": str(error)})
+            return JSONResponse(status_code=409, content={"error": "Visualization failed"})
 
     @router.post("/multi", response_model=None)
     async def visualize_multi(
@@ -197,6 +202,11 @@ def get_visualize_router() -> APIRouter:
                 datasets = await get_authorized_existing_datasets(
                     [pair.dataset_id], "read", target_user
                 )
+                if not datasets:
+                    return JSONResponse(
+                        status_code=409,
+                        content={"error": f"Dataset {pair.dataset_id} not found or access denied"},
+                    )
                 user_dataset_pairs.append((target_user, datasets[0]))
 
             html_visualization = await visualize_multi_user_graph(user_dataset_pairs)


### PR DESCRIPTION
Three endpoints index into the result of `get_authorized_existing_datasets` / `get_specific_user_permission_datasets` without first checking whether the list is empty. Both functions return `list[Dataset]`, never `None`, so when the dataset is absent or the user lacks permission they return `[]` — and `[][0]` raises `IndexError` → HTTP 500 or an unintended exception type.

**`GET /activity/export/{dataset_id}`** (`get_activity_router.py`)
- `dataset_ids[0].id` with no guard → `IndexError` → 500
- Fix: early `return Response(status_code=403)` when list is empty

**`GET /visualize`** (`get_visualize_router.py`)
- `dataset[0].id` inside a bare `except Exception` → 409 with `str(error)` leaking `"list index out of range"` to the caller
- Fix: move auth check outside the try/except so missing-dataset returns 403 before visualization starts; change the catch-all error message to a static string to prevent info disclosure

**`POST /visualize/multi`** (`get_visualize_router.py`)
- `datasets[0]` per-pair with no guard → same `IndexError`
- Fix: guard each pair and return 409 with a clear message

Fixes #4306