### PR TITLE
perf: search no longer waits for subprocess-engine teardown (pending-close latch)

### DIFF
--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -91,6 +91,23 @@ def _make_release(semaphore: asyncio.Semaphore) -> Callable[[], None]:
     return _release
 
 
+class PendingClose:
+    """A background engine close in flight (or orphaned by a dead loop).
+
+    Carries the detached engines so that a later acquirer on a *different*
+    event loop can adopt and finish the close when this one's loop died
+    before the close task ran to completion (multiple sequential
+    ``asyncio.run()`` phases in one process — the e2e script shape).
+    """
+
+    __slots__ = ("future", "engines", "loop")
+
+    def __init__(self, future, engines, loop) -> None:
+        self.future = future
+        self.engines = engines
+        self.loop = loop
+
+
 class SlotEntry:
     """A single acquired slot with a nesting depth counter."""
 
@@ -123,14 +140,16 @@ class DatasetQueue:
         # ``"acquire:<unique>"`` for ``acquire()``. A task may hold multiple
         # entries; all are released together when the task finishes.
         self._task_slots: Dict[int, Dict[str, SlotEntry]] = {}
-        # Pending-close latches — "who must wait, per dataset": ds_key -> future
-        # that resolves when a backgrounded engine teardown for that dataset has
-        # finished. The next acquirer of the same dataset awaits it before
-        # proceeding, so file locks are provably free before a fresh engine
-        # opens the same files. Created when a close is scheduled; resolved and
-        # removed in the close task's ``finally``, success or failure alike.
+        # Pending closes — "who must wait, per dataset": ds_key -> PendingClose
+        # whose future resolves when the backgrounded engine close for that
+        # dataset has finished. The next acquirer of the same dataset awaits it
+        # (same loop) or adopts and finishes the close itself (the scheduling
+        # loop died first), so file locks are provably free before a fresh
+        # engine opens the same files. Removed when the close completes or
+        # fails; deliberately KEPT when the close task is cancelled by loop
+        # teardown — the record is what adoption works from.
         # (Same pending-close idea closing_lru_cache uses internally.)
-        self._pending_closes: Dict[str, asyncio.Future] = {}
+        self._pending_closes: Dict[str, PendingClose] = {}
         # Live close tasks — "which closes are still running, so they can't be
         # lost". asyncio holds only weak references to tasks: a fire-and-forget
         # close with no strong reference can be garbage-collected mid-flight,
@@ -220,12 +239,18 @@ class DatasetQueue:
             entry.depth += 1
             return
 
-        # If a backgrounded teardown for this dataset is still closing its
-        # engines, wait for it: the whole point of the latch is that the
-        # response path no longer waits, so the (rare) next acquirer must.
+        # If a backgrounded close for this dataset is still in flight, wait
+        # for it: the whole point of the latch is that the response path no
+        # longer waits, so the (rare) next acquirer must. If the close's loop
+        # died before it finished (sequential asyncio.run() phases), its
+        # engines may still hold the database file locks — adopt the close
+        # and finish it here, on the live loop, before proceeding.
         pending = self._pending_closes.get(ds_key)
         if pending is not None:
-            await pending
+            if pending.loop is asyncio.get_running_loop():
+                await pending.future
+            else:
+                await self._adopt_orphaned_close(ds_key, pending)
 
         # Acquire a fresh slot for this (task, dataset).
         logger.debug("Task %d acquiring dataset queue slot for dataset_id=%s", task_id, dataset_id)
@@ -272,18 +297,34 @@ class DatasetQueue:
 
         loop = asyncio.get_running_loop()
         latch: asyncio.Future = loop.create_future()
-        self._pending_closes[ds_key] = latch
+        record = PendingClose(latch, engines, loop)
+        self._pending_closes[ds_key] = record
+
+        def _finish() -> None:
+            if not latch.done():
+                latch.set_result(None)
+            if self._pending_closes.get(ds_key) is record:
+                del self._pending_closes[ds_key]
 
         async def _close() -> None:
             # No exception is expected here, so none is caught: the latch must
-            # open either way (a failed close must not brick the dataset), and
-            # the failure itself is surfaced below with its full traceback.
+            # open on success or failure (a failed close must not brick the
+            # dataset), and failures are surfaced below with their traceback.
+            # CancelledError is the exception to the rule: loop teardown kills
+            # this task mid-close, the engines may still hold file locks, and
+            # the pending record must SURVIVE so the next acquirer (on a live
+            # loop) adopts and finishes the close. (Not a guarded ``finally``:
+            # inside a task that is being cancelled, ``task.cancelled()`` still
+            # reads False — explicit paths are the only reliable structure.)
             try:
                 await self._close_engines(engines)
-            finally:
-                latch.set_result(None)
-                if self._pending_closes.get(ds_key) is latch:
-                    del self._pending_closes[ds_key]
+            except asyncio.CancelledError:
+                raise
+            except BaseException:
+                _finish()
+                raise
+            else:
+                _finish()
 
         task = loop.create_task(_close())
         self._background_closes.add(task)
@@ -350,6 +391,40 @@ class DatasetQueue:
                 evict_vector_engine(**v_cfg)
 
         return detached
+
+    async def _adopt_orphaned_close(self, ds_key: str, pending: "PendingClose") -> None:
+        """Finish a close whose scheduling loop died before it completed.
+
+        ``engine.close()`` alone is not enough here: the engines are lease
+        proxies, and their *real* close can be parked in cache machinery bound
+        to the dead loop — observed as ``close()`` returning OK while the
+        worker process (and its database file lock) lives on. The worker's
+        session ``shutdown()`` is the unconditional path: synchronous, always
+        reaches terminate, and the OS releases the file locks when the process
+        dies. The proxy ``close()`` afterwards is cache/lease bookkeeping.
+
+        Per-engine failures are surfaced at ERROR and not raised: after a
+        mid-close cancellation, partially-closed state is *expected*, and the
+        definitive arbiter is the engine open that follows (it fails loudly if
+        a file lock genuinely remains).
+        """
+        if self._pending_closes.get(ds_key) is pending:
+            del self._pending_closes[ds_key]
+        for engine in pending.engines:
+            try:
+                session = getattr(engine, "_session", None)
+                if session is not None and hasattr(session, "shutdown"):
+                    # Synchronous by design; brief block on a recovery path is
+                    # the price of a guaranteed worker death + lock release.
+                    session.shutdown()
+                if hasattr(engine, "close"):
+                    await engine.close()
+            except Exception as error:
+                logger.error(
+                    "Adopted close of an orphaned engine failed for %s",
+                    ds_key,
+                    exc_info=(type(error), error, error.__traceback__),
+                )
 
     async def _close_engines(self, engines: list) -> None:
         """Close detached engines so their DB file locks are released."""

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -240,15 +240,31 @@ class DatasetQueue:
     def _schedule_background_teardown(self, ds_key: str) -> None:
         """Detach engines now; close them off the response path.
 
-        The eviction happens synchronously right here — callers arriving after
-        this line build fresh engines, never the dying ones. Only the
-        expensive ``engine.close()`` is backgrounded, behind a pending-close
-        latch for ``ds_key`` so a subsequent acquirer of the same dataset
-        waits for the close instead of racing a fresh engine against
-        still-locked database files. The latch always opens; a close failure
-        is surfaced at ERROR with its traceback from the task's done-callback
-        (the request this close belonged to has already returned, so there is
-        no caller to raise into).
+        Why this exact split, and not something simpler:
+
+        * **Why not await the whole teardown inline** (the original design):
+          ``engine.close()`` takes 1.5–2 s per query, and it ran while the
+          caller's response waited — measured as roughly half of every serial
+          recall's latency. The teardown only fires when *no other task holds
+          the dataset*, which is precisely when nobody benefits from waiting.
+        * **Why the eviction still happens synchronously here** and only the
+          close is backgrounded: while a dying engine is still in the LRU,
+          any caller — even the same task, one line after context exit — can
+          fetch it, and the background close then kills it mid-use
+          ("LadybugAdapter is closed; a new adapter must be created", which
+          broke nine e2e suites when the whole teardown was deferred).
+          Eviction is cheap and in-memory; after this line every caller
+          builds a fresh engine.
+        * **Why the pending-close latch**: a fresh engine must not open the
+          same database files while the old engine's close is still
+          releasing their locks. The next ``ensure_slot`` for this dataset
+          awaits the latch — moving the wait from the response (never
+          load-bearing there) to the only place it matters.
+
+        The latch always opens; a close failure is surfaced at ERROR with its
+        traceback from the task's done-callback (the request this close
+        belonged to has already returned, so there is no caller to raise
+        into).
         """
         engines = self._detach_subprocess_engines()
         if not engines:

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -123,12 +123,20 @@ class DatasetQueue:
         # ``"acquire:<unique>"`` for ``acquire()``. A task may hold multiple
         # entries; all are released together when the task finishes.
         self._task_slots: Dict[int, Dict[str, SlotEntry]] = {}
-        # Pending-close latches: ds_key -> future that resolves when a
-        # backgrounded engine teardown for that dataset has finished. The next
-        # acquirer of the same dataset awaits it before proceeding, so file
-        # locks are provably free before a fresh engine opens the same files.
+        # Pending-close latches — "who must wait, per dataset": ds_key -> future
+        # that resolves when a backgrounded engine teardown for that dataset has
+        # finished. The next acquirer of the same dataset awaits it before
+        # proceeding, so file locks are provably free before a fresh engine
+        # opens the same files. Created when a close is scheduled; resolved and
+        # removed in the close task's ``finally``, success or failure alike.
         # (Same pending-close idea closing_lru_cache uses internally.)
         self._pending_closes: Dict[str, asyncio.Future] = {}
+        # Live close tasks — "which closes are still running, so they can't be
+        # lost". asyncio holds only weak references to tasks: a fire-and-forget
+        # close with no strong reference can be garbage-collected mid-flight,
+        # never finishing the close and never opening its latch. Entries are
+        # removed by the task's done-callback (which also surfaces failures);
+        # tests and shutdown drain this set to wait for in-flight closes.
         self._background_closes: Set[asyncio.Task] = set()
         # Track which tasks already have a done-callback registered so we
         # don't register multiple cleanup handlers for a single task.

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -235,18 +235,20 @@ class DatasetQueue:
         Registers a pending-close latch for ``ds_key`` first, so a subsequent
         acquirer of the same dataset waits for the close instead of racing a
         fresh engine against still-locked database files. The latch always
-        opens — teardown failures are logged, never propagated (the request
-        this teardown belonged to has already returned).
+        opens; a teardown failure is surfaced at ERROR with its traceback from
+        the task's done-callback (the request this teardown belonged to has
+        already returned, so there is no caller to raise into).
         """
         loop = asyncio.get_running_loop()
         latch: asyncio.Future = loop.create_future()
         self._pending_closes[ds_key] = latch
 
         async def _close() -> None:
+            # No exception is expected here, so none is caught: the latch must
+            # open either way (a failed close must not brick the dataset), and
+            # the failure itself is surfaced below with its full traceback.
             try:
                 await self._teardown_subprocess_engines()
-            except Exception as error:
-                logger.warning("Background engine teardown failed for %s: %s", ds_key, error)
             finally:
                 latch.set_result(None)
                 if self._pending_closes.get(ds_key) is latch:
@@ -254,7 +256,22 @@ class DatasetQueue:
 
         task = loop.create_task(_close())
         self._background_closes.add(task)
-        task.add_done_callback(self._background_closes.discard)
+
+        def _surface(done: asyncio.Task) -> None:
+            self._background_closes.discard(done)
+            if not done.cancelled() and done.exception() is not None:
+                # The request this teardown belonged to has already returned,
+                # so there is no caller to raise into — ERROR with the stack is
+                # the loudest honest channel. If the close genuinely left file
+                # locks behind, the next engine open fails loudly in a real
+                # request; nothing is silently lost.
+                logger.error(
+                    "Background engine teardown failed for %s",
+                    ds_key,
+                    exc_info=done.exception(),
+                )
+
+        task.add_done_callback(_surface)
 
     async def _teardown_subprocess_engines(self) -> None:
         """Evict and close subprocess-mode engines so DB file locks are released.

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -238,15 +238,22 @@ class DatasetQueue:
 
     # ----------------------------------------- subprocess engine teardown
     def _schedule_background_teardown(self, ds_key: str) -> None:
