### PR TITLE
CLO-434 feat: Expose per-agent session usage

### DIFF
--- a/cognee/api/v1/recall/recall.py
+++ b/cognee/api/v1/recall/recall.py
@@ -105,20 +105,13 @@ async def _resolve_session_cache_user_id(session_id: str, caller_user_id: str | 
 
         from cognee.infrastructure.databases.relational import get_relational_engine
         from cognee.modules.session_lifecycle.models import SessionRecord
-        from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
-            get_specific_user_permission_datasets,
-        )
+        from cognee.modules.users.permissions.methods import get_permitted_dataset_ids
 
         caller_uuid = UUID(caller_user_id) if caller_user_id else None
         if caller_uuid is None:
             return caller_user_id
 
-        permitted_ids: list[UUID] = []
-        try:
-            permitted = await get_specific_user_permission_datasets(caller_uuid, "read", None)
-            permitted_ids = [ds.id for ds in permitted] if permitted else []
-        except Exception:
-            permitted_ids = []
+        permitted_ids = await get_permitted_dataset_ids(caller_uuid)
 
         # Fetch ALL candidate rows the caller can see for this
         # session_id. Owner match OR permitted-dataset match.

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -407,15 +407,24 @@ def get_sessions_router() -> APIRouter:
         """Cost + token totals grouped by (user, agent type) — feeds a
         "who spends the most, with which agent" chart (CLO-434 follow-up).
 
-        Role-scoped, not all-or-nothing: a tenant owner/admin (same
-        check ``GET /tenants/{id}/users`` uses) sees every member's
-        spend. A regular member — or anyone with no tenant, i.e.
-        single-user/local mode — falls back to just their own sessions
-        rather than being denied outright.
+        Visibility matches every other endpoint in this router: the
+        caller, their child agents, and dataset-shared sessions. On top
+        of that base scope, a tenant owner/admin (same check
+        ``GET /tenants/{id}/users`` uses) additionally sees every
+        member's spend. A regular member — or anyone with no tenant,
+        i.e. single-user/local mode — just keeps the base scope rather
+        than being denied outright.
         """
         since = _range_since(range)
         try:
-            result = await compute_cost_by_user_agent(user=user, since=since)
+            permitted = await _permitted_dataset_ids_for(user)
+            visible_ids = await _visible_user_ids(user)
+            result = await compute_cost_by_user_agent(
+                user=user,
+                visible_user_ids=visible_ids,
+                permitted_dataset_ids=permitted,
+                since=since,
+            )
             return jsonable_encoder(result)
         except Exception as exc:
             logger.error("cost_by_user_agent failed: %s", exc, exc_info=True)

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -7,17 +7,19 @@ abandonment-by-idle rule so no sweeper is needed.
 
 from datetime import datetime, timedelta, timezone
 from typing import Literal, Optional
-from uuid import UUID as UUIDType
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from sqlalchemy import and_, func, or_, select
 
+from cognee.exceptions import CogneeApiError
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.session_lifecycle.agent_usage import (
-    build_sessions_with_agent_info_page,
-    compute_cost_by_user_agent,
+    _permitted_dataset_ids_for,
+    _visible_user_ids,
+    get_cost_by_user_agent,
+    get_sessions_with_agent_info,
 )
 from cognee.modules.session_lifecycle.metrics import (
     SessionStatus,
@@ -26,12 +28,8 @@ from cognee.modules.session_lifecycle.metrics import (
     list_session_rows,
 )
 from cognee.modules.session_lifecycle.models import SessionModelUsage, SessionRecord
-from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.methods import get_authenticated_user
 from cognee.modules.users.models import User
-from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
-    get_specific_user_permission_datasets,
-)
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("sessions_api")
@@ -49,36 +47,6 @@ def _range_since(range_key: _RangeLiteral) -> Optional[datetime]:
     if range_key == "30d":
         return now - timedelta(days=30)
     return None  # "all"
-
-
-async def _permitted_dataset_ids_for(user: User) -> list[UUIDType]:
-    """Return the UUIDs of datasets this user can read (empty on none)."""
-    try:
-        datasets = await get_specific_user_permission_datasets(user.id, "read", None)
-        return [ds.id for ds in datasets] if datasets else []
-    except PermissionDeniedError:
-        return []
-    except Exception:
-        return []
-
-
-async def _child_agent_user_ids(user_id: UUIDType) -> list[UUIDType]:
-    """Return user IDs of agents whose parent_user_id matches this user."""
-    engine = get_relational_engine()
-    async with engine.get_async_session() as session:
-        from cognee.modules.users.models import User as UserModel
-
-        rows = (
-            await session.execute(select(UserModel.id).where(UserModel.parent_user_id == user_id))
-        ).all()
-        return [row.id for row in rows]
-
-
-async def _visible_user_ids(user: User) -> list[UUIDType]:
-    """User's own ID plus any child agent IDs."""
-    ids = [user.id]
-    ids.extend(await _child_agent_user_ids(user.id))
-    return ids
 
 
 def get_sessions_router() -> APIRouter:
@@ -377,12 +345,8 @@ def get_sessions_router() -> APIRouter:
         """
         since = _range_since(range)
         try:
-            permitted = await _permitted_dataset_ids_for(user)
-            visible_ids = await _visible_user_ids(user)
-            result = await build_sessions_with_agent_info_page(
+            result = await get_sessions_with_agent_info(
                 user=user,
-                permitted_dataset_ids=permitted,
-                visible_user_ids=visible_ids,
                 since=since,
                 status_filter=status,
                 limit=limit,
@@ -391,6 +355,11 @@ def get_sessions_router() -> APIRouter:
                 descending=descending,
             )
             return jsonable_encoder(result)
+        except CogneeApiError:
+            # Cognee errors carry their own status code and actionable
+            # message; the global handler in cognee/api/client.py returns
+            # them to the caller.
+            raise
         except Exception as exc:
             logger.error("list_sessions_with_agent_info failed: %s", exc, exc_info=True)
             return JSONResponse(status_code=500, content={"error": "list failed"})
@@ -417,15 +386,13 @@ def get_sessions_router() -> APIRouter:
         """
         since = _range_since(range)
         try:
-            permitted = await _permitted_dataset_ids_for(user)
-            visible_ids = await _visible_user_ids(user)
-            result = await compute_cost_by_user_agent(
-                user=user,
-                visible_user_ids=visible_ids,
-                permitted_dataset_ids=permitted,
-                since=since,
-            )
+            result = await get_cost_by_user_agent(user=user, since=since)
             return jsonable_encoder(result)
+        except CogneeApiError:
+            # Cognee errors carry their own status code and actionable
+            # message; the global handler in cognee/api/client.py returns
+            # them to the caller.
+            raise
         except Exception as exc:
             logger.error("cost_by_user_agent failed: %s", exc, exc_info=True)
             return JSONResponse(status_code=500, content={"error": "aggregation failed"})

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -16,8 +16,6 @@ from sqlalchemy import and_, func, or_, select
 from cognee.exceptions import CogneeApiError
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.session_lifecycle.agent_usage import (
-    _permitted_dataset_ids_for,
-    _visible_user_ids,
     get_cost_by_user_agent,
     get_sessions_with_agent_info,
 )
@@ -28,8 +26,9 @@ from cognee.modules.session_lifecycle.metrics import (
     list_session_rows,
 )
 from cognee.modules.session_lifecycle.models import SessionModelUsage, SessionRecord
-from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.methods import get_authenticated_user, get_visible_user_ids
 from cognee.modules.users.models import User
+from cognee.modules.users.permissions.methods import get_permitted_dataset_ids
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("sessions_api")
@@ -111,8 +110,8 @@ def get_sessions_router() -> APIRouter:
         """
         since = _range_since(range)
         try:
-            permitted = await _permitted_dataset_ids_for(user)
-            visible_ids = await _visible_user_ids(user)
+            permitted = await get_permitted_dataset_ids(user.id)
+            visible_ids = await get_visible_user_ids(user.id)
             page = await list_session_rows(
                 user_ids=visible_ids,
                 permitted_dataset_ids=permitted,
@@ -165,8 +164,8 @@ def get_sessions_router() -> APIRouter:
         """
         since = _range_since(range)
         eff = get_effective_status_sql()
-        permitted = await _permitted_dataset_ids_for(user)
-        visible_ids = await _visible_user_ids(user)
+        permitted = await get_permitted_dataset_ids(user.id)
+        visible_ids = await get_visible_user_ids(user.id)
 
         engine = get_relational_engine()
         async with engine.get_async_session() as session:
