### PR TITLE
perf: Keep idle subprocess engines alive for a TTL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -583,7 +583,7 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #SUBPROCESS_OPEN_LOCK_BACKOFF=0.1
 # Keep idle workers alive this many seconds before closing them (0 = close at
 # each release). Idle workers hold their DB file locks and memory.
-#SUBPROCESS_IDLE_TTL_SECONDS=900
+#SUBPROCESS_IDLE_TTL_SECONDS=600
 
 # -- AWS / Bedrock extras (in addition to the AWS section above) --------------
 #AWS_PROFILE_NAME=""

--- a/.env.template
+++ b/.env.template
@@ -581,13 +581,8 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # (per-attempt backoff is capped internally).
 #SUBPROCESS_OPEN_LOCK_RETRIES=10
 #SUBPROCESS_OPEN_LOCK_BACKOFF=0.1
-# Idle keep-alive for subprocess engines: after a request finishes, the worker
-# stays alive and is closed only after this many seconds without use, so a
-# request arriving inside the window skips the worker close + respawn
-# (~1s saved per interactive query). 0 closes workers at each release.
-# While idle-kept, a worker holds its database file locks and memory — lower
-# this (or set 0) if other processes need the same database files, or on
-# memory-tight multi-tenant deployments.
+# Keep idle workers alive this many seconds before closing them (0 = close at
+# each release). Idle workers hold their DB file locks and memory.
 #SUBPROCESS_IDLE_TTL_SECONDS=900
 
 # -- AWS / Bedrock extras (in addition to the AWS section above) --------------

--- a/.env.template
+++ b/.env.template
@@ -581,6 +581,14 @@ WEB_SCRAPER_MAX_DELAY=10.0
 # (per-attempt backoff is capped internally).
 #SUBPROCESS_OPEN_LOCK_RETRIES=10
 #SUBPROCESS_OPEN_LOCK_BACKOFF=0.1
+# Idle keep-alive for subprocess engines: after a request finishes, the worker
+# stays alive and is closed only after this many seconds without use, so a
+# request arriving inside the window skips the worker close + respawn
+# (~1s saved per interactive query). 0 closes workers at each release.
+# While idle-kept, a worker holds its database file locks and memory — lower
+# this (or set 0) if other processes need the same database files, or on
+# memory-tight multi-tenant deployments.
+#SUBPROCESS_IDLE_TTL_SECONDS=900
 
 # -- AWS / Bedrock extras (in addition to the AWS section above) --------------
 #AWS_PROFILE_NAME=""

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -35,7 +35,7 @@ Configuration:
 * ``DATASET_QUEUE_MAX_CONCURRENT`` — env var. Defaults to ``DATABASE_MAX_LRU_CACHE_SIZE`` for a safe baseline
 * ``SUBPROCESS_IDLE_TTL_SECONDS`` — env var. Idle keep-alive for subprocess
   engines: at release they are *touched* instead of closed, and a reaper
-  closes them only after this many seconds without use (default 900).
+  closes them only after this many seconds without use (default 600).
   ``0`` disables keep-alive: engines are force-closed at last release, the
   pre-keep-alive behavior.
 """
@@ -63,7 +63,7 @@ class DatasetQueueSettings:
 
     __slots__ = ("enabled", "max_concurrent", "idle_ttl_seconds")
 
-    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 900.0) -> None:
+    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 600.0) -> None:
         self.enabled = enabled
         self.max_concurrent = max_concurrent
         self.idle_ttl_seconds = idle_ttl_seconds
@@ -80,7 +80,7 @@ def get_dataset_queue_settings() -> DatasetQueueSettings:
         max_concurrent = int(DATABASE_MAX_LRU_CACHE_SIZE)
 
     # Negative values make no sense as a TTL; clamp to 0 (= keep-alive off).
-    idle_ttl_seconds = max(0.0, float(os.getenv("SUBPROCESS_IDLE_TTL_SECONDS", "900")))
+    idle_ttl_seconds = max(0.0, float(os.getenv("SUBPROCESS_IDLE_TTL_SECONDS", "600")))
 
     return DatasetQueueSettings(
         enabled=enabled, max_concurrent=max_concurrent, idle_ttl_seconds=idle_ttl_seconds
@@ -121,7 +121,7 @@ class DatasetQueue:
     When ``enabled`` is ``False`` all methods are pass-throughs.
     """
 
-    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 900.0) -> None:
+    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 600.0) -> None:
         # Idle keep-alive TTL for subprocess engines; the default matches the
         # SUBPROCESS_IDLE_TTL_SECONDS default. 0 = off (engines are
         # force-closed at last release). Set before the disabled early-return

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -11,9 +11,9 @@ bump a per-entry depth counter rather than re-acquiring the semaphore. The
 corresponding :meth:`DatasetQueue.release_slot_for` (async) decrements that
 counter; the underlying semaphore slot is freed only when the counter hits
 zero.  When the last holder across all tasks exits, subprocess engines are
-evicted from the engine caches via
-:meth:`DatasetQueue._evict_subprocess_engines`; the caches close them off the
-response path.  This makes nested
+either kept warm for the idle TTL or evicted from the engine caches via
+:meth:`DatasetQueue._release_subprocess_engines`; the caches close them off
+the response path.  This makes nested
 ``async with set_database_global_context_variables(D, u)`` scopes safe — an
 inner exit never steals an outer holder's slot.
 
@@ -33,12 +33,18 @@ Configuration:
 
 * ``DATASET_QUEUE_ENABLED`` — env var. Truthy values enable the queue.
 * ``DATASET_QUEUE_MAX_CONCURRENT`` — env var. Defaults to ``DATABASE_MAX_LRU_CACHE_SIZE`` for a safe baseline
+* ``SUBPROCESS_IDLE_TTL_SECONDS`` — env var. Idle keep-alive for subprocess
+  engines: at release they are *touched* instead of closed, and a reaper
+  closes them only after this many seconds without use (default 900).
+  ``0`` disables keep-alive: engines are force-closed at last release, the
+  pre-keep-alive behavior.
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from contextlib import asynccontextmanager
 from typing import Any, Callable, Dict, Set
 
@@ -55,11 +61,12 @@ TRUE_VALUES = frozenset({"1", "true", "yes", "on", "y", "t"})
 class DatasetQueueSettings:
     """Effective runtime settings for the dataset queue."""
 
-    __slots__ = ("enabled", "max_concurrent")
+    __slots__ = ("enabled", "max_concurrent", "idle_ttl_seconds")
 
