### PR TITLE
fix: Share Docker storage as one non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,10 +81,15 @@ WORKDIR /app
 # separate `chown -R /app` would copy the whole tree up into a second layer.
 # /cognee-storage is baked into the image cognee-owned so a fresh named
 # volume mounted there initializes with the right ownership.
+# ``chown cognee /app`` (the directory inode only): WORKDIR created /app as
+# root, and ``COPY --chown`` sets ownership on the copied content, not the
+# pre-existing target dir — without this the non-root user cannot create
+# ``$HOME/.lbdb`` and the build-time extension pre-install silently fails.
 RUN groupadd --system --gid 1000 cognee \
     && useradd --system --uid 1000 --gid cognee --no-create-home --shell /usr/sbin/nologin cognee \
     && mkdir -p /cognee-storage/system /cognee-storage/data \
-    && chown -R cognee:cognee /cognee-storage
+    && chown -R cognee:cognee /cognee-storage \
+    && chown cognee:cognee /app
 
 COPY --from=uv --chown=cognee:cognee /app /app
 
@@ -107,6 +112,15 @@ ENV SYSTEM_ROOT_DIRECTORY=/cognee-storage/system
 ENV DATA_ROOT_DIRECTORY=/cognee-storage/data
 
 USER cognee
+
+# Pre-install Kuzu/Ladybug's JSON extension at build time (network is available
+# here) so it is baked into the image — same mechanism as the cognee-mcp
+# image. As root the server used to INSTALL it at runtime into /root/.lbdb on
+# every boot; as the non-root user that runtime install races between graph
+# workers and fails ("Directory ... cannot be created"). Best-effort: a failed
+# download must not break the image build.
+RUN python -c "from cognee_db_workers._kuzu_helpers import install_json_extension_local; install_json_extension_local(buffer_pool_size=268435456)" \
+    || echo "WARNING: JSON extension pre-install skipped (no network at build time); it will be installed on first run if the container has network access."
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,9 +74,19 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-COPY --from=uv /app /app
-# COPY --from=uv /app/.venv /app/.venv
-# COPY --from=uv /root/.local /root/.local
+# Run as the same non-root user as the cognee-mcp image (uid/gid 1000) so both
+# containers can share the storage volumes without ownership conflicts (a
+# root-created database directory is unwritable for the uid-1000 MCP server).
+# Created before the COPY so ownership is set in that single layer — a
+# separate `chown -R /app` would copy the whole tree up into a second layer.
+# /cognee-storage is baked into the image cognee-owned so a fresh named
+# volume mounted there initializes with the right ownership.
+RUN groupadd --system --gid 1000 cognee \
+    && useradd --system --uid 1000 --gid cognee --no-create-home --shell /usr/sbin/nologin cognee \
+    && mkdir -p /cognee-storage/system /cognee-storage/data \
+    && chown -R cognee:cognee /cognee-storage
+
+COPY --from=uv --chown=cognee:cognee /app /app
 
 # Strip Windows carriage returns (fixes "no such file" on Windows Docker)
 RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
@@ -87,6 +97,16 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH=/app
 # ENV LOG_LEVEL=ERROR
 ENV PYTHONUNBUFFERED=1
+# Writable HOME for the non-root user (~/.cognee logs, tool caches).
+ENV HOME=/app
+# Default storage OUTSIDE the source tree: the ./cognee bind mount exists for
+# dev reload and must not double as the persistence location (host-uid
+# sensitive, pollutes the checkout, and was shared with the MCP container by
+# accident rather than by design). docker-compose mounts named volumes here.
+ENV SYSTEM_ROOT_DIRECTORY=/cognee-storage/system
+ENV DATA_ROOT_DIRECTORY=/cognee-storage/data
+
+USER cognee
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 

--- a/cognee-mcp/Dockerfile
+++ b/cognee-mcp/Dockerfile
@@ -67,7 +67,9 @@ WORKDIR /app
 # which forces overlayfs to copy up the entire ~9GB /app tree into a second
 # layer (the venv effectively stored twice). `COPY --chown` avoids that.
 RUN groupadd --system --gid 1000 cognee \