@@ -266,8 +265,8 @@ def get_sessions_router() -> APIRouter:
         - **range** (Literal): Time window: 24h, 7d, 30d, or all (default: 30d).
         """
         since = _range_since(range)
-        permitted = await _permitted_dataset_ids_for(user)
-        visible_ids = await _visible_user_ids(user)
+        permitted = await get_permitted_dataset_ids(user.id)
+        visible_ids = await get_visible_user_ids(user.id)
         engine = get_relational_engine()
         async with engine.get_async_session() as session:
             visibility_terms = [SessionRecord.user_id.in_(visible_ids)]
@@ -409,8 +408,8 @@ def get_sessions_router() -> APIRouter:
         ),
         user: User = Depends(get_authenticated_user),
     ):
-        permitted = await _permitted_dataset_ids_for(user)
-        visible_ids = await _visible_user_ids(user)
+        permitted = await get_permitted_dataset_ids(user.id)
+        visible_ids = await get_visible_user_ids(user.id)
         row = await get_session_row(
             session_id=session_id,
             user_id=user.id,

--- a/cognee/api/v1/sessions/routers/get_sessions_router.py
+++ b/cognee/api/v1/sessions/routers/get_sessions_router.py
@@ -15,6 +15,10 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import and_, func, or_, select
 
 from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.session_lifecycle.agent_usage import (
+    build_sessions_with_agent_info_page,
+    compute_cost_by_user_agent,
+)
 from cognee.modules.session_lifecycle.metrics import (
     SessionStatus,
     get_effective_status_sql,
@@ -337,6 +341,85 @@ def get_sessions_router() -> APIRouter:
                 for row in rows
             ]
         )
+
+    @router.get("/with-agent-info")
+    async def list_sessions_with_agent_info(
+        range: _RangeLiteral = Query(
+            "30d",
+            description="Time window filtered on last_activity_at: 24h, 7d, 30d, or all.",
+            examples=["30d"],
+        ),
+        status: Optional[str] = Query(
+            None,
+            description="Effective-status filter: running, completed, failed, or abandoned.",
+        ),
+        limit: int = Query(50, ge=1, le=500, description="Page size (max 500)."),
+        offset: int = Query(0, ge=0, description="Rows to skip for pagination."),
+        order_by: str = Query("last_activity_at"),
+        descending: bool = Query(True),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """Session records merged with their agent-connection metadata (CLO-434).
+
+        Joins ``session_records`` to the agent-connections registry on
+        ``session_id`` so the cloud UI can group/filter usage by client
+        (Claude Code, Codex, Slack, MCP, ...) without a second round
+        trip. When no registered connection matches a session, the
+        agent type is inferred from the session_id/origin_function
+        prefix convention (e.g. ``claude-code-...``, ``codex-...``).
+
+        Memory sources are intentionally omitted — per-agent dataset
+        attribution isn't reliably populated yet.
+
+        Response envelope mirrors ``GET /api/v1/sessions``, with each
+        session additionally carrying ``agent_type``, ``agent_source``,
+        ``agent_session_name``, and ``origin_function``.
+        """
+        since = _range_since(range)
+        try:
+            permitted = await _permitted_dataset_ids_for(user)
+            visible_ids = await _visible_user_ids(user)
+            result = await build_sessions_with_agent_info_page(
+                user=user,
+                permitted_dataset_ids=permitted,
+                visible_user_ids=visible_ids,
+                since=since,
+                status_filter=status,
+                limit=limit,
+                offset=offset,
+                order_by=order_by,
+                descending=descending,
+            )
+            return jsonable_encoder(result)
+        except Exception as exc:
+            logger.error("list_sessions_with_agent_info failed: %s", exc, exc_info=True)
+            return JSONResponse(status_code=500, content={"error": "list failed"})
+
+    @router.get("/cost-by-user-agent")
+    async def cost_by_user_agent(
+        range: _RangeLiteral = Query(
+            "30d",
+            description="Time window filtered on last_activity_at: 24h, 7d, 30d, or all.",
+            examples=["30d"],
+        ),
+        user: User = Depends(get_authenticated_user),
+    ):
+        """Cost + token totals grouped by (user, agent type) — feeds a
+        "who spends the most, with which agent" chart (CLO-434 follow-up).
+
+        Role-scoped, not all-or-nothing: a tenant owner/admin (same
+        check ``GET /tenants/{id}/users`` uses) sees every member's
+        spend. A regular member — or anyone with no tenant, i.e.
+        single-user/local mode — falls back to just their own sessions
+        rather than being denied outright.
+        """
+        since = _range_since(range)
+        try:
+            result = await compute_cost_by_user_agent(user=user, since=since)
+            return jsonable_encoder(result)
+        except Exception as exc:
+            logger.error("cost_by_user_agent failed: %s", exc, exc_info=True)
+            return JSONResponse(status_code=500, content={"error": "aggregation failed"})
 
     @router.get("/{session_id}")
     async def get_session_detail(

--- a/cognee/infrastructure/llm/LLMGateway.py
+++ b/cognee/infrastructure/llm/LLMGateway.py
@@ -1,5 +1,5 @@
 from collections.abc import Coroutine
-from typing import Any, TypeVar
+from typing import Any, Optional, TypeVar
 
 from pydantic import BaseModel
 
@@ -23,6 +23,33 @@ def _inject_agent_memory(text_input: str) -> str:
     return f"Additional Memory Context:\n{context.memory_context}\n\nOriginal Input:\n{text_input}"
 
 
+def _exact_usage_from_result(result: Any) -> tuple[Optional[int], Optional[int]]:
+    """Real prompt/completion token counts, when the instructor path made them
+    available — (None, None) otherwise, so the caller falls back to its
+    char-based estimate.
+
+    Instructor attaches the raw provider response as ``_raw_response`` on
+    every parsed model it returns (see
+    ``instructor.processing.response.process_response``), and that raw
+    response carries ``.usage`` with exact counts. This is the *same*
+    object ``acreate_structured_output`` already returns — no adapter
+    changes or extra provider calls needed, just reading what instructor
+    already attached before it's discarded.
+
+    Returns (None, None) for the plain-string path (skips instructor
+    entirely, see ``acreate_str_output``) and for the litellm_native/BAML
+    frameworks, which don't attach ``_raw_response``.
+    """
+    usage = getattr(getattr(result, "_raw_response", None), "usage", None)
+    if usage is None:
+        return None, None
+    tokens_in = getattr(usage, "prompt_tokens", None)
+    tokens_out = getattr(usage, "completion_tokens", None)
+    if tokens_in is None or tokens_out is None:
+        return None, None
+    return int(tokens_in), int(tokens_out)
+
+
 async def _record_session_usage_after(
     coro: Coroutine,
     *,
@@ -41,10 +68,13 @@ async def _record_session_usage_after(
         else:
             output_repr = str(result)
         model = get_llm_context_config().llm_model
+        tokens_in, tokens_out = _exact_usage_from_result(result)
         await record_llm_call(
             input_text=text_input,
             output_text=output_repr,
             model=model,
+            tokens_in_override=tokens_in,
+            tokens_out_override=tokens_out,
         )
     except Exception:
         pass

--- a/cognee/modules/agents/models.py
+++ b/cognee/modules/agents/models.py
@@ -7,7 +7,25 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
-AgentConnectionType = Literal["sdk", "api", "mcp", "claude_code", "workflow", "unknown"]
+# Free-form on purpose: the set of client types keeps growing (Claude Code,
+# Codex, Slack, Cursor, Windsurf, ...) and gating it behind a closed Literal
+# meant every new integration needed a backend code change just to be
+# recognized. Callers should self-declare their type via
+# ``RegisterAgentRequest.type`` at registration; ``derive_connection_type()``
+# is only a best-effort fallback for sessions that never registered. This
+# list is documentation, not an enum member set — pick a value from it when
+# your client matches one, otherwise just use your own lowercase name.
+KNOWN_AGENT_CONNECTION_TYPES = (
+    "sdk",
+    "api",
+    "mcp",
+    "claude_code",
+    "codex",
+    "slack",
+    "workflow",
+    "unknown",
+)
+AgentConnectionType = str
 AgentMemoryMode = Literal["session", "cognee", "hybrid", "none", "unknown"]
 AgentStatus = Literal["active", "inactive", "unknown"]
 AgentSource = Literal["agent_memory", "session_trace", "serve", "api_key", "mcp", "api"]

--- a/cognee/modules/agents/operations.py
+++ b/cognee/modules/agents/operations.py
@@ -4,9 +4,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, Optional
 from uuid import UUID as UUIDType
 
-from sqlalchemy import select
-
-from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.agents.models import (
     AgentConnection,
     AgentDatasetRef,
@@ -21,11 +18,9 @@ from cognee.modules.agents.registry import (
     list_registered_agent_connections,
     register_agent_connection,
 )
-from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.methods import get_visible_user_ids
 from cognee.modules.users.models import User
-from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
-    get_specific_user_permission_datasets,
-)
+from cognee.modules.users.permissions.methods import get_readable_datasets
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("agents")
@@ -52,39 +47,6 @@ def _entry_to_dict(entry: Any) -> dict[str, Any]:
     if hasattr(entry, "dict"):
         return entry.dict()
     return {"value": str(entry)}
-
-
-async def _readable_datasets_for(user: User) -> list[Any]:
-    try:
-        return await get_specific_user_permission_datasets(user.id, "read", None)
-    except PermissionDeniedError:
-        return []
-    except Exception as error:
-        logger.warning("Failed to resolve readable datasets for agents API: %s", error)
-        return []
-
-
-async def _child_agent_user_ids(user_id: UUIDType) -> list[UUIDType]:
-    try:
-        engine = get_relational_engine()
-        async with engine.get_async_session() as session:
-            from cognee.modules.users.models import User as UserModel
-
-            rows = (
-                await session.execute(
-                    select(UserModel.id).where(UserModel.parent_user_id == user_id)
-                )
-            ).all()
-            return [row.id for row in rows]
-    except Exception as error:
-        logger.debug("Failed to resolve child agent users for agents API: %s", error)
-        return []
-
-
-async def _visible_user_ids(user: User) -> list[UUIDType]:
-    ids = [user.id]
-    ids.extend(await _child_agent_user_ids(user.id))
-    return ids
 
 
 def _memory_sources_from_datasets(datasets: list[Any]) -> list[MemorySourceConnection]:
@@ -171,9 +133,9 @@ async def list_agent_connections(
     limit: int = 50,
     offset: int = 0,
 ) -> AgentsListResponse:
-    readable_datasets = await _readable_datasets_for(user)
+    readable_datasets = await get_readable_datasets(user.id)
     memory_sources = _memory_sources_from_datasets(readable_datasets)
-    visible_user_ids = await _visible_user_ids(user)
+    visible_user_ids = await get_visible_user_ids(user.id)
     visible_user_id_set = set(visible_user_ids)
     permitted_dataset_id_strings = {source.id for source in memory_sources}
 

--- a/cognee/modules/agents/registry.py
+++ b/cognee/modules/agents/registry.py
@@ -66,8 +66,12 @@ def derive_connection_type(
         return source_lower  # type: ignore[return-value]
 
     text = f"{origin_function or ''} {session_id or ''}".lower()
-    if "claude" in text or "claude_code" in text or text.startswith("cc_"):
+    if "claude" in text or "claude_code" in text or (session_id or "").lower().startswith("cc_"):
         return "claude_code"
+    if "codex" in text:
+        return "codex"
+    if "slack" in text:
+        return "slack"
     if "mcp" in text:
         return "mcp"
     return "sdk" if origin_function else "unknown"

--- a/cognee/modules/session_lifecycle/__init__.py
+++ b/cognee/modules/session_lifecycle/__init__.py
@@ -6,6 +6,7 @@ steps; this module only owns lifecycle (status), aggregate counters
 (tokens, cost, duration), and per-session lock primitives.
 """
 
