### PR TITLE
fix: Normalize schemeless Cognee base URL in MCP server (CLO-408)

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -32,6 +32,34 @@ except ImportError:
 
 logger = get_logger()
 
+
+def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
+    """Normalize a Cognee base URL so requests never fail on a missing scheme.
+
+    Users routinely paste a bare tenant host (e.g. ``tenant-xxx.aws.cognee.ai``)
+    into ``COGNEE_BASE_URL`` / ``--api-url``. Without a scheme, httpx raises the
+    cryptic "Request URL is missing an 'http://' or 'https://' protocol" only on
+    the first request (e.g. remember), long after startup. Assume ``https://`` for
+    a schemeless URL and warn, so the common case just works and the fix is clear.
+    """
+    if not api_url:
+        return api_url
+
+    url = api_url.strip()
+    if not url:
+        return None
+
+    if "://" not in url:
+        logger.warning(
+            "COGNEE_BASE_URL/--api-url %r has no scheme; assuming https://. "
+            "Set the full URL (e.g. https://your-tenant.aws.cognee.ai) to silence this.",
+            url,
+        )
+        url = f"https://{url}"
+
+    return url
+
+
 # Read-only GETs (dataset list/status) should fail fast rather than inherit the
 # 300s client timeout intended for long POSTs like cognify: a hung or black-holed
 # GET would otherwise freeze the caller for a full 5 minutes.
@@ -80,6 +108,7 @@ class CogneeClient:
     """
 
     def __init__(self, api_url: Optional[str] = None, api_token: Optional[str] = None):
+        api_url = normalize_api_url(api_url)
         self.api_url = api_url.rstrip("/") if api_url else None
         self.api_token = api_token
         self.use_api = bool(api_url)

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -28,9 +28,9 @@ from starlette.middleware.cors import CORSMiddleware
 import uvicorn
 
 try:
-    from .cognee_client import CogneeClient
+    from .cognee_client import CogneeClient, normalize_api_url
 except ImportError:
-    from cognee_client import CogneeClient
+    from cognee_client import CogneeClient, normalize_api_url
 
 try:
     from .strip_vectors import strip_vectors
@@ -2031,7 +2031,7 @@ async def main():
     apply_tool_mode(args.tool_mode)
 
     # Resolve cloud connection: CLI args take precedence over env vars
-    serve_url = args.serve_url or os.environ.get("COGNEE_SERVICE_URL", "")
+    serve_url = normalize_api_url(args.serve_url or os.environ.get("COGNEE_SERVICE_URL", ""))
     serve_api_key = args.serve_api_key or os.environ.get("COGNEE_API_KEY", "")
 
     # Connect to Cognee Cloud if configured (before migrations — cloud handles its own DB)

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -18,6 +18,7 @@ if str(MCP_ROOT) not in sys.path:
     sys.path.insert(0, str(MCP_ROOT))
 
 CogneeClient = importlib.import_module("src.cognee_client").CogneeClient
+normalize_api_url = importlib.import_module("src.cognee_client").normalize_api_url
 server_utils = importlib.import_module("src.server_utils")
 retrieval_utils = importlib.import_module("src.retrieval_utils")
 format_recall_results = server_utils.format_recall_results
@@ -1227,3 +1228,32 @@ async def test_recall_without_env_default_omits_system_prompt(monkeypatch):
 
     payload = _recall_payload(requests)
     assert "system_prompt" not in payload
+
+
+def test_normalize_api_url_prepends_https_when_scheme_missing():
+    assert normalize_api_url("tenant-abc.aws.cognee.ai") == "https://tenant-abc.aws.cognee.ai"
+
+
+def test_normalize_api_url_preserves_existing_scheme():
+    assert normalize_api_url("http://localhost:8000") == "http://localhost:8000"
+    assert (
+        normalize_api_url("https://tenant-abc.aws.cognee.ai") == "https://tenant-abc.aws.cognee.ai"
+    )
+
+
+def test_normalize_api_url_strips_whitespace():
+    assert normalize_api_url("  tenant-abc.aws.cognee.ai  ") == "https://tenant-abc.aws.cognee.ai"
+
+
+def test_normalize_api_url_passthrough_empty():
+    assert normalize_api_url(None) is None
+    assert normalize_api_url("") == ""
+    assert normalize_api_url("   ") is None
+
+
+def test_client_normalizes_schemeless_api_url():
+    # A schemeless base URL used to reach httpx as-is and raise "missing protocol"
+    # only on the first request; the client must now carry a usable https URL.
+    client = CogneeClient(api_url="tenant-abc.aws.cognee.ai/")
+    assert client.api_url == "https://tenant-abc.aws.cognee.ai"
+    assert client.tenant_id is None  # 'abc' is not a uuid; extraction stays best-effort


### PR DESCRIPTION
## Problem

A base URL passed **without** an `http(s)://` scheme — via `COGNEE_BASE_URL` / `--api-url` (API mode) or `COGNEE_SERVICE_URL` / `--serve-url` (serve mode) — was concatenated straight into request URLs (`CogneeClient` in `cognee_client.py`, `CloudClient` in the SDK). The HTTP layer then raised:

> `Request URL is missing an 'http://' or 'https://' protocol`

...and crucially, in API mode there is **no startup health check**, so the error only surfaced on the *first tool call* (e.g. `remember`) — not at launch. That's why a user's manual `curl` (where they type `https://` by hand) succeeds while the MCP tools fail, making this look like a mysterious client bug.

This bit a real Cloud user connecting Qwen via MCP: `curl` worked, `remember` failed with the protocol error, and the config surface (two flag pairs, two different URL env vars) made it hard to self-diagnose.

## Fix

`normalize_api_url()` normalizes the base URL once: strips whitespace and, for a schemeless value, assumes `https://` and logs a warning pointing at the fix. Applied to both the API-mode client (`CogneeClient.__init__`) and the serve-mode URL resolution in `server.py`. Existing scheme-bearing URLs (`http://localhost:8000`, `https://…`) pass through unchanged.

## Tests

Added coverage in `test_mcp_server_hardening.py`:
- `normalize_api_url` prepends `https://` when scheme missing, preserves existing scheme, strips whitespace, and passes through empty/`None`.
- `CogneeClient` carries a usable `https://` URL when constructed from a schemeless host.

All 61 tests in the file pass; `ruff format`/`check` clean.

## Follow-ups (not in this PR)
- The docs (`cognee-docs` `cloud-cloud/connections/cloud-mcp.mdx`) present API mode and serve mode without distinguishing them and never state the URL must include the scheme — worth a docs note.
- Same schemeless-URL hazard exists in the SDK's `CloudClient` (`cognee/api/v1/serve/cloud_client.py`); this PR only covers the MCP entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)