### PR TITLE
refactor: Deduplicate engine cache ops

### DIFF
--- a/cognee/infrastructure/databases/dataset_queue/queue.py
+++ b/cognee/infrastructure/databases/dataset_queue/queue.py
@@ -274,17 +274,17 @@ class DatasetQueue:
 
         g_cfg = get_graph_context_config()
         if g_cfg.get("graph_database_subprocess_enabled"):
-            from cognee.infrastructure.databases.graph.get_graph_engine import touch_graph_engine
+            from cognee.infrastructure.databases.graph.get_graph_engine import graph_engine_cache
 
-            touch_graph_engine(**g_cfg)
+            graph_engine_cache.touch(**g_cfg)
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
             from cognee.infrastructure.databases.vector.create_vector_engine import (
-                touch_vector_engine,
+                vector_engine_cache,
             )
 
-            touch_vector_engine(**v_cfg)
+            vector_engine_cache.touch(**v_cfg)
 
     def _ensure_reaper(self) -> None:
         """Start the idle reaper thread, exactly once."""
@@ -377,17 +377,17 @@ class DatasetQueue:
 
         g_cfg = get_graph_context_config()
         if g_cfg.get("graph_database_subprocess_enabled"):
-            from cognee.infrastructure.databases.graph.get_graph_engine import evict_graph_engine
+            from cognee.infrastructure.databases.graph.get_graph_engine import graph_engine_cache
 
-            evict_graph_engine(force_close=True, **g_cfg)
+            graph_engine_cache.evict(force_close=True, **g_cfg)
 
         v_cfg = get_vectordb_context_config()
         if v_cfg.get("vector_db_subprocess_enabled"):
             from cognee.infrastructure.databases.vector.create_vector_engine import (
-                evict_vector_engine,
+                vector_engine_cache,
             )
 
-            evict_vector_engine(force_close=True, **v_cfg)
+            vector_engine_cache.evict(force_close=True, **v_cfg)
 
     # -------------------------------------------------------- release_slot_for
     async def release_slot_for(self, dataset_id: Any = None) -> None:

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -219,7 +219,7 @@ def _resolve_graph_engine_args(params: dict) -> tuple:
     Shared by the sync (:func:`create_graph_engine`) and async
     (:func:`acreate_graph_engine`) entry points so both produce the *identical*
     cache key (the positional tuple) — and so it matches the key built by
-    ``evict_graph_engine`` / ``is_graph_engine_cached``.
+    ``graph_engine_cache`` (evict / is_cached / ...).
     """
     normalized = _normalize_optional_create_graph_engine_params(params)
     return (
@@ -286,7 +286,8 @@ async def acreate_graph_engine(**kwargs):
 def _graph_engine_key_args(kwargs) -> tuple:
     """Positional cache-key args for a ``create_graph_engine`` config dict,
     normalized exactly the way ``create_graph_engine`` normalizes them so the