+from .agent_usage import get_cost_by_user_agent, get_sessions_with_agent_info
 from .metrics import (
     SessionListPage,
     SessionRowWithStatus,
@@ -28,8 +29,10 @@ __all__ = [
     "accumulate_usage",
     "ensure_and_touch_session",
     "ensure_session",
+    "get_cost_by_user_agent",
     "get_effective_status_sql",
     "get_session_row",
+    "get_sessions_with_agent_info",
     "list_session_rows",
     "mark_ended",
     "record_llm_call",

--- a/cognee/modules/session_lifecycle/agent_usage.py
+++ b/cognee/modules/session_lifecycle/agent_usage.py
@@ -33,6 +33,18 @@ from cognee.modules.session_lifecycle.models import SessionRecord
 from cognee.modules.users.exceptions import PermissionDeniedError
 from cognee.modules.users.models import User
 from cognee.modules.users.tenants.methods.get_users_in_tenant import get_users_in_tenant
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("session_lifecycle.agent_usage")
+
+# list_agent_connections has no server-side pagination — it builds the
+# full in-memory list, then slices. This is the slice size we ask for
+# when we need "effectively all of them" to build the session->agent
+# map below. If a scope ever has more connections than this, the excess
+# silently falls back to the prefix heuristic (see the has_more check
+# below) rather than erroring, so it's raised here as a single visible
+# constant instead of a bare literal at the call site.
+_AGENT_CONNECTIONS_PAGE_CAP = 10_000
 
 
 def _latest_wins_agent_map(
@@ -87,9 +99,18 @@ async def build_sessions_with_agent_info_page(
         user=user,
         include_sources=False,
         active_only=False,
-        limit=10000,
+        limit=_AGENT_CONNECTIONS_PAGE_CAP,
         offset=0,
     )
+    if agents_response.has_more:
+        logger.warning(
+            "build_sessions_with_agent_info_page: agent-connection page capped at %d of "
+            "%d total for user %s — sessions past the cap fall back to the prefix "
+            "heuristic instead of their registered agent type.",
+            _AGENT_CONNECTIONS_PAGE_CAP,
+            agents_response.total,
+            user.id,
+        )
     agents_by_session = _latest_wins_agent_map(agents_response.agents)
 
     sessions = []

--- a/cognee/modules/session_lifecycle/agent_usage.py
+++ b/cognee/modules/session_lifecycle/agent_usage.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from typing import Iterable, Optional
 from uuid import UUID as UUIDType
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.agents.models import AgentConnection
@@ -117,45 +117,73 @@ async def build_sessions_with_agent_info_page(
     }
 
 
-async def _resolve_scope_emails(user: User) -> dict[UUIDType, str]:
+async def _resolve_scope_emails(
+    user: User, *, visible_user_ids: Iterable[UUIDType]
+) -> dict[UUIDType, str]:
     """Return {user_id: email} for the callers this request may report on.
 
-    A tenant owner/admin (same check ``GET /tenants/{id}/users`` uses)
-    gets every member. Anyone else — a regular member, or a caller with
-    no tenant at all (single-user/local mode) — is scoped to just
-    themselves rather than denied outright.
+    Always includes ``visible_user_ids`` — the caller plus their child
+    agents, the same base scope every other ``/sessions`` endpoint uses
+    (see ``_visible_user_ids`` in the router). A tenant owner/admin (same
+    check ``GET /tenants/{id}/users`` uses) additionally gets every
+    tenant member unioned in on top of that base scope; a regular
+    member — or a caller with no tenant at all (single-user/local mode)
+    — just keeps the base scope rather than being denied outright.
+
+    Child-agent ids without a resolvable email map to "unknown" here;
+    the caller's own email and any tenant member emails (from
+    ``get_users_in_tenant``) are always known.
     """
-    if user.tenant_id is None:
-        return {user.id: user.email}
+    email_by_id: dict[UUIDType, str] = {uid: "unknown" for uid in visible_user_ids}
+    email_by_id[user.id] = user.email
 
-    try:
-        users_data = await get_users_in_tenant(user.tenant_id, user)
-        return {UUIDType(u["id"]): u["email"] for u in users_data}
-    except PermissionDeniedError:
-        return {user.id: user.email}
+    if user.tenant_id is not None:
+        try:
+            users_data = await get_users_in_tenant(user.tenant_id, user)
+            for u in users_data:
+                email_by_id[UUIDType(u["id"])] = u["email"]
+        except PermissionDeniedError:
+            pass
+
+    return email_by_id
 
 
-async def compute_cost_by_user_agent(*, user: User, since: Optional[datetime]) -> list[dict]:
+async def compute_cost_by_user_agent(
+    *,
+    user: User,
+    visible_user_ids: list[UUIDType],
+    permitted_dataset_ids: list[UUIDType],
+    since: Optional[datetime],
+) -> list[dict]:
     """Token/cost totals grouped by (user, agent type) for a spend chart.
 
-    Role-scoped per ``_resolve_scope_emails``. Returns rows sorted by
+    Visibility mirrors every other ``/sessions`` endpoint — the caller,
+    their child agents (``visible_user_ids``), and sessions whose
+    dataset is shared with them (``permitted_dataset_ids``) — unioned
+    with every tenant member's sessions when the caller is a tenant
+    owner/admin (see ``_resolve_scope_emails``). Returns rows sorted by
     ``cost_usd`` descending — ready to feed a "who spends the most, with
     which agent" chart without further client-side sorting.
     """
-    email_by_user_id = await _resolve_scope_emails(user)
+    email_by_user_id = await _resolve_scope_emails(user, visible_user_ids=visible_user_ids)
     scoped_user_ids = list(email_by_user_id.keys())
-    if not scoped_user_ids:
+    if not scoped_user_ids and not permitted_dataset_ids:
         return []
 
     engine = get_relational_engine()
     async with engine.get_async_session() as session:
+        visibility_terms = []
+        if scoped_user_ids:
+            visibility_terms.append(SessionRecord.user_id.in_(scoped_user_ids))
+        if permitted_dataset_ids:
+            visibility_terms.append(SessionRecord.dataset_id.in_(permitted_dataset_ids))
         stmt = select(
             SessionRecord.user_id,
             SessionRecord.session_id,
             SessionRecord.tokens_in,
             SessionRecord.tokens_out,
             SessionRecord.cost_usd,
-        ).where(SessionRecord.user_id.in_(scoped_user_ids))
+        ).where(or_(*visibility_terms) if len(visibility_terms) > 1 else visibility_terms[0])
         if since is not None:
             stmt = stmt.where(SessionRecord.last_activity_at >= since)
         rows = (await session.execute(stmt)).all()

--- a/cognee/modules/session_lifecycle/agent_usage.py
+++ b/cognee/modules/session_lifecycle/agent_usage.py
@@ -31,7 +31,11 @@ from cognee.modules.agents.registry import (
 from cognee.modules.session_lifecycle.metrics import list_session_rows
 from cognee.modules.session_lifecycle.models import SessionRecord
 from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.methods import get_default_user
 from cognee.modules.users.models import User
+from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
+    get_specific_user_permission_datasets,
+)
 from cognee.modules.users.tenants.methods.get_users_in_tenant import get_users_in_tenant
 from cognee.shared.logging_utils import get_logger
 
@@ -45,6 +49,36 @@ logger = get_logger("session_lifecycle.agent_usage")
 # below) rather than erroring, so it's raised here as a single visible
 # constant instead of a bare literal at the call site.
 _AGENT_CONNECTIONS_PAGE_CAP = 10_000
+
+
+async def _permitted_dataset_ids_for(user: User) -> list[UUIDType]:
+    """Return the UUIDs of datasets this user can read (empty on none)."""
+    try:
+        datasets = await get_specific_user_permission_datasets(user.id, "read", None)
+        return [ds.id for ds in datasets] if datasets else []
+    except PermissionDeniedError:
+        return []
+    except Exception:
+        return []
+
+
+async def _child_agent_user_ids(user_id: UUIDType) -> list[UUIDType]:
+    """Return user IDs of agents whose parent_user_id matches this user."""
+    from cognee.modules.users.models import User as UserModel
+
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        rows = (
+            await session.execute(select(UserModel.id).where(UserModel.parent_user_id == user_id))
+        ).all()
+        return [row.id for row in rows]
+
+
+async def _visible_user_ids(user: User) -> list[UUIDType]:
+    """User's own ID plus any child agent IDs."""
+    ids = [user.id]
+    ids.extend(await _child_agent_user_ids(user.id))
+    return ids
 
 
 def _latest_wins_agent_map(
@@ -245,3 +279,67 @@ async def compute_cost_by_user_agent(
     ]
     result.sort(key=lambda r: r["cost_usd"], reverse=True)
     return result
+
+
+async def get_sessions_with_agent_info(
+    *,
+    user: Optional[User] = None,
+    since: Optional[datetime],
+    status_filter: Optional[str],
+    limit: int,
+    offset: int,
+    order_by: str,
+    descending: bool,
+) -> dict:
+    """SDK-usable entry point backing ``GET /sessions/with-agent-info``.
+
+    Resolves the caller's own visibility (child agents + dataset read
+    grants) and delegates to ``build_sessions_with_agent_info_page``.
+    Kept out of the router so a plain Python/SDK caller can await this
+    directly, without going through FastAPI, and so any
+    ``CogneeApiError`` raised while resolving visibility or aggregating
+    propagates to the caller instead of being swallowed by a router-level
+    catch-all.
+
+    ``user`` defaults to ``get_default_user()`` when omitted, matching
+    every other SDK-facing function in ``cognee.api.v1.agents.agents``.
+    """
+    if user is None:
+        user = await get_default_user()
+    permitted = await _permitted_dataset_ids_for(user)
+    visible_ids = await _visible_user_ids(user)
+    return await build_sessions_with_agent_info_page(
+        user=user,
+        permitted_dataset_ids=permitted,
+        visible_user_ids=visible_ids,
+        since=since,
+        status_filter=status_filter,
+        limit=limit,
+        offset=offset,
+        order_by=order_by,
+        descending=descending,
+    )
+
+
+async def get_cost_by_user_agent(
+    *, user: Optional[User] = None, since: Optional[datetime]
+) -> list[dict]:
+    """SDK-usable entry point backing ``GET /sessions/cost-by-user-agent``.
+
+    Resolves visibility the same way ``get_sessions_with_agent_info``
+    does, then delegates to ``compute_cost_by_user_agent``. See that
+    function's docstring for why this isn't just inlined in the router.
+
+    ``user`` defaults to ``get_default_user()`` when omitted, matching
+    every other SDK-facing function in ``cognee.api.v1.agents.agents``.
+    """
+    if user is None:
+        user = await get_default_user()
+    permitted = await _permitted_dataset_ids_for(user)
+    visible_ids = await _visible_user_ids(user)
+    return await compute_cost_by_user_agent(
+        user=user,
+        visible_user_ids=visible_ids,
+        permitted_dataset_ids=permitted,
+        since=since,
+    )

--- a/cognee/modules/session_lifecycle/agent_usage.py
+++ b/cognee/modules/session_lifecycle/agent_usage.py
@@ -1,0 +1,198 @@
+"""Session usage joined with agent-connection metadata (CLO-434).
+
+Token/cost aggregates live in ``session_records``
+(``session_lifecycle.metrics``); which *client* produced them lives in
+the agent-connections registry (``modules.agents``). Neither table
+knows about the other, and ``AgentConnection`` isn't a SQL row (it's
+in-memory + a JSON blob in ``principal_configuration``), so there's no
+real database JOIN to write — these functions do the join in Python,
+keyed on ``session_id``.
+
+Kept out of the router so the join/aggregation logic is independently
+unit-testable and reusable (e.g. from a CLI command or another router)
+without spinning up FastAPI.
+"""
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+from uuid import UUID as UUIDType
+
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.agents.models import AgentConnection
+from cognee.modules.agents.operations import list_agent_connections
+from cognee.modules.agents.registry import (
+    derive_connection_type,
+    list_persisted_agent_connections,
+    list_registered_agent_connections,
+)
+from cognee.modules.session_lifecycle.metrics import list_session_rows
+from cognee.modules.session_lifecycle.models import SessionRecord
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.models import User
+from cognee.modules.users.tenants.methods.get_users_in_tenant import get_users_in_tenant
+
+
+def _latest_wins_agent_map(
+    agents: Iterable[AgentConnection],
+) -> dict[str, AgentConnection]:
+    """Map session_id -> its most-recently-active AgentConnection.
+
+    A session_id can be re-registered across reconnects; sorting
+    ascending by ``last_active_at`` and building the dict last-write-wins
+    keeps only the latest.
+    """
+    sorted_agents = sorted(
+        agents, key=lambda a: a.last_active_at or datetime.min.replace(tzinfo=timezone.utc)
+    )
+    return {a.session_id: a for a in sorted_agents if a.session_id}
+
+
+async def build_sessions_with_agent_info_page(
+    *,
+    user: User,
+    permitted_dataset_ids: list[UUIDType],
+    visible_user_ids: list[UUIDType],
+    since: Optional[datetime],
+    status_filter: Optional[str],
+    limit: int,
+    offset: int,
+    order_by: str,
+    descending: bool,
+) -> dict:
+    """Session records for ``visible_user_ids`` merged with agent-connection
+    metadata, joined on ``session_id``.
+
+    Mirrors the ``GET /sessions`` pagination envelope, with each session
+    additionally carrying ``agent_type`` / ``agent_source`` /
+    ``agent_session_name`` / ``origin_function``. When no registered
+    connection matches a session, ``agent_type`` falls back to the
+    session_id/origin_function prefix heuristic (``derive_connection_type``)
+    so unregistered sessions (e.g. ``codex-...``) still get a sensible type.
+    """
+    page = await list_session_rows(
+        user_ids=visible_user_ids,
+        permitted_dataset_ids=permitted_dataset_ids,
+        since=since,
+        status_filter=status_filter,
+        limit=limit,
+        offset=offset,
+        order_by=order_by,
+        descending=descending,
+    )
+
+    agents_response = await list_agent_connections(
+        user=user,
+        include_sources=False,
+        active_only=False,
+        limit=10000,
+        offset=0,
+    )
+    agents_by_session = _latest_wins_agent_map(agents_response.agents)
+
+    sessions = []
+    for row in page.sessions:
+        record = row.to_dict()
+        agent = agents_by_session.get(record["session_id"])
+        if agent is not None:
+            record["agent_type"] = agent.type
+            record["agent_source"] = agent.source
+            record["agent_session_name"] = agent.agent_session_name
+            record["origin_function"] = agent.origin_function
+        else:
+            record["agent_type"] = derive_connection_type(session_id=record["session_id"])
+            record["agent_source"] = None
+            record["agent_session_name"] = None
+            record["origin_function"] = None
+        sessions.append(record)
+
+    return {
+        "sessions": sessions,
+        "total": page.total,
+        "limit": page.limit,
+        "offset": page.offset,
+        "has_more": page.has_more,
+    }
+
+
+async def _resolve_scope_emails(user: User) -> dict[UUIDType, str]:
+    """Return {user_id: email} for the callers this request may report on.
+
+    A tenant owner/admin (same check ``GET /tenants/{id}/users`` uses)
+    gets every member. Anyone else — a regular member, or a caller with
+    no tenant at all (single-user/local mode) — is scoped to just
+    themselves rather than denied outright.
+    """
+    if user.tenant_id is None:
+        return {user.id: user.email}
+
+    try:
+        users_data = await get_users_in_tenant(user.tenant_id, user)
+        return {UUIDType(u["id"]): u["email"] for u in users_data}
+    except PermissionDeniedError:
+        return {user.id: user.email}
+
+
+async def compute_cost_by_user_agent(*, user: User, since: Optional[datetime]) -> list[dict]:
+    """Token/cost totals grouped by (user, agent type) for a spend chart.
+
+    Role-scoped per ``_resolve_scope_emails``. Returns rows sorted by
+    ``cost_usd`` descending — ready to feed a "who spends the most, with
+    which agent" chart without further client-side sorting.
+    """
+    email_by_user_id = await _resolve_scope_emails(user)
+    scoped_user_ids = list(email_by_user_id.keys())
+    if not scoped_user_ids:
+        return []
+
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        stmt = select(
+            SessionRecord.user_id,
+            SessionRecord.session_id,
+            SessionRecord.tokens_in,
+            SessionRecord.tokens_out,
+            SessionRecord.cost_usd,
+        ).where(SessionRecord.user_id.in_(scoped_user_ids))
+        if since is not None:
+            stmt = stmt.where(SessionRecord.last_activity_at >= since)
+        rows = (await session.execute(stmt)).all()
+
+    persisted_agents = await list_persisted_agent_connections(scoped_user_ids, active_only=False)
+    scoped_id_set = set(scoped_user_ids)
+    registered_agents = [
+        a for a in list_registered_agent_connections() if a.user_id in scoped_id_set
+    ]
+    agents_by_session = _latest_wins_agent_map([*persisted_agents, *registered_agents])
+
+    aggregates: dict[tuple[UUIDType, str], dict] = defaultdict(
+        lambda: {"session_count": 0, "tokens_in": 0, "tokens_out": 0, "cost_usd": 0.0}
+    )
+    for row in rows:
+        agent = agents_by_session.get(row.session_id)
+        agent_type = (
+            agent.type if agent is not None else derive_connection_type(session_id=row.session_id)
+        )
+        bucket = aggregates[(row.user_id, agent_type)]
+        bucket["session_count"] += 1
+        bucket["tokens_in"] += row.tokens_in or 0
+        bucket["tokens_out"] += row.tokens_out or 0
+        bucket["cost_usd"] += row.cost_usd or 0.0
+
+    result = [
+        {
+            "user_id": str(user_id),
+            "user_email": email_by_user_id.get(user_id, "unknown"),
+            "agent_type": agent_type,
+            "session_count": vals["session_count"],
+            "tokens_in": vals["tokens_in"],
+            "tokens_out": vals["tokens_out"],
+            "tokens_total": vals["tokens_in"] + vals["tokens_out"],
+            "cost_usd": round(vals["cost_usd"], 6),
+        }
+        for (user_id, agent_type), vals in aggregates.items()
+    ]
+    result.sort(key=lambda r: r["cost_usd"], reverse=True)
+    return result

--- a/cognee/modules/session_lifecycle/agent_usage.py
+++ b/cognee/modules/session_lifecycle/agent_usage.py
@@ -31,11 +31,9 @@ from cognee.modules.agents.registry import (
 from cognee.modules.session_lifecycle.metrics import list_session_rows
 from cognee.modules.session_lifecycle.models import SessionRecord
 from cognee.modules.users.exceptions import PermissionDeniedError
-from cognee.modules.users.methods import get_default_user
+from cognee.modules.users.methods import get_default_user, get_visible_user_ids
 from cognee.modules.users.models import User
-from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
-    get_specific_user_permission_datasets,
-)
+from cognee.modules.users.permissions.methods import get_permitted_dataset_ids
 from cognee.modules.users.tenants.methods.get_users_in_tenant import get_users_in_tenant
 from cognee.shared.logging_utils import get_logger
 
@@ -49,36 +47,6 @@ logger = get_logger("session_lifecycle.agent_usage")
 # below) rather than erroring, so it's raised here as a single visible
 # constant instead of a bare literal at the call site.
 _AGENT_CONNECTIONS_PAGE_CAP = 10_000
-
-
-async def _permitted_dataset_ids_for(user: User) -> list[UUIDType]:
-    """Return the UUIDs of datasets this user can read (empty on none)."""
-    try:
-        datasets = await get_specific_user_permission_datasets(user.id, "read", None)
-        return [ds.id for ds in datasets] if datasets else []
-    except PermissionDeniedError:
-        return []
-    except Exception:
-        return []
-
-
-async def _child_agent_user_ids(user_id: UUIDType) -> list[UUIDType]:
-    """Return user IDs of agents whose parent_user_id matches this user."""
-    from cognee.modules.users.models import User as UserModel
-
-    engine = get_relational_engine()
-    async with engine.get_async_session() as session:
-        rows = (
-            await session.execute(select(UserModel.id).where(UserModel.parent_user_id == user_id))
-        ).all()
-        return [row.id for row in rows]
-
-
-async def _visible_user_ids(user: User) -> list[UUIDType]:
-    """User's own ID plus any child agent IDs."""
-    ids = [user.id]
-    ids.extend(await _child_agent_user_ids(user.id))
-    return ids
 
 
 def _latest_wins_agent_map(
@@ -179,7 +147,7 @@ async def _resolve_scope_emails(
 
     Always includes ``visible_user_ids`` — the caller plus their child
     agents, the same base scope every other ``/sessions`` endpoint uses
-    (see ``_visible_user_ids`` in the router). A tenant owner/admin (same
+    (see ``get_visible_user_ids``). A tenant owner/admin (same
     check ``GET /tenants/{id}/users`` uses) additionally gets every
     tenant member unioned in on top of that base scope; a regular
     member — or a caller with no tenant at all (single-user/local mode)
@@ -306,8 +274,8 @@ async def get_sessions_with_agent_info(
     """
     if user is None:
         user = await get_default_user()
-    permitted = await _permitted_dataset_ids_for(user)
-    visible_ids = await _visible_user_ids(user)
+    permitted = await get_permitted_dataset_ids(user.id)
+    visible_ids = await get_visible_user_ids(user.id)
     return await build_sessions_with_agent_info_page(
         user=user,
         permitted_dataset_ids=permitted,
@@ -335,8 +303,8 @@ async def get_cost_by_user_agent(
     """
     if user is None:
         user = await get_default_user()
-    permitted = await _permitted_dataset_ids_for(user)
-    visible_ids = await _visible_user_ids(user)
+    permitted = await get_permitted_dataset_ids(user.id)
+    visible_ids = await get_visible_user_ids(user.id)
     return await compute_cost_by_user_agent(
         user=user,
         visible_user_ids=visible_ids,

--- a/cognee/modules/session_lifecycle/usage_tracking.py
+++ b/cognee/modules/session_lifecycle/usage_tracking.py
@@ -6,11 +6,15 @@ Call sites that know the active session_id wrap their work in
 opts in) calls ``record_llm_call`` after each LLM completion. The
 tracker accumulates into the ``SessionRecord`` row.
 
-Token counts are approximate — we don't currently extract
-``response.usage`` from the litellm/instructor client (requires
-changes deeper in the stack). A ~chars/4 heuristic is close enough
-for the dashboard's "are we spending?" question without plumbing
-upstream.
+Token counts are exact for the default instructor-based structured-output
+path — ``LLMGateway`` reads real ``prompt_tokens``/``completion_tokens``
+off the provider response instructor already attaches internally (see
+``LLMGateway._exact_usage_from_result``) and passes them as
+``tokens_in_override``/``tokens_out_override`` below. The litellm_native
+and BAML frameworks, and the plain-string path that skips instructor
+entirely, don't expose that raw response, so calls through those still
+fall back to the ~chars/4 heuristic here — close enough for the
+dashboard's "are we spending?" question on those paths.
 """
 
 from contextlib import asynccontextmanager

--- a/cognee/modules/users/methods/__init__.py
+++ b/cognee/modules/users/methods/__init__.py
@@ -12,3 +12,4 @@ from .get_authenticated_user import (
 from .get_principal_configuration import get_principal_configuration
 from .get_principal_configuration import get_principal_all_configuration
 from .store_principal_configuration import store_principal_configuration
+from .get_visible_user_ids import get_visible_user_ids

--- a/cognee/modules/users/methods/get_visible_user_ids.py
+++ b/cognee/modules/users/methods/get_visible_user_ids.py
@@ -1,0 +1,36 @@
+"""Resolve which user IDs a caller's queries should be scoped to.
+
+Shared across every module that needs to answer "this caller, plus
+anything delegated to them" — sessions, agent connections, usage
+stats, cost aggregates, ... Previously duplicated near-verbatim in
+``cognee.modules.agents.operations`` and
+``cognee.modules.session_lifecycle`` before being consolidated here.
+"""
+
+from uuid import UUID as UUIDType
+
+from sqlalchemy import select
+
+from cognee.infrastructure.databases.relational import get_relational_engine
+from cognee.modules.users.models import User
+
+
+async def _child_agent_user_ids(user_id: UUIDType) -> list[UUIDType]:
+    """Return user IDs of agents whose ``parent_user_id`` matches this user."""
+    engine = get_relational_engine()
+    async with engine.get_async_session() as session:
+        rows = (await session.execute(select(User.id).where(User.parent_user_id == user_id))).all()
+        return [row.id for row in rows]
+
+
+async def get_visible_user_ids(user_id: UUIDType) -> list[UUIDType]:
+    """``user_id`` plus any of its child agent IDs.
+
+    Takes a bare ID rather than a ``User`` object — every call site
+    only ever needs ``.id``, and this keeps the function usable by
+    callers that work with plain IDs (e.g. cache/session lookups) as
+    well as ones with a resolved ``User``.
+    """
+    ids = [user_id]
+    ids.extend(await _child_agent_user_ids(user_id))
+    return ids

--- a/cognee/modules/users/permissions/methods/__init__.py
+++ b/cognee/modules/users/permissions/methods/__init__.py
@@ -13,3 +13,5 @@ from .give_default_permission_to_tenant import give_default_permission_to_tenant
 from .give_default_permission_to_role import give_default_permission_to_role
 from .give_default_permission_to_user import give_default_permission_to_user
 from .has_user_management_permission import has_user_management_permission
+from .get_readable_datasets import get_readable_datasets
+from .get_permitted_dataset_ids import get_permitted_dataset_ids

--- a/cognee/modules/users/permissions/methods/get_permitted_dataset_ids.py
+++ b/cognee/modules/users/permissions/methods/get_permitted_dataset_ids.py
@@ -1,0 +1,14 @@
+from uuid import UUID
+
+from cognee.modules.users.permissions.methods.get_readable_datasets import get_readable_datasets
+
+
+async def get_permitted_dataset_ids(user_id: UUID) -> list[UUID]:
+    """Return the UUIDs of datasets ``user_id`` has read permission for.
+
+    Thin convenience over ``get_readable_datasets`` for callers that only
+    need the IDs (e.g. to filter rows by ``dataset_id``), not the full
+    dataset objects.
+    """
+    datasets = await get_readable_datasets(user_id)
+    return [dataset.id for dataset in datasets]

--- a/cognee/modules/users/permissions/methods/get_readable_datasets.py
+++ b/cognee/modules/users/permissions/methods/get_readable_datasets.py
@@ -1,0 +1,24 @@
+from uuid import UUID
+
+from cognee.modules.data.models.Dataset import Dataset
+from cognee.modules.users.exceptions import PermissionDeniedError
+from cognee.modules.users.permissions.methods.get_specific_user_permission_datasets import (
+    get_specific_user_permission_datasets,
+)
+
+
+async def get_readable_datasets(user_id: UUID) -> list[Dataset]:
+    """Return the datasets ``user_id`` has read permission for (empty on none).
+
+    ``get_specific_user_permission_datasets`` raises ``PermissionDeniedError``
+    when a user has zero datasets with the requested permission — an
+    ordinary, common state (most callers own no shared-with-them
+    datasets), not a real authorization failure — so it's translated to
+    an empty list here rather than propagated. Any other exception is
+    left to propagate: a caller with a genuine problem (e.g. the DB is
+    unreachable) should see that failure, not a silently empty result.
+    """
+    try:
+        return await get_specific_user_permission_datasets(user_id, "read", None)
+    except PermissionDeniedError:
+        return []

--- a/cognee/tests/api/test_agents_e2e.py
+++ b/cognee/tests/api/test_agents_e2e.py
@@ -469,11 +469,11 @@ class TestAgentsE2E:
 
         with (
             patch(
-                "cognee.modules.agents.operations._readable_datasets_for",
+                "cognee.modules.agents.operations.get_readable_datasets",
                 readable_datasets_for,
             ),
             patch(
-                "cognee.modules.agents.operations._visible_user_ids",
+                "cognee.modules.agents.operations.get_visible_user_ids",
                 visible_user_ids,
             ),
             patch(

--- a/cognee/tests/unit/api/test_get_sessions_router_cost_by_user_agent.py
+++ b/cognee/tests/unit/api/test_get_sessions_router_cost_by_user_agent.py
@@ -1,0 +1,62 @@
+"""Wiring tests for GET /api/v1/sessions/cost-by-user-agent (CLO-434 follow-up).
+
+The aggregation/role-scoping logic lives in
+``cognee.modules.session_lifecycle.agent_usage`` and is covered there
+(see ``test_agent_usage.py``). This file only checks that the router
+forwards the range filter and maps errors to HTTP.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cognee.api.v1.sessions.routers import get_sessions_router as router_module
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router_module.get_sessions_router(), prefix="/api/v1/sessions")
+    return app
+
+
+def test_cost_by_user_agent_returns_module_result(monkeypatch):
+    app = _app()
+    user_id = uuid4()
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=user_id, tenant_id=None, email="me@example.com"
+    )
+
+    captured = {}
+    fake_result = [{"user_id": str(user_id), "user_email": "me@example.com", "agent_type": "codex"}]
+
+    async def fake_compute(**kwargs):
+        captured.update(kwargs)
+        return fake_result
+
+    monkeypatch.setattr(router_module, "compute_cost_by_user_agent", fake_compute)
+
+    response = TestClient(app).get("/api/v1/sessions/cost-by-user-agent", params={"range": "7d"})
+
+    assert response.status_code == 200
+    assert response.json() == fake_result
+    assert captured["user"].id == user_id
+    assert captured["since"] is not None
+
+
+def test_cost_by_user_agent_failure_returns_500(monkeypatch):
+    app = _app()
+    user_id = uuid4()
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=user_id, tenant_id=None, email="me@example.com"
+    )
+
+    async def failing_compute(**_kwargs):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(router_module, "compute_cost_by_user_agent", failing_compute)
+
+    response = TestClient(app).get("/api/v1/sessions/cost-by-user-agent")
+    assert response.status_code == 500
+    assert response.json() == {"error": "aggregation failed"}

--- a/cognee/tests/unit/api/test_get_sessions_router_cost_by_user_agent.py
+++ b/cognee/tests/unit/api/test_get_sessions_router_cost_by_user_agent.py
@@ -31,10 +31,18 @@ def test_cost_by_user_agent_returns_module_result(monkeypatch):
     captured = {}
     fake_result = [{"user_id": str(user_id), "user_email": "me@example.com", "agent_type": "codex"}]
 
+    async def fake_permitted(_user):
+        return ["dataset-1"]
+
+    async def fake_visible(_user):
+        return [user_id]
+
     async def fake_compute(**kwargs):
         captured.update(kwargs)
         return fake_result
 
+    monkeypatch.setattr(router_module, "_permitted_dataset_ids_for", fake_permitted)
+    monkeypatch.setattr(router_module, "_visible_user_ids", fake_visible)
     monkeypatch.setattr(router_module, "compute_cost_by_user_agent", fake_compute)
 
     response = TestClient(app).get("/api/v1/sessions/cost-by-user-agent", params={"range": "7d"})
@@ -43,6 +51,8 @@ def test_cost_by_user_agent_returns_module_result(monkeypatch):
     assert response.json() == fake_result
     assert captured["user"].id == user_id
     assert captured["since"] is not None
+    assert captured["visible_user_ids"] == [user_id]
+    assert captured["permitted_dataset_ids"] == ["dataset-1"]
 
 
 def test_cost_by_user_agent_failure_returns_500(monkeypatch):
@@ -52,9 +62,17 @@ def test_cost_by_user_agent_failure_returns_500(monkeypatch):
         id=user_id, tenant_id=None, email="me@example.com"
     )
 
+    async def fake_permitted(_user):
+        return []
+
+    async def fake_visible(_user):
+        return [user_id]
+
     async def failing_compute(**_kwargs):
         raise RuntimeError("db unavailable")
 
+    monkeypatch.setattr(router_module, "_permitted_dataset_ids_for", fake_permitted)
+    monkeypatch.setattr(router_module, "_visible_user_ids", fake_visible)
     monkeypatch.setattr(router_module, "compute_cost_by_user_agent", failing_compute)
 
     response = TestClient(app).get("/api/v1/sessions/cost-by-user-agent")

--- a/cognee/tests/unit/api/test_get_sessions_router_cost_by_user_agent.py
+++ b/cognee/tests/unit/api/test_get_sessions_router_cost_by_user_agent.py
@@ -1,18 +1,22 @@
 """Wiring tests for GET /api/v1/sessions/cost-by-user-agent (CLO-434 follow-up).
 
-The aggregation/role-scoping logic lives in
-``cognee.modules.session_lifecycle.agent_usage`` and is covered there
-(see ``test_agent_usage.py``). This file only checks that the router
-forwards the range filter and maps errors to HTTP.
+The visibility-resolution + aggregation logic lives in
+``cognee.modules.session_lifecycle.agent_usage.get_cost_by_user_agent`` and
+is covered there (see ``test_agent_usage.py``). This file only checks that
+the router forwards the range filter and maps errors to HTTP — including
+that a ``CogneeApiError`` is left for the global handler instead of being
+turned into a generic 500.
 """
 
 from types import SimpleNamespace
 from uuid import uuid4
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from cognee.api.v1.sessions.routers import get_sessions_router as router_module
+from cognee.exceptions import CogneeSystemError
 
 
 def _app() -> FastAPI:
@@ -31,19 +35,11 @@ def test_cost_by_user_agent_returns_module_result(monkeypatch):
     captured = {}
     fake_result = [{"user_id": str(user_id), "user_email": "me@example.com", "agent_type": "codex"}]
 
-    async def fake_permitted(_user):
-        return ["dataset-1"]
-
-    async def fake_visible(_user):
-        return [user_id]
-
-    async def fake_compute(**kwargs):
+    async def fake_get_cost_by_user_agent(**kwargs):
         captured.update(kwargs)
         return fake_result
 
-    monkeypatch.setattr(router_module, "_permitted_dataset_ids_for", fake_permitted)
-    monkeypatch.setattr(router_module, "_visible_user_ids", fake_visible)
-    monkeypatch.setattr(router_module, "compute_cost_by_user_agent", fake_compute)
+    monkeypatch.setattr(router_module, "get_cost_by_user_agent", fake_get_cost_by_user_agent)
 
     response = TestClient(app).get("/api/v1/sessions/cost-by-user-agent", params={"range": "7d"})
 
@@ -51,8 +47,6 @@ def test_cost_by_user_agent_returns_module_result(monkeypatch):
     assert response.json() == fake_result
     assert captured["user"].id == user_id
     assert captured["since"] is not None
-    assert captured["visible_user_ids"] == [user_id]
-    assert captured["permitted_dataset_ids"] == ["dataset-1"]
 
 
 def test_cost_by_user_agent_failure_returns_500(monkeypatch):
@@ -62,19 +56,30 @@ def test_cost_by_user_agent_failure_returns_500(monkeypatch):
         id=user_id, tenant_id=None, email="me@example.com"
     )
 
-    async def fake_permitted(_user):
-        return []
-
-    async def fake_visible(_user):
-        return [user_id]
-
     async def failing_compute(**_kwargs):
         raise RuntimeError("db unavailable")
 
-    monkeypatch.setattr(router_module, "_permitted_dataset_ids_for", fake_permitted)
-    monkeypatch.setattr(router_module, "_visible_user_ids", fake_visible)
-    monkeypatch.setattr(router_module, "compute_cost_by_user_agent", failing_compute)
+    monkeypatch.setattr(router_module, "get_cost_by_user_agent", failing_compute)
 
     response = TestClient(app).get("/api/v1/sessions/cost-by-user-agent")
     assert response.status_code == 500
     assert response.json() == {"error": "aggregation failed"}
+
+
+def test_cost_by_user_agent_lets_cognee_api_error_propagate(monkeypatch):
+    """A CogneeApiError carries its own status/message — it must reach the
+    global exception_handler in cognee/api/client.py, not get flattened
+    into the generic {"error": "aggregation failed"} 500."""
+    app = _app()
+    user_id = uuid4()
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=user_id, tenant_id=None, email="me@example.com"
+    )
+
+    async def failing(**_kwargs):
+        raise CogneeSystemError(message="boom")
+
+    monkeypatch.setattr(router_module, "get_cost_by_user_agent", failing)
+
+    with pytest.raises(CogneeSystemError):
+        TestClient(app).get("/api/v1/sessions/cost-by-user-agent")

--- a/cognee/tests/unit/api/test_get_sessions_router_with_agent_info.py
+++ b/cognee/tests/unit/api/test_get_sessions_router_with_agent_info.py
@@ -1,18 +1,22 @@
 """Wiring tests for GET /api/v1/sessions/with-agent-info (CLO-434).
 
-The join/merge logic itself lives in
-``cognee.modules.session_lifecycle.agent_usage`` and is covered there
-(see ``test_agent_usage.py``). This file only checks that the router
-resolves auth/visibility, forwards params, and maps errors to HTTP.
+The visibility-resolution + join/merge logic lives in
+``cognee.modules.session_lifecycle.agent_usage.get_sessions_with_agent_info``
+and is covered there (see ``test_agent_usage.py``). This file only checks
+that the router forwards params and maps errors to HTTP — including that a
+``CogneeApiError`` is left for the global handler instead of being turned
+into a generic 500.
 """
 
 from types import SimpleNamespace
 from uuid import uuid4
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from cognee.api.v1.sessions.routers import get_sessions_router as router_module
+from cognee.exceptions import CogneeSystemError
 
 
 def _app() -> FastAPI:
@@ -37,19 +41,13 @@ def test_with_agent_info_returns_module_result(monkeypatch):
         "has_more": False,
     }
 
-    async def fake_permitted(_user):
-        return ["dataset-1"]
-
-    async def fake_visible(_user):
-        return [user_id]
-
-    async def fake_build_page(**kwargs):
+    async def fake_get_sessions_with_agent_info(**kwargs):
         captured_kwargs.update(kwargs)
         return fake_page
 
-    monkeypatch.setattr(router_module, "_permitted_dataset_ids_for", fake_permitted)
-    monkeypatch.setattr(router_module, "_visible_user_ids", fake_visible)
-    monkeypatch.setattr(router_module, "build_sessions_with_agent_info_page", fake_build_page)
+    monkeypatch.setattr(
+        router_module, "get_sessions_with_agent_info", fake_get_sessions_with_agent_info
+    )
 
     response = TestClient(app).get(
         "/api/v1/sessions/with-agent-info", params={"limit": 10, "offset": 5}
@@ -57,8 +55,8 @@ def test_with_agent_info_returns_module_result(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == fake_page
-    assert captured_kwargs["visible_user_ids"] == [user_id]
-    assert captured_kwargs["permitted_dataset_ids"] == ["dataset-1"]
+    assert captured_kwargs["user"].id == user_id
+    assert captured_kwargs["since"] is not None
     assert captured_kwargs["limit"] == 10
     assert captured_kwargs["offset"] == 5
 
@@ -70,19 +68,30 @@ def test_with_agent_info_failure_returns_500(monkeypatch):
         id=user_id, tenant_id=None
     )
 
-    async def fake_permitted(_user):
-        return []
-
-    async def fake_visible(_user):
-        return [user_id]
-
-    async def failing_build_page(**_kwargs):
+    async def failing(**_kwargs):
         raise RuntimeError("db unavailable")
 
-    monkeypatch.setattr(router_module, "_permitted_dataset_ids_for", fake_permitted)
-    monkeypatch.setattr(router_module, "_visible_user_ids", fake_visible)
-    monkeypatch.setattr(router_module, "build_sessions_with_agent_info_page", failing_build_page)
+    monkeypatch.setattr(router_module, "get_sessions_with_agent_info", failing)
 
     response = TestClient(app).get("/api/v1/sessions/with-agent-info")
     assert response.status_code == 500
     assert response.json() == {"error": "list failed"}
+
+
+def test_with_agent_info_lets_cognee_api_error_propagate(monkeypatch):
+    """A CogneeApiError carries its own status/message — it must reach the
+    global exception_handler in cognee/api/client.py, not get flattened
+    into the generic {"error": "list failed"} 500."""
+    app = _app()
+    user_id = uuid4()
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=user_id, tenant_id=None
+    )
+
+    async def failing(**_kwargs):
+        raise CogneeSystemError(message="boom")
+
+    monkeypatch.setattr(router_module, "get_sessions_with_agent_info", failing)
+
+    with pytest.raises(CogneeSystemError):
+        TestClient(app).get("/api/v1/sessions/with-agent-info")

