### PR TITLE
chore: Fix red lint/pre-commit on dev (COG-6065)

### DIFF
--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -233,6 +233,7 @@ async def add(
     await setup()
 
     import time as _time
+
     _add_start_ns = _time.monotonic_ns()
 
     with new_span("memory.store") as _span:

--- a/cognee/api/v1/cognify/cognify.py
+++ b/cognee/api/v1/cognify/cognify.py
@@ -240,6 +240,7 @@ async def cognify(
         )
 
     import time as _time
+
     _cognify_start_ns = _time.monotonic_ns()
 
     with new_span("memory.process") as span:

--- a/cognee/api/v1/forget/forget.py
+++ b/cognee/api/v1/forget/forget.py
@@ -101,6 +101,7 @@ async def forget(
     )
 
     import time as _time
+
     _forget_start_ns = _time.monotonic_ns()
 
     with new_span("memory.delete") as span:

--- a/cognee/api/v1/search/search.py
+++ b/cognee/api/v1/search/search.py
@@ -372,7 +372,11 @@ async def search(
             f"Found {n} result(s) via {query_type.value}",
         )
         _duration_ms = (__import__("time").monotonic_ns() - _search_start_ns) / 1_000_000
-        _attrs = {"memory.system": "cognee", "memory.operation": "retrieve", "memory.query.type": str(query_type.value)}
+        _attrs = {
+            "memory.system": "cognee",
+            "memory.operation": "retrieve",
+            "memory.query.type": str(query_type.value),
+        }
         record_operation_duration(_duration_ms, _attrs)
         record_query_results(n, _attrs)
         increment_items_retrieved(n, _attrs)

--- a/cognee/modules/observability/logs.py
+++ b/cognee/modules/observability/logs.py
@@ -71,9 +71,7 @@ def setup_log_bridge(console_output: bool = False) -> Optional[object]:
     if console_output:
         from opentelemetry.sdk._logs.export import ConsoleLogExporter
 
-        _log_provider.add_log_record_processor(
-            SimpleLogRecordProcessor(ConsoleLogExporter())
-        )
+        _log_provider.add_log_record_processor(SimpleLogRecordProcessor(ConsoleLogExporter()))
 
     set_logger_provider(_log_provider)
 

--- a/cognee/modules/observability/metrics.py
+++ b/cognee/modules/observability/metrics.py
@@ -54,6 +54,7 @@ MEMORY_OPERATION_ERRORS = "memory.operation.errors"
 # Null-object pattern — zero overhead when metrics are off
 # ---------------------------------------------------------------------------
 
+
 class _NullInstrument:
     """No-op stand-in for any OTel instrument."""
 
@@ -269,7 +270,10 @@ def _add_http_metric_reader(readers: list, endpoint: str, headers) -> None:
             "Install with: pip install cognee[tracing]"
         )
         _log.error("OTel: %s", msg)
-        warnings.warn(msg, stacklevel=3,)
+        warnings.warn(
+            msg,
+            stacklevel=3,
+        )
 
 
 def get_meter() -> Optional[object]:
@@ -280,6 +284,7 @@ def get_meter() -> Optional[object]:
 # ---------------------------------------------------------------------------
 # Public metric helpers (no-op when not configured)
 # ---------------------------------------------------------------------------
+
 
 def record_operation_duration(duration_ms: float, attributes: dict) -> None:
     _op_duration.record(duration_ms, attributes)