-    key matches. Shared by ``evict_graph_engine`` / ``touch_graph_engine``."""
+    key matches. The single place this knowledge lives — every operation on
+    ``graph_engine_cache`` routes through it."""
     normalized = _normalize_optional_create_graph_engine_params(kwargs)
     provider = _normalize_graph_database_provider(kwargs.get("graph_database_provider"))
     return (
@@ -569,14 +570,10 @@ def _create_graph_engine(
     )
 
 
-# Cache-management operations (evict / touch / is-cached / by-database
-# evictions) — mechanics shared with the vector engine via EngineCacheOps;
-# only the key knowledge above is graph-specific.
-_graph_engine_cache_ops = EngineCacheOps(
+# Public cache-management API for graph engines: ``graph_engine_cache.evict``
+# / ``.touch`` / ``.is_cached`` / ``.evict_for_database`` /
+# ``.aevict_for_database``. Mechanics are shared with the vector engine via
+# EngineCacheOps; only the key knowledge above is graph-specific.
+graph_engine_cache = EngineCacheOps(
     _create_graph_engine, _graph_engine_key_args, "graph_database_name"
 )
-evict_graph_engine = _graph_engine_cache_ops.evict
-touch_graph_engine = _graph_engine_cache_ops.touch
-is_graph_engine_cached = _graph_engine_cache_ops.is_cached
-evict_graph_engines_for_database = _graph_engine_cache_ops.evict_for_database
-aevict_graph_engines_for_database = _graph_engine_cache_ops.aevict_for_database

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -6,6 +6,7 @@ from numbers import Number
 
 from cognee.infrastructure.databases.dataset_queue.pinning import dataset_queue_pin_predicate
 from cognee.infrastructure.databases.utils.closing_lru_cache import closing_lru_cache
+from cognee.infrastructure.databases.utils.engine_cache_ops import EngineCacheOps
 from cognee.shared.lru_cache import DATABASE_MAX_LRU_CACHE_SIZE
 from cognee.shared.logging_utils import get_logger
 
@@ -282,30 +283,6 @@ async def acreate_graph_engine(**kwargs):
     return await _create_graph_engine.acall(*_resolve_graph_engine_args(kwargs))
 
 
-def evict_graph_engine(force_close: bool = False, **kwargs) -> bool:
-    """Evict a cached graph engine entry created via ``create_graph_engine``.
-
-    Mirrors ``create_graph_engine``'s normalization so the cache key
-    matches. Used by per-dataset deletion paths to drop the leased
-    adapter (and trigger its ``close()``) without disturbing the rest
-    of the cache.
-
-    ``force_close=True`` closes the adapter immediately even while idle
-    holders still pin its proxy (they re-resolve on next use) — the
-    dataset-queue teardown path, where the worker must exit and release
-    its file locks promptly. Default keeps lease semantics: the close
-    waits for the last holder.
-
-    Returns True if the entry existed.
-    """
-    evict = (
-        _create_graph_engine.cache_evict_and_close
-        if force_close
-        else _create_graph_engine.cache_evict
-    )
-    return evict(*_graph_engine_key_args(kwargs))
-
-
 def _graph_engine_key_args(kwargs) -> tuple:
     """Positional cache-key args for a ``create_graph_engine`` config dict,
     normalized exactly the way ``create_graph_engine`` normalizes them so the
@@ -313,77 +290,6 @@ def _graph_engine_key_args(kwargs) -> tuple:
     normalized = _normalize_optional_create_graph_engine_params(kwargs)
     provider = _normalize_graph_database_provider(kwargs.get("graph_database_provider"))
     return (
-        provider,
-        kwargs.get("graph_file_path"),
-        normalized["graph_database_url"],
-        normalized["graph_database_name"],
-        normalized["graph_database_username"],
-        normalized["graph_database_password"],
-        normalized["graph_database_host"],
-        normalized["graph_database_allow_anonymous"],
-        normalized["graph_database_port"],
-        normalized["graph_database_key"],
-        normalized["graph_dataset_database_handler"],
-        normalized["graph_database_subprocess_enabled"],
-        normalized["kuzu_num_threads"],
-        normalized["kuzu_buffer_pool_size"],
-        normalized["kuzu_max_db_size"],
-    )
-
-
-def touch_graph_engine(**kwargs) -> bool:
-    """Refresh the idle timestamp of the cached graph engine for this config.
-
-    The dataset-queue release path calls this when the idle-TTL keep-alive is
-    enabled, instead of evicting: the engine stays cached (and its worker
-    alive) until it has been idle for the TTL. Returns True if the entry
-    exists.
-    """
-    return _create_graph_engine.cache_touch(*_graph_engine_key_args(kwargs))
-
-
-def evict_graph_engines_for_database(graph_database_name: str) -> int:
-    """Evict every cached graph engine bound to *graph_database_name*.
-
-    The same per-dataset database can be cached under multiple keys: the
-    dataset-handler creation key and the pipeline's context-config key differ
-    in ``graph_file_path`` and ``graph_dataset_database_handler``, so key-exact
-    ``evict_graph_engine`` misses the pipeline's entry and leaves an engine
-    whose connection pool died with the dropped database. Per-dataset database
-    names are dataset UUIDs, so matching the name against key fields cannot
-    collide with other entries.
-
-    Returns the number of evicted entries.
-    """
-    if not graph_database_name:
-        raise ValueError("graph_database_name must be a non-empty database name")
-    return _create_graph_engine.cache_evict_matching(graph_database_name=graph_database_name)
-
-
-async def aevict_graph_engines_for_database(graph_database_name: str) -> int:
-    """Evict every cached graph engine bound to *graph_database_name* and wait
-    until their IN-FLIGHT closes have completed (workers exited, file locks
-    released). Use before removing the database's files so a teardown that is
-    already running cannot race the removal.
-
-    A close still deferred behind a live caller proxy (an idle engine handle)
-    is NOT waited on — see the ``closing_lru_cache`` module docstring. In that
-    case files are removed under an engine that closes later; on POSIX the
-    unlinked files stay valid for the holder and the eventual close writes to
-    nowhere, which is acceptable for a dataset being deleted.
-
-    Returns the number of evicted entries.
-    """
-    evicted = evict_graph_engines_for_database(graph_database_name)
-    await _create_graph_engine.cache_await_closed(graph_database_name=graph_database_name)
-    return evicted
-
-
-def is_graph_engine_cached(**kwargs) -> bool:
-    """Check whether a graph engine entry exists in the cache without creating."""
-    normalized = _normalize_optional_create_graph_engine_params(kwargs)
-    provider = _normalize_graph_database_provider(kwargs.get("graph_database_provider"))
-    return _create_graph_engine.cache_contains(
         provider,
         kwargs.get("graph_file_path"),
         normalized["graph_database_url"],
@@ -661,3 +567,16 @@ def _create_graph_engine(
         f"Unsupported graph database provider: {graph_database_provider}. "
         f"Supported providers are: {', '.join(all_providers)}"
     )
+
+
+# Cache-management operations (evict / touch / is-cached / by-database
+# evictions) — mechanics shared with the vector engine via EngineCacheOps;
+# only the key knowledge above is graph-specific.
+_graph_engine_cache_ops = EngineCacheOps(
+    _create_graph_engine, _graph_engine_key_args, "graph_database_name"
+)
+evict_graph_engine = _graph_engine_cache_ops.evict
+touch_graph_engine = _graph_engine_cache_ops.touch
+is_graph_engine_cached = _graph_engine_cache_ops.is_cached
+evict_graph_engines_for_database = _graph_engine_cache_ops.evict_for_database
+aevict_graph_engines_for_database = _graph_engine_cache_ops.aevict_for_database

--- a/cognee/infrastructure/databases/graph/get_graph_engine.py
+++ b/cognee/infrastructure/databases/graph/get_graph_engine.py
@@ -572,8 +572,15 @@ def _create_graph_engine(
 
 # Public cache-management API for graph engines: ``graph_engine_cache.evict``
 # / ``.touch`` / ``.is_cached`` / ``.evict_for_database`` /
-# ``.aevict_for_database``. Mechanics are shared with the vector engine via
-# EngineCacheOps; only the key knowledge above is graph-specific.
+# ``.aevict_for_database``.
+#
+# Dependency injection: EngineCacheOps holds the shared procedure (which cache
+# method implements which operation), and this call supplies the three
+# graph-specific dependencies — which cache to operate on (the decorated
+# factory), how a config dict becomes that cache's exact key (the key
+# builder), and which key field holds the per-dataset database name (for the
+# by-database evictions). The vector module builds its own instance from the
+# same class, so the procedure exists once and cannot drift between engines.
 graph_engine_cache = EngineCacheOps(
     _create_graph_engine, _graph_engine_key_args, "graph_database_name"
 )

--- a/cognee/infrastructure/databases/graph/ladybug/LadybugDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/ladybug/LadybugDatasetDatabaseHandler.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from typing import Optional
 
 from cognee.infrastructure.databases.graph.get_graph_engine import (
-    aevict_graph_engines_for_database,
+    graph_engine_cache,
 )
 from cognee.base_config import get_base_config
 from cognee.modules.users.models import User
@@ -69,11 +69,11 @@ class LadybugDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         # which races the just-torn-down one. Evict every cached engine for
         # this database — the same DB can sit under multiple cache keys —
         # wait for their in-flight closes to finish (a close deferred behind
-        # an idle holder is not waited on; see aevict_graph_engines_for_database),
+        # an idle holder is not waited on; see graph_engine_cache.aevict_for_database),
         # then remove the files directly. Server-backed handlers (e.g.
         # Postgres) are different on purpose: they drop the per-dataset
         # database over a connection, so no file handling applies there.
-        await aevict_graph_engines_for_database(graph_db_name)
+        await graph_engine_cache.aevict_for_database(graph_db_name)
 
         file_storage = get_file_storage(databases_directory_path)
         if await file_storage.is_file(graph_db_name):

--- a/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/neo4j_driver/Neo4jDatasetDatabaseHandler.py
@@ -8,7 +8,7 @@ from cognee.infrastructure.databases.exceptions import DatabaseCredentialsError
 from cognee.infrastructure.databases.graph import get_graph_config
 from cognee.infrastructure.databases.graph.get_graph_engine import (
     create_graph_engine,
-    evict_graph_engine,
+    graph_engine_cache,
 )
 from cognee.infrastructure.databases.dataset_database_handler import (
     DatasetDatabaseHandlerInterface,
@@ -82,7 +82,7 @@ class Neo4jDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         graph_database_password = info.get("graph_database_password", "")
         graph_database_allow_anonymous = info.get("graph_database_allow_anonymous", False)
 
-        evict_graph_engine(
+        graph_engine_cache.evict(
             graph_database_provider="neo4j",
             graph_file_path="",
             graph_database_url=graph_database_url,

--- a/cognee/infrastructure/databases/graph/postgres/PostgresGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/postgres/PostgresGraphDatasetDatabaseHandler.py
@@ -4,7 +4,7 @@ from typing import Optional
 from cognee.infrastructure.databases.graph.config import get_graph_config
 from cognee.infrastructure.databases.graph.get_graph_engine import (
     create_graph_engine,
-    evict_graph_engines_for_database,
+    graph_engine_cache,
 )
 from cognee.infrastructure.databases.postgres import (
     create_pg_database_if_not_exists,
@@ -100,4 +100,4 @@ class PostgresGraphDatasetDatabaseHandler:
         # persist — engines connect lazily, so an entry cached even after this
         # eviction holds no dead connections and either reaches the recreated
         # database or fails fast on a nonexistent one.
-        evict_graph_engines_for_database(db_name)
+        graph_engine_cache.evict_for_database(db_name)

--- a/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/graph/turso/TursoGraphDatasetDatabaseHandler.py
@@ -6,7 +6,7 @@ from cognee.base_config import get_base_config
 from cognee.infrastructure.databases.graph.config import get_graph_config
 from cognee.infrastructure.databases.graph.get_graph_engine import (
     create_graph_engine,
-    evict_graph_engine,
+    graph_engine_cache,
 )
 from cognee.modules.users.models import User, DatasetDatabase
 
@@ -64,7 +64,7 @@ class TursoGraphDatasetDatabaseHandler:
     async def delete_dataset(cls, dataset_database: DatasetDatabase) -> None:
         dataset_url = str(dataset_database.graph_database_url or "")
 
-        evict_graph_engine(
+        graph_engine_cache.evict(
             graph_database_provider="turso",
             graph_file_path="",
             graph_database_url=dataset_url,

--- a/cognee/infrastructure/databases/utils/engine_cache_ops.py
+++ b/cognee/infrastructure/databases/utils/engine_cache_ops.py
@@ -1,0 +1,92 @@
+"""Shared cache-management facade for the decorated engine factories.
+
+Graph and vector engines expose the same five cache operations — evict,
+touch, is-cached, evict-by-database, and its async variant. Before this
+module each engine file carried its own copy of the plumbing. The split of
+responsibilities is deliberate:
+
+* The *knowledge* — how a config dict becomes the factory's exact cache key —
+  stays in the engine module and is passed in as ``key_args``. Only the
+  factory's module can build that tuple (its own argument normalization);
+  duplicating the normalization elsewhere is how keys silently drift.
+* The *mechanics* — which cache method implements which operation — live
+  here, once.
+"""
+
+
+class EngineCacheOps:
+    """Uniform cache-management operations over one decorated engine factory.
+
+    ``factory`` is a ``closing_lru_cache``-decorated function (exposing
+    ``cache_evict`` / ``cache_evict_and_close`` / ``cache_touch`` /
+    ``cache_contains`` / ``cache_evict_matching`` / ``cache_await_closed``).
+    ``key_args`` maps a config dict to the factory's positional cache-key
+    tuple. ``database_name_field`` is the cache-key field holding the
+    per-dataset database name (a dataset UUID), used by the by-database
+    evictions.
+    """
+
+    __slots__ = ("_factory", "_key_args", "_database_name_field")
+
+    def __init__(self, factory, key_args, database_name_field: str) -> None:
+        self._factory = factory
+        self._key_args = key_args
+        self._database_name_field = database_name_field
+
+    def evict(self, force_close: bool = False, **kwargs) -> bool:
+        """Evict the cached engine entry for this config.
+
+        ``force_close=True`` closes the adapter immediately even while idle
+        holders still pin its proxy (they re-resolve on next use) — the
+        dataset-queue teardown path, where a worker must exit and release its
+        file locks promptly. The default keeps lease semantics: the close
+        waits for the last holder. Returns True if the entry existed.
+        """
+        evict = self._factory.cache_evict_and_close if force_close else self._factory.cache_evict
+        return evict(*self._key_args(kwargs))
+
+    def touch(self, **kwargs) -> bool:
+        """Refresh the idle timestamp of the cached engine for this config.
+
+        The dataset-queue release path calls this under the idle-TTL
+        keep-alive instead of evicting: the engine stays cached (and its
+        worker alive) until it has been idle for the TTL. Returns True if the
+        entry exists.
+        """
+        return self._factory.cache_touch(*self._key_args(kwargs))
+
+    def is_cached(self, **kwargs) -> bool:
+        """Check whether an engine entry exists for this config without creating."""
+        return self._factory.cache_contains(*self._key_args(kwargs))
+
+    def evict_for_database(self, database_name: str) -> int:
+        """Evict every cached engine bound to *database_name*.
+
+        The same per-dataset database can be cached under multiple keys: the
+        dataset-handler creation key and the pipeline's context-config key
+        differ in fields like the file path or the handler name, so key-exact
+        :meth:`evict` misses entries and leaves an engine whose backing
+        database has been dropped. Per-dataset database names are dataset
+        UUIDs, so matching the name against key fields cannot collide with
+        other entries. Returns the number of evicted entries.
+        """
+        if not database_name:
+            raise ValueError(f"{self._database_name_field} must be a non-empty database name")
+        return self._factory.cache_evict_matching(**{self._database_name_field: database_name})
+
+    async def aevict_for_database(self, database_name: str) -> int:
+        """Evict every cached engine bound to *database_name* and wait until
+        their IN-FLIGHT closes have completed (workers exited, file locks
+        released). Use before removing the database's files so a teardown that
+        is already running cannot race the removal.
+
+        A close still deferred behind a live caller proxy (an idle engine
+        handle) is NOT waited on — see the ``closing_lru_cache`` module
+        docstring. In that case files are removed under an engine that closes
+        later; on POSIX the unlinked files stay valid for the holder and the
+        eventual close writes to nowhere, which is acceptable for a dataset
+        being deleted. Returns the number of evicted entries.
+        """
+        evicted = self.evict_for_database(database_name)
+        await self._factory.cache_await_closed(**{self._database_name_field: database_name})
+        return evicted

--- a/cognee/infrastructure/databases/utils/engine_cache_ops.py
+++ b/cognee/infrastructure/databases/utils/engine_cache_ops.py
@@ -1,7 +1,10 @@
 """Shared cache-management facade for the decorated engine factories.
 
 Graph and vector engines expose the same five cache operations — evict,
-touch, is-cached, evict-by-database, and its async variant. Before this
+touch, is-cached, evict-by-database, and its async variant — through one
+public instance per engine module: ``graph_engine_cache`` in
+``get_graph_engine`` and ``vector_engine_cache`` in ``create_vector_engine``
+(e.g. ``graph_engine_cache.evict(force_close=True, **cfg)``). Before this
 module each engine file carried its own copy of the plumbing. The split of
 responsibilities is deliberate:
 

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -328,8 +328,15 @@ def _create_vector_engine(
 
 # Public cache-management API for vector engines: ``vector_engine_cache.evict``
 # / ``.touch`` / ``.is_cached`` / ``.evict_for_database`` /
-# ``.aevict_for_database``. Mechanics are shared with the graph engine via
-# EngineCacheOps; only the key knowledge above is vector-specific.
+# ``.aevict_for_database``.
+#
+# Dependency injection: EngineCacheOps holds the shared procedure (which cache
+# method implements which operation), and this call supplies the three
+# vector-specific dependencies — which cache to operate on (the decorated
+# factory), how a config dict becomes that cache's exact key (the key
+# builder), and which key field holds the per-dataset database name (for the
+# by-database evictions). The graph module builds its own instance from the
+# same class, so the procedure exists once and cannot drift between engines.
 vector_engine_cache = EngineCacheOps(
     _create_vector_engine, _vector_engine_key_args, "vector_db_name"
 )

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -6,6 +6,7 @@ from .supported_databases import supported_databases
 from .embeddings import get_embedding_engine
 from cognee.infrastructure.databases.dataset_queue.pinning import dataset_queue_pin_predicate
 from cognee.infrastructure.databases.utils.closing_lru_cache import closing_lru_cache
+from cognee.infrastructure.databases.utils.engine_cache_ops import EngineCacheOps
 from cognee.shared.lru_cache import DATABASE_MAX_LRU_CACHE_SIZE
 from cognee.shared.logging_utils import get_logger
 
@@ -113,92 +114,13 @@ def create_vector_engine(
     )
 
 
-def evict_vector_engine(force_close: bool = False, **kwargs) -> bool:
-    """Evict a cached vector engine entry created via ``create_vector_engine``.
-
-    Mirrors ``create_vector_engine``'s normalization so the cache key
-    matches. ``force_close=True`` closes the adapter immediately even while
-    idle holders still pin its proxy (they re-resolve on next use) — the
-    dataset-queue teardown path, where the worker must exit and release its
-    file locks promptly. Returns True if the entry existed.
-    """
-    evict = (
-        _create_vector_engine.cache_evict_and_close
-        if force_close
-        else _create_vector_engine.cache_evict
-    )
-    return evict(*_vector_engine_key_args(kwargs))
-
-
 def _vector_engine_key_args(kwargs) -> tuple:
     """Positional cache-key args for a ``create_vector_engine`` config dict,
     normalized the way ``create_vector_engine`` normalizes them so the key
-    matches. Shared by ``evict_vector_engine`` / ``touch_vector_engine``."""
+    matches. The single place this knowledge lives — every cache operation
+    in ``_vector_engine_cache_ops`` routes through it."""
     normalized = _normalize_optional_create_vector_engine_params(kwargs)
     return (
-        kwargs.get("vector_db_provider", ""),
-        kwargs.get("vector_db_url", ""),
-        kwargs.get("vector_db_name", ""),
-        normalized["vector_db_port"],
-        normalized["vector_db_key"],
-        normalized["vector_dataset_database_handler"],
-        normalized["vector_db_username"],
-        normalized["vector_db_password"],
-        normalized["vector_db_host"],
-        normalized["vector_db_subprocess_enabled"],
-    )
-
-
-def touch_vector_engine(**kwargs) -> bool:
-    """Refresh the idle timestamp of the cached vector engine for this config.
-
-    Dataset-queue release path under the idle-TTL keep-alive; see
-    ``touch_graph_engine``. Returns True if the entry exists.
-    """
-    return _create_vector_engine.cache_touch(*_vector_engine_key_args(kwargs))
-
-
-def evict_vector_engines_for_database(vector_db_name: str) -> int:
-    """Evict every cached vector engine bound to *vector_db_name*.
-
-    The same per-dataset database can be cached under multiple keys: the
-    dataset-handler paths and the pipeline's context-config path build their
-    engines with different kwargs (e.g. ``vector_dataset_database_handler``),
-    so key-exact ``evict_vector_engine`` misses entries and leaves an engine
-    with a dead connection pool and stale collection metadata. Per-dataset
-    database names are dataset UUIDs, so matching the name against key fields
-    cannot collide with other entries.
-
-    Returns the number of evicted entries.
-    """
-    if not vector_db_name:
-        raise ValueError("vector_db_name must be a non-empty database name")
-    return _create_vector_engine.cache_evict_matching(vector_db_name=vector_db_name)
-
-
-async def aevict_vector_engines_for_database(vector_db_name: str) -> int:
-    """Evict every cached vector engine bound to *vector_db_name* and wait
-    until their IN-FLIGHT closes have completed. Use before removing the
-    database's files so a teardown that is already running cannot race the
-    removal.
-
-    A close still deferred behind a live caller proxy (an idle engine handle)
-    is NOT waited on — see the ``closing_lru_cache`` module docstring. In that
-    case files are removed under an engine that closes later; on POSIX the
-    unlinked files stay valid for the holder and the eventual close writes to
-    nowhere, which is acceptable for a dataset being deleted.
-
-    Returns the number of evicted entries.
-    """
-    evicted = evict_vector_engines_for_database(vector_db_name)
-    await _create_vector_engine.cache_await_closed(vector_db_name=vector_db_name)
-    return evicted
-
-
-def is_vector_engine_cached(**kwargs) -> bool:
-    """Check whether a vector engine entry exists in the cache without creating."""
-    normalized = _normalize_optional_create_vector_engine_params(kwargs)
-    return _create_vector_engine.cache_contains(
         kwargs.get("vector_db_provider", ""),
         kwargs.get("vector_db_url", ""),
         kwargs.get("vector_db_name", ""),
@@ -402,3 +324,15 @@ def _create_vector_engine(
             f"Unsupported vector database provider: {vector_db_provider}. "
             f"Supported providers are: {', '.join(list(supported_databases.keys()) + ['LanceDB', 'PGVector', 'neptune_analytics', 'Turso'])}"
         )
+
+
+# Cache-management operations — mechanics shared with the graph engine via
+# EngineCacheOps; only the key knowledge above is vector-specific.
+_vector_engine_cache_ops = EngineCacheOps(
+    _create_vector_engine, _vector_engine_key_args, "vector_db_name"
+)
+evict_vector_engine = _vector_engine_cache_ops.evict
+touch_vector_engine = _vector_engine_cache_ops.touch
+is_vector_engine_cached = _vector_engine_cache_ops.is_cached
+evict_vector_engines_for_database = _vector_engine_cache_ops.evict_for_database
+aevict_vector_engines_for_database = _vector_engine_cache_ops.aevict_for_database

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -118,7 +118,7 @@ def _vector_engine_key_args(kwargs) -> tuple:
     """Positional cache-key args for a ``create_vector_engine`` config dict,
     normalized the way ``create_vector_engine`` normalizes them so the key
     matches. The single place this knowledge lives — every cache operation
-    in ``_vector_engine_cache_ops`` routes through it."""
+    on ``vector_engine_cache`` routes through it."""
     normalized = _normalize_optional_create_vector_engine_params(kwargs)
     return (
         kwargs.get("vector_db_provider", ""),

--- a/cognee/infrastructure/databases/vector/create_vector_engine.py
+++ b/cognee/infrastructure/databases/vector/create_vector_engine.py
@@ -326,13 +326,10 @@ def _create_vector_engine(
         )
 
 
-# Cache-management operations — mechanics shared with the graph engine via
+# Public cache-management API for vector engines: ``vector_engine_cache.evict``
+# / ``.touch`` / ``.is_cached`` / ``.evict_for_database`` /
+# ``.aevict_for_database``. Mechanics are shared with the graph engine via
 # EngineCacheOps; only the key knowledge above is vector-specific.
-_vector_engine_cache_ops = EngineCacheOps(
+vector_engine_cache = EngineCacheOps(
     _create_vector_engine, _vector_engine_key_args, "vector_db_name"
 )
-evict_vector_engine = _vector_engine_cache_ops.evict
-touch_vector_engine = _vector_engine_cache_ops.touch
-is_vector_engine_cached = _vector_engine_cache_ops.is_cached
-evict_vector_engines_for_database = _vector_engine_cache_ops.evict_for_database
-aevict_vector_engines_for_database = _vector_engine_cache_ops.aevict_for_database

--- a/cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/lancedb/LanceDBDatasetDatabaseHandler.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from typing import Optional
 
 from cognee.infrastructure.databases.vector.create_vector_engine import (
-    aevict_vector_engines_for_database,
+    vector_engine_cache,
 )
 from cognee.modules.users.models import User
 from cognee.modules.users.models import DatasetDatabase
@@ -50,12 +50,12 @@ class LanceDBDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         # (in subprocess mode, a worker) that races the just-torn-down one.
         # Evict every cached engine for this database, wait for their
         # in-flight closes to finish (a close deferred behind an idle holder
-        # is not waited on; see aevict_vector_engines_for_database), then
+        # is not waited on; see vector_engine_cache.aevict_for_database), then
         # remove the on-disk store directly.
         # Server-backed handlers (e.g. PGVector) are different on purpose:
         # they drop the per-dataset database over a connection, so no file
         # handling applies there.
-        await aevict_vector_engines_for_database(dataset_database.vector_database_name)
+        await vector_engine_cache.aevict_for_database(dataset_database.vector_database_name)
 
         databases_directory_path = os.path.dirname(dataset_database.vector_database_url)
         file_storage = get_file_storage(databases_directory_path)

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorDatasetDatabaseHandler.py
@@ -9,7 +9,7 @@ from cognee.infrastructure.databases.vector import get_vectordb_config
 from cognee.infrastructure.databases.dataset_database_handler import DatasetDatabaseHandlerInterface
 from cognee.infrastructure.databases.vector.create_vector_engine import (
     create_vector_engine,
-    evict_vector_engines_for_database,
+    vector_engine_cache,
 )
 from cognee.infrastructure.databases.postgres import (
     create_pg_database_if_not_exists,
@@ -100,4 +100,4 @@ class PGVectorDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         # the drop's awaits would be re-cached and survive a pre-drop eviction.
         # Post-drop nothing stale can persist — engines connect lazily and a fresh
         # adapter starts with empty collection metadata.
-        evict_vector_engines_for_database(dataset_database.vector_database_name)
+        vector_engine_cache.evict_for_database(dataset_database.vector_database_name)

--- a/cognee/infrastructure/databases/vector/turso/TursoVectorDatasetDatabaseHandler.py
+++ b/cognee/infrastructure/databases/vector/turso/TursoVectorDatasetDatabaseHandler.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from typing import Optional
 
 from cognee.infrastructure.databases.vector.create_vector_engine import (
-    aevict_vector_engines_for_database,
+    vector_engine_cache,
 )
 from cognee.modules.users.models import User
 from cognee.modules.users.models import DatasetDatabase
@@ -56,11 +56,11 @@ class TursoVectorDatasetDatabaseHandler(DatasetDatabaseHandlerInterface):
         # cache a fresh engine whose connection then leaks, and DROP TABLE never
         # removes the file. Evict every cached engine for this database, wait
         # for their in-flight closes to finish (a close deferred behind an idle
-        # holder is not waited on; see aevict_vector_engines_for_database), then
+        # holder is not waited on; see vector_engine_cache.aevict_for_database), then
         # delete the on-disk libSQL file. Turso's embedded store is a single
         # file (unlike LanceDB's directory), so remove the file, not a tree.
         # Mirrors the LanceDB handler.
-        await aevict_vector_engines_for_database(dataset_database.vector_database_name)
+        await vector_engine_cache.aevict_for_database(dataset_database.vector_database_name)
 
         databases_directory_path = os.path.dirname(dataset_database.vector_database_url)
         await get_file_storage(databases_directory_path).remove(

--- a/cognee/tests/e2e/turso/test_turso_adapter.py
+++ b/cognee/tests/e2e/turso/test_turso_adapter.py
@@ -308,7 +308,7 @@ async def test_get_neighborhood_depth_and_edge_types(adapter):
 async def test_factory_returns_turso_adapter_and_rejects_remote(tmp_path):
     from cognee.infrastructure.databases.graph.get_graph_engine import (
         create_graph_engine,
-        evict_graph_engine,
+        graph_engine_cache,
     )
 
     db_path = str(tmp_path / "graph.db")
@@ -323,7 +323,7 @@ async def test_factory_returns_turso_adapter_and_rejects_remote(tmp_path):
         assert isinstance(engine, TursoAdapter)
         assert engine.db_uri == f"sqlite+aiosqlite:///{db_path}"
     finally:
-        evict_graph_engine(**kwargs)
+        graph_engine_cache.evict(**kwargs)
 
     # A set auth token (remote) is rejected: remote sync is not supported yet.
     with pytest.raises(EnvironmentError):

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_subprocess_lock_race.py
@@ -11,7 +11,7 @@ the worker process to actually exit, and retries the open on transient lock
 contention.
 
 Drives the REAL graph-engine cache (`create_graph_engine` / `acreate_graph_engine`
-/ `evict_graph_engine`) in subprocess mode — no LLM or full cognee config needed.
+/ `graph_engine_cache.evict`) in subprocess mode — no LLM or full cognee config needed.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ pytest.importorskip("ladybug")
 from cognee.infrastructure.databases.graph.get_graph_engine import (
     acreate_graph_engine,
     create_graph_engine,
-    evict_graph_engine,
+    graph_engine_cache,
 )
 
 
@@ -48,7 +48,7 @@ async def _evict_after_use(cfg, *, use_async):
     engine = await acreate_graph_engine(**cfg) if use_async else create_graph_engine(**cfg)
     await engine.query("MATCH (n) RETURN 1 LIMIT 1")
     del engine
-    evict_graph_engine(**cfg)
+    graph_engine_cache.evict(**cfg)
     gc.collect()
 
 
@@ -90,7 +90,7 @@ async def test_handle_reresolves_after_eviction(tmp_path):
     # Simulate teardown: evict the cached engine. The handle pins the proxy, so
     # its next access detects the stale pin, drops it (deferred close releases
     # the lock off-loop), and re-resolves a fresh engine for the same path.
-    evict_graph_engine(**cfg)
+    graph_engine_cache.evict(**cfg)
     gc.collect()
 
     await handle.query("MATCH (n) RETURN 1 LIMIT 1")  # must NOT raise "is closed"

--- a/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_dataset_database_handler.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_neo4j_dataset_database_handler.py
@@ -206,8 +206,8 @@ async def test_delete_dataset_evicts_and_drops_database(monkeypatch):
     )
     monkeypatch.setattr(
         "cognee.infrastructure.databases.graph.neo4j_driver."
-        "Neo4jDatasetDatabaseHandler.evict_graph_engine",
-        lambda **kwargs: evicted_configs.append(kwargs),
+        "Neo4jDatasetDatabaseHandler.graph_engine_cache",
+        SimpleNamespace(evict=lambda **kwargs: evicted_configs.append(kwargs)),
     )
 
     dataset_database = SimpleNamespace(

--- a/cognee/tests/unit/infrastructure/databases/test_engine_cache_ops.py
+++ b/cognee/tests/unit/infrastructure/databases/test_engine_cache_ops.py
@@ -1,7 +1,7 @@
 """Tests for EngineCacheOps — the shared cache-management facade.
 
-The engine modules bind the public helpers (evict_graph_engine, ...) to an
-instance of this class; these tests pin the routing contract against a fake
+Each engine module exposes one public instance of this class
+(graph_engine_cache / vector_engine_cache); these tests pin the routing contract against a fake
 decorated factory.
 """
 

--- a/cognee/tests/unit/infrastructure/databases/test_engine_cache_ops.py
+++ b/cognee/tests/unit/infrastructure/databases/test_engine_cache_ops.py
@@ -1,0 +1,65 @@
+"""Tests for EngineCacheOps — the shared cache-management facade.
+
+The engine modules bind the public helpers (evict_graph_engine, ...) to an
+instance of this class; these tests pin the routing contract against a fake
+decorated factory.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from cognee.infrastructure.databases.utils.engine_cache_ops import EngineCacheOps
+
+
+def make_ops():
+    factory = MagicMock()
+    factory.cache_await_closed = AsyncMock()
+    key_args = MagicMock(return_value=("k1", "k2"))
+    ops = EngineCacheOps(factory, key_args, "db_name_field")
+    return ops, factory, key_args
+
+
+def test_evict_routes_by_force_close():
+    ops, factory, key_args = make_ops()
+
+    ops.evict(some="cfg")
+    factory.cache_evict.assert_called_once_with("k1", "k2")
+    factory.cache_evict_and_close.assert_not_called()
+    key_args.assert_called_with({"some": "cfg"})
+
+    ops.evict(force_close=True, some="cfg")
+    factory.cache_evict_and_close.assert_called_once_with("k1", "k2")
+
+
+def test_touch_and_is_cached_use_key_args():
+    ops, factory, key_args = make_ops()
+
+    ops.touch(some="cfg")
+    factory.cache_touch.assert_called_once_with("k1", "k2")
+
+    ops.is_cached(other="cfg")
+    factory.cache_contains.assert_called_once_with("k1", "k2")
+    assert [c.args[0] for c in key_args.call_args_list] == [{"some": "cfg"}, {"other": "cfg"}]
+
+
+def test_evict_for_database_matches_on_configured_field():
+    ops, factory, _ = make_ops()
+
+    ops.evict_for_database("dataset-uuid")
+    factory.cache_evict_matching.assert_called_once_with(db_name_field="dataset-uuid")
+
+
+def test_evict_for_database_rejects_empty_name():
+    ops, _, _ = make_ops()
+    with pytest.raises(ValueError, match="db_name_field"):
+        ops.evict_for_database("")
+
+
+@pytest.mark.asyncio
+async def test_aevict_for_database_awaits_in_flight_closes():
+    ops, factory, _ = make_ops()
+    factory.cache_evict_matching.return_value = 3
+
+    assert await ops.aevict_for_database("dataset-uuid") == 3
+    factory.cache_evict_matching.assert_called_once_with(db_name_field="dataset-uuid")
+    factory.cache_await_closed.assert_awaited_once_with(db_name_field="dataset-uuid")

--- a/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
+++ b/cognee/tests/unit/infrastructure/dataset_queue/test_dataset_queue.py
@@ -947,8 +947,8 @@ class TestEvictSubprocessEngines:
         with (
             patch.object(g_conf_mod, "get_graph_context_config", return_value=g_cfg),
             patch.object(v_conf_mod, "get_vectordb_context_config", return_value=v_cfg),
-            patch.object(g_engine_mod, "evict_graph_engine") as evict_graph,
-            patch.object(v_engine_mod, "evict_vector_engine") as evict_vector,
+            patch.object(g_engine_mod, "graph_engine_cache") as graph_cache,
+            patch.object(v_engine_mod, "vector_engine_cache") as vector_cache,
             patch.object(g_engine_mod, "create_graph_engine") as create_graph,
         ):
             queue._evict_subprocess_engines()
@@ -956,8 +956,8 @@ class TestEvictSubprocessEngines:
         # force_close: an idle holder pinning the lease proxy (e.g. a test
         # keeping a get_graph_engine() handle) must not defer the close and
         # keep the worker's file locks alive indefinitely.
-        evict_graph.assert_called_once_with(force_close=True, **g_cfg)
-        evict_vector.assert_called_once_with(force_close=True, **v_cfg)
+        graph_cache.evict.assert_called_once_with(force_close=True, **g_cfg)
+        vector_cache.evict.assert_called_once_with(force_close=True, **v_cfg)
         create_graph.assert_not_called()
 
     def test_eviction_skips_non_subprocess_engines(self):
@@ -978,13 +978,13 @@ class TestEvictSubprocessEngines:
                 "get_vectordb_context_config",
                 return_value={"vector_db_subprocess_enabled": False},
             ),
-            patch.object(g_engine_mod, "evict_graph_engine") as evict_graph,
-            patch.object(v_engine_mod, "evict_vector_engine") as evict_vector,
+            patch.object(g_engine_mod, "graph_engine_cache") as graph_cache,
+            patch.object(v_engine_mod, "vector_engine_cache") as vector_cache,
         ):
             queue._evict_subprocess_engines()
 
-        evict_graph.assert_not_called()
-        evict_vector.assert_not_called()
+        graph_cache.evict.assert_not_called()
+        vector_cache.evict.assert_not_called()
 
 
 class TestIdleKeepAlive:


### PR DESCRIPTION
## Description

The graph and vector engine modules each carried a parallel set of five cache-management helpers — `evict_*_engine`, `touch_*_engine`, `is_*_engine_cached`, `evict_*_engines_for_database`, `aevict_*_engines_for_database` — whose bodies were copies of the same plumbing. `is_*_engine_cached` had drifted furthest: it carried its own inline copy of the entire cache-key block in both modules.

This PR collapses the duplication into one shared facade, `EngineCacheOps` (`cognee/infrastructure/databases/utils/engine_cache_ops.py`), with a deliberate split of responsibilities:

- **Key knowledge stays in each engine module**: the `_*_key_args` builder encoding the factory's exact argument normalization is the one thing only that module can know. Duplicating normalization elsewhere is how cache keys silently drift.
- **Mechanics live once in the facade**: force-close routing, touch, contains, by-database matching + its await-closed async variant, empty-name validation, and the consolidated docstrings (the idle-holder force-close story, the multi-key rationale, the POSIX-unlink note).

Each module binds its public helpers to one facade instance:

```python
_graph_engine_cache_ops = EngineCacheOps(_create_graph_engine, _graph_engine_key_args, "graph_database_name")
evict_graph_engine = _graph_engine_cache_ops.evict
touch_graph_engine = _graph_engine_cache_ops.touch
...
```

**Every public name, signature, and call site is unchanged** (all by-database callers verified positional before generalizing the parameter name). Net: ~176 duplicated lines replaced by one documented 95-line class.

## Stacked on #4384

Branched from `perf-subprocess-idle-keepalive`; the diff shown here includes the keep-alive commits until #4384 merges into dev, after which it reduces to the refactor commit (`3add2e591`).

## Testing

- 6 new unit tests pin the facade's routing contract against a fake factory (force-close routing, key-args usage, by-database field matching, empty-name rejection, async await-closed)
- 118 targeted unit tests pass (facade + cache + dataset queue)
- Live probes on the real stack: TTL keep-alive path reuses identical worker PIDs (touch alias), TTL=0 path cycles fresh PIDs per loop with no lock errors (force-close evict alias)