### PR TITLE
feat(agents): recognize OpenCode connections

### DIFF
--- a/cognee-frontend/public/visuals/logos/opencode.svg
+++ b/cognee-frontend/public/visuals/logos/opencode.svg
@@ -1,0 +1,18 @@
+<svg width="300" height="300" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(30, 0)">
+    <g clip-path="url(#clip0_1401_86274)">
+      <mask id="mask0_1401_86274" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="240" height="300">
+        <path d="M240 0H0V300H240V0Z" fill="white"/>
+      </mask>
+      <g mask="url(#mask0_1401_86274)">
+        <path d="M180 240H60V120H180V240Z" fill="#CFCECD"/>
+        <path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#211E1E"/>
+      </g>
+    </g>
+  </g>
+  <defs>
+    <clipPath id="clip0_1401_86274">
+      <rect width="240" height="300" fill="white"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/cognee-frontend/src/app/(app)/dashboard/hooks/useConnectedIntegrations.ts
+++ b/cognee-frontend/src/app/(app)/dashboard/hooks/useConnectedIntegrations.ts
@@ -9,11 +9,13 @@ import {
 
 // Per-integration session_id prefix. Detection is coarse on purpose — any session
 // whose id starts with the prefix counts as connected. Keep these in sync with
-// the shipped integrations (claude-code → "cc_", codex → "codex_" as emitted by
-// the plugins' _generate_session_id). Openclaw and API/MCP have no fixed prefix.
+// the shipped integrations (claude-code → "cc_", codex → "codex_", opencode →
+// "opencode_" as emitted by their plugins' _generate_session_id). Openclaw and
+// API/MCP have no fixed prefix.
 const INTEGRATION_SESSION_PREFIX: Record<string, string> = {
   "claude-code": "cc_",
   codex: "codex_",
+  opencode: "opencode_",
 };
 
 /**

--- a/cognee-frontend/src/app/(app)/dashboard/partials/AciCard.tsx
+++ b/cognee-frontend/src/app/(app)/dashboard/partials/AciCard.tsx
@@ -104,6 +104,12 @@ function buildLogoNode(key: AciAgentKey, name: string): React.ReactElement {
       </svg>
     );
   }
-  const src = key === "claude-code" ? "/visuals/logos/claude.svg" : key === "codex" ? "/visuals/logos/codex.svg" : "/visuals/logos/openclaw.svg";
+  const src = key === "claude-code"
+    ? "/visuals/logos/claude.svg"
+    : key === "codex"
+      ? "/visuals/logos/codex.svg"
+      : key === "opencode"
+        ? "/visuals/logos/opencode.svg"
+        : "/visuals/logos/openclaw.svg";
   return <img src={src} alt={name} style={{ height: 110, width: "auto" }} />;
 }

--- a/cognee-frontend/src/app/(app)/dashboard/partials/AgentConnectionSection.tsx
+++ b/cognee-frontend/src/app/(app)/dashboard/partials/AgentConnectionSection.tsx
@@ -102,6 +102,8 @@ export function AgentConnectionSection({
       ? "/visuals/logos/claude.svg"
       : activeKey === "codex"
       ? "/visuals/logos/codex.svg"
+      : activeKey === "opencode"
+      ? "/visuals/logos/opencode.svg"
       : "/visuals/logos/openclaw.svg";
 
   const popupContent =

--- a/cognee-frontend/src/app/(app)/dashboard/partials/agentConnectionSteps.ts
+++ b/cognee-frontend/src/app/(app)/dashboard/partials/agentConnectionSteps.ts
@@ -4,6 +4,7 @@ import {
   CODEX_HOOKS_ENABLE,
   CODEX_MARKETPLACE_ADD,
   CODEX_PLUGIN_INSTALL,
+  OPENCODE_PLUGIN_SETUP,
   OPENCLAW_SKILL_INSTALL,
   GENERIC_SKILL_INSTALL,
   UPLOAD_MEMORY_PROMPT,
@@ -22,7 +23,7 @@ export interface AciStepDef {
   skillContent?: string;
 }
 
-export type AciAgentKey = "upload" | "claude-code" | "codex" | "openclaw" | "api-mcp";
+export type AciAgentKey = "upload" | "claude-code" | "codex" | "opencode" | "openclaw" | "api-mcp";
 
 export interface AciCardConfig {
   key: AciAgentKey;
@@ -33,6 +34,7 @@ export interface AciCardConfig {
 export const CARDS_CFG: AciCardConfig[] = [
   { key: "claude-code", name: "Claude Code",   description: "Give Claude Code persistent memory across all your projects" },
   { key: "codex",       name: "Codex",         description: "Connect OpenAI Codex to your knowledge graph via the Cognee plugin" },
+  { key: "opencode",    name: "OpenCode",      description: "Give OpenCode persistent memory with the Cognee plugin" },
   { key: "openclaw",    name: "Openclaw",       description: "Connect Openclaw to your knowledge graph via AGENTS.md" },
   { key: "api-mcp",     name: "API / MCP",      description: "Connect any agent or app via the REST API or MCP" },
   { key: "upload",      name: "Company Brain",  description: "Upload PDFs, docs, and data to build your knowledge graph" },
@@ -108,6 +110,32 @@ export function getSteps(key: AciAgentKey, opts: StepOptions): AciStepDef[] {
     {
       title: "You're all set",
       description: "The Cognee plugin hooks into Codex's lifecycle — no curl or manual API calls — and captures your session as you work. When a session ends (e.g. /exit), it consolidates that session into your Cognee Cloud knowledge graph, and every new session automatically recalls it back. Sessions are disposable; your memory isn't.",
+    },
+  ];
+
+  if (key === "opencode") return [
+    credStep,
+    {
+      title: "Install the Cognee plugin",
+      description: "Run the OpenCode plugin setup command in your terminal, then restart OpenCode.",
+      codeBlocks: [{ code: OPENCODE_PLUGIN_SETUP }],
+    },
+    {
+      title: "Upload something to Cognee",
+      description: "Pick one and paste it into OpenCode — it stores the content in your Cognee memory so you can recall it in the next step.",
+      codeBlocks: [
+        { label: "Option A · Your existing memory", code: UPLOAD_MEMORY_PROMPT },
+        { label: "Option B · Try it with a sample", code: UPLOAD_SAMPLE_PROMPT },
+      ],
+    },
+    {
+      title: "Recall it from Cognee",
+      description: "Open a fresh OpenCode session and ask the question below. Answering from the new session proves it is recalling your Cognee memory.",
+      codeBlocks: [{ code: RECALL_SAMPLE_PROMPT }],
+    },
+    {
+      title: "You're all set",
+      description: "The Cognee plugin captures OpenCode sessions as you work and recalls relevant knowledge in new sessions. Your sessions are disposable; your memory isn't.",
     },
   ];
 

--- a/cognee-frontend/src/data/prompts.ts
+++ b/cognee-frontend/src/data/prompts.ts
@@ -456,6 +456,10 @@ export const CODEX_HOOKS_ENABLE = "codex features enable hooks";
 export const CODEX_MARKETPLACE_ADD = "codex plugin marketplace add topoteretes/cognee-integrations --ref main";
 export const CODEX_PLUGIN_INSTALL = "codex plugin add cognee@cognee";
 
+// OpenCode's native Cognee plugin installs and configures itself through its
+// package setup command. Credentials are supplied in the preceding dashboard step.
+export const OPENCODE_PLUGIN_SETUP = "npx @cognee/cognee-opencode setup";
+
 // Onboarding: a ready-to-paste prompt telling the connected agent to push the
 // user's existing context into Cognee as long-term memory.
 //

--- a/cognee/modules/agents/models.py
+++ b/cognee/modules/agents/models.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
-AgentConnectionType = Literal["sdk", "api", "mcp", "claude_code", "workflow", "unknown"]
+AgentConnectionType = Literal["sdk", "api", "mcp", "claude_code", "opencode", "workflow", "unknown"]
 AgentMemoryMode = Literal["session", "cognee", "hybrid", "none", "unknown"]
 AgentStatus = Literal["active", "inactive", "unknown"]
 AgentSource = Literal["agent_memory", "session_trace", "serve", "api_key", "mcp", "api"]

--- a/cognee/tests/api/test_agents_e2e.py
+++ b/cognee/tests/api/test_agents_e2e.py
@@ -282,6 +282,39 @@ class TestAgentsE2E:
         resp = client.get("/api/v1/agents/connections", headers=headers)
         assert resp.json()["total"] == 1
 
+    def test_opencode_connection_lifecycle(self, client, headers, _patch_operations):
+        clear_registered_agent_connections()
+        payload = {
+            "agent_session_name": "opencode_workspace",
+            "type": "opencode",
+            "source": "api",
+        }
+
+        registered = client.post("/api/v1/agents/register", headers=headers, json=payload)
+        assert registered.status_code == 201, registered.text
+        connection_id = registered.json()["id"]
+        assert registered.json()["type"] == "opencode"
+
+        repeated = client.post("/api/v1/agents/register", headers=headers, json=payload)
+        assert repeated.status_code == 201, repeated.text
+        assert repeated.json()["id"] == connection_id
+
+        listed = client.get("/api/v1/agents/connections", headers=headers)
+        assert listed.status_code == 200, listed.text
+        assert listed.json()["total"] == 1
+        assert listed.json()["agents"][0]["type"] == "opencode"
+
+        unregistered = client.post(
+            "/api/v1/agents/unregister",
+            headers=headers,
+            json={"agent_session_name": payload["agent_session_name"]},
+        )
+        assert unregistered.status_code == 200, unregistered.text
+
+        remaining = client.get("/api/v1/agents/connections", headers=headers)
+        assert remaining.status_code == 200, remaining.text
+        assert remaining.json()["agents"] == []
+
     # ------------------------------------------------------------------ #
     # Sub-user agent CRUD endpoints
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
- Adds `opencode` as an agent connection type, with end-to-end coverage for idempotent registration, listing, and unregistration.
- Adds an OpenCode dashboard card with the official logo, setup command, and `opencode_` session detection.

Fixes #4315

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Validation
- `uv run ruff format --check cognee/modules/agents/models.py cognee/tests/api/test_agents_e2e.py`
- `uv run ruff check cognee/modules/agents/models.py cognee/tests/api/test_agents_e2e.py`
- `uv run pytest cognee/tests/api/test_agents_e2e.py -v --tb=short` (29 passed)
- Scoped frontend ESLint (0 errors; two existing `next/image` warnings on unchanged image elements)
- `npm run build` compiles successfully, then stops at an existing unused `@ts-expect-error` in `src/app/(graph)/GraphVisualization.tsx:210`.

## Screenshot
Terminal transcript of the local validation commands above:

<img width="1100" alt="Cognee 4333 local validation transcript showing ruff checks and 29 passing focused tests" src="https://raw.githubusercontent.com/zrh805/cognee/codex/cognee-4333-evidence/cognee-4333-validation.svg" />

## Pre-submission Checklist
- [x] I have tested the change thoroughly before submitting.
- [x] This PR contains the minimal changes needed for OpenCode connections.
- [x] I added tests that prove the new backend connection type works.
- [x] I searched existing PRs before implementing the issue.
- [x] Every commit is signed off for the DCO.

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin