### PR TITLE
Feature/cog 6063 review lucas pr

### DIFF
--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -7,6 +7,7 @@ This module provides a unified interface for interacting with Cognee, supporting
 """
 
 import os
+import re
 import sys
 import base64
 import hashlib
@@ -33,6 +34,15 @@ except ImportError:
 logger = get_logger()
 
 
+# A scheme is "scheme://", per RFC 3986 (letter, then letters/digits/+-.).
+# Deliberately requires the "//" so a bare "localhost:8000" is treated as a
+# schemeless host:port rather than a URL whose scheme is "localhost" — the
+# reading urlsplit() gives it.
+_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://")
+# ...and the same prefix with a single slash, the common typo ("https:/host").
+_SINGLE_SLASH_SCHEME_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.\-]*):/(?!/)")
+
+
 def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
     """Normalize a Cognee base URL so requests never fail on a missing scheme.
 
@@ -49,15 +59,27 @@ def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
     if not url:
         return None
 
-    if "://" not in url:
-        logger.warning(
-            "COGNEE_BASE_URL/--api-url %r has no scheme; assuming https://. "
-            "Set the full URL (e.g. https://your-tenant.aws.cognee.ai) to silence this.",
-            url,
-        )
-        url = f"https://{url}"
+    if _SCHEME_RE.match(url):
+        return url
 
-    return url
+    # Repair near-misses rather than prefixing them into nonsense: "https:/host"
+    # would otherwise become "https://https:/host", and the protocol-relative
+    # "//host" would become "https:////host".
+    repaired = _SINGLE_SLASH_SCHEME_RE.sub(r"\1://", url, count=1)
+    if repaired != url:
+        logger.warning(
+            "COGNEE_BASE_URL/--api-url %r is missing a slash after the scheme; reading it as %r.",
+            url,
+            repaired,
+        )
+        return repaired
+
+    logger.warning(
+        "COGNEE_BASE_URL/--api-url %r has no scheme; assuming https://. "
+        "Set the full URL (e.g. https://your-tenant.aws.cognee.ai) to silence this.",
+        url,
+    )
+    return f"https://{url.lstrip('/')}"
 
 
 # Read-only GETs (dataset list/status) should fail fast rather than inherit the
@@ -116,8 +138,6 @@ class CogneeClient:
         # Extract tenant ID from tenant URL pattern: tenant-<uuid>.*.cognee.ai
         self.tenant_id: Optional[str] = None
         if self.api_url:
-            import re
-
             match = re.search(r"tenant-([0-9a-f-]{36})", self.api_url)
             if match:
                 self.tenant_id = match.group(1)

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -61,7 +61,9 @@ def _assumed_scheme(url: str) -> str:
     return "http" if host.lower() in _LOOPBACK_HOSTS else "https"
 
 
-def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
+def normalize_api_url(
+    api_url: Optional[str], source: str = "COGNEE_BASE_URL/--api-url"
+) -> Optional[str]:
     """Normalize a Cognee base URL so requests never fail on a missing scheme.
 
     Users routinely paste a bare tenant host (e.g. ``tenant-xxx.aws.cognee.ai``)
@@ -69,6 +71,10 @@ def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
     cryptic "Request URL is missing an 'http://' or 'https://' protocol" only on
     the first request (e.g. remember), long after startup. Infer the scheme for a
     schemeless URL and warn, so the common case just works and the fix is clear.
+
+    ``source`` names the setting the value came from; it is echoed in the warning
+    so the reader is pointed at the knob they actually set (serve mode resolves
+    ``COGNEE_SERVICE_URL`` / ``--serve-url``, not ``COGNEE_BASE_URL``).
     """
     if not api_url:
         return api_url
@@ -86,9 +92,7 @@ def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
     repaired = _SINGLE_SLASH_SCHEME_RE.sub(r"\1://", url, count=1)
     if repaired != url:
         logger.warning(
-            "COGNEE_BASE_URL/--api-url %r is missing a slash after the scheme; reading it as %r.",
-            url,
-            repaired,
+            "%s %r is missing a slash after the scheme; reading it as %r.", source, url, repaired
         )
         return repaired
 
