### PR TITLE
CLO-444: correct core-team roster (goran-radonic, LStromann, pazonex)

### DIFF
--- a/.github/core-team.txt
+++ b/.github/core-team.txt
@@ -5,7 +5,9 @@ dexters1
 hajdul88
 hande-k
 lxobr
-pazone
+pazonex
 siillee
 vasilije1990
 NMZivkovic
+goran-radonic
+LStromann


### PR DESCRIPTION
Adds `goran-radonic` and `LStromann` to `.github/core-team.txt` and fixes `pazone` → `pazonex`.

This roster feeds `label-core-team.yml` and `test_suites.yml` (core-team test gating), so this grants those three logins core-team treatment there — intended.

Linear: CLO-444