### PR TITLE
fix: explicit pool_args outrank PGVector's built-in access-control default

### DIFF
--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -93,17 +93,19 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
 
         # Resolve effective pool_args for any new PGVector engine we create:
         # 1. Explicit VECTOR_POOL_ARGS always wins.
-        # 2. When access control is on, each dataset gets its own engine — use a small default
-        #    to avoid connection fan-out (N datasets × pool_size).
-        # 3. Otherwise inherit the relational pool config.
+        # 2. Then the relational POOL_ARGS, when configured — an operator who
+        #    sized the pool explicitly outranks our built-in default.
+        # 3. Otherwise, when access control is on, each dataset gets its own
+        #    engine — use a small default to avoid connection fan-out
+        #    (N datasets × pool_size).
         if vector_config.vector_pool_args is not None:
             effective_pool_args = dict(vector_config.vector_pool_args)
+        elif relational_config.pool_args:
+            effective_pool_args = dict(relational_config.pool_args)
         elif backend_access_control_enabled():
             effective_pool_args = _ACCESS_CONTROL_DEFAULT_POOL_ARGS
         else:
-            effective_pool_args = (
-                dict(relational_config.pool_args) if relational_config.pool_args else {}
-            )
+            effective_pool_args = {}
 
         # A per-dataset PGVector engine may connect to managed
         # Postgres (Neon) which requires SSL. Reuse the relational connect_args


### PR DESCRIPTION
## Problem
With backend access control enabled, `PGVectorAdapter` resolved pool arguments as: `VECTOR_POOL_ARGS` → built-in access-control default → relational `POOL_ARGS`. The built-in default (`{"pool_size": 2, "max_overflow": 20}`) therefore beat an operator's explicit `POOL_ARGS` — sizing the pool via `POOL_ARGS` silently did nothing in multi-user mode.

## Fix
Precedence is now: **`VECTOR_POOL_ARGS`** (explicit vector setting) → **relational `POOL_ARGS`** (explicit operator sizing) → **access-control default** (only when neither is set and multi-user mode is on; empty otherwise). Explicit configuration outranks built-in defaults — a 5-line reorder of the `if/elif` chain plus the updated rationale comment.

## Testing
- Full database unit suite: 466 pass
- Ruff clean; ty shows only the file's pre-existing diagnostics, none on the changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)