--- a/cognee/tests/unit/api/test_get_sessions_router_with_agent_info.py
+++ b/cognee/tests/unit/api/test_get_sessions_router_with_agent_info.py
@@ -1,0 +1,88 @@
+"""Wiring tests for GET /api/v1/sessions/with-agent-info (CLO-434).
+
+The join/merge logic itself lives in
+``cognee.modules.session_lifecycle.agent_usage`` and is covered there
+(see ``test_agent_usage.py``). This file only checks that the router
+resolves auth/visibility, forwards params, and maps errors to HTTP.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cognee.api.v1.sessions.routers import get_sessions_router as router_module
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router_module.get_sessions_router(), prefix="/api/v1/sessions")
+    return app
+
+
+def test_with_agent_info_returns_module_result(monkeypatch):
+    app = _app()
+    user_id = uuid4()
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=user_id, tenant_id=None
+    )
+
+    captured_kwargs = {}
+    fake_page = {
+        "sessions": [{"session_id": "claude-code-123", "agent_type": "claude_code"}],
+        "total": 1,
+        "limit": 50,
+        "offset": 0,
+        "has_more": False,
+    }
+
+    async def fake_permitted(_user):
+        return ["dataset-1"]
+
+    async def fake_visible(_user):
+        return [user_id]
+
+    async def fake_build_page(**kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_page
+
+    monkeypatch.setattr(router_module, "_permitted_dataset_ids_for", fake_permitted)
+    monkeypatch.setattr(router_module, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(router_module, "build_sessions_with_agent_info_page", fake_build_page)
+
+    response = TestClient(app).get(
+        "/api/v1/sessions/with-agent-info", params={"limit": 10, "offset": 5}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == fake_page
+    assert captured_kwargs["visible_user_ids"] == [user_id]
+    assert captured_kwargs["permitted_dataset_ids"] == ["dataset-1"]
+    assert captured_kwargs["limit"] == 10
+    assert captured_kwargs["offset"] == 5
+
+
+def test_with_agent_info_failure_returns_500(monkeypatch):
+    app = _app()
+    user_id = uuid4()
+    app.dependency_overrides[router_module.get_authenticated_user] = lambda: SimpleNamespace(
+        id=user_id, tenant_id=None
+    )
+
+    async def fake_permitted(_user):
+        return []
+
+    async def fake_visible(_user):
+        return [user_id]
+
+    async def failing_build_page(**_kwargs):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(router_module, "_permitted_dataset_ids_for", fake_permitted)
+    monkeypatch.setattr(router_module, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(router_module, "build_sessions_with_agent_info_page", failing_build_page)
+
+    response = TestClient(app).get("/api/v1/sessions/with-agent-info")
+    assert response.status_code == 500
+    assert response.json() == {"error": "list failed"}

--- a/cognee/tests/unit/infrastructure/llm/test_llm_gateway_usage.py
+++ b/cognee/tests/unit/infrastructure/llm/test_llm_gateway_usage.py
@@ -1,0 +1,127 @@
+"""LLMGateway must record REAL token counts when instructor makes them
+available, instead of always falling back to the char-based estimate.
+
+Instructor attaches the raw provider response as ``_raw_response`` on every
+parsed model it returns (``instructor.processing.response.process_response``);
+that raw response carries ``.usage`` with exact ``prompt_tokens`` /
+``completion_tokens``. ``_exact_usage_from_result`` reads it, and
+``_record_session_usage_after`` passes it through as
+``tokens_in_override``/``tokens_out_override`` so ``record_llm_call`` never
+has to guess for this path.
+"""
+
+import sys
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.infrastructure.llm.LLMGateway import (
+    _exact_usage_from_result,
+    _record_session_usage_after,
+)
+from cognee.modules.session_lifecycle import usage_tracking
+from cognee.modules.session_lifecycle.usage_tracking import track_session_usage
+
+# `cognee.infrastructure.llm.__init__` does `from .LLMGateway import LLMGateway`,
+# which overwrites the `LLMGateway` attribute on the package with the class —
+# so `import cognee.infrastructure.llm.LLMGateway as x` binds `x` to the class,
+# not the module. Go through sys.modules to get the actual module for patching.
+llm_gateway_module = sys.modules["cognee.infrastructure.llm.LLMGateway"]
+
+
+class _Answer(BaseModel):
+    value: str
+
+
+def _with_raw_response(model: BaseModel, prompt_tokens=None, completion_tokens=None) -> BaseModel:
+    usage = SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens)
+    model._raw_response = SimpleNamespace(usage=usage)
+    return model
+
+
+# --------------------------------------------------------------------------- #
+# _exact_usage_from_result
+# --------------------------------------------------------------------------- #
+
+
+def test_exact_usage_extracted_from_raw_response():
+    result = _with_raw_response(_Answer(value="hi"), prompt_tokens=123, completion_tokens=45)
+    assert _exact_usage_from_result(result) == (123, 45)
+
+
+def test_exact_usage_none_when_no_raw_response():
+    # Plain string path (skips instructor) has no _raw_response attribute at all.
+    assert _exact_usage_from_result("just a string") == (None, None)
+
+
+def test_exact_usage_none_when_raw_response_has_no_usage():
+    model = _Answer(value="hi")
+    model._raw_response = SimpleNamespace()  # no .usage
+    assert _exact_usage_from_result(model) == (None, None)
+
+
+def test_exact_usage_none_when_usage_fields_missing():
+    # e.g. a provider that returns a usage object without token fields.
+    result = _with_raw_response(_Answer(value="hi"), prompt_tokens=None, completion_tokens=10)
+    assert _exact_usage_from_result(result) == (None, None)
+
+
+# --------------------------------------------------------------------------- #
+# _record_session_usage_after end-to-end
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_record_session_usage_after_uses_exact_counts(monkeypatch):
+    captured = {}
+
+    async def fake_record_llm_call(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(usage_tracking, "record_llm_call", fake_record_llm_call)
+    monkeypatch.setattr(
+        llm_gateway_module,
+        "get_llm_context_config",
+        lambda: SimpleNamespace(llm_model="openai/gpt-4o-mini"),
+    )
+
+    async def coro():
+        return _with_raw_response(_Answer(value="hi"), prompt_tokens=200, completion_tokens=50)
+
+    user_id = uuid4()
+    async with track_session_usage("sess-1", user_id):
+        await _record_session_usage_after(coro(), text_input="some long prompt text")
+
+    assert captured["tokens_in_override"] == 200
+    assert captured["tokens_out_override"] == 50
+
+
+@pytest.mark.asyncio
+async def test_record_session_usage_after_falls_back_to_estimate_without_raw_response(
+    monkeypatch,
+):
+    captured = {}
+
+    async def fake_record_llm_call(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(usage_tracking, "record_llm_call", fake_record_llm_call)
+    monkeypatch.setattr(
+        llm_gateway_module,
+        "get_llm_context_config",
+        lambda: SimpleNamespace(llm_model="openai/gpt-4o-mini"),
+    )
+
+    async def coro():
+        return "a plain string response, no instructor involved"
+
+    user_id = uuid4()
+    async with track_session_usage("sess-2", user_id):
+        await _record_session_usage_after(coro(), text_input="prompt")
+
+    # No exact usage available -> overrides are None, letting record_llm_call
+    # fall back to its own char-based estimate.
+    assert captured["tokens_in_override"] is None
+    assert captured["tokens_out_override"] is None

--- a/cognee/tests/unit/modules/agents/test_agent_registry.py
+++ b/cognee/tests/unit/modules/agents/test_agent_registry.py
@@ -7,10 +7,24 @@ import cognee
 from cognee.modules.agents.registry import (
     classify_memory_source_type,
     clear_registered_agent_connections,
+    derive_connection_type,
     list_registered_agent_connections,
     register_agent_connection,
 )
 from cognee.modules.users.methods import get_default_user
+
+
+def test_agent_connection_type_accepts_arbitrary_client_names():
+    """AgentConnectionType is intentionally a free string (not a closed
+    Literal) so a brand-new client (Cursor, Windsurf, ...) can self-declare
+    its own type without a backend code change. See models.py for why."""
+    from cognee.modules.agents.models import AgentConnection, RegisterAgentRequest
+
+    connection = AgentConnection(id="x", agent_session_name="y", type="cursor")
+    assert connection.type == "cursor"
+
+    request = RegisterAgentRequest(agent_session_name="z", type="windsurf")
+    assert request.type == "windsurf"
 
 
 @pytest.mark.asyncio
@@ -44,6 +58,32 @@ async def test_register_agent_connection_normalizes_memory_sources():
 )
 def test_classify_memory_source_type(name, expected):
     assert classify_memory_source_type(name) == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "origin_function", "session_id", "expected"),
+    [
+        ("mcp", None, None, "mcp"),
+        ("api_key", None, None, "api"),
+        ("serve", None, None, "api"),
+        (None, None, "cc_myproj_ab12cd34", "claude_code"),
+        (None, "claude_code_remember", None, "claude_code"),
+        (None, None, "claude-code-1718000000", "claude_code"),
+        (None, None, "codex-1718000000", "codex"),
+        (None, "codex_cli", None, "codex"),
+        (None, None, "slack-bot-session", "slack"),
+        (None, None, "some_mcp_session", "mcp"),
+        (None, "custom_sdk_call", None, "sdk"),
+        (None, None, None, "unknown"),
+    ],
+)
+def test_derive_connection_type(source, origin_function, session_id, expected):
+    assert (
+        derive_connection_type(
+            origin_function=origin_function, session_id=session_id, source=source
+        )
+        == expected
+    )
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
+++ b/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
@@ -154,12 +154,42 @@ async def test_single_user_mode_falls_back_to_caller_only(monkeypatch):
     monkeypatch.setattr(agent_usage, "list_persisted_agent_connections", fake_persisted)
     monkeypatch.setattr(agent_usage, "list_registered_agent_connections", lambda: [])
 
-    result = await agent_usage.compute_cost_by_user_agent(user=user, since=None)
+    result = await agent_usage.compute_cost_by_user_agent(
+        user=user, visible_user_ids=[user_id], permitted_dataset_ids=[], since=None
+    )
     by_type = {r["agent_type"]: r for r in result}
 
     assert by_type["claude_code"]["user_email"] == "solo@example.com"
     assert by_type["claude_code"]["session_count"] == 1
     assert by_type["codex"]["session_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_solo_mode_includes_child_agent_sessions(monkeypatch):
+    """No tenant, but the caller has a child agent (e.g. a delegated
+    sub-account) — those sessions must still be included, same as
+    every other /sessions endpoint does via ``_visible_user_ids``."""
+    user_id = uuid4()
+    child_id = uuid4()
+    user = SimpleNamespace(id=user_id, tenant_id=None, email="solo@example.com")
+
+    rows = [_row(user_id, "claude-code-1"), _row(child_id, "codex-1")]
+    monkeypatch.setattr(agent_usage, "get_relational_engine", lambda: _FakeEngine(rows))
+
+    async def fake_persisted(_user_ids, active_only=False):
+        return []
+
+    monkeypatch.setattr(agent_usage, "list_persisted_agent_connections", fake_persisted)
+    monkeypatch.setattr(agent_usage, "list_registered_agent_connections", lambda: [])
+
+    result = await agent_usage.compute_cost_by_user_agent(
+        user=user, visible_user_ids=[user_id, child_id], permitted_dataset_ids=[], since=None
+    )
+    by_type = {r["agent_type"]: r for r in result}
+
+    assert by_type["claude_code"]["user_email"] == "solo@example.com"
+    assert by_type["codex"]["user_id"] == str(child_id)
+    assert by_type["codex"]["user_email"] == "unknown"
 
 
 @pytest.mark.asyncio
@@ -196,7 +226,9 @@ async def test_tenant_mode_aggregates_across_users_and_sorts_by_cost(monkeypatch
     monkeypatch.setattr(agent_usage, "list_persisted_agent_connections", fake_persisted)
     monkeypatch.setattr(agent_usage, "list_registered_agent_connections", lambda: [])
 
-    result = await agent_usage.compute_cost_by_user_agent(user=user, since=None)
+    result = await agent_usage.compute_cost_by_user_agent(
+        user=user, visible_user_ids=[caller_id], permitted_dataset_ids=[], since=None
+    )
 
     # Highest spender first.
     assert result[0]["user_email"] == "member@example.com"
@@ -209,7 +241,8 @@ async def test_tenant_mode_aggregates_across_users_and_sorts_by_cost(monkeypatch
 @pytest.mark.asyncio
 async def test_tenant_mode_member_falls_back_to_own_sessions(monkeypatch):
     """A non-admin member isn't denied outright — they just don't get the