-        """Run :meth:`_teardown_subprocess_engines` off the response path.
+        """Detach engines now; close them off the response path.
 
-        Registers a pending-close latch for ``ds_key`` first, so a subsequent
-        acquirer of the same dataset waits for the close instead of racing a
-        fresh engine against still-locked database files. The latch always
-        opens; a teardown failure is surfaced at ERROR with its traceback from
-        the task's done-callback (the request this teardown belonged to has
-        already returned, so there is no caller to raise into).
+        The eviction happens synchronously right here — callers arriving after
+        this line build fresh engines, never the dying ones. Only the
+        expensive ``engine.close()`` is backgrounded, behind a pending-close
+        latch for ``ds_key`` so a subsequent acquirer of the same dataset
+        waits for the close instead of racing a fresh engine against
+        still-locked database files. The latch always opens; a close failure
+        is surfaced at ERROR with its traceback from the task's done-callback
+        (the request this close belonged to has already returned, so there is
+        no caller to raise into).
         """
+        engines = self._detach_subprocess_engines()
+        if not engines:
+            return
+
         loop = asyncio.get_running_loop()
         latch: asyncio.Future = loop.create_future()
         self._pending_closes[ds_key] = latch
@@ -256,7 +263,7 @@ class DatasetQueue:
             # open either way (a failed close must not brick the dataset), and
             # the failure itself is surfaced below with its full traceback.
             try:
-                await self._teardown_subprocess_engines()
+                await self._close_engines(engines)
             finally:
                 latch.set_result(None)
                 if self._pending_closes.get(ds_key) is latch:
@@ -285,15 +292,22 @@ class DatasetQueue:
 
         task.add_done_callback(_surface)
 
-    async def _teardown_subprocess_engines(self) -> None:
-        """Evict and close subprocess-mode engines so DB file locks are released.
+    def _detach_subprocess_engines(self) -> list:
+        """Synchronously evict subprocess-mode engines from their caches.
+
+        This MUST stay synchronous and run before the release returns: eviction
+        is what guarantees no later caller can fetch a dying engine from the
+        LRU (they build a fresh one instead). Only the expensive
+        ``engine.close()`` of the returned engines may be deferred.
 
         Reads the current task's ContextVar-based graph/vector config to
-        identify which cached engines to tear down.  Lazy imports avoid
-        circular dependencies at module load time.
+        identify which cached engines to detach.  Lazy imports avoid circular
+        dependencies at module load time.
         """
         from cognee.infrastructure.databases.graph.config import get_graph_context_config
         from cognee.infrastructure.databases.vector.config import get_vectordb_context_config
+
+        detached = []
 
         g_cfg = get_graph_context_config()
         if g_cfg.get("graph_database_subprocess_enabled"):
@@ -304,10 +318,8 @@ class DatasetQueue:
             )
 
             if is_graph_engine_cached(**g_cfg):
-                engine = create_graph_engine(**g_cfg)
+                detached.append(create_graph_engine(**g_cfg))
                 evict_graph_engine(**g_cfg)
-                if hasattr(engine, "close"):
-                    await engine.close()
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
@@ -318,10 +330,24 @@ class DatasetQueue:
             )
 
             if is_vector_engine_cached(**v_cfg):
-                engine = create_vector_engine(**v_cfg)
+                detached.append(create_vector_engine(**v_cfg))
                 evict_vector_engine(**v_cfg)
-                if hasattr(engine, "close"):
-                    await engine.close()
+
+        return detached
+
+    async def _close_engines(self, engines: list) -> None:
+        """Close detached engines so their DB file locks are released."""
+        for engine in engines:
+            if hasattr(engine, "close"):
+                await engine.close()
+
+    async def _teardown_subprocess_engines(self) -> None:
+        """Detach and close subprocess-mode engines in one awaited step.
+
+        Used where there is no task to background the close onto (and by
+        callers/tests that want the full synchronous-contract teardown).
+        """
+        await self._close_engines(self._detach_subprocess_engines())
 
     # -------------------------------------------------------- release_slot_for
     async def release_slot_for(self, dataset_id: Any = None) -> None:
@@ -357,14 +383,15 @@ class DatasetQueue:
         if entry.depth > 0:
             return
 
