### PR TITLE
fix: Avoid nested DB sessions that deadlock the pool

### DIFF
--- a/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
+++ b/cognee/infrastructure/databases/utils/get_or_create_dataset_database.py
@@ -91,9 +91,12 @@ async def get_or_create_dataset_database(
     if isinstance(dataset, str):
         from cognee.modules.data.methods import create_authorized_dataset
 
-        async with db_engine.get_async_session() as session:
-            if isinstance(dataset, str):
-                dataset = await create_authorized_dataset(dataset, user)
+        # create_authorized_dataset opens its own relational session (and so does
+        # the permission grant it performs). Don't wrap it in an extra session
+        # here: that outer connection was never used, and holding it idle while
+        # the callee acquires more connections deadlocks the pool under
+        # concurrency (same class as #4197).
+        dataset = await create_authorized_dataset(dataset, user)
 
     # If dataset database already exists return it
     existing_dataset_database = await _existing_dataset_database(dataset_id, user)

--- a/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
+++ b/cognee/infrastructure/databases/vector/pgvector/PGVectorAdapter.py
@@ -604,9 +604,12 @@ class PGVectorAdapter(SQLAlchemyAdapter, VectorDBInterface):
             return None
 
         async with self._get_write_lock(collection_name):
+            # Resolve the table BEFORE opening the session. get_table() checks out
+            # its own connection; doing it inside the session would hold two pooled
+            # connections at once and deadlock the pool under concurrency (same
+            # class as #4197). Mirrors retrieve()/search().
+            PGVectorDataPoint = await self.get_table(collection_name)
             async with self.get_async_session() as session:
-                PGVectorDataPoint = await self.get_table(collection_name)
-
                 results = None
                 if not data_point_ids:
                     results = await session.execute(


### PR DESCRIPTION
## Context

Follow-up to the #4197 fix. A codebase scan for the same bug class — holding one relational connection open while a **second** is acquired — found two more instances on **concurrent** paths. On a bounded pool (Postgres / PGVector), each in-flight call pins two connections at once; once concurrency reaches the pool size this becomes a circular wait that deadlocks the pool and strands backends `idle in transaction`.

This PR fixes those two with the **minimal** change at each site. Both are behavior-preserving.

## Changes

**1. `get_or_create_dataset_database`** (`infrastructure/databases/utils/get_or_create_dataset_database.py`)
The `async with db_engine.get_async_session() as session:` around `create_authorized_dataset(...)` **never used `session`**, yet held a connection while the callee opened its own session (plus a permission grant that opens more). Removed the dead wrapper (and a redundant inner `isinstance` check). Runs on `add()`/`cognify()` when a dataset is passed by name — a concurrent request path.

**2. `PGVectorAdapter.delete_data_points`** (`infrastructure/databases/vector/pgvector/PGVectorAdapter.py`)
`get_table()` checks out its own connection; it was being called **inside** the write session, holding two pooled connections at once. Moved it before the session — exactly as the sibling `retrieve()` / `search()` methods already do. PGVector reuses the relational engine, so this contends the same pool (and an even smaller per-dataset pool under access control).

## Why minimal / low risk
- Both mirror existing, already-safe patterns in the same files (or remove provably-dead code).
- No behavior change other than releasing a connection sooner.
- Lint/format clean.

## Scope / not included
The scan also found lower-severity instances on **admin / user-management** paths (`tenants/`, `roles/`, `get_deletion_counts`) and a few dormant/latent ones (`get_pipeline_run_metrics`, `get_document_ids_for_user`, some `SqlAlchemyAdapter` helpers). Those are left out to keep this change minimal; they can follow up separately. A systemic note: `SqlAlchemyAdapter.get_table/get_table_names/get_schema_list` each open their own connection, so any method calling them while holding a session nests a second — worth a guard later.

Related: #4197