-    tenant-wide view; the function scopes down to their own sessions."""
+    tenant-wide view; the function scopes down to their base visibility
+    (self + child agents), same as every other /sessions endpoint."""
     caller_id = uuid4()
     tenant_id = uuid4()
     user = SimpleNamespace(id=caller_id, tenant_id=tenant_id, email="member@example.com")
@@ -227,9 +260,48 @@ async def test_tenant_mode_member_falls_back_to_own_sessions(monkeypatch):
     monkeypatch.setattr(agent_usage, "list_persisted_agent_connections", fake_persisted)
     monkeypatch.setattr(agent_usage, "list_registered_agent_connections", lambda: [])
 
-    result = await agent_usage.compute_cost_by_user_agent(user=user, since=None)
+    result = await agent_usage.compute_cost_by_user_agent(
+        user=user, visible_user_ids=[caller_id], permitted_dataset_ids=[], since=None
+    )
 
     assert len(result) == 1
     assert result[0]["user_id"] == str(caller_id)
     assert result[0]["user_email"] == "member@example.com"
     assert result[0]["agent_type"] == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_tenant_mode_member_keeps_child_agents_when_denied_tenant_view(monkeypatch):
+    """A non-admin member denied the tenant-wide view must still keep
+    their own child-agent sessions — the tenant lookup failing shouldn't
+    collapse the base visibility down to just the caller."""
+    caller_id = uuid4()
+    child_id = uuid4()
+    tenant_id = uuid4()
+    user = SimpleNamespace(id=caller_id, tenant_id=tenant_id, email="member@example.com")
+
+    async def fake_get_users_in_tenant(_tenant_id, _user):
+        raise PermissionDeniedError(message="nope")
+
+    rows = [
+        _row(caller_id, "claude-code-1", cost_usd=0.02),
+        _row(child_id, "codex-1", cost_usd=0.03),
+    ]
+
+    async def fake_persisted(_user_ids, active_only=False):
+        return []
+
+    monkeypatch.setattr(agent_usage, "get_users_in_tenant", fake_get_users_in_tenant)
+    monkeypatch.setattr(agent_usage, "get_relational_engine", lambda: _FakeEngine(rows))
+    monkeypatch.setattr(agent_usage, "list_persisted_agent_connections", fake_persisted)
+    monkeypatch.setattr(agent_usage, "list_registered_agent_connections", lambda: [])
+
+    result = await agent_usage.compute_cost_by_user_agent(
+        user=user, visible_user_ids=[caller_id, child_id], permitted_dataset_ids=[], since=None
+    )
+    by_type = {r["agent_type"]: r for r in result}
+
+    assert len(result) == 2
+    assert by_type["claude_code"]["user_email"] == "member@example.com"
+    assert by_type["codex"]["user_id"] == str(child_id)
+    assert by_type["codex"]["user_email"] == "unknown"

