### PR TITLE
feat: Keep cognified data + stop cleanly on budget exhaustion (CLO-421)

### DIFF
--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -397,18 +397,13 @@ def get_datasets_router() -> APIRouter:
         if dataset_data is None:
             return []
 
-        from cognee.modules.pipelines.models.DataItemStatus import DataItemStatus
-
-        def _cognify_completed(data) -> bool:
-            return (data.pipeline_status or {}).get("cognify_pipeline", {}).get(
-                str(dataset_id)
-            ) == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
+        from cognee.modules.pipelines.utils import is_data_item_cognified
 
         return [
             dict(
                 **jsonable_encoder(data),
                 dataset_id=dataset_id,
-                cognify_completed=_cognify_completed(data),
+                cognify_completed=is_data_item_cognified(data, "cognify_pipeline", dataset_id),
             )
             for data in dataset_data
         ]

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -52,6 +52,10 @@ class DataDTO(OutDTO):
     mime_type: str
     raw_data_location: str
     dataset_id: UUID
+    # Whether this document has been fully cognified into this dataset's graph.
+    # False means it isn't in the graph yet (e.g. a cognify run stopped early on
+    # budget) — re-running cognify processes the still-incomplete documents.
+    cognify_completed: bool = False
 
 
 class DatasetGraphSummaryDTO(OutDTO):
@@ -393,10 +397,18 @@ def get_datasets_router() -> APIRouter:
         if dataset_data is None:
             return []
 
+        from cognee.modules.pipelines.models.DataItemStatus import DataItemStatus
+
+        def _cognify_completed(data) -> bool:
+            return (data.pipeline_status or {}).get("cognify_pipeline", {}).get(
+                str(dataset_id)
+            ) == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
+
         return [
             dict(
                 **jsonable_encoder(data),
                 dataset_id=dataset_id,
+                cognify_completed=_cognify_completed(data),
             )
             for data in dataset_data
         ]

--- a/cognee/infrastructure/llm/exceptions.py
+++ b/cognee/infrastructure/llm/exceptions.py
@@ -14,19 +14,8 @@ class LLMPaymentRequiredError(CogneeValidationError):
         super().__init__(message=message, name="LLMPaymentRequiredError", status_code=402)
 
 
-def is_budget_exhausted_error(e: Exception) -> bool:
-    """Return True if e signals LLM budget or payment exhaustion.
-
-    Three cases are handled:
-    1. Any provider returning HTTP 402 Payment Required directly.
-    2. litellm's own budget manager raising BudgetExceededError (status_code 429,
-       rate_limit_type "budget") when litellm is used as a library with a configured budget.
-    3. LiteLLM proxy (≥v1.x) returning HTTP 429 with a JSON body whose "error.type" field
-       equals "budget_exceeded". This is LiteLLM-proxy-specific: the proxy enforces virtual-key
-       and per-user spend caps and uses this response shape to distinguish budget exhaustion from
-       ordinary rate limiting. If LiteLLM changes this response format this branch silently falls
-       through, so callers should monitor for unhandled 429s after proxy upgrades.
-    """
+def _is_budget_exhausted_single(e: BaseException) -> bool:
+    """Whether a single exception object (ignoring its cause chain) is a budget error."""
     # Case 1: provider-level payment required
     if getattr(e, "status_code", None) == 402:
         return True
@@ -52,6 +41,32 @@ def is_budget_exhausted_error(e: Exception) -> bool:
             except Exception:
                 pass
 