-    def __init__(self, enabled: bool, max_concurrent: int) -> None:
+    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 0.0) -> None:
         self.enabled = enabled
         self.max_concurrent = max_concurrent
+        self.idle_ttl_seconds = idle_ttl_seconds
 
 
 def get_dataset_queue_settings() -> DatasetQueueSettings:
@@ -72,7 +79,12 @@ def get_dataset_queue_settings() -> DatasetQueueSettings:
         # Default to the same max concurrency as the LRU cache size, which is a reasonable baseline for a shared resource limit.
         max_concurrent = int(DATABASE_MAX_LRU_CACHE_SIZE)
 
-    return DatasetQueueSettings(enabled=enabled, max_concurrent=max_concurrent)
+    # Negative values make no sense as a TTL; clamp to 0 (= keep-alive off).
+    idle_ttl_seconds = max(0.0, float(os.getenv("SUBPROCESS_IDLE_TTL_SECONDS", "900")))
+
+    return DatasetQueueSettings(
+        enabled=enabled, max_concurrent=max_concurrent, idle_ttl_seconds=idle_ttl_seconds
+    )
 
 
 def _make_release(semaphore: asyncio.Semaphore) -> Callable[[], None]:
@@ -109,7 +121,16 @@ class DatasetQueue:
     When ``enabled`` is ``False`` all methods are pass-throughs.
     """
 
-    def __init__(self, enabled: bool, max_concurrent: int) -> None:
+    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 0.0) -> None:
+        # Idle keep-alive TTL for subprocess engines. 0 = off (engines are
+        # force-closed at last release). Set before the disabled early-return
+        # so the attribute always exists.
+        self._idle_ttl_seconds: float = max(0.0, float(idle_ttl_seconds))
+        # Reaper thread state — started lazily on the first kept-alive
+        # release, exactly once per queue instance.
+        self._reaper_started: bool = False
+        self._reaper_lock = threading.Lock()
+
         safe_max = int(max_concurrent)
         if safe_max < 1:
             self._enabled: bool = False
@@ -217,6 +238,96 @@ class DatasetQueue:
         self._task_slots[task_id][ds_key] = SlotEntry(release, depth=1)
 
     # ----------------------------------------- subprocess engine teardown
+    def _release_subprocess_engines(self) -> None:
+        """Last-holder release: keep the engines warm or tear them down.
+
+        With the idle-TTL keep-alive on (``SUBPROCESS_IDLE_TTL_SECONDS`` > 0),
+        the engines stay cached — their idle timestamps are refreshed and the
+        reaper closes them only after a full TTL without use, so a request
+        arriving inside the window skips both the close and the respawn.
+        With the TTL at 0 this is exactly the pre-keep-alive behavior:
+        force-close eviction at last release.
+
+        Queue/cache synchronization needs no new state: the queue keeps only
+        concurrency permits, the cache keeps the engines and their idle
+        timestamps, and the single shared fact — which datasets are active
+        right now — is computed live from the slot table by
+        ``active_dataset_ids()`` and read by the reaper through the cache's
+        pinned predicate. Nothing is duplicated, so nothing can drift.
+        """
+        if self._idle_ttl_seconds > 0:
+            self._touch_subprocess_engines()
+            self._ensure_reaper()
+        else:
+            self._evict_subprocess_engines()
+
+    def _touch_subprocess_engines(self) -> None:
+        """Refresh idle timestamps for this context's subprocess engines.
+
+        Pinned engine handles bypass cache lookups, so hit-time refreshes
+        under-count usage; release is the one moment that reliably means
+        "a request just finished with these engines".
+        """
+        from cognee.infrastructure.databases.graph.config import get_graph_context_config
+        from cognee.infrastructure.databases.vector.config import get_vectordb_context_config
+
+        g_cfg = get_graph_context_config()
+        if g_cfg.get("graph_database_subprocess_enabled"):
+            from cognee.infrastructure.databases.graph.get_graph_engine import touch_graph_engine
+
+            touch_graph_engine(**g_cfg)
+
+        v_cfg = get_vectordb_context_config()
+        if v_cfg.get("vector_db_subprocess_enabled"):
+            from cognee.infrastructure.databases.vector.create_vector_engine import (
+                touch_vector_engine,
+            )
+
+            touch_vector_engine(**v_cfg)
+
+    def _ensure_reaper(self) -> None:
+        """Start the idle reaper thread, exactly once."""
+        if self._reaper_started:
+            return
+        with self._reaper_lock:
+            if self._reaper_started:
+                return
+            thread = threading.Thread(
+                target=self._reap_loop, name="subprocess-idle-reaper", daemon=True
+            )
+            thread.start()
+            self._reaper_started = True
+
+    def _reap_loop(self) -> None:
+        """Daemon loop: force-close engines idle for more than the TTL.
+
+        Runs off the event loop (the closes it triggers run on the cache's
+        close threads and register in the pending-close registry, same as a
+        release-time force-close). Active datasets are skipped via the
+        cache's pinned predicate, so a query outliving the TTL never has its
+        engine closed underneath it. A sweep failure is surfaced at ERROR and
+        the loop continues — a broken sweep must not silently end reaping.
+        """
+        import time
+
+        from cognee.infrastructure.databases.graph.get_graph_engine import (
+            reap_idle_graph_engines,
+        )
+        from cognee.infrastructure.databases.vector.create_vector_engine import (
+            reap_idle_vector_engines,
+        )
+
+        interval = max(5.0, min(60.0, self._idle_ttl_seconds / 4))
+        while True:
+            time.sleep(interval)
+            try:
+                reaped = reap_idle_graph_engines(self._idle_ttl_seconds)
+                reaped += reap_idle_vector_engines(self._idle_ttl_seconds)
+                if reaped:
+                    logger.debug("Idle reaper closed %d subprocess engine(s)", reaped)
+            except Exception:
+                logger.error("Idle reaper sweep failed", exc_info=True)
+
     def _evict_subprocess_engines(self) -> None:
         """Evict this context's subprocess-mode engines from their caches.
 
@@ -285,10 +396,10 @@ class DatasetQueue:
         the semaphore slot when the counter reaches zero.
 
         When this is the very last holder across all tasks for
-        ``dataset_id``, subprocess engines are evicted via
-        :meth:`_evict_subprocess_engines` while the semaphore slot is still
-        held, so no new operation can fetch a dying engine from the cache.
-        The slot is freed afterwards regardless of whether the eviction
+        ``dataset_id``, subprocess engines are released via
+        :meth:`_release_subprocess_engines` (kept warm under the idle TTL,
+        force-close evicted otherwise) while the semaphore slot is still
+        held. The slot is freed afterwards regardless of whether the release
         succeeds or raises.
 
         No-op when the queue is disabled, there is no running task, or the
@@ -299,7 +410,7 @@ class DatasetQueue:
 
         task = asyncio.current_task()
         if task is None:
-            self._evict_subprocess_engines()
+            self._release_subprocess_engines()
             return
 
         task_id = id(task)
@@ -313,17 +424,17 @@ class DatasetQueue:
         if entry.depth > 0:
             return
 
-        # About to fully release.  Evict subprocess engines only when no other
-        # task holds the same dataset; the engine cache closes them off the
-        # response path (see ``_evict_subprocess_engines`` for the full
-        # contract). The caller's response must not wait on the close of
-        # engines it has already finished using.
+        # About to fully release.  Release subprocess engines only when no
+        # other task holds the same dataset: kept warm under the idle TTL,
+        # force-close evicted otherwise (see ``_release_subprocess_engines``).
+        # The caller's response must not wait on the close of engines it has
+        # already finished using.
         try:
             other_holds = any(
                 ds_key in slots for tid, slots in self._task_slots.items() if tid != task_id
             )
             if not other_holds:
-                self._evict_subprocess_engines()
+                self._release_subprocess_engines()
         finally:
             self._task_slots.get(task_id, {}).pop(ds_key, None)
             logger.debug(
@@ -395,6 +506,7 @@ def dataset_queue() -> DatasetQueue:
     instance = DatasetQueue(
         enabled=settings.enabled,
         max_concurrent=settings.max_concurrent,
+        idle_ttl_seconds=settings.idle_ttl_seconds,
     )
     dataset_queue._instance = instance  # type: ignore[attr-defined]
     return instance

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -302,28 +302,26 @@ class DatasetQueue:
     def _reap_loop(self) -> None:
         """Daemon loop: force-close engines idle for more than the TTL.
 
-        Runs off the event loop (the closes it triggers run on the cache's
-        close threads and register in the pending-close registry, same as a
-        release-time force-close). Active datasets are skipped via the
-        cache's pinned predicate, so a query outliving the TTL never has its
-        engine closed underneath it. A sweep failure is surfaced at ERROR and
+        One sweep call covers every engine cache: the caches register
+        themselves at decoration time, and the sweep itself skips active
+        datasets (the pinned predicate) and non-subprocess values — so this
+        loop needs no knowledge of which engine modules exist. It runs off
+        the event loop; the closes it triggers run on the cache's close
+        threads and register in the pending-close registry, same as a
+        release-time force-close. A sweep failure is surfaced at ERROR and
         the loop continues — a broken sweep must not silently end reaping.
         """
         import time
 
-        from cognee.infrastructure.databases.graph.get_graph_engine import (
-            reap_idle_graph_engines,
-        )
-        from cognee.infrastructure.databases.vector.create_vector_engine import (
-            reap_idle_vector_engines,
+        from cognee.infrastructure.databases.utils.closing_lru_cache import (
+            evict_and_close_idle_all,
         )
 
         interval = max(5.0, min(60.0, self._idle_ttl_seconds / 4))
         while True:
             time.sleep(interval)
             try:
-                reaped = reap_idle_graph_engines(self._idle_ttl_seconds)
-                reaped += reap_idle_vector_engines(self._idle_ttl_seconds)
+                reaped = evict_and_close_idle_all(self._idle_ttl_seconds)
                 if reaped:
                     logger.debug("Idle reaper closed %d subprocess engine(s)", reaped)
             except Exception:

--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -63,7 +63,7 @@ class DatasetQueueSettings:
 
     __slots__ = ("enabled", "max_concurrent", "idle_ttl_seconds")
 
-    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 0.0) -> None:
+    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 900.0) -> None:
         self.enabled = enabled
         self.max_concurrent = max_concurrent
         self.idle_ttl_seconds = idle_ttl_seconds
@@ -121,8 +121,9 @@ class DatasetQueue:
     When ``enabled`` is ``False`` all methods are pass-throughs.
     """
 
-    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 0.0) -> None:
-        # Idle keep-alive TTL for subprocess engines. 0 = off (engines are
+    def __init__(self, enabled: bool, max_concurrent: int, idle_ttl_seconds: float = 900.0) -> None:
+        # Idle keep-alive TTL for subprocess engines; the default matches the
+        # SUBPROCESS_IDLE_TTL_SECONDS default. 0 = off (engines are
         # force-closed at last release). Set before the disabled early-return
         # so the attribute always exists.
         self._idle_ttl_seconds: float = max(0.0, float(idle_ttl_seconds))

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -298,14 +298,21 @@ def evict_graph_engine(force_close: bool = False, **kwargs) -> bool:
 
     Returns True if the entry existed.
     """
-    normalized = _normalize_optional_create_graph_engine_params(kwargs)
-    provider = _normalize_graph_database_provider(kwargs.get("graph_database_provider"))
     evict = (
         _create_graph_engine.cache_evict_and_close
         if force_close
         else _create_graph_engine.cache_evict
     )
-    return evict(
+    return evict(*_graph_engine_key_args(kwargs))
+
+
+def _graph_engine_key_args(kwargs) -> tuple:
+    """Positional cache-key args for a ``create_graph_engine`` config dict,
+    normalized exactly the way ``create_graph_engine`` normalizes them so the
+    key matches. Shared by ``evict_graph_engine`` / ``touch_graph_engine``."""
+    normalized = _normalize_optional_create_graph_engine_params(kwargs)
+    provider = _normalize_graph_database_provider(kwargs.get("graph_database_provider"))
+    return (
         provider,
         kwargs.get("graph_file_path"),
         normalized["graph_database_url"],
@@ -322,6 +329,26 @@ def evict_graph_engine(force_close: bool = False, **kwargs) -> bool:
         normalized["kuzu_buffer_pool_size"],
         normalized["kuzu_max_db_size"],
     )
+
+
+def touch_graph_engine(**kwargs) -> bool:
+    """Refresh the idle timestamp of the cached graph engine for this config.
+
+    The dataset-queue release path calls this when the idle-TTL keep-alive is
+    enabled, instead of evicting: the engine stays cached (and its worker
+    alive) until it has been idle for the TTL. Returns True if the entry
+    exists.
+    """
+    return _create_graph_engine.cache_touch(*_graph_engine_key_args(kwargs))
+
+
+def reap_idle_graph_engines(idle_seconds: float) -> int:
+    """Force-close cached graph engines idle for more than *idle_seconds*.
+
+    Skips engines whose dataset currently holds a queue slot (the cache's
+    pinned predicate). Returns the number of engines closed.
+    """
+    return _create_graph_engine.cache_evict_and_close_idle(idle_seconds)
 
 
 def evict_graph_engines_for_database(graph_database_name: str) -> int:

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -342,18 +342,6 @@ def touch_graph_engine(**kwargs) -> bool:
     return _create_graph_engine.cache_touch(*_graph_engine_key_args(kwargs))
 
 
-def reap_idle_graph_engines(idle_seconds: float) -> int:
-    """Force-close cached subprocess-backed graph engines idle for more
-    than *idle_seconds*.
-
-    Skips engines whose dataset currently holds a queue slot (the cache's
-    pinned predicate) and in-process/remote adapters (no worker process, no
-    file locks — the keep-alive lifecycle does not apply to them). Returns
-    the number of engines closed.
-    """
-    return _create_graph_engine.cache_evict_and_close_idle(idle_seconds)
-
-
 def evict_graph_engines_for_database(graph_database_name: str) -> int:
     """Evict every cached graph engine bound to *graph_database_name*.
 

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -343,10 +343,13 @@ def touch_graph_engine(**kwargs) -> bool:
 
 
 def reap_idle_graph_engines(idle_seconds: float) -> int:
-    """Force-close cached graph engines idle for more than *idle_seconds*.
+    """Force-close cached subprocess-backed graph engines idle for more
+    than *idle_seconds*.
 
     Skips engines whose dataset currently holds a queue slot (the cache's
-    pinned predicate). Returns the number of engines closed.
+    pinned predicate) and in-process/remote adapters (no worker process, no
+    file locks — the keep-alive lifecycle does not apply to them). Returns
+    the number of engines closed.
     """
     return _create_graph_engine.cache_evict_and_close_idle(idle_seconds)
 

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -87,6 +87,7 @@ import asyncio
 import concurrent.futures
 import inspect
 import logging
+import time
 import weakref
 from collections import OrderedDict
 from functools import wraps
@@ -300,6 +301,11 @@ class _LeasedCacheEntry:
         self.in_cache = True
         self.close_requested = False
         self.closed = False
+        # Last time this entry was used or released, ``time.monotonic()``
+        # based. Read by the idle sweep (``evict_and_close_idle``); refreshed
+        # on cache hits and via ``touch`` at dataset-queue release, so idle
+        # time measures "since the last request finished with it".
+        self.last_touched = time.monotonic()
         self._lock = Lock()
 
     def _close(self, value):
@@ -659,6 +665,7 @@ class ClosingLRUCache:
         with self._lock:
             if key in self._cache:
                 self._cache.move_to_end(key)
+                self._cache[key].last_touched = time.monotonic()
                 return self._wrap_cached_value(self._cache[key])
             pending_closes = self._snapshot_pending_closes(key)
 
@@ -743,6 +750,7 @@ class ClosingLRUCache:
         with self._lock:
             if key in self._cache:
                 self._cache.move_to_end(key)
+                self._cache[key].last_touched = time.monotonic()
                 return self._wrap_cached_value(self._cache[key])
             pending_closes = self._snapshot_pending_closes(key)
 
@@ -824,6 +832,50 @@ class ClosingLRUCache:
             self._track_close(entry.key, value_to_close)
         del proxy_to_drop
         return True
+
+    def touch(self, key) -> bool:
+        """Refresh *key*'s idle timestamp without creating or returning it.
+
+        Called at dataset-queue release when the idle-TTL keep-alive is on:
+        pinned engine handles bypass cache lookups entirely, so hit-time
+        refreshes alone would under-count usage. Returns True if the entry
+        exists.
+        """
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return False
+            entry.last_touched = time.monotonic()
+            return True
+
+    def evict_and_close_idle(self, idle_seconds: float) -> int:
+        """Force-close every entry idle for more than *idle_seconds*.
+
+        The idle-TTL reaper's sweep. Keys matching the pinned predicate are
+        skipped — the same live "this dataset holds an active queue slot"
+        check that protects entries from capacity eviction; a query running
+        longer than the TTL must not have its engine closed underneath it.
+
+        Each expired entry goes through :meth:`evict_and_close` (immediate
+        close despite idle proxy holders, registered in the pending-close
+        registry, off-loop for subprocess adapters). A request racing the
+        sweep at the exact expiry instant is absorbed by the registry wait,
+        the worker open-retry, and handle re-resolution. Returns the number
+        of entries closed.
+        """
+        deadline = time.monotonic() - idle_seconds
+        with self._lock:
+            expired = [
+                key
+                for key, entry in self._cache.items()
+                if entry.last_touched < deadline
+                and (self._pinned_predicate is None or not self._pinned_predicate(key))
+            ]
+        closed = 0
+        for key in expired:
+            if self.evict_and_close(key):
+                closed += 1
+        return closed
 
     def evict_where(self, predicate) -> int:
         """Remove every entry whose key satisfies *predicate* and request close.
@@ -918,6 +970,12 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True, pinned_p
             """
             return cache.evict_and_close(_key(args, kwargs))
 
+        def cache_touch(*args, **kwargs) -> bool:
+            """Refresh the idle timestamp of the entry matching the given
+            args (key scheme matches ``cache_evict``). Returns True if the
+            entry exists."""
+            return cache.touch(_key(args, kwargs))
+
         def cache_evict_where(predicate) -> int:
             """Evict every cached entry whose key satisfies *predicate*.
 
@@ -992,6 +1050,8 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True, pinned_p
         wrapper.cache_clear = cache.cache_clear
         wrapper.cache_evict = cache_evict
         wrapper.cache_evict_and_close = cache_evict_and_close
+        wrapper.cache_touch = cache_touch
+        wrapper.cache_evict_and_close_idle = cache.evict_and_close_idle
         wrapper.cache_evict_where = cache_evict_where
         wrapper.cache_evict_matching = cache_evict_matching
         wrapper.cache_await_closed = cache_await_closed

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -96,6 +96,26 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Every cache created by the ``closing_lru_cache`` decorator registers here so
+# the idle-TTL reaper can sweep them all through one entry point
+# (``evict_and_close_idle_all``) without knowing which engine modules exist.
+# Weak references: a decorated factory that goes out of scope (tests) drops
+# its cache from the registry automatically.
+_DECORATED_CACHES: "weakref.WeakSet[ClosingLRUCache]" = weakref.WeakSet()
+
+
+def evict_and_close_idle_all(idle_seconds: float) -> int:
+    """Force-close idle subprocess-backed entries across every decorated cache.
+
+    The idle-TTL reaper's single entry point: sweeps each registered cache via
+    :meth:`ClosingLRUCache.evict_and_close_idle`, which skips pinned (active)
+    keys and any value without ``_subprocess_mode`` — so caches holding
+    in-process or remote adapters contribute nothing, and a future
+    subprocess-backed engine cache is covered without anyone registering it by
+    hand. Returns the total number of entries closed.
+    """
+    return sum(cache.evict_and_close_idle(idle_seconds) for cache in list(_DECORATED_CACHES))
+
 
 class CacheInfo(dict):
     """Cache info mapping with functools.lru_cache-style attributes."""
@@ -944,6 +964,7 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True, pinned_p
             bind_signature(_param_positions)
 
         cache = ClosingLRUCache(maxsize=maxsize, lease=lease, pinned_predicate=pinned_predicate)
+        _DECORATED_CACHES.add(cache)
 
         def _key(args, kwargs):
             # ``_KW_MARK`` separates positional from keyword args so
@@ -1061,7 +1082,6 @@ def closing_lru_cache(maxsize: Optional[int] = 128, lease: bool = True, pinned_p
         wrapper.cache_evict = cache_evict
         wrapper.cache_evict_and_close = cache_evict_and_close
         wrapper.cache_touch = cache_touch
-        wrapper.cache_evict_and_close_idle = cache.evict_and_close_idle
         wrapper.cache_evict_where = cache_evict_where
         wrapper.cache_evict_matching = cache_evict_matching
         wrapper.cache_await_closed = cache_await_closed

--- a/cognee/infrastructure/databases/utils/closing_lru_cache.py
+++ b/cognee/infrastructure/databases/utils/closing_lru_cache.py
@@ -849,16 +849,25 @@ class ClosingLRUCache:
             return True
 
     def evict_and_close_idle(self, idle_seconds: float) -> int:
-        """Force-close every entry idle for more than *idle_seconds*.
+        """Force-close every subprocess-backed entry idle for more than
+        *idle_seconds*.
 
-        The idle-TTL reaper's sweep. Keys matching the pinned predicate are
-        skipped — the same live "this dataset holds an active queue slot"
-        check that protects entries from capacity eviction; a query running
-        longer than the TTL must not have its engine closed underneath it.
+        The idle-TTL reaper's sweep. Two kinds of entries are skipped:
+
+        * Keys matching the pinned predicate — the same live "this dataset
+          holds an active queue slot" check that protects entries from
+          capacity eviction; a query running longer than the TTL must not
+          have its engine closed underneath it.
+        * Values without ``_subprocess_mode`` — remote adapters (Postgres,
+          Neo4j, ...) hold no worker process and no file locks, so the
+          keep-alive lifecycle does not apply to them; they stay cached
+          under the LRU capacity rules exactly as before the TTL existed.
+          Closing them here would also dispose loop-bound resources (e.g.
+          SQLAlchemy pools) from the reaper thread's foreign event loop.
 
         Each expired entry goes through :meth:`evict_and_close` (immediate
         close despite idle proxy holders, registered in the pending-close
-        registry, off-loop for subprocess adapters). A request racing the
+        registry, off-loop on the close threads). A request racing the
         sweep at the exact expiry instant is absorbed by the registry wait,
         the worker open-retry, and handle re-resolution. Returns the number
         of entries closed.
@@ -869,6 +878,7 @@ class ClosingLRUCache:
                 key
                 for key, entry in self._cache.items()
                 if entry.last_touched < deadline
+                and getattr(entry.value, "_subprocess_mode", False)
                 and (self._pinned_predicate is None or not self._pinned_predicate(key))
             ]
         closed = 0

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -122,13 +122,20 @@ def evict_vector_engine(force_close: bool = False, **kwargs) -> bool:
     dataset-queue teardown path, where the worker must exit and release its
     file locks promptly. Returns True if the entry existed.
     """
-    normalized = _normalize_optional_create_vector_engine_params(kwargs)
     evict = (
         _create_vector_engine.cache_evict_and_close
         if force_close
         else _create_vector_engine.cache_evict
     )
-    return evict(
+    return evict(*_vector_engine_key_args(kwargs))
+
+
+def _vector_engine_key_args(kwargs) -> tuple:
+    """Positional cache-key args for a ``create_vector_engine`` config dict,
+    normalized the way ``create_vector_engine`` normalizes them so the key
+    matches. Shared by ``evict_vector_engine`` / ``touch_vector_engine``."""
+    normalized = _normalize_optional_create_vector_engine_params(kwargs)
+    return (
         kwargs.get("vector_db_provider", ""),
         kwargs.get("vector_db_url", ""),
         kwargs.get("vector_db_name", ""),
@@ -140,6 +147,24 @@ def evict_vector_engine(force_close: bool = False, **kwargs) -> bool:
         normalized["vector_db_host"],
         normalized["vector_db_subprocess_enabled"],
     )
+
+
+def touch_vector_engine(**kwargs) -> bool:
+    """Refresh the idle timestamp of the cached vector engine for this config.
+
+    Dataset-queue release path under the idle-TTL keep-alive; see
+    ``touch_graph_engine``. Returns True if the entry exists.
+    """
+    return _create_vector_engine.cache_touch(*_vector_engine_key_args(kwargs))
+
+
+def reap_idle_vector_engines(idle_seconds: float) -> int:
+    """Force-close cached vector engines idle for more than *idle_seconds*.
+
+    Skips engines whose dataset currently holds a queue slot (the cache's
+    pinned predicate). Returns the number of engines closed.
+    """
+    return _create_vector_engine.cache_evict_and_close_idle(idle_seconds)
 
 
 def evict_vector_engines_for_database(vector_db_name: str) -> int:

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -158,18 +158,6 @@ def touch_vector_engine(**kwargs) -> bool:
     return _create_vector_engine.cache_touch(*_vector_engine_key_args(kwargs))
 
 
-def reap_idle_vector_engines(idle_seconds: float) -> int:
-    """Force-close cached subprocess-backed vector engines idle for more
-    than *idle_seconds*.
-
-    Skips engines whose dataset currently holds a queue slot (the cache's
-    pinned predicate) and in-process/remote adapters (no worker process, no
-    file locks — the keep-alive lifecycle does not apply to them). Returns
-    the number of engines closed.
-    """
-    return _create_vector_engine.cache_evict_and_close_idle(idle_seconds)
-
-
 def evict_vector_engines_for_database(vector_db_name: str) -> int:
     """Evict every cached vector engine bound to *vector_db_name*.
 

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -159,10 +159,13 @@ def touch_vector_engine(**kwargs) -> bool:
 
 
 def reap_idle_vector_engines(idle_seconds: float) -> int:
-    """Force-close cached vector engines idle for more than *idle_seconds*.
+    """Force-close cached subprocess-backed vector engines idle for more
+    than *idle_seconds*.
 
     Skips engines whose dataset currently holds a queue slot (the cache's
-    pinned predicate). Returns the number of engines closed.
+    pinned predicate) and in-process/remote adapters (no worker process, no
+    file locks — the keep-alive lifecycle does not apply to them). Returns
+    the number of engines closed.
     """
     return _create_vector_engine.cache_evict_and_close_idle(idle_seconds)
 

--- a/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
+++ b/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
@@ -1580,3 +1580,38 @@ def test_cache_hit_refreshes_idle_timestamp():
     import time
 
     assert time.monotonic() - cache._cache["k"].last_touched < 5
+
+
+def test_evict_and_close_idle_all_sweeps_decorated_caches():
+    """The reaper's single entry point: decorated caches register themselves,
+    and one sweep covers them all — closing only idle subprocess-backed
+    values, leaving remote adapters and fresh entries alone."""
+    from cognee.infrastructure.databases.utils.closing_lru_cache import (
+        evict_and_close_idle_all,
+    )
+
+    @closing_lru_cache(maxsize=4, lease=True)
+    def graph_like(name):
+        return _SubprocessCloseable(name)
+
+    @closing_lru_cache(maxsize=4, lease=True)
+    def remote_like(name):
+        return _Closeable(name)
+
+    stale = graph_like("stale").__wrapped__
+    fresh = graph_like("fresh").__wrapped__
+    remote = remote_like("remote").__wrapped__
+
+    # Back-date the idle candidates through the registry itself.
+    import cognee.infrastructure.databases.utils.closing_lru_cache as clc
+
+    for cache in list(clc._DECORATED_CACHES):
+        for entry in cache._cache.values():
+            if entry.value in (stale, remote):
+                entry.last_touched -= 1000
+
+    closed = evict_and_close_idle_all(900)
+    assert closed >= 1
+    assert stale.closed is True, "idle subprocess value must be reaped"
+    assert fresh.closed is False, "fresh value must survive"
+    assert remote.closed is False, "non-subprocess value must never be reaped"

--- a/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
+++ b/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
@@ -1519,9 +1519,15 @@ def test_touch_refreshes_idle_timestamp():
     assert cache.touch("absent") is False
 
 
+class _SubprocessCloseable(_Closeable):
+    """Stub for a subprocess-backed adapter as the idle sweep sees it."""
+
+    _subprocess_mode = True
+
+
 def test_evict_and_close_idle_closes_only_expired():
     cache = ClosingLRUCache(maxsize=8, lease=True)
-    stale, fresh = _Closeable("stale"), _Closeable("fresh")
+    stale, fresh = _SubprocessCloseable("stale"), _SubprocessCloseable("fresh")
     cache.get_or_create("stale", lambda: stale)
     cache.get_or_create("fresh", lambda: fresh)
     cache._cache["stale"].last_touched -= 1000
@@ -1536,7 +1542,7 @@ def test_evict_and_close_idle_skips_pinned():
     """An active dataset's engine must never be reaped, no matter how old its
     timestamp (a query can outlive the TTL)."""
     cache = ClosingLRUCache(maxsize=8, lease=True, pinned_predicate=lambda key: key == "active")
-    active, idle = _Closeable("active"), _Closeable("idle")
+    active, idle = _SubprocessCloseable("active"), _SubprocessCloseable("idle")
     cache.get_or_create("active", lambda: active)
     cache.get_or_create("idle", lambda: idle)
     cache._cache["active"].last_touched -= 1000
@@ -1545,6 +1551,24 @@ def test_evict_and_close_idle_skips_pinned():
     assert cache.evict_and_close_idle(900) == 1
     assert active.closed is False
     assert idle.closed is True
+
+
+def test_evict_and_close_idle_skips_non_subprocess_values():
+    """Remote/in-process adapters (no ``_subprocess_mode``) are never reaped:
+    the keep-alive lifecycle only governs worker-backed engines. They stay
+    cached under LRU capacity rules, and their loop-bound close (e.g. a
+    SQLAlchemy pool dispose) is never run from the reaper thread."""
+    cache = ClosingLRUCache(maxsize=8, lease=True)
+    worker, remote = _SubprocessCloseable("worker"), _Closeable("remote")
+    cache.get_or_create("worker", lambda: worker)
+    cache.get_or_create("remote", lambda: remote)
+    cache._cache["worker"].last_touched -= 1000
+    cache._cache["remote"].last_touched -= 1000
+
+    assert cache.evict_and_close_idle(900) == 1
+    assert worker.closed is True
+    assert remote.closed is False
+    assert cache.contains("remote"), "remote adapter must stay cached"
 
 
 def test_cache_hit_refreshes_idle_timestamp():

--- a/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
+++ b/cognee/tests/unit/infrastructure/databases/test_closing_lru_cache.py
@@ -1505,3 +1505,54 @@ def test_decorator_cache_evict_and_close():
     assert create.cache_evict_and_close("a") is True
     assert proxy.__wrapped__.closed is True
     assert create.cache_evict_and_close("a") is False
+
+
+def test_touch_refreshes_idle_timestamp():
+    cache = ClosingLRUCache(maxsize=8, lease=True)
+    cache.get_or_create("k", lambda: _Closeable("v"))
+
+    cache._cache["k"].last_touched -= 1000
+    assert cache.touch("k") is True
+    import time
+
+    assert time.monotonic() - cache._cache["k"].last_touched < 5
+    assert cache.touch("absent") is False
+
+
+def test_evict_and_close_idle_closes_only_expired():
+    cache = ClosingLRUCache(maxsize=8, lease=True)
+    stale, fresh = _Closeable("stale"), _Closeable("fresh")
+    cache.get_or_create("stale", lambda: stale)
+    cache.get_or_create("fresh", lambda: fresh)
+    cache._cache["stale"].last_touched -= 1000
+
+    assert cache.evict_and_close_idle(900) == 1
+    assert stale.closed is True
+    assert fresh.closed is False
+    assert cache.cache_info().currsize == 1
+
+
+def test_evict_and_close_idle_skips_pinned():
+    """An active dataset's engine must never be reaped, no matter how old its
+    timestamp (a query can outlive the TTL)."""
+    cache = ClosingLRUCache(maxsize=8, lease=True, pinned_predicate=lambda key: key == "active")
+    active, idle = _Closeable("active"), _Closeable("idle")
+    cache.get_or_create("active", lambda: active)
+    cache.get_or_create("idle", lambda: idle)
+    cache._cache["active"].last_touched -= 1000
+    cache._cache["idle"].last_touched -= 1000
+
+    assert cache.evict_and_close_idle(900) == 1
+    assert active.closed is False
+    assert idle.closed is True
+
+
+def test_cache_hit_refreshes_idle_timestamp():
+    cache = ClosingLRUCache(maxsize=8, lease=True)
+    cache.get_or_create("k", lambda: _Closeable("v"))
+    cache._cache["k"].last_touched -= 1000
+
+    cache.get_or_create("k", lambda: _Closeable("never"))
+    import time
+
+    assert time.monotonic() - cache._cache["k"].last_touched < 5

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -985,3 +985,65 @@ class TestEvictSubprocessEngines:
 
         evict_graph.assert_not_called()
         evict_vector.assert_not_called()
+
+
+class TestIdleKeepAlive:
+    """SUBPROCESS_IDLE_TTL_SECONDS keeps engines warm across releases."""
+
+    def _counting_queue(self, ttl):
+        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=ttl)
+        calls = {"touch": 0, "evict": 0, "reaper": 0}
+        queue._touch_subprocess_engines = lambda: calls.__setitem__("touch", calls["touch"] + 1)
+        queue._evict_subprocess_engines = lambda: calls.__setitem__("evict", calls["evict"] + 1)
+        queue._ensure_reaper = lambda: calls.__setitem__("reaper", calls["reaper"] + 1)
+        return queue, calls
+
+    @pytest.mark.asyncio
+    async def test_ttl_release_touches_instead_of_evicting(self):
+        queue, calls = self._counting_queue(ttl=900)
+
+        await queue.ensure_slot("ds-K")
+        await queue.release_slot_for("ds-K")
+        assert calls == {"touch": 1, "evict": 0, "reaper": 1}
+
+    @pytest.mark.asyncio
+    async def test_zero_ttl_evicts_at_release(self):
+        queue, calls = self._counting_queue(ttl=0)
+
+        await queue.ensure_slot("ds-K")
+        await queue.release_slot_for("ds-K")
+        assert calls == {"touch": 0, "evict": 1, "reaper": 0}
+
+    def test_reaper_starts_exactly_once(self):
+        from unittest.mock import MagicMock
+
+        from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
+
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=900)
+        thread = MagicMock()
+        with patch(
+            "cognee.infrastructure.databases.dataset_queue.queue.threading.Thread",
+            return_value=thread,
+        ) as thread_cls:
+            queue._ensure_reaper()
+            queue._ensure_reaper()
+        thread_cls.assert_called_once()
+        thread.start.assert_called_once()
+
+    def test_settings_read_ttl_from_env(self):
+        import os
+        from unittest.mock import patch as env_patch
+
+        from cognee.infrastructure.databases.dataset_queue.queue import (
+            get_dataset_queue_settings,
+        )
+
+        with env_patch.dict(os.environ, {"SUBPROCESS_IDLE_TTL_SECONDS": "42.5"}):
+            assert get_dataset_queue_settings().idle_ttl_seconds == 42.5
+        with env_patch.dict(os.environ, {"SUBPROCESS_IDLE_TTL_SECONDS": "-3"}):
+            assert get_dataset_queue_settings().idle_ttl_seconds == 0.0
+        with env_patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SUBPROCESS_IDLE_TTL_SECONDS", None)
+            assert get_dataset_queue_settings().idle_ttl_seconds == 900.0

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -1046,4 +1046,4 @@ class TestIdleKeepAlive:
             assert get_dataset_queue_settings().idle_ttl_seconds == 0.0
         with env_patch.dict(os.environ, {}, clear=False):
             os.environ.pop("SUBPROCESS_IDLE_TTL_SECONDS", None)