-    && useradd --system --uid 1000 --gid cognee --no-create-home --shell /usr/sbin/nologin cognee
+    && useradd --system --uid 1000 --gid cognee --no-create-home --shell /usr/sbin/nologin cognee \
+    && mkdir -p /cognee-storage/system /cognee-storage/data \
+    && chown -R cognee:cognee /cognee-storage
 
 # Copy the virtual environment from the uv stage
 COPY --from=uv /usr/local /usr/local
@@ -85,6 +87,10 @@ ENV PYTHONPATH=/app
 # Give the non-root user a stable, writable HOME so Kuzu/Ladybug caches its
 # downloaded extensions in a consistent location across build and runtime.
 ENV HOME=/app
+# Default storage OUTSIDE the source tree, matching the main image — both
+# containers share the same named volumes with the same uid (1000).
+ENV SYSTEM_ROOT_DIRECTORY=/cognee-storage/system
+ENV DATA_ROOT_DIRECTORY=/cognee-storage/data
 
 # Add labels for API mode usage
 LABEL org.opencontainers.image.description="Cognee MCP Server with API mode support"

--- a/cognee-mcp/Dockerfile
+++ b/cognee-mcp/Dockerfile
@@ -66,10 +66,16 @@ WORKDIR /app
 # single layer. A separate `chown -R /app` rewrites metadata on every file,
 # which forces overlayfs to copy up the entire ~9GB /app tree into a second
 # layer (the venv effectively stored twice). `COPY --chown` avoids that.
+# ``chown cognee /app`` (the directory inode only): WORKDIR created /app as
+# root, and ``COPY --chown`` sets ownership on the copied content, not the
+# pre-existing target dir — without this the JSON-extension pre-install below
+# cannot create ``$HOME/.lbdb`` and has been silently falling back to its
+# build warning (and the runtime install fails the same way as non-root).
 RUN groupadd --system --gid 1000 cognee \
     && useradd --system --uid 1000 --gid cognee --no-create-home --shell /usr/sbin/nologin cognee \
     && mkdir -p /cognee-storage/system /cognee-storage/data \
-    && chown -R cognee:cognee /cognee-storage
+    && chown -R cognee:cognee /cognee-storage \
+    && chown cognee:cognee /app
 
 # Copy the virtual environment from the uv stage
 COPY --from=uv /usr/local /usr/local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,8 @@ services:
       - DB_HOST=${DB_HOST:-host.docker.internal}
       - DB_PORT=${DB_PORT:-5432}
       - DB_NAME=${DB_NAME:-cognee_db}
-      - DB_USERNAME=${DB_USERNAME}
-      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_USERNAME=${DB_USERNAME:-}
+      - DB_PASSWORD=${DB_PASSWORD:-}
       # CAUTION: Default '*' allows all origins. Override with specific domains in production.
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-*}
     extra_hosts:
@@ -83,8 +83,8 @@ services:
       - DB_HOST=${DB_HOST:-host.docker.internal}
       - DB_PORT=${DB_PORT:-5432}
       - DB_NAME=${DB_NAME:-cognee_db}
-      - DB_USERNAME=${DB_USERNAME}
-      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_USERNAME=${DB_USERNAME:-}
+      - DB_PASSWORD=${DB_PASSWORD:-}
       # MCP specific configuration
       - PYTHONUNBUFFERED=1
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,14 +8,29 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
+      # Source bind mount is for dev reload only; persistence lives in the
+      # named volumes below (shared with cognee-mcp, both run as uid 1000).
       - ./cognee:/app/cognee
-      - .env:/app/.env
+      - .env:/app/.env:ro
+      - cognee_system:/cognee-storage/system
+      - cognee_data:/cognee-storage/data
       # Uncomment to allow ingestion of local files from host:
       # - /path/to/your/data:/data
     environment:
       - DEBUG=false # Change to true if debugging
       - ENV=local
       - LOG_LEVEL=INFO