--- a/cognee/modules/observability/tracing.py
+++ b/cognee/modules/observability/tracing.py
@@ -284,13 +284,13 @@ def _requires_http_exporter(endpoint: str) -> bool:
     closed) which causes traces to disappear without any visible error.
     """
     http_only_patterns = (
-        "/api/public/otel",        # Langfuse
-        "live.dynatrace.com",      # Dynatrace SaaS
-        "dynatrace.com",           # Dynatrace (any subdomain)
-        "/api/v2/otlp",            # Dynatrace OTLP path
-        "otel.live.dynatrace.com", # Dynatrace dedicated ingest
-        ":4318",                   # standard OTLP HTTP port
-        ":443/",                   # standard HTTPS — almost certainly HTTP OTLP
+        "/api/public/otel",  # Langfuse
+        "live.dynatrace.com",  # Dynatrace SaaS
+        "dynatrace.com",  # Dynatrace (any subdomain)
+        "/api/v2/otlp",  # Dynatrace OTLP path
+        "otel.live.dynatrace.com",  # Dynatrace dedicated ingest
+        ":4318",  # standard OTLP HTTP port
+        ":443/",  # standard HTTPS — almost certainly HTTP OTLP
     )
     return any(pat in endpoint for pat in http_only_patterns)
 
@@ -408,6 +408,7 @@ def setup_tracing(console_output: bool = False) -> "trace.Tracer":
         )
 
         import logging as _logging
+
         _log = _logging.getLogger("cognee.observability")
 
         _provider = TracerProvider(resource=resource)
@@ -424,7 +425,9 @@ def setup_tracing(console_output: bool = False) -> "trace.Tracer":
         endpoint = config.otel_exporter_otlp_endpoint
         _log.info(
             "OTel tracing initialised — service=%s version=%s endpoint=%s",
-            config.otel_service_name, version, endpoint or "none (in-memory only)",
+            config.otel_service_name,
+            version,
+            endpoint or "none (in-memory only)",
         )
 
     _tracer = _provider.get_tracer("cognee", version)

--- a/cognee/tests/unit/modules/observability/test_memory_semconv.py
+++ b/cognee/tests/unit/modules/observability/test_memory_semconv.py
@@ -57,7 +57,13 @@ def test_memory_semconv_constants_exported():
 
 def test_enable_tracing_sets_up_all_signals():
     """enable_tracing() initialises tracing, metrics, and log bridge without error."""
-    from cognee.modules.observability.trace_context import enable_tracing, disable_tracing, is_tracing_enabled
+    pytest.importorskip("opentelemetry")
+
+    from cognee.modules.observability.trace_context import (
+        enable_tracing,
+        disable_tracing,
+        is_tracing_enabled,
+    )
 
     enable_tracing()
     assert is_tracing_enabled()
@@ -74,7 +80,13 @@ def test_new_span_emits_memory_operation_retrieve():
     pytest.importorskip("opentelemetry")
 
     from cognee.modules.observability.trace_context import enable_tracing
-    from cognee.modules.observability import new_span, MEMORY_SYSTEM, MEMORY_OPERATION, MEMORY_QUERY_TEXT, MEMORY_RESULT_COUNT
+    from cognee.modules.observability import (
+        new_span,
+        MEMORY_SYSTEM,
+        MEMORY_OPERATION,
+        MEMORY_QUERY_TEXT,
+        MEMORY_RESULT_COUNT,
+    )
     from cognee.modules.observability.trace_context import get_last_trace
 
     enable_tracing()
@@ -103,7 +115,12 @@ def test_new_span_emits_memory_operation_store():
     pytest.importorskip("opentelemetry")
 
     from cognee.modules.observability.trace_context import enable_tracing
-    from cognee.modules.observability import new_span, MEMORY_SYSTEM, MEMORY_OPERATION, MEMORY_COLLECTION
+    from cognee.modules.observability import (
+        new_span,
+        MEMORY_SYSTEM,
+        MEMORY_OPERATION,
+        MEMORY_COLLECTION,
+    )
     from cognee.modules.observability.trace_context import get_last_trace
 
     enable_tracing()
@@ -267,12 +284,10 @@ def test_log_bridge_attaches_without_error():
     import logging
     from cognee.modules.observability.logs import setup_log_bridge, shutdown_log_bridge
 
-    provider = setup_log_bridge()
+    setup_log_bridge()
 
     cognee_logger = logging.getLogger("cognee")
-    has_otel_handler = any(
-        type(h).__name__ == "LoggingHandler" for h in cognee_logger.handlers
-    )
+    has_otel_handler = any(type(h).__name__ == "LoggingHandler" for h in cognee_logger.handlers)
     assert has_otel_handler, "Expected OTel LoggingHandler on cognee logger"
 
     # Logging through the bridge should not raise


### PR DESCRIPTION
`pre-commit run --all-files` fails on `dev`, so **Code Quality** and **basic checks / Lockfile and Pre-commit Hooks** are red on every open PR regardless of its contents — confirmed identical failures on unrelated PRs #4331 and #4332.

Linear: [COG-6065](https://linear.app/cognee/issue/COG-6065/fix-red-lintpre-commit-on-dev)

## Three causes

**1. Eight unformatted files.** Pure `ruff format` output — blank lines after inline imports, dict/argument rewrapping, comment realignment, and one expansion caused by a magic trailing comma. No behaviour change; I read every hunk.

```
cognee/api/v1/add/add.py
cognee/api/v1/cognify/cognify.py
cognee/api/v1/forget/forget.py
cognee/api/v1/search/search.py
cognee/modules/observability/logs.py
cognee/modules/observability/metrics.py
cognee/modules/observability/tracing.py
cognee/tests/unit/modules/observability/test_memory_semconv.py
```

**2. `ruff check` F841** — an unused `provider` binding in `test_log_bridge_attaches_without_error`. The test asserts on the logger's handlers and never uses the return value, so the binding is dropped rather than asserted on.

**3. `test_enable_tracing_sets_up_all_signals` raised `ImportError`.** It imports opentelemetry with no guard, but no test job installs the `tracing` extra — so it failed at import rather than running. Its **8 sibling tests in the same file already use `pytest.importorskip("opentelemetry")`**; this one was missed. It now skips like the others. This also clears **Unit Tests (Mocked, No Secrets) (3.11.x)** and the **Test Completion Status** aggregate.

## Verification

Repo-wide, with the version pre-commit pins (`ruff` v0.15.11):

```
ruff format --check .     → 2013 files already formatted
ruff check .              → All checks passed!
pre-commit run --all-files → all 6 hooks Passed
uv lock --check           → Resolved 551 packages
```

And no test regression — `cognee/tests/unit` gives the same result on this branch as on clean `dev` (`4 skipped, 6 errors`, those errors being pre-existing collection failures). The observability file itself goes from 1 failure to `7 passed, 9 skipped`.

## Note

No test job installs `[tracing]`, so the OTel tests never actually execute in CI — they all skip, which is what the existing `importorskip` guards imply is intended. If that coverage is wanted, the right fix is adding the extra to the unit-test job, not removing the guards. Left alone here.