### PR TITLE
CLO-406 feat: sign more than one field in OAuth state, not just one

### DIFF
--- a/cognee/api/v1/integrations/routers/get_integrations_router.py
+++ b/cognee/api/v1/integrations/routers/get_integrations_router.py
@@ -101,9 +101,7 @@ def get_integrations_router():
             span.set_attribute("cognee.integrations.provider", provider)
             integration = _integration_or_404(provider)
             try:
-                state = make_state(
-                    user_id=user.id, signing_secret=integration.state_signing_secret()
-                )
+                state = make_state(user.id, signing_secret=integration.state_signing_secret())
                 return AuthorizeUrlDTO(authorize_url=integration.authorize_url(state))
             except RuntimeError:
                 # A provider's require()-style settings guard raises when its

--- a/cognee/modules/integrations/oauth_flow.py
+++ b/cognee/modules/integrations/oauth_flow.py
@@ -11,15 +11,20 @@ adapter (see :mod:`cognee.modules.integrations.slack.oauth`, which now just
 supplies its own signing secret to the functions here) so a second provider
 never has to re-derive or copy this HMAC scheme.
 
-The state format is ``{user_id}:{expires}:{hmac}`` — plain, not encoded,
-since none of the three fields need to survive arbitrary transport beyond a
-URL query parameter.
+The state format is ``{field_1}:...:{field_n}:{expires}:{hmac}`` — plain, not
+encoded, since none of the fields need to survive arbitrary transport beyond
+a URL query parameter. Every provider today signs exactly one field (the
+initiating user id), which is why ``make_state``/``validate_state`` default
+to that shape — a caller that needs to bind more than one id to the same
+install (e.g. a deployment scoping the callback to both a workspace/org id
+and the initiating user) passes more fields and reads them back with a
+matching ``field_count``.
 """
 
 import hmac
 import hashlib
 import time
-from typing import Optional
+from typing import Optional, Union
 from uuid import UUID
 
 # Long enough to pick a workspace/account and click through the provider's
@@ -34,29 +39,49 @@ def sign_state_payload(payload: str, *, signing_secret: str) -> str:
 
 
 def make_state(
-    user_id: UUID,
-    *,
+    *fields: Union[str, UUID],
     signing_secret: str,
     ttl_seconds: int = DEFAULT_STATE_TTL_SECONDS,
 ) -> str:
-    """Mint the CSRF state binding an OAuth install to its initiating user."""
+    """Mint the CSRF state binding an OAuth install to its initiating fields.
+
+    ``fields`` are signed in the order given and must be read back with the
+    same count via ``validate_state(..., field_count=len(fields))``. One
+    field (the initiating user id) is today's only real usage across every
+    provider.
+    """
+    if not fields:
+        raise ValueError("make_state requires at least one field")
+
     expires = int(time.time()) + ttl_seconds
-    payload = f"{user_id}:{expires}"
+    payload = ":".join([*(str(field) for field in fields), str(expires)])
     return f"{payload}:{sign_state_payload(payload, signing_secret=signing_secret)}"
 
 
-def validate_state(state: str, *, signing_secret: str) -> Optional[UUID]:
-    """Return the ``user_id`` for a valid, unexpired state; ``None`` otherwise.
+def validate_state(
+    state: str,
+    *,
+    signing_secret: str,
+    field_count: int = 1,
+) -> Optional[Union[UUID, tuple]]:
+    """Return the signed fields for a valid, unexpired state; ``None`` otherwise.
 
     Verifies the HMAC before reading any field, so a forged or tampered
     state never influences behavior — not even error messages.
+
+    With the default ``field_count=1`` (every provider today), returns the
+    single field parsed as a ``UUID`` — the original single-field contract,
+    unchanged. With ``field_count`` > 1, returns a tuple of the raw string
+    fields in the order ``make_state`` received them; the caller knows what
+    each position means and converts as needed.
     """
     parts = (state or "").split(":")
-    if len(parts) != 3:
+    if len(parts) != field_count + 2:
         return None
-    user_id_str, expires_str, signature = parts
 
-    payload = f"{user_id_str}:{expires_str}"
+    *field_strs, expires_str, signature = parts
+    payload = ":".join([*field_strs, expires_str])
+
     if not hmac.compare_digest(
         sign_state_payload(payload, signing_secret=signing_secret), signature
     ):
@@ -65,6 +90,13 @@ def validate_state(state: str, *, signing_secret: str) -> Optional[UUID]:
     try:
         if int(expires_str) < time.time():
             return None
-        return UUID(user_id_str)
     except ValueError:
         return None
+
+    if field_count == 1:
+        try:
+            return UUID(field_strs[0])
+        except ValueError:
+            return None
+
+    return tuple(field_strs)

--- a/cognee/tests/unit/modules/integrations/test_get_integrations_router.py
+++ b/cognee/tests/unit/modules/integrations/test_get_integrations_router.py
@@ -132,7 +132,7 @@ def test_callback_surfaces_missing_frontend_url_as_503_not_a_raw_crash(client):
 def test_callback_success_redirects_connected(client):
     from cognee.modules.integrations.oauth_flow import make_state
 
-    state = make_state(user_id=USER_ID, signing_secret="fake-secret")
+    state = make_state(USER_ID, signing_secret="fake-secret")
     with patch.object(
         _router_module,
         "complete_installation",
@@ -147,7 +147,7 @@ def test_callback_success_redirects_connected(client):
 def test_callback_cross_user_conflict_redirects_already_connected(client):
     from cognee.modules.integrations.oauth_flow import make_state
 
-    state = make_state(user_id=USER_ID, signing_secret="fake-secret")
+    state = make_state(USER_ID, signing_secret="fake-secret")
     with patch.object(
         _router_module,
         "complete_installation",
@@ -162,7 +162,7 @@ def test_callback_cross_user_conflict_redirects_already_connected(client):
 def test_callback_unexpected_error_redirects_exchange_failed(client):
     from cognee.modules.integrations.oauth_flow import make_state
 
-    state = make_state(user_id=USER_ID, signing_secret="fake-secret")
+    state = make_state(USER_ID, signing_secret="fake-secret")
     with patch.object(
         _router_module,
         "complete_installation",

--- a/cognee/tests/unit/modules/integrations/test_oauth_flow.py
+++ b/cognee/tests/unit/modules/integrations/test_oauth_flow.py
@@ -73,3 +73,44 @@ def test_different_signing_secrets_are_isolated():
     assert validate_state(state_b, signing_secret="secret-a") is None
     assert validate_state(state_a, signing_secret="secret-a") == user_id
     assert validate_state(state_b, signing_secret="secret-b") == user_id
+
+
+def test_make_state_requires_at_least_one_field():
+    with pytest.raises(ValueError):
+        make_state(signing_secret=_SECRET)
+
+
+def test_multi_field_roundtrip_returns_raw_string_tuple():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    state = make_state(tenant_id, user_id, signing_secret=_SECRET)
+    assert validate_state(state, signing_secret=_SECRET, field_count=2) == (
+        str(tenant_id),
+        str(user_id),
+    )
+
+
+def test_multi_field_wrong_field_count_fails():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    state = make_state(tenant_id, user_id, signing_secret=_SECRET)
+    # Reading a 2-field state back with field_count=1 (or 3) must fail closed
+    # rather than misparse the fields/expires/hmac boundary.
+    assert validate_state(state, signing_secret=_SECRET, field_count=1) is None
+    assert validate_state(state, signing_secret=_SECRET, field_count=3) is None
+
+
+def test_multi_field_tampered_field_fails():
+    state = make_state(uuid4(), uuid4(), signing_secret=_SECRET)
+    tenant_str, _user_str, expires_part, signature = state.split(":")
+    forged = f"{tenant_str}:{uuid4()}:{expires_part}:{signature}"
+    assert validate_state(forged, signing_secret=_SECRET, field_count=2) is None
+
+
+def test_multi_field_expired_state_fails():
+    tenant_id = uuid4()
+    user_id = uuid4()
+    expires = int(time.time()) - 1
+    payload = f"{tenant_id}:{user_id}:{expires}"
+    state = f"{payload}:{sign_state_payload(payload, signing_secret=_SECRET)}"
+    assert validate_state(state, signing_secret=_SECRET, field_count=2) is None


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

`oauth_flow.make_state`/`validate_state` hardcoded exactly one signed field
(the initiating user id), so a caller that needs to bind more than one id to
an OAuth install (e.g. a workspace/tenant id alongside the user) had no way
to extend it and would have to hand-roll a separate HMAC state scheme
instead. This generalizes both functions to accept an ordered list of
fields (`*fields`) instead of a single `user_id: UUID`, with a
`field_count` parameter on `validate_state` to read them back.

`field_count` defaults to `1`, so every existing caller (the Slack adapter's
`slack/oauth.py`, the generic `get_integrations_router.py`) keeps working
unchanged with no call-site changes required for the default case.

While wiring this up I found one real call site using `make_state(user_id=...)`
as a keyword argument (`get_integrations_router.py`), which the new
`*fields` var-positional signature can no longer accept as a keyword —
fixed to call positionally, along with the same pattern repeated 3x in that
router's test file.

Related: CLO-406 (tracks the follow-up work — adding a second owner column
to `IntegrationCredential` so cloud-backend's Slack integration can stop
forking the credential/crypto layer).

## Acceptance Criteria

* `make_state`/`validate_state` support signing/reading back an arbitrary
  number of fields (`field_count`), not just one.
* Default behavior (`field_count=1`) is 100% unchanged for every existing
  caller — same input/output contract as before.
* `make_state` raises `ValueError` if called with zero fields.
* `validate_state` fails closed (returns `None`) on a field-count mismatch,
  a tampered field, an expired state, or a wrong signing secret — for both
  the 1-field and N-field cases.
* All existing and new unit tests pass; `ruff check`/`ruff format` clean.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

No UI surface — backend-only change. Test run instead:
