### PR TITLE
CLO-406 feat: add an optional workspace_id owner dimension to Integra…

### DIFF
--- a/cognee/alembic/versions/d4e6f8a0b2c3_add_integration_credentials_workspace_id.py
+++ b/cognee/alembic/versions/d4e6f8a0b2c3_add_integration_credentials_workspace_id.py
@@ -1,0 +1,54 @@
+"""add_integration_credentials_workspace_id
+
+Revision ID: d4e6f8a0b2c3
+Revises: c3d5e7f9a1b2
+Create Date: 2026-08-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e6f8a0b2c3"
+down_revision: Union[str, None] = "c3d5e7f9a1b2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    columns = {col["name"] for col in insp.get_columns("integration_credentials")}
+    if "workspace_id" not in columns:
+        op.add_column(
+            "integration_credentials",
+            sa.Column("workspace_id", sa.UUID(), nullable=True),
+        )
+
+    indexes = {idx["name"] for idx in insp.get_indexes("integration_credentials")}
+    if "ix_integration_credentials_workspace_id" not in indexes:
+        op.create_index(
+            "ix_integration_credentials_workspace_id",
+            "integration_credentials",
+            ["workspace_id"],
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    indexes = {idx["name"] for idx in insp.get_indexes("integration_credentials")}
+    if "ix_integration_credentials_workspace_id" in indexes:
+        op.drop_index(
+            "ix_integration_credentials_workspace_id", table_name="integration_credentials"
+        )
+
+    columns = {col["name"] for col in insp.get_columns("integration_credentials")}
+    if "workspace_id" in columns:
+        op.drop_column("integration_credentials", "workspace_id")

--- a/cognee/modules/integrations/credentials.py
+++ b/cognee/modules/integrations/credentials.py
@@ -27,12 +27,15 @@ STATUS_REVOKED = "revoked"
 
 
 class CrossUserConflictError(Exception):
-    """A different user already holds an active connection for this external account.
+    """A different owner already holds an active connection for this external account.
 
-    A workspace maps to exactly one user (UNIQUE(provider,
+    An external account maps to exactly one owner (UNIQUE(provider,
     provider_account_id)). Silently reassigning it on reconnect would let one
-    user take over another's connection with no trace — so we refuse and let
+    owner take over another's connection with no trace — so we refuse and let
     the original owner disconnect first.
+
+    "Owner" is ``workspace_id`` when the caller passes one to
+    :func:`upsert_credential`, otherwise ``user_id`` — see that function.
     """
 
 