--- a/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
+++ b/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
@@ -1,0 +1,235 @@
+"""Unit tests for cognee.modules.session_lifecycle.agent_usage (CLO-434).
+
+Covers the session_records <-> agent_connections join and the
+per-(user, agent type) cost aggregation directly, independent of FastAPI —
+the HTTP layer (get_sessions_router) is exercised separately as thin wiring.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from cognee.modules.session_lifecycle import agent_usage
+from cognee.modules.agents.models import AgentConnection, AgentsListResponse
+from cognee.modules.session_lifecycle.metrics import SessionListPage, SessionRowWithStatus
+from cognee.modules.session_lifecycle.models import SessionRecord
+from cognee.modules.users.exceptions import PermissionDeniedError
+
+
+def _session_row(session_id: str, user_id) -> SessionRowWithStatus:
+    record = SessionRecord(
+        session_id=session_id,
+        user_id=user_id,
+        status="completed",
+        started_at=datetime.now(timezone.utc),
+        last_activity_at=datetime.now(timezone.utc),
+        tokens_in=10,
+        tokens_out=20,
+        cost_usd=0.01,
+        error_count=0,
+        last_model=None,
+    )
+    return SessionRowWithStatus(record=record, effective_status="completed")
+
+
+def _row(user_id, session_id, tokens_in=10, tokens_out=20, cost_usd=0.01):
+    return SimpleNamespace(
+        user_id=user_id,
+        session_id=session_id,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        cost_usd=cost_usd,
+    )
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._rows)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_async_session(self):
+        return _FakeSession(self._rows)
+
+
+# --------------------------------------------------------------------------- #
+# build_sessions_with_agent_info_page
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_merges_matched_and_falls_back_for_unmatched(monkeypatch):
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, tenant_id=None, email="me@example.com")
+
+    matched_row = _session_row("claude-code-123", user_id)
+    unmatched_row = _session_row("codex-456", user_id)
+
+    async def fake_list_session_rows(**_kwargs):
+        return SessionListPage(sessions=[matched_row, unmatched_row], total=2, limit=50, offset=0)
+
+    async def fake_list_agent_connections(**_kwargs):
+        conn = AgentConnection(
+            id="conn-1",
+            agent_session_name="my-claude-code",
+            type="claude_code",
+            source="mcp",
+            session_id="claude-code-123",
+            user_id=user_id,
+            origin_function="remember",
+        )
+        return AgentsListResponse(
+            agents=[conn], memory_sources=[], total=1, limit=10000, offset=0, has_more=False
+        )
+
+    monkeypatch.setattr(agent_usage, "list_session_rows", fake_list_session_rows)
+    monkeypatch.setattr(agent_usage, "list_agent_connections", fake_list_agent_connections)
+
+    result = await agent_usage.build_sessions_with_agent_info_page(
+        user=user,
+        permitted_dataset_ids=[],
+        visible_user_ids=[user_id],
+        since=None,
+        status_filter=None,
+        limit=50,
+        offset=0,
+        order_by="last_activity_at",
+        descending=True,
+    )
+
+    assert result["total"] == 2
+    sessions_by_id = {s["session_id"]: s for s in result["sessions"]}
+
+    matched = sessions_by_id["claude-code-123"]
+    assert matched["agent_type"] == "claude_code"
+    assert matched["agent_source"] == "mcp"
+    assert matched["agent_session_name"] == "my-claude-code"
+    assert matched["origin_function"] == "remember"
+
+    # No registered connection for this session -> prefix-derived fallback.
+    unmatched = sessions_by_id["codex-456"]
+    assert unmatched["agent_type"] == "codex"
+    assert unmatched["agent_source"] is None
+    assert unmatched["agent_session_name"] is None
+
+
+# --------------------------------------------------------------------------- #
+# compute_cost_by_user_agent
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_single_user_mode_falls_back_to_caller_only(monkeypatch):
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, tenant_id=None, email="solo@example.com")
+
+    rows = [_row(user_id, "claude-code-1"), _row(user_id, "codex-1")]
+    monkeypatch.setattr(agent_usage, "get_relational_engine", lambda: _FakeEngine(rows))
+
+    async def fake_persisted(_user_ids, active_only=False):
+        return []
+
+    monkeypatch.setattr(agent_usage, "list_persisted_agent_connections", fake_persisted)
+    monkeypatch.setattr(agent_usage, "list_registered_agent_connections", lambda: [])
+
+    result = await agent_usage.compute_cost_by_user_agent(user=user, since=None)
+    by_type = {r["agent_type"]: r for r in result}
+
+    assert by_type["claude_code"]["user_email"] == "solo@example.com"
+    assert by_type["claude_code"]["session_count"] == 1
+    assert by_type["codex"]["session_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tenant_mode_aggregates_across_users_and_sorts_by_cost(monkeypatch):
+    caller_id = uuid4()
+    other_id = uuid4()
+    tenant_id = uuid4()
+    user = SimpleNamespace(id=caller_id, tenant_id=tenant_id, email="admin@example.com")
+
+    async def fake_get_users_in_tenant(_tenant_id, _user):
+        return [
+            {"id": str(caller_id), "email": "admin@example.com", "roles": []},
+            {"id": str(other_id), "email": "member@example.com", "roles": []},
+        ]
+
+    rows = [
+        _row(caller_id, "claude-code-1", cost_usd=0.01),
+        _row(other_id, "codex-1", cost_usd=5.00),
+    ]
+
+    conn = AgentConnection(
+        id="conn-1",
+        agent_session_name="member-codex",
+        type="codex",
+        session_id="codex-1",
+        user_id=other_id,
+    )
+
+    async def fake_persisted(_user_ids, active_only=False):
+        return [conn]
+
+    monkeypatch.setattr(agent_usage, "get_users_in_tenant", fake_get_users_in_tenant)
+    monkeypatch.setattr(agent_usage, "get_relational_engine", lambda: _FakeEngine(rows))
+    monkeypatch.setattr(agent_usage, "list_persisted_agent_connections", fake_persisted)
+    monkeypatch.setattr(agent_usage, "list_registered_agent_connections", lambda: [])
+
+    result = await agent_usage.compute_cost_by_user_agent(user=user, since=None)
+
+    # Highest spender first.
+    assert result[0]["user_email"] == "member@example.com"
+    assert result[0]["agent_type"] == "codex"
+    assert result[0]["cost_usd"] == pytest.approx(5.00)
+    assert result[1]["user_email"] == "admin@example.com"
+    assert result[1]["agent_type"] == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_tenant_mode_member_falls_back_to_own_sessions(monkeypatch):
+    """A non-admin member isn't denied outright — they just don't get the
+    tenant-wide view; the function scopes down to their own sessions."""
+    caller_id = uuid4()
+    tenant_id = uuid4()
+    user = SimpleNamespace(id=caller_id, tenant_id=tenant_id, email="member@example.com")
+
+    async def fake_get_users_in_tenant(_tenant_id, _user):
+        raise PermissionDeniedError(message="nope")
+
+    rows = [_row(caller_id, "claude-code-1", cost_usd=0.02)]
+
+    async def fake_persisted(_user_ids, active_only=False):
+        return []
+
+    monkeypatch.setattr(agent_usage, "get_users_in_tenant", fake_get_users_in_tenant)
+    monkeypatch.setattr(agent_usage, "get_relational_engine", lambda: _FakeEngine(rows))
+    monkeypatch.setattr(agent_usage, "list_persisted_agent_connections", fake_persisted)
+    monkeypatch.setattr(agent_usage, "list_registered_agent_connections", lambda: [])
+
+    result = await agent_usage.compute_cost_by_user_agent(user=user, since=None)
+
+    assert len(result) == 1
+    assert result[0]["user_id"] == str(caller_id)
+    assert result[0]["user_email"] == "member@example.com"
+    assert result[0]["agent_type"] == "claude_code"

--- a/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
+++ b/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
@@ -347,3 +347,145 @@ async def test_tenant_mode_member_keeps_child_agents_when_denied_tenant_view(mon
     assert by_type["claude_code"]["user_email"] == "member@example.com"
     assert by_type["codex"]["user_id"] == str(child_id)
     assert by_type["codex"]["user_email"] == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# get_sessions_with_agent_info / get_cost_by_user_agent (SDK-usable entry
+# points — resolve visibility, then delegate; see review discussion on
+# moving this out of the router so a plain SDK caller can use it too)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_with_agent_info_resolves_visibility_then_delegates(monkeypatch):
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, tenant_id=None, email="me@example.com")
+
+    async def fake_permitted(_user):
+        return ["dataset-1"]
+
+    async def fake_visible(_user):
+        return [user_id]
+
+    captured = {}
+
+    async def fake_build_page(**kwargs):
+        captured.update(kwargs)
+        return {"sessions": [], "total": 0, "limit": 50, "offset": 0, "has_more": False}
+
+    monkeypatch.setattr(agent_usage, "_permitted_dataset_ids_for", fake_permitted)
+    monkeypatch.setattr(agent_usage, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(agent_usage, "build_sessions_with_agent_info_page", fake_build_page)
+
+    result = await agent_usage.get_sessions_with_agent_info(
+        user=user,
+        since=None,
+        status_filter=None,
+        limit=10,
+        offset=5,
+        order_by="last_activity_at",
+        descending=True,
+    )
+
+    assert result["total"] == 0
+    assert captured["user"] is user
+    assert captured["permitted_dataset_ids"] == ["dataset-1"]
+    assert captured["visible_user_ids"] == [user_id]
+    assert captured["limit"] == 10
+    assert captured["offset"] == 5
+
+
+@pytest.mark.asyncio
+async def test_get_cost_by_user_agent_resolves_visibility_then_delegates(monkeypatch):
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, tenant_id=None, email="me@example.com")
+
+    async def fake_permitted(_user):
+        return ["dataset-1"]
+
+    async def fake_visible(_user):
+        return [user_id]
+
+    captured = {}
+
+    async def fake_compute(**kwargs):
+        captured.update(kwargs)
+        return [{"user_id": str(user_id)}]
+
+    monkeypatch.setattr(agent_usage, "_permitted_dataset_ids_for", fake_permitted)
+    monkeypatch.setattr(agent_usage, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(agent_usage, "compute_cost_by_user_agent", fake_compute)
+
+    result = await agent_usage.get_cost_by_user_agent(user=user, since=None)
+
+    assert result == [{"user_id": str(user_id)}]
+    assert captured["user"] is user
+    assert captured["permitted_dataset_ids"] == ["dataset-1"]
+    assert captured["visible_user_ids"] == [user_id]
+
+
+@pytest.mark.asyncio
+async def test_get_sessions_with_agent_info_defaults_user_when_omitted(monkeypatch):
+    """Matches every other SDK-facing function in cognee.api.v1.agents.agents:
+    a caller with no HTTP auth context can omit ``user`` entirely."""
+    default_user = SimpleNamespace(id=uuid4(), tenant_id=None, email="default@example.com")
+
+    async def fake_get_default_user():
+        return default_user
+
+    async def fake_permitted(_user):
+        return []
+
+    async def fake_visible(_user):
+        return [default_user.id]
+
+    captured = {}
+
+    async def fake_build_page(**kwargs):
+        captured.update(kwargs)
+        return {"sessions": [], "total": 0, "limit": 50, "offset": 0, "has_more": False}
+
+    monkeypatch.setattr(agent_usage, "get_default_user", fake_get_default_user)
+    monkeypatch.setattr(agent_usage, "_permitted_dataset_ids_for", fake_permitted)
+    monkeypatch.setattr(agent_usage, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(agent_usage, "build_sessions_with_agent_info_page", fake_build_page)
+
+    await agent_usage.get_sessions_with_agent_info(
+        since=None,
+        status_filter=None,
+        limit=50,
+        offset=0,
+        order_by="last_activity_at",
+        descending=True,
+    )
+
+    assert captured["user"] is default_user
+
+
+@pytest.mark.asyncio
+async def test_get_cost_by_user_agent_defaults_user_when_omitted(monkeypatch):
+    default_user = SimpleNamespace(id=uuid4(), tenant_id=None, email="default@example.com")
+
+    async def fake_get_default_user():
+        return default_user
+
+    async def fake_permitted(_user):
+        return []
+
+    async def fake_visible(_user):
+        return [default_user.id]
+
+    captured = {}
+
+    async def fake_compute(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(agent_usage, "get_default_user", fake_get_default_user)
+    monkeypatch.setattr(agent_usage, "_permitted_dataset_ids_for", fake_permitted)
+    monkeypatch.setattr(agent_usage, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(agent_usage, "compute_cost_by_user_agent", fake_compute)
+
+    await agent_usage.get_cost_by_user_agent(since=None)
+
+    assert captured["user"] is default_user

--- a/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
+++ b/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
@@ -135,6 +135,48 @@ async def test_merges_matched_and_falls_back_for_unmatched(monkeypatch):
     assert unmatched["agent_session_name"] is None
 
 
+@pytest.mark.asyncio
+async def test_warns_when_agent_connection_page_is_capped(monkeypatch, caplog):
+    """If a scope has more agent connections than the page cap, sessions past
+    the cap silently fall back to the prefix heuristic — that should at least
+    be visible in logs instead of failing silently."""
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, tenant_id=None, email="me@example.com")
+
+    row = _session_row("claude-code-123", user_id)
+
+    async def fake_list_session_rows(**_kwargs):
+        return SessionListPage(sessions=[row], total=1, limit=50, offset=0)
+
+    async def fake_list_agent_connections(**_kwargs):
+        return AgentsListResponse(
+            agents=[],
+            memory_sources=[],
+            total=20_000,
+            limit=agent_usage._AGENT_CONNECTIONS_PAGE_CAP,
+            offset=0,
+            has_more=True,
+        )
+
+    monkeypatch.setattr(agent_usage, "list_session_rows", fake_list_session_rows)
+    monkeypatch.setattr(agent_usage, "list_agent_connections", fake_list_agent_connections)
+
+    with caplog.at_level("WARNING"):
+        await agent_usage.build_sessions_with_agent_info_page(
+            user=user,
+            permitted_dataset_ids=[],
+            visible_user_ids=[user_id],
+            since=None,
+            status_filter=None,
+            limit=50,
+            offset=0,
+            order_by="last_activity_at",
+            descending=True,
+        )
+
+    assert any("capped" in record.message for record in caplog.records)
+
+
 # --------------------------------------------------------------------------- #
 # compute_cost_by_user_agent
 # --------------------------------------------------------------------------- #

--- a/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
+++ b/cognee/tests/unit/modules/session_lifecycle/test_agent_usage.py
@@ -210,7 +210,7 @@ async def test_single_user_mode_falls_back_to_caller_only(monkeypatch):
 async def test_solo_mode_includes_child_agent_sessions(monkeypatch):
     """No tenant, but the caller has a child agent (e.g. a delegated
     sub-account) — those sessions must still be included, same as
