### PR TITLE
feat: Load nightly perf reports into MotherDuck (SDK-37)

### DIFF
--- a/.github/scripts/motherduck_nightly_etl.py
+++ b/.github/scripts/motherduck_nightly_etl.py
@@ -1,0 +1,215 @@
+"""Load nightly performance reports from S3 into MotherDuck (SDK-37).
+
+Every performance job already uploads its full report JSON to S3 before the
+Slack message is built:
+
+    s3://<bucket>/performance_results/{backend}/{label}/{mode}_{TS}.json
+
+That JSON carries far more than Slack shows — every percentile
+(min/max/mean/p50/p75/p90/p95/p99) for every metric, plus per-run detail in
+`raw_runs`. This script points MotherDuck at those objects and shapes them into
+a small set of views the dashboards read.
+
+Design notes:
+
+* The read is driven off the S3 object list, not off the workflow's job
+  outputs. That keeps every percentile (Slack carries only p50/p90/p99 for four
+  metrics) and means a first run backfills the whole bucket rather than
+  starting from empty.
+* `raw_perf_reports` stores each report as a whole JSON value instead of an
+  inferred schema. The backends emit genuinely different metric sets (cloud has
+  tenant_* and, when it does not create a tenant, no prune_time_s), so a typed
+  table would drift and break. All shaping happens in the views.
+* The INSERT is an anti-join on the S3 key, so the script is idempotent and the
+  backfill and the nightly increment are the same statement.
+
+Env:
+  motherduck_token       — MotherDuck token (duckdb reads this exact name)
+  MD_TARGET              — target catalog.schema (default: ci_analytics.nightly)
+  AWS_ACCESS_KEY_ID      — S3 read credentials for the reports bucket
+  AWS_SECRET_ACCESS_KEY
+  AWS_SESSION_TOKEN      — optional, only for temporary credentials
+  AWS_DEFAULT_REGION     — default: eu-west-1
+  PERF_BUCKET            — default: github-runner-cognee-tests
+  PERF_PREFIX            — default: performance_results
+"""
+
+import os
+import sys
+
+import duckdb
+
+MD_TARGET = os.environ.get("MD_TARGET", "ci_analytics.nightly")
+CATALOG, SCHEMA = MD_TARGET.split(".", 1)
+BUCKET = os.environ.get("PERF_BUCKET", "github-runner-cognee-tests")
+PREFIX = os.environ.get("PERF_PREFIX", "performance_results").strip("/")
+REGION = os.environ.get("AWS_DEFAULT_REGION", "eu-west-1")
+ROOT = f"s3://{BUCKET}/{PREFIX}"
+
+TGT = f'"{CATALOG}"."{SCHEMA}"'
+
+# Two globs rather than '**': the bucket holds both the current
+# {backend}/{label}/ layout and the pre-2026-06-04 {label}/ layout that predates
+# 9301645b7 ("add postgres to nightly CI runs").
+GLOBS = [f"{ROOT}/*/*.json", f"{ROOT}/*/*/*.json"]
+
+VIEWS = {
+    # One row per report: the run header.
+    "v_perf_runs": """
+        WITH parsed AS (
+            SELECT s3_key, uploaded_at, report,
+                   regexp_extract(s3_key,
+                       'performance_results/(?:([^/]+)/)?([^/]+)/([^/]+)\\.json$',
+                       ['backend_raw', 'label', 'stem']) AS p
+            FROM {t}.raw_perf_reports
+        ),
+        split AS (
+            SELECT *,
+                   -- mode can itself contain '_' ("mock_llm"), so anchor on the
+                   -- trailing timestamp instead of splitting on the first '_'.
+                   regexp_extract(p.stem,
+                       '^(.*)_(\\d{{4}}-\\d{{2}}-\\d{{2}}_\\d{{2}}-\\d{{2}}-\\d{{2}}Z)$',
+                       ['mode', 'ts']) AS s,
+                   coalesce(nullif(p.backend_raw, ''), 'file_based') AS backend,
+                   p.backend_raw = '' AS legacy_path
+            FROM parsed
+        )
+        SELECT
+            s3_key,
+            -- run_ts is deliberately TIMESTAMP and there is no DATE column:
+            -- Superset/Preset cannot serialize a DATE as a pivot key
+            -- ("keys must be str, int, float, bool or None, not datetime.date").
+            -- Callers that want a day should cast: run_ts::DATE.
+            strptime(s.ts, '%Y-%m-%d_%H-%M-%SZ')            AS run_ts,
+            backend,
+            legacy_path,
+            CASE WHEN backend LIKE 'rust\\_%' ESCAPE '\\' THEN 'rust' ELSE 'python' END AS sdk,
+            regexp_replace(backend, '^rust_', '')           AS store,
+            p.label                                         AS label,
+            s.mode                                          AS mode,
+            concat_ws('/',
+                CASE WHEN backend LIKE 'rust\\_%' ESCAPE '\\' THEN 'rust' ELSE 'python' END,
+                regexp_replace(backend, '^rust_', ''), p.label, s.mode) AS suite,
+            (report ->> '$.num_runs')::INT                   AS num_runs,
+            (report ->> '$.succeeded')::INT                  AS succeeded,
+            (report ->> '$.failed')::INT                     AS failed,
+            (report ->> '$.succeeded')::INT = (report ->> '$.num_runs')::INT AS all_passed,
+            report ->> '$.git_sha'                           AS git_sha,
+            report ->> '$.run_id'                            AS run_id,
+            report ->> '$.config.llm_model'                  AS llm_model,
+            report ->> '$.config.embedding_model'            AS embedding_model,
+            report ->> '$.config.embedding_dimensions'       AS embedding_dimensions,
+            (report ->> '$.config.mock_llm')::BOOLEAN        AS mock_llm,
+            report ->> '$.config.tenant_url'                 AS tenant_url,
+            uploaded_at
+        FROM split
+    """,
+    # Long format — one row per run x metric x stat. Charts filter to a single
+    # metric + stat and group by suite; this survives per-backend metric drift.
+    "v_perf_metrics": """
+        WITH per_metric AS (
+            SELECT r.s3_key, r.run_ts, r.suite, r.sdk, r.store, r.label, r.mode,
+                   r.git_sha, r.all_passed,
+                   m.metric                            AS metric,
+                   raw.report -> '$.stats' -> m.metric AS mstats
+            FROM {t}.v_perf_runs r
+            JOIN {t}.raw_perf_reports raw USING (s3_key),
+                 UNNEST(json_keys(raw.report, '$.stats')) AS m(metric)
+        )
+        SELECT s3_key, run_ts, suite, sdk, store, label, mode, git_sha, all_passed,
+               metric, st.stat AS stat, (mstats ->> st.stat)::DOUBLE AS value_s
+        FROM per_metric, UNNEST(json_keys(mstats)) AS st(stat)
+    """,
+    # Latest run vs the median of the previous seven, per suite/metric/stat.
+    "v_perf_regression": """
+        WITH ranked AS (
+            SELECT *, row_number() OVER (
+                       PARTITION BY suite, metric, stat ORDER BY run_ts DESC) AS rn
+            FROM {t}.v_perf_metrics
+            WHERE stat IN ('p50', 'p90', 'p99')
+        )
+        SELECT suite, metric, stat,
+               max(run_ts) FILTER (WHERE rn = 1)                   AS latest_ts,
+               max(value_s) FILTER (WHERE rn = 1)                  AS latest_s,
+               median(value_s) FILTER (WHERE rn BETWEEN 2 AND 8)   AS baseline_s,
+               round(100.0 * (max(value_s) FILTER (WHERE rn = 1)
+                     - median(value_s) FILTER (WHERE rn BETWEEN 2 AND 8))
+                     / nullif(median(value_s) FILTER (WHERE rn BETWEEN 2 AND 8), 0), 1)
+                                                                   AS pct_change
+        FROM ranked WHERE rn <= 8
+        GROUP BY suite, metric, stat
+    """,
+}
+
+
+def main() -> int:
+    con = duckdb.connect("md:")
+
+    # The S3 read runs on MotherDuck's cloud engine, not on the runner, so the
+    # credential has to be registered server-side -- a session-local DuckDB
+    # secret is not visible to it. Use a read-only IAM key scoped to this
+    # bucket: it is stored (encrypted) in MotherDuck until the next run
+    # replaces it.
+    params = [
+        "TYPE s3",
+        f"KEY_ID '{os.environ['AWS_ACCESS_KEY_ID']}'",
+        f"SECRET '{os.environ['AWS_SECRET_ACCESS_KEY']}'",
+        f"REGION '{REGION}'",
+        f"SCOPE 's3://{BUCKET}'",
+    ]
+    if os.environ.get("AWS_SESSION_TOKEN"):
+        params.insert(3, f"SESSION_TOKEN '{os.environ['AWS_SESSION_TOKEN']}'")
+    try:
+        con.execute(f"CREATE OR REPLACE SECRET cognee_ci_s3 IN MOTHERDUCK ({', '.join(params)});")
+    except Exception as exc:  # never echo the statement -- it holds the key
+        raise RuntimeError(f"failed to register S3 secret: {type(exc).__name__}") from None
+    print(f"registered S3 secret for s3://{BUCKET} ({REGION})")
+
+    con.execute(f'CREATE DATABASE IF NOT EXISTS "{CATALOG}";')
+    con.execute(f'CREATE SCHEMA IF NOT EXISTS "{CATALOG}"."{SCHEMA}";')
+    con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {TGT}.raw_perf_reports (
+            s3_key      VARCHAR,
+            uploaded_at TIMESTAMP,
+            size_bytes  BIGINT,
+            report      JSON
+        );
+        """
+    )
+
+    before = con.execute(f"SELECT count(*) FROM {TGT}.raw_perf_reports").fetchone()[0]
+    globs = ", ".join(f"'{g}'" for g in GLOBS)
+    con.execute(
+        f"""
+        INSERT INTO {TGT}.raw_perf_reports
+        SELECT filename, last_modified, size, content::JSON
+        FROM read_text([{globs}])
+        WHERE filename NOT IN (SELECT s3_key FROM {TGT}.raw_perf_reports);
+        """
+    )
+    after = con.execute(f"SELECT count(*) FROM {TGT}.raw_perf_reports").fetchone()[0]
+    print(f"raw_perf_reports: {after} reports (+{after - before} new)")
+
+    failures = 0
+    for name, sql in VIEWS.items():
+        try:
+            con.execute(f"CREATE OR REPLACE VIEW {TGT}.{name} AS {sql.format(t=TGT)};")
+            print(f"view {name}: created")
+        except Exception as exc:
+            failures += 1
+            print(f"WARN view {name} failed ({type(exc).__name__}): {str(exc).splitlines()[0]}")
+
+    if not failures:
+        runs, suites, bad = con.execute(
+            f"""SELECT count(*), count(DISTINCT suite),
+                       sum(CASE WHEN NOT all_passed THEN 1 ELSE 0 END)
+                FROM {TGT}.v_perf_runs"""
+        ).fetchone()
+        print(f"{MD_TARGET}: {runs} runs across {suites} suites, {bad} with failures")
+
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if main() else 0)

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -358,6 +358,35 @@ jobs:
                   text: |
                     <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
 
+      - name: Load performance reports into MotherDuck
+        # Reads the report JSON the perf jobs already uploaded to S3 and loads it
+        # into ci_analytics.nightly (SDK-37). Deliberately placed BEFORE the
+        # failure gate and marked continue-on-error: a warehouse hiccup must not
+        # turn a green nightly red, and the reports from a failed suite are the
+        # interesting rows, so they still need to land.
+        # Skipped on pull_request for the same reason as the Slack post — the
+        # trigger exists to validate this file, not to write to the warehouse.
+        if: ${{ github.event_name != 'pull_request' }}
+        continue-on-error: true
+        env:
+          # duckdb is PINNED: an unpinned install pulled a release MotherDuck
+          # rejects and broke the sibling analytics ETL (COG-5953).
+          DUCKDB_VERSION: '1.4.5'
+          motherduck_token: ${{ secrets.MOTHERDUCK_TOKEN }}
+          MD_TARGET: ci_analytics.nightly
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_DEV_USER_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_DEV_USER_SECRET_KEY }}
+          AWS_DEFAULT_REGION: eu-west-1
+          PERF_BUCKET: github-runner-cognee-tests
+        run: |
+          set -euo pipefail
+          if [ -z "${motherduck_token:-}" ]; then
+            echo "MOTHERDUCK_TOKEN is not set — skipping warehouse load."
+            exit 0
+          fi
+          python -m pip install --quiet "duckdb==${DUCKDB_VERSION}"
+          python .github/scripts/motherduck_nightly_etl.py
+
       - name: Fail if any suite failed
         if: ${{ steps.status.outputs.passed != 'true' }}
         run: |


### PR DESCRIPTION
## Context

Every nightly performance job already uploads its full report JSON to S3:

```
s3://github-runner-cognee-tests/performance_results/{backend}/{label}/{mode}_{TS}.json
```

Nothing reads it afterwards. The Slack post renders p50/p90/p99 for four metrics and is then gone — there's no way to see whether a suite is drifting slower over weeks, and no baseline to compare a run against. The report JSON has far more in it: every percentile (min/max/mean/p50/p75/p90/p95/p99) for every metric, plus per-run detail in `raw_runs`.

Closes SDK-37.

## Scope

- **`.github/scripts/motherduck_nightly_etl.py`** — loads the reports into `ci_analytics.nightly`:
  - `raw_perf_reports` — one row per report file, JSON kept whole
  - `v_perf_runs` — one row per run (suite, backend, mode, pass/fail, config)
  - `v_perf_metrics` — long format, one row per run × metric × stat
  - `v_perf_regression` — latest run vs median of the previous seven
- **`.github/workflows/nightly_tests.yml`** — one step in the existing `notify` job.

## Design notes

**Driven off the S3 object listing, not the job outputs.** Keeps every percentile rather than the twelve numbers Slack carries, and the first run backfills the whole bucket instead of starting empty. It also means the perf jobs are untouched — no new failure mode in the benchmarks themselves.

**Reports are stored as whole JSON values.** The backends emit genuinely different metric sets: cloud has `tenant_create_time_s` / `tenant_delete_time_s` and, when it reuses a tenant, no `prune_time_s`. A typed table would drift and break on the next backend that adds a metric; the views do the shaping instead.

**Two path layouts are handled.** The backend level was added by `9301645b7` ("add postgres to nightly CI runs", 2026-06-04). Ten objects predate it and use `performance_results/{label}/…`; they load with `legacy_path = true` so the history is continuous but the provenance stays explicit.

**Placed before the failure gate, `continue-on-error: true`.** A warehouse hiccup must not turn a green nightly red, and reports from a failed suite are exactly the rows worth keeping. Skipped on `pull_request` for the same reason as the Slack post — that trigger exists to validate this file, not to write to the warehouse.

**`duckdb` is pinned.** An unpinned install pulled a release MotherDuck rejects and broke the sibling analytics ETL (COG-5953).

**No DATE columns in the views.** Superset/Preset cannot serialize a DATE as a pivot key (`keys must be str, int, float, bool or None, not datetime.date`). Callers that want a day cast `run_ts::DATE`.

## Before this can run

Add a **`MOTHERDUCK_TOKEN`** repository secret. The step no-ops with a log line if it's missing, so merging early is safe.

The S3 credential is registered as a MotherDuck-side secret, because MotherDuck's dual execution runs `s3://` reads on its cloud engine rather than on the runner — a session-local DuckDB secret isn't visible to it. It currently reuses `AWS_S3_DEV_USER_KEY_ID`; **a read-only IAM key scoped to this bucket would be the better credential** and is a reasonable follow-up.

## Verification

- All three views were built from this script's own SQL against the live warehouse: 745 runs, 14 suites, 43,280 metric rows, 336 regression rows.
- Key parsing was checked against all 745 real S3 keys — zero unparsed, including `mock_llm` (whose mode contains the delimiter) and the ten legacy-layout objects.
- The incremental `INSERT` is an anti-join on the S3 key; re-running leaves the count at 745.
- `pre-commit run --files …` passes (ruff + ruff-format + check-yaml).
- Not yet exercised end-to-end inside Actions — the first scheduled run is the real test, and `continue-on-error` bounds the blast radius.

## Follow-up (not in this PR)

`git_sha` is null on all 745 runs — nothing stamps it into the report JSON, so a regression can't be traced to a commit. That's a one-line `jq` in each of the three reusable perf workflows and is worth doing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)