### PR TITLE
fix(migration): stop an empty wrapper alias from emptying Mem0 and LangMem imports

### DIFF
--- a/cognee/modules/migration/sources/langmem.py
+++ b/cognee/modules/migration/sources/langmem.py
@@ -43,15 +43,24 @@ class LangMemSource(MemorySource):
         if isinstance(data, (str, Path)):
             data = json.loads(Path(data).read_text(encoding="utf-8"))
         if isinstance(data, dict):
+            recognized = False
             for key in ("memories", "results", "items", "data"):
-                if isinstance(data.get(key), list):
-                    data = data[key]
-                    break
-            else:
+                value = data.get(key)
+                if not isinstance(value, list):
+                    continue
+                recognized = True
+                # An accepted alias that is present but empty must not shadow a
+                # populated one later in the list -- unwrapping on it imports
+                # nothing at all. Same rule as sources/zep.py's _first_list.
+                records = [item for item in value if isinstance(item, dict)]
+                if records:
+                    return records
+            if not recognized:
                 raise ValueError(
                     "Unrecognized LangMem export shape: expected a list or a dict "
                     "with a 'memories'/'results' key."
                 )
+            return []
         if not isinstance(data, list):
             raise ValueError("Unrecognized LangMem export shape: expected a list of memories.")
         return [item for item in data if isinstance(item, dict)]

--- a/cognee/modules/migration/sources/mem0.py
+++ b/cognee/modules/migration/sources/mem0.py
@@ -34,15 +34,24 @@ class Mem0Source(MemorySource):
         if isinstance(data, (str, Path)):
             data = json.loads(Path(data).read_text(encoding="utf-8"))
         if isinstance(data, dict):
+            recognized = False
             for key in ("results", "memories", "items"):
-                if isinstance(data.get(key), list):
-                    data = data[key]
-                    break
-            else:
+                value = data.get(key)
+                if not isinstance(value, list):
+                    continue
+                recognized = True
+                # An accepted alias that is present but empty must not shadow a
+                # populated one later in the list -- unwrapping on it imports
+                # nothing at all. Same rule as sources/zep.py's _first_list.
+                records = [item for item in value if isinstance(item, dict)]
+                if records:
+                    return records
+            if not recognized:
                 raise ValueError(
                     "Unrecognized Mem0 export shape: expected a list or a dict "
                     "with a 'results'/'memories' key."
                 )
+            return []
         if not isinstance(data, list):
             raise ValueError("Unrecognized Mem0 export shape: expected a list of memories.")
         return [item for item in data if isinstance(item, dict)]

--- a/cognee/tests/unit/migration/test_langmem_source.py
+++ b/cognee/tests/unit/migration/test_langmem_source.py
@@ -69,6 +69,17 @@ def test_dict_wrapper_is_unwrapped():
     assert records[0].external_id == "lm-1"
 
 
+def test_empty_wrapper_alias_does_not_shadow_the_populated_one():
+    source = LangMemSource({"memories": [], "data": _SAMPLE})
+    records = _collect(source)
+
+    assert [r.external_id for r in records] == ["lm-1", "lm-2"]
+
+
+def test_all_empty_wrapper_aliases_yield_nothing_without_raising():
+    assert _collect(LangMemSource({"memories": [], "results": []})) == []
+
+
 def test_file_path_is_read():
     path = Path(__file__).parent / "langmem_sample_dump.json"
     path.write_text(json.dumps(_SAMPLE), encoding="utf-8")

--- a/cognee/tests/unit/migration/test_migration.py
+++ b/cognee/tests/unit/migration/test_migration.py
@@ -217,6 +217,23 @@ class TestMem0Source:
     def test_skips_items_without_content(self):
         assert collect(Mem0Source([{"id": "1"}, {"id": "2", "memory": "kept"}])) != []
 
+    def test_empty_wrapper_alias_does_not_shadow_the_populated_one(self):
+        memories = collect(
+            Mem0Source(
+                {
+                    "results": [],
+                    "memories": [
+                        {"id": "1", "memory": "kept"},
+                        {"id": "2", "memory": "also kept"},
+                    ],
+                }
+            )
+        )
+        assert [memory.external_id for memory in memories] == ["1", "2"]
+
+    def test_all_empty_wrapper_aliases_yield_nothing_without_raising(self):
+        assert collect(Mem0Source({"results": [], "memories": []})) == []
+
 
 class TestLettaSource:
     def test_agent_file(self):


### PR DESCRIPTION
## Description

`#4253` fixed `_first_list` in `letta.py` and `zep.py` so that an alias which is present but empty stops shadowing a populated one. While re-reading the migration sources I found the same mistake in the two adapters that helper does not cover: `mem0.py` and `langmem.py` pick their wrapper key in `_load_raw`, and they unwrap on the **first key that is a list** rather than the **first key that carries records**.

```python
# Before (mem0.py)
if isinstance(data, dict):
    for key in ("results", "memories", "items"):
        if isinstance(data.get(key), list):
            data = data[key]
            break
```

`[]` is a list, so an accepted alias that is present and empty satisfies the check and wins. The remaining aliases are never read, `_load_raw` returns nothing, `records()` yields an empty stream, and the import reports success having imported zero memories. Nothing raises.