-        # About to fully release.  Tear down subprocess engines only when
-        # no other task holds the same dataset — but do it in the background:
-        # the caller's response must not wait on engine.close() of engines it
-        # has already finished using.  Correctness moves to the pending-close
-        # latch: the eviction + close run in a task that inherits this
-        # context (create_task snapshots contextvars, so the teardown sees
-        # this dataset's engine config), and the next ``ensure_slot`` for the
-        # same dataset awaits the latch before touching engines.
+        # About to fully release.  Detach (evict) subprocess engines only when
+        # no other task holds the same dataset. The eviction itself is
+        # synchronous — after this line no caller can fetch the dying engines
+        # from the cache; they build fresh ones. Only the expensive
+        # ``engine.close()`` runs in the background: the caller's response
+        # must not wait on the close of engines it has already finished
+        # using. The pending-close latch makes the next ``ensure_slot`` for
+        # the same dataset wait for that close before spawning fresh engines
+        # against the same database files.
         try:
             other_holds = any(
                 ds_key in slots for tid, slots in self._task_slots.items() if tid != task_id

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -123,6 +123,13 @@ class DatasetQueue:
         # ``"acquire:<unique>"`` for ``acquire()``. A task may hold multiple
         # entries; all are released together when the task finishes.
         self._task_slots: Dict[int, Dict[str, SlotEntry]] = {}
+        # Pending-close latches: ds_key -> future that resolves when a
+        # backgrounded engine teardown for that dataset has finished. The next
+        # acquirer of the same dataset awaits it before proceeding, so file
+        # locks are provably free before a fresh engine opens the same files.
+        # (Same pending-close idea closing_lru_cache uses internally.)
+        self._pending_closes: Dict[str, asyncio.Future] = {}
+        self._background_closes: Set[asyncio.Task] = set()
         # Track which tasks already have a done-callback registered so we
         # don't register multiple cleanup handlers for a single task.
         self._registered_tasks: Set[int] = set()
@@ -205,6 +212,13 @@ class DatasetQueue:
             entry.depth += 1
             return
 
+        # If a backgrounded teardown for this dataset is still closing its
+        # engines, wait for it: the whole point of the latch is that the
+        # response path no longer waits, so the (rare) next acquirer must.
+        pending = self._pending_closes.get(ds_key)
+        if pending is not None:
+            await pending
+
         # Acquire a fresh slot for this (task, dataset).
         logger.debug("Task %d acquiring dataset queue slot for dataset_id=%s", task_id, dataset_id)
         await self._semaphore.acquire()
@@ -215,6 +229,33 @@ class DatasetQueue:
         self._task_slots[task_id][ds_key] = SlotEntry(release, depth=1)
 
     # ----------------------------------------- subprocess engine teardown
+    def _schedule_background_teardown(self, ds_key: str) -> None:
+        """Run :meth:`_teardown_subprocess_engines` off the response path.
+
+        Registers a pending-close latch for ``ds_key`` first, so a subsequent
+        acquirer of the same dataset waits for the close instead of racing a
+        fresh engine against still-locked database files. The latch always
+        opens — teardown failures are logged, never propagated (the request
+        this teardown belonged to has already returned).
+        """
+        loop = asyncio.get_running_loop()
+        latch: asyncio.Future = loop.create_future()
+        self._pending_closes[ds_key] = latch
+
+        async def _close() -> None:
+            try:
+                await self._teardown_subprocess_engines()
+            except Exception as error:
+                logger.warning("Background engine teardown failed for %s: %s", ds_key, error)
+            finally:
+                latch.set_result(None)
+                if self._pending_closes.get(ds_key) is latch:
+                    del self._pending_closes[ds_key]
+
+        task = loop.create_task(_close())
+        self._background_closes.add(task)
+        task.add_done_callback(self._background_closes.discard)
+
     async def _teardown_subprocess_engines(self) -> None:
         """Evict and close subprocess-mode engines so DB file locks are released.
 
@@ -288,17 +329,19 @@ class DatasetQueue:
             return
 
         # About to fully release.  Tear down subprocess engines only when
-        # no other task holds the same dataset.  The cross-task scan and
-        # the cache eviction are both synchronous, so no other task can
-        # interleave between the check and the eviction.  The subsequent
-        # ``await engine.close()`` happens after eviction, so new callers
-        # already get a fresh engine by that point.
+        # no other task holds the same dataset — but do it in the background:
+        # the caller's response must not wait on engine.close() of engines it
+        # has already finished using.  Correctness moves to the pending-close
+        # latch: the eviction + close run in a task that inherits this
+        # context (create_task snapshots contextvars, so the teardown sees
+        # this dataset's engine config), and the next ``ensure_slot`` for the
+        # same dataset awaits the latch before touching engines.
         try:
             other_holds = any(
                 ds_key in slots for tid, slots in self._task_slots.items() if tid != task_id
             )
             if not other_holds:
-                await self._teardown_subprocess_engines()
+                self._schedule_background_teardown(ds_key)
         finally:
             self._task_slots.get(task_id, {}).pop(ds_key, None)
             logger.debug(

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -238,6 +238,15 @@ class DatasetQueue:
         * a close on those threads survives event-loop teardown, so
           sequential ``asyncio.run()`` phases in one process are safe.
 
+        The eviction is ``force_close=True``: the adapter closes now even if
+        an idle holder still pins its lease proxy (e.g. a test keeping a
+        ``get_graph_engine()`` handle across pipeline calls). A deferred
+        lease-close would keep the worker — and its file locks — alive
+        indefinitely, and the next engine open for the dataset would exhaust
+        its retries against a lock that never frees. Holders re-resolve on
+        next use; nothing is mid-query here because teardown only fires when
+        no other task holds the dataset.
+
         Closing engines here instead re-implements that machinery one level
         up, loop-bound and invisible to the registry: fetching a lease proxy
         in order to close it defers the real close behind the lease and hides
@@ -260,7 +269,7 @@ class DatasetQueue:
         if g_cfg.get("graph_database_subprocess_enabled"):
             from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
 
-            evict_graph_engine(**g_cfg)
+            evict_graph_engine(force_close=True, **g_cfg)
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
@@ -268,7 +277,7 @@ class DatasetQueue:
                 evict_vector_engine,
             )
 
-            evict_vector_engine(**v_cfg)
+            evict_vector_engine(force_close=True, **v_cfg)
 
     # -------------------------------------------------------- release_slot_for
     async def release_slot_for(self, dataset_id: Any = None) -> None:

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -11,9 +11,11 @@ bump a per-entry depth counter rather than re-acquiring the semaphore. The
 corresponding :meth:`DatasetQueue.release_slot_for` (async) decrements that
 counter; the underlying semaphore slot is freed only when the counter hits
 zero.  When the last holder across all tasks exits, subprocess engines are
-torn down via :meth:`DatasetQueue._teardown_subprocess_engines`.  This
-makes nested ``async with set_database_global_context_variables(D, u)`` scopes
-safe — an inner exit never steals an outer holder's slot.
+evicted from the engine caches via
+:meth:`DatasetQueue._evict_subprocess_engines`; the caches close them off the
+response path.  This makes nested
+``async with set_database_global_context_variables(D, u)`` scopes safe — an
+inner exit never steals an outer holder's slot.
 
 Task-end cleanup is a safety net: when the current task finishes, every entry
 still in ``_task_slots`` is force-released regardless of depth. This covers
@@ -91,23 +93,6 @@ def _make_release(semaphore: asyncio.Semaphore) -> Callable[[], None]:
     return _release
 
 
-class PendingClose:
-    """A background engine close in flight (or orphaned by a dead loop).
-
-    Carries the detached engines so that a later acquirer on a *different*
-    event loop can adopt and finish the close when this one's loop died
-    before the close task ran to completion (multiple sequential
-    ``asyncio.run()`` phases in one process — the e2e script shape).
-    """
-
-    __slots__ = ("future", "engines", "loop")
-
-    def __init__(self, future, engines, loop) -> None:
-        self.future = future
-        self.engines = engines
-        self.loop = loop
-
-
 class SlotEntry:
     """A single acquired slot with a nesting depth counter."""
 
@@ -140,23 +125,6 @@ class DatasetQueue:
         # ``"acquire:<unique>"`` for ``acquire()``. A task may hold multiple
         # entries; all are released together when the task finishes.
         self._task_slots: Dict[int, Dict[str, SlotEntry]] = {}
-        # Pending closes — "who must wait, per dataset": ds_key -> PendingClose
-        # whose future resolves when the backgrounded engine close for that
-        # dataset has finished. The next acquirer of the same dataset awaits it
-        # (same loop) or adopts and finishes the close itself (the scheduling
-        # loop died first), so file locks are provably free before a fresh
-        # engine opens the same files. Removed when the close completes or
-        # fails; deliberately KEPT when the close task is cancelled by loop
-        # teardown — the record is what adoption works from.
-        # (Same pending-close idea closing_lru_cache uses internally.)
-        self._pending_closes: Dict[str, PendingClose] = {}
-        # Live close tasks — "which closes are still running, so they can't be
-        # lost". asyncio holds only weak references to tasks: a fire-and-forget
-        # close with no strong reference can be garbage-collected mid-flight,
-        # never finishing the close and never opening its latch. Entries are
-        # removed by the task's done-callback (which also surfaces failures);
-        # tests and shutdown drain this set to wait for in-flight closes.
-        self._background_closes: Set[asyncio.Task] = set()
         # Track which tasks already have a done-callback registered so we
         # don't register multiple cleanup handlers for a single task.
         self._registered_tasks: Set[int] = set()
@@ -239,19 +207,6 @@ class DatasetQueue:
             entry.depth += 1
             return
 
-        # If a backgrounded close for this dataset is still in flight, wait
-        # for it: the whole point of the latch is that the response path no
-        # longer waits, so the (rare) next acquirer must. If the close's loop
-        # died before it finished (sequential asyncio.run() phases), its
-        # engines may still hold the database file locks — adopt the close
-        # and finish it here, on the live loop, before proceeding.
-        pending = self._pending_closes.get(ds_key)
-        if pending is not None:
-            if pending.loop is asyncio.get_running_loop():
-                await pending.future
-            else:
-                await self._adopt_orphaned_close(ds_key, pending)
-
         # Acquire a fresh slot for this (task, dataset).
         logger.debug("Task %d acquiring dataset queue slot for dataset_id=%s", task_id, dataset_id)
         await self._semaphore.acquire()
@@ -262,183 +217,58 @@ class DatasetQueue:
         self._task_slots[task_id][ds_key] = SlotEntry(release, depth=1)
 
     # ----------------------------------------- subprocess engine teardown
-    def _schedule_background_teardown(self, ds_key: str) -> None:
-        """Detach engines now; close them off the response path.
+    def _evict_subprocess_engines(self) -> None:
+        """Evict this context's subprocess-mode engines from their caches.
 
-        Why this exact split, and not something simpler:
+        Eviction is the queue's entire teardown responsibility — the engine
+        cache owns the close lifecycle, and it already gives the release path
+        everything it needs:
 
-        * **Why not await the whole teardown inline** (the original design):
-          ``engine.close()`` takes 1.5–2 s per query, and it ran while the
-          caller's response waited — measured as roughly half of every serial
-          recall's latency. The teardown only fires when *no other task holds
-          the dataset*, which is precisely when nobody benefits from waiting.
-        * **Why the eviction still happens synchronously here** and only the
-          close is backgrounded: while a dying engine is still in the LRU,
-          any caller — even the same task, one line after context exit — can
-          fetch it, and the background close then kills it mid-use
-          ("LadybugAdapter is closed; a new adapter must be created", which
-          broke nine e2e suites when the whole teardown was deferred).
-          Eviction is cheap and in-memory; after this line every caller
-          builds a fresh engine.
-        * **Why the pending-close latch**: a fresh engine must not open the
-          same database files while the old engine's close is still
-          releasing their locks. The next ``ensure_slot`` for this dataset
-          awaits the latch — moving the wait from the response (never
-          load-bearing there) to the only place it matters.
+        * a subprocess-backed adapter's close runs on the cache's dedicated
+          close threads, so it makes progress even while this loop's thread is
+          blocked. (An earlier revision scheduled the close as a task on this
+          loop; a synchronous engine spawn right after release then starved it
+          and exhausted the worker's bounded open-retry — the "Lock is held by
+          PID N" e2e failures.)
+        * the close is registered in the cache's pending-close registry, so
+          the next creation of the same engine — through the queue or a direct
+          ``get_graph_engine()`` — waits for the old worker to exit before
+          opening the same database files, with the worker's open-retry as the
+          backstop for the residual window.
+        * a close on those threads survives event-loop teardown, so
+          sequential ``asyncio.run()`` phases in one process are safe.
 
-        The latch always opens; a close failure is surfaced at ERROR with its
-        traceback from the task's done-callback (the request this close
-        belonged to has already returned, so there is no caller to raise
-        into).
-        """
-        engines = self._detach_subprocess_engines()
-        if not engines:
-            return
+        Closing engines here instead re-implements that machinery one level
+        up, loop-bound and invisible to the registry: fetching a lease proxy
+        in order to close it defers the real close behind the lease and hides
+        it from creators.
 
-        loop = asyncio.get_running_loop()
-        latch: asyncio.Future = loop.create_future()
-        record = PendingClose(latch, engines, loop)
-        self._pending_closes[ds_key] = record
-
-        def _finish() -> None:
-            if not latch.done():
-                latch.set_result(None)
-            if self._pending_closes.get(ds_key) is record:
-                del self._pending_closes[ds_key]
-
-        async def _close() -> None:
-            # No exception is expected here, so none is caught: the latch must
-            # open on success or failure (a failed close must not brick the
-            # dataset), and failures are surfaced below with their traceback.
-            # CancelledError is the exception to the rule: loop teardown kills
-            # this task mid-close, the engines may still hold file locks, and
-            # the pending record must SURVIVE so the next acquirer (on a live
-            # loop) adopts and finishes the close. (Not a guarded ``finally``:
-            # inside a task that is being cancelled, ``task.cancelled()`` still
-            # reads False — explicit paths are the only reliable structure.)
-            try:
-                await self._close_engines(engines)
-            except asyncio.CancelledError:
-                raise
-            except BaseException:
-                _finish()
-                raise
-            else:
-                _finish()
-
-        task = loop.create_task(_close())
-        self._background_closes.add(task)
-
-        def _surface(done: asyncio.Task) -> None:
-            self._background_closes.discard(done)
-            if not done.cancelled() and done.exception() is not None:
-                # The request this teardown belonged to has already returned,
-                # so there is no caller to raise into — ERROR with the stack is
-                # the loudest honest channel. If the close genuinely left file
-                # locks behind, the next engine open fails loudly in a real
-                # request; nothing is silently lost.
-                exc = done.exception()
-                logger.error(
-                    "Background engine teardown failed for %s",
-                    ds_key,
-                    # The structlog exception processor only unpacks a real
-                    # (type, value, traceback) tuple; anything else falls back
-                    # to sys.exc_info(), which is empty in a done-callback.
-                    exc_info=(type(exc), exc, exc.__traceback__),
-                )
-
-        task.add_done_callback(_surface)
-
-    def _detach_subprocess_engines(self) -> list:
-        """Synchronously evict subprocess-mode engines from their caches.
-
-        This MUST stay synchronous and run before the release returns: eviction
-        is what guarantees no later caller can fetch a dying engine from the
-        LRU (they build a fresh one instead). Only the expensive
-        ``engine.close()`` of the returned engines may be deferred.
+        Eviction runs synchronously on the release path on purpose: a dying
+        engine left in the LRU can be fetched by the very next caller and then
+        die mid-use ("LadybugAdapter is closed; a new adapter must be
+        created", which broke nine e2e suites when the whole teardown was
+        deferred). After eviction every caller builds a fresh engine.
 
         Reads the current task's ContextVar-based graph/vector config to
-        identify which cached engines to detach.  Lazy imports avoid circular
+        identify which cached engines to evict. Lazy imports avoid circular
         dependencies at module load time.
         """
         from cognee.infrastructure.databases.graph.config import get_graph_context_config
         from cognee.infrastructure.databases.vector.config import get_vectordb_context_config
 
-        detached = []
-
         g_cfg = get_graph_context_config()
         if g_cfg.get("graph_database_subprocess_enabled"):
-            from cognee.infrastructure.databases.graph.get_graph_engine import (
-                create_graph_engine,
-                evict_graph_engine,
-                is_graph_engine_cached,
-            )
+            from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
 
-            if is_graph_engine_cached(**g_cfg):
-                detached.append(create_graph_engine(**g_cfg))
-                evict_graph_engine(**g_cfg)
+            evict_graph_engine(**g_cfg)
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
             from cognee.infrastructure.databases.vector.create_vector_engine import (
-                create_vector_engine,
                 evict_vector_engine,
-                is_vector_engine_cached,
             )
 
-            if is_vector_engine_cached(**v_cfg):
-                detached.append(create_vector_engine(**v_cfg))
-                evict_vector_engine(**v_cfg)
-
-        return detached
-
-    async def _adopt_orphaned_close(self, ds_key: str, pending: "PendingClose") -> None:
-        """Finish a close whose scheduling loop died before it completed.
-
-        ``engine.close()`` alone is not enough here: the engines are lease
-        proxies, and their *real* close can be parked in cache machinery bound
-        to the dead loop — observed as ``close()`` returning OK while the
-        worker process (and its database file lock) lives on. The worker's
-        session ``shutdown()`` is the unconditional path: synchronous, always
-        reaches terminate, and the OS releases the file locks when the process
-        dies. The proxy ``close()`` afterwards is cache/lease bookkeeping.
-
-        Per-engine failures are surfaced at ERROR and not raised: after a
-        mid-close cancellation, partially-closed state is *expected*, and the
-        definitive arbiter is the engine open that follows (it fails loudly if
-        a file lock genuinely remains).
-        """
-        if self._pending_closes.get(ds_key) is pending:
-            del self._pending_closes[ds_key]
-        for engine in pending.engines:
-            try:
-                session = getattr(engine, "_session", None)
-                if session is not None and hasattr(session, "shutdown"):
-                    # Synchronous by design; brief block on a recovery path is
-                    # the price of a guaranteed worker death + lock release.
-                    session.shutdown()
-                if hasattr(engine, "close"):
-                    await engine.close()
-            except Exception as error:
-                logger.error(
-                    "Adopted close of an orphaned engine failed for %s",
-                    ds_key,
-                    exc_info=(type(error), error, error.__traceback__),
-                )
-
-    async def _close_engines(self, engines: list) -> None:
-        """Close detached engines so their DB file locks are released."""
-        for engine in engines:
-            if hasattr(engine, "close"):
-                await engine.close()
-
-    async def _teardown_subprocess_engines(self) -> None:
-        """Detach and close subprocess-mode engines in one awaited step.
-
-        Used where there is no task to background the close onto (and by
-        callers/tests that want the full synchronous-contract teardown).
-        """
-        await self._close_engines(self._detach_subprocess_engines())
+            evict_vector_engine(**v_cfg)
 
     # -------------------------------------------------------- release_slot_for
     async def release_slot_for(self, dataset_id: Any = None) -> None:
@@ -446,11 +276,11 @@ class DatasetQueue:
         the semaphore slot when the counter reaches zero.
 
         When this is the very last holder across all tasks for
-        ``dataset_id``, subprocess engines are torn down via
-        :meth:`_teardown_subprocess_engines` while the semaphore slot is
-        still held so that no new operation can observe a half-torn-down
-        resource.  The slot is freed afterwards regardless of whether the
-        teardown succeeds or raises.
+        ``dataset_id``, subprocess engines are evicted via
+        :meth:`_evict_subprocess_engines` while the semaphore slot is still
+        held, so no new operation can fetch a dying engine from the cache.
+        The slot is freed afterwards regardless of whether the eviction
+        succeeds or raises.
 
         No-op when the queue is disabled, there is no running task, or the
         current task does not hold a slot for ``dataset_id``.
@@ -460,7 +290,7 @@ class DatasetQueue:
 
         task = asyncio.current_task()
         if task is None:
-            await self._teardown_subprocess_engines()
+            self._evict_subprocess_engines()
             return
 
         task_id = id(task)
@@ -474,21 +304,17 @@ class DatasetQueue:
         if entry.depth > 0:
             return
 
-        # About to fully release.  Detach (evict) subprocess engines only when
-        # no other task holds the same dataset. The eviction itself is
-        # synchronous — after this line no caller can fetch the dying engines
-        # from the cache; they build fresh ones. Only the expensive
-        # ``engine.close()`` runs in the background: the caller's response
-        # must not wait on the close of engines it has already finished
-        # using. The pending-close latch makes the next ``ensure_slot`` for
-        # the same dataset wait for that close before spawning fresh engines
-        # against the same database files.
+        # About to fully release.  Evict subprocess engines only when no other
+        # task holds the same dataset; the engine cache closes them off the
+        # response path (see ``_evict_subprocess_engines`` for the full
+        # contract). The caller's response must not wait on the close of
+        # engines it has already finished using.
         try:
             other_holds = any(
                 ds_key in slots for tid, slots in self._task_slots.items() if tid != task_id
             )
             if not other_holds:
-                self._schedule_background_teardown(ds_key)
+                self._evict_subprocess_engines()
         finally:
             self._task_slots.get(task_id, {}).pop(ds_key, None)
             logger.debug(

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -265,10 +265,14 @@ class DatasetQueue:
                 # the loudest honest channel. If the close genuinely left file
                 # locks behind, the next engine open fails loudly in a real
                 # request; nothing is silently lost.
+                exc = done.exception()
                 logger.error(
                     "Background engine teardown failed for %s",
                     ds_key,
-                    exc_info=done.exception(),
+                    # The structlog exception processor only unpacks a real
+                    # (type, value, traceback) tuple; anything else falls back
+                    # to sys.exc_info(), which is empty in a done-callback.
+                    exc_info=(type(exc), exc, exc.__traceback__),
                 )
 
         task.add_done_callback(_surface)

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -91,8 +91,8 @@ class _GraphEngineHandle:
     CI) — so a fresh engine relies on the worker's open-retry
     (``SUBPROCESS_OPEN_LOCK_RETRIES``) for the overlap. Once a close is
     actually in flight, creators wait for it deterministically; the primary
-    multi-tenant teardown path (``dataset_queue._teardown_subprocess_engines``)
-    also ``await``s ``engine.close()`` to completion before any re-creation.
+    multi-tenant teardown path (``dataset_queue._evict_subprocess_engines``)
+    routes through plain cache eviction, so its closes register here too.
     """
 
     __slots__ = ("_config", "_last_initialized_id", "_pinned")

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -282,7 +282,7 @@ async def acreate_graph_engine(**kwargs):
     return await _create_graph_engine.acall(*_resolve_graph_engine_args(kwargs))
 
 
-def evict_graph_engine(**kwargs) -> bool:
+def evict_graph_engine(force_close: bool = False, **kwargs) -> bool:
     """Evict a cached graph engine entry created via ``create_graph_engine``.
 
     Mirrors ``create_graph_engine``'s normalization so the cache key
@@ -290,11 +290,22 @@ def evict_graph_engine(**kwargs) -> bool:
     adapter (and trigger its ``close()``) without disturbing the rest
     of the cache.
 
+    ``force_close=True`` closes the adapter immediately even while idle
+    holders still pin its proxy (they re-resolve on next use) — the
+    dataset-queue teardown path, where the worker must exit and release
+    its file locks promptly. Default keeps lease semantics: the close
+    waits for the last holder.
+
     Returns True if the entry existed.
     """
     normalized = _normalize_optional_create_graph_engine_params(kwargs)
     provider = _normalize_graph_database_provider(kwargs.get("graph_database_provider"))
-    return _create_graph_engine.cache_evict(
+    evict = (
+        _create_graph_engine.cache_evict_and_close
+        if force_close
+        else _create_graph_engine.cache_evict
+    )
+    return evict(
         provider,
         kwargs.get("graph_file_path"),
         normalized["graph_database_url"],

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -779,6 +779,52 @@ class ClosingLRUCache:
         self._detach_entry(entry)
         return True
 
+    def evict_and_close(self, key) -> bool:
+        """Remove *key* and close its value NOW, even while callers still hold
+        proxies.
+
+        For deliberate teardown (the dataset-queue release path): the worker
+        process must exit and release its on-disk file locks promptly, and an
+        idle holder — e.g. a test keeping an engine handle across pipeline
+        calls — would otherwise defer the close indefinitely, so the next
+        creation for the same database exhausts the worker's open-retry
+        against a lock that is never released. Holders of the now-dead value
+        re-resolve on next use (the engine handles' re-resolution path).
+
+        Capacity eviction must NOT use this — it would close a value that is
+        actively in use mid-call; plain :meth:`evict` defers for those.
+
+        The close is tracked in the pending-close registry (creators for the
+        same key wait for it) and, for subprocess-backed values, runs on the
+        dedicated close threads. Returns True if the entry was present.
+        """
+        with self._lock:
+            entry = self._cache.pop(key, None)
+        if entry is None:
+            return False
+
+        value_to_close = None
+        with entry._lock:
+            entry.in_cache = False
+            entry.close_requested = True
+            # Marking the entry closed under the lock makes a stray proxy
+            # finalizer firing later a no-op (no double close). The proxy ref
+            # itself must be held past the lock: if it is the last reference,
+            # dropping it runs the weakref finalizer, which re-enters
+            # ``proxy_released`` and deadlocks on ``entry._lock`` (same hazard
+            # as ``detach_from_cache``).
+            proxy_to_drop = entry.proxy
+            entry.proxy = None
+            if not entry.closed:
+                entry.closed = True
+                value_to_close = entry.value
+
+        # Outside the locks — close code can log or re-enter cache paths.
+        if value_to_close is not None:
+            self._track_close(entry.key, value_to_close)
+        del proxy_to_drop
+        return True
+
     def evict_where(self, predicate) -> int:
         """Remove every entry whose key satisfies *predicate* and request close.
 
@@ -864,6 +910,14 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True, pinned_p
             """
             return cache.evict(_key(args, kwargs))
 
+        def cache_evict_and_close(*args, **kwargs) -> bool:
+            """Evict a single entry and close its value immediately, even if
+            callers still hold proxies — see ``ClosingLRUCache.evict_and_close``
+            for when this is (and is not) appropriate. Key scheme matches
+            ``cache_evict``. Returns True if the entry was present.
+            """
+            return cache.evict_and_close(_key(args, kwargs))
+
         def cache_evict_where(predicate) -> int:
             """Evict every cached entry whose key satisfies *predicate*.
 
@@ -937,6 +991,7 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True, pinned_p
 
         wrapper.cache_clear = cache.cache_clear
         wrapper.cache_evict = cache_evict
+        wrapper.cache_evict_and_close = cache_evict_and_close
         wrapper.cache_evict_where = cache_evict_where
         wrapper.cache_evict_matching = cache_evict_matching
         wrapper.cache_await_closed = cache_await_closed

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -113,14 +113,22 @@ def create_vector_engine(
     )
 
 
-def evict_vector_engine(**kwargs) -> bool:
+def evict_vector_engine(force_close: bool = False, **kwargs) -> bool:
     """Evict a cached vector engine entry created via ``create_vector_engine``.
 
     Mirrors ``create_vector_engine``'s normalization so the cache key
-    matches. Returns True if the entry existed.
+    matches. ``force_close=True`` closes the adapter immediately even while
+    idle holders still pin its proxy (they re-resolve on next use) — the
+    dataset-queue teardown path, where the worker must exit and release its
+    file locks promptly. Returns True if the entry existed.
     """
     normalized = _normalize_optional_create_vector_engine_params(kwargs)
-    return _create_vector_engine.cache_evict(
+    evict = (
+        _create_vector_engine.cache_evict_and_close
+        if force_close
+        else _create_vector_engine.cache_evict
+    )
+    return evict(
         kwargs.get("vector_db_provider", ""),
         kwargs.get("vector_db_url", ""),
         kwargs.get("vector_db_name", ""),

--- a/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
+++ b/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
@@ -1468,3 +1468,40 @@ def test_proxied_method_exceptions_always_propagate_to_the_caller():
     engine = cache.get_or_create("k", _EngineWithBadMethod)
     with pytest.raises(RuntimeError, match="boom in engine usage"):
         engine.query()
+
+
+def test_evict_and_close_closes_despite_outstanding_proxy():
+    """evict_and_close is deliberate teardown: an idle holder pinning the
+    lease proxy must not defer the close (a deferred close keeps a worker
+    process — and its file locks — alive indefinitely)."""
+    cache = ClosingLRUCache(maxsize=8, lease=True)
+    value = _Closeable("held")
+    proxy = cache.get_or_create("k", lambda: value)
+
+    assert cache.evict_and_close("k") is True
+    assert value.closed is True, "close must not be deferred behind the live proxy"
+    assert cache.cache_info().currsize == 0
+
+    # The stray holder's proxy finalizer must not double-close.
+    value.closed = "closed-once"
+    del proxy
+    gc.collect()
+    assert value.closed == "closed-once"
+
+
+def test_evict_and_close_missing_key_returns_false():
+    cache = ClosingLRUCache(maxsize=8, lease=True)
+    assert cache.evict_and_close("absent") is False
+
+
+def test_decorator_cache_evict_and_close():
+    """Decorator exposure: key scheme matches cache_evict."""
+
+    @closing_lru_cache(maxsize=4, lease=True)
+    def create(name):
+        return _Closeable(name)
+
+    proxy = create("a")
+    assert create.cache_evict_and_close("a") is True
+    assert proxy.__wrapped__.closed is True
+    assert create.cache_evict_and_close("a") is False

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -914,6 +914,21 @@ class TestEvictSubprocessEngines:
         await queue.release_slot_for("ds-S")
         assert evicted, "eviction must run inline at release"
 
+    @staticmethod
+    def _modules():
+        """Resolve the patched modules via importlib: dotted-string patch
+        targets like ``...graph.get_graph_engine`` can resolve to the
+        same-named FUNCTION exported by the package __init__ instead of the
+        submodule (broke on Python 3.10 in CI)."""
+        import importlib
+
+        return (
+            importlib.import_module("cognee.infrastructure.databases.graph.config"),
+            importlib.import_module("cognee.infrastructure.databases.vector.config"),
+            importlib.import_module("cognee.infrastructure.databases.graph.get_graph_engine"),
+            importlib.import_module("cognee.infrastructure.databases.vector.create_vector_engine"),
+        )
+
     def test_eviction_routes_through_cache_evict(self):
         """_evict_subprocess_engines must evict via the cache helpers — it must
         NOT fetch engines or close them itself: a fetched lease proxy defers
@@ -924,33 +939,25 @@ class TestEvictSubprocessEngines:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
+        g_conf_mod, v_conf_mod, g_engine_mod, v_engine_mod = self._modules()
 
         g_cfg = {"graph_database_subprocess_enabled": True, "graph_database_name": "g"}
         v_cfg = {"vector_db_subprocess_enabled": True, "vector_db_name": "v"}
 
         with (
-            patch(
-                "cognee.infrastructure.databases.graph.config.get_graph_context_config",
-                return_value=g_cfg,
-            ),
-            patch(
-                "cognee.infrastructure.databases.vector.config.get_vectordb_context_config",
-                return_value=v_cfg,
-            ),
-            patch(
-                "cognee.infrastructure.databases.graph.get_graph_engine.evict_graph_engine"
-            ) as evict_graph,
-            patch(
-                "cognee.infrastructure.databases.vector.create_vector_engine.evict_vector_engine"
-            ) as evict_vector,
-            patch(
-                "cognee.infrastructure.databases.graph.get_graph_engine.create_graph_engine"
-            ) as create_graph,
+            patch.object(g_conf_mod, "get_graph_context_config", return_value=g_cfg),
+            patch.object(v_conf_mod, "get_vectordb_context_config", return_value=v_cfg),
+            patch.object(g_engine_mod, "evict_graph_engine") as evict_graph,
+            patch.object(v_engine_mod, "evict_vector_engine") as evict_vector,
+            patch.object(g_engine_mod, "create_graph_engine") as create_graph,
         ):
             queue._evict_subprocess_engines()
 
-        evict_graph.assert_called_once_with(**g_cfg)
-        evict_vector.assert_called_once_with(**v_cfg)
+        # force_close: an idle holder pinning the lease proxy (e.g. a test
+        # keeping a get_graph_engine() handle) must not defer the close and
+        # keep the worker's file locks alive indefinitely.
+        evict_graph.assert_called_once_with(force_close=True, **g_cfg)
+        evict_vector.assert_called_once_with(force_close=True, **v_cfg)
         create_graph.assert_not_called()
 
     def test_eviction_skips_non_subprocess_engines(self):
@@ -958,22 +965,21 @@ class TestEvictSubprocessEngines:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
+        g_conf_mod, v_conf_mod, g_engine_mod, v_engine_mod = self._modules()
 
         with (
-            patch(
-                "cognee.infrastructure.databases.graph.config.get_graph_context_config",
+            patch.object(
+                g_conf_mod,
+                "get_graph_context_config",
                 return_value={"graph_database_subprocess_enabled": False},
             ),
-            patch(
-                "cognee.infrastructure.databases.vector.config.get_vectordb_context_config",
+            patch.object(
+                v_conf_mod,
+                "get_vectordb_context_config",
                 return_value={"vector_db_subprocess_enabled": False},
             ),
-            patch(
-                "cognee.infrastructure.databases.graph.get_graph_engine.evict_graph_engine"
-            ) as evict_graph,
-            patch(
-                "cognee.infrastructure.databases.vector.create_vector_engine.evict_vector_engine"
-            ) as evict_vector,
+            patch.object(g_engine_mod, "evict_graph_engine") as evict_graph,
+            patch.object(v_engine_mod, "evict_vector_engine") as evict_vector,
         ):
             queue._evict_subprocess_engines()
 

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -433,14 +433,20 @@ class TestReleaseSlotFor:
 
     @staticmethod
     def _mock_teardown(queue):
-        """Replace _teardown_subprocess_engines with a counter."""
+        """Count teardown firings via the synchronous detach seam.
+
+        Detach is the part that must run inline at release (it evicts the
+        engines from the cache); returning no engines means nothing needs a
+        background close, which keeps these tests synchronous.
+        """
         call_count = 0
 
-        async def fake_teardown():
+        def fake_detach():
             nonlocal call_count
             call_count += 1
+            return []
 
-        queue._teardown_subprocess_engines = fake_teardown
+        queue._detach_subprocess_engines = fake_detach
 
         class Counter:
             @property
@@ -585,10 +591,12 @@ class TestReleaseSlotFor:
         queue = DatasetQueue(enabled=True, max_concurrent=1)
         ds = "ds-E"
 
-        async def failing_teardown():
+        queue._detach_subprocess_engines = lambda: [object()]
+
+        async def failing_close(engines):
             raise ValueError("engine teardown failed")
 
-        queue._teardown_subprocess_engines = failing_teardown
+        queue._close_engines = failing_close
 
         await queue.ensure_slot(ds)
 
@@ -856,13 +864,15 @@ class TestReleaseSlotFor:
         queue = DatasetQueue(enabled=True, max_concurrent=5)
         call_count = 0
 
-        async def teardown_fails_once():
+        queue._detach_subprocess_engines = lambda: [object()]
+
+        async def close_fails_once(engines):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise RuntimeError("kaboom")
 
-        queue._teardown_subprocess_engines = teardown_fails_once
+        queue._close_engines = close_fails_once
 
         await queue.ensure_slot("ds-ok")
         await queue.ensure_slot("ds-fail")
@@ -930,7 +940,29 @@ class TestActiveDatasetIds:
 
 
 class TestBackgroundTeardownLatch:
-    """The teardown runs off the response path; the latch keeps correctness."""
+    """The close runs off the response path; detach stays synchronous."""
+
+    @pytest.mark.asyncio
+    async def test_detach_is_synchronous_at_release(self):
+        """Eviction must complete before release returns — a caller on the
+        very next line must never fetch a dying engine from the cache.
+        (Regression: deferring eviction into the background task let e2e
+        flows grab an engine the close then killed under them:
+        "LadybugAdapter is closed; a new adapter must be created".)"""
+        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        detached = False
+
+        def detach():
+            nonlocal detached
+            detached = True
+            return []
+
+        queue._detach_subprocess_engines = detach
+        await queue.ensure_slot("ds-S")
+        await queue.release_slot_for("ds-S")
+        assert detached, "detach must run inline at release, not in the background task"
 
     @pytest.mark.asyncio
     async def test_release_returns_before_teardown_completes(self):
@@ -943,13 +975,15 @@ class TestBackgroundTeardownLatch:
         finish = asyncio.Event()
         done = False
 
-        async def slow_teardown():
+        queue._detach_subprocess_engines = lambda: [object()]
+
+        async def slow_close(engines):
             nonlocal done
             started.set()
             await finish.wait()
             done = True
 
-        queue._teardown_subprocess_engines = slow_teardown
+        queue._close_engines = slow_close
 
         await queue.ensure_slot("ds-L")
         await queue.release_slot_for("ds-L")  # must NOT wait for the close
@@ -971,10 +1005,12 @@ class TestBackgroundTeardownLatch:
         queue = DatasetQueue(enabled=True, max_concurrent=5)
         finish = asyncio.Event()
 
-        async def slow_teardown():
+        queue._detach_subprocess_engines = lambda: [object()]
+
+        async def slow_close(engines):
             await finish.wait()
 
-        queue._teardown_subprocess_engines = slow_teardown
+        queue._close_engines = slow_close
 
         await queue.ensure_slot("ds-L")
         await queue.release_slot_for("ds-L")
@@ -999,10 +1035,12 @@ class TestBackgroundTeardownLatch:
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
 
-        async def broken_teardown():
+        queue._detach_subprocess_engines = lambda: [object()]
+
+        async def broken_close(engines):
             raise RuntimeError("boom")
 
-        queue._teardown_subprocess_engines = broken_teardown
+        queue._close_engines = broken_close
 
         await queue.ensure_slot("ds-L")
         await queue.release_slot_for("ds-L")

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -404,9 +404,9 @@ class TestDatasetQueueEdgeCases:
 
 
 class TestReleaseSlotFor:
-    """Tests for release_slot_for — verifies that _teardown_subprocess_engines
+    """Tests for release_slot_for — verifies that _evict_subprocess_engines
     fires at the right time (last holder) and that the semaphore is always
-    released regardless of teardown outcome."""
+    released regardless of eviction outcome."""
 
     @pytest.fixture(autouse=True)
     def reset_queue_singleton(self):
@@ -419,34 +419,20 @@ class TestReleaseSlotFor:
         yield
 
     @staticmethod
-    async def _drain(queue):
-        """Wait for any backgrounded teardown tasks to finish.
+    def _mock_evict(queue):
+        """Count eviction firings via the synchronous eviction seam.
 
-        return_exceptions: a failing teardown propagates out of its task (it
-        is surfaced by the done-callback, not eaten) — draining must not
-        re-raise it into the test.
-        """
-        import asyncio
-
-        while queue._background_closes:
-            await asyncio.gather(*list(queue._background_closes), return_exceptions=True)
-
-    @staticmethod
-    def _mock_teardown(queue):
-        """Count teardown firings via the synchronous detach seam.
-
-        Detach is the part that must run inline at release (it evicts the
-        engines from the cache); returning no engines means nothing needs a
-        background close, which keeps these tests synchronous.
+        Eviction is the queue's entire teardown responsibility — the engine
+        cache closes evicted engines on its own threads, so there is nothing
+        asynchronous left to wait for at this layer.
         """
         call_count = 0
 
-        def fake_detach():
+        def fake_evict():
             nonlocal call_count
             call_count += 1
-            return []
 
-        queue._detach_subprocess_engines = fake_detach
+        queue._evict_subprocess_engines = fake_evict
 
         class Counter:
             @property
@@ -456,41 +442,38 @@ class TestReleaseSlotFor:
         return Counter()
 
     @pytest.mark.asyncio
-    async def test_teardown_fires_for_single_holder(self):
+    async def test_eviction_fires_for_single_holder(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
 
         await queue.ensure_slot("ds-A")
         await queue.release_slot_for("ds-A")
-        await self._drain(queue)
         assert counter.value == 1
 
     @pytest.mark.asyncio
-    async def test_teardown_skipped_for_nested_depth(self):
+    async def test_eviction_skipped_for_nested_depth(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
 
         await queue.ensure_slot("ds-B")
         await queue.ensure_slot("ds-B")  # depth = 2
 
         await queue.release_slot_for("ds-B")
-        await self._drain(queue)
         assert counter.value == 0  # inner exit — skipped
 
         await queue.release_slot_for("ds-B")
-        await self._drain(queue)
         assert counter.value == 1  # outer exit — fires
 
     @pytest.mark.asyncio
-    async def test_teardown_skipped_when_cross_task_holder_exists(self):
+    async def test_eviction_skipped_when_cross_task_holder_exists(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
         ds = "ds-C"
 
         other_ready = asyncio.Event()
@@ -507,20 +490,18 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot(ds)
         await queue.release_slot_for(ds)
-        await self._drain(queue)
         assert counter.value == 0  # other task still holds the dataset
 
         check_done.set()
         await task
-        await self._drain(queue)
         assert counter.value == 1  # other task was last
 
     @pytest.mark.asyncio
-    async def test_teardown_fires_after_last_cross_task_holder_releases(self):
+    async def test_eviction_fires_after_last_cross_task_holder_releases(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
         ds = "ds-D"
 
         other_ready = asyncio.Event()
@@ -537,20 +518,18 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot(ds)
         await queue.release_slot_for(ds)
-        await self._drain(queue)
         assert counter.value == 0  # not last
 
         main_released.set()
         await task
-        await self._drain(queue)
-        assert counter.value == 1  # other task was last, teardown fired
+        assert counter.value == 1  # other task was last, eviction fired
 
     @pytest.mark.asyncio
-    async def test_different_dataset_does_not_block_teardown(self):
+    async def test_different_dataset_does_not_block_eviction(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
 
         other_ready = asyncio.Event()
         check_done = asyncio.Event()
@@ -566,51 +545,44 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot("dataset-OURS")
         await queue.release_slot_for("dataset-OURS")
-        await self._drain(queue)
         assert counter.value == 1  # different dataset — we're last for ours
 
         check_done.set()
         await task
 
     @pytest.mark.asyncio
-    async def test_disabled_queue_skips_teardown(self):
+    async def test_disabled_queue_skips_eviction(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=False, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
 
         await queue.release_slot_for("any-dataset")
-        await self._drain(queue)
         assert counter.value == 0
 
     @pytest.mark.asyncio
-    async def test_teardown_exception_still_releases_slot(self):
-        """Slot must be freed even if _teardown_subprocess_engines raises."""
+    async def test_eviction_exception_still_releases_slot(self):
+        """Slot must be freed even if _evict_subprocess_engines raises; the
+        error propagates to the caller rather than being eaten."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=1)
         ds = "ds-E"
 
-        queue._detach_subprocess_engines = lambda: [object()]
+        def failing_evict():
+            raise ValueError("eviction failed")
 
-        async def failing_close(engines):
-            raise ValueError("engine teardown failed")
-
-        queue._close_engines = failing_close
+        queue._evict_subprocess_engines = failing_evict
 
         await queue.ensure_slot(ds)
-
-        # The teardown runs in the background: its failure is logged, never
-        # raised into the caller (whose response has already returned).
-        await queue.release_slot_for(ds)
-        await self._drain(queue)
-        assert queue._pending_closes == {}
+        with pytest.raises(ValueError, match="eviction failed"):
+            await queue.release_slot_for(ds)
 
         # Replace the failing mock so the verification calls below don't blow up.
-        self._mock_teardown(queue)
+        self._mock_evict(queue)
 
         # Semaphore must have been released — acquiring again should not block.
-        await queue.ensure_slot(ds)
+        await asyncio.wait_for(queue.ensure_slot(ds), timeout=1)
         await queue.release_slot_for(ds)
 
     @pytest.mark.asyncio
@@ -619,11 +591,10 @@ class TestReleaseSlotFor:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
 
         await queue.release_slot_for("never-acquired")
-        await self._drain(queue)
-        assert counter.value == 0  # no entry — teardown not called
+        assert counter.value == 0  # no entry — eviction not called
         assert queue._semaphore._value == 5  # nothing consumed
 
     @pytest.mark.asyncio
@@ -632,7 +603,7 @@ class TestReleaseSlotFor:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=2)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
         ds = "ds-G"
 
         await queue.ensure_slot(ds)
@@ -640,13 +611,11 @@ class TestReleaseSlotFor:
 
         await queue.release_slot_for(ds)
         assert queue._semaphore._value == 2
-        await self._drain(queue)
         assert counter.value == 1
 
         # Second release — entry already popped, should be a no-op.
         await queue.release_slot_for(ds)
         assert queue._semaphore._value == 2  # not over-released
-        await self._drain(queue)
         assert counter.value == 1  # not called again
 
     @pytest.mark.asyncio
@@ -655,7 +624,7 @@ class TestReleaseSlotFor:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=3)
-        self._mock_teardown(queue)
+        self._mock_evict(queue)
 
         await queue.ensure_slot("ds1")
         await queue.ensure_slot("ds2")
@@ -674,12 +643,12 @@ class TestReleaseSlotFor:
         assert queue._semaphore._value == 3  # all back
 
     @pytest.mark.asyncio
-    async def test_three_tasks_teardown_fires_only_on_last(self):
-        """With three tasks on the same dataset, teardown fires once on the last exit."""
+    async def test_three_tasks_eviction_fires_only_on_last(self):
+        """With three tasks on the same dataset, eviction fires once on the last exit."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
         ds = "shared-ds"
 
         gate_1 = asyncio.Event()
@@ -707,27 +676,24 @@ class TestReleaseSlotFor:
         await queue.ensure_slot(ds)
 
         await queue.release_slot_for(ds)
-        await self._drain(queue)
         assert counter.value == 0
 
         gate_1.set()
         await t1
-        await self._drain(queue)
         assert counter.value == 0
 
         gate_2.set()
         await t2
-        await self._drain(queue)
         assert counter.value == 1
 
     @pytest.mark.asyncio
-    async def test_teardown_fires_exactly_once_under_stress(self):
-        """Many tasks on the same dataset; teardown fires exactly once total."""
+    async def test_eviction_fires_exactly_once_under_stress(self):
+        """Many tasks on the same dataset; eviction fires exactly once total."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         n_tasks = 20
         queue = DatasetQueue(enabled=True, max_concurrent=n_tasks + 1)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
         ds = "stress-ds"
 
         arrived = 0
@@ -744,17 +710,16 @@ class TestReleaseSlotFor:
             await queue.release_slot_for(ds)
 
         await asyncio.gather(*[asyncio.create_task(worker()) for _ in range(n_tasks)])
-        await self._drain(queue)
         assert counter.value == 1
 
     @pytest.mark.asyncio
-    async def test_backstop_frees_slot_then_remaining_task_fires_teardown(self):
-        """Task-end backstop releases a crashed task's slot without teardown.
-        The surviving task should then be the last holder and fire teardown."""
+    async def test_backstop_frees_slot_then_remaining_task_fires_eviction(self):
+        """Task-end backstop releases a crashed task's slot without eviction.
+        The surviving task should then be the last holder and fire eviction."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
         ds = "backstop-ds"
 
         crashed_ready = asyncio.Event()
@@ -777,7 +742,6 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot(ds)
         await queue.release_slot_for(ds)
-        await self._drain(queue)
         assert counter.value == 1
 
     @pytest.mark.asyncio
@@ -787,7 +751,7 @@ class TestReleaseSlotFor:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
         ds = "combo-ds"
 
         other_ready = asyncio.Event()
@@ -806,16 +770,13 @@ class TestReleaseSlotFor:
         await queue.ensure_slot(ds)  # depth = 2
 
         await queue.release_slot_for(ds)
-        await self._drain(queue)
         assert counter.value == 0  # depth 2 → 1
 
         await queue.release_slot_for(ds)
-        await self._drain(queue)
         assert counter.value == 0  # depth 0, but other task holds it
 
         main_done.set()
         await task
-        await self._drain(queue)
         assert counter.value == 1  # other task was last
 
     @pytest.mark.asyncio
@@ -824,19 +785,17 @@ class TestReleaseSlotFor:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
 
         await queue.ensure_slot("ds-A")
         await queue.ensure_slot("ds-B")
         assert queue._semaphore._value == 3
 
         await queue.release_slot_for("ds-A")
-        await self._drain(queue)
         assert counter.value == 1
         assert queue._semaphore._value == 4
 
         await queue.release_slot_for("ds-B")
-        await self._drain(queue)
         assert counter.value == 2
         assert queue._semaphore._value == 5
 
@@ -846,48 +805,40 @@ class TestReleaseSlotFor:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=2)
-        counter = self._mock_teardown(queue)
+        counter = self._mock_evict(queue)
 
         await queue.ensure_slot(None)
         assert queue._semaphore._value == 1
 
         await queue.release_slot_for(None)
-        await self._drain(queue)
         assert counter.value == 1
         assert queue._semaphore._value == 2
 
     @pytest.mark.asyncio
-    async def test_teardown_exception_does_not_affect_other_datasets(self):
-        """If teardown raises for one dataset, another dataset's slot is unaffected."""
+    async def test_eviction_exception_does_not_affect_other_datasets(self):
+        """If eviction raises for one dataset, another dataset's slot is unaffected."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
         call_count = 0
 
-        queue._detach_subprocess_engines = lambda: [object()]
-
-        async def close_fails_once(engines):
+        def evict_fails_once():
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise RuntimeError("kaboom")
 
-        queue._close_engines = close_fails_once
+        queue._evict_subprocess_engines = evict_fails_once
 
         await queue.ensure_slot("ds-ok")
         await queue.ensure_slot("ds-fail")
 
-        # Background teardown failure for ds-fail is logged, not raised.
-        await queue.release_slot_for("ds-fail")
+        with pytest.raises(RuntimeError, match="kaboom"):
+            await queue.release_slot_for("ds-fail")
 
         # ds-ok is still held and can be released normally.
         await queue.release_slot_for("ds-ok")
-        while queue._background_closes:
-            import asyncio
-
-            await asyncio.gather(*list(queue._background_closes), return_exceptions=True)
         assert call_count == 2
-        assert queue._pending_closes == {}
         assert queue._semaphore._value == 5
 
 
@@ -939,199 +890,92 @@ class TestActiveDatasetIds:
         assert queue.active_dataset_ids() == set()
 
 
-class TestBackgroundTeardownLatch:
-    """The close runs off the response path; detach stays synchronous."""
+class TestEvictSubprocessEngines:
+    """The queue's teardown is eviction only — the engine cache owns the close."""
 
     @pytest.mark.asyncio
-    async def test_detach_is_synchronous_at_release(self):
+    async def test_evict_is_synchronous_at_release(self):
         """Eviction must complete before release returns — a caller on the
         very next line must never fetch a dying engine from the cache.
-        (Regression: deferring eviction into the background task let e2e
-        flows grab an engine the close then killed under them:
-        "LadybugAdapter is closed; a new adapter must be created".)"""
+        (Regression: deferring eviction let e2e flows grab an engine whose
+        close then killed it under them: "LadybugAdapter is closed; a new
+        adapter must be created".)"""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        detached = False
+        evicted = False
 
-        def detach():
-            nonlocal detached
-            detached = True
-            return []
+        def evict():
+            nonlocal evicted
+            evicted = True
 
-        queue._detach_subprocess_engines = detach
+        queue._evict_subprocess_engines = evict
         await queue.ensure_slot("ds-S")
         await queue.release_slot_for("ds-S")
-        assert detached, "detach must run inline at release, not in the background task"
+        assert evicted, "eviction must run inline at release"
 
-    @pytest.mark.asyncio
-    async def test_release_returns_before_teardown_completes(self):
-        import asyncio
-
-        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
-
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
-        started = asyncio.Event()
-        finish = asyncio.Event()
-        done = False
-
-        queue._detach_subprocess_engines = lambda: [object()]
-
-        async def slow_close(engines):
-            nonlocal done
-            started.set()
-            await finish.wait()
-            done = True
-
-        queue._close_engines = slow_close
-
-        await queue.ensure_slot("ds-L")
-        await queue.release_slot_for("ds-L")  # must NOT wait for the close
-        assert not done, "release_slot_for waited on the teardown"
-
-        await started.wait()
-        finish.set()
-        while queue._background_closes:
-            await asyncio.gather(*list(queue._background_closes), return_exceptions=True)
-        assert done
-        assert queue._pending_closes == {}
-
-    @pytest.mark.asyncio
-    async def test_next_acquirer_waits_on_pending_close(self):
-        import asyncio
-
-        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
-
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
-        finish = asyncio.Event()
-
-        queue._detach_subprocess_engines = lambda: [object()]
-
-        async def slow_close(engines):
-            await finish.wait()
-
-        queue._close_engines = slow_close
-
-        await queue.ensure_slot("ds-L")
-        await queue.release_slot_for("ds-L")
-
-        async def reacquire():
-            await queue.ensure_slot("ds-L")
-            return True
-
-        acquirer = asyncio.create_task(reacquire())
-        await asyncio.sleep(0.05)
-        assert not acquirer.done(), "acquirer must wait for the in-flight close"
-
-        finish.set()
-        assert await asyncio.wait_for(acquirer, timeout=1)
-        await queue.release_slot_for("ds-L")
-
-    @pytest.mark.asyncio
-    async def test_failed_teardown_still_opens_the_latch(self):
-        import asyncio
-
+    def test_eviction_routes_through_cache_evict(self):
+        """_evict_subprocess_engines must evict via the cache helpers — it must
+        NOT fetch engines or close them itself: a fetched lease proxy defers
+        the real close behind the lease and hides it from the cache's
+        pending-close registry, and a loop-scheduled close starves when a
+        synchronous engine spawn blocks the loop (the "Lock is held by PID N"
+        e2e failures)."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
 
-        queue._detach_subprocess_engines = lambda: [object()]
+        g_cfg = {"graph_database_subprocess_enabled": True, "graph_database_name": "g"}
+        v_cfg = {"vector_db_subprocess_enabled": True, "vector_db_name": "v"}
 
-        async def broken_close(engines):
-            raise RuntimeError("boom")
+        with (
+            patch(
+                "cognee.infrastructure.databases.graph.config.get_graph_context_config",
+                return_value=g_cfg,
+            ),
+            patch(
+                "cognee.infrastructure.databases.vector.config.get_vectordb_context_config",
+                return_value=v_cfg,
+            ),
+            patch(
+                "cognee.infrastructure.databases.graph.get_graph_engine.evict_graph_engine"
+            ) as evict_graph,
+            patch(
+                "cognee.infrastructure.databases.vector.create_vector_engine.evict_vector_engine"
+            ) as evict_vector,
+            patch(
+                "cognee.infrastructure.databases.graph.get_graph_engine.create_graph_engine"
+            ) as create_graph,
+        ):
+            queue._evict_subprocess_engines()
 
-        queue._close_engines = broken_close
+        evict_graph.assert_called_once_with(**g_cfg)
+        evict_vector.assert_called_once_with(**v_cfg)
+        create_graph.assert_not_called()
 
-        await queue.ensure_slot("ds-L")
-        await queue.release_slot_for("ds-L")
-        while queue._background_closes:
-            await asyncio.gather(*list(queue._background_closes), return_exceptions=True)
-        assert queue._pending_closes == {}
-        # And the dataset is acquirable again.
-        await asyncio.wait_for(queue.ensure_slot("ds-L"), timeout=1)
-        await queue.release_slot_for("ds-L")
-
-
-class TestOrphanedCloseAdoption:
-    """A close whose event loop died is finished by the next acquirer."""
-
-    def test_two_loop_phases_adopt_and_close(self):
-        """The e2e script shape: asyncio.run() #1 schedules a close and dies
-        before it runs; asyncio.run() #2 must adopt it — closing the old
-        engines on the live loop — before proceeding."""
-        import asyncio
-
+    def test_eviction_skips_non_subprocess_engines(self):
+        """Engines running in-process are not evicted at release."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         queue = DatasetQueue(enabled=True, max_concurrent=5)
-        closed = []
 
-        class FakeEngine:
-            async def close(self):
-                closed.append(self)
+        with (
+            patch(
+                "cognee.infrastructure.databases.graph.config.get_graph_context_config",
+                return_value={"graph_database_subprocess_enabled": False},
+            ),
+            patch(
+                "cognee.infrastructure.databases.vector.config.get_vectordb_context_config",
+                return_value={"vector_db_subprocess_enabled": False},
+            ),
+            patch(
+                "cognee.infrastructure.databases.graph.get_graph_engine.evict_graph_engine"
+            ) as evict_graph,
+            patch(
+                "cognee.infrastructure.databases.vector.create_vector_engine.evict_vector_engine"
+            ) as evict_vector,
+        ):
+            queue._evict_subprocess_engines()
 
-        engine = FakeEngine()
-        queue._detach_subprocess_engines = lambda: [engine]
-
-        async def never_finishes(engines):
-            await asyncio.Event().wait()
-
-        queue._close_engines = never_finishes
-
-        async def phase_one():
-            await queue.ensure_slot("ds-O")
-            await queue.release_slot_for("ds-O")
-            # Loop ends here with the close task pending -> cancelled.
-
-        asyncio.run(phase_one())
-        assert "ds:ds-O" in queue._pending_closes, "record must survive loop teardown"
-        assert closed == [], "close must not have completed on the dead loop"
-
-        async def phase_two():
-            await queue.ensure_slot("ds-O")
-            await queue.release_slot_for("ds-O")
-
-        asyncio.run(phase_two())
-        assert closed == [engine], "the next acquirer must adopt and finish the close"
-
-    def test_adoption_tolerates_already_closed_engines(self):
-        """After a mid-close cancellation some engines are already closed;
-        a double-close error must not block the adopting acquirer."""
-        import asyncio
-
-        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
-
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
-        closed = []
-
-        class BrokenEngine:
-            async def close(self):
-                raise RuntimeError("already closed")
-
-        class GoodEngine:
-            async def close(self):
-                closed.append("good")
-
-        queue._detach_subprocess_engines = lambda: [BrokenEngine(), GoodEngine()]
-
-        async def never_finishes(engines):
-            await asyncio.Event().wait()
-
-        queue._close_engines = never_finishes
-
-        async def phase_one():
-            await queue.ensure_slot("ds-P")
-            await queue.release_slot_for("ds-P")
-
-        asyncio.run(phase_one())
-
-        async def phase_two():
-            await queue.ensure_slot("ds-P")  # must not raise despite BrokenEngine
-            # Nothing new to detach: this release must not create a fresh
-            # pending record — we are asserting the adopted one was consumed.
-            queue._detach_subprocess_engines = lambda: []
-            await queue.release_slot_for("ds-P")
-
-        asyncio.run(phase_two())
-        assert closed == ["good"], "surviving engines still get closed"
-        assert "ds:ds-P" not in queue._pending_closes
+        evict_graph.assert_not_called()
+        evict_vector.assert_not_called()

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -420,11 +420,16 @@ class TestReleaseSlotFor:
 
     @staticmethod
     async def _drain(queue):
-        """Wait for any backgrounded teardown tasks to finish."""
+        """Wait for any backgrounded teardown tasks to finish.
+
+        return_exceptions: a failing teardown propagates out of its task (it
+        is surfaced by the done-callback, not eaten) — draining must not
+        re-raise it into the test.
+        """
         import asyncio
 
         while queue._background_closes:
-            await asyncio.gather(*list(queue._background_closes))
+            await asyncio.gather(*list(queue._background_closes), return_exceptions=True)
 
     @staticmethod
     def _mock_teardown(queue):
@@ -870,7 +875,7 @@ class TestReleaseSlotFor:
         while queue._background_closes:
             import asyncio
 
-            await asyncio.gather(*list(queue._background_closes))
+            await asyncio.gather(*list(queue._background_closes), return_exceptions=True)
         assert call_count == 2
         assert queue._pending_closes == {}
         assert queue._semaphore._value == 5
@@ -953,7 +958,7 @@ class TestBackgroundTeardownLatch:
         await started.wait()
         finish.set()
         while queue._background_closes:
-            await asyncio.gather(*list(queue._background_closes))
+            await asyncio.gather(*list(queue._background_closes), return_exceptions=True)
         assert done
         assert queue._pending_closes == {}
 
@@ -1002,7 +1007,7 @@ class TestBackgroundTeardownLatch:
         await queue.ensure_slot("ds-L")
         await queue.release_slot_for("ds-L")
         while queue._background_closes:
-            await asyncio.gather(*list(queue._background_closes))
+            await asyncio.gather(*list(queue._background_closes), return_exceptions=True)
         assert queue._pending_closes == {}
         # And the dataset is acquirable again.
         await asyncio.wait_for(queue.ensure_slot("ds-L"), timeout=1)

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -419,6 +419,14 @@ class TestReleaseSlotFor:
         yield
 
     @staticmethod
+    async def _drain(queue):
+        """Wait for any backgrounded teardown tasks to finish."""
+        import asyncio
+
+        while queue._background_closes:
+            await asyncio.gather(*list(queue._background_closes))
+
+    @staticmethod
     def _mock_teardown(queue):
         """Replace _teardown_subprocess_engines with a counter."""
         call_count = 0
@@ -445,6 +453,7 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot("ds-A")
         await queue.release_slot_for("ds-A")
+        await self._drain(queue)
         assert counter.value == 1
 
     @pytest.mark.asyncio
@@ -458,9 +467,11 @@ class TestReleaseSlotFor:
         await queue.ensure_slot("ds-B")  # depth = 2
 
         await queue.release_slot_for("ds-B")
+        await self._drain(queue)
         assert counter.value == 0  # inner exit — skipped
 
         await queue.release_slot_for("ds-B")
+        await self._drain(queue)
         assert counter.value == 1  # outer exit — fires
 
     @pytest.mark.asyncio
@@ -485,10 +496,12 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot(ds)
         await queue.release_slot_for(ds)
+        await self._drain(queue)
         assert counter.value == 0  # other task still holds the dataset
 
         check_done.set()
         await task
+        await self._drain(queue)
         assert counter.value == 1  # other task was last
 
     @pytest.mark.asyncio
@@ -513,10 +526,12 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot(ds)
         await queue.release_slot_for(ds)
+        await self._drain(queue)
         assert counter.value == 0  # not last
 
         main_released.set()
         await task
+        await self._drain(queue)
         assert counter.value == 1  # other task was last, teardown fired
 
     @pytest.mark.asyncio
@@ -540,6 +555,7 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot("dataset-OURS")
         await queue.release_slot_for("dataset-OURS")
+        await self._drain(queue)
         assert counter.value == 1  # different dataset — we're last for ours
 
         check_done.set()
@@ -553,6 +569,7 @@ class TestReleaseSlotFor:
         counter = self._mock_teardown(queue)
 
         await queue.release_slot_for("any-dataset")
+        await self._drain(queue)
         assert counter.value == 0
 
     @pytest.mark.asyncio
@@ -570,8 +587,11 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot(ds)
 
-        with pytest.raises(ValueError, match="engine teardown failed"):
-            await queue.release_slot_for(ds)
+        # The teardown runs in the background: its failure is logged, never
+        # raised into the caller (whose response has already returned).
+        await queue.release_slot_for(ds)
+        await self._drain(queue)
+        assert queue._pending_closes == {}
 
         # Replace the failing mock so the verification calls below don't blow up.
         self._mock_teardown(queue)
@@ -589,6 +609,7 @@ class TestReleaseSlotFor:
         counter = self._mock_teardown(queue)
 
         await queue.release_slot_for("never-acquired")
+        await self._drain(queue)
         assert counter.value == 0  # no entry — teardown not called
         assert queue._semaphore._value == 5  # nothing consumed
 
@@ -606,11 +627,13 @@ class TestReleaseSlotFor:
 
         await queue.release_slot_for(ds)
         assert queue._semaphore._value == 2
+        await self._drain(queue)
         assert counter.value == 1
 
         # Second release — entry already popped, should be a no-op.
         await queue.release_slot_for(ds)
         assert queue._semaphore._value == 2  # not over-released
+        await self._drain(queue)
         assert counter.value == 1  # not called again
 
     @pytest.mark.asyncio
@@ -671,14 +694,17 @@ class TestReleaseSlotFor:
         await queue.ensure_slot(ds)
 
         await queue.release_slot_for(ds)
+        await self._drain(queue)
         assert counter.value == 0
 
         gate_1.set()
         await t1
+        await self._drain(queue)
         assert counter.value == 0
 
         gate_2.set()
         await t2
+        await self._drain(queue)
         assert counter.value == 1
 
     @pytest.mark.asyncio
@@ -705,6 +731,7 @@ class TestReleaseSlotFor:
             await queue.release_slot_for(ds)
 
         await asyncio.gather(*[asyncio.create_task(worker()) for _ in range(n_tasks)])
+        await self._drain(queue)
         assert counter.value == 1
 
     @pytest.mark.asyncio
@@ -737,6 +764,7 @@ class TestReleaseSlotFor:
 
         await queue.ensure_slot(ds)
         await queue.release_slot_for(ds)
+        await self._drain(queue)
         assert counter.value == 1
 
     @pytest.mark.asyncio
@@ -765,13 +793,16 @@ class TestReleaseSlotFor:
         await queue.ensure_slot(ds)  # depth = 2
 
         await queue.release_slot_for(ds)
+        await self._drain(queue)
         assert counter.value == 0  # depth 2 → 1
 
         await queue.release_slot_for(ds)
+        await self._drain(queue)
         assert counter.value == 0  # depth 0, but other task holds it
 
         main_done.set()
         await task
+        await self._drain(queue)
         assert counter.value == 1  # other task was last
 
     @pytest.mark.asyncio
@@ -787,10 +818,12 @@ class TestReleaseSlotFor:
         assert queue._semaphore._value == 3
 
         await queue.release_slot_for("ds-A")
+        await self._drain(queue)
         assert counter.value == 1
         assert queue._semaphore._value == 4
 
         await queue.release_slot_for("ds-B")
+        await self._drain(queue)
         assert counter.value == 2
         assert queue._semaphore._value == 5
 
@@ -806,6 +839,7 @@ class TestReleaseSlotFor:
         assert queue._semaphore._value == 1
 
         await queue.release_slot_for(None)
+        await self._drain(queue)
         assert counter.value == 1
         assert queue._semaphore._value == 2
 
@@ -828,12 +862,17 @@ class TestReleaseSlotFor:
         await queue.ensure_slot("ds-ok")
         await queue.ensure_slot("ds-fail")
 
-        with pytest.raises(RuntimeError, match="kaboom"):
-            await queue.release_slot_for("ds-fail")
+        # Background teardown failure for ds-fail is logged, not raised.
+        await queue.release_slot_for("ds-fail")
 
         # ds-ok is still held and can be released normally.
         await queue.release_slot_for("ds-ok")
+        while queue._background_closes:
+            import asyncio
+
+            await asyncio.gather(*list(queue._background_closes))
         assert call_count == 2
+        assert queue._pending_closes == {}
         assert queue._semaphore._value == 5
 
 
@@ -883,3 +922,88 @@ class TestActiveDatasetIds:
         assert queue.active_dataset_ids() == {"dataset-1"}  # depth 1 remains
         await queue.release_slot_for("dataset-1")
         assert queue.active_dataset_ids() == set()
+
+
+class TestBackgroundTeardownLatch:
+    """The teardown runs off the response path; the latch keeps correctness."""
+
+    @pytest.mark.asyncio
+    async def test_release_returns_before_teardown_completes(self):
+        import asyncio
+
+        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        started = asyncio.Event()
+        finish = asyncio.Event()
+        done = False
+
+        async def slow_teardown():
+            nonlocal done
+            started.set()
+            await finish.wait()
+            done = True
+
+        queue._teardown_subprocess_engines = slow_teardown
+
+        await queue.ensure_slot("ds-L")
+        await queue.release_slot_for("ds-L")  # must NOT wait for the close
+        assert not done, "release_slot_for waited on the teardown"
+
+        await started.wait()
+        finish.set()
+        while queue._background_closes:
+            await asyncio.gather(*list(queue._background_closes))
+        assert done
+        assert queue._pending_closes == {}
+
+    @pytest.mark.asyncio
+    async def test_next_acquirer_waits_on_pending_close(self):
+        import asyncio
+
+        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        finish = asyncio.Event()
+
+        async def slow_teardown():
+            await finish.wait()
+
+        queue._teardown_subprocess_engines = slow_teardown
+
+        await queue.ensure_slot("ds-L")
+        await queue.release_slot_for("ds-L")
+
+        async def reacquire():
+            await queue.ensure_slot("ds-L")
+            return True
+
+        acquirer = asyncio.create_task(reacquire())
+        await asyncio.sleep(0.05)
+        assert not acquirer.done(), "acquirer must wait for the in-flight close"
+
+        finish.set()
+        assert await asyncio.wait_for(acquirer, timeout=1)
+        await queue.release_slot_for("ds-L")
+
+    @pytest.mark.asyncio
+    async def test_failed_teardown_still_opens_the_latch(self):
+        import asyncio
+
+        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+        queue = DatasetQueue(enabled=True, max_concurrent=5)
+
+        async def broken_teardown():
+            raise RuntimeError("boom")
+
+        queue._teardown_subprocess_engines = broken_teardown
+
+        await queue.ensure_slot("ds-L")
+        await queue.release_slot_for("ds-L")
+        while queue._background_closes:
+            await asyncio.gather(*list(queue._background_closes))
+        assert queue._pending_closes == {}
+        # And the dataset is acquirable again.
+        await asyncio.wait_for(queue.ensure_slot("ds-L"), timeout=1)
+        await queue.release_slot_for("ds-L")

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -1050,3 +1050,88 @@ class TestBackgroundTeardownLatch:
         # And the dataset is acquirable again.
         await asyncio.wait_for(queue.ensure_slot("ds-L"), timeout=1)
         await queue.release_slot_for("ds-L")
+
+
+class TestOrphanedCloseAdoption:
+    """A close whose event loop died is finished by the next acquirer."""
+
+    def test_two_loop_phases_adopt_and_close(self):
+        """The e2e script shape: asyncio.run() #1 schedules a close and dies
+        before it runs; asyncio.run() #2 must adopt it — closing the old
+        engines on the live loop — before proceeding."""
+        import asyncio
+
+        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        closed = []
+
+        class FakeEngine:
+            async def close(self):
+                closed.append(self)
+
+        engine = FakeEngine()
+        queue._detach_subprocess_engines = lambda: [engine]
+
+        async def never_finishes(engines):
+            await asyncio.Event().wait()
+
+        queue._close_engines = never_finishes
+
+        async def phase_one():
+            await queue.ensure_slot("ds-O")
+            await queue.release_slot_for("ds-O")
+            # Loop ends here with the close task pending -> cancelled.
+
+        asyncio.run(phase_one())
+        assert "ds:ds-O" in queue._pending_closes, "record must survive loop teardown"
+        assert closed == [], "close must not have completed on the dead loop"
+
+        async def phase_two():
+            await queue.ensure_slot("ds-O")
+            await queue.release_slot_for("ds-O")
+
+        asyncio.run(phase_two())
+        assert closed == [engine], "the next acquirer must adopt and finish the close"
+
+    def test_adoption_tolerates_already_closed_engines(self):
+        """After a mid-close cancellation some engines are already closed;
+        a double-close error must not block the adopting acquirer."""
+        import asyncio
+
+        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        closed = []
+
+        class BrokenEngine:
+            async def close(self):
+                raise RuntimeError("already closed")
+
+        class GoodEngine:
+            async def close(self):
+                closed.append("good")
+
+        queue._detach_subprocess_engines = lambda: [BrokenEngine(), GoodEngine()]
+
+        async def never_finishes(engines):
+            await asyncio.Event().wait()
+
+        queue._close_engines = never_finishes
+
+        async def phase_one():
+            await queue.ensure_slot("ds-P")
+            await queue.release_slot_for("ds-P")
+
+        asyncio.run(phase_one())
+
+        async def phase_two():
+            await queue.ensure_slot("ds-P")  # must not raise despite BrokenEngine
+            # Nothing new to detach: this release must not create a fresh
+            # pending record — we are asserting the adopted one was consumed.
+            queue._detach_subprocess_engines = lambda: []
+            await queue.release_slot_for("ds-P")
+
+        asyncio.run(phase_two())
+        assert closed == ["good"], "surviving engines still get closed"
+        assert "ds:ds-P" not in queue._pending_closes


### PR DESCRIPTION
## Problem
With backend access control on, every search/recall exits its per-dataset context by **awaiting the destruction of the subprocess engines it just used**: `release_slot_for` → `await _teardown_subprocess_engines()` → `await engine.close()` × 2. Measured on a full-corpus benchmark (War and Peace, ladybug + lancedb + sqlite, access control on): **~1.6 s of every ~3.4 s serial recall is the caller waiting for cleanup** of resources its response no longer needs. The teardown only fires when *no other task holds the dataset* — i.e. precisely when its synchronous-ness protects no one.

## Fix
`release_slot_for` now schedules the teardown as a background task and returns immediately; slot bookkeeping stays synchronous. Correctness moves to a **per-dataset pending-close latch**: the next `ensure_slot` for the same dataset awaits any in-flight close before proceeding, so file locks are provably free before a fresh engine opens the same files — the wait moves from the response path (never load-bearing there) to the next acquirer (the only place it is). The background task inherits the dataset's engine config via contextvars; teardown failures open the latch and are logged instead of detonating inside a request that already returned. Same pending-close idea `closing_lru_cache` already uses internally.

## Measured effect (full-book benchmark, all-on configuration)
- **Isolated search on a running service** (arrives after idle — the normal interactive case): **3,460 ms → 1,856 ms (1.86x)**. The ~1.6 s close now overlaps user think-time.
- **First call after process start**: 3,874 → 3,465 ms (dominated by one-time init, little to save).
- **Zero-pause saturated loop**: unchanged by design — the next query waits on the latch instead of the previous one waiting on the close (file-lock safety preserved).
- 12-way concurrency: behavior unchanged (teardown was already amortized under load); no deadlocks across 3 rounds.

The remaining ~1.0 s over the 851 ms in-process floor is engine respawn + cold caches — a follow-up (idle grace period / LRU-only reclamation) can address that; this PR deliberately changes only *who waits*, not *whether engines are torn down*.


Teardown exceptions no longer propagate from `release_slot_for` — they are logged from the background task (the caller's response has already returned). Two tests asserting the old propagation were updated; three new tests pin the latch: release returns before the close completes, the next acquirer waits on an in-flight close, and a failed close still opens the latch.

## Testing
- `test_dataset_queue.py` + context-variable suites: 43 pass (updated for the async contract + new latch tests)
- Full retrieval benchmark re-run on the same ingested corpus: all arms healthy, mechanism counters unchanged (teardown still fires 1.00×/query — just off the response path)
- Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Contract change
Teardown exceptions no longer propagate from `release_slot_for` — but they are **not eaten** either. No exception is expected there, so none is caught: the background close runs `try/finally` (the latch must open either way — a failed close must not brick the dataset), and the task's done-callback surfaces any failure at **ERROR with its full traceback**. If a close genuinely left file locks behind, the next engine open fails loudly inside a real request, so nothing is silently lost — and no innocent caller is failed for cleanup it didn't own. Two tests asserting the old propagation were updated; three new tests pin the latch: release returns before the close completes, the next acquirer waits on an in-flight close, and a failed close still opens the latch.

## Testing
- `test_dataset_queue.py` + context-variable suites: 43 pass (updated for the async contract + new latch tests)
- Full retrieval benchmark re-run on the same ingested corpus: all arms healthy, mechanism counters unchanged (teardown still fires 1.00×/query — just off the response path)
- Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
