### PR TITLE
fix: Skip unused graph projection in improve stage 3

### DIFF
--- a/cognee/api/v1/improve/improve.py
+++ b/cognee/api/v1/improve/improve.py
@@ -243,6 +243,14 @@ async def improve(
 
                 kwargs["node_type"] = NodeSet
 
+            # The default memify tasks never read the projected graph: they
+            # stream triplets straight from the graph DB (or no-op). Pass the
+            # non-empty sentinel the other improve stages already use so
+            # memify skips the full-graph projection. Custom tasks/data keep
+            # the projection, since a caller-supplied task may consume it.
+            if not any(kwargs.get(key) for key in ("extraction_tasks", "enrichment_tasks", "data")):
+                kwargs["data"] = [{}]
+
             result = await memify(
                 dataset=dataset,
                 node_name=node_name,

--- a/cognee/tests/unit/api/v1/improve/test_improve_default_projection_skip.py
+++ b/cognee/tests/unit/api/v1/improve/test_improve_default_projection_skip.py
@@ -1,0 +1,84 @@
+"""Unit tests for improve() stage 3's projection-skip sentinel.
+
+The default memify tasks never read the projected graph (they stream triplets
+from the graph DB or no-op), so improve() passes the non-empty ``data=[{}]``
+sentinel — the same one every other improve stage uses — to skip the
+full-graph projection. Caller-supplied tasks/data must keep the projection,
+since a custom task may consume the fragment.
+"""
+
+import importlib
+import types
+from uuid import uuid4
+
+import pytest
+
+
+def _make_user():
+    return types.SimpleNamespace(id=uuid4())
+
+
+@pytest.fixture
+def improve_mod():
+    return importlib.import_module("cognee.api.v1.improve.improve")
+
+
+@pytest.fixture
+def memify_calls(monkeypatch, improve_mod):
+    """Stub out everything improve() needs before stage 3 and capture the memify call."""
+    user = _make_user()
+    dataset = types.SimpleNamespace(id=uuid4(), owner_id=user.id)
+
+    async def fake_resolve(_dataset, _user):
+        return _user, [dataset]
+
+    monkeypatch.setattr(improve_mod, "resolve_authorized_user_datasets", fake_resolve)
+
+    state_mod = importlib.import_module("cognee.api.v1.serve.state")
+    monkeypatch.setattr(state_mod, "get_remote_client", lambda: None)
+
+    utils_mod = importlib.import_module("cognee.shared.utils")
+    monkeypatch.setattr(utils_mod, "send_telemetry", lambda *args, **kwargs: None)
+
+    calls = []
+    memify_mod = importlib.import_module("cognee.modules.memify")
+
+    async def fake_memify(**kwargs):
+        calls.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(memify_mod, "memify", fake_memify)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_default_call_skips_projection_via_sentinel(memify_calls):
+    improve_mod = importlib.import_module("cognee.api.v1.improve.improve")
+
+    await improve_mod.improve(user=_make_user())
+
+    assert len(memify_calls) == 1
+    assert memify_calls[0]["data"] == [{}]
+
+
+@pytest.mark.asyncio
+async def test_custom_extraction_tasks_keep_projection(memify_calls):
+    improve_mod = importlib.import_module("cognee.api.v1.improve.improve")
+    custom_tasks = [object()]
+
+    await improve_mod.improve(user=_make_user(), extraction_tasks=custom_tasks)
+
+    assert len(memify_calls) == 1
+    assert memify_calls[0]["extraction_tasks"] == custom_tasks
+    assert memify_calls[0].get("data") is None
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_data_is_preserved(memify_calls):
+    improve_mod = importlib.import_module("cognee.api.v1.improve.improve")
+    caller_data = ["my content"]
+
+    await improve_mod.improve(user=_make_user(), data=caller_data)
+
+    assert len(memify_calls) == 1
+    assert memify_calls[0]["data"] == caller_data


### PR DESCRIPTION
## Description

`improve()`'s stage 3 (default enrichment) called `memify()` with no `data`, which makes memify project the **entire graph** into memory (`get_memory_fragment` → `project_graph_from_db` → `adapter.get_graph_data()`, logged as "Retrieving full graph."). That projection has zero consumers on the default path:

- `get_triplet_datapoints` only checks `data` for a log line (it already special-cases the `[{}]` sentinel), then streams triplets straight from the graph DB via `get_triplets_batch(offset, limit)` in batches of 100.
- `index_data_points` explicitly skips non-DataPoint inputs (its comment names `CogneeGraph` as the expected skip case), so with `triplet_embedding=False` (the default) the fragment is discarded untouched.
- On an empty graph, the projection's `EntityNotFoundError` is swallowed inside `get_memory_fragment` anyway.

Every *other* improve stage (feedback weights, persist sessions, persist traces, global context index) already passes the non-empty `data=[{}]` sentinel to bypass the projection. Stage 3 was the only call that didn't — and the only one paying O(graph-size) memory plus a full `get_graph_data()` scan on every `improve()` run, including every session-end auto-improve.

## Change

Two lines in `cognee/api/v1/improve/improve.py`: pass `data=[{}]` to the stage-3 memify call, **only when the caller supplied no custom `extraction_tasks`, `enrichment_tasks`, or `data`**. Callers whose custom tasks consume the projected fragment keep today's behavior exactly.

Enrichment output is unchanged in both configurations:

| Config | Pipeline | Before | After |
|---|---|---|---|
| `triplet_embedding=True` | `get_triplet_datapoints → index_data_points` | fragment projected, ignored; triplets streamed from DB | same triplets streamed from DB |
| `triplet_embedding=False` (default) | `index_data_points` only | fragment projected, skipped by no-metadata guard | sentinel skipped by same guard |

## Tests

`cognee/tests/unit/api/v1/improve/test_improve_default_projection_skip.py`:

- default `improve()` → memify receives `data == [{}]`
- custom `extraction_tasks` → sentinel NOT injected (projection preserved)
- caller-supplied `data` → passed through untouched

## Notes

- Pre-existing quirk, unchanged by this PR: `improve(node_name=[...])` never actually restricted default enrichment — the projection was filtered but discarded, while triplets streamed from the whole DB. Same before and after.
- Follow-up candidate: make `memify()` itself skip/lazily defer projection when running its own default tasks, so direct `cognee.memify()` callers get the same win.
