### PR TITLE
feat(telemetry): Add tenant-local sink, fix event identity (COG-6062)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -395,6 +395,30 @@ LITELLM_LOG="ERROR"
 #DEFAULT_USER_EMAIL=""
 #DEFAULT_USER_PASSWORD=""
 
+# -- Product Telemetry ---------------------------------------------------------
+# Where telemetry events go. Comma-separated, so a deployment can write to more
+# than one place:
+#   http     (default) POST to the analytics proxy
+#   postgres store in this deployment's own relational DB as a rolling window,
+#            readable via GET /v1/activity/events. Nothing leaves the machine.
+# e.g. "postgres" for local-only, "postgres,http" for both.
+#TELEMETRY_SINK="http"
+# Point the http sink at your own collector instead of the default proxy.
+#TELEMETRY_ENDPOINT="https://telemetry.example.com"
+# Labels which interface a call came through ("api", "mcp", "cli", …). The API
+# sets this per request from the X-Cognee-Client header; this is the fallback.
+#TELEMETRY_ORIGIN="sdk"
+# How long the postgres sink keeps events before pruning them.
+#TELEMETRY_RETENTION_DAYS=30
+# Postgres-sink buffering. Events are batched rather than written one at a time;
+# the buffer is bounded and drops the oldest events rather than ever blocking.
+#TELEMETRY_BUFFER_MAX=5000
+#TELEMETRY_FLUSH_INTERVAL=5
+#TELEMETRY_FLUSH_BATCH=200
+# Overrides the machine-level analytics id. Set this when the filesystem is
+# ephemeral (containers), or the id is regenerated on every restart.
+#TRACKING_ID=""
+
 # -- Cognee Logging -----------------------------------------------------------
 # Console log level: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: INFO)
 #LOG_LEVEL="INFO"

--- a/cognee/alembic/env.py
+++ b/cognee/alembic/env.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 from cognee.infrastructure.databases.relational import get_relational_engine, Base
 import cognee.modules.session_lifecycle.models  # noqa: F401
 import cognee.modules.migrations.models  # noqa: F401
+import cognee.modules.telemetry.models  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/cognee/alembic/versions/a3f7c1b9d2e4_add_telemetry_events.py
+++ b/cognee/alembic/versions/a3f7c1b9d2e4_add_telemetry_events.py
@@ -31,6 +31,8 @@ def upgrade() -> None:
         "telemetry_events",
         sa.Column("id", sa.UUID(), primary_key=True),
         sa.Column("event_name", sa.String(), nullable=True),
+        sa.Column("operation", sa.String(), nullable=True),
+        sa.Column("event_kind", sa.String(), nullable=True),
         sa.Column("user_id", sa.UUID(), nullable=True),
         sa.Column("tenant_id", sa.UUID(), nullable=True),
         sa.Column("dataset_id", sa.UUID(), nullable=True),
@@ -41,6 +43,8 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
     )
     op.create_index("ix_telemetry_events_event_name", "telemetry_events", ["event_name"])
+    op.create_index("ix_telemetry_events_operation", "telemetry_events", ["operation"])
+    op.create_index("ix_telemetry_events_event_kind", "telemetry_events", ["event_kind"])
     op.create_index("ix_telemetry_events_user_id", "telemetry_events", ["user_id"])
     op.create_index("ix_telemetry_events_tenant_id", "telemetry_events", ["tenant_id"])
     op.create_index("ix_telemetry_events_dataset_id", "telemetry_events", ["dataset_id"])

--- a/cognee/alembic/versions/a3f7c1b9d2e4_add_telemetry_events.py
+++ b/cognee/alembic/versions/a3f7c1b9d2e4_add_telemetry_events.py
@@ -1,0 +1,48 @@
+"""Add telemetry_events table
+
+Backs the local telemetry sink (``TELEMETRY_SINK=postgres``). Unused by
+deployments on the default HTTP sink, so creating it is harmless there.
+
+Revision ID: a3f7c1b9d2e4
+Revises: c3d5e7f9a1b2
+Create Date: 2026-08-04
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision: str = "a3f7c1b9d2e4"
+down_revision: Union[str, None] = "c3d5e7f9a1b2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+    if "telemetry_events" in insp.get_table_names():
+        return
+
+    op.create_table(
+        "telemetry_events",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("event_name", sa.String(), nullable=True),
+        sa.Column("user_id", sa.UUID(), nullable=True),
+        sa.Column("tenant_id", sa.UUID(), nullable=True),
+        sa.Column("anonymous_id", sa.String(), nullable=True),
+        sa.Column("properties", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_telemetry_events_event_name", "telemetry_events", ["event_name"])
+    op.create_index("ix_telemetry_events_user_id", "telemetry_events", ["user_id"])
+    op.create_index("ix_telemetry_events_tenant_id", "telemetry_events", ["tenant_id"])
+    # The retention prune and every read path filter on created_at.
+    op.create_index("ix_telemetry_events_created_at", "telemetry_events", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("telemetry_events")

--- a/cognee/alembic/versions/a3f7c1b9d2e4_add_telemetry_events.py
+++ b/cognee/alembic/versions/a3f7c1b9d2e4_add_telemetry_events.py
@@ -33,6 +33,7 @@ def upgrade() -> None:
         sa.Column("event_name", sa.String(), nullable=True),
         sa.Column("user_id", sa.UUID(), nullable=True),
         sa.Column("tenant_id", sa.UUID(), nullable=True),
+        sa.Column("dataset_id", sa.UUID(), nullable=True),
         sa.Column("anonymous_id", sa.String(), nullable=True),
         sa.Column("properties", sa.JSON(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
@@ -40,6 +41,7 @@ def upgrade() -> None:
     op.create_index("ix_telemetry_events_event_name", "telemetry_events", ["event_name"])
     op.create_index("ix_telemetry_events_user_id", "telemetry_events", ["user_id"])
     op.create_index("ix_telemetry_events_tenant_id", "telemetry_events", ["tenant_id"])
+    op.create_index("ix_telemetry_events_dataset_id", "telemetry_events", ["dataset_id"])
     # The retention prune and every read path filter on created_at.
     op.create_index("ix_telemetry_events_created_at", "telemetry_events", ["created_at"])
 

--- a/cognee/alembic/versions/a3f7c1b9d2e4_add_telemetry_events.py
+++ b/cognee/alembic/versions/a3f7c1b9d2e4_add_telemetry_events.py
@@ -34,6 +34,8 @@ def upgrade() -> None:
         sa.Column("user_id", sa.UUID(), nullable=True),
         sa.Column("tenant_id", sa.UUID(), nullable=True),
         sa.Column("dataset_id", sa.UUID(), nullable=True),
+        sa.Column("pipeline_run_id", sa.UUID(), nullable=True),
+        sa.Column("origin", sa.String(), nullable=True),
         sa.Column("anonymous_id", sa.String(), nullable=True),
         sa.Column("properties", sa.JSON(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
@@ -42,6 +44,8 @@ def upgrade() -> None:
     op.create_index("ix_telemetry_events_user_id", "telemetry_events", ["user_id"])
     op.create_index("ix_telemetry_events_tenant_id", "telemetry_events", ["tenant_id"])
     op.create_index("ix_telemetry_events_dataset_id", "telemetry_events", ["dataset_id"])
+    op.create_index("ix_telemetry_events_pipeline_run_id", "telemetry_events", ["pipeline_run_id"])
+    op.create_index("ix_telemetry_events_origin", "telemetry_events", ["origin"])
     # The retention prune and every read path filter on created_at.
     op.create_index("ix_telemetry_events_created_at", "telemetry_events", ["created_at"])
 

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -91,6 +91,16 @@ async def lifespan(app: FastAPI):
 
     yield
 
+    # Drain buffered telemetry before the DB engines go away. The local sink
+    # batches on an interval, so without this every restart loses its last
+    # window of events — noticeable on a hosted deployment that redeploys often.
+    try:
+        from cognee.modules.telemetry.postgres_sink import flush as flush_telemetry
+
+        await flush_telemetry()
+    except Exception as error:
+        logger.debug("Telemetry flush on shutdown failed: %s", error)
+
     # Flush and close all cached database adapters so Ladybug can
     # CHECKPOINT its WAL before the process exits.  Without this,
     # a SIGTERM during an active WAL write leaves a half-written

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -136,6 +136,27 @@ app.add_middleware(
     allow_methods=["OPTIONS", "GET", "PUT", "POST", "DELETE"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def tag_telemetry_origin(request: Request, call_next):
+    """Label this request's telemetry with the interface it came through.
+
+    Clients that identify themselves (`X-Cognee-Client: mcp`, a coding-agent
+    name, …) are recorded verbatim; everything else is plain `api`. Without this
+    every cloud event looks identical and there is no way to tell an MCP or
+    coding-agent call from someone using the dashboard.
+    """
+    from cognee.context_global_variables import telemetry_origin
+
+    client = (request.headers.get("x-cognee-client") or "api").strip()[:64]
+    token = telemetry_origin.set(client or "api")
+    try:
+        return await call_next(request)
+    finally:
+        telemetry_origin.reset(token)
+
+
 # To allow origins, set CORS_ALLOWED_ORIGINS env variable to a comma-separated list, e.g.:
 # CORS_ALLOWED_ORIGINS="https://yourdomain.com,https://another.com"
 

--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -400,4 +400,61 @@ def get_activity_router() -> APIRouter:
             headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         )
 
+    @router.get("/events")
+    async def get_telemetry_events(
+        days: int = Query(30, ge=1, le=90),
+        event_name: Optional[str] = Query(None),
+        limit: int = Query(500, ge=1, le=5000),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """Return recent telemetry events recorded by the local sink.
+
+        Empty unless the deployment runs with ``TELEMETRY_SINK=postgres`` — the
+        table exists everywhere but only that sink writes to it.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from sqlalchemy import select
+
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.telemetry.models.TelemetryEvent import TelemetryEvent
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+        stmt = (
+            select(TelemetryEvent)
+            .where(TelemetryEvent.created_at >= cutoff)
+            .order_by(TelemetryEvent.created_at.desc())
+            .limit(limit)
+        )
+        # The relational DB is per-tenant on hosted deployments, so rows are
+        # already scoped. Filter anyway: a shared-DB deployment must not leak
+        # another tenant's events through this endpoint.
+        if user.tenant_id:
+            stmt = stmt.where(TelemetryEvent.tenant_id == user.tenant_id)
+        if event_name:
+            stmt = stmt.where(TelemetryEvent.event_name == event_name)
+
+        db_engine = get_relational_engine()
+        try:
+            async with db_engine.get_async_session() as session:
+                result = await session.execute(stmt)
+                events = result.scalars().all()
+        except Exception:
+            # Table absent (migration not yet applied) — an empty feed is the
+            # right answer for a UI, not a 500.
+            return []
+
+        return [
+            {
+                "id": str(event.id),
+                "event_name": event.event_name,
+                "user_id": str(event.user_id) if event.user_id else None,
+                "tenant_id": str(event.tenant_id) if event.tenant_id else None,
+                "properties": event.properties,
+                "created_at": event.created_at.isoformat() if event.created_at else None,
+            }
+            for event in events
+        ]
+
     return router