+      - SYSTEM_ROOT_DIRECTORY=/cognee-storage/system
+      - DATA_ROOT_DIRECTORY=/cognee-storage/data
+      # Relational DB configuration — defaults to embedded SQLite. For
+      # `--profile postgres` set DB_PROVIDER=postgres and DB_HOST=postgres
+      # (the service name) in your environment or .env.
+      - DB_PROVIDER=${DB_PROVIDER:-sqlite}
+      - DB_HOST=${DB_HOST:-host.docker.internal}
+      - DB_PORT=${DB_PORT:-5432}
+      - DB_NAME=${DB_NAME:-cognee_db}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
       # CAUTION: Default '*' allows all origins. Override with specific domains in production.
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-*}
     extra_hosts:
@@ -48,14 +63,20 @@ services:
       dockerfile: cognee-mcp/Dockerfile
     command: --no-migration
     volumes:
-      - .env:/app/.env
+      - .env:/app/.env:ro
       - ./cognee:/app/cognee
+      # Same storage volumes as the main service: shared memory between the
+      # API and the MCP server is the point of running both (same uid 1000).
+      - cognee_system:/cognee-storage/system
+      - cognee_data:/cognee-storage/data
       # Uncomment to allow ingestion of local files from host:
       # - /path/to/your/data:/data
     environment:
       - DEBUG=false # Change to true if debugging
       - ENV=local
       - LOG_LEVEL=INFO
+      - SYSTEM_ROOT_DIRECTORY=/cognee-storage/system
+      - DATA_ROOT_DIRECTORY=/cognee-storage/data
       - TRANSPORT_MODE=sse
       # Database configuration - should match the main cognee service
       - DB_PROVIDER=${DB_PROVIDER:-sqlite}
@@ -161,5 +182,7 @@ networks:
     name: cognee-network
 
 volumes:
+  cognee_system:
+  cognee_data:
   postgres_data:
   redis_data:


### PR DESCRIPTION
## Description

Fixes the storage-ownership failures reported on Discord: the main image ran as **root** while `cognee-mcp` runs as **uid 1000**, and both bind-mounted `./cognee`, whose `.cognee_system` doubled as the persistence location.

The ownership arithmetic made every mixed-uid deployment converge to broken, regardless of start order:
- **Main first**: storage created root-owned → the MCP server (uid 1000) cannot write the SQLite file or create anything in the databases dir.
- **MCP first**: works initially (root ignores ownership) — but every *new* filesystem object the root container creates (per-dataset database dirs, SQLite `-wal`/`-shm` sidecars) lands root-owned, and MCP progressively loses write access to exactly the newest data.
- Bonus failure mode: persistence inside the source bind mount pollutes the host checkout with root-owned files and is host-uid-sensitive (the reporter's host uid was 1002).

## Change

- Main image now runs as the same `cognee` uid/gid-1000 user the MCP image already defines (`COPY --chown` in one layer, writable `HOME=/app`, no more root-by-default).
- Default storage moves **outside the source tree** to `/cognee-storage/{system,data}`, baked into both images cognee-owned — so a fresh named volume mounted there initializes with the right ownership.
- docker-compose mounts shared named volumes (`cognee_system`, `cognee_data`) on **both** services: shared memory between the API and the MCP server is the point of running both, now by design instead of by accident of the bind mount. The `./cognee` bind mount goes back to being dev-reload only.
- `.env` mounts are `:ro` (Discord bug #2), and the main service gets the same `DB_*` passthrough the MCP service already had, with a comment on wiring `--profile postgres` (`DB_HOST=postgres`).

## Migration note for existing deployments

Data previously written under `./cognee/.cognee_system` stays on the host; copy it into the named volume or override `SYSTEM_ROOT_DIRECTORY`/`DATA_ROOT_DIRECTORY` to keep the old location.

## Related

Complements #4390 (Docker/MCP migration-path fixes) — disjoint files, either merge order works.

## Testing

Docker build + boot verification in both start orders and cross-container write checks — results being posted as a follow-up comment.