Both adapters accept several wrapper spellings on purpose — that is what the alias list is for, and both module docstrings advertise the tolerance:

| Adapter | Wrapper aliases accepted | Lost when an earlier one is empty |
|---|---|---|
| `mem0.py` | `results` / `memories` / `items` | every memory in the export |
| `langmem.py` | `memories` / `results` / `items` / `data` | every memory in the export |

Because the wrapper is the whole payload here, the blast radius is larger than in `#4253`: there the empty alias cost you one collection, here it costs you the entire import.

**On how the shape arises — I want to be straight about this rather than overclaim.** I checked the mem0 client before writing the fix, and mem0 itself consistently emits `{"results": [...]}` on both the OSS and platform paths; `memories` appears there only as a *request* body key for batch operations. So I am not claiming a specific exporter ships two aliases today. The case I am fixing is the one the adapters' own contract creates: both accept a documented set of wrapper spellings, both document the "fetch with the client yourself and pass the response in" path where a caller assembles or merges that payload, and when two accepted spellings are present the module silently returns nothing. The rule that an empty alias must not shadow a populated one is already this package's rule — it is written into `_first_list`'s docstring in the two neighbouring files — and these two adapters simply never got it.

The fix applies that same rule, keeping the scan going until an alias yields records:

```python
# After (mem0.py)
if isinstance(data, dict):
    recognized = False
    for key in ("results", "memories", "items"):
        value = data.get(key)
        if not isinstance(value, list):
            continue
        recognized = True
        records = [item for item in value if isinstance(item, dict)]
        if records:
            return records
    if not recognized:
        raise ValueError(...)
    return []
```

**Why `recognized` and not just reusing `_first_list`** — `_first_list` returns `[]` both when an alias is empty and when no alias is present at all, and these two adapters need to tell those apart: a dict carrying no accepted alias must still raise `ValueError` ("Unrecognized … export shape"), which is existing behaviour with an existing test. The flag preserves that distinction; everything else matches `_first_list` exactly, including filtering to dicts before deciding an alias is populated.

**What I rejected** — (a) hoisting `_first_list` into a shared module and calling it from all four adapters. `#4253` named that as the obvious follow-up and I still think it is right, but it is a refactor across four files plus a new shared module, and it cannot express the raise-vs-empty distinction above without also changing the helper's contract for its two current callers. That is a bigger change than this bug needs, so I corrected these two in place and left the duplication note standing. (b) Merging every populated alias instead of taking the first: that changes what a payload with two populated aliases means, which is a semantic decision this bug does not require — same reasoning as `#4253`.

**Behaviour change** — confined to inputs that imported nothing before. A single populated alias still wins in the same priority order, all-empty still yields nothing without raising, and a dict with no accepted alias still raises.

No existing issue — I found this by reading the adapters, so the report is above rather than linked.

## Acceptance Criteria

- **Reproduction:** `Mem0Source({"results": [], "memories": [<2 memories>]})` imports **0 records** on `dev` and 2 after. `LangMemSource({"memories": [], "data": [<1 memory>]})` imports **0** on `dev` and 1 after.
- **The new tests fail on `dev`.** Run against unpatched sources first: **2 failed, 2 passed, 4 collected** — the 2 failures are the two shadow tests, the 2 passes are the all-empty control tests, which must pass both ways. After the fix, **4 passed**.
- **Migration suite:** **148 passed** (144 on `dev`, +4 added) — `cognee/tests/unit/migration/`.
- **Full unit suite:** `16 failed / 3504 passed / 48 skipped`, unchanged from `dev`. The failures are pre-existing and confined to `modules/retrieval/`, which this diff does not touch; that directory alone is **10 failed / 374 passed / 1 skipped** identically before and after. Two further files fail collection locally on missing optional extras (`neo4j`, the eval dashboard) both ways, so they are excluded from both runs.
- **Lint:** `ruff format --check` reports all four files already formatted. `ruff check` reports **18 findings in the two source files before and after** — identical, none introduced. Left alone rather than mixing unrelated cleanup into this diff, per `#4248`.

| Test | Asserts |
|---|---|
| `TestMem0Source::test_empty_wrapper_alias_does_not_shadow_the_populated_one` | both memories survive when `results` is present but empty |
| `TestMem0Source::test_all_empty_wrapper_aliases_yield_nothing_without_raising` | an all-empty payload still yields nothing and does not raise |
| `test_empty_wrapper_alias_does_not_shadow_the_populated_one` (langmem) | both memories survive when `memories` is present but empty |
| `test_all_empty_wrapper_aliases_yield_nothing_without_raising` (langmem) | an all-empty payload still yields nothing and does not raise |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

The migration suite after the change (148 passing), and the four new tests run on their own:

<img width="2248" height="600" alt="cognee migration suite: 148 passed, and the four new wrapper-alias tests passing" src="https://github.com/user-attachments/assets/1a166b6a-2335-4c16-84e6-4da8354d0adf" />

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable) — the rule is stated in a comment at both sites
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description — no existing issue; reported inline
- [x] My commits have clear and descriptive messages

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
