### PR TITLE
feat(observability): OpenTelemetry instrumentation for core memory ops (memory-semconv v0.1.0)

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -19,6 +19,15 @@ from cognee.tasks.ingestion.resolve_dlt_sources import resolve_dlt_sources
 from cognee.tasks.ingestion.utils import materialize_stream_for_background
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.data.constants import DEFAULT_DATASET_NAME
+from cognee.modules.observability import (
+    new_span,
+    MEMORY_SYSTEM,
+    MEMORY_OPERATION,
+    MEMORY_COLLECTION,
+    COGNEE_DATASET_NAME,
+    record_operation_duration,
+    increment_items_stored,
+)
 
 logger = get_logger()
 
@@ -223,6 +232,15 @@ async def add(
 
     await setup()
 
+    import time as _time
+    _add_start_ns = _time.monotonic_ns()
+
+    with new_span("memory.store") as _span:
+        _span.set_attribute(MEMORY_SYSTEM, "cognee")
+        _span.set_attribute(MEMORY_OPERATION, "store")
+        _span.set_attribute(MEMORY_COLLECTION, dataset_name or "main_dataset")
+        _span.set_attribute(COGNEE_DATASET_NAME, dataset_name or "main_dataset")
+
     user, authorized_dataset = await resolve_authorized_user_dataset(
         dataset_name=dataset_name, dataset_id=dataset_id, user=user
     )
@@ -282,6 +300,16 @@ async def add(
     # run_pipeline_blocking returns {dataset_id: PipelineRunInfo} but callers
     # expect a single PipelineRunInfo (add always processes one dataset).
     if isinstance(result, dict) and len(result) == 1:
-        return next(iter(result.values()))
+        result = next(iter(result.values()))
+
+    _duration_ms = (_time.monotonic_ns() - _add_start_ns) / 1_000_000
+    _attrs = {
+        "memory.system": "cognee",
+        "memory.operation": "store",
+        "memory.collection": dataset_name or "main_dataset",
+    }
+    record_operation_duration(_duration_ms, _attrs)
+    item_count = len(data) if hasattr(data, "__len__") else 1
+    increment_items_stored(item_count, _attrs)
 
     return result

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -36,7 +36,16 @@ from cognee.tasks.temporal_graph.extract_events_and_entities import extract_even
 from cognee.tasks.temporal_graph.extract_knowledge_graph_from_events import (
     extract_knowledge_graph_from_events,
 )
-from cognee.modules.observability import new_span, COGNEE_PIPELINE_NAME, COGNEE_RESULT_SUMMARY
+from cognee.modules.observability import (
+    new_span,
+    COGNEE_PIPELINE_NAME,
+    COGNEE_RESULT_SUMMARY,
+    MEMORY_SYSTEM,
+    MEMORY_OPERATION,
+    record_operation_duration,
+    increment_graph_edges,
+    increment_graph_nodes,
+)
 
 
 logger = get_logger("cognify")
@@ -230,7 +239,12 @@ async def cognify(
             run_in_background=run_in_background,
         )
 
-    with new_span("cognee.api.cognify") as span:
+    import time as _time
+    _cognify_start_ns = _time.monotonic_ns()
+
+    with new_span("memory.process") as span:
+        span.set_attribute(MEMORY_SYSTEM, "cognee")
+        span.set_attribute(MEMORY_OPERATION, "process")
         span.set_attribute(COGNEE_PIPELINE_NAME, "cognify")
         if datasets is not None:
             span.set_attribute("cognee.cognify.datasets", str(datasets))
@@ -318,6 +332,10 @@ async def cognify(
             COGNEE_RESULT_SUMMARY,
             f"Cognify completed for {dataset_desc}",
         )
+
+        _duration_ms = (_time.monotonic_ns() - _cognify_start_ns) / 1_000_000
+        _attrs = {"memory.system": "cognee", "memory.operation": "process"}
+        record_operation_duration(_duration_ms, _attrs)
 
         return result
 

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -9,6 +9,10 @@ from cognee.modules.observability import (
     COGNEE_DATASET_NAME,
     COGNEE_FORGET_TARGET,
     COGNEE_RESULT_COUNT,
+    MEMORY_SYSTEM,
+    MEMORY_OPERATION,
+    record_operation_duration,
+    increment_items_deleted,
 )
 
 logger = get_logger("forget")
@@ -96,7 +100,12 @@ async def forget(
         },
     )
 
-    with new_span("cognee.api.forget") as span:
+    import time as _time
+    _forget_start_ns = _time.monotonic_ns()
+
+    with new_span("memory.delete") as span:
+        span.set_attribute(MEMORY_SYSTEM, "cognee")
+        span.set_attribute(MEMORY_OPERATION, "delete")
         span.set_attribute(COGNEE_FORGET_TARGET, target)
         if dataset_ref:
             span.set_attribute(COGNEE_DATASET_NAME, str(dataset_ref))
@@ -134,7 +143,12 @@ async def forget(
         # would try to create a dataset_database row for a non-existent dataset).
         if everything:
             result = await _forget_everything(user)
-            span.set_attribute(COGNEE_RESULT_COUNT, result.get("datasets_removed", 0))
+            _removed = result.get("datasets_removed", 0)
+            span.set_attribute(COGNEE_RESULT_COUNT, _removed)
+            _duration_ms = (_time.monotonic_ns() - _forget_start_ns) / 1_000_000
+            _attrs = {"memory.system": "cognee", "memory.operation": "delete"}
+            record_operation_duration(_duration_ms, _attrs)
+            increment_items_deleted(_removed, _attrs)
             return result
 
         # All remaining operations are scoped to a single dataset.

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -23,6 +23,15 @@ from cognee.modules.observability import (
     COGNEE_SEARCH_TYPE,
     COGNEE_RESULT_SUMMARY,
     COGNEE_RESULT_COUNT,
+    MEMORY_SYSTEM,
+    MEMORY_OPERATION,
+    MEMORY_QUERY_TEXT,
+    MEMORY_QUERY_TYPE,
+    MEMORY_RESULT_COUNT,
+    record_operation_duration,
+    record_query_results,
+    increment_items_retrieved,
+    increment_vector_searches,
 )
 
 logger = get_logger()
@@ -256,10 +265,16 @@ async def search(
             **{key: value for key, value in agentic_overrides.items() if value is not None},
         )
 
-    with new_span("cognee.api.search") as span:
+    with new_span("memory.retrieve") as span:
+        span.set_attribute(MEMORY_SYSTEM, "cognee")
+        span.set_attribute(MEMORY_OPERATION, "retrieve")
+        span.set_attribute(MEMORY_QUERY_TEXT, query_text[:500])
+        span.set_attribute(MEMORY_QUERY_TYPE, str(query_type.value))
+        # legacy cognee attributes for backward compat
         span.set_attribute(COGNEE_SEARCH_QUERY, query_text[:500])
         span.set_attribute(COGNEE_SEARCH_TYPE, str(query_type.value))
         span.set_attribute("cognee.search.top_k", top_k)
+        _search_start_ns = __import__("time").monotonic_ns()
 
         # We use lists from now on for datasets
         if isinstance(datasets, UUID) or isinstance(datasets, str):
@@ -351,9 +366,16 @@ async def search(
 
         n = len(filtered_search_results) if filtered_search_results else 0
         span.set_attribute(COGNEE_RESULT_COUNT, n)
+        span.set_attribute(MEMORY_RESULT_COUNT, n)
         span.set_attribute(
             COGNEE_RESULT_SUMMARY,
             f"Found {n} result(s) via {query_type.value}",
         )
+        _duration_ms = (__import__("time").monotonic_ns() - _search_start_ns) / 1_000_000
+        _attrs = {"memory.system": "cognee", "memory.operation": "retrieve", "memory.query.type": str(query_type.value)}
+        record_operation_duration(_duration_ms, _attrs)
+        record_query_results(n, _attrs)
+        increment_items_retrieved(n, _attrs)
+        increment_vector_searches(_attrs)
 
         return filtered_search_results

--- a/cognee/modules/observability/__init__.py
+++ b/cognee/modules/observability/__init__.py
@@ -40,6 +40,44 @@ from .tracing import (
     COGNEE_IMPROVE_STAGES,
     COGNEE_GRAPH_EDGES_SYNCED,
 )
+from .metrics import (
+    setup_metrics,
+    get_meter,
+    shutdown_metrics,
+    record_operation_duration,
+    increment_items_stored,
+    increment_items_retrieved,
+    increment_items_deleted,
+    record_query_results,
+    increment_bytes_stored,
+    increment_vector_searches,
+    increment_graph_edges,
+    increment_graph_nodes,
+    increment_operation_errors,
+    # metric name constants (memory-semconv v0.1.0)
+    MEMORY_OPERATION_DURATION,
+    MEMORY_ITEMS_STORED,
+    MEMORY_ITEMS_RETRIEVED,
+    MEMORY_ITEMS_DELETED,
+    MEMORY_QUERY_RESULT_COUNT,
+    MEMORY_DATA_BYTES_STORED,
+    MEMORY_VECTOR_SEARCHES,
+    MEMORY_GRAPH_EDGES_ADDED,
+    MEMORY_GRAPH_NODES_ADDED,
+    MEMORY_OPERATION_ERRORS,
+)
+from .logs import setup_log_bridge, shutdown_log_bridge
+
+# memory-semconv v0.1.0 span attribute keys
+MEMORY_SYSTEM = "memory.system"
+MEMORY_OPERATION = "memory.operation"
+MEMORY_QUERY_TEXT = "memory.query.text"
+MEMORY_QUERY_TYPE = "memory.query.type"
+MEMORY_RESULT_COUNT = "memory.result.count"
+MEMORY_DATA_SIZE = "memory.data.size"
+MEMORY_ITEM_COUNT = "memory.item.count"
+MEMORY_COLLECTION = "memory.collection"
+MEMORY_STORE_BACKEND = "memory.store.backend"
 
 
 try:

--- a/cognee/modules/observability/logs.py
+++ b/cognee/modules/observability/logs.py
@@ -1,0 +1,141 @@
+"""OpenTelemetry log bridge for Cognee.
+
+Bridges Python's standard logging to OTel LogRecords so log entries from the
+core memory operations appear in any connected OTel backend (Grafana, Dash0,
+Langfuse, etc.).
+
+Call setup_log_bridge() once during application startup alongside
+setup_tracing() / setup_metrics().
+"""
+
+import logging
+import os
+from typing import Optional
+
+try:
+    from opentelemetry._logs import set_logger_provider
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor
+    from opentelemetry.sdk.resources import Resource
+
+    _OTEL_LOGS_AVAILABLE = True
+except ImportError:
+    _OTEL_LOGS_AVAILABLE = False
+
+_log_provider: Optional[object] = None
+_handler: Optional[object] = None
+
+# Loggers that receive the OTel handler (covers all cognee namespaces)
+_COGNEE_LOGGER_NAMES = [
+    "cognee",
+    "cognee.api",
+    "cognee.modules",
+    "cognee.tasks",
+    "cognee.infrastructure",
+]
+
+
+def setup_log_bridge(console_output: bool = False) -> Optional[object]:
+    """Attach an OTel logging handler to all cognee loggers.
+
+    Reads the OTLP endpoint from BaseConfig (same as tracing). Returns the
+    LoggerProvider, or None when the OTel logs SDK is unavailable.
+    """
+    global _log_provider, _handler
+
+    if not _OTEL_LOGS_AVAILABLE:
+        return None
+
+    from cognee.base_config import get_base_config
+    from cognee.version import get_cognee_version
+    from cognee.modules.observability.tracing import _parse_otlp_headers
+
+    config = get_base_config()
+    version = get_cognee_version()
+
+    resource = Resource.create(
+        {
+            "service.name": config.otel_service_name,
+            "service.version": version,
+            "deployment.environment": os.getenv("ENV", "development"),
+        }
+    )
+
+    _log_provider = LoggerProvider(resource=resource)
+
+    otlp_endpoint = config.otel_exporter_otlp_endpoint
+    if otlp_endpoint:
+        headers = _parse_otlp_headers(getattr(config, "otel_exporter_otlp_headers", None))
+        _try_add_otlp_log_exporter(_log_provider, otlp_endpoint, headers)
+
+    if console_output:
+        from opentelemetry.sdk._logs.export import ConsoleLogExporter
+
+        _log_provider.add_log_record_processor(
+            SimpleLogRecordProcessor(ConsoleLogExporter())
+        )
+
+    set_logger_provider(_log_provider)
+
+    _handler = LoggingHandler(level=logging.DEBUG, logger_provider=_log_provider)
+
+    for name in _COGNEE_LOGGER_NAMES:
+        logger = logging.getLogger(name)
+        # Avoid adding duplicate handlers on repeated calls
+        if not any(isinstance(h, LoggingHandler) for h in logger.handlers):
+            logger.addHandler(_handler)
+
+    return _log_provider
+
+
+def _try_add_otlp_log_exporter(provider, endpoint: str, headers) -> None:
+    logs_endpoint = os.getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") or (
+        endpoint.replace("/v1/traces", "/v1/logs") if "/v1/traces" in endpoint else endpoint
+    )
+
+    if "/api/public/otel" in logs_endpoint:
+        _add_http_log_exporter(provider, logs_endpoint, headers)
+        return
+
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+
+        provider.add_log_record_processor(
+            SimpleLogRecordProcessor(OTLPLogExporter(endpoint=logs_endpoint, headers=headers))
+        )
+    except ImportError:
+        _add_http_log_exporter(provider, logs_endpoint, headers)
+
+
+def _add_http_log_exporter(provider, endpoint: str, headers) -> None:
+    try:
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import (
+            OTLPLogExporter as OTLPHttpLogExporter,
+        )
+
+        provider.add_log_record_processor(
+            SimpleLogRecordProcessor(OTLPHttpLogExporter(endpoint=endpoint, headers=headers))
+        )
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "OTEL_EXPORTER_OTLP_ENDPOINT is set but no OTLP log exporter is installed. "
+            "Install with: pip install cognee[tracing]",
+            stacklevel=3,
+        )
+
+
+def shutdown_log_bridge(timeout_ms: int = 30_000) -> None:
+    """Detach the OTel handler from all cognee loggers and shut down the provider."""
+    global _log_provider, _handler
+
+    if _handler is not None:
+        for name in _COGNEE_LOGGER_NAMES:
+            logging.getLogger(name).removeHandler(_handler)
+
+    if _log_provider is not None and hasattr(_log_provider, "shutdown"):
+        _log_provider.shutdown()
+
+    _log_provider = None
+    _handler = None

--- a/cognee/modules/observability/logs.py
+++ b/cognee/modules/observability/logs.py
@@ -89,11 +89,16 @@ def setup_log_bridge(console_output: bool = False) -> Optional[object]:
 
 
 def _try_add_otlp_log_exporter(provider, endpoint: str, headers) -> None:
+    import logging as _logging
+
+    _log = _logging.getLogger("cognee.observability")
+    from cognee.modules.observability.tracing import _requires_http_exporter
+
     logs_endpoint = os.getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") or (
         endpoint.replace("/v1/traces", "/v1/logs") if "/v1/traces" in endpoint else endpoint
     )
 
