### PR TITLE
fix(storage): isolate file health check probes

### DIFF
--- a/cognee/api/v1/health/health.py
+++ b/cognee/api/v1/health/health.py
@@ -7,6 +7,7 @@ from sqlalchemy import text
 from datetime import datetime, timezone
 from typing import Dict
 from enum import Enum
+from uuid import uuid4
 from pydantic import BaseModel
 
 from cognee.version import get_cognee_version
@@ -148,7 +149,6 @@ class HealthChecker:
         """Check file storage health."""
         start_time = time.time()
         try:
-            import os
             from cognee.infrastructure.files.storage.get_file_storage import get_file_storage
             from cognee.base_config import get_base_config
 
@@ -158,18 +158,13 @@ class HealthChecker:
             # Determine provider
             provider = "s3" if base_config.data_root_directory.startswith("s3://") else "local"
 
-            # Test storage accessibility - for local storage, just check directory exists
-            if provider == "local":
-                os.makedirs(base_config.data_root_directory, exist_ok=True)
-                # Simple write/read test
-                test_file = os.path.join(base_config.data_root_directory, "health_check_test")
-                with open(test_file, "w") as f:
-                    f.write("test")
-                os.remove(test_file)
-            else:
-                # For S3, test basic operations
-                test_path = "health_check_test"
+            # Use a unique key so concurrent probes cannot collide or delete a
+            # pre-existing object. Exercise the same StorageManager path for
+            # local and remote backends, and clean up even after a partial write.
+            test_path = f".cognee-health-{uuid4().hex}"
+            try:
                 await storage.store(test_path, BytesIO(b"test"))
+            finally:
                 await storage.remove(test_path)
 
             response_time = int((time.time() - start_time) * 1000)

--- a/cognee/tests/unit/api/v1/health/test_file_storage_health.py
+++ b/cognee/tests/unit/api/v1/health/test_file_storage_health.py
@@ -1,0 +1,90 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from cognee.api.v1.health.health import HealthChecker, HealthStatus
+from cognee.infrastructure.files.storage.LocalFileStorage import LocalFileStorage
+from cognee.infrastructure.files.storage.StorageManager import StorageManager
+
+
+base_config_module = importlib.import_module("cognee.base_config")
+file_storage_module = importlib.import_module(
+    "cognee.infrastructure.files.storage.get_file_storage"
+)
+health_module = importlib.import_module("cognee.api.v1.health.health")
+
+
+def _use_storage(monkeypatch, storage, root_path):
+    monkeypatch.setattr(
+        base_config_module,
+        "get_base_config",
+        lambda: SimpleNamespace(data_root_directory=str(root_path)),
+    )
+    monkeypatch.setattr(file_storage_module, "get_file_storage", lambda _: storage)
+
+
+class _RecordingStorageManager:
+    def __init__(self, fail_after_store=False):
+        self.fail_after_store = fail_after_store
+        self.objects = {}
+        self.store_keys = []
+        self.remove_keys = []
+
+    async def store(self, key, data, overwrite=False):
+        self.store_keys.append(key)
+        data.seek(0)
+        self.objects[key] = data.read()
+        if self.fail_after_store:
+            raise OSError("store failed after creating the probe")
+        return key
+
+    async def remove(self, key):
+        self.remove_keys.append(key)
+        self.objects.pop(key, None)
+
+
+@pytest.mark.asyncio
+async def test_file_storage_health_preserves_legacy_probe_file(monkeypatch, tmp_path):
+    legacy_probe = tmp_path / "health_check_test"
+    legacy_probe.write_text("real user data")
+    storage = StorageManager(LocalFileStorage(str(tmp_path)))
+    _use_storage(monkeypatch, storage, tmp_path)
+
+    result = await HealthChecker().check_file_storage()
+
+    assert result.status == HealthStatus.HEALTHY
+    assert legacy_probe.read_text() == "real user data"
+    assert [path.name for path in tmp_path.iterdir()] == ["health_check_test"]
+
+
+@pytest.mark.asyncio
+async def test_file_storage_health_uses_unique_keys_and_cleans_each_probe(monkeypatch):
+    storage = _RecordingStorageManager()
+    probe_ids = iter([SimpleNamespace(hex="probe-one"), SimpleNamespace(hex="probe-two")])
+    monkeypatch.setattr(health_module, "uuid4", lambda: next(probe_ids))
+    _use_storage(monkeypatch, storage, "s3://bucket/data")
+
+    first = await HealthChecker().check_file_storage()
+    second = await HealthChecker().check_file_storage()
+
+    assert first.status == HealthStatus.HEALTHY
+    assert second.status == HealthStatus.HEALTHY
+    assert storage.store_keys == [".cognee-health-probe-one", ".cognee-health-probe-two"]
+    assert storage.remove_keys == storage.store_keys
+    assert storage.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_file_storage_health_cleans_probe_when_store_partially_fails(monkeypatch):
+    storage = _RecordingStorageManager(fail_after_store=True)
+    monkeypatch.setattr(health_module, "uuid4", lambda: SimpleNamespace(hex="partial-write"))
+    _use_storage(monkeypatch, storage, "s3://bucket/data")
+
+    result = await HealthChecker().check_file_storage()
+
+    assert result.status == HealthStatus.UNHEALTHY
+    assert "store failed after creating the probe" in result.details
+    assert storage.store_keys == [".cognee-health-partial-write"]
+    assert storage.remove_keys == storage.store_keys
+    assert storage.objects == {}


### PR DESCRIPTION
## What changed

`check_file_storage()` used the same `health_check_test` key for every probe. If that key already existed, a local probe overwrote and removed it. With S3, `store(overwrite=False)` could leave the existing object untouched and cleanup would still remove it.

This change gives each probe its own hidden UUID-based key and cleans it up in `finally`, including after a partial write failure. Local and S3-backed checks now use the same `StorageManager` path.

I added focused tests for:

- preserving an existing `health_check_test` object
- using a fresh key for each probe
- cleaning up after a store failure

Fixes #4329.

## Local checks

```text
uv run pytest cognee/tests/unit/api/v1/health/test_file_storage_health.py -q
3 passed, 10 warnings in 0.01s

uv run ruff check cognee/api/v1/health/health.py cognee/tests/unit/api/v1/health/test_file_storage_health.py
All checks passed!

uv run ruff format --check cognee/api/v1/health/health.py cognee/tests/unit/api/v1/health/test_file_storage_health.py
2 files already formatted
```

## Coordination

#4190 also edits `health.py`, but it covers endpoint routing and timeouts. This patch is limited to the storage probe lifecycle and can be rebased if that lands first.

## Checklist

- [x] Bug fix with the smallest practical scope
- [x] Regression tests added
- [x] Existing PRs checked for overlap
- [x] Commit includes DCO sign-off

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