@@ -42,6 +45,7 @@ async def upsert_credential(
     user_id: UUID,
     provider_account_id: str,
     token_payload: dict[str, Any],
+    workspace_id: Optional[UUID] = None,
     account_label: Optional[str] = None,
     auth_type: str = "oauth2",
     scopes: Optional[str] = None,
@@ -50,13 +54,20 @@ async def upsert_credential(
 ) -> IntegrationCredential:
     """Insert or replace the credential for a ``(provider, provider_account_id)``.
 
-    Keyed on the external account, not the user. A reconnect by the **same**
-    user takes the existing row over (a token refresh, matching the
+    Keyed on the external account, not the owner. A reconnect by the **same**
+    owner takes the existing row over (a token refresh, matching the
     providers' invalidate-on-reinstall behavior). A reconnect by a **different**
-    user while the current one is still active raises
+    owner while the current one is still active raises
     :class:`CrossUserConflictError` rather than silently stealing the
-    workspace — the original owner must disconnect (or the account be revoked)
-    first.
+    connection — the original owner must disconnect (or the account be
+    revoked) first.
+
+    ``workspace_id`` is optional and defaults to ``None``, which reproduces
+    the original single-user contract exactly: ``user_id`` is the owner, and
+    conflicts are compared on it. Pass ``workspace_id`` when several users
+    share one connection (a cognee-hosted multi-user workspace, or a
+    downstream layer's own tenant concept) — it then becomes the owner/
+    conflict key instead, while ``user_id`` still records who connected it.
     """
     ciphertext, nonce, encryption_version, key_id = encrypt_credentials(token_payload)
 
@@ -70,19 +81,20 @@ async def upsert_credential(
         )
         credential = result.scalar_one_or_none()
 
-        if (
-            credential is not None
-            and credential.status == STATUS_ACTIVE
-            and credential.user_id != user_id
-        ):
-            logger.warning(
-                "Refused %s reconnect: account %s already active for user %s, not %s",
-                provider,
-                provider_account_id,
-                credential.user_id,
-                user_id,
+        if credential is not None and credential.status == STATUS_ACTIVE:
+            existing_owner = (
+                credential.workspace_id if workspace_id is not None else credential.user_id
             )
-            raise CrossUserConflictError(provider_account_id)
+            new_owner = workspace_id if workspace_id is not None else user_id
+            if existing_owner != new_owner:
+                logger.warning(
+                    "Refused %s reconnect: account %s already active for owner %s, not %s",
+                    provider,
+                    provider_account_id,
+                    existing_owner,
+                    new_owner,
+                )
+                raise CrossUserConflictError(provider_account_id)
 
         if credential is None:
             credential = IntegrationCredential(
@@ -91,6 +103,7 @@ async def upsert_credential(
             db.add(credential)
 
         credential.user_id = user_id
+        credential.workspace_id = workspace_id
         credential.account_label = account_label
         credential.auth_type = auth_type
         credential.scopes = scopes
@@ -139,6 +152,30 @@ async def get_active_credential_for_user(
             select(IntegrationCredential)
             .where(
                 IntegrationCredential.user_id == user_id,
+                IntegrationCredential.provider == provider,
+                IntegrationCredential.status == STATUS_ACTIVE,
+            )
+            .order_by(IntegrationCredential.created_at.desc())
+        )
+        return result.scalars().first()
+
+
+async def get_active_credential_for_workspace(
+    workspace_id: UUID, provider: str
+) -> Optional[IntegrationCredential]:
+    """The workspace's active connection for a provider.
+
+    Mirrors :func:`get_active_credential_for_user` for the ``workspace_id``
+    owner dimension — use this instead when the connection was upserted with
+    a ``workspace_id`` (several users sharing one connection), since
+    ``user_id`` on that row is only who connected it, not the owner.
+    """
+    engine = get_relational_engine()
+    async with engine.get_async_session() as db:
+        result = await db.execute(
+            select(IntegrationCredential)
+            .where(
+                IntegrationCredential.workspace_id == workspace_id,
                 IntegrationCredential.provider == provider,
                 IntegrationCredential.status == STATUS_ACTIVE,
             )

--- a/cognee/modules/integrations/models/IntegrationCredential.py
+++ b/cognee/modules/integrations/models/IntegrationCredential.py
@@ -18,10 +18,20 @@ class IntegrationCredential(Base):
     ``provider_account_id`` is the external workspace/org id (Slack ``team_id``,
     a Notion workspace id, a GitHub org id). The UNIQUE(provider,
     provider_account_id) constraint is what lets an inbound webhook that
-    carries only that external id resolve back to exactly one owning user — so
-    a workspace can belong to only one cognee user, and the routing is never
-    ambiguous. It is scoped by ``user_id`` (the connecting cognee user), not a
-    tenant — this is a single/multi-user SDK concept, not a SaaS tenant.
+    carries only that external id resolve back to exactly one owning row — so
+    the external account belongs to exactly one owner, and the routing is
+    never ambiguous.
+
+    ``user_id`` is always the connecting cognee user. ``workspace_id`` is an
+    optional second owner dimension — nullable, no FK — for a deployment
+    where several users share one connection (a cognee-hosted multi-user
+    workspace, or a downstream layer's own tenant concept). When
+    ``workspace_id`` is set, it is the conflict/ownership key instead of
+    ``user_id`` (see
+    :func:`cognee.modules.integrations.credentials.upsert_credential`);
+    ``user_id`` still records who actually connected it. Left unset (the
+    default), behavior is exactly the original single-user contract:
+    ``user_id`` is the owner.
     """
 
     __tablename__ = "integration_credentials"
@@ -38,6 +48,10 @@ class IntegrationCredential(Base):
     id: Mapped[UUID] = mapped_column(SAUUID, primary_key=True, default=uuid4)
 
     user_id: Mapped[UUID] = mapped_column(SAUUID, nullable=False, index=True)
+
+    # Optional second owner dimension — see the class docstring. No FK: a
+    # plain opaque id, same as user_id.
+    workspace_id: Mapped[Optional[UUID]] = mapped_column(SAUUID, nullable=True, index=True)
 
     provider: Mapped[str] = mapped_column(String, nullable=False)
     provider_account_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)

--- a/cognee/tests/unit/modules/integrations/test_credentials.py
+++ b/cognee/tests/unit/modules/integrations/test_credentials.py
@@ -17,6 +17,7 @@ from cognee.modules.integrations.credentials import (
     STATUS_ACTIVE,
     STATUS_REVOKED,
     CrossUserConflictError,
+    get_active_credential_for_workspace,
     upsert_credential,
 )
 
@@ -24,6 +25,8 @@ PROVIDER = "slack"
 ACCOUNT_ID = "T123"
 USER_A = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 USER_B = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+WORKSPACE_A = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+WORKSPACE_B = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
 
 
 @pytest.fixture(autouse=True)
@@ -32,9 +35,12 @@ def _credentials_key(monkeypatch):
     monkeypatch.setenv("INTEGRATION_CREDENTIALS_KEY", base64.b64encode(b"0" * 32).decode())
 
 
-def make_existing(user_id: UUID, status: str = STATUS_ACTIVE) -> MagicMock:
+def make_existing(
+    user_id: UUID, status: str = STATUS_ACTIVE, workspace_id: UUID | None = None
+) -> MagicMock:
     credential = MagicMock()
     credential.user_id = user_id
+    credential.workspace_id = workspace_id
     credential.status = status
     return credential
 
@@ -61,7 +67,7 @@ def make_engine(session: MagicMock) -> MagicMock:
     return engine
 
 
-async def _upsert(user_id: UUID, session: MagicMock):
+async def _upsert(user_id: UUID, session: MagicMock, workspace_id: UUID | None = None):
     with patch(
         "cognee.modules.integrations.credentials.get_relational_engine",
         return_value=make_engine(session),
@@ -71,6 +77,7 @@ async def _upsert(user_id: UUID, session: MagicMock):
             user_id=user_id,
             provider_account_id=ACCOUNT_ID,
             token_payload={"access_token": "xoxb-secret"},
+            workspace_id=workspace_id,
         )
 
 
@@ -105,6 +112,59 @@ async def test_first_connection_inserts():
     await _upsert(USER_A, session)
     session.add.assert_called_once()
     session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_workspace_scoped_different_workspace_active_is_refused():
+    # Owned by WORKSPACE_A; a different workspace reconnecting must be
+    # refused even though the connecting user differs too — workspace_id is
+    # the conflict key here, not user_id.
+    existing = make_existing(USER_A, STATUS_ACTIVE, workspace_id=WORKSPACE_A)
+    session = make_session(existing)
+    with pytest.raises(CrossUserConflictError):
+        await _upsert(USER_B, session, workspace_id=WORKSPACE_B)
+    session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_workspace_scoped_same_workspace_different_user_reconnect_is_allowed():
+    # Same workspace, a different member of it reconnecting (e.g. someone
+    # else on the team clicks "Connect" again) takes the row over — the
+    # workspace owns it, not whichever user happened to connect it first.
+    existing = make_existing(USER_A, STATUS_ACTIVE, workspace_id=WORKSPACE_A)
+    session = make_session(existing)
+    await _upsert(USER_B, session, workspace_id=WORKSPACE_A)
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_omitting_workspace_id_falls_back_to_user_id_even_if_row_has_one():
+    # A caller that doesn't pass workspace_id keeps the original single-user
+    # contract literally: it compares against user_id, not workspace_id, even
+    # if the existing row happens to carry a workspace_id from a previous
+    # workspace-scoped connect.
+    existing = make_existing(USER_A, STATUS_ACTIVE, workspace_id=WORKSPACE_A)
+    session = make_session(existing)
+    with pytest.raises(CrossUserConflictError):
+        await _upsert(USER_B, session)
+    session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_active_credential_for_workspace_filters_by_workspace_and_status():
+    existing = make_existing(USER_A, STATUS_ACTIVE, workspace_id=WORKSPACE_A)
+    execute_result = MagicMock()
+    execute_result.scalars.return_value.first.return_value = existing
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=execute_result)
+
+    with patch(
+        "cognee.modules.integrations.credentials.get_relational_engine",
+        return_value=make_engine(session),
+    ):
+        result = await get_active_credential_for_workspace(WORKSPACE_A, PROVIDER)
+
+    assert result is existing
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

`IntegrationCredential` only had `user_id` as an owner — the docstring said
so explicitly ("not a tenant, this is a single/multi-user SDK concept").
That's fine for the SDK's own single-user case, but a deployment where
several users share one connection (a cognee-hosted multi-user workspace,
or a downstream layer's own tenant concept) had no column to record that,
and no way to key the cross-owner-conflict check on it.

This adds a nullable `workspace_id` column (no FK, indexed) alongside
`user_id`, plus a migration. `upsert_credential` takes an optional
`workspace_id`: when passed, it becomes the conflict/ownership key instead
of `user_id` (which still just records who connected it); when omitted
(the default), behavior is byte-for-byte the original single-user
contract — same comparison, same exception, same everything. Also adds
`get_active_credential_for_workspace`, mirroring the existing
`get_active_credential_for_user` for the workspace dimension.

Builds on the `oauth_flow` multi-field state signing from #4317 — a
caller can now sign a `workspace_id` alongside `user_id` in the OAuth
state and persist both here.

Related: CLO-406.

## Acceptance Criteria

* `IntegrationCredential` has a nullable `workspace_id` column (no FK,
  indexed), with a migration that only adds it if it doesn't already
  exist (safe to run twice).
* `upsert_credential(workspace_id=None)` (the default) is byte-for-byte
  the original single-user behavior: conflict is checked on `user_id`,
  same exception, same fields written.
* `upsert_credential(workspace_id=...)` makes `workspace_id` the
  conflict/ownership key instead — a different workspace reconnecting is
  refused; the same workspace reconnecting under a *different* user is
  allowed (the workspace owns the connection, not whichever user
  happened to connect it first).
* `get_active_credential_for_workspace(workspace_id, provider)` returns
  the workspace's active connection, mirroring the existing per-user
  lookup.
* All existing and new unit tests pass; `ruff check`/`ruff format` clean;
  `alembic heads` resolves to a single head after the new migration.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

No UI surface — backend-only change. Test run instead:
