### PR TITLE
ci: remove first-PR greeting comment (COG-6103)

### DIFF
--- a/.github/workflows/community_greetings.yml
+++ b/.github/workflows/community_greetings.yml
@@ -3,22 +3,18 @@ name: community | Greetings
 on:
   issues:
     types: [opened]
-  pull_request_target:
-    types: [opened]
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   greeting:
-    if: github.actor != 'github-actions[bot]' && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.body, 'Generated with [Claude Code]')
+    if: github.actor != 'github-actions[bot]' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/first-interaction@v3
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        pr_message:  'Hello @${{ github.actor }}, thank you for submitting a PR! We will respond as soon as possible.'
         issue_message: |
           Hello @${{ github.actor }}, thank you for your interest in our work!
 


### PR DESCRIPTION
## Summary
Removes the auto-posted "Hello @user, thank you for submitting a PR! We will respond as soon as possible." comment on first-time contributor PRs — it's pointless and noisy.

- Drop `pr_message` and the `pull_request_target` trigger from `community_greetings.yml`
- Drop the now-unneeded `pull-requests: write` permission and the Claude Code PR-body exclusion
- Keep the first-issue greeting, which asks for screenshots and a minimal repro and is still useful

Linear: COG-6103

🤖 Generated with [Claude Code](https://claude.com/claude-code)