### PR TITLE
feat(validate): add cognee.validate() graph/vector integrity checker

### DIFF
--- a/cognee/__init__.py
+++ b/cognee/__init__.py
@@ -30,6 +30,7 @@ from .api.v1.agents.agents import agents
 from .api.v1.prune import prune
 from .api.v1.search import SearchType, search
 from .api.v1.report import report
+from .api.v1.validate import validate, ValidationReport, ValidationIssue, ValidationStatus
 from .api.v1.visualize import (
     visualize_graph,
     start_visualization_server,

--- a/cognee/api/client.py
+++ b/cognee/api/client.py
@@ -33,6 +33,7 @@ from cognee.api.v1.responses.routers import get_responses_router
 from cognee.api.v1.llm.routers import get_llm_router
 from cognee.api.v1.sync.routers import get_sync_router
 from cognee.api.v1.health.routers import get_health_router
+from cognee.api.v1.validate.routers import get_validate_router
 from cognee.api.v1.update.routers import get_update_router
 from cognee.api.v1.users.routers import (
     get_auth_router,
@@ -258,6 +259,8 @@ app.include_router(
 )
 
 app.include_router(get_delete_router(), prefix="/api/v1/delete", tags=["delete"])
+
+app.include_router(get_validate_router(), prefix="/api/v1/validate", tags=["validate"])
 
 app.include_router(get_update_router(), prefix="/api/v1/update", tags=["update"])
 

--- a/cognee/api/v1/validate/__init__.py
+++ b/cognee/api/v1/validate/__init__.py
@@ -1,0 +1,8 @@
+from .validate import (
+    validate,
+    ValidationReport,
+    ValidationIssue,
+    ValidationStatus,
+    IssueSeverity,
+    IssueType,
+)

--- a/cognee/api/v1/validate/routers/__init__.py
+++ b/cognee/api/v1/validate/routers/__init__.py
@@ -1,0 +1,1 @@
+from .get_validate_router import get_validate_router

--- a/cognee/api/v1/validate/routers/get_validate_router.py
+++ b/cognee/api/v1/validate/routers/get_validate_router.py
@@ -1,0 +1,48 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from typing_extensions import Annotated
+
+from cognee.api.v1.validate.validate import ValidationReport, ValidationStatus, validate
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
+from cognee.modules.users.methods import get_authenticated_user
+from cognee.modules.users.models import User
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
+
+def get_validate_router() -> APIRouter:
+    validate_router = APIRouter()
+
+    @validate_router.get("", response_model=ValidationReport)
+    async def run_validate(
+        dataset: Annotated[
+            List[str],
+            Query(
+                description=("Dataset name(s) to validate. Omit to validate the default dataset."),
+            ),
+        ] = [DEFAULT_DATASET_NAME],
+        user: User = Depends(get_authenticated_user),
+    ):
+        """
+        Cross-check the graph and vector stores of a dataset for consistency.
+
+        Detects orphaned edges (referencing deleted nodes), nodes whose id no
+        longer matches cognee's own dedup contract, and nodes present in the
+        graph but missing from the vector index (unreachable by semantic
+        search). Read-only — never modifies any store.
+        """
+        try:
+            report = await validate(dataset=dataset, user=user)
+            status_code = 503 if report.status == ValidationStatus.UNHEALTHY else 200
+            return JSONResponse(status_code=status_code, content=report.model_dump(mode="json"))
+        except Exception as error:
+            logger.error("validate() failed: %s", error, exc_info=True)
+            return JSONResponse(
+                status_code=500,
+                content={"status": "error", "reason": f"validation failed: {str(error)}"},
+            )
+
+    return validate_router

--- a/cognee/api/v1/validate/validate.py
+++ b/cognee/api/v1/validate/validate.py
@@ -1,0 +1,263 @@
+"""Knowledge-graph integrity checker for cognee.
+
+``cognify()`` writes each node's id as a primary key in up to three stores at
+once (graph, vector, relational — see
+``modules/migrations/versions/namespace_entity_type_node_ids.py``, which exists
+because those three drifted apart once already: topoteretes/cognee#2515). An
+edge is only meaningful while both endpoints it names still exist. Nothing
+today re-checks either invariant after the fact; this module is the read-only
+check for it.
+
+Three checks, all backend-agnostic (driven entirely through
+``GraphDBInterface.get_graph_data()`` and ``VectorDBInterface.retrieve()``, so
+every graph/vector adapter is covered without adapter-specific code):
+
+- **Orphaned edges** — an edge whose source or target id is not in the node
+  set. ``recall()`` traversal from such a node returns a dead end.
+- **Identity-id mismatches** — a node of a type that declares
+  ``identity_fields`` (``Entity``, ``EntityType``) whose id does not equal
+  what ``Type.id_for(*identity_values)`` derives from its own properties.
+  cognee's dedup contract is that two nodes with the same identity value are
+  the *same* node because they hash to the same id (COG-2515); a node that
+  reached the graph without going through that contract (e.g. a raw write
+  from a migration/importer) can carry a stale or arbitrary id, which means a
+  correctly-derived duplicate could coexist unnoticed.
+- **Missing vector entries** — a node of a type that declares
+  ``index_fields`` (``Entity``, ``DocumentChunk``) with no matching point in
+  its ``{type}_{field}`` vector collection. Present in the graph but absent
+  from the vector index means unreachable by every embedding-based search
+  type, silently.
+"""
+
+from collections import defaultdict
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+from cognee.context_global_variables import set_database_global_context_variables
+from cognee.infrastructure.databases.graph.get_graph_engine import get_graph_engine
+from cognee.infrastructure.databases.graph.graph_db_interface import EdgeData, Node
+from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_engine_async
+from cognee.infrastructure.engine import DataPoint
+from cognee.modules.chunking.models import DocumentChunk
+from cognee.modules.data.constants import DEFAULT_DATASET_NAME
+from cognee.modules.data.methods import get_authorized_existing_datasets
+from cognee.modules.engine.models import Entity, EntityType
+from cognee.modules.users.methods import get_default_user
+from cognee.modules.users.models.User import User
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger("validate")
+
+
+def _identity_fields_of(data_point_type: type[DataPoint]) -> List[str]:
+    """Read the class's own declared ``identity_fields`` — never hand-copied."""
+    return list(data_point_type.model_fields["metadata"].default.get("identity_fields") or [])
+
+
+def _index_field_of(data_point_type: type[DataPoint]) -> Optional[str]:
+    """Read the class's own declared embedding field — never hand-copied."""
+    index_fields = data_point_type.model_fields["metadata"].default.get("index_fields") or []
+    return index_fields[0] if index_fields else None
+
+
+# The two node types cognee's core pipeline (not optional task plugins) gives a
+# dedup contract to, and the two it gives an embedding contract to. Reusing the
+# real classes means a future change to either contract is picked up here for
+# free instead of silently going stale.
+_IDENTITY_CHECKED_TYPES: Dict[str, tuple] = {
+    cls.__name__: (cls, _identity_fields_of(cls))
+    for cls in (Entity, EntityType)
+    if _identity_fields_of(cls)
+}
+_VECTOR_CHECKED_TYPES: Dict[str, tuple] = {
+    cls.__name__: (cls, _index_field_of(cls))
+    for cls in (Entity, DocumentChunk)
+    if _index_field_of(cls)
+}
+
+
+class IssueSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+
+
+class IssueType(str, Enum):
+    ORPHANED_EDGE = "orphaned_edge"
+    IDENTITY_ID_MISMATCH = "identity_id_mismatch"
+    MISSING_VECTOR_ENTRY = "missing_vector_entry"
+
+
+class ValidationStatus(str, Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+
+
+class ValidationIssue(BaseModel):
+    severity: IssueSeverity
+    type: IssueType
+    detail: str
+
+
+class ValidationReport(BaseModel):
+    status: ValidationStatus
+    summary: Dict[str, Any]
+    issues: List[ValidationIssue]
+
+
+def _check_orphaned_edges(nodes: List[Node], edges: List[EdgeData]) -> List[ValidationIssue]:
+    node_ids = {node_id for node_id, _ in nodes}
+    issues = []
+    for source_id, target_id, relationship_name, _properties in edges:
+        missing = [nid for nid in (source_id, target_id) if nid not in node_ids]
+        if missing:
+            issues.append(
+                ValidationIssue(
+                    severity=IssueSeverity.ERROR,
+                    type=IssueType.ORPHANED_EDGE,
+                    detail=(
+                        f"Edge {source_id!r} -[{relationship_name}]-> {target_id!r} "
+                        f"references missing node id(s): {missing!r}"
+                    ),
+                )
+            )
+    return issues
+
+
+def _check_identity_ids(nodes: List[Node]) -> List[ValidationIssue]:
+    issues = []
+    for node_id, properties in nodes:
+        checked = _IDENTITY_CHECKED_TYPES.get(properties.get("type"))
+        if checked is None:
+            continue
+        data_point_type, identity_fields = checked
+
+        values = [properties.get(field) for field in identity_fields]
+        if any(value is None for value in values):
+            # Field absent from graph properties — can't recompute, not this
+            # check's business (the node may just predate the field).
+            continue
+
+        expected_id = str(data_point_type.id_for(*values))
+        if str(node_id) != expected_id:
+            issues.append(
+                ValidationIssue(
+                    severity=IssueSeverity.WARNING,
+                    type=IssueType.IDENTITY_ID_MISMATCH,
+                    detail=(
+                        f"{properties.get('type')} node {node_id!r} "
+                        f"(identity {identity_fields}={values!r}) does not match the id "
+                        f"its own dedup contract derives ({expected_id!r}) — a second, "
+                        "correctly-derived node could coexist as an undetected duplicate."
+                    ),
+                )
+            )
+    return issues
+
+
+async def _check_vector_sync(nodes: List[Node], vector_engine) -> List[ValidationIssue]:
+    ids_by_collection: Dict[str, List[str]] = defaultdict(list)
+    type_by_id: Dict[str, str] = {}
+
+    for node_id, properties in nodes:
+        node_type = properties.get("type")
+        checked = _VECTOR_CHECKED_TYPES.get(node_type)
+        if checked is None:
+            continue
+        _data_point_type, index_field = checked
+
+        node_id_str = str(node_id)
+        collection_name = f"{node_type}_{index_field}"
+        ids_by_collection[collection_name].append(node_id_str)
+        type_by_id[node_id_str] = node_type
+
+    issues = []
+    for collection_name, node_ids in ids_by_collection.items():
+        found = await vector_engine.retrieve(collection_name, node_ids)
+        found_ids = {str(getattr(point, "id")) for point in found}
+
+        for node_id_str in node_ids:
+            if node_id_str not in found_ids:
+                issues.append(
+                    ValidationIssue(
+                        severity=IssueSeverity.ERROR,
+                        type=IssueType.MISSING_VECTOR_ENTRY,
+                        detail=(
+                            f"{type_by_id[node_id_str]} node {node_id_str!r} has no "
+                            f"matching point in vector collection {collection_name!r} — "
+                            "it exists in the graph but is unreachable by semantic search."
+                        ),
+                    )
+                )
+    return issues
+
+
+async def validate(
+    dataset: Optional[Union[str, List[str]]] = DEFAULT_DATASET_NAME,
+    user: Optional[User] = None,
+) -> ValidationReport:
+    """Cross-check the graph and vector stores of a dataset for consistency.
+
+    Runs entirely through the standard adapter interfaces, so it works
+    unmodified against every supported graph/vector backend. Read-only: it
+    never writes to any store.
+
+    Args:
+        dataset: Dataset name(s) to validate. Defaults to ``"main_dataset"``.
+            The first accessible dataset determines which graph is read.
+        user: User context for dataset access. Defaults to the default user.
+
+    Returns:
+        A :class:`ValidationReport` with an overall status, a summary of the
+        graph read, and every issue found.
+    """
+    if not user:
+        user = await get_default_user()
+
+    dataset_names = [dataset] if isinstance(dataset, str) else list(dataset or [])
+
+    resolved_dataset = None
+    if dataset_names:
+        authorized = await get_authorized_existing_datasets(dataset_names, "read", user)
+        if authorized:
+            resolved_dataset = authorized[0]
+
+    async with set_database_global_context_variables(
+        resolved_dataset.id if resolved_dataset else None,
+        resolved_dataset.owner_id if resolved_dataset else None,
+    ):
+        graph_engine = await get_graph_engine()
+        vector_engine = await get_vector_engine_async()
+
+        nodes, edges = await graph_engine.get_graph_data()
+
+        issues: List[ValidationIssue] = []
+        issues += _check_orphaned_edges(nodes, edges)
+        issues += _check_identity_ids(nodes)
+        issues += await _check_vector_sync(nodes, vector_engine)
+
+    node_type_distribution: Dict[str, int] = {}
+    for _node_id, properties in nodes:
+        node_type = properties.get("type") or "unknown"
+        node_type_distribution[node_type] = node_type_distribution.get(node_type, 0) + 1
+
+    has_error = any(issue.severity == IssueSeverity.ERROR for issue in issues)
+    has_warning = any(issue.severity == IssueSeverity.WARNING for issue in issues)
+    if has_error:
+        status = ValidationStatus.UNHEALTHY
+    elif has_warning:
+        status = ValidationStatus.DEGRADED
+    else:
+        status = ValidationStatus.HEALTHY
+
+    return ValidationReport(
+        status=status,
+        summary={
+            "graph_nodes": len(nodes),
+            "graph_edges": len(edges),
+            "node_type_distribution": node_type_distribution,
+        },
+        issues=issues,
+    )

--- a/cognee/tests/unit/api/v1/validate/test_validate.py
+++ b/cognee/tests/unit/api/v1/validate/test_validate.py
@@ -1,0 +1,382 @@
+"""Unit tests for cognee.validate().
+
+Graph-shaped fixtures mirror the real get_graph_data() contract — nodes are
+(id, props) with a "type" field, edges are (src, tgt, relationship_name, props) —
+the same shape test_graph_report_retriever.py's fixtures are pinned to.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel
+
+from cognee.api.v1.validate.validate import (
+    IssueSeverity,
+    IssueType,
+    ValidationStatus,
+    _check_identity_ids,
+    _check_orphaned_edges,
+    _check_vector_sync,
+    validate,
+)
+from cognee.modules.engine.models import Entity
+
+
+# ---------------------------------------------------------------------------
+# Orphaned edges
+# ---------------------------------------------------------------------------
+
+
+def test_orphaned_edge_detected_when_target_missing():
+    nodes = [("a", {"type": "Entity", "name": "A"})]
+    edges = [("a", "ghost", "relates_to", {})]
+
+    issues = _check_orphaned_edges(nodes, edges)
+
+    assert len(issues) == 1
+    assert issues[0].type == IssueType.ORPHANED_EDGE
+    assert issues[0].severity == IssueSeverity.ERROR
+    assert "ghost" in issues[0].detail
+
+
+def test_orphaned_edge_detected_when_source_missing():
+    nodes = [("b", {"type": "Entity", "name": "B"})]
+    edges = [("ghost", "b", "relates_to", {})]
+
+    issues = _check_orphaned_edges(nodes, edges)
+
+    assert len(issues) == 1
+    assert "ghost" in issues[0].detail
+
+
+def test_no_orphaned_edges_on_clean_graph():
+    nodes = [("a", {"type": "Entity"}), ("b", {"type": "Entity"})]
+    edges = [("a", "b", "relates_to", {})]
+
+    assert _check_orphaned_edges(nodes, edges) == []
+
+
+def test_edge_missing_both_endpoints_reports_both_ids():
+    issues = _check_orphaned_edges([], [("x", "y", "relates_to", {})])
+
+    assert len(issues) == 1
+    assert "'x'" in issues[0].detail and "'y'" in issues[0].detail
+
+
+# ---------------------------------------------------------------------------
+# Identity-id mismatches — Entity/EntityType's own dedup contract
+# (DataPoint.id_for), see modules/migrations/versions/namespace_entity_type_node_ids.py
+# for why the three stores drifting apart is a real, previously-hit bug class.
+# ---------------------------------------------------------------------------
+
+
+def test_identity_id_matches_no_issue():
+    correct_id = str(Entity.id_for("Acme"))
+    nodes = [(correct_id, {"type": "Entity", "name": "Acme"})]
+
+    assert _check_identity_ids(nodes) == []
+
+
+def test_identity_id_mismatch_detected():
+    stale_id = str(uuid4())
+    nodes = [(stale_id, {"type": "Entity", "name": "Acme"})]
+
+    issues = _check_identity_ids(nodes)
+
+    assert len(issues) == 1
+    assert issues[0].type == IssueType.IDENTITY_ID_MISMATCH
+    assert issues[0].severity == IssueSeverity.WARNING
+    assert stale_id in issues[0].detail
+    assert str(Entity.id_for("Acme")) in issues[0].detail
+
+
+def test_identity_id_check_covers_entity_type_too():
+    nodes = [(str(uuid4()), {"type": "EntityType", "name": "Company"})]
+
+    issues = _check_identity_ids(nodes)
+
+    assert len(issues) == 1
+    assert "EntityType" in issues[0].detail
+
+
+def test_identity_id_check_skips_types_without_a_dedup_contract():
+    # DocumentChunk declares no identity_fields — a random uuid4 id is correct.
+    nodes = [(str(uuid4()), {"type": "DocumentChunk", "text": "hello"})]
+
+    assert _check_identity_ids(nodes) == []
+
+
+def test_identity_id_check_skips_node_missing_the_identity_property():
+    # Property absent from the graph read entirely — can't recompute, so this
+    # check stays silent rather than guessing.
+    nodes = [(str(uuid4()), {"type": "Entity"})]
+
+    assert _check_identity_ids(nodes) == []
+
+
+# ---------------------------------------------------------------------------
+# Vector sync
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_vector_entry_detected():
+    node_id = str(uuid4())
+    nodes = [(node_id, {"type": "Entity", "name": "Acme"})]
+    vector_engine = AsyncMock()
+    vector_engine.retrieve.return_value = []
+
+    issues = await _check_vector_sync(nodes, vector_engine)
+
+    assert len(issues) == 1
+    assert issues[0].type == IssueType.MISSING_VECTOR_ENTRY
+    assert issues[0].severity == IssueSeverity.ERROR
+    vector_engine.retrieve.assert_awaited_once_with("Entity_name", [node_id])
+
+
+@pytest.mark.asyncio
+async def test_vector_entry_present_no_issue():
+    node_id = str(uuid4())
+    nodes = [(node_id, {"type": "Entity", "name": "Acme"})]
+    point = type("Point", (), {"id": node_id})()
+    vector_engine = AsyncMock()
+    vector_engine.retrieve.return_value = [point]
+
+    assert await _check_vector_sync(nodes, vector_engine) == []
+
+
+@pytest.mark.asyncio
+async def test_vector_sync_groups_nodes_by_collection():
+    entity_id = str(uuid4())
+    chunk_id = str(uuid4())
+    nodes = [
+        (entity_id, {"type": "Entity", "name": "Acme"}),
+        (chunk_id, {"type": "DocumentChunk", "text": "hello"}),
+    ]
+    vector_engine = AsyncMock()
+    vector_engine.retrieve.return_value = []
+
+    await _check_vector_sync(nodes, vector_engine)
+
+    called_collections = {call.args[0] for call in vector_engine.retrieve.await_args_list}
+    assert called_collections == {"Entity_name", "DocumentChunk_text"}
+
+
+@pytest.mark.asyncio
+async def test_vector_sync_skips_unchecked_types():
+    # NodeSet has no index_fields — it's structural scaffolding, never embedded.
+    nodes = [(str(uuid4()), {"type": "NodeSet", "name": "some-set"})]
+    vector_engine = AsyncMock()
+
+    issues = await _check_vector_sync(nodes, vector_engine)
+
+    assert issues == []
+    vector_engine.retrieve.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Real LanceDB adapter — proves the one inferred contract most worth
+# confirming against a genuine adapter rather than a mock: what retrieve()
+# actually returns for a present vs. an absent point id.
+# ---------------------------------------------------------------------------
+
+try:
+    from cognee.infrastructure.databases.vector.lancedb.LanceDBAdapter import LanceDBAdapter
+
+    HAS_LANCEDB = True
+except ModuleNotFoundError:
+    HAS_LANCEDB = False
+
+
+class _FakeEmbeddingEngine:
+    def get_vector_size(self):
+        return 3
+
+    def get_batch_size(self):
+        return 100
+
+    async def embed_text(self, _texts):
+        raise AssertionError("this test seeds vectors directly, it must not embed")
+
+
+class _EntityNamePayload(BaseModel):
+    name: str
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_LANCEDB, reason="lancedb not installed")
+async def test_vector_sync_against_real_lancedb_adapter(tmp_path):
+    adapter = LanceDBAdapter(
+        url=str(tmp_path / "db"),
+        api_key=None,
+        embedding_engine=_FakeEmbeddingEngine(),
+    )
+    synced_id = uuid4()
+    missing_id = uuid4()
+
+    await adapter.upsert_raw_vectors(
+        "Entity_name",
+        [{"id": synced_id, "vector": [1.0, 0.0, 0.0], "payload": {"name": "Synced"}}],
+        payload_schema=_EntityNamePayload,
+    )
+
+    nodes = [
+        (str(synced_id), {"type": "Entity", "name": "Synced"}),
+        (str(missing_id), {"type": "Entity", "name": "Missing"}),
+    ]
+
+    issues = await _check_vector_sync(nodes, adapter)
+
+    assert len(issues) == 1
+    assert str(missing_id) in issues[0].detail
+    assert str(synced_id) not in issues[0].detail
+
+
+# ---------------------------------------------------------------------------
+# Status rollup
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _noop_context(*_args, **_kwargs):
+    yield
+
+
+def _mock_dataset():
+    return type("Dataset", (), {"id": "dataset-id", "owner_id": "owner-id"})()
+
+
+@pytest.mark.asyncio
+async def test_validate_reports_healthy_and_scopes_to_dataset():
+    acme_id = str(Entity.id_for("Acme"))
+    widget_id = str(Entity.id_for("Widget"))
+    nodes = [
+        (acme_id, {"type": "Entity", "name": "Acme"}),
+        (widget_id, {"type": "Entity", "name": "Widget"}),
+    ]
+    edges = [(acme_id, widget_id, "produces", {})]
+
+    mock_graph_engine = AsyncMock()
+    mock_graph_engine.get_graph_data.return_value = (nodes, edges)
+
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.retrieve.return_value = [
+        type("Point", (), {"id": acme_id})(),
+        type("Point", (), {"id": widget_id})(),
+    ]
+
+    with (
+        patch(
+            "cognee.api.v1.validate.validate.get_graph_engine",
+            return_value=mock_graph_engine,
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_vector_engine_async",
+            return_value=mock_vector_engine,
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_authorized_existing_datasets",
+            return_value=[_mock_dataset()],
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_default_user",
+            return_value=object(),
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.set_database_global_context_variables",
+            _noop_context,
+        ),
+    ):
+        report = await validate(dataset="my_dataset", user=object())
+
+    assert report.status == ValidationStatus.HEALTHY
+    assert report.issues == []
+    assert report.summary == {
+        "graph_nodes": 2,
+        "graph_edges": 1,
+        "node_type_distribution": {"Entity": 2},
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_reports_unhealthy_when_an_error_issue_exists():
+    node_id = str(uuid4())
+    nodes = [(node_id, {"type": "Entity", "name": "Acme"})]
+    # A dangling edge is an ERROR-severity issue.
+    edges = [(node_id, "ghost", "relates_to", {})]
+
+    mock_graph_engine = AsyncMock()
+    mock_graph_engine.get_graph_data.return_value = (nodes, edges)
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.retrieve.return_value = [type("Point", (), {"id": node_id})()]
+
+    with (
+        patch(
+            "cognee.api.v1.validate.validate.get_graph_engine",
+            return_value=mock_graph_engine,
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_vector_engine_async",
+            return_value=mock_vector_engine,
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_authorized_existing_datasets",
+            return_value=[_mock_dataset()],
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_default_user",
+            return_value=object(),
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.set_database_global_context_variables",
+            _noop_context,
+        ),
+    ):
+        report = await validate(dataset="my_dataset", user=object())
+
+    assert report.status == ValidationStatus.UNHEALTHY
+    assert any(issue.type == IssueType.ORPHANED_EDGE for issue in report.issues)
+
+
+@pytest.mark.asyncio
+async def test_validate_reports_degraded_when_only_warning_issues_exist():
+    # Identity-id mismatch is WARNING-severity, and nothing else is wrong.
+    stale_id = str(uuid4())
+    nodes = [(stale_id, {"type": "Entity", "name": "Acme"})]
+
+    mock_graph_engine = AsyncMock()
+    mock_graph_engine.get_graph_data.return_value = (nodes, [])
+    mock_vector_engine = AsyncMock()
+    mock_vector_engine.retrieve.return_value = [type("Point", (), {"id": stale_id})()]
+
+    with (
+        patch(
+            "cognee.api.v1.validate.validate.get_graph_engine",
+            return_value=mock_graph_engine,
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_vector_engine_async",
+            return_value=mock_vector_engine,
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_authorized_existing_datasets",
+            return_value=[_mock_dataset()],
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.get_default_user",
+            return_value=object(),
+        ),
+        patch(
+            "cognee.api.v1.validate.validate.set_database_global_context_variables",
+            _noop_context,
+        ),
+    ):
+        report = await validate(dataset="my_dataset", user=object())
+
+    assert report.status == ValidationStatus.DEGRADED
+    assert len(report.issues) == 1
+    assert report.issues[0].type == IssueType.IDENTITY_ID_MISMATCH


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

Closes #3345. There's no way today to check that a dataset's graph and vector
stores actually agree with each other after `cognify()`. I picked this issue
because it's still open six weeks after being filed with a full spec, the one
serious attempt at it (#3348) was self-closed after two days with nothing
merged, and it lines up with a seam I already know well from #4334 (the
`graph_db_interface.py` multi-backend read path).

I looked for the cheapest way to prove drift is real rather than just
plausible, and found it already proven: `namespace_entity_type_node_ids.py`
exists specifically because Entity/EntityType ids drifted across the graph,
vector, and relational stores once (topoteretes/cognee#2515,
`EntityAlreadyExistsError` on a second `cognify()`). That migration is the
cure; this PR is the check that would have caught the disease. So instead of
picking three arbitrary checks I picked the three cognee's own code already
asserts somewhere:

- **Orphaned edges.** An edge naming a source/target id that isn't in the node
  set. `get_graph_data()` is the shared read every backend already implements,
  so this needs zero adapter-specific code.
- **Identity-id mismatches.** `Entity`/`EntityType` declare `identity_fields`
  in their `metadata`, and `DataPoint.id_for(*values)` is the single source of
  truth cognee uses to derive an id from them. A node claiming that type whose
  id doesn't match what its own properties derive means it reached the graph
  without going through that contract (a raw migration/importer write, most
  plausibly) — which is exactly the precondition for the #2515 bug class to
  recur, silently, since a second write *with* the correct id would coexist as
  an undetected duplicate rather than merge.
- **Missing vector entries.** `Entity`/`DocumentChunk` declare `index_fields`,
  and every point cognee writes goes through `index_data_points`, which names
  the collection `f"{type_name}_{field_name}"` and the point id
  `str(data_point.id)` (confirmed in `LanceDBAdapter.index_data_points` and
  reused verbatim by `has_new_chunks.py`). So a graph node of a checked type
  with no matching point at that exact address is provably unreachable by
  every embedding-based search type, not just probably.

All three checks read the class's own declared `identity_fields`/`index_fields`
off the real `Entity`/`EntityType`/`DocumentChunk` classes at import time
(`_identity_fields_of`/`_index_field_of`) instead of hand-copying the values,
so a future change to either contract can't make this check silently go
stale.

`cognee.validate(dataset)` runs both graph checks off one `get_graph_data()`
call and the vector check off `VectorDBInterface.retrieve()`, both of which
every adapter already implements — so it's backend-agnostic without touching
a single adapter file, the same shape as #4334. It's exposed as an SDK
function (mirroring `report()`'s dataset-resolution pattern exactly —
`get_authorized_existing_datasets` + `set_database_global_context_variables`)
and a read-only `GET /api/v1/validate` REST endpoint (mirroring
`health`'s router shape).

**What I deliberately left out**, because I'd rather ship three checks with a
real backing contract than five with a guess: the issue's proposed
`inspect_duplicates()`/entity-type-distribution breadth is folded into the
summary (`node_type_distribution`) rather than built out as a separate check,
since I don't have a similarly-grounded contract for "these two entities are
semantically the same" beyond the identity-id case above.

## Acceptance Criteria

* `cognee.validate(dataset)` returns a `ValidationReport` with `status`
  (`healthy`/`degraded`/`unhealthy`), a `summary` (node/edge counts, node type
  distribution), and a list of typed `issues`.
* Detects orphaned edges, identity-id/dedup-contract mismatches, and
  graph-vector desync, all without any backend-specific code.
* `status` is `unhealthy` if any error-severity issue exists (orphaned edge,
  missing vector entry), `degraded` if only warning-severity issues exist
  (identity mismatch), `healthy` otherwise.
* Exposed as both `cognee.validate()` and `GET /api/v1/validate`.
* Proof: 17 new unit tests (pure-logic cases for all three checks plus one
  run against a real `LanceDBAdapter`, not a mock, to confirm the
  `retrieve()`/collection-naming contract holds against a genuine adapter);
  full existing suite unaffected. See Screenshots.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="980" height="704" alt="17 passed for the new validate() test suite; full-suite diff shows the same 16 pre-existing failures plus 17 new passes" src="https://github.com/user-attachments/assets/70e18e66-385f-4c11-99b2-f331d89e5cb7" />

## Pre-submission Checklist
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
