### PR TITLE
fix: repair dev CI ruff failures (COG-6101)

### DIFF
--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -658,18 +658,6 @@ class NeptuneGraphDB(GraphDBInterface):
             logger.error(f"Failed to delete graph: {error_msg}")
             raise Exception(f"Failed to delete graph: {error_msg}") from e
 
-    async def is_empty(self) -> bool:
-        """
-        Check if the graph is empty.
-        """
-        query = """
-        MATCH (n)
-        RETURN true
-        LIMIT 1;
-        """
-        query_result = await self.query(query)
-        return len(query_result) == 0
-
     async def get_graph_data(self) -> Tuple[List[Node], List[EdgeData]]:
         """
         Retrieve all nodes and edges within the graph.

--- a/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
+++ b/cognee/infrastructure/loaders/external/beautiful_soup_loader.py
@@ -307,9 +307,7 @@ class BeautifulSoupLoader(LoaderInterface):
             pieces = []
             used_nodes = []
             for el in nodes:
-                if any(
-                    ancestor in extracted_elements for ancestor in (id(p) for p in el.parents)
-                ):
+                if any(ancestor in extracted_elements for ancestor in (id(p) for p in el.parents)):
                     continue
                 if rule.attr:
                     val = el.get(rule.attr)


### PR DESCRIPTION
## Summary

`dev` is currently red on the Code Quality / pre-commit checks, so every open PR that merges `dev` inherits the failures (first noticed on #4061). Two defects, both landed during the recent merge spree:

1. **F811 — duplicate `is_empty`** in `cognee/infrastructure/databases/graph/neptune_driver/adapter.py` (lines 663 and 791). Removed the first definition: it is dead code (Python resolves the later one at runtime), and the surviving definition is also the better one — label-scoped query with error handling, consistent with the adapter's other methods.
2. **ruff-format violation** in `cognee/infrastructure/loaders/external/beautiful_soup_loader.py` — reformatted with `ruff format`.

## Test plan

- [x] `ruff check cognee/` — clean on the whole tree
- [x] `ruff format --check cognee/` — 1858 files, all formatted
- [x] Both failures reproduced against plain `origin/dev` before the fix

Linear: COG-6101

🤖 Generated with [Claude Code](https://claude.com/claude-code)