@@ -96,8 +100,8 @@ def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
     scheme = _assumed_scheme(host_part)
     normalized = f"{scheme}://{host_part}"
     logger.warning(
-        "COGNEE_BASE_URL/--api-url %r has no scheme; assuming %s://. "
-        "Set the full URL (e.g. %s) to silence this.",
+        "%s %r has no scheme; assuming %s://. Set the full URL (e.g. %s) to silence this.",
+        source,
         url,
         scheme,
         normalized,

--- a/cognee-mcp/src/cognee_client.py
+++ b/cognee-mcp/src/cognee_client.py
@@ -42,6 +42,24 @@ _SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://")
 # ...and the same prefix with a single slash, the common typo ("https:/host").
 _SINGLE_SLASH_SCHEME_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.\-]*):/(?!/)")
 
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"})
+
+
+def _assumed_scheme(url: str) -> str:
+    """Pick the scheme to assume for a schemeless URL from its host.
+
+    Loopback hosts are self-hosted dev servers that almost never speak TLS —
+    assuming https there swaps the "missing protocol" error for an equally
+    cryptic "[SSL: WRONG_VERSION_NUMBER]". Everything else is a real host and
+    should get https.
+    """
+    host = url.split("/", 1)[0].rsplit("@", 1)[-1]
+    if host.startswith("["):  # bracketed IPv6, e.g. [::1]:8000
+        host = host[: host.find("]") + 1]
+    else:
+        host = host.split(":", 1)[0]  # strip :port
+    return "http" if host.lower() in _LOOPBACK_HOSTS else "https"
+
 
 def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
     """Normalize a Cognee base URL so requests never fail on a missing scheme.
@@ -49,8 +67,8 @@ def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
     Users routinely paste a bare tenant host (e.g. ``tenant-xxx.aws.cognee.ai``)
     into ``COGNEE_BASE_URL`` / ``--api-url``. Without a scheme, httpx raises the
     cryptic "Request URL is missing an 'http://' or 'https://' protocol" only on
-    the first request (e.g. remember), long after startup. Assume ``https://`` for
-    a schemeless URL and warn, so the common case just works and the fix is clear.
+    the first request (e.g. remember), long after startup. Infer the scheme for a
+    schemeless URL and warn, so the common case just works and the fix is clear.
     """
     if not api_url:
         return api_url
@@ -74,12 +92,17 @@ def normalize_api_url(api_url: Optional[str]) -> Optional[str]:
         )
         return repaired
 
+    host_part = url.lstrip("/")
+    scheme = _assumed_scheme(host_part)
+    normalized = f"{scheme}://{host_part}"
     logger.warning(
-        "COGNEE_BASE_URL/--api-url %r has no scheme; assuming https://. "
-        "Set the full URL (e.g. https://your-tenant.aws.cognee.ai) to silence this.",
+        "COGNEE_BASE_URL/--api-url %r has no scheme; assuming %s://. "
+        "Set the full URL (e.g. %s) to silence this.",
         url,
+        scheme,
+        normalized,
     )
-    return f"https://{url.lstrip('/')}"
+    return normalized
 
 
 # Read-only GETs (dataset list/status) should fail fast rather than inherit the

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -2031,7 +2031,10 @@ async def main():
     apply_tool_mode(args.tool_mode)
 
     # Resolve cloud connection: CLI args take precedence over env vars
-    serve_url = normalize_api_url(args.serve_url or os.environ.get("COGNEE_SERVICE_URL", ""))
+    serve_url = normalize_api_url(
+        args.serve_url or os.environ.get("COGNEE_SERVICE_URL", ""),
+        source="COGNEE_SERVICE_URL/--serve-url",
+    )
     serve_api_key = args.serve_api_key or os.environ.get("COGNEE_API_KEY", "")
 
     # Connect to Cognee Cloud if configured (before migrations — cloud handles its own DB)

--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -2023,8 +2023,14 @@ async def main():
 
     args = parser.parse_args()
 
+    # Normalize once here, not just inside CogneeClient: the mode decisions below
+    # must agree with the client about what counts as a URL, or a blank-but-present
+    # COGNEE_BASE_URL reads as "remote" (skipping migrations) while the client
+    # falls back to direct mode.
+    api_url = normalize_api_url(args.api_url)
+
     # Initialize the global CogneeClient