--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -404,6 +404,7 @@ def get_activity_router() -> APIRouter:
     async def get_telemetry_events(
         days: int = Query(30, ge=1, le=90),
         event_name: Optional[str] = Query(None),
+        dataset_id: Optional[UUID] = Query(None),
         limit: int = Query(500, ge=1, le=5000),
         user: User = Depends(get_authenticated_user),
     ):
@@ -434,6 +435,8 @@ def get_activity_router() -> APIRouter:
             stmt = stmt.where(TelemetryEvent.tenant_id == user.tenant_id)
         if event_name:
             stmt = stmt.where(TelemetryEvent.event_name == event_name)
+        if dataset_id:
+            stmt = stmt.where(TelemetryEvent.dataset_id == dataset_id)
 
         db_engine = get_relational_engine()
         try:
@@ -451,6 +454,7 @@ def get_activity_router() -> APIRouter:
                 "event_name": event.event_name,
                 "user_id": str(event.user_id) if event.user_id else None,
                 "tenant_id": str(event.tenant_id) if event.tenant_id else None,
+                "dataset_id": str(event.dataset_id) if event.dataset_id else None,
                 "properties": event.properties,
                 "created_at": event.created_at.isoformat() if event.created_at else None,
             }

--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -405,6 +405,7 @@ def get_activity_router() -> APIRouter:
         days: int = Query(30, ge=1, le=90),
         event_name: Optional[str] = Query(None),
         dataset_id: Optional[UUID] = Query(None),
+        origin: Optional[str] = Query(None),
         limit: int = Query(500, ge=1, le=5000),
         user: User = Depends(get_authenticated_user),
     ):
@@ -437,6 +438,8 @@ def get_activity_router() -> APIRouter:
             stmt = stmt.where(TelemetryEvent.event_name == event_name)
         if dataset_id:
             stmt = stmt.where(TelemetryEvent.dataset_id == dataset_id)
+        if origin:
+            stmt = stmt.where(TelemetryEvent.origin == origin)
 
         db_engine = get_relational_engine()
         try:
@@ -455,6 +458,8 @@ def get_activity_router() -> APIRouter:
                 "user_id": str(event.user_id) if event.user_id else None,
                 "tenant_id": str(event.tenant_id) if event.tenant_id else None,
                 "dataset_id": str(event.dataset_id) if event.dataset_id else None,
+                "pipeline_run_id": str(event.pipeline_run_id) if event.pipeline_run_id else None,
+                "origin": event.origin,
                 "properties": event.properties,
                 "created_at": event.created_at.isoformat() if event.created_at else None,
             }

--- a/cognee/api/v1/activity/routers/get_activity_router.py
+++ b/cognee/api/v1/activity/routers/get_activity_router.py
@@ -404,6 +404,8 @@ def get_activity_router() -> APIRouter:
     async def get_telemetry_events(
         days: int = Query(30, ge=1, le=90),
         event_name: Optional[str] = Query(None),
+        operation: Optional[str] = Query(None),
+        event_kind: Optional[str] = Query(None),
         dataset_id: Optional[UUID] = Query(None),
         origin: Optional[str] = Query(None),
         limit: int = Query(500, ge=1, le=5000),
@@ -436,6 +438,12 @@ def get_activity_router() -> APIRouter:
             stmt = stmt.where(TelemetryEvent.tenant_id == user.tenant_id)
         if event_name:
             stmt = stmt.where(TelemetryEvent.event_name == event_name)
+        # Prefer these two over event_name: they are the stable contract, while
+        # event_name is the raw emitted string in one of several legacy styles.
+        if operation:
+            stmt = stmt.where(TelemetryEvent.operation == operation)
+        if event_kind:
+            stmt = stmt.where(TelemetryEvent.event_kind == event_kind)
         if dataset_id:
             stmt = stmt.where(TelemetryEvent.dataset_id == dataset_id)
         if origin:
@@ -455,6 +463,8 @@ def get_activity_router() -> APIRouter:
             {
                 "id": str(event.id),
                 "event_name": event.event_name,
+                "operation": event.operation,
+                "event_kind": event.event_kind,
                 "user_id": str(event.user_id) if event.user_id else None,
                 "tenant_id": str(event.tenant_id) if event.tenant_id else None,
                 "dataset_id": str(event.dataset_id) if event.dataset_id else None,

--- a/cognee/api/v1/add/routers/get_add_router.py
+++ b/cognee/api/v1/add/routers/get_add_router.py
@@ -95,7 +95,7 @@ def get_add_router() -> APIRouter:
         """
         send_telemetry(
             "Add API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/add",
                 "node_set": node_set,

--- a/cognee/api/v1/api_keys/routers/get_api_key_management_router.py
+++ b/cognee/api/v1/api_keys/routers/get_api_key_management_router.py
@@ -26,7 +26,7 @@ def get_api_key_management_router():
     async def get_api_keys_for_user(user: User = Depends(get_authenticated_user)):
         send_telemetry(
             "Api Key Management API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/auth/api-keys",
             },
@@ -63,7 +63,7 @@ def get_api_key_management_router():
     ):
         send_telemetry(
             "Api Key Management API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/auth/api-keys",
             },
@@ -89,7 +89,7 @@ def get_api_key_management_router():
     ):
         send_telemetry(
             "Api Key Management API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "DELETE /v1/auth/api-keys",
             },

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -188,7 +188,7 @@ def get_cognify_router() -> APIRouter:
         """
         send_telemetry(
             "Cognify API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/cognify",
                 "cognee_version": cognee_version,

--- a/cognee/api/v1/datasets/routers/get_datasets_router.py
+++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
@@ -122,7 +122,7 @@ def get_datasets_router() -> APIRouter:
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/datasets",
                 "cognee_version": cognee_version,
@@ -170,7 +170,7 @@ def get_datasets_router() -> APIRouter:
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/datasets",
                 "cognee_version": cognee_version,
@@ -235,7 +235,7 @@ def get_datasets_router() -> APIRouter:
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"DELETE /v1/datasets/{str(dataset_id)}",
                 "dataset_id": str(dataset_id),
@@ -285,7 +285,7 @@ def get_datasets_router() -> APIRouter:
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"DELETE /v1/datasets/{str(dataset_id)}/data/{str(data_id)}",
                 "dataset_id": str(dataset_id),
@@ -367,7 +367,7 @@ def get_datasets_router() -> APIRouter:
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"GET /v1/datasets/{str(dataset_id)}/data",
                 "dataset_id": str(dataset_id),
@@ -463,7 +463,7 @@ def get_datasets_router() -> APIRouter:
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/datasets/status",
                 "datasets": [str(dataset_id) for dataset_id in datasets],
@@ -524,7 +524,7 @@ def get_datasets_router() -> APIRouter:
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/datasets/graph-summary",
                 "dataset_ids": [str(dataset_id) for dataset_id in dataset_ids],
@@ -676,7 +676,7 @@ def get_datasets_router() -> APIRouter:
         """
         send_telemetry(
             "Datasets API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"GET /v1/datasets/{str(dataset_id)}/data/{str(data_id)}/raw",
                 "dataset_id": str(dataset_id),

--- a/cognee/api/v1/delete/routers/get_delete_router.py
+++ b/cognee/api/v1/delete/routers/get_delete_router.py
@@ -43,7 +43,7 @@ def get_delete_router() -> APIRouter:
         """
         send_telemetry(
             "Delete API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "DELETE /v1/delete",
                 "dataset_id": str(dataset_id),

--- a/cognee/api/v1/forget/routers/get_forget_router.py
+++ b/cognee/api/v1/forget/routers/get_forget_router.py
@@ -89,7 +89,7 @@ def get_forget_router() -> APIRouter:
         """
         send_telemetry(
             "Forget API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/forget",
                 "cognee_version": cognee_version,

--- a/cognee/api/v1/improve/improve.py
+++ b/cognee/api/v1/improve/improve.py
@@ -102,7 +102,7 @@ async def improve(
         # Enrich graph only (no session bridging)
         await cognee.improve(dataset="docs")
     """
-    from cognee.shared.utils import send_telemetry
+    from cognee.shared.utils import as_uuid, send_telemetry
     from cognee import __version__ as cognee_version
 
     stages_run = []
@@ -111,7 +111,13 @@ async def improve(
         "cognee.improve",
         kwargs.get("user", "sdk"),
         additional_properties={
+            # `dataset` accepts either a name or an id, so split it out: the
+            # activity table's dataset_id column can only be populated when the
+            # id is identifiable. `dataset` is kept as-is for the existing
+            # warehouse queries that read it.
             "dataset": str(dataset),
+            "dataset_id": str(dataset) if as_uuid(dataset) else "",
+            "dataset_name": "" if as_uuid(dataset) else str(dataset),
             "session_count": len(session_ids) if session_ids else 0,
             "session_ids": ",".join(session_ids) if session_ids else "",
             "run_in_background": run_in_background,

--- a/cognee/api/v1/improve/routers/get_improve_router.py
+++ b/cognee/api/v1/improve/routers/get_improve_router.py
@@ -65,7 +65,7 @@ def get_improve_router() -> APIRouter:
         """
         send_telemetry(
             "Improve API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/improve",
                 "cognee_version": cognee_version,

--- a/cognee/api/v1/llm/routers/get_llm_router.py
+++ b/cognee/api/v1/llm/routers/get_llm_router.py
@@ -215,7 +215,7 @@ def get_llm_router() -> APIRouter:
         """
         send_telemetry(
             "LLM Custom Prompt Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/llm/custom-prompt",
                 "response_model": "str",
@@ -273,7 +273,7 @@ def get_llm_router() -> APIRouter:
         """
         send_telemetry(
             "LLM Infer Schema Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/llm/infer-schema",
                 "filenames": [f.filename for f in (data or [])],

--- a/cognee/api/v1/memify/routers/get_memify_router.py
+++ b/cognee/api/v1/memify/routers/get_memify_router.py
@@ -85,7 +85,7 @@ def get_memify_router() -> APIRouter:
 
         send_telemetry(
             "Memify API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={"endpoint": "POST /v1/memify", "cognee_version": cognee_version},
         )
 

--- a/cognee/api/v1/ontologies/routers/get_ontology_router.py
+++ b/cognee/api/v1/ontologies/routers/get_ontology_router.py
@@ -60,7 +60,7 @@ def get_ontology_router() -> APIRouter:
         """
         send_telemetry(
             "Ontology Upload API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /api/v1/ontologies",
                 "cognee_version": cognee_version,
@@ -126,7 +126,7 @@ def get_ontology_router() -> APIRouter:
         """
         send_telemetry(
             "Ontology Delete API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "DELETE /api/v1/ontologies/{ontology_key}",
                 "cognee_version": cognee_version,
@@ -158,7 +158,7 @@ def get_ontology_router() -> APIRouter:
         """
         send_telemetry(
             "Ontology List API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /api/v1/ontologies",
                 "cognee_version": cognee_version,

--- a/cognee/api/v1/permissions/routers/get_permissions_router.py
+++ b/cognee/api/v1/permissions/routers/get_permissions_router.py
@@ -75,7 +75,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"POST /v1/permissions/datasets/{str(principal_id)}",
                 "dataset_ids": str(dataset_ids),
@@ -116,7 +116,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"DELETE /v1/permissions/datasets/{str(principal_id)}",
                 "dataset_ids": str(dataset_ids),
@@ -168,7 +168,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/permissions/roles",
                 "role_name": role_name,
@@ -204,7 +204,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"DELETE /v1/permissions/roles/{str(role_id)}",
                 "role_id": str(role_id),
@@ -255,7 +255,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"POST /v1/permissions/users/{str(user_id)}/roles",
                 "user_id": str(user_id),
@@ -287,7 +287,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"DELETE /v1/permissions/users/{str(user_id)}/roles",
                 "user_id": str(user_id),
@@ -332,7 +332,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"POST /v1/permissions/users/{str(user_id)}/tenants",
                 "user_id": str(user_id),
@@ -377,7 +377,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"DELETE /v1/permissions/tenants/{str(tenant_id)}/users/{str(user_id)}",
                 "tenant_id": str(tenant_id),
@@ -413,7 +413,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/permissions/tenants",
                 "tenant_name": tenant_name,
@@ -448,7 +448,7 @@ def get_permissions_router() -> APIRouter:
         """
         send_telemetry(
             "Permissions API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": f"POST /v1/permissions/tenants/{str(payload.tenant_id)}",
                 "tenant_id": str(payload.tenant_id),

--- a/cognee/api/v1/proposals/routers/get_proposals_router.py
+++ b/cognee/api/v1/proposals/routers/get_proposals_router.py
@@ -86,7 +86,7 @@ def get_proposals_router() -> APIRouter:
         """Return one skill-improvement proposal with its before/after procedures."""
         send_telemetry(
             "Skill Proposal Get API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/proposals/{proposal_id}",
                 "dataset_id": str(dataset_id),

--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -393,7 +393,9 @@ async def recall(
     from cognee import __version__ as cognee_version
     from cognee.shared.utils import send_telemetry
 
-    telemetry_user = getattr(user, "id", user) or "sdk"
+    # Pass the User through rather than pre-resolving its id: send_telemetry
+    # reads both id and tenant_id off it.
+    telemetry_user = user or "sdk"
 
     # Resolve scope → concrete source list. "auto" (the default) picks
     # sources based on what the caller supplied:

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -107,7 +107,7 @@ def get_recall_router() -> APIRouter:
         """Get search/recall history for the authenticated user."""
         send_telemetry(
             "Recall API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={"endpoint": "GET /v1/recall", "cognee_version": cognee_version},
         )
 
@@ -162,7 +162,7 @@ def get_recall_router() -> APIRouter:
         """
         send_telemetry(
             "Recall API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/recall",
                 "search_type": str(payload.search_type),

--- a/cognee/api/v1/remember/routers/get_remember_router.py
+++ b/cognee/api/v1/remember/routers/get_remember_router.py
@@ -266,7 +266,7 @@ def get_remember_router() -> APIRouter:
         """
         send_telemetry(
             "Remember API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/remember",
                 "node_set": node_set,
@@ -446,7 +446,7 @@ def get_remember_router() -> APIRouter:
         """
         send_telemetry(
             "Remember Entry API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/remember/entry",
                 "entry_type": payload.entry.type,

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -140,7 +140,7 @@ def get_search_router() -> APIRouter:
         """
         send_telemetry(
             "Search API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={"endpoint": "GET /v1/search", "cognee_version": cognee_version},
         )
 
@@ -207,7 +207,7 @@ def get_search_router() -> APIRouter:
         """
         send_telemetry(
             "Search API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/search",
                 "search_type": str(payload.search_type),

--- a/cognee/api/v1/skills/routers/get_skills_router.py
+++ b/cognee/api/v1/skills/routers/get_skills_router.py
@@ -108,7 +108,7 @@ def get_skills_router() -> APIRouter:
 
         send_telemetry(
             "Skill Ingest API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/skills",
                 "cognee_version": cognee_version,
@@ -156,7 +156,7 @@ def get_skills_router() -> APIRouter:
         """Return the skills available in an authorized dataset, with publisher metadata."""
         send_telemetry(
             "Skills List API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/skills",
                 "dataset_id": str(dataset_id),

--- a/cognee/api/v1/sync/routers/get_sync_router.py
+++ b/cognee/api/v1/sync/routers/get_sync_router.py
@@ -96,7 +96,7 @@ def get_sync_router() -> APIRouter:
         """
         send_telemetry(
             "Cloud Sync API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/sync",
                 "cognee_version": cognee_version,
@@ -203,7 +203,7 @@ def get_sync_router() -> APIRouter:
         """
         send_telemetry(
             "Sync Status Overview API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/sync/status",
                 "cognee_version": cognee_version,

--- a/cognee/api/v1/update/routers/get_update_router.py
+++ b/cognee/api/v1/update/routers/get_update_router.py
@@ -91,7 +91,7 @@ def get_update_router() -> APIRouter:
         """
         send_telemetry(
             "Update API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "PATCH /v1/update",
                 "dataset_id": str(dataset_id),

--- a/cognee/api/v1/users/routers/get_visualize_router.py
+++ b/cognee/api/v1/users/routers/get_visualize_router.py
@@ -112,7 +112,7 @@ def get_visualize_router() -> APIRouter:
         """
         send_telemetry(
             "Visualize API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/visualize",
                 "dataset_id": str(dataset_id),
@@ -174,7 +174,7 @@ def get_visualize_router() -> APIRouter:
         """
         send_telemetry(
             "Visualize Multi API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "POST /v1/visualize/multi",
                 "pair_count": len(pairs),

--- a/cognee/api/v1/visualize/routers/get_schema_router.py
+++ b/cognee/api/v1/visualize/routers/get_schema_router.py
@@ -100,7 +100,7 @@ def get_schema_router() -> APIRouter:
         """
         send_telemetry(
             "Schema Inventory API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/schema/inventory",
                 "dataset_id": str(dataset_id),
@@ -156,7 +156,7 @@ def get_schema_router() -> APIRouter:
         """
         send_telemetry(
             "Schema Provenance API Endpoint Invoked",
-            user.id,
+            user,
             additional_properties={
                 "endpoint": "GET /v1/schema/provenance",
                 "cognee_version": cognee_version,

--- a/cognee/context_global_variables.py
+++ b/cognee/context_global_variables.py
@@ -38,6 +38,17 @@ session_user = ContextVar("session_user", default=None)
 current_pipeline_stage: ContextVar[Optional[str]] = ContextVar(
     "current_pipeline_stage", default=None
 )
+# Which interface the current call arrived through — "api", "mcp", "cli", a
+# coding-agent name, … — recorded on every telemetry event. Set per request by
+# the API layer; falls back to the TELEMETRY_ORIGIN env var, then "sdk", so a
+# deployment can label all of its traffic without touching call sites.
+telemetry_origin: ContextVar[Optional[str]] = ContextVar("telemetry_origin", default=None)
+# The pipeline run the current work belongs to, so telemetry emitted anywhere
+# inside a pipeline can be correlated with the PipelineRun row without every
+# emitter having to thread it through.
+current_pipeline_run_id: ContextVar[Optional[UUID]] = ContextVar(
+    "current_pipeline_run_id", default=None
+)
 
 
 async def set_session_user_context_variable(user):

--- a/cognee/eval_framework/corpus_builder/task_getters/get_cascade_graph_tasks.py
+++ b/cognee/eval_framework/corpus_builder/task_getters/get_cascade_graph_tasks.py
@@ -44,6 +44,6 @@ async def get_cascade_graph_tasks(
             Task(add_data_points, task_config={"batch_size": 10}),
         ]
     except Exception as error:
-        send_telemetry("cognee.cognify DEFAULT TASKS CREATION ERRORED", user.id)
+        send_telemetry("cognee.cognify DEFAULT TASKS CREATION ERRORED", user)
         raise error
     return default_tasks

--- a/cognee/modules/pipelines/operations/run_tasks_base.py
+++ b/cognee/modules/pipelines/operations/run_tasks_base.py
@@ -162,7 +162,7 @@ async def handle_task(
     logger.info(f"{task_type} task started: `{running_task.executable.__name__}`")
     send_telemetry(
         f"{task_type} Task Started",
-        user_id=user.id,
+        user,
         additional_properties={
             "task_name": running_task.executable.__name__,
             "cognee_version": cognee_version,
@@ -233,7 +233,7 @@ async def handle_task(
             logger.info(f"{task_type} task completed: `{task_name}`")
             send_telemetry(
                 f"{task_type} Task Completed",
-                user_id=user.id,
+                user,
                 additional_properties={
                     "task_name": task_name,
                     "cognee_version": cognee_version,
@@ -251,7 +251,7 @@ async def handle_task(
             )
             send_telemetry(
                 f"{task_type} Task Errored",
-                user_id=user.id,
+                user,
                 additional_properties={
                     "task_name": task_name,
                     "cognee_version": cognee_version,

--- a/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
+++ b/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
@@ -26,7 +26,7 @@ async def run_tasks_with_telemetry(
         logger.info("Pipeline run started: `%s`", pipeline_name)
         send_telemetry(
             "Pipeline Run Started",
-            user.id,
+            user,
             additional_properties={
                 "pipeline_name": str(pipeline_name),
                 "cognee_version": cognee_version,
@@ -41,7 +41,7 @@ async def run_tasks_with_telemetry(
         logger.info("Pipeline run completed: `%s`", pipeline_name)
         send_telemetry(
             "Pipeline Run Completed",
-            user.id,
+            user,
             additional_properties={
                 "pipeline_name": str(pipeline_name),
                 "cognee_version": cognee_version,
@@ -58,7 +58,7 @@ async def run_tasks_with_telemetry(
         )
         send_telemetry(
             "Pipeline Run Errored",
-            user.id,
+            user,
             additional_properties={
                 "pipeline_name": str(pipeline_name),
                 "cognee_version": cognee_version,

--- a/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
+++ b/cognee/modules/pipelines/operations/run_tasks_with_telemetry.py
@@ -1,10 +1,11 @@
 import json
 from typing import Optional
 
+from cognee.context_global_variables import current_pipeline_run_id
 from cognee.modules.settings import get_current_settings
 from cognee.modules.users.models import User
 from cognee.shared.logging_utils import get_logger
-from cognee.shared.utils import send_telemetry
+from cognee.shared.utils import as_uuid, send_telemetry
 from cognee import __version__ as cognee_version
 from cognee.modules.pipelines.models import PipelineContext
 
@@ -21,6 +22,13 @@ async def run_tasks_with_telemetry(
     config = get_current_settings()
 
     logger.debug("\nRunning pipeline with configuration:\n%s\n", json.dumps(config, indent=1))
+
+    # Publish the run id for the duration of the pipeline so every telemetry
+    # event raised inside it — here and in nested tasks — can be correlated with
+    # the PipelineRun row, without threading the id through each emitter.
+    run_id_token = None
+    if ctx is not None and getattr(ctx, "pipeline_run_id", None):
+        run_id_token = current_pipeline_run_id.set(as_uuid(ctx.pipeline_run_id))
 
     try:
         logger.info("Pipeline run started: `%s`", pipeline_name)
@@ -68,3 +76,6 @@ async def run_tasks_with_telemetry(
         )
 
         raise error
+    finally:
+        if run_id_token is not None:
+            current_pipeline_run_id.reset(run_id_token)

--- a/cognee/modules/retrieval/utils/description_to_codepart_search.py
+++ b/cognee/modules/retrieval/utils/description_to_codepart_search.py
@@ -55,7 +55,7 @@ async def code_description_to_code_part(
         logger.error("Failed to initialize engines: %s", init_error, exc_info=True)
         raise RuntimeError("System initialization error. Please try again later.") from init_error
 
-    send_telemetry("code_description_to_code_part_search EXECUTION STARTED", user.id)
+    send_telemetry("code_description_to_code_part_search EXECUTION STARTED", user)
     logger.info("Search initiated by user %s with query: '%s' and top_k: %d", user.id, query, top_k)
 
     context_from_documents = ""
@@ -138,7 +138,7 @@ async def code_description_to_code_part(
             exec_error,
             exc_info=True,
         )
-        send_telemetry("code_description_to_code_part_search EXECUTION FAILED", user.id)
+        send_telemetry("code_description_to_code_part_search EXECUTION FAILED", user)
         raise RuntimeError("An error occurred while processing your request.") from exec_error
 
 

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -79,7 +79,7 @@ async def search(
     query = await log_query(query_text, query_type.value, user.id)
     send_telemetry(
         "cognee.search EXECUTION STARTED",
-        user.id,
+        user,
         additional_properties={
             "cognee_version": cognee_version,
             "tenant_id": str(user.tenant_id) if user.tenant_id else "Single User Tenant",
@@ -124,7 +124,7 @@ async def search(
 
     send_telemetry(
         "cognee.search EXECUTION COMPLETED",
-        user.id,
+        user,
         additional_properties={
             "cognee_version": cognee_version,
             "tenant_id": str(user.tenant_id) if user.tenant_id else "Single User Tenant",

--- a/cognee/modules/telemetry/__init__.py
+++ b/cognee/modules/telemetry/__init__.py
@@ -1,0 +1,3 @@
+from .models.TelemetryEvent import TelemetryEvent
+
+__all__ = ["TelemetryEvent"]

--- a/cognee/modules/telemetry/__init__.py
+++ b/cognee/modules/telemetry/__init__.py
@@ -1,3 +1,6 @@
-from .models.TelemetryEvent import TelemetryEvent
+"""Telemetry sinks and the local event model.
 
-__all__ = ["TelemetryEvent"]
+The model is deliberately NOT re-exported here: importing it from two paths gives
+the declarative class two chances to register the same table on ``Base.metadata``.
+Import it from ``cognee.modules.telemetry.models`` instead.
+"""

--- a/cognee/modules/telemetry/event_names.py
+++ b/cognee/modules/telemetry/event_names.py
@@ -1,0 +1,120 @@
+"""Normalise telemetry event names into a stable contract for consumers.
+
+Event names grew organically into five incompatible styles — measured across
+three days of production traffic there are 60+ distinct names:
+
+===============================================  ===========================
+style                                            examples
+===============================================  ===========================
+``cognee.<op>``                                  ``cognee.remember``
+``cognee.<op> EXECUTION <STATE>``                ``cognee.search EXECUTION STARTED``
+``<Thing> API Endpoint Invoked``                 ``Remember Entry API Endpoint Invoked``
+``Pipeline Run <State>``                         ``Pipeline Run Completed``
+``<Type> Task <State>``                          ``Coroutine Task Started``
+===============================================  ===========================
+
+Renaming the emitters would give one clean scheme, but the same names are the
+warehouse's ``pipeline_events.tracking_event`` — renaming breaks every existing
+dashboard and splits history at the cutover. So the raw name is preserved as
+``event_name`` and this module derives two stable fields alongside it:
+
+``operation``
+    The user-facing verb: ``remember``, ``recall``, ``cognify``, … A UI groups
+    and filters on this instead of pattern-matching names. ``None`` for events
+    that aren't tied to one operation (pipeline and task bookkeeping).
+
+``event_kind``
+    Which layer emitted it, so a consumer can pick one and avoid showing the
+    same action several times:
+
+    - ``operation`` — the SDK-level call a user made
+    - ``endpoint``  — an HTTP route was invoked
+    - ``pipeline``  — a pipeline run started/finished
+    - ``task``      — internal task bookkeeping (excluded from local sinks)
+
+Both are derived, so adding an emitter needs no change here: it falls through to
+the heuristics and still gets a sensible ``operation``/``event_kind``.
+"""
+
+import re
+
+TASK_SUFFIXES = (" Task Started", " Task Completed", " Task Errored")
+_ENDPOINT_SUFFIX = " API Endpoint Invoked"
+# The `cognee.` prefix is optional: some emitters use it, some don't
+# (`code_description_to_code_part_search EXECUTION STARTED`).
+_EXECUTION_RE = re.compile(r"^(?:cognee\.)?(?P<op>[\w.]+) EXECUTION [A-Z]+$")
+
+KIND_OPERATION = "operation"
+KIND_ENDPOINT = "endpoint"
+KIND_PIPELINE = "pipeline"
+KIND_TASK = "task"
+
+# Endpoint prefixes whose first word alone would read badly or split one
+# operation across two names. Everything else falls back to its first word.
+_ENDPOINT_OVERRIDES = {
+    "Api Key Management": "api_key",
+    "Add By Text": "add",
+    "Add AISOC": "add",
+    "Cognify AIPTS": "cognify",
+    "Cognify AISOC": "cognify",
+    "Remember Entry": "remember",
+    "Sync Status Overview": "sync",
+    "Visualize Live Events": "visualize",
+    "Visualize Brains": "visualize",
+    "Schema Inventory": "schema",
+    "Schema Provenance JSON": "schema",
+    "Skills List": "skills",
+    "Skill Ingest": "skills",
+    "Skill Proposal Get": "proposals",
+    "Ontology Upload": "ontology",
+    "Ontology Delete": "ontology",
+    "Ontology List": "ontology",
+    "List Principal Dataset Grants": "permissions",
+    "Knowledge Views": "knowledge_views",
+    "LLM Custom Prompt Endpoint": "llm",
+    "LLM Infer Schema Endpoint": "llm",
+    "Cloud Sync": "sync",
+}
+
+
+def _slug(value: str) -> str:
+    """Lower-case, underscore-separated, punctuation stripped."""
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def normalize_event(event_name: str) -> tuple[str | None, str]:
+    """Return ``(operation, event_kind)`` for a raw telemetry event name.
+
+    Never raises and never returns an empty ``event_kind`` — an unrecognised
+    name is treated as an operation named after itself, which is strictly more
+    useful to a consumer than a null.
+    """
+    if not event_name:
+        return None, KIND_OPERATION
+
+    # Internal bookkeeping: no single operation owns these.
+    if event_name.endswith(TASK_SUFFIXES):
+        return None, KIND_TASK
+    if event_name.startswith("Pipeline Run "):
+        return None, KIND_PIPELINE
+
+    if event_name.endswith(_ENDPOINT_SUFFIX):
+        prefix = event_name[: -len(_ENDPOINT_SUFFIX)].strip()
+        # Some prefixes already end in "Endpoint" (LLM Custom Prompt Endpoint).
+        operation = _ENDPOINT_OVERRIDES.get(prefix)
+        if operation is None:
+            operation = _slug(prefix.split()[0]) if prefix else None
+        return operation, KIND_ENDPOINT
+
+    execution = _EXECUTION_RE.match(event_name)
+    if execution:
+        return _slug(execution.group("op").split(".")[0]), KIND_OPERATION
+
+    if event_name.startswith("cognee."):
+        # cognee.remember -> remember; cognee.session.add_qa -> session;
+        # cognee.remember.import -> remember; and drop any trailing prose, as in
+        # "cognee.cognify DEFAULT TASKS CREATION ERRORED" -> cognify.
+        tail = event_name[len("cognee.") :].split()[0]
+        return _slug(tail.split(".")[0]), KIND_OPERATION
+
+    return _slug(event_name) or None, KIND_OPERATION

--- a/cognee/modules/telemetry/models/TelemetryEvent.py
+++ b/cognee/modules/telemetry/models/TelemetryEvent.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import JSON, Column, DateTime, String, UUID
+
+from cognee.infrastructure.databases.relational import Base
+
+
+class TelemetryEvent(Base):
+    """One product-telemetry event, stored locally instead of (or alongside) being
+    POSTed to the analytics proxy.
+
+    Column names mirror the warehouse table the HTTP sink ultimately feeds
+    (``analytics.main.pipeline_events``) so queries port between the two without
+    a reshape:
+
+    - ``event_name`` here == ``tracking_event`` there (the *cognee* event name;
+      the warehouse's own ``event_name`` holds the Segment call type, which is an
+      artifact of that transport and has no meaning locally).
+    - ``properties`` is the same payload dict either way.
+
+    Rows are pruned to a retention window by the sink (see
+    ``TELEMETRY_RETENTION_DAYS``); this table is a rolling window, not an archive.
+    """
+
+    __tablename__ = "telemetry_events"
+
+    id = Column(UUID, primary_key=True, default=uuid4)
+
+    event_name = Column(String, index=True)
+    user_id = Column(UUID, index=True, nullable=True)
+    tenant_id = Column(UUID, index=True, nullable=True)
+    # Machine/install identity as sent to the proxy. Kept for parity with the
+    # warehouse rows; on a per-tenant deployment it is constant per pod.
+    anonymous_id = Column(String, nullable=True)
+
+    properties = Column(JSON, nullable=True)
+
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
+    )

--- a/cognee/modules/telemetry/models/TelemetryEvent.py
+++ b/cognee/modules/telemetry/models/TelemetryEvent.py
@@ -39,6 +39,11 @@ class TelemetryEvent(Base):
     # dataset without a JSON scan. Null for events with no dataset (or with
     # several — a multi-dataset recall keeps the full list in ``properties``).
     dataset_id = Column(UUID, index=True, nullable=True)
+    # Correlates the event with its PipelineRun row (and so with
+    # /v1/activity/pipeline-runs). Null for events raised outside a pipeline.
+    pipeline_run_id = Column(UUID, index=True, nullable=True)
+    # Which interface the call arrived through: "api", "mcp", "cli", "sdk", …
+    origin = Column(String, index=True, nullable=True)
     # Machine/install identity as sent to the proxy. Kept for parity with the
     # warehouse rows; on a per-tenant deployment it is constant per pod.
     anonymous_id = Column(String, nullable=True)

--- a/cognee/modules/telemetry/models/TelemetryEvent.py
+++ b/cognee/modules/telemetry/models/TelemetryEvent.py
@@ -35,6 +35,10 @@ class TelemetryEvent(Base):
     event_name = Column(String, index=True)
     user_id = Column(UUID, index=True, nullable=True)
     tenant_id = Column(UUID, index=True, nullable=True)
+    # Promoted out of ``properties`` so an activity view can be filtered per
+    # dataset without a JSON scan. Null for events with no dataset (or with
+    # several — a multi-dataset recall keeps the full list in ``properties``).
+    dataset_id = Column(UUID, index=True, nullable=True)
     # Machine/install identity as sent to the proxy. Kept for parity with the
     # warehouse rows; on a per-tenant deployment it is constant per pod.
     anonymous_id = Column(String, nullable=True)

--- a/cognee/modules/telemetry/models/TelemetryEvent.py
+++ b/cognee/modules/telemetry/models/TelemetryEvent.py
@@ -32,7 +32,15 @@ class TelemetryEvent(Base):
 
     id = Column(UUID, primary_key=True, default=uuid4)
 
+    # The raw emitted name, preserved verbatim so this table stays comparable
+    # with the warehouse's pipeline_events.tracking_event.
     event_name = Column(String, index=True)
+    # Stable, derived contract for consumers — see modules/telemetry/event_names.
+    # `operation` is the user-facing verb ("remember", "recall", …); `event_kind`
+    # is the layer that emitted it (operation | endpoint | pipeline | task), so a
+    # UI can pick one layer instead of showing an action several times.
+    operation = Column(String, index=True, nullable=True)
+    event_kind = Column(String, index=True, nullable=True)
     user_id = Column(UUID, index=True, nullable=True)
     tenant_id = Column(UUID, index=True, nullable=True)
     # Promoted out of ``properties`` so an activity view can be filtered per

--- a/cognee/modules/telemetry/models/TelemetryEvent.py
+++ b/cognee/modules/telemetry/models/TelemetryEvent.py
@@ -24,6 +24,11 @@ class TelemetryEvent(Base):
     """
 
     __tablename__ = "telemetry_events"
+    # A process that prunes metadata and re-runs migrations (the performance
+    # benchmark does this between runs) executes this declaration more than once
+    # against the same MetaData, which is an error by default. Same reason
+    # PGVectorAdapter sets it on its dynamically-built tables.
+    __table_args__ = {"extend_existing": True}
 
     id = Column(UUID, primary_key=True, default=uuid4)
 

--- a/cognee/modules/telemetry/models/__init__.py
+++ b/cognee/modules/telemetry/models/__init__.py
@@ -1,0 +1,3 @@
+from .TelemetryEvent import TelemetryEvent
+
+__all__ = ["TelemetryEvent"]

--- a/cognee/modules/telemetry/postgres_sink.py
+++ b/cognee/modules/telemetry/postgres_sink.py
@@ -1,0 +1,161 @@
+"""Local (relational-DB) telemetry sink.
+
+Writes product-telemetry events into the deployment's own relational database
+instead of shipping them to the analytics proxy. Selected via
+``TELEMETRY_SINK=postgres`` (see ``cognee.shared.utils.send_telemetry``); the
+default remains the HTTP sink, so open-source behaviour is unchanged.
+
+Why it exists: a hosted, multi-tenant deployment wants each tenant to see its
+own recent activity, live, without that data leaving the tenant's boundary. The
+table is a rolling ``TELEMETRY_RETENTION_DAYS`` window, not an archive.
+
+Design notes:
+
+- **Buffered.** Events accumulate in a bounded in-memory deque and are inserted
+  in batches by a background flusher. One INSERT per event would put the
+  telemetry write path in contention with the workload that produced it, and
+  pipelines emit in bursts.
+- **Lossy under pressure, never blocking.** The buffer has a hard cap and drops
+  the oldest events when full. Telemetry must never slow down or fail the
+  operation it observes.
+- **Best-effort.** Every DB interaction is wrapped; failures are logged at debug
+  and dropped.
+"""
+
+import asyncio
+import os
+from collections import deque
+from datetime import datetime, timedelta, timezone
+
+from cognee.shared.logging_utils import get_logger
+from cognee.shared.utils import as_uuid
+
+logger = get_logger(__name__)
+
+# Bounded so a DB outage can't turn telemetry into a memory leak.
+_BUFFER_MAX = int(os.getenv("TELEMETRY_BUFFER_MAX", "5000"))
+_FLUSH_INTERVAL_SECONDS = float(os.getenv("TELEMETRY_FLUSH_INTERVAL", "5"))
+_FLUSH_BATCH = int(os.getenv("TELEMETRY_FLUSH_BATCH", "200"))
+_RETENTION_DAYS = int(os.getenv("TELEMETRY_RETENTION_DAYS", "30"))
+# Prune runs on a flush multiple rather than a timer — one cheap indexed DELETE
+# every ~N flushes is plenty for a rolling window.
+_PRUNE_EVERY_N_FLUSHES = int(os.getenv("TELEMETRY_PRUNE_EVERY_N_FLUSHES", "120"))
+
+_buffer: deque = deque(maxlen=_BUFFER_MAX)
+_dropped = 0
+_flush_count = 0
+
+_flusher_task: asyncio.Task | None = None
+_flusher_loop: asyncio.AbstractEventLoop | None = None
+
+
+def enqueue(payload: dict) -> None:
+    """Queue one telemetry payload for insertion. Sync, non-blocking, never raises.
+
+    Also (re)starts the background flusher when called from inside a running
+    loop. With no running loop the event is still buffered — it will be written
+    by whichever later call does have one, and dropped if none ever does.
+    """
+    global _dropped
+
+    if len(_buffer) == _BUFFER_MAX:
+        # deque(maxlen=...) evicts silently; count it so the loss is visible.
+        _dropped += 1
+        if _dropped % 1000 == 1:
+            logger.debug("Telemetry buffer full; dropped %s event(s) so far", _dropped)
+
+    _buffer.append(payload)
+
+    try:
+        _ensure_flusher(asyncio.get_running_loop())
+    except RuntimeError:
+        pass
+
+
+def _ensure_flusher(loop: asyncio.AbstractEventLoop) -> None:
+    """Start the background flusher if it isn't running on this loop.
+
+    The task is loop-bound, so a loop change (tests, ``asyncio.run`` boundaries)
+    requires a fresh task.
+    """
+    global _flusher_task, _flusher_loop
+
+    if _flusher_task is not None and not _flusher_task.done() and _flusher_loop is loop:
+        return
+
+    _flusher_task = loop.create_task(_flusher())
+    _flusher_loop = loop
+
+
+async def _flusher() -> None:
+    """Drain the buffer on an interval until cancelled."""
+    while True:
+        try:
+            await asyncio.sleep(_FLUSH_INTERVAL_SECONDS)
+            if _buffer:
+                await flush()
+        except asyncio.CancelledError:
+            await flush()
+            raise
+        except Exception as error:
+            logger.debug("Telemetry flusher iteration failed: %s", error)
+
+
+async def flush() -> None:
+    """Insert everything currently buffered. Best-effort; never raises.
+
+    Call directly on shutdown to avoid losing the tail of the buffer.
+    """
+    global _flush_count
+
+    if not _buffer:
+        return
+
+    batch = [_buffer.popleft() for _ in range(min(len(_buffer), _FLUSH_BATCH))]
+
+    try:
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.telemetry.models.TelemetryEvent import TelemetryEvent
+
+        engine = get_relational_engine()
+        async with engine.get_async_session() as session:
+            session.add_all([_to_row(TelemetryEvent, payload) for payload in batch])
+            await session.commit()
+    except Exception as error:
+        # Dropped, not requeued: a persistent failure would otherwise spin the
+        # same batch forever and starve fresh events out of a bounded buffer.
+        logger.debug("Telemetry flush of %s event(s) failed: %s", len(batch), error)
+        return
+
+    _flush_count += 1
+    if _flush_count % _PRUNE_EVERY_N_FLUSHES == 0:
+        await _prune()
+
+
+def _to_row(model, payload: dict):
+    """Map a proxy-shaped telemetry payload onto a ``TelemetryEvent`` row."""
+    properties = payload.get("properties") or {}
+    return model(
+        event_name=payload.get("event_name"),
+        user_id=as_uuid(properties.get("user_id")),
+        tenant_id=as_uuid(properties.get("tenant_id")),
+        anonymous_id=payload.get("anonymous_id"),
+        properties=properties,
+    )
+
+
+async def _prune() -> None:
+    """Delete events older than the retention window. Best-effort."""
+    try:
+        from sqlalchemy import delete
+
+        from cognee.infrastructure.databases.relational import get_relational_engine
+        from cognee.modules.telemetry.models.TelemetryEvent import TelemetryEvent
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=_RETENTION_DAYS)
+        engine = get_relational_engine()
+        async with engine.get_async_session() as session:
+            await session.execute(delete(TelemetryEvent).where(TelemetryEvent.created_at < cutoff))
+            await session.commit()
+    except Exception as error:
+        logger.debug("Telemetry prune failed: %s", error)

--- a/cognee/modules/telemetry/postgres_sink.py
+++ b/cognee/modules/telemetry/postgres_sink.py
@@ -166,6 +166,8 @@ def _to_row(model, payload: dict):
         user_id=as_uuid(properties.get("user_id")),
         tenant_id=as_uuid(properties.get("tenant_id")),
         dataset_id=_dataset_id(properties),
+        pipeline_run_id=as_uuid(properties.get("pipeline_run_id")),
+        origin=properties.get("origin"),
         anonymous_id=payload.get("anonymous_id"),
         properties=properties,
     )

--- a/cognee/modules/telemetry/postgres_sink.py
+++ b/cognee/modules/telemetry/postgres_sink.py
@@ -160,9 +160,15 @@ def _dataset_id(properties: dict):
 
 def _to_row(model, payload: dict):
     """Map a proxy-shaped telemetry payload onto a ``TelemetryEvent`` row."""
+    from cognee.modules.telemetry.event_names import normalize_event
+
     properties = payload.get("properties") or {}
+    event_name = payload.get("event_name")
+    operation, event_kind = normalize_event(event_name)
     return model(
-        event_name=payload.get("event_name"),
+        event_name=event_name,
+        operation=operation,
+        event_kind=event_kind,
         user_id=as_uuid(properties.get("user_id")),
         tenant_id=as_uuid(properties.get("tenant_id")),
         dataset_id=_dataset_id(properties),

--- a/cognee/modules/telemetry/postgres_sink.py
+++ b/cognee/modules/telemetry/postgres_sink.py
@@ -132,6 +132,32 @@ async def flush() -> None:
         await _prune()
 
 
+def _dataset_id(properties: dict):
+    """Pull a single dataset UUID out of a payload's properties, if there is one.
+
+    Call sites spell it several ways — ``dataset_id`` (remember, forget),
+    ``dataset_ids`` as a comma-joined list (recall), and ``dataset`` which may be
+    a name or an id (improve). Normalising here rather than at each call site
+    keeps the emitters untouched and means a new one only has to use any of the
+    existing spellings.
+
+    Returns None when there is no dataset or when the event legitimately spans
+    several; the full list is still in ``properties`` either way.
+    """
+    single = as_uuid(properties.get("dataset_id"))
+    if single:
+        return single
+
+    joined = properties.get("dataset_ids") or ""
+    if isinstance(joined, str):
+        candidates = [part for part in (p.strip() for p in joined.split(",")) if part]
+        if len(candidates) == 1:
+            return as_uuid(candidates[0])
+
+    # ``dataset`` is usually a name; keep it only when it happens to be an id.
+    return as_uuid(properties.get("dataset"))
+
+
 def _to_row(model, payload: dict):
     """Map a proxy-shaped telemetry payload onto a ``TelemetryEvent`` row."""
     properties = payload.get("properties") or {}
@@ -139,6 +165,7 @@ def _to_row(model, payload: dict):
         event_name=payload.get("event_name"),
         user_id=as_uuid(properties.get("user_id")),
         tenant_id=as_uuid(properties.get("tenant_id")),
+        dataset_id=_dataset_id(properties),
         anonymous_id=payload.get("anonymous_id"),
         properties=properties,
     )

--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -293,11 +293,15 @@ def _telemetry_sinks() -> list[str]:
 # HTTP sink still receives them — historical analytics depend on them — but
 # local sinks skip them so a tenant-facing table stays small and readable, and
 # so telemetry writes don't peak exactly when the workload is busiest.
-_LOCAL_SINK_EXCLUDED_SUFFIXES = (" Task Started", " Task Completed", " Task Errored")
-
-
 def _is_internal_task_event(event_name: str) -> bool:
-    return event_name.endswith(_LOCAL_SINK_EXCLUDED_SUFFIXES)
+    """True for the per-task bookkeeping events local sinks skip.
+
+    The suffix list lives with the rest of the event-name logic so the two can
+    never drift apart.
+    """
+    from cognee.modules.telemetry.event_names import TASK_SUFFIXES
+
+    return event_name.endswith(TASK_SUFFIXES)
 
 
 def send_telemetry(

--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -17,8 +17,9 @@ from cognee.shared.logging_utils import get_logger
 
 logger = get_logger()
 
-# Analytics Proxy Url, currently hosted by Vercel
-proxy_url = "https://test.prometh.ai"
+# Analytics Proxy Url, currently hosted by Vercel. Overridable so a deployment
+# can point the HTTP sink at its own collector without a code change.
+proxy_url = os.getenv("TELEMETRY_ENDPOINT", "https://test.prometh.ai")
 
 # Timeout for telemetry HTTP request; short to avoid blocking if proxy is unreachable
 TELEMETRY_REQUEST_TIMEOUT: int = int(os.getenv("TELEMETRY_REQUEST_TIMEOUT", "5"))
@@ -231,21 +232,86 @@ def _get_api_key_fingerprint() -> str:
     return _get_api_key_tracking_id()
 
 
-def send_telemetry(event_name: str, user_id: str | UUID, additional_properties: dict | None = None):
+def _resolve_identity(user) -> tuple[str, str | None]:
+    """Resolve a telemetry caller into ``(user_id, tenant_id)`` strings.
+
+    Callers pass whatever they have in hand — a ``User`` model, a bare UUID, or
+    the literal ``"sdk"`` sentinel. Resolving here rather than at each call site
+    is deliberate: ``str()`` on a ``User`` yields its object repr (the model
+    defines no ``__str__``), so any site that forwarded the object was silently
+    recording ``<...User object at 0x...>`` as the user id. Centralising it fixes
+    every emitter at once and keeps ``tenant_id`` from having to be threaded
+    through ~40 call sites by hand.
+    """
+    resolved_id = getattr(user, "id", user)
+    tenant_id = getattr(user, "tenant_id", None)
+    return str(resolved_id), str(tenant_id) if tenant_id else None
+
+
+def _telemetry_sinks() -> list[str]:
+    """Sinks this deployment writes telemetry to, in order.
+
+    ``TELEMETRY_SINK`` is a comma-separated list rather than a single choice so
+    that adding a destination is configuration, not code: a hosted deployment can
+    start on ``postgres`` only (tenant-local, nothing leaves the boundary) and
+    later run ``postgres,http`` to *also* feed the shared analytics pipeline,
+    with no redeploy of new logic and no schema change.
+    """
+    raw = os.getenv("TELEMETRY_SINK", "http")
+    return [sink.strip().lower() for sink in raw.split(",") if sink.strip()]
+
+
+# Per-task pipeline events (``f"{task_type} Task Started"`` and friends, emitted
+# from run_tasks_base) are internal execution detail: they are the majority of
+# all telemetry volume by a wide margin and mean nothing to an end user. The
+# HTTP sink still receives them — historical analytics depend on them — but
+# local sinks skip them so a tenant-facing table stays small and readable, and
+# so telemetry writes don't peak exactly when the workload is busiest.
+_LOCAL_SINK_EXCLUDED_SUFFIXES = (" Task Started", " Task Completed", " Task Errored")
+
+
+def _is_internal_task_event(event_name: str) -> bool:
+    return event_name.endswith(_LOCAL_SINK_EXCLUDED_SUFFIXES)
+
+
+def send_telemetry(
+    event_name: str,
+    user=None,
+    additional_properties: dict | None = None,
+    *,
+    user_id=None,
+):
     """Send a product telemetry event.
 
-    Three identity layers are sent with every event:
+    Args:
+        event_name: The event to record.
+        user: A ``User`` model, a user UUID, or a string sentinel such as
+            ``"sdk"``. When a ``User`` is given, both its ``id`` and its
+            ``tenant_id`` are recorded — prefer passing the model over
+            pre-resolving ``user.id``, or the event carries no tenant.
+        additional_properties: Extra event properties.
+        user_id: Deprecated alias for ``user``, kept so out-of-tree callers that
+            pass it by keyword keep working. Ignored when ``user`` is given.
+
+    Identity layers sent with every event:
 
     - **anonymous_id**: Original project-root ID (.anon_id). May change
       on reinstall. Kept for backward compatibility with historical data.
+      Overridable with ``TRACKING_ID`` — hosted deployments should set it to a
+      stable per-deployment value, since the on-disk file is regenerated
+      whenever the filesystem is ephemeral.
     - **persistent_id**: Stable machine-level ID (~/.cognee/.persistent_id).
       Survives data deletion, reinstalls, user recreation. Use this to
       correlate a single machine across all user_id changes.
     - **user_id**: Transient Cognee User UUID from the database. Changes
       when the user is deleted and recreated via forget(everything=True).
+    - **tenant_id**: The user's tenant UUID, or ``"Single User Tenant"`` when the
+      deployment has no tenancy.
     - **api_key_tracking_id**: Stable pseudonymous ID derived from the full
       LLM API key when configured. Use this to group activity by key without
       sending the key or visible key fragments.
+
+    Destinations are controlled by ``TELEMETRY_SINK`` (default ``http``).
     """
     if additional_properties is None:
         additional_properties = {}
@@ -258,6 +324,7 @@ def send_telemetry(event_name: str, user_id: str | UUID, additional_properties: 
     additional_properties = _sanitize_nested_properties(
         obj=additional_properties, property_names=["url"]
     )
+    resolved_user_id, tenant_id = _resolve_identity(user if user is not None else user_id)
     anonymous_id = str(get_anonymous_id())
     persistent_id = str(get_persistent_id())
     api_key_tracking_id = _get_api_key_tracking_id()
@@ -266,29 +333,44 @@ def send_telemetry(event_name: str, user_id: str | UUID, additional_properties: 
         "anonymous_id": anonymous_id,
         "event_name": event_name,
         "user_properties": {
-            "user_id": str(user_id),
+            "user_id": resolved_user_id,
+            "tenant_id": tenant_id or "Single User Tenant",
             "persistent_id": persistent_id,
             "api_key_tracking_id": api_key_tracking_id,
             "api_key_hash": api_key_tracking_id,
         },
         "properties": {
             "time": current_time.strftime("%m/%d/%Y"),
-            "user_id": str(user_id),
+            "user_id": resolved_user_id,
+            "tenant_id": tenant_id or "Single User Tenant",
             "anonymous_id": anonymous_id,
             "persistent_id": persistent_id,
             "api_key_tracking_id": api_key_tracking_id,
             "api_key_hash": api_key_tracking_id,
+            # An explicit tenant_id in additional_properties still wins, so
+            # existing call sites that pass their own keep their behaviour.
             **additional_properties,
         },
     }
 
-    try:
-        loop = asyncio.get_running_loop()
-        loop.create_task(_send_telemetry_request(payload))
-    except RuntimeError:
-        # No running event loop (shutdown, sync context, etc.) — telemetry is
-        # best-effort; dropping the event is better than crashing the caller.
-        pass
+    sinks = _telemetry_sinks()
+
+    if "postgres" in sinks and not _is_internal_task_event(event_name):
+        try:
+            from cognee.modules.telemetry.postgres_sink import enqueue
+
+            enqueue(payload)
+        except Exception as error:
+            logger.debug("Local telemetry sink failed: %s", error)
+
+    if "http" in sinks:
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_send_telemetry_request(payload))
+        except RuntimeError:
+            # No running event loop (shutdown, sync context, etc.) — telemetry is
+            # best-effort; dropping the event is better than crashing the caller.
+            pass
 
 
 def embed_logo(p: Any, layout_scale: float, logo_alpha: float, position: str):

--- a/cognee/shared/utils.py
+++ b/cognee/shared/utils.py
@@ -248,6 +248,32 @@ def _resolve_identity(user) -> tuple[str, str | None]:
     return str(resolved_id), str(tenant_id) if tenant_id else None
 
 
+def _telemetry_context() -> tuple[str, str | None]:
+    """Resolve ``(origin, pipeline_run_id)`` from the ambient context.
+
+    Both are read from ContextVars rather than passed by callers, because the
+    interesting emitters are deep inside pipelines that have no reason to know
+    which interface invoked them. ``origin`` falls back to ``TELEMETRY_ORIGIN``
+    so a deployment can label all of its traffic with one env var.
+
+    Imported lazily: ``cognee.context_global_variables`` pulls in config models,
+    and this module is imported during package init.
+    """
+    try:
+        from cognee.context_global_variables import (
+            current_pipeline_run_id,
+            telemetry_origin,
+        )
+
+        origin = telemetry_origin.get()
+        pipeline_run_id = current_pipeline_run_id.get()
+    except Exception:
+        origin, pipeline_run_id = None, None
+
+    origin = origin or os.getenv("TELEMETRY_ORIGIN") or "sdk"
+    return origin, str(pipeline_run_id) if pipeline_run_id else None
+
+
 def _telemetry_sinks() -> list[str]:
     """Sinks this deployment writes telemetry to, in order.
 
@@ -325,6 +351,7 @@ def send_telemetry(
         obj=additional_properties, property_names=["url"]
     )
     resolved_user_id, tenant_id = _resolve_identity(user if user is not None else user_id)
+    origin, pipeline_run_id = _telemetry_context()
     anonymous_id = str(get_anonymous_id())
     persistent_id = str(get_persistent_id())
     api_key_tracking_id = _get_api_key_tracking_id()
@@ -347,8 +374,11 @@ def send_telemetry(
             "persistent_id": persistent_id,
             "api_key_tracking_id": api_key_tracking_id,
             "api_key_hash": api_key_tracking_id,
-            # An explicit tenant_id in additional_properties still wins, so
-            # existing call sites that pass their own keep their behaviour.
+            "origin": origin,
+            **({"pipeline_run_id": pipeline_run_id} if pipeline_run_id else {}),
+            # An explicit value in additional_properties still wins, so existing
+            # call sites that pass their own tenant_id / pipeline_run_id keep
+            # their behaviour.
             **additional_properties,
         },
     }

--- a/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
+++ b/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
@@ -231,6 +231,46 @@ def test_to_row_maps_payload_onto_the_model():
     assert row.properties["mode"] == "test"
 
 
+def test_dataset_id_is_extracted_from_every_spelling_call_sites_use():
+    """remember/forget use dataset_id, recall uses dataset_ids, improve uses dataset."""
+    from cognee.modules.telemetry.postgres_sink import _dataset_id
+
+    dataset = uuid.uuid4()
+
+    assert _dataset_id({"dataset_id": str(dataset)}) == dataset
+    assert _dataset_id({"dataset_ids": str(dataset)}) == dataset
+    assert _dataset_id({"dataset": str(dataset)}) == dataset
+
+
+def test_dataset_id_is_null_when_absent_ambiguous_or_a_name():
+    from cognee.modules.telemetry.postgres_sink import _dataset_id
+
+    one, two = uuid.uuid4(), uuid.uuid4()
+
+    assert _dataset_id({}) is None
+    assert _dataset_id({"dataset_id": ""}) is None
+    # A multi-dataset recall has no single dataset; the list stays in properties.
+    assert _dataset_id({"dataset_ids": f"{one},{two}"}) is None
+    # ``dataset`` is usually a human name, not an id.
+    assert _dataset_id({"dataset": "product-docs"}) is None
+
+
+def test_to_row_populates_dataset_id():
+    from cognee.modules.telemetry.postgres_sink import _to_row
+
+    dataset = uuid.uuid4()
+
+    class Row:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    row = _to_row(
+        Row, {"event_name": "cognee.remember", "properties": {"dataset_id": str(dataset)}}
+    )
+
+    assert row.dataset_id == dataset
+
+
 def test_model_declaration_is_idempotent():
     """The table must survive its declaration running twice.
 

--- a/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
+++ b/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
@@ -354,6 +354,66 @@ def test_to_row_populates_pipeline_run_id_and_origin():
     assert row.origin == "mcp"
 
 
+def test_event_names_normalise_to_a_stable_operation_and_kind():
+    """Five legacy naming styles must collapse to one contract for the UI."""
+    from cognee.modules.telemetry.event_names import normalize_event
+
+    cases = {
+        # cognee.<op>
+        "cognee.remember": ("remember", "operation"),
+        "cognee.forget": ("forget", "operation"),
+        "cognee.remember.code_graph": ("remember", "operation"),
+        "cognee.session.add_qa": ("session", "operation"),
+        # cognee.<op> EXECUTION <STATE>, with and without the prefix
+        "cognee.search EXECUTION STARTED": ("search", "operation"),
+        "cognee.add EXECUTION COMPLETED": ("add", "operation"),
+        "code_description_to_code_part_search EXECUTION FAILED": (
+            "code_description_to_code_part_search",
+            "operation",
+        ),
+        # trailing prose must not leak into the operation
+        "cognee.cognify DEFAULT TASKS CREATION ERRORED": ("cognify", "operation"),
+        # <Thing> API Endpoint Invoked
+        "Remember API Endpoint Invoked": ("remember", "endpoint"),
+        "Remember Entry API Endpoint Invoked": ("remember", "endpoint"),
+        "Cognify AIPTS API Endpoint Invoked": ("cognify", "endpoint"),
+        "Add By Text API Endpoint Invoked": ("add", "endpoint"),
+        "Api Key Management API Endpoint Invoked": ("api_key", "endpoint"),
+        "List Principal Dataset Grants API Endpoint Invoked": ("permissions", "endpoint"),
+        "Datasets API Endpoint Invoked": ("datasets", "endpoint"),
+        # bookkeeping: owned by no single operation
+        "Pipeline Run Started": (None, "pipeline"),
+        "Pipeline Run Errored": (None, "pipeline"),
+        "Coroutine Task Started": (None, "task"),
+        "Async Generator Task Completed": (None, "task"),
+        "Function Task Errored": (None, "task"),
+    }
+    for raw, expected in cases.items():
+        assert normalize_event(raw) == expected, raw
+
+
+def test_unknown_event_names_still_get_a_kind():
+    """A new emitter must never produce a null event_kind."""
+    from cognee.modules.telemetry.event_names import normalize_event
+
+    assert normalize_event("Something Brand New") == ("something_brand_new", "operation")
+    assert normalize_event("") == (None, "operation")
+
+
+def test_to_row_populates_operation_and_event_kind():
+    from cognee.modules.telemetry.postgres_sink import _to_row
+
+    class Row:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    row = _to_row(Row, {"event_name": "Remember Entry API Endpoint Invoked", "properties": {}})
+
+    assert row.event_name == "Remember Entry API Endpoint Invoked"  # raw preserved
+    assert row.operation == "remember"
+    assert row.event_kind == "endpoint"
+
+
 def test_model_declaration_is_idempotent():
     """The table must survive its declaration running twice.
 

--- a/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
+++ b/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
@@ -231,6 +231,25 @@ def test_to_row_maps_payload_onto_the_model():
     assert row.properties["mode"] == "test"
 
 
+def test_model_declaration_is_idempotent():
+    """The table must survive its declaration running twice.
+
+    A process that prunes metadata and re-runs migrations in-process (the
+    performance benchmark does) re-executes the model module, which raises
+    "Table 'telemetry_events' is already defined for this MetaData instance"
+    unless the declaration opts into extend_existing.
+    """
+    import importlib
+
+    module = importlib.import_module("cognee.modules.telemetry.models.TelemetryEvent")
+
+    importlib.reload(module)  # must not raise
+
+    from cognee.infrastructure.databases.relational import Base
+
+    assert "telemetry_events" in Base.metadata.tables
+
+
 def test_to_row_tolerates_a_non_uuid_tenant_sentinel():
     """``"Single User Tenant"`` must land as NULL, not raise."""
     from cognee.modules.telemetry.postgres_sink import _to_row

--- a/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
+++ b/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
@@ -1,0 +1,244 @@
+"""Unit tests for telemetry identity resolution and sink selection."""
+
+import uuid
+from collections.abc import Coroutine
+from typing import Any
+
+from cognee.shared import utils
+from cognee.shared.utils import (
+    _is_internal_task_event,
+    _resolve_identity,
+    _telemetry_sinks,
+    send_telemetry,
+)
+
+
+class FakeUser:
+    """Stands in for the User model, which defines no ``__str__``.
+
+    ``str()`` on it yields an object repr — the exact failure this suite guards.
+    """
+
+    def __init__(self, user_id, tenant_id=None):
+        self.id = user_id
+        self.tenant_id = tenant_id
+
+
+def test_resolve_identity_reads_id_and_tenant_off_a_user_model():
+    user_id, tenant_id = uuid.uuid4(), uuid.uuid4()
+
+    resolved_user, resolved_tenant = _resolve_identity(FakeUser(user_id, tenant_id))
+
+    assert resolved_user == str(user_id)
+    assert resolved_tenant == str(tenant_id)
+
+
+def test_resolve_identity_never_returns_an_object_repr():
+    """A User forwarded whole must not be stringified into ``<... object at 0x...>``."""
+    user = FakeUser(uuid.uuid4(), uuid.uuid4())
+    assert "object at 0x" in str(user)
+
+    resolved_user, _ = _resolve_identity(user)
+
+    assert "object at 0x" not in resolved_user
+
+
+def test_resolve_identity_passes_through_sentinels_and_bare_uuids():
+    user_id = uuid.uuid4()
+
+    assert _resolve_identity("sdk") == ("sdk", None)
+    assert _resolve_identity(user_id) == (str(user_id), None)
+    assert _resolve_identity(None) == ("None", None)
+
+
+def test_resolve_identity_reports_no_tenant_for_untenanted_users():
+    assert _resolve_identity(FakeUser(uuid.uuid4(), None))[1] is None
+
+
+def test_telemetry_sinks_defaults_to_http(monkeypatch):
+    monkeypatch.delenv("TELEMETRY_SINK", raising=False)
+    assert _telemetry_sinks() == ["http"]
+
+
+def test_telemetry_sinks_parses_a_list(monkeypatch):
+    """Adding a destination must be configuration, not code."""
+    monkeypatch.setenv("TELEMETRY_SINK", " Postgres , http ")
+    assert _telemetry_sinks() == ["postgres", "http"]
+
+
+def test_internal_per_task_events_are_recognised():
+    # Names are built as f"{task_type} Task Started" in run_tasks_base, so match
+    # on the suffix rather than enumerating task types.
+    assert _is_internal_task_event("Coroutine Task Started")
+    assert _is_internal_task_event("Async Generator Task Completed")
+    assert _is_internal_task_event("Some Future Type Task Errored")
+    assert not _is_internal_task_event("cognee.remember")
+    assert not _is_internal_task_event("Add API Endpoint Invoked")
+
+
+def _capture_http(monkeypatch) -> list[dict[str, Any]]:
+    """Capture HTTP-sink payloads without touching the network."""
+    payloads: list[dict[str, Any]] = []
+
+    def capture(payload: dict[str, Any]) -> Coroutine[Any, Any, None]:
+        payloads.append(payload)
+
+        async def noop() -> None:
+            return None
+
+        return noop()
+
+    class CapturingLoop:
+        def create_task(self, coroutine: Coroutine[Any, Any, None]) -> None:
+            coroutine.close()
+
+    monkeypatch.setenv("ENV", "prod")
+    monkeypatch.delenv("TELEMETRY_DISABLED", raising=False)
+    monkeypatch.setattr(utils, "get_anonymous_id", lambda: "anonymous-test-id")
+    monkeypatch.setattr(utils, "get_persistent_id", lambda: "persistent-test-id")
+    monkeypatch.setattr(utils, "_send_telemetry_request", capture)
+    monkeypatch.setattr(utils.asyncio, "get_running_loop", lambda: CapturingLoop())
+    return payloads
+
+
+def test_payload_carries_tenant_id(monkeypatch):
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+    user_id, tenant_id = uuid.uuid4(), uuid.uuid4()
+
+    send_telemetry("cognee.remember", FakeUser(user_id, tenant_id))
+
+    properties = payloads[0]["properties"]
+    assert properties["user_id"] == str(user_id)
+    assert properties["tenant_id"] == str(tenant_id)
+    assert payloads[0]["user_properties"]["tenant_id"] == str(tenant_id)
+
+
+def test_payload_falls_back_when_deployment_has_no_tenancy(monkeypatch):
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+
+    send_telemetry("cognee.recall", "sdk")
+
+    assert payloads[0]["properties"]["tenant_id"] == "Single User Tenant"
+
+
+def test_explicit_tenant_id_property_still_wins(monkeypatch):
+    """Call sites that already pass their own tenant_id keep their behaviour."""
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+
+    send_telemetry(
+        "cognee.search EXECUTION STARTED",
+        FakeUser(uuid.uuid4(), uuid.uuid4()),
+        additional_properties={"tenant_id": "explicit-value"},
+    )
+
+    assert payloads[0]["properties"]["tenant_id"] == "explicit-value"
+
+
+def test_legacy_user_id_keyword_is_still_accepted(monkeypatch):
+    """Out-of-tree callers passing ``user_id=`` must not break."""
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+    user_id = uuid.uuid4()
+
+    send_telemetry("legacy_event", user_id=user_id)
+
+    assert payloads[0]["properties"]["user_id"] == str(user_id)
+
+
+def test_local_sink_receives_user_events_but_not_internal_task_events(monkeypatch):
+    enqueued: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "cognee.modules.telemetry.postgres_sink.enqueue", lambda payload: enqueued.append(payload)
+    )
+    _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "postgres")
+    user = FakeUser(uuid.uuid4(), uuid.uuid4())
+
+    send_telemetry("cognee.improve", user)
+    send_telemetry("Coroutine Task Started", user)
+
+    assert [payload["event_name"] for payload in enqueued] == ["cognee.improve"]
+
+
+def test_http_only_configuration_does_not_write_locally(monkeypatch):
+    enqueued: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "cognee.modules.telemetry.postgres_sink.enqueue", lambda payload: enqueued.append(payload)
+    )
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+
+    send_telemetry("cognee.forget", FakeUser(uuid.uuid4(), uuid.uuid4()))
+
+    assert enqueued == []
+    assert len(payloads) == 1
+
+
+def test_both_sinks_receive_the_same_event(monkeypatch):
+    """The configuration the cross-tenant warehouse follow-up will switch on."""
+    enqueued: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "cognee.modules.telemetry.postgres_sink.enqueue", lambda payload: enqueued.append(payload)
+    )
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "postgres,http")
+
+    send_telemetry("cognee.remember", FakeUser(uuid.uuid4(), uuid.uuid4()))
+
+    assert len(enqueued) == 1
+    assert len(payloads) == 1
+    assert enqueued[0] == payloads[0]
+
+
+def test_telemetry_disabled_beats_every_sink(monkeypatch):
+    enqueued: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "cognee.modules.telemetry.postgres_sink.enqueue", lambda payload: enqueued.append(payload)
+    )
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "postgres,http")
+    monkeypatch.setenv("TELEMETRY_DISABLED", "1")
+
+    send_telemetry("cognee.remember", FakeUser(uuid.uuid4(), uuid.uuid4()))
+
+    assert enqueued == []
+    assert payloads == []
+
+
+def test_to_row_maps_payload_onto_the_model():
+    from cognee.modules.telemetry.postgres_sink import _to_row
+
+    user_id, tenant_id = uuid.uuid4(), uuid.uuid4()
+    payload = {
+        "anonymous_id": "anonymous-test-id",
+        "event_name": "cognee.remember",
+        "properties": {"user_id": str(user_id), "tenant_id": str(tenant_id), "mode": "test"},
+    }
+
+    class Row:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    row = _to_row(Row, payload)
+
+    assert row.event_name == "cognee.remember"
+    assert row.user_id == user_id
+    assert row.tenant_id == tenant_id
+    assert row.anonymous_id == "anonymous-test-id"
+    assert row.properties["mode"] == "test"
+
+
+def test_to_row_tolerates_a_non_uuid_tenant_sentinel():
+    """``"Single User Tenant"`` must land as NULL, not raise."""
+    from cognee.modules.telemetry.postgres_sink import _to_row
+
+    class Row:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    row = _to_row(Row, {"event_name": "e", "properties": {"tenant_id": "Single User Tenant"}})
+
+    assert row.tenant_id is None

--- a/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
+++ b/cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py
@@ -271,6 +271,89 @@ def test_to_row_populates_dataset_id():
     assert row.dataset_id == dataset
 
 
+def test_origin_defaults_to_sdk(monkeypatch):
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+    monkeypatch.delenv("TELEMETRY_ORIGIN", raising=False)
+
+    send_telemetry("cognee.remember", FakeUser(uuid.uuid4(), uuid.uuid4()))
+
+    assert payloads[0]["properties"]["origin"] == "sdk"
+
+
+def test_origin_can_be_set_deployment_wide_by_env(monkeypatch):
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+    monkeypatch.setenv("TELEMETRY_ORIGIN", "cloud")
+
+    send_telemetry("cognee.remember", FakeUser(uuid.uuid4(), uuid.uuid4()))
+
+    assert payloads[0]["properties"]["origin"] == "cloud"
+
+
+def test_context_origin_beats_the_env_default(monkeypatch):
+    """The API middleware sets this per request, so it must win."""
+    from cognee.context_global_variables import telemetry_origin
+
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+    monkeypatch.setenv("TELEMETRY_ORIGIN", "cloud")
+
+    token = telemetry_origin.set("mcp")
+    try:
+        send_telemetry("cognee.recall", FakeUser(uuid.uuid4(), uuid.uuid4()))
+    finally:
+        telemetry_origin.reset(token)
+
+    assert payloads[0]["properties"]["origin"] == "mcp"
+
+
+def test_pipeline_run_id_is_picked_up_from_context(monkeypatch):
+    from cognee.context_global_variables import current_pipeline_run_id
+
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+    run_id = uuid.uuid4()
+
+    token = current_pipeline_run_id.set(run_id)
+    try:
+        send_telemetry("Pipeline Run Completed", FakeUser(uuid.uuid4(), uuid.uuid4()))
+    finally:
+        current_pipeline_run_id.reset(token)
+
+    assert payloads[0]["properties"]["pipeline_run_id"] == str(run_id)
+
+
+def test_pipeline_run_id_absent_outside_a_pipeline(monkeypatch):
+    payloads = _capture_http(monkeypatch)
+    monkeypatch.setenv("TELEMETRY_SINK", "http")
+
+    send_telemetry("cognee.forget", FakeUser(uuid.uuid4(), uuid.uuid4()))
+
+    assert "pipeline_run_id" not in payloads[0]["properties"]
+
+
+def test_to_row_populates_pipeline_run_id_and_origin():
+    from cognee.modules.telemetry.postgres_sink import _to_row
+
+    run_id = uuid.uuid4()
+
+    class Row:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    row = _to_row(
+        Row,
+        {
+            "event_name": "cognee.remember",
+            "properties": {"pipeline_run_id": str(run_id), "origin": "mcp"},
+        },
+    )
+
+    assert row.pipeline_run_id == run_id
+    assert row.origin == "mcp"
+
+
 def test_model_declaration_is_idempotent():
     """The table must survive its declaration running twice.
 


### PR DESCRIPTION
Makes the existing SDK telemetry usable as the cloud activity log, replacing the bespoke per-operation activity log from #4291 (closed). Paired with cloud-backend#287, which enables it for v2 tenants.

Linear: [COG-6062](https://linear.app/cognee/issue/COG-6062/enable-enriched-sdk-telemetry-for-cloud-tenants)

**Open-source behaviour is unchanged** — `TELEMETRY_SINK` defaults to `http`, so nothing new is written or stored unless a deployment opts in.

## 1. Identity — fixes a live OSS bug

`send_telemetry` does `str(user_id)`, but `remember.py`, `improve.py` and `forget.py` pass the **`User` model object**, which defines no `__str__`. Those events have been recording `<cognee.modules.users.models.User.User object at 0x...>` as the user id. From the warehouse, last 3 days:

| `tracking_event` | events | with `tenant_id` | `user_id` = object repr |
|---|---:|---:|---:|
| `Pipeline Run Started` | 1,043,396 | 1,043,253 | 0 |
| `cognee.improve` | 289,828 | **0** | **288,511** |
| `cognee.remember` | 64,313 | **0** | **35,387** |
| `cognee.recall` | 147,365 | **0** | 355 |
| `cognee.forget` | 4,978 | **0** | **4,173** |
| `* API Endpoint Invoked` | ~2.0M | **0** | 0 |

~2.6M corrupted events per 30 days. `run_tasks_with_telemetry` already did this correctly, which is why `Pipeline Run *` is clean — this PR generalises that pattern.

`send_telemetry` now resolves its caller itself (`User` / `UUID` / `"sdk"`) and records `tenant_id`. Fixing it **centrally** rather than at four call sites corrects every emitter at once and avoids threading `tenant_id` through ~40 sites. Sites that pre-resolved `user.id` now pass the model, so their events gain a tenant too — done with an AST rewrite restricted to `send_telemetry`'s second positional argument, not a regex.

## 2. Sinks are a list, not a switch

`TELEMETRY_SINK` is comma-separated. A deployment can run `postgres` (nothing leaves its boundary) and later `postgres,http` to *also* feed the shared analytics pipeline. Adding a destination is configuration, not code.

The `postgres` sink buffers events and writes them to the deployment's own relational DB as a rolling window (`TELEMETRY_RETENTION_DAYS`, default 30), read back via `GET /v1/activity/events`. It is bounded, batched, flushed on shutdown, and lossy under pressure by design — telemetry must never slow down or fail the operation it observes.

Per-task events (`f"{task_type} Task Started"` etc.) are excluded from local sinks: 54% of all volume and meaningless to an end user. The HTTP sink still receives them, so historical analytics are unaffected.

The table mirrors `analytics.main.pipeline_events` columns so warehouse queries port over without a reshape.

## 3. Columns promoted out of `properties`

So an activity view can filter on them without a JSON scan:

| Column | Source | Null when |
|---|---|---|
| `dataset_id` | normalised from the three spellings call sites use (`dataset_id`, `dataset_ids`, `dataset`) | no dataset, or the event spans several — the list stays in `properties` |
| `pipeline_run_id` | `current_pipeline_run_id` ContextVar, published by `run_tasks_with_telemetry` from `ctx.pipeline_run_id` | event raised outside a pipeline |
| `origin` | `telemetry_origin` ContextVar, set per request by the API layer from `X-Cognee-Client`; falls back to `TELEMETRY_ORIGIN`, then `"sdk"` | never |

`pipeline_run_id` is what makes `/v1/activity/events` joinable to `/v1/activity/pipeline-runs`. `origin` distinguishes dashboard traffic from MCP/coding-agent traffic. Both travel on ContextVars rather than arguments, because the emitters worth labelling sit deep inside pipelines that have no reason to know how they were invoked.

`improve()`'s ambiguous `dataset` property is also split into explicit `dataset_id` / `dataset_name` — it accepts either a name or an id, so the column was previously only populated when the caller happened to pass an id. `dataset` is unchanged for the warehouse queries that read it.

## Also

- `TELEMETRY_ENDPOINT` overrides the hardcoded proxy URL.
- The deprecated `user_id=` keyword still works, for out-of-tree callers.
- New env vars documented in `.env.template`.

## Testing

- 30 unit tests in `cognee/tests/unit/shared/test_telemetry_identity_and_sinks.py`.
- Round-trip verified against a real SQLite DB: real UUIDs persist, internal events excluded, `http`-only writes nothing locally, `postgres,http` delivers to both, `TELEMETRY_DISABLED` beats every sink, and `dataset_id`/`pipeline_run_id`/`origin` populate as documented.
- Nullability matrix confirmed: `id`, `event_name`, `origin`, `anonymous_id`, `properties`, `created_at` are never null; `user_id`/`tenant_id` are null only without a real `User` (the OSS default user or the `"sdk"` sentinel).
- `ruff` v0.15.11 (the pre-commit pin) clean and formatted.
- Pipeline suite compared against clean `dev` at identical scope — 6 failed / 61 passed on both, identical failure sets. `run_tasks_with_telemetry` gained a `finally`, so this was checked deliberately.

### Red CI is pre-existing on `dev`

`Code Quality`, `basic checks / Lockfile and Pre-commit Hooks`, `Community Tests Status`, `Unit Tests (Mocked, No Secrets) (3.11.x)` and `Test Completion Status` fail identically on unrelated PRs (e.g. #4331). On a clean `origin/dev` worktree with the pinned hook version: `ruff format --check` wants 8 files (`cognee/api/v1/search/search.py`, four `cognee/modules/observability/*`, …), `ruff check` reports 1 error, and `test_memory_semconv.py` raises `ImportError: OpenTelemetry packages are required for tracing`. These look to originate in `107fdd857`. I deliberately did not fold an unrelated 8-file reformat plus a lint fix into a telemetry PR.

## Note for the cloud side

Tenant pods run cloud-backend's Alembic chain (`COGNEE_ALEMBIC_PATH`), not this one, so the companion PR adds `telemetry_events` there as well. The migration here is for OSS/self-hosted deployments.