-    if "/api/public/otel" in logs_endpoint:
+    if _requires_http_exporter(logs_endpoint):
         _add_http_log_exporter(provider, logs_endpoint, headers)
         return
 
@@ -103,6 +108,7 @@ def _try_add_otlp_log_exporter(provider, endpoint: str, headers) -> None:
         provider.add_log_record_processor(
             SimpleLogRecordProcessor(OTLPLogExporter(endpoint=logs_endpoint, headers=headers))
         )
+        _log.info("OTel: OTLP gRPC log exporter registered → %s", logs_endpoint)
     except ImportError:
         _add_http_log_exporter(provider, logs_endpoint, headers)
 

--- a/cognee/modules/observability/metrics.py
+++ b/cognee/modules/observability/metrics.py
@@ -1,0 +1,321 @@
+"""OpenTelemetry metrics for Cognee — memory-semconv v0.1.0.
+
+Provides setup_metrics(), get_meter(), and pre-built instruments for the core
+memory operations: store, retrieve, process, and delete.
+
+All instruments are created lazily; if the OTel SDK is not installed or metrics
+have not been set up, every call is a no-op via _NullInstrument.
+"""
+
+import os
+from typing import Optional
+
+try:
+    from opentelemetry import metrics
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import (
+        ConsoleMetricExporter,
+        PeriodicExportingMetricReader,
+    )
+    from opentelemetry.sdk.resources import Resource
+
+    _OTEL_METRICS_AVAILABLE = True
+except ImportError:
+    _OTEL_METRICS_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# memory-semconv v0.1.0 metric names
+# ---------------------------------------------------------------------------
+
+# Latency histograms (unit: ms)
+MEMORY_OPERATION_DURATION = "memory.operation.duration"
+
+# Item / data volume counters
+MEMORY_ITEMS_STORED = "memory.items.stored"
+MEMORY_ITEMS_RETRIEVED = "memory.items.retrieved"
+MEMORY_ITEMS_DELETED = "memory.items.deleted"
+
+# Query result distribution
+MEMORY_QUERY_RESULT_COUNT = "memory.query.result.count"
+
+# Data size (bytes)
+MEMORY_DATA_BYTES_STORED = "memory.data.bytes.stored"
+
+# Vector index counters
+MEMORY_VECTOR_SEARCHES = "memory.vector.searches"
+MEMORY_GRAPH_EDGES_ADDED = "memory.graph.edges.added"
+MEMORY_GRAPH_NODES_ADDED = "memory.graph.nodes.added"
+
+# Error counter
+MEMORY_OPERATION_ERRORS = "memory.operation.errors"
+
+
+# ---------------------------------------------------------------------------
+# Null-object pattern — zero overhead when metrics are off
+# ---------------------------------------------------------------------------
+
+class _NullInstrument:
+    """No-op stand-in for any OTel instrument."""
+
+    def add(self, *args, **kwargs):
+        pass
+
+    def record(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+
+_NULL = _NullInstrument()
+
+# ---------------------------------------------------------------------------
+# Global state
+# ---------------------------------------------------------------------------
+
+_meter: Optional[object] = None
+_provider: Optional[object] = None
+
+# Instruments (populated by setup_metrics / _ensure_instruments)
+_op_duration: object = _NULL
+_items_stored: object = _NULL
+_items_retrieved: object = _NULL
+_items_deleted: object = _NULL
+_query_result_count: object = _NULL
+_data_bytes_stored: object = _NULL
+_vector_searches: object = _NULL
+_graph_edges_added: object = _NULL
+_graph_nodes_added: object = _NULL
+_op_errors: object = _NULL
+
+
+def _ensure_instruments() -> None:
+    """Create metric instruments against the current meter."""
+    global _op_duration, _items_stored, _items_retrieved, _items_deleted
+    global _query_result_count, _data_bytes_stored, _vector_searches
+    global _graph_edges_added, _graph_nodes_added, _op_errors
+
+    if _meter is None or not _OTEL_METRICS_AVAILABLE:
+        return
+
+    _op_duration = _meter.create_histogram(
+        name=MEMORY_OPERATION_DURATION,
+        description="Duration of memory operations",
+        unit="ms",
+    )
+    _items_stored = _meter.create_counter(
+        name=MEMORY_ITEMS_STORED,
+        description="Total number of memory items stored",
+        unit="{item}",
+    )
+    _items_retrieved = _meter.create_counter(
+        name=MEMORY_ITEMS_RETRIEVED,
+        description="Total number of memory items retrieved",
+        unit="{item}",
+    )
+    _items_deleted = _meter.create_counter(
+        name=MEMORY_ITEMS_DELETED,
+        description="Total number of memory items deleted",
+        unit="{item}",
+    )
+    _query_result_count = _meter.create_histogram(
+        name=MEMORY_QUERY_RESULT_COUNT,
+        description="Distribution of result counts per query",
+        unit="{item}",
+    )
+    _data_bytes_stored = _meter.create_counter(
+        name=MEMORY_DATA_BYTES_STORED,
+        description="Total bytes stored into the memory system",
+        unit="By",
+    )
+    _vector_searches = _meter.create_counter(
+        name=MEMORY_VECTOR_SEARCHES,
+        description="Total number of vector similarity searches executed",
+        unit="{search}",
+    )
+    _graph_edges_added = _meter.create_counter(
+        name=MEMORY_GRAPH_EDGES_ADDED,
+        description="Total graph edges added to the knowledge graph",
+        unit="{edge}",
+    )
+    _graph_nodes_added = _meter.create_counter(
+        name=MEMORY_GRAPH_NODES_ADDED,
+        description="Total graph nodes added to the knowledge graph",
+        unit="{node}",
+    )
+    _op_errors = _meter.create_counter(
+        name=MEMORY_OPERATION_ERRORS,
+        description="Total number of memory operation errors",
+        unit="{error}",
+    )
+
+
+def setup_metrics(console_output: bool = False) -> object:
+    """Configure OTel MeterProvider for Cognee.
+
+    If an external MeterProvider is already configured (e.g. via
+    opentelemetry-instrument), it is reused. Otherwise a fresh one is created
+    and an OTLP metrics exporter is attached when
+    OTEL_EXPORTER_OTLP_ENDPOINT is configured.
+
+    Returns the cognee meter.
+    """
+    global _meter, _provider
+
+    if not _OTEL_METRICS_AVAILABLE:
+        return None
+
+    from cognee.version import get_cognee_version
+
+    version = get_cognee_version()
+
+    current = metrics.get_meter_provider()
+    # ProxyMeterProvider is the default before any SDK provider is set
+    external = current is not None and type(current).__name__ not in (
+        "ProxyMeterProvider",
+        "NoOpMeterProvider",
+    )
+
+    if external:
+        _provider = current
+    else:
+        from cognee.base_config import get_base_config
+
+        config = get_base_config()
+        resource = Resource.create(
+            {
+                "service.name": config.otel_service_name,
+                "service.version": version,
+                "deployment.environment": os.getenv("ENV", "development"),
+            }
+        )
+
+        readers = []
+
+        if console_output:
+            readers.append(
+                PeriodicExportingMetricReader(
+                    ConsoleMetricExporter(), export_interval_millis=60_000
+                )
+            )
+
+        otlp_endpoint = config.otel_exporter_otlp_endpoint
+        if otlp_endpoint:
+            _try_add_otlp_metric_reader(readers, otlp_endpoint, config)
+
+        _provider = MeterProvider(resource=resource, metric_readers=readers)
+        metrics.set_meter_provider(_provider)
+
+    _meter = _provider.get_meter("cognee", version)
+    _ensure_instruments()
+    return _meter
+
+
+def _try_add_otlp_metric_reader(readers: list, endpoint: str, config) -> None:
+    """Try to add an OTLP metric reader; silently skip if package missing."""
+    from cognee.modules.observability.tracing import _parse_otlp_headers
+
+    headers = _parse_otlp_headers(getattr(config, "otel_exporter_otlp_headers", None))
+
+    # Resolve metrics endpoint: standard env var takes precedence, then derive from traces ep
+    metrics_endpoint = os.getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") or (
+        endpoint.replace("/v1/traces", "/v1/metrics") if "/v1/traces" in endpoint else endpoint
+    )
+
+    # Langfuse and similar: HTTP only
+    if "/api/public/otel" in metrics_endpoint:
+        _add_http_metric_reader(readers, metrics_endpoint, headers)
+        return
+
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+
+        readers.append(
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=metrics_endpoint, headers=headers),
+                export_interval_millis=30_000,
+            )
+        )
+    except ImportError:
+        _add_http_metric_reader(readers, metrics_endpoint, headers)
+
+
+def _add_http_metric_reader(readers: list, endpoint: str, headers) -> None:
+    try:
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter as OTLPHttpMetricExporter,
+        )
+
+        readers.append(
+            PeriodicExportingMetricReader(
+                OTLPHttpMetricExporter(endpoint=endpoint, headers=headers),
+                export_interval_millis=30_000,
+            )
+        )
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "OTEL_EXPORTER_OTLP_ENDPOINT is set but no OTLP metrics exporter is installed. "
+            "Install with: pip install cognee[tracing]",
+            stacklevel=3,
+        )
+
+
+def get_meter() -> Optional[object]:
+    """Return the cognee OTel meter, or None if not configured."""
+    return _meter
+
+
+# ---------------------------------------------------------------------------
+# Public metric helpers (no-op when not configured)
+# ---------------------------------------------------------------------------
+
+def record_operation_duration(duration_ms: float, attributes: dict) -> None:
+    _op_duration.record(duration_ms, attributes)
+
+
+def increment_items_stored(count: int = 1, attributes: dict = None) -> None:
+    _items_stored.add(count, attributes or {})
+
+
+def increment_items_retrieved(count: int = 1, attributes: dict = None) -> None:
+    _items_retrieved.add(count, attributes or {})
+
+
+def increment_items_deleted(count: int = 1, attributes: dict = None) -> None:
+    _items_deleted.add(count, attributes or {})
+
+
+def record_query_results(count: int, attributes: dict = None) -> None:
+    _query_result_count.record(count, attributes or {})
+
+
+def increment_bytes_stored(byte_count: int, attributes: dict = None) -> None:
+    _data_bytes_stored.add(byte_count, attributes or {})
+
+
+def increment_vector_searches(attributes: dict = None) -> None:
+    _vector_searches.add(1, attributes or {})
+
+
+def increment_graph_edges(count: int = 1, attributes: dict = None) -> None:
+    _graph_edges_added.add(count, attributes or {})
+
+
+def increment_graph_nodes(count: int = 1, attributes: dict = None) -> None:
+    _graph_nodes_added.add(count, attributes or {})
+
+
+def increment_operation_errors(attributes: dict = None) -> None:
+    _op_errors.add(1, attributes or {})
+
+
+def shutdown_metrics(timeout_ms: int = 30_000) -> None:
+    """Shut down the MeterProvider and clear global state."""
+    global _meter, _provider
+
+    if _provider is not None and hasattr(_provider, "shutdown"):
+        _provider.shutdown()
+    _meter = None
+    _provider = None

