### PR TITLE
SDK 329 - Add demo converting GraphCompletion triplets into Hybrid evidence 

### DIFF
--- a/examples/demos/graph_completion_to_hybrid.py
+++ b/examples/demos/graph_completion_to_hybrid.py
@@ -1,0 +1,128 @@
+"""Minimal demo: GraphCompletion triplets -> Hybrid context + answer.
+
+uv run python examples/demos/graph_completion_to_hybrid.py
+"""
+
+import asyncio
+import pathlib
+from typing import List, cast
+
+import cognee
+from cognee.modules.graph.cognee_graph.CogneeGraphElements import Edge, Node
+from cognee.modules.retrieval.graph_completion_retriever import GraphCompletionRetriever
+from cognee.modules.retrieval.hybrid_retriever import HybridRetriever
+from cognee.modules.retrieval.utils.brute_force_triplet_search import format_triplets
+
+DATASET = "graph_completion_to_hybrid_demo"
+QUERY = "Who works on Cognee, and how do Alice and Bob collaborate?"
+
+DOCUMENTS = [
+    "Alice is a Cognee engineer.",
+    "Bob is Cognee's product manager.",
+    "Cognee turns documents into AI memory.",
+    "Alice builds Cognee hybrid retrieval.",
+    "Alice and Bob meet weekly on Cognee demos.",
+    "Bob sends Cognee feedback to Alice.",
+]
+
+
+def triplets_to_hybrid(edges: List[Edge]) -> dict:
+    """Map GraphCompletion edges into Hybrid's chunks/ entities/ facts channels.
+
+    Relationships already attached to an entity are not repeated as facts.
+    ``made_from`` edges (summary↔chunk) are structural and skipped as facts.
+    """
+    chunks_by_id, entities_by_id, facts = {}, {}, []
+
+    def label(n: Node) -> str:
+        return n.attributes.get("name") or n.attributes.get("text") or n.id
+
+    for edge in edges:
+        for node in (edge.node1, edge.node2):
+            ntype = node.attributes.get("type")
+            text = node.attributes.get("text")
+            if ntype in {"DocumentChunk", "TextSummary"} and text and node.id not in chunks_by_id:
+                chunks_by_id[node.id] = {"id": node.id, "text": text}
+            elif ntype == "Entity" and node.id not in entities_by_id:
+                entities_by_id[node.id] = {
+                    "id": node.id,
+                    "name": node.attributes.get("name") or node.id,
+                    "description": node.attributes.get("description"),
+                    "edges": [],
+                }
+
+        rel = (
+            edge.attributes.get("relationship_type")
+            or edge.attributes.get("relationship_name")
+            or edge.attributes.get("edge_text")
+        )
+        if not rel or rel == "made_from":
+            continue
+
+        bullet = f"{label(edge.node1)} -- {rel} -- {label(edge.node2)}"
+        touches_entity = False
+        for node in (edge.node1, edge.node2):
+            entity = entities_by_id.get(node.id)
+            if entity is not None:
+                entity["edges"].append({"text": bullet})
+                touches_entity = True
+
+        # Already shown under an entity (or as passage/summary via chunks): skip facts.
+        if not touches_entity:
+            facts.append({"id": f"{edge.node1.id}:{edge.node2.id}", "text": bullet})
+
+    return {
+        "chunks": list(chunks_by_id.values()),
+        "chunk_summaries": {},
+        "entities": list(entities_by_id.values()),
+        "facts": facts,
+    }
+
+
+async def main() -> None:
+    root = pathlib.Path(__file__).resolve().parents[2]
+    cognee.config.system_root_directory(
+        str(root / ".cognee_system/graph_completion_to_hybrid_demo")
+    )
+    cognee.config.data_root_directory(str(root / ".data_storage/graph_completion_to_hybrid_demo"))
+
+    await cognee.forget(everything=True)
+    await cognee.remember(DOCUMENTS, dataset_name=DATASET, self_improvement=False)
+
+    retrieved = await GraphCompletionRetriever(top_k=8).get_retrieved_objects(query=QUERY)
+    # get_retrieved_objects() is typed as Union[List[Edge], List[List[Edge]]] because it
+    # also supports query_batch=. This demo only ever passes a single `query=`, so the
+    # result is always a flat List[Edge] -- narrow it explicitly here (both for the type
+    # checker and as a defensive runtime check) instead of accessing .node1/.node2
+    # directly on a value the checker can't prove isn't a nested list.
+    if retrieved and isinstance(retrieved[0], list):
+        raise TypeError(
+            "get_retrieved_objects() returned batch-mode results (List[List[Edge]]); "
+            "this demo only supports the single-query List[Edge] shape."
+        )
+    edges = cast(List[Edge], retrieved)
+
+    print("TRIPLETS\n", format_triplets(edges) if edges else "[none]")
+
+    evidence = triplets_to_hybrid(edges)
+    print(
+        "\nCHANNEL COUNTS\n",
+        f"chunks={len(evidence['chunks'])} "
+        f"entities={len(evidence['entities'])} "
+        f"facts={len(evidence['facts'])}",
+    )
+
+    hybrid = HybridRetriever()
+    context = await hybrid.get_context_from_objects(query=QUERY, retrieved_objects=evidence)
+    print("\nCONTEXT\n", context or "[empty]")
+
+    answer = await hybrid.get_completion_from_context(
+        query=QUERY, retrieved_objects=evidence, context=context
+    )
+    print("\nANSWER")
+    for item in answer:
+        print(item)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/demos/graph_completion_to_hybrid.py
+++ b/examples/demos/graph_completion_to_hybrid.py
@@ -30,9 +30,25 @@ def triplets_to_hybrid(edges: List[Edge]) -> dict:
     """Map GraphCompletion edges into Hybrid's chunks/ entities/ facts channels.
 
     Relationships already attached to an entity are not repeated as facts.
-    ``made_from`` edges (summary↔chunk) are structural and skipped as facts.
+    ``made_from`` edges (summary -> chunk) are structural and skipped as facts,
+    but still used below to pair a summary with its source chunk.
+
+    Chunks and summaries are tracked separately, matching how Hybrid itself
+    splits them (see ``hybrid/context.py::format_passages``): a summary whose
+    source chunk was also retrieved is paired with it via ``chunk_summaries``
+    (rendered as "[Passage Summary]: ...\\n[Raw Passage]: ..."), never shown
+    as a second, unrelated passage. A summary whose source chunk was not
+    retrieved is still shown -- as a standalone passage -- instead of being
+    dropped.
+
+    Note: ``TextSummary.source_chunk_id`` is *not* exposed on the retrieved
+    node's attributes here (verified empirically -- GraphCompletionRetriever's
+    node projection only carries id/description/name/type/text/
+    importance_weight/vector_distance), so pairing is derived from the
+    ``made_from`` edge itself instead.
     """
