### PR TITLE
fix: Route Docker migrations through cognee's system

### DIFF
--- a/cognee-mcp/src/server.py
+++ b/cognee-mcp/src/server.py
@@ -2047,19 +2047,23 @@ async def main():
     # Skip migrations when in API or Cloud mode (remote handles its own database)
     is_remote = bool(args.api_url) or bool(serve_url)
     if not args.no_migration and not is_remote:
-        from cognee.modules.engine.operations.setup import setup
         from cognee.run_migrations import run_migrations
 
         logger.info("Running database migrations...")
 
-        # Database setup and migrations print progress and "table already
-        # exists" notices to stdout. In stdio transport stdout is the JSON-RPC
-        # channel, so route that output to stderr — the same guard every tool
-        # applies around its cognee calls.
+        # Migrations print progress and "table already exists" notices to
+        # stdout. In stdio transport stdout is the JSON-RPC channel, so route
+        # that output to stderr — the same guard every tool applies around its
+        # cognee calls.
         with redirect_stdout(sys.stderr):
-            await setup()
-            # Full startup migrations (relational schema + graph/vector revision
-            # chains) — MCP writes new-scheme data, so it must migrate like the API.
+            # run_migrations() alone — it tells a fresh database from an
+            # existing one (fresh: schema from the models + `alembic stamp
+            # head`; existing: Alembic deltas + the graph/vector data chain).
+            # Running setup() before it used to spoil that check: create_all
+            # built the schema unstamped, so a brand-new database was
+            # classified as existing and replayed the full migration history.
+            # Vector-store tables are created on first write (add() runs
+            # setup()), the same as every SDK flow.
             await run_migrations()
 
         logger.info("Database migrations done.")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,29 +15,34 @@ echo "Debug port: $DEBUG_PORT"
 echo "HTTP port: $HTTP_PORT"
 echo "Bind address: $BIND_ADDRESS"
 
-# Run Alembic migrations with proper error handling.
+# Run migrations through cognee's own migration system rather than raw
+# alembic: it knows a fresh database from an existing one (fresh -> create
+# directories + build the schema from the models + `alembic stamp head`;
+# existing -> apply Alembic deltas + the graph/vector data chain), honors
+# ENABLE_AUTO_MIGRATIONS, and needs no working directory. Raw
+# `alembic upgrade head` had none of that: on a fresh volume it died on the
+# missing databases directory and the silent create_all fallback left the
+# schema unstamped.
+#
+# A relational migration failure aborts the boot (set -e). Per-dataset
+# data-chain failures do not: the server comes up, cognee blocks writes to
+# just those datasets and retries on the next start — the same semantics as
+# the in-app startup path.
 echo "Running database migrations..."
+python <<'PYTHON'
+import asyncio
 
-# Move to the cognee directory to run alembic migrations from there
-set +e # Disable exit on error to handle specific migration errors
-MIGRATION_OUTPUT=$(cd cognee && alembic upgrade head)
-MIGRATION_EXIT_CODE=$?
-set -e
+from cognee.modules.migrations.startup import run_migrations
 
-if [[ $MIGRATION_EXIT_CODE -ne 0 ]]; then
-    echo "Migration failed with unexpected error. Trying to run Cognee without migrations."
-
-    echo "Initializing database tables..."
-    python /app/cognee/modules/engine/operations/setup.py
-    INIT_EXIT_CODE=$?
-
-    if [[ $INIT_EXIT_CODE -ne 0 ]]; then
-        echo "Database initialization failed!"
-        exit 1
-    fi
-else
-    echo "Database migrations done."
-fi
+failed = asyncio.run(run_migrations())
+if failed:
+    print(
+        "Data migrations failed for: " + ", ".join(failed)
+        + ". Writes to those datasets are blocked until they migrate; "
+        "retried on the next start."
+    )
+PYTHON
+echo "Database migrations done."
 
 echo "Starting server..."
 


### PR DESCRIPTION
## Description

Fixes the docker-compose first-run failures reported on Discord (missing databases directory, misleading migration tracebacks, silent migration skips).

`entrypoint.sh` ran raw `cd cognee && alembic upgrade head` with a silent `setup.py` fallback — a shell reimplementation of half of cognee's migration system (`cognee/modules/migrations/startup.py`), missing everything the real one does:

- **Fresh volume:** the databases directory doesn't exist yet, so raw alembic dies with `sqlite3.OperationalError: unable to open database file` (reproduced locally). The fallback then builds the schema via `create_all` **without stamping**, and the server's own startup later classifies the DB as existing and replays the full migration history against a head-shaped schema — surviving only because migrations are defensively guarded.
- **Silent skip time bomb:** a genuine migration failure was reduced to a log line + fallback, so every fresh deployment booted without alembic ever succeeding — any real schema migration a future release carries would be silently skipped.
- The misleading Postgres first-run traceback ('works the second time') is the same fallback pattern.

## Change

The entrypoint now delegates to `run_migrations()` — the same path the FastAPI lifespan, SDK first-write, and `cognee-cli upgrade` already use:

- fresh database → directories created, schema built from the models, `alembic stamp head`
- existing database → Alembic deltas + the graph/vector data chain
- `ENABLE_AUTO_MIGRATIONS=false` honored (operator-driven migrations)
- relational migration failure **aborts the boot** (no fallback); per-dataset data-chain failures keep in-app semantics (server up, writes to those datasets blocked, retried next start)

One migration system, one owner; the shell duplicate is deleted.

**MCP had the same disease in a subtler form** (second commit): `server.py` ran `setup()` *before* `run_migrations()`, so on a fresh database `create_all` built the schema unstamped, the freshness check then saw the `users` table, classified the database as *existing*, and replayed the full Alembic history against a head-shaped schema instead of stamping. Traced live: setup-first takes the upgrade/replay path on a fresh DB; `run_migrations()` alone takes the stamp path. The `setup()` call is dropped — vector-store tables are created on first write (`add()` runs `setup()`), the same as every SDK flow.

## Testing

Verified the exact boot step locally in all three shapes (clean env, sqlite):
- fresh volume with missing directories: boots cleanly, 31 tables created, `alembic_version` stamped at head
- existing database, second boot: delta path, no-op, exit 0
- unwritable databases directory: exits non-zero → `set -e` aborts the boot loudly

## Follow-ups (not this PR)

- compose CI leg with `--profile mcp` + an assertion that migrations actually ran
- `.env` mounts `:ro`; `USER` decision for the main image vs the mcp image (uid 1000) sharing the bind-mounted db dir; wiring or documenting the postgres profile