-            assert get_dataset_queue_settings().idle_ttl_seconds == 900.0
+            assert get_dataset_queue_settings().idle_ttl_seconds == 600.0

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -445,7 +445,7 @@ class TestReleaseSlotFor:
     async def test_eviction_fires_for_single_holder(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
 
         await queue.ensure_slot("ds-A")
@@ -456,7 +456,7 @@ class TestReleaseSlotFor:
     async def test_eviction_skipped_for_nested_depth(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
 
         await queue.ensure_slot("ds-B")
@@ -472,7 +472,7 @@ class TestReleaseSlotFor:
     async def test_eviction_skipped_when_cross_task_holder_exists(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
         ds = "ds-C"
 
@@ -500,7 +500,7 @@ class TestReleaseSlotFor:
     async def test_eviction_fires_after_last_cross_task_holder_releases(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
         ds = "ds-D"
 
@@ -528,7 +528,7 @@ class TestReleaseSlotFor:
     async def test_different_dataset_does_not_block_eviction(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
 
         other_ready = asyncio.Event()
@@ -554,7 +554,7 @@ class TestReleaseSlotFor:
     async def test_disabled_queue_skips_eviction(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=False, max_concurrent=5)
+        queue = DatasetQueue(enabled=False, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
 
         await queue.release_slot_for("any-dataset")
@@ -566,7 +566,7 @@ class TestReleaseSlotFor:
         error propagates to the caller rather than being eaten."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=1)
+        queue = DatasetQueue(enabled=True, max_concurrent=1, idle_ttl_seconds=0)
         ds = "ds-E"
 
         def failing_evict():
@@ -590,7 +590,7 @@ class TestReleaseSlotFor:
         """Releasing a slot that was never acquired must not crash."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
 
         await queue.release_slot_for("never-acquired")
@@ -602,7 +602,7 @@ class TestReleaseSlotFor:
         """Calling release twice for the same slot must not crash or over-release."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=2)
+        queue = DatasetQueue(enabled=True, max_concurrent=2, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
         ds = "ds-G"
 
@@ -623,7 +623,7 @@ class TestReleaseSlotFor:
         """Semaphore value must be exactly right after acquires and releases."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=3)
+        queue = DatasetQueue(enabled=True, max_concurrent=3, idle_ttl_seconds=0)
         self._mock_evict(queue)
 
         await queue.ensure_slot("ds1")
@@ -647,7 +647,7 @@ class TestReleaseSlotFor:
         """With three tasks on the same dataset, eviction fires once on the last exit."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
         ds = "shared-ds"
 
@@ -692,7 +692,7 @@ class TestReleaseSlotFor:
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
         n_tasks = 20
-        queue = DatasetQueue(enabled=True, max_concurrent=n_tasks + 1)
+        queue = DatasetQueue(enabled=True, max_concurrent=n_tasks + 1, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
         ds = "stress-ds"
 
@@ -718,7 +718,7 @@ class TestReleaseSlotFor:
         The surviving task should then be the last holder and fire eviction."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
         ds = "backstop-ds"
 
@@ -750,7 +750,7 @@ class TestReleaseSlotFor:
         outer exit skips (other task present), other task fires."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
         ds = "combo-ds"
 
@@ -784,7 +784,7 @@ class TestReleaseSlotFor:
         """Releasing one dataset doesn't affect a slot held for another."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
 
         await queue.ensure_slot("ds-A")
@@ -804,7 +804,7 @@ class TestReleaseSlotFor:
         """dataset_id=None uses the ds:<none> key and works correctly."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=2)
+        queue = DatasetQueue(enabled=True, max_concurrent=2, idle_ttl_seconds=0)
         counter = self._mock_evict(queue)
 
         await queue.ensure_slot(None)
@@ -819,7 +819,7 @@ class TestReleaseSlotFor:
         """If eviction raises for one dataset, another dataset's slot is unaffected."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         call_count = 0
 
         def evict_fails_once():
@@ -849,7 +849,7 @@ class TestActiveDatasetIds:
     async def test_tracks_slots_and_excludes_sentinels(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=4)
+        queue = DatasetQueue(enabled=True, max_concurrent=4, idle_ttl_seconds=0)
         assert queue.active_dataset_ids() == set()
 
         await queue.ensure_slot("dataset-1")
@@ -865,21 +865,21 @@ class TestActiveDatasetIds:
     async def test_acquire_only_slots_are_not_dataset_ids(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=4)
+        queue = DatasetQueue(enabled=True, max_concurrent=4, idle_ttl_seconds=0)
         async with queue.acquire():  # scoped slot without a dataset id
             assert queue.active_dataset_ids() == set()
 
     def test_disabled_queue_reports_no_active_datasets(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=False, max_concurrent=4)
+        queue = DatasetQueue(enabled=False, max_concurrent=4, idle_ttl_seconds=0)
         assert queue.active_dataset_ids() == set()
 
     @pytest.mark.asyncio
     async def test_depth_does_not_duplicate_and_survives_until_last_release(self):
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=4)
+        queue = DatasetQueue(enabled=True, max_concurrent=4, idle_ttl_seconds=0)
         await queue.ensure_slot("dataset-1")
         await queue.ensure_slot("dataset-1")  # re-entrant: depth bump, same slot
         assert queue.active_dataset_ids() == {"dataset-1"}
@@ -902,7 +902,7 @@ class TestEvictSubprocessEngines:
         adapter must be created".)"""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         evicted = False
 
         def evict():
@@ -938,7 +938,7 @@ class TestEvictSubprocessEngines:
         e2e failures)."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         g_conf_mod, v_conf_mod, g_engine_mod, v_engine_mod = self._modules()
 
         g_cfg = {"graph_database_subprocess_enabled": True, "graph_database_name": "g"}
@@ -964,7 +964,7 @@ class TestEvictSubprocessEngines:
         """Engines running in-process are not evicted at release."""
         from cognee.infrastructure.databases.dataset_queue.queue import DatasetQueue
 
-        queue = DatasetQueue(enabled=True, max_concurrent=5)
+        queue = DatasetQueue(enabled=True, max_concurrent=5, idle_ttl_seconds=0)
         g_conf_mod, v_conf_mod, g_engine_mod, v_engine_mod = self._modules()
 
         with (


### PR DESCRIPTION
## Description

Every request currently pays a full subprocess-engine close (~1.6s) at release plus a fresh spawn on the next request for the same dataset — measured as roughly half of interactive recall latency. This PR keeps the workers alive between requests: the last-holder release refreshes the engine's idle timestamp instead of evicting, and a reaper thread force-closes engines only after `SUBPROCESS_IDLE_TTL_SECONDS` (default **600** = 10 min) without use.

**Measured** (full War and Peace corpus, ladybug + lancedb + sqlite, access control on):
- Think-time recall: **~1.9s → 897–1,096ms**, with identical worker PIDs across queries (zero respawns)
- TTL expiry: workers reaped within the sweep window after going idle; next request respawns cleanly
- Sequential `asyncio.run()` phases now get cache **hits** on live engines across loops (889ms in loop 2)
- `SUBPROCESS_IDLE_TTL_SECONDS=0` restores the current dev behavior exactly (force-close at last release)

## Queue/cache synchronization

No new shared state. The queue keeps only concurrency permits; the cache owns the engines and their idle timestamps. The one shared fact — which datasets are active right now — is computed live from the slot table (`active_dataset_ids()`) and read by the reaper through the cache's existing pinned predicate, so an engine whose dataset holds a slot is never reaped, even if a query outlives the TTL. Capacity pressure is unchanged: LRU eviction with the same pinning. The reaper closes via `evict_and_close` (from #4358), so expired engines close on the cache's dedicated threads, register in the pending-close registry, and cannot be immortalized by idle proxy holders; a request racing the sweep at the expiry instant is absorbed by the registry wait, the worker open-retry, and handle re-resolution.

## Trade-offs to be aware of

- **Database file locks are now held for up to the TTL while idle.** In-process everything is safer and faster; a *second process* touching the same DB files (CLI against a live server's data dir, backup jobs) will see "Lock is held by PID" until the TTL expires. Worth a docs note before un-drafting.
- **Idle workers hold RAM and PIDs** for the TTL; the LRU cap bounds the count. On dense multi-tenant deployments the TTL is effectively a memory-sizing knob.

## Testing

- 15 new unit tests (cache touch/idle-sweep/pin-skip, queue TTL dispatch, reaper single-start, env parsing); full infrastructure unit suite green (pre-existing `neo4j` import skip and `test_llm_payment_required` timeout fail identically on pristine dev)
- Live probes: warm-reuse latency + PID stability, short-TTL expiry + respawn, cross-loop cache hits
