### PR TITLE
fix(test): Pin shared timestamp in ranker equality test (COG-6105)

### DIFF
--- a/cognee/tests/unit/infrastructure/session/test_session_embeddings.py
+++ b/cognee/tests/unit/infrastructure/session/test_session_embeddings.py
@@ -329,8 +329,12 @@ class TestRankerRelevance:
 
     def test_stored_embeddings_do_not_affect_ranking(self):
         ranker = DeterministicRanker()
-        aligned = _entry("rules", "same words", embedding=[1.0, 0.0])
-        misaligned = _entry("rules", "same words", embedding=[0.0, 1.0])
+        # Pin one timestamp for both entries: score() has a recency term, so
+        # per-entry utcnow() stamps make the scores differ by an ulp whenever
+        # the two _entry() calls land a few milliseconds apart.
+        created_at = datetime.utcnow().isoformat()
+        aligned = _entry("rules", "same words", embedding=[1.0, 0.0], created_at=created_at)
+        misaligned = _entry("rules", "same words", embedding=[0.0, 1.0], created_at=created_at)
 
         assert ranker.score(aligned, "same words") == ranker.score(misaligned, "same words")
 


### PR DESCRIPTION
## Description

`test_stored_embeddings_do_not_affect_ranking` flaked on the 3.10 unit job today (`34.00089309895717 == 34.00089309895718`).

The test creates its two entries with per-call `utcnow()` stamps, but `DeterministicRanker.score()` includes a recency term (`timestamp / 1e12 * W_RECENCY`). Whenever the two `_entry()` calls land more than ~4 ms apart, the recency delta crosses one ulp at the score's magnitude and the strict `==` fails — the embeddings the test is about were never the difference.

Fix: pin one shared `created_at` for both entries so the assertion isolates exactly the embedding difference it is meant to test. This is the only strict-equality score assertion in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)