-    chunks_by_id, entities_by_id, facts = {}, {}, []
+    document_chunks_by_id, summaries_by_id, entities_by_id, facts = {}, {}, {}, []
+    summary_to_chunk_id: dict = {}
 
     def label(n: Node) -> str:
         return n.attributes.get("name") or n.attributes.get("text") or n.id
@@ -41,8 +57,10 @@ def triplets_to_hybrid(edges: List[Edge]) -> dict:
         for node in (edge.node1, edge.node2):
             ntype = node.attributes.get("type")
             text = node.attributes.get("text")
-            if ntype in {"DocumentChunk", "TextSummary"} and text and node.id not in chunks_by_id:
-                chunks_by_id[node.id] = {"id": node.id, "text": text}
+            if ntype == "DocumentChunk" and text and node.id not in document_chunks_by_id:
+                document_chunks_by_id[node.id] = {"id": node.id, "text": text}
+            elif ntype == "TextSummary" and text and node.id not in summaries_by_id:
+                summaries_by_id[node.id] = {"id": node.id, "text": text}
             elif ntype == "Entity" and node.id not in entities_by_id:
                 entities_by_id[node.id] = {
                     "id": node.id,
@@ -56,7 +74,17 @@ def triplets_to_hybrid(edges: List[Edge]) -> dict:
             or edge.attributes.get("relationship_name")
             or edge.attributes.get("edge_text")
         )
-        if not rel or rel == "made_from":
+
+        if rel == "made_from":
+            n1_type = edge.node1.attributes.get("type")
+            n2_type = edge.node2.attributes.get("type")
+            if n1_type == "TextSummary" and n2_type == "DocumentChunk":
+                summary_to_chunk_id[edge.node1.id] = edge.node2.id
+            elif n2_type == "TextSummary" and n1_type == "DocumentChunk":
+                summary_to_chunk_id[edge.node2.id] = edge.node1.id
+            continue
+
+        if not rel:
             continue
 
         bullet = f"{label(edge.node1)} -- {rel} -- {label(edge.node2)}"
@@ -71,9 +99,21 @@ def triplets_to_hybrid(edges: List[Edge]) -> dict:
         if not touches_entity:
             facts.append({"id": f"{edge.node1.id}:{edge.node2.id}", "text": bullet})
 
+    # Pair each retrieved summary with its source chunk when that chunk was
+    # also retrieved; otherwise fall back to showing the summary itself as a
+    # standalone passage instead of dropping it.
+    chunks_by_id = dict(document_chunks_by_id)
+    chunk_summaries: dict = {}
+    for summary_id, summary in summaries_by_id.items():
+        source_chunk_id = summary_to_chunk_id.get(summary_id)
+        if source_chunk_id and source_chunk_id in chunks_by_id:
+            chunk_summaries[source_chunk_id] = summary["text"]
+        else:
+            chunks_by_id.setdefault(summary_id, {"id": summary_id, "text": summary["text"]})
+
     return {
         "chunks": list(chunks_by_id.values()),
-        "chunk_summaries": {},
+        "chunk_summaries": chunk_summaries,
         "entities": list(entities_by_id.values()),
         "facts": facts,
     }
@@ -108,6 +148,7 @@ async def main() -> None:
     print(
         "\nCHANNEL COUNTS\n",
         f"chunks={len(evidence['chunks'])} "
+        f"chunk_summaries={len(evidence['chunk_summaries'])} "
         f"entities={len(evidence['entities'])} "
         f"facts={len(evidence['facts'])}",
     )


### PR DESCRIPTION
SDK-329

<!-- .github/pull_request_template.md -->

## Description

- Adds examples/demos/graph_completion_to_hybrid.py: a minimal demo that runs GraphCompletionRetriever once, converts the returned triplets locally into Hybrid's chunks/entities/facts evidence shape, then passes that dictionary straight into HybridRetriever.get_context_from_objects() / get_completion_from_context() for formatting and the final answer.

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