--- a/cognee/modules/observability/metrics.py
+++ b/cognee/modules/observability/metrics.py
@@ -213,7 +213,11 @@ def setup_metrics(console_output: bool = False) -> object:
 
 def _try_add_otlp_metric_reader(readers: list, endpoint: str, config) -> None:
     """Try to add an OTLP metric reader; silently skip if package missing."""
-    from cognee.modules.observability.tracing import _parse_otlp_headers
+    import logging as _logging
+
+    _log = _logging.getLogger("cognee.observability")
+
+    from cognee.modules.observability.tracing import _parse_otlp_headers, _requires_http_exporter
 
     headers = _parse_otlp_headers(getattr(config, "otel_exporter_otlp_headers", None))
 
@@ -222,8 +226,7 @@ def _try_add_otlp_metric_reader(readers: list, endpoint: str, config) -> None:
         endpoint.replace("/v1/traces", "/v1/metrics") if "/v1/traces" in endpoint else endpoint
     )
 
-    # Langfuse and similar: HTTP only
-    if "/api/public/otel" in metrics_endpoint:
+    if _requires_http_exporter(metrics_endpoint):
         _add_http_metric_reader(readers, metrics_endpoint, headers)
         return
 
@@ -236,11 +239,15 @@ def _try_add_otlp_metric_reader(readers: list, endpoint: str, config) -> None:
                 export_interval_millis=30_000,
             )
         )
