### PR TITLE
CLO-401 feat: Expose visualization payload as JSON

### DIFF
--- a/cognee/api/v1/users/routers/get_visualize_router.py
+++ b/cognee/api/v1/users/routers/get_visualize_router.py
@@ -209,7 +209,8 @@ def get_visualize_router() -> APIRouter:
 
         ## Error Codes
         - **409 Conflict**: Dataset not found, permission denied, or the
-          payload could not be built (detail in the `error` field)
+          payload could not be built (generic message; full detail is
+          server-logged, not returned, to avoid leaking internals)
 
         ## Notes
         - User must have read permissions on the dataset
@@ -242,9 +243,12 @@ def get_visualize_router() -> APIRouter:
             )
             return JSONResponse(status_code=200, content=payload)
 
-        except Exception as error:
+        except Exception:
             logger.exception("Visualization JSON payload failed for dataset %s", dataset_id)
-            return JSONResponse(status_code=409, content={"error": str(error)})
+            return JSONResponse(
+                status_code=409,
+                content={"error": "Failed to build the visualization payload"},
+            )
 
     @router.get("/semantic", response_model=None)
     async def visualize_semantic(
@@ -305,7 +309,8 @@ def get_visualize_router() -> APIRouter:
 
         ## Error Codes
         - **409 Conflict**: Dataset not found, permission denied, or the
-          payload could not be built (detail in the `error` field)
+          payload could not be built (generic message; full detail is
+          server-logged, not returned, to avoid leaking internals)
 
         ## Notes
         - User must have read permissions on the dataset
@@ -337,9 +342,12 @@ def get_visualize_router() -> APIRouter:
             )
             return JSONResponse(status_code=200, content=payload)
 
-        except Exception as error:
+        except Exception:
             logger.exception("Semantic payload failed for dataset %s", dataset_id)
