### PR TITLE
fix: Return single task result from run_tasks_parallel

### DIFF
--- a/cognee/modules/pipelines/operations/run_parallel.py
+++ b/cognee/modules/pipelines/operations/run_parallel.py
@@ -8,6 +8,6 @@ def run_tasks_parallel(tasks: List[Task]) -> Callable[[Any], Generator[Any, Any,
         parallel_tasks = [asyncio.create_task(task.run(*args, **kwargs)) for task in tasks]
 
         results = await asyncio.gather(*parallel_tasks)
-        return results[len(results) - 1] if len(results) > 1 else []
+        return results[-1] if results else []
 
     return Task(parallel_run)

--- a/cognee/tests/unit/pipelines/test_run_tasks_parallel.py
+++ b/cognee/tests/unit/pipelines/test_run_tasks_parallel.py
@@ -1,0 +1,32 @@
+"""Tests for run_tasks_parallel's return value."""
+
+import pytest
+
+from cognee.modules.pipelines.operations.run_parallel import run_tasks_parallel
+from cognee.modules.pipelines.tasks.task import Task
+
+
+async def echo(value):
+    return value
+
+
+@pytest.mark.asyncio
+async def test_single_task_returns_its_result():
+    """A one-task list used to return [] because the guard tested len(results) > 1."""
+    parallel = run_tasks_parallel([Task(echo)])
+
+    assert await parallel.run("important-value") == "important-value"
+
+
+@pytest.mark.asyncio
+async def test_multiple_tasks_return_last_result():
+    parallel = run_tasks_parallel([Task(echo), Task(echo)])
+
+    assert await parallel.run("value") == "value"
+
+
+@pytest.mark.asyncio
+async def test_no_tasks_returns_empty_list():
+    parallel = run_tasks_parallel([])
+
+    assert await parallel.run("value") == []


### PR DESCRIPTION
Fixes #4319.

`run_tasks_parallel` returned `[]` when the task list had exactly one entry.
The guard was `results[len(results) - 1] if len(results) > 1 else []`, so a
single result fell to the else branch and the task's output was dropped
silently. The next pipeline stage received an empty list and the run still
reported success.

Changed to `results[-1] if results else []`, which keeps the existing
"last result wins" contract for multiple tasks and the empty list for no
tasks.

### Test plan

- Added `cognee/tests/unit/pipelines/test_run_tasks_parallel.py` covering one,
  many, and zero tasks. The single-task case fails on dev and passes with this
  change.
- `pytest cognee/tests/unit/pipelines/`: 45 passed.