-    cognee_client = CogneeClient(api_url=args.api_url, api_token=args.api_token)
+    cognee_client = CogneeClient(api_url=api_url, api_token=args.api_token)
 
     host = args.host
     port = int(args.port)
@@ -2038,7 +2044,7 @@ async def main():
     serve_api_key = args.serve_api_key or os.environ.get("COGNEE_API_KEY", "")
 
     # Connect to Cognee Cloud if configured (before migrations — cloud handles its own DB)
-    if serve_url and not args.api_url:
+    if serve_url and not api_url:
         import cognee
 
         serve_kwargs = {"url": serve_url}
@@ -2048,7 +2054,7 @@ async def main():
         logger.info(f"Connected to Cognee Cloud: {serve_url}")
 
     # Skip migrations when in API or Cloud mode (remote handles its own database)
-    is_remote = bool(args.api_url) or bool(serve_url)
+    is_remote = bool(api_url) or bool(serve_url)
     if not args.no_migration and not is_remote:
         from cognee.modules.engine.operations.setup import setup
         from cognee.run_migrations import run_migrations

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -1245,6 +1245,20 @@ def test_normalize_api_url_strips_whitespace():
     assert normalize_api_url("  tenant-abc.aws.cognee.ai  ") == "https://tenant-abc.aws.cognee.ai"
 
 
+def test_normalize_api_url_repairs_near_miss_schemes():
+    # Neither may be blindly prefixed: that yields "https://https:/host" and
+    # "https:////host" respectively.
+    assert (
+        normalize_api_url("https:/tenant-abc.aws.cognee.ai") == "https://tenant-abc.aws.cognee.ai"
+    )
+    assert normalize_api_url("//tenant-abc.aws.cognee.ai") == "https://tenant-abc.aws.cognee.ai"
+
+
+def test_normalize_api_url_leaves_explicit_non_http_scheme_alone():
+    # Not ours to rewrite — httpx reports the unsupported protocol clearly.
+    assert normalize_api_url("ftp://weird.host") == "ftp://weird.host"
+
+
 def test_normalize_api_url_passthrough_empty():
     assert normalize_api_url(None) is None
     assert normalize_api_url("") == ""

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -1275,6 +1275,26 @@ def test_normalize_api_url_leaves_explicit_non_http_scheme_alone():
     assert normalize_api_url("ftp://weird.host") == "ftp://weird.host"
 
 
+def test_normalize_api_url_warning_names_the_setting_it_was_given(monkeypatch):
+    # Serve mode resolves COGNEE_SERVICE_URL, so pointing the reader at
+    # COGNEE_BASE_URL would send them to a knob they never set.
+    warnings = []
+    client_module = importlib.import_module("src.cognee_client")
+    monkeypatch.setattr(
+        client_module.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warnings.append(msg % args if args else msg),
+    )
+
+    normalize_api_url("tenant-abc.aws.cognee.ai", source="COGNEE_SERVICE_URL/--serve-url")
+
+    assert len(warnings) == 1
+    assert "COGNEE_SERVICE_URL/--serve-url" in warnings[0]
+    assert "COGNEE_BASE_URL" not in warnings[0]
+    # The suggested value is the actual fix, ready to paste.
+    assert "https://tenant-abc.aws.cognee.ai" in warnings[0]
+
+
 def test_normalize_api_url_passthrough_empty():
     assert normalize_api_url(None) is None
     assert normalize_api_url("") == ""

--- a/cognee-mcp/tests/test_mcp_server_hardening.py
+++ b/cognee-mcp/tests/test_mcp_server_hardening.py
@@ -1245,6 +1245,22 @@ def test_normalize_api_url_strips_whitespace():
     assert normalize_api_url("  tenant-abc.aws.cognee.ai  ") == "https://tenant-abc.aws.cognee.ai"
 
 