+    return False
+
+
+def is_budget_exhausted_error(e: Exception) -> bool:
+    """Return True if e — or anything it wraps via ``__cause__`` — signals LLM budget
+    or payment exhaustion.
+
+    Three underlying cases are recognized on each exception in the chain:
+    1. Any provider returning HTTP 402 Payment Required directly.
+    2. litellm's own budget manager raising BudgetExceededError (status_code 429,
+       rate_limit_type "budget") when litellm is used as a library with a configured budget.
+    3. LiteLLM proxy (≥v1.x) returning HTTP 429 with a JSON body whose "error.type" field
+       equals "budget_exceeded".
+
+    The ``__cause__`` chain is walked (like ``retry_config.is_quota_or_billing_error``)
+    because budget errors travel wrapped in practice (``raise X from budget_err``). Only
+    the explicit-cause chain is followed, not ``__context__``, so an unrelated error
+    merely raised while handling a budget error is not misclassified.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = e
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if _is_budget_exhausted_single(current):
+            return True
+        current = current.__cause__
     return False
 
 

--- a/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
+++ b/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
@@ -7,9 +7,21 @@ from cognee.modules.pipelines.utils import summarize_run_info_data
 
 
 async def log_pipeline_run_complete(
-    pipeline_run_id: UUID, pipeline_id: UUID, pipeline_name: str, dataset_id: UUID, data: Any
+    pipeline_run_id: UUID,
+    pipeline_id: UUID,
+    pipeline_name: str,
+    dataset_id: UUID,
+    data: Any,
+    run_info_extra: dict | None = None,
 ):
     data_info = summarize_run_info_data(data)
+
+    run_info = {"data": data_info}
+    # Extra keys let a completed-but-partial run record why it stopped early and how
+    # much is left (e.g. stopped_reason="budget_exhausted", documents_remaining=N),
+    # without adding a new PipelineRunStatus. run_info is a JSON column, no migration.
+    if run_info_extra:
+        run_info.update(run_info_extra)
 
     pipeline_run = PipelineRun(
         pipeline_run_id=pipeline_run_id,
@@ -17,9 +29,7 @@ async def log_pipeline_run_complete(
         pipeline_id=pipeline_id,
         status=PipelineRunStatus.DATASET_PROCESSING_COMPLETED,
         dataset_id=dataset_id,
-        run_info={
-            "data": data_info,
-        },
+        run_info=run_info,
     )
 
     db_engine = get_relational_engine()

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -17,6 +17,9 @@ from cognee.modules.users.methods import get_default_user
 from cognee.modules.pipelines.utils import generate_pipeline_id
 from cognee.modules.pipelines.exceptions import PipelineRunFailedError
 from cognee.tasks.ingestion import resolve_data_directories
+from cognee.infrastructure.llm.exceptions import is_budget_exhausted_error
+from cognee.modules.data.methods import get_dataset_data
+from cognee.modules.pipelines.models.DataItemStatus import DataItemStatus
 from cognee.modules.pipelines.models import PipelineContext
 from cognee.modules.pipelines.models.PipelineRunInfo import (
     PipelineRunCompleted,
@@ -33,6 +36,28 @@ from ..tasks.task import Task
 
 
 logger = get_logger("run_tasks(tasks: [Task], data)")
+
+
+async def _cognify_progress(dataset_id: UUID, pipeline_name: str) -> dict:
+    """Per-document progress for a dataset, derived from the completion markers.
+
+    Reports how many of the dataset's documents are already cognified (carry the
+    ``DATA_ITEM_PROCESSING_COMPLETED`` flag for this pipeline) vs still remaining —
+    used to tell the caller what is left when a run stops early (e.g. budget).
+    """
+    items = await get_dataset_data(dataset_id)
+    total = len(items)
+    cognified = sum(
+        1
+        for d in items
+        if (d.pipeline_status or {}).get(pipeline_name, {}).get(str(dataset_id))
+        == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
+    )
+    return {
+        "documents_total": total,
+        "documents_cognified": cognified,
+        "documents_remaining": total - cognified,
+    }
 
 
 def override_run_tasks(new_gen):
@@ -129,9 +154,10 @@ async def run_tasks(
                         data_cache,
                     )
 
-            gathered = await asyncio.gather(
-                *[asyncio.create_task(_run_item(item)) for item in data],
-            )
+            # Keep task references so siblings can be cancelled if the run stops
+            # early (see the budget-exhaustion path in the except below).
+            in_flight = [asyncio.create_task(_run_item(item)) for item in data]
+            gathered = await asyncio.gather(*in_flight)
 
             # Separate successes from unhandled exceptions
             results = []
@@ -185,6 +211,50 @@ async def run_tasks(
             )
 
         except Exception as error:
+            # Stop any siblings still running so a failed or budget-limited run does
+            # not keep issuing (and, on a budget stop, billing) LLM calls after we
+            # have already decided to stop.
+            in_flight = locals().get("in_flight") or []
+            for task in in_flight:
+                if not task.done():
+                    task.cancel()
+            if in_flight:
+                await asyncio.gather(*in_flight, return_exceptions=True)
+
+            # Budget/quota exhaustion is a resource limit, not a failure. Keep every
+            # document already cognified (skip rollback, so the graph stays queryable)
+            # and record a COMPLETED run that reports what is left — a later cognify
+            # resumes only the remaining documents (incremental loading skips the ones
+            # already marked complete). No new pipeline status is introduced: the
+            # "stopped early" signal lives in run_info.stopped_reason.
+            if is_budget_exhausted_error(error):
+                progress = await _cognify_progress(dataset.id, pipeline_name)
+                logger.warning(
+                    "Cognify stopped early for dataset %s: budget exhausted — "
+                    "%s/%s documents cognified, %s remaining",
+                    dataset.id,
+                    progress["documents_cognified"],
+                    progress["documents_total"],
+                    progress["documents_remaining"],
+                )
+                stopped_info = {"stopped_reason": "budget_exhausted", **progress}
+                await log_pipeline_run_complete(
+                    pipeline_run_id,
+                    pipeline_id,
+                    pipeline_name,
+                    dataset.id,
+                    data,
+                    run_info_extra=stopped_info,
+                )
+                yield PipelineRunCompleted(
+                    pipeline_run_id=pipeline_run_id,
+                    dataset_id=dataset.id,
+                    dataset_name=dataset.name,
+                    payload=stopped_info,
+                    data_ingestion_info=locals().get("results"),
+                )
+                return
+
             if callable(rollback_handler):
                 try:
                     await rollback_handler(

--- a/cognee/modules/pipelines/operations/run_tasks.py
+++ b/cognee/modules/pipelines/operations/run_tasks.py
@@ -14,12 +14,11 @@ from cognee.infrastructure.llm.config import LLMConfig
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.users.methods import get_default_user
-from cognee.modules.pipelines.utils import generate_pipeline_id
+from cognee.modules.pipelines.utils import generate_pipeline_id, is_data_item_cognified
 from cognee.modules.pipelines.exceptions import PipelineRunFailedError
 from cognee.tasks.ingestion import resolve_data_directories
 from cognee.infrastructure.llm.exceptions import is_budget_exhausted_error
 from cognee.modules.data.methods import get_dataset_data
-from cognee.modules.pipelines.models.DataItemStatus import DataItemStatus
 from cognee.modules.pipelines.models import PipelineContext
 from cognee.modules.pipelines.models.PipelineRunInfo import (
     PipelineRunCompleted,
@@ -47,12 +46,7 @@ async def _cognify_progress(dataset_id: UUID, pipeline_name: str) -> dict:
     """
     items = await get_dataset_data(dataset_id)
     total = len(items)
-    cognified = sum(
-        1
-        for d in items
-        if (d.pipeline_status or {}).get(pipeline_name, {}).get(str(dataset_id))
-        == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED
-    )
+    cognified = sum(1 for d in items if is_data_item_cognified(d, pipeline_name, dataset_id))
     return {
         "documents_total": total,
         "documents_cognified": cognified,
@@ -121,6 +115,10 @@ async def run_tasks(
         llm_config=llm_config,
         embedding_config=embedding_config,
     ):
+        # Initialized before the try so the except can reference them directly even if
+        # an error is raised before they're assigned (scheduling / the results loop).
+        in_flight: list = []
+        results = None
         try:
             if not isinstance(data, list):
                 data = [data]
@@ -214,7 +212,6 @@ async def run_tasks(
             # Stop any siblings still running so a failed or budget-limited run does
             # not keep issuing (and, on a budget stop, billing) LLM calls after we
             # have already decided to stop.
-            in_flight = locals().get("in_flight") or []
             for task in in_flight:
                 if not task.done():
                     task.cancel()
@@ -227,7 +224,13 @@ async def run_tasks(
             # resumes only the remaining documents (incremental loading skips the ones
             # already marked complete). No new pipeline status is introduced: the
             # "stopped early" signal lives in run_info.stopped_reason.
-            if is_budget_exhausted_error(error):
+            #
+            # Gated on incremental_loading: the resume-without-re-bill guarantee and
+            # the per-document counts both rely on the DATA_ITEM_PROCESSING_COMPLETED
+            # markers, which only the incremental path writes. Without it, fall through
+            # to the normal error path rather than record misleading progress. (cognify
+            # runs incremental by default.)
+            if is_budget_exhausted_error(error) and incremental_loading:
                 progress = await _cognify_progress(dataset.id, pipeline_name)
                 logger.warning(
                     "Cognify stopped early for dataset %s: budget exhausted — "
@@ -251,7 +254,7 @@ async def run_tasks(
                     dataset_id=dataset.id,
                     dataset_name=dataset.name,
                     payload=stopped_info,
-                    data_ingestion_info=locals().get("results"),
+                    data_ingestion_info=results,
                 )
                 return
 
@@ -264,7 +267,7 @@ async def run_tasks(
                         dataset=dataset,
                         user=user,
                         data=data,
-                        data_ingestion_info=locals().get("results"),
+                        data_ingestion_info=results,
                         error=error,
                     )
                 except Exception as rollback_error:
@@ -279,9 +282,7 @@ async def run_tasks(
                 payload=repr(error),
                 dataset_id=dataset.id,
                 dataset_name=dataset.name,
-                data_ingestion_info=locals().get(
-                    "results"
-                ),  # Returns results if they exist or returns None
+                data_ingestion_info=results,  # Returns results if they exist or returns None
             )
 
             # In case of error during incremental loading of data just let the user know the pipeline Errored, don't raise error

--- a/cognee/modules/pipelines/operations/run_tasks_data_item.py
+++ b/cognee/modules/pipelines/operations/run_tasks_data_item.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 import cognee.modules.ingestion as ingestion
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.infrastructure.files.utils.open_data_file import open_data_file
+from cognee.infrastructure.llm.exceptions import is_budget_exhausted_error
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.users.models import User
 from cognee.modules.data.models import Data, Dataset
@@ -152,7 +153,15 @@ async def run_tasks_data_item_incremental(
             "data_id": data_id,
         }
 
-        if os.getenv("RAISE_INCREMENTAL_LOADING_ERRORS", "true").lower() == "true":
+        # Budget/quota exhaustion is terminal — every remaining document would hit the
+        # same dead key, and run_tasks' graceful-stop handler needs the typed error to
+        # keep already-cognified data. So always propagate it, even when
+        # RAISE_INCREMENTAL_LOADING_ERRORS is off (otherwise it'd be masked as a
+        # PipelineRunErrored result → PipelineRunFailedError the handler can't classify).
+        if (
+            is_budget_exhausted_error(error)
+            or os.getenv("RAISE_INCREMENTAL_LOADING_ERRORS", "true").lower() == "true"
+        ):
             raise error
 
 

--- a/cognee/modules/pipelines/utils/__init__.py
+++ b/cognee/modules/pipelines/utils/__init__.py
@@ -1,3 +1,4 @@
 from .generate_pipeline_id import generate_pipeline_id
 from .generate_pipeline_run_id import generate_pipeline_run_id
 from .summarize_run_info_data import summarize_run_info_data
+from .is_data_item_cognified import is_data_item_cognified

--- a/cognee/modules/pipelines/utils/is_data_item_cognified.py
+++ b/cognee/modules/pipelines/utils/is_data_item_cognified.py
@@ -1,0 +1,17 @@
+from uuid import UUID
+from typing import Union
+
+from cognee.modules.pipelines.models.DataItemStatus import DataItemStatus
+
+
+def is_data_item_cognified(data, pipeline_name: str, dataset_id: Union[UUID, str]) -> bool:
+    """True if ``data`` has been fully processed by ``pipeline_name`` for ``dataset_id``.
+
+    Reads the per-item ``pipeline_status`` marker (written only on full-item success,
+    so it is genuinely all-or-nothing): ``pipeline_status[pipeline_name][dataset_id]
+    == DATA_ITEM_PROCESSING_COMPLETED``. Shared by the incremental skip/progress logic
+    and the dataset-data endpoint so the two can't drift.
+    """
+    return (getattr(data, "pipeline_status", None) or {}).get(pipeline_name, {}).get(
+        str(dataset_id)
+    ) == DataItemStatus.DATA_ITEM_PROCESSING_COMPLETED

--- a/cognee/tests/unit/modules/pipelines/test_run_tasks_budget_stop.py
+++ b/cognee/tests/unit/modules/pipelines/test_run_tasks_budget_stop.py
@@ -1,0 +1,130 @@
+"""Budget-exhaustion during cognify stops cleanly and keeps already-cognified data.
+
+When an LLM budget/quota is exhausted mid-run, run_tasks must NOT roll back (so the
+graph stays queryable), must NOT mark the run errored, and must report how much is
+left — a later cognify resumes the remaining documents. See CLO-421.
+"""
+
+import importlib
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError
+from cognee.modules.pipelines.models.PipelineRunInfo import (
+    PipelineRunCompleted,
+    PipelineRunErrored,
+    PipelineRunStarted,
+)
+from cognee.modules.pipelines.tasks.task import Task
+
+run_tasks_module = importlib.import_module("cognee.modules.pipelines.operations.run_tasks")
+
+
+class _FakeSession:
+    def __init__(self, dataset):
+        self._dataset = dataset
+
+    async def get(self, _model, _dataset_id):
+        return self._dataset
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self, dataset):
+        self._dataset = dataset
+
+    def get_async_session(self):
+        return _FakeSession(self._dataset)
+
+
+@asynccontextmanager
+async def _no_op_context(*_args, **_kwargs):
+    yield
+
+
+@pytest.mark.asyncio
+async def test_budget_exhaustion_stops_cleanly_without_rollback(monkeypatch):
+    dataset_id = uuid4()
+    pipeline_run_id = uuid4()
+    dataset = SimpleNamespace(id=dataset_id, name="dataset-1", owner_id=uuid4())
+    user = SimpleNamespace(id=uuid4(), tenant_id=uuid4())
+    data_item = SimpleNamespace(id=uuid4())
+
+    # The item hits the budget wall (post-#4321 shape: a 402 LLMPaymentRequiredError).
+    async def _budget_item(*_args, **_kwargs):
+        raise LLMPaymentRequiredError()
+
+    # Three documents in the dataset; one already cognified before the stop.
+    def _data(completed: bool):
+        status = (
+            {"cognify_pipeline": {str(dataset_id): "DATA_ITEM_PROCESSING_COMPLETED"}}
+            if completed
+            else {}
+        )
+        return SimpleNamespace(pipeline_status=status)
+
+    async def _get_dataset_data(_dataset_id):
+        return [_data(True), _data(False), _data(False)]
+
+    rollback_calls = []
+    complete_calls = []
+
+    async def _rollback_handler(**kwargs):
+        rollback_calls.append(kwargs)
+
+    async def _log_start(*_args, **_kwargs):
+        return SimpleNamespace(pipeline_run_id=pipeline_run_id)
+
+    async def _log_complete(*_args, **kwargs):
+        complete_calls.append(kwargs)
+
+    async def _log_error(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(run_tasks_module, "get_relational_engine", lambda: _FakeEngine(dataset))
+    monkeypatch.setattr(run_tasks_module, "generate_pipeline_id", lambda *_args: uuid4())
+    monkeypatch.setattr(run_tasks_module, "set_database_global_context_variables", _no_op_context)
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", _budget_item)
+    monkeypatch.setattr(run_tasks_module, "get_dataset_data", _get_dataset_data)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_start", _log_start)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_complete", _log_complete)
+    monkeypatch.setattr(run_tasks_module, "log_pipeline_run_error", _log_error)
+
+    yielded = []
+    async for item in run_tasks_module.run_tasks(
+        tasks=[Task(lambda x: x)],
+        dataset_id=dataset_id,
+        data=[data_item],
+        user=user,
+        pipeline_name="cognify_pipeline",
+        rollback_handler=_rollback_handler,
+    ):
+        yielded.append(item)
+
+    # Terminal event is COMPLETED (a clean stop), NOT errored.
+    assert isinstance(yielded[0], PipelineRunStarted)
+    assert isinstance(yielded[-1], PipelineRunCompleted)
+    assert not any(isinstance(y, PipelineRunErrored) for y in yielded)
+
+    # It carries the stopped reason + how much is left.
+    payload = yielded[-1].payload
+    assert payload["stopped_reason"] == "budget_exhausted"
+    assert payload["documents_total"] == 3
+    assert payload["documents_cognified"] == 1
+    assert payload["documents_remaining"] == 2
+
+    # Data is preserved: rollback must NOT run; the completed run is logged with the
+    # same stopped-reason info persisted to run_info.
+    assert rollback_calls == []
+    assert (
+        complete_calls
+        and complete_calls[0]["run_info_extra"]["stopped_reason"] == "budget_exhausted"
+    )

--- a/cognee/tests/unit/modules/pipelines/test_run_tasks_budget_stop.py
+++ b/cognee/tests/unit/modules/pipelines/test_run_tasks_budget_stop.py
@@ -3,6 +3,10 @@
 When an LLM budget/quota is exhausted mid-run, run_tasks must NOT roll back (so the
 graph stays queryable), must NOT mark the run errored, and must report how much is
 left — a later cognify resumes the remaining documents. See CLO-421.
+
+The budget error is exercised **wrapped** (``raise X from budget_err``) because it
+travels wrapped in practice — that's the shape most likely to defeat detection and
+silently trigger the destructive rollback this feature exists to prevent.
 """
 
 import importlib
@@ -12,7 +16,10 @@ from uuid import uuid4
 
 import pytest
 
-from cognee.infrastructure.llm.exceptions import LLMPaymentRequiredError
+from cognee.infrastructure.llm.exceptions import (
+    LLMPaymentRequiredError,
+    is_budget_exhausted_error,
+)
 from cognee.modules.pipelines.models.PipelineRunInfo import (
     PipelineRunCompleted,
     PipelineRunErrored,
@@ -50,81 +57,139 @@ async def _no_op_context(*_args, **_kwargs):
     yield
 
 
-@pytest.mark.asyncio
-async def test_budget_exhaustion_stops_cleanly_without_rollback(monkeypatch):
+class _FakeBudget429(Exception):
+    """LiteLLM proxy budget rejection shape: 429 whose body.error.type is budget_exceeded."""
+
+    status_code = 429
+
+    def __init__(self):
+        super().__init__("Litellm_proxyException - Budget has been exceeded!")
+        self.response = SimpleNamespace(json=lambda: {"error": {"type": "budget_exceeded"}})
+
+
+def _wrapped_budget_error() -> Exception:
+    """A budget error wrapped in an unrelated exception (as `raise X from budget_err`
+    would produce): the outer error carries the budget error on __cause__."""
+    outer = RuntimeError("task blew up")
+    outer.__cause__ = LLMPaymentRequiredError()
+    return outer
+
+
+# --------------------------------------------------------------------------- #
+# Detection is robust to wrapping (the CLO-421 review's "high" concern).
+# --------------------------------------------------------------------------- #
+def test_is_budget_exhausted_error_walks_the_cause_chain():
+    assert is_budget_exhausted_error(_wrapped_budget_error()) is True
+    wrapped_429 = RuntimeError("wrap")
+    wrapped_429.__cause__ = _FakeBudget429()
+    assert is_budget_exhausted_error(wrapped_429) is True
+    # An unrelated error (even wrapping another unrelated one) is not a budget error.
+    unrelated = RuntimeError("outer")
+    unrelated.__cause__ = ValueError("inner")
+    assert is_budget_exhausted_error(unrelated) is False
+
+
+def _run(monkeypatch, *, incremental_loading, rollback_calls, complete_calls, item_error):
     dataset_id = uuid4()
-    pipeline_run_id = uuid4()
-    dataset = SimpleNamespace(id=dataset_id, name="dataset-1", owner_id=uuid4())
+    prid = uuid4()
+    dataset = SimpleNamespace(id=dataset_id, name="ds", owner_id=uuid4())
     user = SimpleNamespace(id=uuid4(), tenant_id=uuid4())
-    data_item = SimpleNamespace(id=uuid4())
 
-    # The item hits the budget wall (post-#4321 shape: a 402 LLMPaymentRequiredError).
-    async def _budget_item(*_args, **_kwargs):
-        raise LLMPaymentRequiredError()
+    async def _item(*_args, **_kwargs):
+        raise item_error
 
-    # Three documents in the dataset; one already cognified before the stop.
-    def _data(completed: bool):
-        status = (
-            {"cognify_pipeline": {str(dataset_id): "DATA_ITEM_PROCESSING_COMPLETED"}}
-            if completed
-            else {}
+    def _d(done):
+        return SimpleNamespace(
+            pipeline_status=(
+                {"cognify_pipeline": {str(dataset_id): "DATA_ITEM_PROCESSING_COMPLETED"}}
+                if done
+                else {}
+            )
         )
-        return SimpleNamespace(pipeline_status=status)
 
-    async def _get_dataset_data(_dataset_id):
-        return [_data(True), _data(False), _data(False)]
+    async def _get_dataset_data(_id):
+        return [_d(True), _d(False), _d(False)]
 
-    rollback_calls = []
-    complete_calls = []
-
-    async def _rollback_handler(**kwargs):
+    async def _rollback(**kwargs):
         rollback_calls.append(kwargs)
 
-    async def _log_start(*_args, **_kwargs):
-        return SimpleNamespace(pipeline_run_id=pipeline_run_id)
+    async def _log_start(*_a, **_k):
+        return SimpleNamespace(pipeline_run_id=prid)
 
-    async def _log_complete(*_args, **kwargs):
+    async def _log_complete(*_a, **kwargs):
         complete_calls.append(kwargs)
 
-    async def _log_error(*_args, **_kwargs):
+    async def _log_error(*_a, **_k):
         return None
 
     monkeypatch.setattr(run_tasks_module, "get_relational_engine", lambda: _FakeEngine(dataset))
-    monkeypatch.setattr(run_tasks_module, "generate_pipeline_id", lambda *_args: uuid4())
+    monkeypatch.setattr(run_tasks_module, "generate_pipeline_id", lambda *_a: uuid4())
     monkeypatch.setattr(run_tasks_module, "set_database_global_context_variables", _no_op_context)
-    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", _budget_item)
+    monkeypatch.setattr(run_tasks_module, "run_tasks_data_item", _item)
     monkeypatch.setattr(run_tasks_module, "get_dataset_data", _get_dataset_data)
     monkeypatch.setattr(run_tasks_module, "log_pipeline_run_start", _log_start)
     monkeypatch.setattr(run_tasks_module, "log_pipeline_run_complete", _log_complete)
     monkeypatch.setattr(run_tasks_module, "log_pipeline_run_error", _log_error)
 
-    yielded = []
-    async for item in run_tasks_module.run_tasks(
-        tasks=[Task(lambda x: x)],
-        dataset_id=dataset_id,
-        data=[data_item],
-        user=user,
-        pipeline_name="cognify_pipeline",
-        rollback_handler=_rollback_handler,
-    ):
-        yielded.append(item)
+    async def _drive():
+        out = []
+        async for item in run_tasks_module.run_tasks(
+            tasks=[Task(lambda x: x)],
+            dataset_id=dataset_id,
+            data=[SimpleNamespace(id=uuid4())],
+            user=user,
+            pipeline_name="cognify_pipeline",
+            incremental_loading=incremental_loading,
+            rollback_handler=_rollback,
+        ):
+            out.append(item)
+        return out
 
-    # Terminal event is COMPLETED (a clean stop), NOT errored.
+    return _drive
+
+
+@pytest.mark.asyncio
+async def test_wrapped_budget_error_stops_cleanly_without_rollback(monkeypatch):
+    rollback_calls, complete_calls = [], []
+    drive = _run(
+        monkeypatch,
+        incremental_loading=True,
+        rollback_calls=rollback_calls,
+        complete_calls=complete_calls,
+        item_error=_wrapped_budget_error(),  # budget error, wrapped
+    )
+    yielded = await drive()
+
     assert isinstance(yielded[0], PipelineRunStarted)
     assert isinstance(yielded[-1], PipelineRunCompleted)
     assert not any(isinstance(y, PipelineRunErrored) for y in yielded)
 
-    # It carries the stopped reason + how much is left.
     payload = yielded[-1].payload
     assert payload["stopped_reason"] == "budget_exhausted"
-    assert payload["documents_total"] == 3
-    assert payload["documents_cognified"] == 1
-    assert payload["documents_remaining"] == 2
-
-    # Data is preserved: rollback must NOT run; the completed run is logged with the
-    # same stopped-reason info persisted to run_info.
-    assert rollback_calls == []
     assert (
-        complete_calls
-        and complete_calls[0]["run_info_extra"]["stopped_reason"] == "budget_exhausted"
+        payload["documents_total"],
+        payload["documents_cognified"],
+        payload["documents_remaining"],
+    ) == (3, 1, 2)
+
+    assert rollback_calls == []  # data preserved
+    assert complete_calls[0]["run_info_extra"]["stopped_reason"] == "budget_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_budget_stop_is_gated_on_incremental_loading(monkeypatch):
+    # Without incremental loading there are no completion markers, so resume/counts
+    # would be meaningless — fall through to the normal error path (rollback + raise).
+    rollback_calls, complete_calls = [], []
+    drive = _run(
+        monkeypatch,
+        incremental_loading=False,
+        rollback_calls=rollback_calls,
+        complete_calls=complete_calls,
+        item_error=_wrapped_budget_error(),
     )
+    with pytest.raises(RuntimeError, match="task blew up"):
+        await drive()
+
+    assert rollback_calls, "non-incremental budget error must still roll back"
+    assert complete_calls == []


### PR DESCRIPTION
**CLO-421** (Fix 3 of the CLO-409 budget-overshoot work). Today a budget-exhausted cognify run marks the whole dataset failed **and rolls back everything already processed** — so paid-for, cognified work is destroyed. This makes budget exhaustion a *clean stop* instead.

## Behavior
- On `is_budget_exhausted_error` mid-run: **cancel in-flight siblings** (stop further billing), **skip the destructive rollback** (all already-cognified documents stay in the graph, queryable), and record a **COMPLETED** run — not errored.
- The run's `run_info` carries `stopped_reason="budget_exhausted"` + `{documents_total, documents_cognified, documents_remaining}`, so callers see how much is left.
- **Resume is automatic**: re-running cognify processes only the remaining documents (incremental loading skips those already marked complete). No re-bill of finished docs.
- Non-budget errors are **unchanged** (rollback + errored + raise).

## Deliberately NOT done
- **No new `PipelineRunStatus`** and **no DB migration** — `run_info` is already a JSON column, and per-document completion already exists as `DATA_ITEM_PROCESSING_COMPLETED`. The split between "errored" and "stopped on budget" is `PipelineRunCompleted` + `run_info.stopped_reason`, not a status enum.

## Also
- Surface the existing completion flag over HTTP as derived **`DataDTO.cognify_completed`** on `GET /v1/datasets/{id}/data`, so clients/UI can show which documents are in the graph vs pending (the Python SDK already exposed it via raw `Data.pipeline_status`).

## OSS impact
None on the happy path or non-budget errors. The graceful stop only triggers on `is_budget_exhausted_error` (HTTP 402 / `litellm.BudgetExceededError` / LiteLLM-proxy `budget_exceeded` 429), which a typical OSS user running against a provider directly won't hit.

## Dependency
Stacks on **#4321** — that PR makes budget errors surface as a detectable `LLMPaymentRequiredError` (402) rather than a wrapped `InstructorRetryException`. Without it the graceful stop simply won't trigger (no regression). Rebase once #4321 lands in `dev`.

## Testing
`test_run_tasks_budget_stop.py`: budget mid-run → COMPLETED (not errored), `stopped_reason` + remaining counts, rollback **not** called. Validated end-to-end locally via an `asyncio.run` harness (the `@pytest.mark.asyncio` test runs in CI; local `uv run pytest` can't build `ladybug`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)