-    every other /sessions endpoint does via ``_visible_user_ids``."""
+    every other /sessions endpoint does via ``get_visible_user_ids``."""
     user_id = uuid4()
     child_id = uuid4()
     user = SimpleNamespace(id=user_id, tenant_id=None, email="solo@example.com")
@@ -373,8 +373,8 @@ async def test_get_sessions_with_agent_info_resolves_visibility_then_delegates(m
         captured.update(kwargs)
         return {"sessions": [], "total": 0, "limit": 50, "offset": 0, "has_more": False}
 
-    monkeypatch.setattr(agent_usage, "_permitted_dataset_ids_for", fake_permitted)
-    monkeypatch.setattr(agent_usage, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(agent_usage, "get_permitted_dataset_ids", fake_permitted)
+    monkeypatch.setattr(agent_usage, "get_visible_user_ids", fake_visible)
     monkeypatch.setattr(agent_usage, "build_sessions_with_agent_info_page", fake_build_page)
 
     result = await agent_usage.get_sessions_with_agent_info(
@@ -412,8 +412,8 @@ async def test_get_cost_by_user_agent_resolves_visibility_then_delegates(monkeyp
         captured.update(kwargs)
         return [{"user_id": str(user_id)}]
 
-    monkeypatch.setattr(agent_usage, "_permitted_dataset_ids_for", fake_permitted)
-    monkeypatch.setattr(agent_usage, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(agent_usage, "get_permitted_dataset_ids", fake_permitted)
+    monkeypatch.setattr(agent_usage, "get_visible_user_ids", fake_visible)
     monkeypatch.setattr(agent_usage, "compute_cost_by_user_agent", fake_compute)
 
     result = await agent_usage.get_cost_by_user_agent(user=user, since=None)
@@ -446,8 +446,8 @@ async def test_get_sessions_with_agent_info_defaults_user_when_omitted(monkeypat
         return {"sessions": [], "total": 0, "limit": 50, "offset": 0, "has_more": False}
 
     monkeypatch.setattr(agent_usage, "get_default_user", fake_get_default_user)
-    monkeypatch.setattr(agent_usage, "_permitted_dataset_ids_for", fake_permitted)
-    monkeypatch.setattr(agent_usage, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(agent_usage, "get_permitted_dataset_ids", fake_permitted)
+    monkeypatch.setattr(agent_usage, "get_visible_user_ids", fake_visible)
     monkeypatch.setattr(agent_usage, "build_sessions_with_agent_info_page", fake_build_page)
 
     await agent_usage.get_sessions_with_agent_info(
@@ -482,8 +482,8 @@ async def test_get_cost_by_user_agent_defaults_user_when_omitted(monkeypatch):
         return []
 
     monkeypatch.setattr(agent_usage, "get_default_user", fake_get_default_user)
-    monkeypatch.setattr(agent_usage, "_permitted_dataset_ids_for", fake_permitted)
-    monkeypatch.setattr(agent_usage, "_visible_user_ids", fake_visible)
+    monkeypatch.setattr(agent_usage, "get_permitted_dataset_ids", fake_permitted)
+    monkeypatch.setattr(agent_usage, "get_visible_user_ids", fake_visible)
     monkeypatch.setattr(agent_usage, "compute_cost_by_user_agent", fake_compute)
 
     await agent_usage.get_cost_by_user_agent(since=None)

--- a/cognee/tests/unit/modules/users/test_get_readable_datasets_and_permitted_ids.py
+++ b/cognee/tests/unit/modules/users/test_get_readable_datasets_and_permitted_ids.py
@@ -1,0 +1,100 @@
+"""Unit tests for get_readable_datasets / get_permitted_dataset_ids.
+
+Consolidated out of duplicated private wrappers (see the review
+discussion on cognee/pull/4342) around
+get_specific_user_permission_datasets, which raises PermissionDeniedError
+when a user simply has zero permitted datasets — an ordinary, common
+state that both functions translate to an empty result rather than
+propagate. Any other exception is left to propagate.
+"""
+
+import sys
+from uuid import uuid4
+
+import pytest
+
+import cognee.modules.users.permissions.methods.get_permitted_dataset_ids  # noqa: F401
+import cognee.modules.users.permissions.methods.get_readable_datasets  # noqa: F401
+from cognee.modules.users.exceptions import PermissionDeniedError
+
+# Both packages' __init__.py do `from .get_x import get_x`, which overwrites the
+# `get_x` attribute on the package with the function — so an attribute-style
+# import binds to the function, not the module. Go through sys.modules to get
+# the actual modules for patching (see test_llm_gateway_usage.py for the same
+# pattern against a different package).
+readable_module = sys.modules["cognee.modules.users.permissions.methods.get_readable_datasets"]
+permitted_ids_module = sys.modules[
+    "cognee.modules.users.permissions.methods.get_permitted_dataset_ids"
+]
+
+
+class _FakeDataset:
+    def __init__(self, id_):
+        self.id = id_
+
+
+def _user_id():
+    return uuid4()
+
+
+@pytest.mark.asyncio
+async def test_get_readable_datasets_returns_datasets(monkeypatch):
+    datasets = [_FakeDataset(uuid4()), _FakeDataset(uuid4())]
+
+    async def fake_get_specific(_user_id, _permission_type, _dataset_ids):
+        return datasets
+
+    monkeypatch.setattr(readable_module, "get_specific_user_permission_datasets", fake_get_specific)
+
+    result = await readable_module.get_readable_datasets(_user_id())
+
+    assert result == datasets
+
+
+@pytest.mark.asyncio
+async def test_get_readable_datasets_returns_empty_on_permission_denied(monkeypatch):
+    async def fake_get_specific(*_args, **_kwargs):
+        raise PermissionDeniedError(message="no datasets")
+
+    monkeypatch.setattr(readable_module, "get_specific_user_permission_datasets", fake_get_specific)
+
+    result = await readable_module.get_readable_datasets(_user_id())
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_readable_datasets_propagates_other_errors(monkeypatch):
+    async def fake_get_specific(*_args, **_kwargs):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(readable_module, "get_specific_user_permission_datasets", fake_get_specific)
+
+    with pytest.raises(RuntimeError):
+        await readable_module.get_readable_datasets(_user_id())
+
+
+@pytest.mark.asyncio
+async def test_get_permitted_dataset_ids_extracts_ids(monkeypatch):
+    id_a, id_b = uuid4(), uuid4()
+
+    async def fake_get_readable_datasets(_user):
+        return [_FakeDataset(id_a), _FakeDataset(id_b)]
+
+    monkeypatch.setattr(permitted_ids_module, "get_readable_datasets", fake_get_readable_datasets)
+
+    result = await permitted_ids_module.get_permitted_dataset_ids(_user_id())
+
+    assert result == [id_a, id_b]
+
+
+@pytest.mark.asyncio
+async def test_get_permitted_dataset_ids_empty_when_no_datasets(monkeypatch):
+    async def fake_get_readable_datasets(_user):
+        return []
+
+    monkeypatch.setattr(permitted_ids_module, "get_readable_datasets", fake_get_readable_datasets)
+
+    result = await permitted_ids_module.get_permitted_dataset_ids(_user_id())
+
+    assert result == []

--- a/cognee/tests/unit/modules/users/test_get_visible_user_ids.py
+++ b/cognee/tests/unit/modules/users/test_get_visible_user_ids.py
@@ -1,0 +1,78 @@
+"""Unit tests for cognee.modules.users.methods.get_visible_user_ids.
+
+Shared across sessions, agents, and usage-reporting code — see the
+review discussion on cognee/pull/4342 for why this was consolidated
+out of three near-identical private copies.
+"""
+
+import sys
+from uuid import uuid4
+
+import pytest
+
+import cognee.modules.users.methods.get_visible_user_ids  # noqa: F401 - registers the submodule
+
+# `cognee.modules.users.methods.__init__` does
+# `from .get_visible_user_ids import get_visible_user_ids`, which overwrites the
+# `get_visible_user_ids` attribute on the package with the function — so an
+# attribute-style import binds to the function, not the module. Go through
+# sys.modules to get the actual module for patching.
+module = sys.modules["cognee.modules.users.methods.get_visible_user_ids"]
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._rows)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_async_session(self):
+        return _FakeSession(self._rows)
+
+
+class _Row:
+    def __init__(self, id_):
+        self.id = id_
+
+
+@pytest.mark.asyncio
+async def test_returns_only_self_when_no_child_agents(monkeypatch):
+    user_id = uuid4()
+
+    monkeypatch.setattr(module, "get_relational_engine", lambda: _FakeEngine([]))
+
+    result = await module.get_visible_user_ids(user_id)
+
+    assert result == [user_id]
+
+
+@pytest.mark.asyncio
+async def test_includes_child_agent_ids(monkeypatch):
+    user_id = uuid4()
+    child_id = uuid4()
+
+    monkeypatch.setattr(module, "get_relational_engine", lambda: _FakeEngine([_Row(child_id)]))
+
+    result = await module.get_visible_user_ids(user_id)
+
+    assert result == [user_id, child_id]


### PR DESCRIPTION
Cloud UI needs to show which client (Claude Code, Codex, Slack, ...) and which user is driving token/cost spend. session_records and the agent-connections registry tracked this separately with no way to correlate them, and token counts were a chars/4 estimate everywhere.

Add two read endpoints that join on session_id:
- GET /sessions/with-agent-info: per-session detail merged with agent-connection metadata (type, source, session name, origin).
- GET /sessions/cost-by-user-agent: totals grouped by (user, agent type), sorted by spend, chart-ready. Role-scoped: a tenant owner/admin sees every member, a regular member falls back to their own sessions instead of being denied outright.

Join/aggregation logic lives in modules/session_lifecycle/agent_usage.py so it's unit-testable independent of FastAPI; the router stays a thin HTTP layer.

AgentConnectionType moves from a closed Literal to a free string so a new client (Cursor, Windsurf, ...) can self-declare its own type at registration without a backend code change; derive_connection_type() is now only a best-effort fallback for sessions that never registered. Also fixes a dead cc_ prefix check (the leading space in the joined text meant it could never match).

Token counts are now exact, not estimated, for the default instructor-based LLM path: LLMGateway reads the real prompt/completion counts instructor already attaches to every parsed response as _raw_response, instead of guessing from character length. This is what feeds every endpoint above, so "who spends the most" is now a real number for that path (litellm_native/BAML still estimate).

<!-- .github/pull_request_template.md -->

## Description
<!--
Please provide a clear, human-generated description of the changes in this PR.
DO NOT use AI-generated descriptions. We want to understand your thought process and reasoning.
-->

## Acceptance Criteria
<!--
* Key requirements to the new feature or modification;
* Proof that the changes work and meet the requirements;
-->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [ ] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [ ] **This PR contains minimal changes necessary to address the issue/feature**
- [ ] My code follows the project's coding standards and style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [ ] All new and existing tests pass
- [ ] I have searched existing PRs to ensure this change hasn't been submitted already
- [ ] I have linked any relevant issues in the description
- [ ] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