+def test_normalize_api_url_assumes_http_for_loopback():
+    # A self-hosted server on localhost almost never speaks TLS; assuming https
+    # would trade "missing protocol" for an equally cryptic SSL handshake error.
+    assert normalize_api_url("localhost:8000") == "http://localhost:8000"
+    assert normalize_api_url("127.0.0.1:8000") == "http://127.0.0.1:8000"
+    assert normalize_api_url("[::1]:8000") == "http://[::1]:8000"
+    assert normalize_api_url("localhost") == "http://localhost"
+
+
+def test_normalize_api_url_keeps_https_for_remote_host_with_port():
+    assert (
+        normalize_api_url("tenant-abc.aws.cognee.ai:8000")
+        == "https://tenant-abc.aws.cognee.ai:8000"
+    )
+
+
 def test_normalize_api_url_repairs_near_miss_schemes():
     # Neither may be blindly prefixed: that yields "https://https:/host" and
     # "https:////host" respectively.


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description
A few bugs were uncovered during review of PR #4320 which this PR aims to address.

Bug 1: "://" not in url treated any URL containing :// as already schemed, so https:/host became https://https:/host and //host became https:////host. Fixed by matching schemes by prefix rather than substring, repairing the single-slash typo, and stripping leading slashes before prefixing. 

Bug 2: #4320 assumed https for every schemeless URL, so COGNEE_BASE_URL=localhost:8000 reached a plain-HTTP local server over TLS and failed with [SSL: WRONG_VERSION_NUMBER]. Fix: assume http for schemeless loopback URLs and https for everything else; ports and userinfo are stripped before the check so tenant.cognee.ai:8000 stays https.

Bug 3: The warning hardcoded COGNEE_BASE_URL/--api-url, but serve mode runs it over COGNEE_SERVICE_URL. Users were pointed at a variable they never set, defeating the whole purpose of the warning. The fix: normalize_api_url now takes a source label naming the setting the value came from, defaulted to COGNEE_BASE_URL/--api-url; server.py passes COGNEE_SERVICE_URL/--serve-url when resolving the serve-mode URL.

Bug 4: The PR has four commits. The fourth: main() branched on the raw args.api_url while CogneeClient normalized internally, so with COGNEE_BASE_URL="  " the two disagreed (is_remote skipped migrations while the client started in direct mode against an unmigrated DB.) Fixed by normalizing at the CLI boundary and reading one value everywhere.
Also added new tests to check all of these bugs, which are detailed below in acceptance criteria per-bug.

## Acceptance Criteria
Bug 1. One test checks the two malformed inputs now come out clean instead of mangled (using a URL missing a slash after the scheme, and one starting with just two slashes.) A second test checks we don't overreach and rewrite schemes that aren't ours, like ftp.

Bug 2. One test checks every local-address form comes out as http: localhost, the IPv4 and IPv6 loopback addresses, with and without a port. A second checks a real cloud host with a port still comes out as https, so the local-address rule can't quietly downgrade cloud traffic.

Bug 3. One test captures the warning and confirms it names the setting the URL actually came from, mentions no other setting, fires only once, and quotes the corrected URL so the user can paste it.

Bug 4. No automated test since the startup function has no test harness in this repo. Checked by hand instead: the two mode flags now agree for a blank URL, a real one, and none at all.

The five tests from #4320 still pass unchanged, confirming the cloud path and ordinary http/https URLs behave as before.

## Type of Change
<!-- Please check the relevant option -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
MCP server hardening tests (pytest tests/test_mcp_server_hardening.py -q):
INCLUDES NEW TESTS
<img width="502" height="213" alt="Screenshot 2026-08-04 at 12 58 40 PM" src="https://github.com/user-attachments/assets/d61182ab-d8a3-4183-9f47-39e60ff04b17" />

All MCP tests (pytest tests/ -q in cognee-mcp):
<img width="506" height="182" alt="Screenshot 2026-08-04 at 1 02 15 PM" src="https://github.com/user-attachments/assets/18e96fbd-0b54-4aa2-8ca7-e2a3a7ba2002" />


## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [X] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [X] **This PR contains minimal changes necessary to address the issue/feature**
- [X] My code follows the project's coding standards and style guidelines
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if applicable)
- [X] All new and existing tests pass
- [X]  I have searched existing PRs to ensure this change hasn't been submitted already
- [X] I have linked any relevant issues in the description
- [X] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.