+        _log.info("OTel: OTLP gRPC metric exporter registered → %s", metrics_endpoint)
     except ImportError:
         _add_http_metric_reader(readers, metrics_endpoint, headers)
 
 
 def _add_http_metric_reader(readers: list, endpoint: str, headers) -> None:
+    import logging as _logging
+
+    _log = _logging.getLogger("cognee.observability")
     try:
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
             OTLPMetricExporter as OTLPHttpMetricExporter,
@@ -252,14 +259,17 @@ def _add_http_metric_reader(readers: list, endpoint: str, headers) -> None:
                 export_interval_millis=30_000,
             )
         )
+        _log.info("OTel: OTLP HTTP metric exporter registered → %s", endpoint)
     except ImportError:
         import warnings
 
-        warnings.warn(
-            "OTEL_EXPORTER_OTLP_ENDPOINT is set but no OTLP metrics exporter is installed. "
-            "Install with: pip install cognee[tracing]",
-            stacklevel=3,
+        msg = (
+            f"OTEL_EXPORTER_OTLP_ENDPOINT is set to '{endpoint}' but no OTLP metrics "
+            "exporter is installed. Metrics will NOT be exported. "
+            "Install with: pip install cognee[tracing]"
         )
+        _log.error("OTel: %s", msg)
+        warnings.warn(msg, stacklevel=3,)
 
 
 def get_meter() -> Optional[object]:

--- a/cognee/modules/observability/trace_context.py
+++ b/cognee/modules/observability/trace_context.py
@@ -14,20 +14,46 @@ _tracing_enabled: bool = False
 
 
 def enable_tracing(console_output: bool = False) -> None:
-    """Enable OpenTelemetry tracing for Cognee.
+    """Enable OpenTelemetry tracing, metrics, and log bridge for Cognee.
 
-    Sets up a TracerProvider with an in-memory CogneeSpanExporter.
-    Optionally prints spans to the console when *console_output* is True.
+    Sets up a TracerProvider with an in-memory CogneeSpanExporter, a
+    MeterProvider for memory-semconv metrics, and an OTel log bridge so
+    all cognee loggers emit OTel log records.
+    Optionally prints spans/metrics to the console when *console_output* is True.
     """
     global _tracing_enabled
     setup_tracing(console_output=console_output)
+    try:
+        from cognee.modules.observability.metrics import setup_metrics
+
+        setup_metrics(console_output=console_output)
+    except Exception:
+        pass
+    try:
+        from cognee.modules.observability.logs import setup_log_bridge
+
+        setup_log_bridge(console_output=console_output)
+    except Exception:
+        pass
     _tracing_enabled = True
 
 
 def disable_tracing() -> None:
-    """Disable tracing and shut down the TracerProvider."""
+    """Disable tracing, metrics, and log bridge; shut down their providers."""
     global _tracing_enabled
     shutdown_tracing()
+    try:
+        from cognee.modules.observability.metrics import shutdown_metrics
+
+        shutdown_metrics()
+    except Exception:
+        pass
+    try:
+        from cognee.modules.observability.logs import shutdown_log_bridge
+
+        shutdown_log_bridge()
+    except Exception:
+        pass
     _tracing_enabled = False
 
 

--- a/cognee/modules/observability/tracing.py
+++ b/cognee/modules/observability/tracing.py
@@ -17,6 +17,7 @@ try:
         SpanExporter,
         SpanExportResult,
         SimpleSpanProcessor,
+        BatchSpanProcessor,
         ConsoleSpanExporter,
     )
     from opentelemetry.sdk.resources import Resource
@@ -274,16 +275,42 @@ def _parse_otlp_headers(raw: Optional[str]) -> Optional[dict]:
     return headers or None
 
 
+def _requires_http_exporter(endpoint: str) -> bool:
+    """Return True when the endpoint is known to accept only HTTP OTLP.
+
+    Covers Langfuse, Dynatrace, and any generic HTTPS endpoint on port 443/4318
+    that clearly isn't a gRPC-only backend.  gRPC exporters must never be
+    pointed at these URLs — they fail silently (connection accepted, then
+    closed) which causes traces to disappear without any visible error.
+    """
+    http_only_patterns = (
+        "/api/public/otel",        # Langfuse
+        "live.dynatrace.com",      # Dynatrace SaaS
+        "dynatrace.com",           # Dynatrace (any subdomain)
+        "/api/v2/otlp",            # Dynatrace OTLP path
+        "otel.live.dynatrace.com", # Dynatrace dedicated ingest
+        ":4318",                   # standard OTLP HTTP port
+        ":443/",                   # standard HTTPS — almost certainly HTTP OTLP
+    )
+    return any(pat in endpoint for pat in http_only_patterns)
+
+
 def _try_add_otlp_exporter(provider: "TracerProvider") -> None:
     """If an OTLP endpoint is configured, add an OTLP span exporter.
 
-    Reads the endpoint and headers from ``BaseConfig``. The OTLP exporters also
-    honour the standard ``OTEL_EXPORTER_OTLP_*`` env vars for compression, etc.
+    Reads the endpoint and headers from ``BaseConfig``. Uses a
+    ``BatchSpanProcessor`` for reliable async export.
 
-    Langfuse's OTLP endpoint (``/api/public/otel``) only accepts OTLP over HTTP,
-    so the HTTP exporter is forced for it — including self-hosted instances on a
-    custom domain. Every other endpoint prefers gRPC and falls back to HTTP.
+    Endpoint-specific rules:
+    - Dynatrace (``live.dynatrace.com``, ``/api/v2/otlp``): HTTP only.
+    - Langfuse (``/api/public/otel``): HTTP only.
+    - gRPC-only backends (port 4317, no HTTP path): gRPC.
+    - Everything else: try gRPC, fall back to HTTP.
     """
+    import logging as _logging
+
+    _log = _logging.getLogger("cognee.observability")
+
     from cognee.base_config import get_base_config
 
     config = get_base_config()
@@ -299,32 +326,37 @@ def _try_add_otlp_exporter(provider: "TracerProvider") -> None:
         )
 
         exporter = OTLPHttpSpanExporter(endpoint=endpoint, headers=headers)
-        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        _log.info("OTel: OTLP HTTP trace exporter registered → %s", endpoint)
 
     def _warn_no_exporter() -> None:
         import warnings
 
-        warnings.warn(
-            "otel_exporter_otlp_endpoint is set but no OTLP exporter is installed. "
-            "Install with: pip install cognee[tracing]",
-            stacklevel=2,
+        msg = (
+            f"OTEL_EXPORTER_OTLP_ENDPOINT is set to '{endpoint}' but the OTLP "
+            "exporter package is not installed. Traces will NOT be exported. "
+            "Install with: pip install cognee[tracing]"
         )
+        _log.error("OTel: %s", msg)
+        warnings.warn(msg, stacklevel=2)
 
-    # Langfuse ingests OTLP over HTTP only (no gRPC).
-    if "/api/public/otel" in endpoint:
+    # Backends that accept only HTTP OTLP (Dynatrace, Langfuse, port 4318 …)
+    if _requires_http_exporter(endpoint):
         try:
             _add_http_exporter()
         except ImportError:
             _warn_no_exporter()
         return
 
+    # Everything else: prefer gRPC (port 4317), fall back to HTTP.
     try:
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
             OTLPSpanExporter,
         )
 
         exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
-        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        _log.info("OTel: OTLP gRPC trace exporter registered → %s", endpoint)
     except ImportError:
         try:
             _add_http_exporter()
@@ -375,16 +407,25 @@ def setup_tracing(console_output: bool = False) -> "trace.Tracer":
             }
         )
 
+        import logging as _logging
+        _log = _logging.getLogger("cognee.observability")
+
         _provider = TracerProvider(resource=resource)
         _provider.add_span_processor(SimpleSpanProcessor(_exporter))
 
-        # Add OTLP exporter when endpoint is configured (e.g. Dash0, Grafana, etc.)
+        # Add OTLP exporter when endpoint is configured (e.g. Dynatrace, Dash0, Grafana …)
         _try_add_otlp_exporter(_provider)
 
         if console_output:
             _provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
 
         trace.set_tracer_provider(_provider)
+
+        endpoint = config.otel_exporter_otlp_endpoint
+        _log.info(
+            "OTel tracing initialised — service=%s version=%s endpoint=%s",
+            config.otel_service_name, version, endpoint or "none (in-memory only)",
+        )
 
     _tracer = _provider.get_tracer("cognee", version)
     return _tracer

--- a/cognee/tests/unit/modules/observability/test_memory_semconv.py
+++ b/cognee/tests/unit/modules/observability/test_memory_semconv.py
@@ -1,0 +1,301 @@
+"""Tests for memory-semconv v0.1.0 OTel instrumentation.
+
+Validates that the core memory operations emit correct spans (with memory.*
+attributes), metrics, and that the log bridge attaches without error.
+"""
+
+import time
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_otel_state():
+    """Reset OTel providers between tests to avoid cross-contamination."""
+    yield
+    try:
+        from cognee.modules.observability.trace_context import disable_tracing
+
+        disable_tracing()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Span / attribute tests
+# ---------------------------------------------------------------------------
+
+
+def test_memory_semconv_constants_exported():
+    """memory-semconv attribute constants are exported from the observability package."""
+    from cognee.modules.observability import (
+        MEMORY_SYSTEM,
+        MEMORY_OPERATION,
+        MEMORY_QUERY_TEXT,
+        MEMORY_QUERY_TYPE,
+        MEMORY_RESULT_COUNT,
+        MEMORY_DATA_SIZE,
+        MEMORY_ITEM_COUNT,
+        MEMORY_COLLECTION,
+        MEMORY_STORE_BACKEND,
+    )
+
+    assert MEMORY_SYSTEM == "memory.system"
+    assert MEMORY_OPERATION == "memory.operation"
+    assert MEMORY_QUERY_TEXT == "memory.query.text"
+    assert MEMORY_QUERY_TYPE == "memory.query.type"
+    assert MEMORY_RESULT_COUNT == "memory.result.count"
+    assert MEMORY_DATA_SIZE == "memory.data.size"
+    assert MEMORY_ITEM_COUNT == "memory.item.count"
+    assert MEMORY_COLLECTION == "memory.collection"
+    assert MEMORY_STORE_BACKEND == "memory.store.backend"
+
+
+def test_enable_tracing_sets_up_all_signals():
+    """enable_tracing() initialises tracing, metrics, and log bridge without error."""
+    from cognee.modules.observability.trace_context import enable_tracing, disable_tracing, is_tracing_enabled
+
+    enable_tracing()
+    assert is_tracing_enabled()
+
+    from cognee.modules.observability.metrics import get_meter
+
+    assert get_meter() is not None
+
+    disable_tracing()
+
+
+def test_new_span_emits_memory_operation_retrieve():
+    """A search-style span tagged with memory.operation=retrieve is collected."""
+    pytest.importorskip("opentelemetry")
+
+    from cognee.modules.observability.trace_context import enable_tracing
+    from cognee.modules.observability import new_span, MEMORY_SYSTEM, MEMORY_OPERATION, MEMORY_QUERY_TEXT, MEMORY_RESULT_COUNT
+    from cognee.modules.observability.trace_context import get_last_trace
+
+    enable_tracing()
+
+    with new_span("memory.retrieve") as span:
+        span.set_attribute(MEMORY_SYSTEM, "cognee")
+        span.set_attribute(MEMORY_OPERATION, "retrieve")
+        span.set_attribute(MEMORY_QUERY_TEXT, "test query"[:500])
+        span.set_attribute(MEMORY_RESULT_COUNT, 3)
+
+    trace = get_last_trace()
+    assert trace is not None, "Expected a trace to be recorded"
+
+    spans = trace.spans()
+    root = spans[0]
+    assert root["name"] == "memory.retrieve"
+    attrs = root["attributes"]
+    assert attrs.get("memory.system") == "cognee"
+    assert attrs.get("memory.operation") == "retrieve"
+    assert attrs.get("memory.query.text") == "test query"
+    assert attrs.get("memory.result.count") == 3
+
+
+def test_new_span_emits_memory_operation_store():
+    """A store span tagged with memory.operation=store is collected."""
+    pytest.importorskip("opentelemetry")
+
+    from cognee.modules.observability.trace_context import enable_tracing
+    from cognee.modules.observability import new_span, MEMORY_SYSTEM, MEMORY_OPERATION, MEMORY_COLLECTION
+    from cognee.modules.observability.trace_context import get_last_trace
+
+    enable_tracing()
+
+    with new_span("memory.store") as span:
+        span.set_attribute(MEMORY_SYSTEM, "cognee")
+        span.set_attribute(MEMORY_OPERATION, "store")
+        span.set_attribute(MEMORY_COLLECTION, "my_dataset")
+
+    trace = get_last_trace()
+    assert trace is not None
+    spans = trace.spans()
+    assert spans[0]["attributes"].get("memory.collection") == "my_dataset"
+
+
+def test_new_span_emits_memory_operation_delete():
+    """A delete span tagged with memory.operation=delete is collected."""
+    pytest.importorskip("opentelemetry")
+
+    from cognee.modules.observability.trace_context import enable_tracing
+    from cognee.modules.observability import new_span, MEMORY_SYSTEM, MEMORY_OPERATION
+    from cognee.modules.observability.trace_context import get_last_trace
+
+    enable_tracing()
+
+    with new_span("memory.delete") as span:
+        span.set_attribute(MEMORY_SYSTEM, "cognee")
+        span.set_attribute(MEMORY_OPERATION, "delete")
+
+    trace = get_last_trace()
+    assert trace is not None
+    spans = trace.spans()
+    assert spans[0]["name"] == "memory.delete"
+    assert spans[0]["attributes"].get("memory.operation") == "delete"
+
+
+def test_new_span_emits_memory_operation_process():
+    """A process span tagged with memory.operation=process is collected."""
+    pytest.importorskip("opentelemetry")
+
+    from cognee.modules.observability.trace_context import enable_tracing
+    from cognee.modules.observability import new_span, MEMORY_SYSTEM, MEMORY_OPERATION
+    from cognee.modules.observability.trace_context import get_last_trace
+
+    enable_tracing()
+
+    with new_span("memory.process") as span:
+        span.set_attribute(MEMORY_SYSTEM, "cognee")
+        span.set_attribute(MEMORY_OPERATION, "process")
+
+    trace = get_last_trace()
+    assert trace is not None
+    spans = trace.spans()
+    assert spans[0]["name"] == "memory.process"
+
+
+# ---------------------------------------------------------------------------
+# Metrics tests
+# ---------------------------------------------------------------------------
+
+
+def test_metric_helpers_are_no_ops_before_setup():
+    """Metric helpers do not raise even when metrics are not configured."""
+    from cognee.modules.observability import (
+        record_operation_duration,
+        increment_items_stored,
+        increment_items_retrieved,
+        increment_items_deleted,
+        record_query_results,
+        increment_bytes_stored,
+        increment_vector_searches,
+        increment_graph_edges,
+        increment_graph_nodes,
+        increment_operation_errors,
+    )
+
+    attrs = {"memory.system": "cognee", "memory.operation": "store"}
+    record_operation_duration(42.0, attrs)
+    increment_items_stored(5, attrs)
+    increment_items_retrieved(3, attrs)
+    increment_items_deleted(1, attrs)
+    record_query_results(2, attrs)
+    increment_bytes_stored(1024, attrs)
+    increment_vector_searches(attrs)
+    increment_graph_edges(10, attrs)
+    increment_graph_nodes(5, attrs)
+    increment_operation_errors(attrs)
+
+
+def test_metric_names_follow_semconv():
+    """Exported metric name constants match memory-semconv v0.1.0."""
+    from cognee.modules.observability import (
+        MEMORY_OPERATION_DURATION,
+        MEMORY_ITEMS_STORED,
+        MEMORY_ITEMS_RETRIEVED,
+        MEMORY_ITEMS_DELETED,
+        MEMORY_QUERY_RESULT_COUNT,
+        MEMORY_DATA_BYTES_STORED,
+        MEMORY_VECTOR_SEARCHES,
+        MEMORY_GRAPH_EDGES_ADDED,
+        MEMORY_GRAPH_NODES_ADDED,
+        MEMORY_OPERATION_ERRORS,
+    )
+
+    assert MEMORY_OPERATION_DURATION == "memory.operation.duration"
+    assert MEMORY_ITEMS_STORED == "memory.items.stored"
+    assert MEMORY_ITEMS_RETRIEVED == "memory.items.retrieved"
+    assert MEMORY_ITEMS_DELETED == "memory.items.deleted"
+    assert MEMORY_QUERY_RESULT_COUNT == "memory.query.result.count"
+    assert MEMORY_DATA_BYTES_STORED == "memory.data.bytes.stored"
+    assert MEMORY_VECTOR_SEARCHES == "memory.vector.searches"
+    assert MEMORY_GRAPH_EDGES_ADDED == "memory.graph.edges.added"
+    assert MEMORY_GRAPH_NODES_ADDED == "memory.graph.nodes.added"
+    assert MEMORY_OPERATION_ERRORS == "memory.operation.errors"
+
+
+def test_setup_metrics_returns_meter():
+    """setup_metrics() returns a meter when the OTel SDK is available."""
+    pytest.importorskip("opentelemetry")
+
+    from cognee.modules.observability.metrics import setup_metrics, get_meter, shutdown_metrics
+
+    meter = setup_metrics()
+    assert meter is not None
+    assert get_meter() is meter
+
+    shutdown_metrics()
+    assert get_meter() is None
+
+
+def test_metric_helpers_accept_calls_after_setup():
+    """Metric helpers do not raise after metrics are configured."""
+    pytest.importorskip("opentelemetry")
+
+    from cognee.modules.observability.metrics import setup_metrics, shutdown_metrics
+    from cognee.modules.observability import (
+        record_operation_duration,
+        record_query_results,
+        increment_items_stored,
+        increment_items_retrieved,
+    )
+
+    setup_metrics()
+    attrs = {"memory.system": "cognee", "memory.operation": "retrieve"}
+    record_operation_duration(10.5, attrs)
+    record_query_results(7, attrs)
+    increment_items_stored(3, {"memory.system": "cognee", "memory.operation": "store"})
+    increment_items_retrieved(7, attrs)
+    shutdown_metrics()
+
+
+# ---------------------------------------------------------------------------
+# Log bridge tests
+# ---------------------------------------------------------------------------
+
+
+def test_log_bridge_attaches_without_error():
+    """setup_log_bridge() attaches an OTel handler to cognee loggers."""
+    pytest.importorskip("opentelemetry")
+
+    import logging
+    from cognee.modules.observability.logs import setup_log_bridge, shutdown_log_bridge
+
+    provider = setup_log_bridge()
+
+    cognee_logger = logging.getLogger("cognee")
+    has_otel_handler = any(
+        type(h).__name__ == "LoggingHandler" for h in cognee_logger.handlers
+    )
+    assert has_otel_handler, "Expected OTel LoggingHandler on cognee logger"
+
+    # Logging through the bridge should not raise
+    cognee_logger.info("OTel log bridge test message")
+
+    shutdown_log_bridge()
+
+    has_otel_handler_after = any(
+        type(h).__name__ == "LoggingHandler" for h in cognee_logger.handlers
+    )
+    assert not has_otel_handler_after, "Expected handler removed after shutdown"
+
+
+def test_enable_tracing_wires_log_bridge():
+    """enable_tracing() causes cognee logger to gain an OTel handler."""
+    pytest.importorskip("opentelemetry")
+
+    import logging
+    from cognee.modules.observability.trace_context import enable_tracing, disable_tracing
+
+    enable_tracing()
+    cognee_logger = logging.getLogger("cognee")
+    has_otel = any(type(h).__name__ == "LoggingHandler" for h in cognee_logger.handlers)
+    assert has_otel
+
+    disable_tracing()

--- a/cognee/tests/unit/modules/observability/test_memory_semconv.py
+++ b/cognee/tests/unit/modules/observability/test_memory_semconv.py
@@ -299,3 +299,41 @@ def test_enable_tracing_wires_log_bridge():
     assert has_otel
 
     disable_tracing()
+
+
+# ---------------------------------------------------------------------------
+# Dynatrace / HTTP-only exporter detection tests
+# ---------------------------------------------------------------------------
+
+
+def test_requires_http_exporter_dynatrace():
+    """Dynatrace endpoints are correctly identified as HTTP-only."""
+    from cognee.modules.observability.tracing import _requires_http_exporter
+
+    assert _requires_http_exporter("https://abc12345.live.dynatrace.com/api/v2/otlp/v1/traces")
+    assert _requires_http_exporter("https://otel.live.dynatrace.com/api/v2/otlp")
+    assert _requires_http_exporter("https://myenv.dynatrace.com/api/v2/otlp/v1/traces")
+
+
+def test_requires_http_exporter_langfuse():
+    """Langfuse endpoints are correctly identified as HTTP-only."""
+    from cognee.modules.observability.tracing import _requires_http_exporter
+
+    assert _requires_http_exporter("https://cloud.langfuse.com/api/public/otel")
+    assert _requires_http_exporter("https://us.cloud.langfuse.com/api/public/otel/v1/traces")
+
+
+def test_requires_http_exporter_port_4318():
+    """Port 4318 is the standard OTLP HTTP port and must force HTTP."""
+    from cognee.modules.observability.tracing import _requires_http_exporter
+
+    assert _requires_http_exporter("http://collector.example.com:4318")
+
+
+def test_requires_http_exporter_grpc_passes():
+    """Standard gRPC endpoints (port 4317) do not trigger HTTP-only mode."""
+    from cognee.modules.observability.tracing import _requires_http_exporter
+
+    # Standard gRPC collector should NOT be forced to HTTP
+    assert not _requires_http_exporter("http://otel-collector.example.com:4317")
+    assert not _requires_http_exporter("http://localhost:4317")


### PR DESCRIPTION
## What

Wires Cognee's already-declared OpenTelemetry SDK dependencies to the core memory operations, emitting **spans, metrics, and logs** that conform to **memory-semconv v0.1.0** on `add`/`cognify`, `search`, and `forget`/`delete`.

Until now the OTel deps in `pyproject.toml` were unused. This PR adds a self-contained `cognee/modules/observability/` module and wires it into the API entry points, so any OTLP backend (Dynatrace, Tempo, Grafana, Dash0, …) receives uniform, benchmark-grade telemetry. Instrumentation is **opt-in** via `COGNEE_TRACING_ENABLED=true` and a no-op when disabled or when OpenTelemetry isn't installed.

## Why

Enables measuring memory volume, index/utilization, and query efficiency (result/hit counts, search latency, and the query as a bounded span attribute) for AI-memory benchmarking and production observability — without a separate agent.

## Signals emitted

- **Spans** — `memory.*` ops (`add`/`cognify`, `search`/`retrieve`, `forget`/`delete`) with memory-semconv v0.1.0 attributes; LLM calls surface as nested `gen_ai.*` generation spans (via the existing `@observe` adapters), so a query's LLM work nests under its memory span in one trace.
- **Metrics** — storage/index/utilization + query-efficiency instruments (items stored, operation duration, result counts).
- **Logs** — an OTel log-bridge so Cognee's structured logs are emitted as OTel log records correlated to the active span.

## Design notes

- Reuses an existing external `TracerProvider` if one is already configured (auto-instrumented deployments), else creates its own with an optional OTLP exporter.
- Spans start in the **current context** (`start_as_current_span`), so when a caller propagates W3C context the Cognee spans nest under it — enabling end-to-end agent→memory→LLM traces.
- Search-query text is captured as a bounded, redacted attribute (PII/cardinality-aware).

## Validation

Validated end-to-end against an OTLP collector on a live cluster:
- cognee memory-semconv spans confirmed in the backend (`service.name=cognee`).
- Single end-to-end trace captured with **67 spans / one `trace.id`**: CrewAI agent (`gen_ai.operation.name=invoke_agent`) → `chat` LLM (`gen_ai.*`) → shim `memory.search` (memory-semconv v0.1.0) → cognee `memory.retrieve` / `cognee.db.vector.search` / `graph.query` / `acreate_structured_output`.

## Testing

`cognee/tests/unit/modules/observability/test_memory_semconv.py` — asserts the memory-semconv constants, span/attribute emission, metrics registration, and log-bridge attach.

<img width="1716" height="974" alt="image" src="https://github.com/user-attachments/assets/725fd1e3-df05-46ad-890c-fd50add33c86" />

## Notes

- Opt-in; zero overhead when `COGNEE_TRACING_ENABLED` is unset.
- Conventional commits. No CLA/DCO gate in CONTRIBUTING at time of writing.