-            return JSONResponse(status_code=409, content={"error": str(error)})
+            return JSONResponse(
+                status_code=409,
+                content={"error": "Failed to build the semantic layout"},
+            )
 
     @router.get("/brains", response_model=None)
     async def visualize_brains(
@@ -386,9 +394,12 @@ def get_visualize_router() -> APIRouter:
             payload = await build_brains_payload(user=user, max_nodes=max_nodes)
             return JSONResponse(status_code=200, content=payload)
 
-        except Exception as error:
+        except Exception:
             logger.exception("Brains overview payload failed")
-            return JSONResponse(status_code=409, content={"error": str(error)})
+            return JSONResponse(
+                status_code=409,
+                content={"error": "Failed to build the brains overview"},
+            )
 
     @router.get("/live-events", response_model=None)
     async def visualize_live_events(
@@ -429,8 +440,9 @@ def get_visualize_router() -> APIRouter:
         ## Error Codes
         - **403 Forbidden**: Caller lacks read permission on the dataset (or
           it does not exist)
-        - **409 Conflict**: Payload could not be built (detail in the
-          `error` field)
+        - **409 Conflict**: Payload could not be built (generic message;
+          full detail is server-logged, not returned, to avoid leaking
+          internals)
 
         ## Notes
         - User must have read permissions on the dataset
@@ -456,9 +468,12 @@ def get_visualize_router() -> APIRouter:
                 status_code=403,
                 content={"error": "Not authorized to read this dataset"},
             )
-        except Exception as error:
+        except Exception:
             logger.exception("Live events payload failed for dataset %s", dataset_id)
-            return JSONResponse(status_code=409, content={"error": str(error)})
+            return JSONResponse(
+                status_code=409,
+                content={"error": "Failed to fetch live events"},
+            )
 
     @router.post("/multi", response_model=None)
     async def visualize_multi(

--- a/cognee/api/v1/users/routers/get_visualize_router.py
+++ b/cognee/api/v1/users/routers/get_visualize_router.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, Field
 from uuid import UUID
+from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.shared.logging_utils import get_logger
 from cognee.modules.visualization.subgraph_data import (
     DEFAULT_MAX_NODES,
@@ -141,6 +143,321 @@ def get_visualize_router() -> APIRouter:
 
         except Exception as error:
             logger.exception("Visualization failed for dataset %s", dataset_id)
+            return JSONResponse(status_code=409, content={"error": str(error)})
+
+    @router.get("/json", response_model=None)
+    async def visualize_json(
+        dataset_id: UUID = Query(
+            ...,
+            description=(
+                "UUID of the dataset to visualize. "
+                "List your datasets via GET /api/v1/datasets to find it."
+            ),
+            examples=[""],
+        ),
+        full: bool = Query(
+            False,
+            description="Include the entire graph instead of a bounded subgraph.",
+        ),
+        query: Optional[str] = Query(
+            None,
+            description="Query string whose nearest vector hits seed the subgraph.",
+        ),
+        seed_node_ids: Optional[List[str]] = Query(
+            None,
+            description="Explicit seed node ids for subgraph neighborhood expansion.",
+        ),
+        neighborhood_depth: int = Query(
+            DEFAULT_NEIGHBORHOOD_DEPTH,
+            ge=1,
+            le=10,
+            description="k-hop neighborhood depth for subgraph expansion.",
+        ),
+        neighborhood_seed_top_k: int = Query(
+            DEFAULT_SEED_TOP_K,
+            ge=1,
+            le=100,
+            description="Maximum number of seed nodes.",
+        ),
+        max_nodes: int = Query(
+            DEFAULT_MAX_NODES,
+            ge=1,
+            le=5000,
+            description="Hard cap on rendered nodes after expansion.",
+        ),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        Return the dataset's knowledge graph as a JSON-safe payload.
+
+        Same authorization, dataset resolution and bounded fetch as `GET
+        /visualize` — pass the same arguments to get the JSON behind the
+        same subgraph the HTML page would have shown. Does not include the
+        semantic layout; see `GET /visualize/semantic` for that, computed
+        separately so a client that never opens the semantic tab never pays
+        for it.
+
+        ## Query Parameters
+        Same as `GET /visualize` (dataset_id, full, query, seed_node_ids,
+        neighborhood_depth, neighborhood_seed_top_k, max_nodes).
+
+        ## Response
+        A JSON object with `nodes`, `links`, `color_maps`, `schema_graph`,
+        `schema_data`, `pipeline_stages`, `edge_classes`, `bundles`,
+        `provenance_index`, `has_meaningful_topological_rank`, `memory_map`
+        and `search_events`.
+
+        ## Error Codes
+        - **409 Conflict**: Dataset not found, permission denied, or the
+          payload could not be built (detail in the `error` field)
+
+        ## Notes
+        - User must have read permissions on the dataset
+        """
+        send_telemetry(
+            "Visualize JSON API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "GET /v1/visualize/json",
+                "dataset_id": str(dataset_id),
+                "full": full,
+                "cognee_version": cognee_version,
+            },
+        )
+
+        from cognee.api.v1.visualize import visualize_graph_json
+
+        try:
+            dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
+
+            payload = await visualize_graph_json(
+                dataset=dataset[0].id,
+                user=user,
+                full=full,
+                query=query,
+                seed_node_ids=seed_node_ids,
+                neighborhood_depth=neighborhood_depth,
+                neighborhood_seed_top_k=neighborhood_seed_top_k,
+                max_nodes=max_nodes,
+            )
+            return JSONResponse(status_code=200, content=payload)
+
+        except Exception as error:
+            logger.exception("Visualization JSON payload failed for dataset %s", dataset_id)
+            return JSONResponse(status_code=409, content={"error": str(error)})
+
+    @router.get("/semantic", response_model=None)
+    async def visualize_semantic(
+        dataset_id: UUID = Query(
+            ...,
+            description=(
+                "UUID of the dataset to visualize. "
+                "List your datasets via GET /api/v1/datasets to find it."
+            ),
+            examples=[""],
+        ),
+        full: bool = Query(
+            False,
+            description="Include the entire graph instead of a bounded subgraph.",
+        ),
+        query: Optional[str] = Query(
+            None,
+            description="Query string whose nearest vector hits seed the subgraph.",
+        ),
+        seed_node_ids: Optional[List[str]] = Query(
+            None,
+            description="Explicit seed node ids for subgraph neighborhood expansion.",
+        ),
+        neighborhood_depth: int = Query(
+            DEFAULT_NEIGHBORHOOD_DEPTH,
+            ge=1,
+            le=10,
+            description="k-hop neighborhood depth for subgraph expansion.",
+        ),
+        neighborhood_seed_top_k: int = Query(
+            DEFAULT_SEED_TOP_K,
+            ge=1,
+            le=100,
+            description="Maximum number of seed nodes.",
+        ),
+        max_nodes: int = Query(
+            DEFAULT_MAX_NODES,
+            ge=1,
+            le=5000,
+            description="Hard cap on rendered nodes after expansion.",
+        ),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        Return semantic positions and clusters for the same subgraph as `GET /visualize/json`.
+
+        Pass the same arguments used for `GET /visualize/json` to lay out the
+        same subgraph semantically. This is the one call that fetches
+        embeddings (up to 2000 nodes) and runs PCA/UMAP over them, so it is
+        only worth calling when the semantic tab is actually open.
+
+        ## Query Parameters
+        Same as `GET /visualize/json`.
+
+        ## Response
+        A JSON object with `semantic_positions` and `semantic_clusters`,
+        either of which is `null` when there are no embeddings to lay out.
+
+        ## Error Codes
+        - **409 Conflict**: Dataset not found, permission denied, or the
+          payload could not be built (detail in the `error` field)
+
+        ## Notes
+        - User must have read permissions on the dataset
+        """
+        send_telemetry(
+            "Visualize Semantic API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "GET /v1/visualize/semantic",
+                "dataset_id": str(dataset_id),
+                "cognee_version": cognee_version,
+            },
+        )
+
+        from cognee.api.v1.visualize import visualize_semantic_json
+
+        try:
+            dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
+
+            payload = await visualize_semantic_json(
+                dataset=dataset[0].id,
+                user=user,
+                full=full,
+                query=query,
+                seed_node_ids=seed_node_ids,
+                neighborhood_depth=neighborhood_depth,
+                neighborhood_seed_top_k=neighborhood_seed_top_k,
+                max_nodes=max_nodes,
+            )
+            return JSONResponse(status_code=200, content=payload)
+
+        except Exception as error:
+            logger.exception("Semantic payload failed for dataset %s", dataset_id)
+            return JSONResponse(status_code=409, content={"error": str(error)})
+
+    @router.get("/brains", response_model=None)
+    async def visualize_brains(
+        max_nodes: int = Query(
+            DEFAULT_MAX_NODES,
+            ge=1,
+            le=5000,
+            description="Hard cap on rendered nodes per dataset.",
+        ),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        Return every dataset the caller may read, each as a small graph preview.
+
+        No `dataset_id`: this is the Brains overview, not one brain. Built on
+        the same union CLO-399 already uses to decide which datasets a user
+        can see — their own, their tenant's, and anything granted to a role
+        they belong to — so a dataset shared with a group appears here with
+        no separate authorization logic.
+
+        ## Query Parameters
+        - **max_nodes** (int): Node cap applied independently to each
+          dataset (default 500) — there is no larger, separate cap for "all
+          datasets at once".
+
+        ## Response
+        `{dataset_id: {"name", "nodes", "links", "node_set_colors"}}`.
+
+        ## Notes
+        - Only datasets the caller has read permission on are included
+        """
+        send_telemetry(
+            "Visualize Brains API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "GET /v1/visualize/brains",
+                "cognee_version": cognee_version,
+            },
+        )
+
+        from cognee.api.v1.visualize import build_brains_payload
+
+        try:
+            payload = await build_brains_payload(user=user, max_nodes=max_nodes)
+            return JSONResponse(status_code=200, content=payload)
+
+        except Exception as error:
+            logger.exception("Brains overview payload failed")
+            return JSONResponse(status_code=409, content={"error": str(error)})
+
+    @router.get("/live-events", response_model=None)
+    async def visualize_live_events(
+        dataset_id: UUID = Query(
+            ...,
+            description=(
+                "UUID of the dataset this poll is for. Gates who may call this "
+                "endpoint (same read-permission check as every other visualize "
+                "route) — the events themselves are the caller's own, not "
+                "filtered to this dataset's graph."
+            ),
+            examples=[""],
+        ),
+        since: Optional[datetime] = Query(
+            None,
+            description=(
+                "Cursor from a previous call's response. Omit on the first "
+                "call to get every available event."
+            ),
+        ),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        Return search/improve events newer than a cursor, for the Memory tab's live timeline.
+
+        Meant to be polled instead of re-fetching the whole `GET
+        /visualize/json` payload just to refresh the timeline: pass the
+        previous response's `cursor` back as `since` and only new events
+        come back. The filter is strict, so nothing is ever delivered twice.
+
+        ## Query Parameters
+        - **dataset_id** (UUID): authorization only, see above
+        - **since** (datetime, optional): cursor from a previous call
+
+        ## Response
+        `{"events": [...], "cursor": <ISO datetime or null>}`
+
+        ## Error Codes
+        - **403 Forbidden**: Caller lacks read permission on the dataset (or
+          it does not exist)
+        - **409 Conflict**: Payload could not be built (detail in the
+          `error` field)
+
+        ## Notes
+        - User must have read permissions on the dataset
+        """
+        send_telemetry(
+            "Visualize Live Events API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "GET /v1/visualize/live-events",
+                "dataset_id": str(dataset_id),
+                "cognee_version": cognee_version,
+            },
+        )
+
+        from cognee.api.v1.visualize import get_live_events
+
+        try:
+            payload = await get_live_events(dataset_id, since=since, user=user)
+            return JSONResponse(status_code=200, content=payload)
+
+        except PermissionDeniedError:
+            return JSONResponse(
+                status_code=403,
+                content={"error": "Not authorized to read this dataset"},
+            )
+        except Exception as error:
+            logger.exception("Live events payload failed for dataset %s", dataset_id)
             return JSONResponse(status_code=409, content={"error": str(error)})
 
     @router.post("/multi", response_model=None)

--- a/cognee/api/v1/visualize/__init__.py
+++ b/cognee/api/v1/visualize/__init__.py
@@ -1,11 +1,19 @@
-from .visualize import visualize_graph, visualize_multi_user_graph
+from .visualize import (
+    visualize_graph,
+    visualize_multi_user_graph,
+    visualize_graph_json,
+    visualize_semantic_json,
+    build_brains_payload,
+    get_live_events,
+)
 from .get_schema_inventory import get_schema_inventory
 
 # build_provenance_graph is an internal assembly helper (it operates on records
 # already gathered by get_memory_provenance_graph), so it is intentionally not
-# re-exported here — only the two user-facing entry points are public.
+# re-exported here — only the user-facing entry points are public.
 from .memory_provenance import (
     get_memory_provenance_graph,
+    get_memory_provenance_payload,
     visualize_memory_provenance,
 )
 from .start_visualization_server import visualization_server

--- a/cognee/api/v1/visualize/memory_provenance.py
+++ b/cognee/api/v1/visualize/memory_provenance.py
@@ -12,11 +12,14 @@ When ``include_memory=True`` the extracted memory (entities/relationships) is
 folded in from the relational ``nodes``/``edges`` tables and linked back to the
 files it was extracted from.
 
-Two entry points:
+Entry points:
     * ``build_provenance_graph(...)`` — pure, side-effect-free assembly from
       plain records (unit-testable).
     * ``get_memory_provenance_graph(...)`` — async reader that pulls live data
       from the relational layer and calls the builder.
+    * ``visualize_memory_provenance(...)`` / ``get_memory_provenance_payload(...)``
+      — the same graph rendered as HTML or packaged as a JSON dict, sharing
+      one ``preprocess()`` call so the two cannot drift.
 """
 
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypedDict, cast
@@ -65,6 +68,26 @@ class UserRecord(_HasId, total=False):
     tenant_ids: List[str]
 
 
+class RoleRecord(_HasId, total=False):
+    name: Optional[str]
+    tenant_id: Optional[str]
+    user_ids: List[str]
+
+
+class AclGrantRecord(TypedDict, total=False):
+    """One ACL row: a permission a principal holds on a dataset.
+
+    ``principal_kind`` is one of "role" | "user" | "tenant" — the same
+    vocabulary the CLO-399 dataset-groups endpoint uses, so a client already
+    rendering that distinction elsewhere does not learn a second one here.
+    """
+
+    principal_id: str
+    principal_kind: str
+    dataset_id: str
+    permission: str
+
+
 class DatasetRecord(_HasId, total=False):
     name: Optional[str]
     owner_id: Optional[str]
@@ -102,14 +125,28 @@ class MemoryPayload(TypedDict, total=False):
     links: List[Dict[str, Any]]
 
 
+# Delete/share are still projected (as their own edge, not folded into reads/
+# writes) rather than dropped: an ACL row exists because someone granted it,
+# and hiding half of what a principal can do would misstate the story this
+# graph exists to tell.
+_ACL_EDGE_RELATIONS = {
+    "read": "reads",
+    "write": "writes",
+    "delete": "can_delete",
+    "share": "can_share",
+}
+
+
 def build_provenance_graph(
     *,
     tenants: Optional[List[TenantRecord]] = None,
     users: Optional[List[UserRecord]] = None,
+    roles: Optional[List[RoleRecord]] = None,
     datasets: Optional[List[DatasetRecord]] = None,
     files: Optional[List[FileRecord]] = None,
     agents: Optional[List[AgentRecord]] = None,
     sessions: Optional[List[SessionRecord]] = None,
+    acl_grants: Optional[List[AclGrantRecord]] = None,
     memory: Optional[MemoryPayload] = None,
 ) -> Tuple[List[Node], List[EdgeData]]:
     """Assemble actor/ownership/session records into a ``(nodes, edges)`` graph.
@@ -117,11 +154,14 @@ def build_provenance_graph(
     Record shapes (all ids are strings):
         tenants:  {"id", "name"}
         users:    {"id", "name", "tenant_ids": [..]}
+        roles:    {"id", "name", "tenant_id", "user_ids": [..]}
         datasets: {"id", "name", "owner_id", "tenant_id"}
         files:    {"id", "name", "dataset_ids": [..], "dataset_name"?}
         agents:   {"id", "name", "user_id", "session_id"?,
                    "datasets": [{"dataset_id", "role": "read"|"read_write"}]}
         sessions: {"id", "name", "user_id", "dataset_id", "agent_id"?}
+        acl_grants: [{"principal_id", "principal_kind": "role"|"user"|"tenant",
+                      "dataset_id", "permission": "read"|"write"|"delete"|"share"}]
         memory:   optional {"nodes": [(id, props)], "edges": [(s, t, rel, props)],
                             "links": [{"node_id", "data_id", "dataset_id"}]}
 
@@ -130,10 +170,12 @@ def build_provenance_graph(
     """
     tenants = tenants or []
     users = users or []
+    roles = roles or []
     datasets = datasets or []
     files = files or []
     agents = agents or []
     sessions = sessions or []
+    acl_grants = acl_grants or []
 
     nodes: Dict[str, Node] = {}
     edges: List[EdgeData] = []
@@ -157,6 +199,8 @@ def build_provenance_graph(
         add_node(f"tenant:{tenant['id']}", "Tenant", tenant.get("name") or "Tenant")
     for user in users:
         add_node(f"user:{user['id']}", "User", user.get("name") or str(user["id"]))
+    for role in roles:
+        add_node(f"role:{role['id']}", "Role", role.get("name") or str(role["id"]))
     for dataset in datasets:
         add_node(f"dataset:{dataset['id']}", "Dataset", dataset.get("name") or "Dataset")
     for file in files:
@@ -175,6 +219,13 @@ def build_provenance_graph(
     for user in users:
         for tenant_id in user.get("tenant_ids") or []:
             add_edge(f"tenant:{tenant_id}", f"user:{user['id']}", "has_member")
+
+    for role in roles:
+        role_tenant_id = role.get("tenant_id")
+        if role_tenant_id:
+            add_edge(f"tenant:{role_tenant_id}", f"role:{role['id']}", "has_role")
+        for user_id in role.get("user_ids") or []:
+            add_edge(f"role:{role['id']}", f"user:{user_id}", "has_member")
 
     for dataset in datasets:
         owner_id = dataset.get("owner_id")
@@ -207,6 +258,19 @@ def build_provenance_graph(
         sess_dataset_id = sess.get("dataset_id")
         if sess_dataset_id:
             add_edge(f"session:{sess['id']}", f"dataset:{sess_dataset_id}", "recorded_in")
+
+    # ACL grants: what a role, a user or the tenant principal itself can do
+    # with a dataset, as distinct from who *owns* it (the "owns" edges above,
+    # from Dataset.owner_id). A dataset shared via ShareDatasetModal with a
+    # group, an individual, or the whole workspace shows up here and nowhere
+    # else — before this, only ownership was visible, so a shared dataset
+    # with no ACL projection looked unshared.
+    for grant in acl_grants:
+        edge_relation = _ACL_EDGE_RELATIONS.get(grant.get("permission"))
+        if edge_relation is None:
+            continue
+        source = f"{grant['principal_kind']}:{grant['principal_id']}"
+        add_edge(source, f"dataset:{grant['dataset_id']}", edge_relation)
 
     # ── Optional memory layer ────────────────────────────────────────
     if memory:
@@ -448,6 +512,89 @@ async def _read_memory_graph_provenance(
     return {"nodes": nodes, "edges": edges, "links": links}
 
 
+async def _read_roles_and_grants(
+    tenant_ids: Optional[List[str]],
+    dataset_ids: List[str],
+    scope_user_ids: Optional[List[str]] = None,
+) -> Tuple[List[RoleRecord], List[AclGrantRecord]]:
+    """Best-effort read of roles (with membership) and ACL grants on the
+    in-scope datasets.
+
+    ``Principal.id``/``Principal.type`` are read as bare columns rather than
+    through ``select(Principal)`` or an outer join onto ``User``/``Role``/
+    ``Tenant``: the latter makes SQLAlchemy try to resolve the polymorphic
+    identity across all three subclass tables at once and it folds rows
+    together — the exact bug CLO-399's dataset-groups endpoint hit first.
+    Reading the two plain columns sidesteps that; there is no entity to
+    misidentify when nothing is asking the ORM to build one.
+
+    ``tenant_ids=None`` with ``scope_user_ids`` set (the OSS/single-user path,
+    where roles are not owned by a user) keeps only roles the scoped users are
+    actually members of, so this cannot surface a group of people outside the
+    requested scope.
+    """
+    from uuid import UUID as _UUID
+
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.users.models import ACL, Permission, Role
+    from cognee.modules.users.models.Principal import Principal
+
+    def _to_uuid(value):
+        # Role.tenant_id and ACL.dataset_id are sqlalchemy.UUID(as_uuid=True):
+        # on SQLite the bind processor calls value.hex, which a plain string
+        # does not have. Callers pass either — get_memory_provenance_graph's
+        # dataset_ids are already stringified — so coerce once here instead
+        # of pushing that constraint onto every caller.
+        return value if isinstance(value, _UUID) else _UUID(str(value))
+
+    roles: List[RoleRecord] = []
+    grants: List[AclGrantRecord] = []
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        role_stmt = select(Role).options(selectinload(Role.users))
+        if tenant_ids is not None:
+            role_stmt = role_stmt.where(Role.tenant_id.in_(_to_uuid(t) for t in tenant_ids))
+        role_rows = (await session.execute(role_stmt)).scalars().all()
+
+        if tenant_ids is None and scope_user_ids is not None:
+            allowed = set(scope_user_ids)
+            role_rows = [r for r in role_rows if {str(u.id) for u in r.users} & allowed]
+
+        for role in role_rows:
+            roles.append(
+                {
+                    "id": str(role.id),
+                    "name": role.name,
+                    "tenant_id": str(role.tenant_id),
+                    "user_ids": [str(u.id) for u in (role.users or [])],
+                }
+            )
+
+        if dataset_ids:
+            grant_stmt = (
+                select(Principal.id, Principal.type, ACL.dataset_id, Permission.name)
+                .select_from(ACL)
+                .join(Principal, Principal.id == ACL.principal_id)
+                .join(Permission, Permission.id == ACL.permission_id)
+                .where(ACL.dataset_id.in_(_to_uuid(d) for d in dataset_ids))
+            )
+            for principal_id, kind, dataset_id, permission in await session.execute(grant_stmt):
+                grants.append(
+                    {
+                        "principal_id": str(principal_id),
+                        "principal_kind": kind,
+                        "dataset_id": str(dataset_id),
+                        "permission": permission,
+                    }
+                )
+
+    return roles, grants
+
+
 async def get_memory_provenance_graph(
     include_memory: bool = False,
     scope_tenant_ids: Optional[List[Any]] = None,
@@ -545,6 +692,16 @@ async def get_memory_provenance_graph(
         allowed_user_ids = set(user_ids)
         agents = [a for a in agents if a.get("user_id") in allowed_user_ids]
     sessions = await _read_sessions(user_ids, agents)
+    roles, acl_grants = await _read_roles_and_grants(
+        tenant_ids=scope_tenant_ids,
+        dataset_ids=dataset_ids,
+        # user_ids is already resolved to this call's in-scope users (strings);
+        # only meaningful without a tenant scope, where roles carry no other
+        # link back to "in scope" at all.
+        scope_user_ids=user_ids
+        if scope_tenant_ids is None and scope_user_ids is not None
+        else None,
+    )
     # Scope memory to the in-scope datasets so it never leaks across tenants.
     memory = None
     if include_memory:
@@ -555,10 +712,12 @@ async def get_memory_provenance_graph(
     return build_provenance_graph(
         tenants=cast(List[TenantRecord], tenants),
         users=cast(List[UserRecord], users),
+        roles=cast(List[RoleRecord], roles),
         datasets=cast(List[DatasetRecord], datasets),
         files=cast(List[FileRecord], list(files.values())),
         agents=agents,
         sessions=sessions,
+        acl_grants=cast(List[AclGrantRecord], acl_grants),
         memory=memory,
     )
 
@@ -588,3 +747,33 @@ async def visualize_memory_provenance(
     if destination_file_path:
         logger.info(f"Memory provenance visualization saved at: {destination_file_path}")
     return html
+
+
+async def get_memory_provenance_payload(
+    include_memory: bool = False,
+    scope_tenant_ids: Optional[List[Any]] = None,
+    scope_user_ids: Optional[List[Any]] = None,
+) -> dict:
+    """The live memory-provenance graph as a JSON-safe dict, for a client
+    that renders it itself instead of an embedded HTML page.
+
+    Routes the same ``(nodes, edges)`` from ``get_memory_provenance_graph``
+    through ``build_visualization_payload`` — the same preprocessing
+    (``preprocess()``) the HTML path already runs the provenance graph
+    through via ``cognee_network_visualization``, just packaged as a dict
+    instead of interpolated into a template. The two cannot drift on the
+    data for the same reason CLO-401's dataset visualization JSON and HTML
+    paths cannot: both come from one ``preprocess()`` call.
+
+    ``scope_tenant_ids`` / ``scope_user_ids``: see ``get_memory_provenance_graph``.
+    """
+    from cognee.modules.visualization.cognee_network_visualization import (
+        build_visualization_payload,
+    )
+
+    graph_data = await get_memory_provenance_graph(
+        include_memory=include_memory,
+        scope_tenant_ids=scope_tenant_ids,
+        scope_user_ids=scope_user_ids,
+    )
+    return build_visualization_payload(graph_data)

--- a/cognee/api/v1/visualize/routers/get_schema_router.py
+++ b/cognee/api/v1/visualize/routers/get_schema_router.py
@@ -187,4 +187,63 @@ def get_schema_router() -> APIRouter:
                 content={"error": "Failed to build memory provenance"},
             )
 
+    @router.get(
+        "/provenance/json",
+        response_model=None,
+        responses={409: {"model": ErrorResponse}},
+    )
+    async def schema_provenance_json(
+        include_memory: bool = Query(
+            default=False,
+            description=(
+                "When true, include the extracted memory subgraph "
+                "(entities/relationships) in the provenance payload."
+            ),
+        ),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """Return a caller-scoped memory-provenance graph as a JSON-safe dict.
+
+        Same scoping as `GET /schema/provenance` (tenant when the caller has
+        one, otherwise just the caller) and the same underlying graph —
+        packaged as a dict instead of an HTML page.
+
+        Query parameters:
+            include_memory: when true, also folds the extracted memory
+                (entities/relationships) into the payload alongside data
+                lineage (default false).
+        """
+        send_telemetry(
+            "Schema Provenance JSON API Endpoint Invoked",
+            user.id,
+            additional_properties={
+                "endpoint": "GET /v1/schema/provenance/json",
+                "cognee_version": cognee_version,
+            },
+        )
+
+        from cognee.api.v1.visualize import get_memory_provenance_payload
+
+        tenant_id = getattr(user, "tenant_id", None)
+        if tenant_id is not None:
+            scope_tenant_ids = [tenant_id]
+            scope_user_ids = None
+        else:
+            scope_tenant_ids = None
+            scope_user_ids = [user.id]
+
+        try:
+            payload = await get_memory_provenance_payload(
+                include_memory=include_memory,
+                scope_tenant_ids=scope_tenant_ids,
+                scope_user_ids=scope_user_ids,
+            )
+            return JSONResponse(status_code=200, content=payload)
+        except Exception as exc:
+            logger.error("schema provenance json failed: %s", exc, exc_info=True)
+            return JSONResponse(
+                status_code=409,
+                content={"error": "Failed to build memory provenance"},
+            )
+
     return router

--- a/cognee/api/v1/visualize/visualize.py
+++ b/cognee/api/v1/visualize/visualize.py
@@ -1,11 +1,16 @@
-from typing import Any, List, Tuple, Optional, Union
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Tuple, Optional, Union
 from uuid import UUID
 from cognee.modules.users.models.User import User
 
 from cognee.modules.visualization.cognee_network_visualization import (
     cognee_network_visualization,
     aggregate_multi_user_graphs,
+    build_visualization_payload,
+    build_semantic_payload,
+    build_brain_summary_payload,
 )
+from cognee.modules.visualization.session_events import collect_session_events
 from cognee.modules.visualization.subgraph_data import (
     DEFAULT_MAX_NODES,
     DEFAULT_NEIGHBORHOOD_DEPTH,
@@ -14,6 +19,8 @@ from cognee.modules.visualization.subgraph_data import (
 )
 from cognee.infrastructure.databases.graph import get_graph_engine
 from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.permissions.methods import get_all_user_permission_datasets
 from cognee.modules.users.methods import get_default_user
 from cognee.context_global_variables import set_database_global_context_variables
 from cognee.shared.logging_utils import get_logger, setup_logging, ERROR
@@ -24,6 +31,105 @@ from cognee.modules.data.constants import DEFAULT_DATASET_NAME
 
 
 logger = get_logger()
+
+
+async def fetch_visualization_data(
+    user: Optional[User] = None,
+    dataset: Optional[Union[str, UUID]] = DEFAULT_DATASET_NAME,
+    *,
+    full: bool = False,
+    query: Optional[str] = None,
+    seed_node_ids: Optional[List[str]] = None,
+    recall_result: Optional[Any] = None,
+    neighborhood_depth: int = DEFAULT_NEIGHBORHOOD_DEPTH,
+    neighborhood_seed_top_k: int = DEFAULT_SEED_TOP_K,
+    max_nodes: int = DEFAULT_MAX_NODES,
+    include_session_events: bool = True,
+    session_ids: list = None,
+) -> Tuple[Any, Optional[list]]:
+    """Authorize, fetch and bound the graph data behind a visualization.
+
+    Shared by the HTML renderer (``visualize_graph``) and the JSON payload
+    builders (``visualize_graph_json``, ``visualize_semantic_json``) so every
+    caller starts from the identical authorized, bounded ``graph_data`` — the
+    same ``fetch_visualization_graph_data`` call, the same seed/depth/cap
+    knobs, inside the same dataset-scoped database context. What each caller
+    does with the result — render HTML or serialize JSON — is the only thing
+    that differs from here on.
+
+    Args, Returns: as documented on ``visualize_graph``, which this was split
+    out of. Returns ``(graph_data, search_events)``.
+    """
+    if not user:
+        user = await get_default_user()
+
+    # Only authorize when a dataset is given. get_authorized_existing_datasets
+    # expects a list, so wrap the single dataset. With no dataset the context
+    # is set with None: a no-op when access control is off, and an (expected)
+    # error in multi-user mode where a dataset is required.
+    resolved_dataset = None
+    if dataset:
+        authorized = await get_authorized_existing_datasets([dataset], "read", user)
+        resolved_dataset = authorized[0] if authorized else None
+
+    graph_data = await fetch_dataset_graph_data(
+        resolved_dataset,
+        full=full,
+        query=query,
+        seed_node_ids=seed_node_ids,
+        recall_result=recall_result,
+        neighborhood_depth=neighborhood_depth,
+        neighborhood_seed_top_k=neighborhood_seed_top_k,
+        max_nodes=max_nodes,
+    )
+
+    search_events = None
+    if include_session_events:
+        from cognee.modules.visualization.session_events import collect_session_events
+
+        search_events = await collect_session_events(user=user, session_ids=session_ids)
+
+    return graph_data, search_events
+
+
+async def fetch_dataset_graph_data(
+    dataset: Optional[Any],
+    *,
+    full: bool = False,
+    query: Optional[str] = None,
+    seed_node_ids: Optional[List[str]] = None,
+    recall_result: Optional[Any] = None,
+    neighborhood_depth: int = DEFAULT_NEIGHBORHOOD_DEPTH,
+    neighborhood_seed_top_k: int = DEFAULT_SEED_TOP_K,
+    max_nodes: int = DEFAULT_MAX_NODES,
+) -> Any:
+    """Bounded graph read for one already-authorized dataset (or none).
+
+    Split out of ``fetch_visualization_data`` so ``build_brains_payload`` can
+    read one dataset at a time without re-running authorization on every one
+    of them — it already has the authorized list from
+    ``get_all_user_permission_datasets`` and would otherwise be paying for
+    the same permission check twice per dataset.
+
+    ``dataset=None`` sets the context with ``None``: a no-op when access
+    control is off, and an (expected) error in multi-user mode where a
+    dataset is required.
+    """
+    async with set_database_global_context_variables(
+        dataset.id if dataset else None,
+        dataset.owner_id if dataset else None,
+    ):
+        graph_engine = await get_graph_engine()
+        return await fetch_visualization_graph_data(
+            graph_engine,
+            full=full,
+            query=query,
+            seed_node_ids=seed_node_ids,
+            recall_result=recall_result,
+            neighborhood_depth=neighborhood_depth,
+            seed_top_k=neighborhood_seed_top_k,
+            max_nodes=max_nodes,
+        )
 
 
 async def visualize_graph(
@@ -75,50 +181,233 @@ async def visualize_graph(
         neighborhood_seed_top_k: Maximum number of seed nodes (default 10).
         max_nodes: Hard cap on rendered nodes after expansion (default 500).
     """
+    graph_data, search_events = await fetch_visualization_data(
+        user=user,
+        dataset=dataset,
+        full=full,
+        query=query,
+        seed_node_ids=seed_node_ids,
+        recall_result=recall_result,
+        neighborhood_depth=neighborhood_depth,
+        neighborhood_seed_top_k=neighborhood_seed_top_k,
+        max_nodes=max_nodes,
+        include_session_events=include_session_events,
+        session_ids=session_ids,
+    )
+
+    graph = await cognee_network_visualization(
+        graph_data, destination_file_path, search_events=search_events
+    )
+
+    if destination_file_path:
+        logger.info(f"The HTML file has been stored at path: {destination_file_path}")
+    else:
+        logger.info(
+            "The HTML file has been stored on your home directory! Navigate there with cd ~"
+        )
+
+    return graph
+
+
+async def visualize_graph_json(
+    include_session_events: bool = True,
+    session_ids: list = None,
+    user: Optional[User] = None,
+    dataset: Optional[Union[str, UUID]] = DEFAULT_DATASET_NAME,
+    *,
+    full: bool = False,
+    query: Optional[str] = None,
+    seed_node_ids: Optional[List[str]] = None,
+    recall_result: Optional[Any] = None,
+    neighborhood_depth: int = DEFAULT_NEIGHBORHOOD_DEPTH,
+    neighborhood_seed_top_k: int = DEFAULT_SEED_TOP_K,
+    max_nodes: int = DEFAULT_MAX_NODES,
+) -> dict:
+    """The graph, as a JSON-safe dict, without the semantic layout.
+
+    Same authorization, dataset resolution and bounded fetch as
+    ``visualize_graph`` (they share ``fetch_visualization_data``), so a JSON
+    caller sees exactly the subgraph the HTML page would have shown for the
+    same arguments. Semantic positions/clusters are a separate, heavier call
+    — see ``visualize_semantic_json`` — so a client that never opens the
+    semantic tab never pays for the embedding fetch and PCA behind it.
+
+    Returns:
+        dict: every field of ``PreprocessedGraph`` (nodes, links, color_maps,
+        schema_graph, schema_data, pipeline_stages, edge_classes, bundles,
+        provenance_index, has_meaningful_topological_rank, memory_map) plus
+        ``search_events``.
+    """
+    graph_data, search_events = await fetch_visualization_data(
+        user=user,
+        dataset=dataset,
+        full=full,
+        query=query,
+        seed_node_ids=seed_node_ids,
+        recall_result=recall_result,
+        neighborhood_depth=neighborhood_depth,
+        neighborhood_seed_top_k=neighborhood_seed_top_k,
+        max_nodes=max_nodes,
+        include_session_events=include_session_events,
+        session_ids=session_ids,
+    )
+
+    return build_visualization_payload(graph_data, search_events=search_events)
+
+
+async def visualize_semantic_json(
+    user: Optional[User] = None,
+    dataset: Optional[Union[str, UUID]] = DEFAULT_DATASET_NAME,
+    *,
+    full: bool = False,
+    query: Optional[str] = None,
+    seed_node_ids: Optional[List[str]] = None,
+    recall_result: Optional[Any] = None,
+    neighborhood_depth: int = DEFAULT_NEIGHBORHOOD_DEPTH,
+    neighborhood_seed_top_k: int = DEFAULT_SEED_TOP_K,
+    max_nodes: int = DEFAULT_MAX_NODES,
+) -> dict:
+    """Semantic positions and clusters for the same subgraph, computed on demand.
+
+    Pass the same dataset/seed/depth/cap arguments used for
+    ``visualize_graph_json`` to get semantic layout for the same subgraph.
+    This re-runs the (cheap) fetch and preprocessing rather than reusing a
+    previous call's result, because the point of splitting this out is to
+    make the expensive part — embeddings for up to 2000 nodes, then PCA —
+    conditional on the semantic tab actually being opened, not to cache the
+    cheap part.
+    """
+    graph_data, _ = await fetch_visualization_data(
+        user=user,
+        dataset=dataset,
+        full=full,
+        query=query,
+        seed_node_ids=seed_node_ids,
+        recall_result=recall_result,
+        neighborhood_depth=neighborhood_depth,
+        neighborhood_seed_top_k=neighborhood_seed_top_k,
+        max_nodes=max_nodes,
+        include_session_events=False,
+    )
+
+    return await build_semantic_payload(graph_data)
+
+
+async def build_brains_payload(
+    user: Optional[User] = None,
+    max_nodes: int = DEFAULT_MAX_NODES,
+) -> dict:
+    """Every dataset the caller may read, each as a small graph preview.
+
+    ``{dataset_id: {"name", "nodes", "links", "node_set_colors"}}`` — see
+    ``build_brain_summary_payload`` for why that shape and not the full
+    visualize payload per dataset.
+
+    Built on ``get_all_user_permission_datasets`` (CLO-399's group work), the
+    same union already used to decide which datasets a user can see: their
+    own, their tenant's, and anything granted to a role they belong to. A
+    dataset shared with a group the caller is in appears here with no extra
+    code — the authorization this reuses is already group-aware.
+
+    Each dataset's fetch is independently bounded by ``max_nodes``, same as a
+    single-dataset visualization; there is no separate, larger cap for "all
+    datasets at once" to defeat.
+    """
     if not user:
         user = await get_default_user()
 
-    # Only authorize when a dataset is given. get_authorized_existing_datasets
-    # expects a list, so wrap the single dataset. With no dataset the context
-    # is set with None: a no-op when access control is off, and an (expected)
-    # error in multi-user mode where a dataset is required.
-    if dataset:
-        dataset = await get_authorized_existing_datasets([dataset], "read", user)
+    datasets = await get_all_user_permission_datasets(user, "read")
 
-    async with set_database_global_context_variables(
-        dataset[0].id if dataset else None,
-        dataset[0].owner_id if dataset else None,
-    ):
-        graph_engine = await get_graph_engine()
-        graph_data = await fetch_visualization_graph_data(
-            graph_engine,
-            full=full,
-            query=query,
-            seed_node_ids=seed_node_ids,
-            recall_result=recall_result,
-            neighborhood_depth=neighborhood_depth,
-            seed_top_k=neighborhood_seed_top_k,
-            max_nodes=max_nodes,
-        )
+    payload: dict = {}
+    for dataset in datasets:
+        graph_data = await fetch_dataset_graph_data(dataset, max_nodes=max_nodes)
+        payload[str(dataset.id)] = build_brain_summary_payload(dataset.name, graph_data)
 
-        search_events = None
-        if include_session_events:
-            from cognee.modules.visualization.session_events import collect_session_events
+    return payload
 
-            search_events = await collect_session_events(user=user, session_ids=session_ids)
 
-        graph = await cognee_network_visualization(
-            graph_data, destination_file_path, search_events=search_events
-        )
+def _as_naive_utc(value: datetime) -> datetime:
+    """Normalize to match the write side.
 
-        if destination_file_path:
-            logger.info(f"The HTML file has been stored at path: {destination_file_path}")
-        else:
-            logger.info(
-                "The HTML file has been stored on your home directory! Navigate there with cd ~"
-            )
+    ``SessionQAEntry.time`` is always ``datetime.utcnow().isoformat()`` —
+    naive, UTC. A ``since`` sent with a timezone offset compares fine against
+    another aware datetime, but not against those naive strings once parsed
+    back, so it is converted here rather than left to fail the comparison
+    below with a raised ``TypeError`` at an unexpected place.
+    """
+    if value.tzinfo is not None:
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
 
-        return graph
+
+def _event_time(event: Dict[str, Any]) -> Optional[datetime]:
+    raw = event.get("time")
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+async def get_live_events(
+    dataset_id: UUID,
+    since: Optional[datetime] = None,
+    user: Optional[User] = None,
+) -> Dict[str, Any]:
+    """Delta of search/improve events since a cursor, for the Memory tab's
+    live timeline.
+
+    ``dataset_id`` gates who may call this — the same read-permission check
+    every other visualize endpoint runs (``get_authorized_existing_datasets``)
+    — not which events come back. Session events are collected per *user*,
+    not per dataset, matching how ``visualize_graph``'s own
+    ``include_session_events`` already embeds the same events into whichever
+    dataset's page happens to be open. Scoping the event *content* to one
+    dataset would mean checking each event's referenced node/edge ids against
+    that dataset's graph membership — real extra cost that this endpoint's
+    one job (avoid recomputing the whole graph payload every ~1.5s just to
+    refresh a timeline) does not need, and it would make this endpoint
+    disagree with the very same events already shown in ``search_events`` on
+    ``/visualize/json`` for that dataset.
+
+    ``since=None`` returns every available event — the first call, before a
+    client has a cursor of its own.
+
+    Returns ``{"events": [...], "cursor": <ISO datetime or None>}``. The
+    filter is strict (``>``, not ``>=``): pass the previous response's
+    ``cursor`` straight back as the next call's ``since`` and nothing is
+    delivered twice. ``cursor`` is the newest event's own timestamp string,
+    not a re-derived one, so it can never drift from what the client actually
+    received.
+
+    Raises:
+        PermissionDeniedError: dataset does not exist, or the caller lacks
+            read permission on it.
+    """
+    if not user:
+        user = await get_default_user()
+
+    authorized = await get_authorized_existing_datasets([dataset_id], "read", user)
+    if not authorized:
+        raise PermissionDeniedError(message="Not authorized to read this dataset")
+
+    events = await collect_session_events(user=user)
+
+    if since is not None:
+        cutoff = _as_naive_utc(since)
+        events = [
+            event
+            for event in events
+            if (event_time := _event_time(event)) is not None and event_time > cutoff
+        ]
+
+    if events:
+        cursor = events[-1]["time"]
+    else:
+        cursor = since.isoformat() if since is not None else None
+
+    return {"events": events, "cursor": cursor}
 
 
 async def visualize_multi_user_graph(

--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -20,6 +20,7 @@ caller of ``cognee_network_visualization`` or
 
 import json
 import os
+from dataclasses import asdict
 from typing import Optional
 
 from cognee.shared.logging_utils import get_logger
@@ -63,6 +64,74 @@ async def _semantic_payload(pre) -> tuple[Optional[dict], Optional[dict]]:
     except Exception as exc:
         logger.warning("Semantic map: payload computation failed (%s); tab shows empty state.", exc)
         return None, None
+
+
+def build_visualization_payload(
+    graph_data,
+    schema_data: Optional[dict] = None,
+    search_events: Optional[list] = None,
+) -> dict:
+    """JSON-safe snapshot of the graph, for a client that renders it itself.
+
+    Runs the same ``preprocess()`` the HTML path renders from, so the two
+    cannot drift on the data — only on how each packages it (template tokens
+    here vs. a plain dict there). Everything in the result already passes
+    through ``json.dumps`` in the HTML path via ``_safe_json_embed``, which
+    is why this needs no custom encoder.
+
+    Returns ``asdict(pre)`` in full, not the eight fields the HTML template
+    turns into tokens. ``pipeline_stages``, ``edge_classes``, ``bundles``,
+    ``provenance_index`` and ``has_meaningful_topological_rank`` never become
+    tokens today — the view modules read them straight off ``pre`` through
+    ``emit_js(pre)`` — but a client that replaces those modules needs them.
+
+    Semantic positions/clusters are deliberately not included here; see
+    ``build_semantic_payload``. Folding them in would mean every caller pays
+    for the embedding fetch and PCA behind them even when the semantic tab is
+    never opened, which is exactly the cost this split removes.
+    """
+    pre = preprocess(graph_data, schema_data=schema_data)
+    return {**asdict(pre), "search_events": search_events or []}
+
+
+async def build_semantic_payload(graph_data, schema_data: Optional[dict] = None) -> dict:
+    """Semantic layout for the graph, computed on demand.
+
+    Re-runs ``preprocess()`` rather than accepting an already-built ``pre``:
+    that step is cheap dict-shuffling, and keeping this function
+    self-contained means a caller reaching for semantic data alone (as the
+    JSON API does) never has to thread a ``pre`` through from somewhere else.
+    The expensive part this isolates is ``_semantic_payload`` — fetching
+    embeddings for up to 2000 nodes, then PCA (or UMAP) over them — which the
+    HTML path below runs unconditionally on every render.
+    """
+    pre = preprocess(graph_data, schema_data=schema_data)
+    positions, clusters = await _semantic_payload(pre)
+    return {"semantic_positions": positions, "semantic_clusters": clusters}
+
+
+def build_brain_summary_payload(dataset_name: str, graph_data) -> dict:
+    """One dataset's graph, in the shape a multi-dataset overview needs.
+
+    ``{"name", "nodes", "links", "node_set_colors"}`` — not the full
+    ``build_visualization_payload`` shape, because this is meant to be called
+    once per dataset a user can read (see ``visualize.build_brains_payload``)
+    and schema_graph/memory_map/pipeline_stages/etc. are one dataset's worth
+    of detail that an overview showing many datasets at once does not need
+    multiplied by each of them.
+
+    This is also, deliberately, the exact shape a static Business-view export
+    already embeds per dataset under a top-level ``brainsData`` object keyed
+    by dataset id — matching it means a client built against that export
+    reads this from a live endpoint with no adaptation.
+    """
+    pre = preprocess(graph_data)
+    return {
+        "name": dataset_name,
+        "nodes": pre.nodes,
+        "links": pre.links,
+        "node_set_colors": pre.color_maps.get("node_set", {}),
+    }
 
 
 _TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "template.html")

--- a/cognee/tests/unit/api/test_build_brains_payload.py
+++ b/cognee/tests/unit/api/test_build_brains_payload.py
@@ -1,0 +1,73 @@
+"""build_brains_payload: the overview across every dataset a user may read.
+
+Patches at the ``fetch_dataset_graph_data`` boundary rather than the graph
+engine: seed resolution and bounded truncation are already exercised end to
+end in test_visualize_subgraph.py, and get_all_user_permission_datasets is
+CLO-399's existing group-aware union, not new here. What is new, and what
+this pins, is the loop and keying logic in build_brains_payload itself —
+one independent fetch per authorized dataset, assembled into a dict keyed by
+dataset id with the {"name", "nodes", "links", "node_set_colors"} shape, not
+the full visualize payload.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Same shadowing gotcha as test_visualize_subgraph.py: cognee.api.v1.__init__
+# rebinds `visualize` on the v1 package to the visualize_graph *function*, so a
+# dotted-string patch target has to go through sys.modules instead.
+from cognee.api.v1.visualize.visualize import build_brains_payload as _build_brains_payload  # noqa: F401,E501
+
+visualize_module = sys.modules["cognee.api.v1.visualize.visualize"]
+
+
+def _dataset(dataset_id: str, name: str):
+    return SimpleNamespace(id=dataset_id, name=name, owner_id="owner-1")
+
+
+def _graph_for(label: str):
+    return (
+        [(f"{label}-n1", {"type": "Entity", "name": label})],
+        [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_each_dataset_gets_its_own_fetch_keyed_by_id():
+    datasets = [_dataset("D1", "billing"), _dataset("D2", "support")]
+    fetched_for = []
+
+    async def fake_fetch(dataset, **_kwargs):
+        fetched_for.append(dataset.id)
+        return _graph_for(dataset.name)
+
+    with (
+        patch.object(
+            visualize_module,
+            "get_all_user_permission_datasets",
+            AsyncMock(return_value=datasets),
+        ),
+        patch.object(visualize_module, "fetch_dataset_graph_data", fake_fetch),
+    ):
+        payload = await visualize_module.build_brains_payload(user=MagicMock())
+
+    assert set(payload) == {"D1", "D2"}
+    assert payload["D1"]["name"] == "billing"
+    assert payload["D2"]["name"] == "support"
+    assert set(payload["D1"]) == {"name", "nodes", "links", "node_set_colors"}
+    # One fetch per dataset, not a single fetch reused for both — each
+    # dataset's data lives behind its own dataset-scoped read.
+    assert fetched_for == ["D1", "D2"]
+
+
+@pytest.mark.asyncio
+async def test_no_datasets_is_an_empty_payload_not_an_error():
+    with patch.object(
+        visualize_module, "get_all_user_permission_datasets", AsyncMock(return_value=[])
+    ):
+        payload = await visualize_module.build_brains_payload(user=MagicMock())
+
+    assert payload == {}

--- a/cognee/tests/unit/api/test_live_events.py
+++ b/cognee/tests/unit/api/test_live_events.py
@@ -1,0 +1,125 @@
+"""get_live_events: the delta cursor for the Memory tab's live timeline.
+
+Authorization and session-event collection are mocked (get_authorized_
+existing_datasets, collect_session_events); what this pins is the cursor
+arithmetic itself — strict '>' filtering so nothing repeats, the response
+cursor coming from the newest delivered event rather than being re-derived,
+and datetime.now(timezone.utc)-vs-naive-UTC-string comparisons not raising.
+"""
+
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cognee.api.v1.visualize.visualize import get_live_events as _get_live_events  # noqa: F401,E501
+from cognee.modules.users.exceptions import PermissionDeniedError
+
+visualize_module = sys.modules["cognee.api.v1.visualize.visualize"]
+
+DATASET_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _event(time: str, kind: str = "search"):
+    return {"kind": kind, "time": time, "qa_id": time}
+
+
+def _patches(events, authorized=True):
+    return (
+        patch.object(
+            visualize_module,
+            "get_authorized_existing_datasets",
+            AsyncMock(return_value=[SimpleNamespace(id=DATASET_ID)] if authorized else []),
+        ),
+        patch.object(visualize_module, "collect_session_events", AsyncMock(return_value=events)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_since_returns_every_event_and_cursor_is_the_newest():
+    events = [_event("2026-08-03T09:00:00.000000"), _event("2026-08-03T09:00:05.000000")]
+
+    ctx_a, ctx_b = _patches(events)
+    with ctx_a, ctx_b:
+        result = await visualize_module.get_live_events(DATASET_ID)
+
+    assert result["events"] == events
+    assert result["cursor"] == "2026-08-03T09:00:05.000000"
+
+
+@pytest.mark.asyncio
+async def test_since_filters_strictly_greater_so_the_cursor_event_never_repeats():
+    events = [
+        _event("2026-08-03T09:00:00.000000"),
+        _event("2026-08-03T09:00:05.000000"),
+        _event("2026-08-03T09:00:10.000000"),
+    ]
+
+    ctx_a, ctx_b = _patches(events)
+    with ctx_a, ctx_b:
+        result = await visualize_module.get_live_events(
+            DATASET_ID, since=datetime(2026, 8, 3, 9, 0, 5)
+        )
+
+    # The event AT the cursor is excluded — only strictly newer ones return.
+    assert result["events"] == [_event("2026-08-03T09:00:10.000000")]
+    assert result["cursor"] == "2026-08-03T09:00:10.000000"
+
+
+@pytest.mark.asyncio
+async def test_nothing_new_echoes_the_given_since_back_as_cursor():
+    events = [_event("2026-08-03T09:00:00.000000")]
+    since = datetime(2026, 8, 3, 9, 30, 0)
+
+    ctx_a, ctx_b = _patches(events)
+    with ctx_a, ctx_b:
+        result = await visualize_module.get_live_events(DATASET_ID, since=since)
+
+    assert result["events"] == []
+    assert result["cursor"] == since.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_first_call_with_nothing_available_has_a_null_cursor():
+    ctx_a, ctx_b = _patches([])
+    with ctx_a, ctx_b:
+        result = await visualize_module.get_live_events(DATASET_ID)
+
+    assert result == {"events": [], "cursor": None}
+
+
+@pytest.mark.asyncio
+async def test_timezone_aware_since_is_normalized_before_comparing():
+    """The write side stamps naive UTC strings; an aware `since` (a client
+    that includes an offset) must not raise trying to compare against them."""
+    events = [_event("2026-08-03T09:00:10.000000")]
+    aware_since = datetime(2026, 8, 3, 9, 0, 5, tzinfo=timezone.utc)
+
+    ctx_a, ctx_b = _patches(events)
+    with ctx_a, ctx_b:
+        result = await visualize_module.get_live_events(DATASET_ID, since=aware_since)
+
+    assert result["events"] == events
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_dataset_raises_permission_denied():
+    ctx_a, ctx_b = _patches([], authorized=False)
+    with ctx_a, ctx_b:
+        with pytest.raises(PermissionDeniedError):
+            await visualize_module.get_live_events(DATASET_ID)
+
+
+@pytest.mark.asyncio
+async def test_an_event_with_no_time_is_dropped_by_a_since_filter_rather_than_crashing():
+    events = [{"kind": "search", "qa_id": "malformed"}, _event("2026-08-03T09:00:10.000000")]
+
+    ctx_a, ctx_b = _patches(events)
+    with ctx_a, ctx_b:
+        result = await visualize_module.get_live_events(
+            DATASET_ID, since=datetime(2026, 8, 3, 9, 0, 0)
+        )
+
+    assert result["events"] == [_event("2026-08-03T09:00:10.000000")]

--- a/cognee/tests/unit/api/test_memory_provenance.py
+++ b/cognee/tests/unit/api/test_memory_provenance.py
@@ -116,3 +116,78 @@ def test_dangling_references_are_skipped():
         datasets=[{"id": "D1", "name": "Fleet", "owner_id": "U9", "tenant_id": "T"}],
     )
     assert not any(t == "dataset:D1" and rel == "owns" for _, t, rel in edges)
+
+
+def test_role_nodes_and_membership():
+    """CLO-401: memory_provenance.py only read Tenant/User, so a role — a
+    group of people with shared dataset access — had no node at all."""
+    node_types, edges = _build(
+        roles=[{"id": "R1", "name": "billing", "tenant_id": "T", "user_ids": ["U1", "U2"]}],
+    )
+    assert node_types["role:R1"] == "Role"
+    assert ("tenant:T", "role:R1", "has_role") in edges
+    assert ("role:R1", "user:U1", "has_member") in edges
+    assert ("role:R1", "user:U2", "has_member") in edges
+
+
+def test_role_without_a_tenant_id_still_gets_a_node_but_no_has_role_edge():
+    node_types, edges = _build(
+        roles=[{"id": "R1", "name": "orphan", "user_ids": []}],
+    )
+    assert node_types["role:R1"] == "Role"
+    assert not any(t == "role:R1" and rel == "has_role" for _, t, rel in edges)
+
+
+def test_acl_grants_reach_role_user_and_tenant_principals():
+    """A dataset shared via a grant (ShareDatasetModal: group, person, or the
+    whole workspace) is invisible in provenance unless the grant itself is
+    projected — ownership alone does not tell that story."""
+    _, edges = _build(
+        roles=[{"id": "R1", "name": "billing", "tenant_id": "T", "user_ids": ["U1"]}],
+        acl_grants=[
+            {
+                "principal_id": "R1",
+                "principal_kind": "role",
+                "dataset_id": "D1",
+                "permission": "read",
+            },
+            {
+                "principal_id": "R1",
+                "principal_kind": "role",
+                "dataset_id": "D1",
+                "permission": "write",
+            },
+            {
+                "principal_id": "U2",
+                "principal_kind": "user",
+                "dataset_id": "D2",
+                "permission": "share",
+            },
+            {
+                "principal_id": "T",
+                "principal_kind": "tenant",
+                "dataset_id": "D1",
+                "permission": "delete",
+            },
+        ],
+    )
+    assert ("role:R1", "dataset:D1", "reads") in edges
+    assert ("role:R1", "dataset:D1", "writes") in edges
+    assert ("user:U2", "dataset:D2", "can_share") in edges
+    assert ("tenant:T", "dataset:D1", "can_delete") in edges
+
+
+def test_acl_grant_on_a_principal_outside_scope_produces_no_edge():
+    """The principal never became a node (it was filtered out of scope
+    upstream), so the grant edge for it must not appear either."""
+    _, edges = _build(
+        acl_grants=[
+            {
+                "principal_id": "R-not-in-scope",
+                "principal_kind": "role",
+                "dataset_id": "D1",
+                "permission": "read",
+            },
+        ],
+    )
+    assert not any(s == "role:R-not-in-scope" for s, _, _ in edges)

--- a/cognee/tests/unit/api/test_memory_provenance_role_grants.py
+++ b/cognee/tests/unit/api/test_memory_provenance_role_grants.py
@@ -1,0 +1,237 @@
+"""_read_roles_and_grants runs against a real database.
+
+Mocking cannot cover the failure this exists to catch: CLO-399's own
+dataset-groups endpoint first read Principal.id/Principal.type through an
+outer join across User/Role/Tenant and got a user labelled "tenant" back,
+because the ORM tried to resolve one polymorphic identity across three
+subclass tables at once. That only shows up against a real schema.
+"""
+
+import asyncio
+import os
+import pathlib
+from uuid import uuid4
+
+import pytest
+
+import cognee
+
+_SYSTEM_ROOT = str(
+    pathlib.Path(
+        os.path.join(
+            pathlib.Path(__file__).parent.parent.parent,
+            ".cognee_system/test_memory_provenance_role_grants",
+        )
+    ).resolve()
+)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _isolated_db():
+    from cognee.infrastructure.databases.relational.create_relational_engine import (
+        create_relational_engine,
+    )
+
+    cognee.config.system_root_directory(_SYSTEM_ROOT)
+    create_relational_engine.cache_clear()
+
+    async def _run():
+        from cognee.infrastructure.databases.relational import get_relational_engine
+
+        import cognee.modules.data.models  # noqa: F401
+        import cognee.modules.users.models  # noqa: F401
+
+        await get_relational_engine().create_database()
+
+    asyncio.run(_run())
+    create_relational_engine.cache_clear()
+
+
+async def _permission_id(session, name: str):
+    """Return the id of the named permission, creating the row the first time.
+
+    Permission.name is unique, and this module's DB is shared across every
+    test in the file (module-scoped fixture), so a plain insert on the second
+    call collides with the first.
+    """
+    from sqlalchemy import select
+
+    from cognee.modules.users.models import Permission
+
+    existing = (
+        (await session.execute(select(Permission).where(Permission.name == name))).scalars().first()
+    )
+    if existing is not None:
+        return existing.id
+
+    permission = Permission(id=uuid4(), name=name)
+    session.add(permission)
+    await session.flush()
+    return permission.id
+
+
+async def _seed():
+    """One tenant, two users, one role with one member, one dataset, and a
+    grant on each of the three principal kinds — role, user, tenant."""
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.data.models import Dataset
+    from cognee.modules.users.models import ACL, Permission, Role, Tenant, User, UserRole
+
+    tenant_id = uuid4()
+    owner_id = uuid4()
+    member_id = uuid4()
+    role_id = uuid4()
+    dataset_id = uuid4()
+
+    db_engine = get_relational_engine()
+    async with db_engine.get_async_session() as session:
+        session.add(Tenant(id=tenant_id, name="Acme", owner_id=owner_id))
+        for user_id in (owner_id, member_id):
+            session.add(
+                User(
+                    id=user_id,
+                    email=f"{user_id}@example.com",
+                    hashed_password="x",
+                    is_active=True,
+                    is_superuser=False,
+                    is_verified=True,
+                    tenant_id=tenant_id,
+                )
+            )
+        await session.flush()
+
+        session.add(Role(id=role_id, name="billing", tenant_id=tenant_id))
+        await session.flush()
+        session.add(UserRole(user_id=member_id, role_id=role_id))
+
+        session.add(Dataset(id=dataset_id, name="ds", owner_id=owner_id, tenant_id=tenant_id))
+        await session.flush()
+
+        read_id = await _permission_id(session, "read")
+        write_id = await _permission_id(session, "write")
+
+        session.add_all(
+            [
+                ACL(principal_id=role_id, permission_id=read_id, dataset_id=dataset_id),
+                ACL(principal_id=member_id, permission_id=read_id, dataset_id=dataset_id),
+                ACL(principal_id=tenant_id, permission_id=write_id, dataset_id=dataset_id),
+            ]
+        )
+        await session.commit()
+
+    return {
+        "tenant_id": tenant_id,
+        "owner_id": owner_id,
+        "member_id": member_id,
+        "role_id": role_id,
+        "dataset_id": dataset_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_role_membership_and_grant_kinds_are_labelled_correctly():
+    from cognee.api.v1.visualize.memory_provenance import _read_roles_and_grants
+
+    seed = await _seed()
+
+    roles, grants = await _read_roles_and_grants(
+        tenant_ids=[seed["tenant_id"]],
+        dataset_ids=[str(seed["dataset_id"])],
+    )
+
+    assert len(roles) == 1
+    assert roles[0]["id"] == str(seed["role_id"])
+    assert roles[0]["user_ids"] == [str(seed["member_id"])]
+
+    by_principal = {(g["principal_id"], g["permission"]): g["principal_kind"] for g in grants}
+    assert by_principal[(str(seed["role_id"]), "read")] == "role"
+    assert by_principal[(str(seed["member_id"]), "read")] == "user"
+    assert by_principal[(str(seed["tenant_id"]), "write")] == "tenant"
+    # The bug this test exists for: none of the three may be mislabelled as
+    # one of the others.
+    assert len(by_principal) == 3
+
+
+@pytest.mark.asyncio
+async def test_role_in_another_tenant_is_excluded_by_tenant_scope():
+    from cognee.api.v1.visualize.memory_provenance import _read_roles_and_grants
+
+    seed = await _seed()
+
+    roles, _ = await _read_roles_and_grants(
+        tenant_ids=[uuid4()],
+        dataset_ids=[str(seed["dataset_id"])],
+    )
+
+    assert roles == []
+
+
+@pytest.mark.asyncio
+async def test_no_tenant_scope_keeps_only_roles_the_scoped_users_belong_to():
+    """The OSS/single-user path: no tenant to filter by, so membership does
+    the scoping instead."""
+    from cognee.api.v1.visualize.memory_provenance import _read_roles_and_grants
+
+    seed = await _seed()
+
+    in_scope, _ = await _read_roles_and_grants(
+        tenant_ids=None,
+        dataset_ids=[str(seed["dataset_id"])],
+        scope_user_ids=[str(seed["member_id"])],
+    )
+    out_of_scope, _ = await _read_roles_and_grants(
+        tenant_ids=None,
+        dataset_ids=[str(seed["dataset_id"])],
+        scope_user_ids=[str(seed["owner_id"])],
+    )
+
+    assert len(in_scope) == 1
+    assert in_scope[0]["id"] == str(seed["role_id"])
+    assert out_of_scope == []
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provenance_graph_includes_the_role_and_its_grant():
+    """End-to-end through the public entry point, not just the private reader."""
+    from cognee.api.v1.visualize.memory_provenance import get_memory_provenance_graph
+
+    seed = await _seed()
+
+    nodes, edges = await get_memory_provenance_graph(scope_tenant_ids=[seed["tenant_id"]])
+
+    node_types = {nid: props["type"] for nid, props in nodes}
+    edge_set = {(s, t, rel) for s, t, rel, _ in edges}
+
+    role_id = str(seed["role_id"])
+    tenant_id = str(seed["tenant_id"])
+    dataset_id = str(seed["dataset_id"])
+    member_id = str(seed["member_id"])
+
+    assert node_types[f"role:{role_id}"] == "Role"
+    assert (f"tenant:{tenant_id}", f"role:{role_id}", "has_role") in edge_set
+    assert (f"role:{role_id}", f"user:{member_id}", "has_member") in edge_set
+    assert (f"role:{role_id}", f"dataset:{dataset_id}", "reads") in edge_set
+    assert (f"tenant:{tenant_id}", f"dataset:{dataset_id}", "writes") in edge_set
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provenance_payload_is_json_safe_and_carries_the_role():
+    """CLO-401's provenance-as-JSON, routed through the same
+    build_visualization_payload as the dataset-visualization JSON endpoint —
+    proof the two share one preprocess() call rather than two shapes that
+    could drift."""
+    import json
+
+    from cognee.api.v1.visualize.memory_provenance import get_memory_provenance_payload
+
+    seed = await _seed()
+
+    payload = await get_memory_provenance_payload(scope_tenant_ids=[seed["tenant_id"]])
+
+    json.dumps(payload)  # must not raise
+    for field in ("nodes", "links", "color_maps", "provenance_index", "search_events"):
+        assert field in payload
+
+    role_id = str(seed["role_id"])
+    node_names = {n["id"]: n.get("name") for n in payload["nodes"]}
+    assert f"role:{role_id}" in node_names

--- a/cognee/tests/unit/modules/visualization/test_visualization_payload.py
+++ b/cognee/tests/unit/modules/visualization/test_visualization_payload.py
@@ -1,0 +1,104 @@
+"""build_visualization_payload / build_semantic_payload: the JSON API surface.
+
+The one thing worth pinning here that test_preprocessor.py does not: the
+whole payload has to survive a real ``json.dumps``, including
+``provenance_index`` — the field CLO-401 flagged as unverified because it is
+the one dataclass field that does not pass through ``_safe_json_embed`` on
+the HTML path today. If a UUID, datetime or other non-JSON-safe value ever
+reached it, this is where that would show up first.
+"""
+
+import json
+
+from cognee.modules.visualization.cognee_network_visualization import (
+    build_brain_summary_payload,
+    build_semantic_payload,
+    build_visualization_payload,
+)
+from cognee.tests.unit.modules.visualization.test_preprocessor import _alice_like_graph
+
+
+def test_payload_is_json_serializable_including_provenance_index():
+    payload = build_visualization_payload(_alice_like_graph())
+
+    encoded = json.dumps(payload)
+
+    # provenance_index is keyed off the same nodes that source_pipeline /
+    # source_task above, so the fixture must actually populate it — an empty
+    # dict here would mean this test passed for the wrong reason.
+    assert payload["provenance_index"]
+    assert json.loads(encoded)["provenance_index"] == payload["provenance_index"]
+
+
+def test_payload_carries_every_preprocessed_graph_field():
+    """Not the eight HTML tokens — asdict(pre) in full.
+
+    pipeline_stages, edge_classes, bundles, provenance_index and
+    has_meaningful_topological_rank never become template tokens on the HTML
+    path (the view modules read them off `pre` directly through emit_js), so
+    a curated subset would silently drop them from the JSON client.
+    """
+    payload = build_visualization_payload(_alice_like_graph())
+
+    for field in (
+        "nodes",
+        "links",
+        "color_maps",
+        "schema_graph",
+        "schema_data",
+        "pipeline_stages",
+        "edge_classes",
+        "bundles",
+        "provenance_index",
+        "has_meaningful_topological_rank",
+        "memory_map",
+        "search_events",
+    ):
+        assert field in payload, f"missing {field}"
+
+
+def test_search_events_default_to_an_empty_list():
+    payload = build_visualization_payload(_alice_like_graph())
+
+    assert payload["search_events"] == []
+
+
+def test_search_events_pass_through_when_given():
+    events = [{"kind": "search", "time": "2026-06-10T10:31:02", "qa_id": "q1"}]
+
+    payload = build_visualization_payload(_alice_like_graph(), search_events=events)
+
+    assert payload["search_events"] == events
+
+
+def test_semantic_payload_has_no_embeddings_to_lay_out():
+    """No embedding fetch is wired into this fixture, so the honest answer is
+    null/null — not an exception, and not a fabricated layout.
+
+    Run via asyncio.run rather than the asyncio marker so this file carries
+    no plugin dependency beyond what the rest of the suite already uses.
+    """
+    import asyncio
+
+    result = asyncio.run(build_semantic_payload(_alice_like_graph()))
+
+    assert result == {"semantic_positions": None, "semantic_clusters": None}
+    json.dumps(result)
+
+
+def test_brain_summary_payload_matches_the_business_export_contract():
+    """{"name", "nodes", "links", "node_set_colors"} — the exact per-dataset
+    shape a static Business-view export already embeds under a top-level
+    ``brainsData`` object keyed by dataset id (see CLO-401's description of
+    that export), so a client built against it needs no adaptation to read
+    this from a live endpoint. Nothing more, nothing less: schema_graph,
+    memory_map and the rest of PreprocessedGraph are deliberately absent —
+    they are one dataset's worth of detail, and this shape gets called once
+    per dataset a user can read."""
+    payload = build_brain_summary_payload("billing", _alice_like_graph())
+
+    assert set(payload) == {"name", "nodes", "links", "node_set_colors"}
+    assert payload["name"] == "billing"
+    assert payload["nodes"]
+    assert payload["links"]
+    json.dumps(payload)


### PR DESCRIPTION
## Description

The `/visualize` HTML page and its multi-user variant were the only way to get a dataset's graph out of cognee - no programmatic JSON access existed, so any external UI (e.g. a custom knowledge-graph dashboard) had no supported way to consume the same data.

Adds JSON-returning siblings alongside the existing HTML endpoints: graph, semantic layout, schema/provenance, per-dataset "brains" summaries, and live search-session events. Refactors the shared fetch/authorize/bound logic (`fetch_visualization_data`, `fetch_dataset_graph_data`) so the HTML and JSON paths run through the identical authorized, bounded graph read instead of diverging.

Covered by new unit tests for the brains payload, live events, memory provenance role grants, and the visualization payload builder.

## Acceptance Criteria

- `GET /v1/visualize/json` returns the same authorized, bounded graph as `GET /v1/visualize` for a dataset, serialized as JSON instead of HTML
- A semantic-layout JSON endpoint exists and is only computed when requested (no cost paid by callers who never open the semantic view)
- A JSON endpoint exposes memory/schema provenance data
- A per-dataset "brains" summary endpoint and a live search-session-events endpoint exist for building an external dashboard on top of cognee's graph data
- All endpoints enforce the same read-permission checks as their HTML counterparts

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

31 passed, 0 failed - `pytest cognee/tests/unit/api/test_build_brains_payload.py cognee/tests/unit/api/test_live_events.py cognee/tests/unit/api/test_memory_provenance_role_grants.py cognee/tests/unit/modules/visualization/test_visualization_payload.py cognee/tests/unit/api/test_memory_provenance.py`

`ruff check` on all changed files: all checks passed.

## Pre-submission Checklist

- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.