### PR TITLE
fix: Release DB connection before nested acquisitions

### DIFF
--- a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
+++ b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py
@@ -306,16 +306,20 @@ class SQLAlchemyAdapter:
             return 0
 
         try:
+            # Resolve the table BEFORE opening the write connection. get_table()
+            # checks out its own connection; doing it inside would hold two pooled
+            # connections at once and deadlock the pool under concurrency (#4197).
+            if self.engine.dialect.name == "sqlite":
+                table = await self.get_table(table_name)  # SQLite ignores schemas
+            else:
+                table = await self.get_table(table_name, schema_name)
+
             # Use SQLAlchemy Core insert with execution options
             async with self.engine.begin() as conn:
-                # Dialect-agnostic table reference
                 if self.engine.dialect.name == "sqlite":
                     # Foreign key constraints are disabled by default in SQLite (for backwards compatibility),
                     # so must be enabled for each database connection/session separately.
                     await conn.execute(text("PRAGMA foreign_keys=ON"))
-                    table = await self.get_table(table_name)  # SQLite ignores schemas
-                else:
-                    table = await self.get_table(table_name, schema_name)
 
                 result = await conn.execute(table.insert().values(data))
 
@@ -362,10 +366,13 @@ class SQLAlchemyAdapter:
             - schema_name (Optional[str]): The name of the schema where the table resides,
               defaults to 'public'. (default 'public')
         """
+        # Resolve the table BEFORE opening the session. get_table() checks out its
+        # own connection; doing it inside would hold two pooled connections at once
+        # and deadlock the pool under concurrency (#4197).
+        TableModel = await self.get_table(table_name, schema_name)
+
         if self.engine.dialect.name == "sqlite":
             async with self.get_async_session() as session:
-                TableModel = await self.get_table(table_name, schema_name)
-
                 # Foreign key constraints are disabled by default in SQLite (for backwards compatibility),
                 # so must be enabled for each database connection/session separately.
                 await session.execute(text("PRAGMA foreign_keys = ON;"))
@@ -374,7 +381,6 @@ class SQLAlchemyAdapter:
                 await session.commit()
         else:
             async with self.get_async_session() as session:
-                TableModel = await self.get_table(table_name, schema_name)
                 await session.execute(TableModel.delete().where(TableModel.c.id == data_id))
                 await session.commit()
 
@@ -502,6 +508,11 @@ class SQLAlchemyAdapter:
             - List[str]: A list of all table names in the database.
         """
         table_names = []
+        # Resolve the schema list BEFORE opening our reflection connection.
+        # get_schema_list() checks out its own connection; calling it inside would
+        # hold two pooled connections at once and deadlock the pool under
+        # concurrency (#4197).
+        schema_list = await self.get_schema_list() if self.engine.dialect.name != "sqlite" else []
         async with self.engine.begin() as connection:
             if self.engine.dialect.name == "sqlite":
                 # Use a new MetaData instance to reflect all tables
@@ -509,7 +520,6 @@ class SQLAlchemyAdapter:
                 await connection.run_sync(metadata.reflect)  # Reflect the entire database
                 table_names = list(metadata.tables.keys())  # Get table names
             else:
-                schema_list = await self.get_schema_list()
                 metadata = MetaData()
                 for schema_name in schema_list:
                     await connection.run_sync(metadata.reflect, schema=schema_name)
@@ -569,18 +579,21 @@ class SQLAlchemyAdapter:
 
             A list of dictionaries representing all rows in the specified table.
         """
+        # Validate inputs to prevent SQL injection
+        if not table_name.isidentifier():
+            raise ValueError("Invalid table name")
+        if schema and not schema.isidentifier():
+            raise ValueError("Invalid schema name")
+
+        # Resolve the table BEFORE opening the session. get_table() checks out its
+        # own connection; doing it inside would hold two pooled connections at once
+        # and deadlock the pool under concurrency (#4197).
+        if self.engine.dialect.name == "sqlite":
+            table = await self.get_table(table_name)
+        else:
+            table = await self.get_table(table_name, schema)
+
         async with self.get_async_session() as session:
-            # Validate inputs to prevent SQL injection
-            if not table_name.isidentifier():
-                raise ValueError("Invalid table name")
-            if schema and not schema.isidentifier():
-                raise ValueError("Invalid schema name")
-
-            if self.engine.dialect.name == "sqlite":
-                table = await self.get_table(table_name)
-            else:
-                table = await self.get_table(table_name, schema)
-
             # Query all data from the table
             query = select(table)
             result = await session.execute(query)
@@ -732,9 +745,13 @@ class SQLAlchemyAdapter:
 
             A dictionary containing the schema details of the database.
         """
-        async with self.engine.begin() as connection:
-            tables = await self.get_table_names()
+        # Resolve table names / schema list BEFORE opening our connection. Each of
+        # these checks out its own connection; calling them inside would hold two
+        # pooled connections at once and deadlock the pool under concurrency (#4197).
+        tables = await self.get_table_names()
+        schema_list = await self.get_schema_list() if self.engine.dialect.name != "sqlite" else []
 
+        async with self.engine.begin() as connection:
             schema = {}
 
             if self.engine.dialect.name == "sqlite":
@@ -770,7 +787,6 @@ class SQLAlchemyAdapter:
                             }
                         )
             else:
-                schema_list = await self.get_schema_list()
                 for schema_name in schema_list:
                     # Get tables for the current schema via the inspector.
                     tables = await connection.run_sync(

--- a/cognee/modules/data/methods/get_deletion_counts.py
+++ b/cognee/modules/data/methods/get_deletion_counts.py
@@ -26,6 +26,17 @@ async def get_deletion_counts(
     """
     counts = DeletionCountsPreview()
     relational_engine = get_relational_engine()
+
+    # Resolve the user (opens its own session) BEFORE opening ours so we don't
+    # hold a pooled connection across get_user — that overlap deadlocks the pool
+    # under concurrency (issue #4197 class).
+    user = None
+    if user_id and not dataset_name and not all_data:
+        try:
+            user = await get_user(user_id)
+        except (ValueError, EntityNotFoundError):
+            raise CliCommandException(f"No User exists with ID {user_id}", error_code=1)
+
     async with relational_engine.get_async_session() as session:
         if dataset_name:
             # Find the dataset by name
@@ -66,11 +77,6 @@ async def get_deletion_counts(
 
         # Placeholder for user_id logic
         elif user_id:
-            user = None
-            try:
-                user = await get_user(user_id)
-            except (ValueError, EntityNotFoundError):
-                raise CliCommandException(f"No User exists with ID {user_id}", error_code=1)
             counts.users = 1
             # Find all datasets owned by this user
             datasets_query = select(Dataset).where(Dataset.owner_id == user.id)

--- a/cognee/modules/metrics/operations/get_pipeline_run_metrics.py
+++ b/cognee/modules/metrics/operations/get_pipeline_run_metrics.py
@@ -47,9 +47,13 @@ async def get_pipeline_run_metrics(pipeline_run: PipelineRunInfo, include_option
             cache_status = "cache hit"
         else:
             graph_metrics = await graph_engine.get_graph_metrics(include_optional)
+            # Use the current session for the token count; calling fetch_token_count
+            # here would open a second pooled connection while this one is held
+            # (#4197 class).
+            num_tokens = (await session.execute(select(func.sum(Data.token_count)))).scalar()
             metrics = GraphMetrics(
                 id=pipeline_run.pipeline_run_id,
-                num_tokens=await fetch_token_count(db_engine),
+                num_tokens=num_tokens,
                 num_nodes=graph_metrics["num_nodes"],
                 num_edges=graph_metrics["num_edges"],
                 mean_degree=graph_metrics["mean_degree"],

--- a/cognee/modules/users/methods/get_default_user.py
+++ b/cognee/modules/users/methods/get_default_user.py
@@ -25,16 +25,19 @@ async def get_default_user() -> User:
 
             result = await session.execute(query)
             user = result.scalars().first()
+
+        # Our session is closed here (the `async with` has exited), so
+        # create_default_user — which opens its own session — no longer runs
+        # nested inside it: we never hold two pooled connections at once (#4197
+        # class). It stays inside this `try` so a missing-database error still
+        # maps to DatabaseNotCreatedError.
+        if user is None:
+            return await create_default_user()
+
+        return user
     except Exception as error:
         if "principals" in str(error.args):
             raise DatabaseNotCreatedError() from error
         if isinstance(error, NoResultFound):
             raise UserNotFoundError(f"Failed to retrieve default user: {default_email}") from error
         raise
-
-    # create_default_user opens its own session; call it only after ours is
-    # closed so we never hold two pooled connections at once (#4197 class).
-    if user is None:
-        return await create_default_user()
-
-    return user

--- a/cognee/modules/users/methods/get_default_user.py
+++ b/cognee/modules/users/methods/get_default_user.py
@@ -25,14 +25,16 @@ async def get_default_user() -> User:
 
             result = await session.execute(query)
             user = result.scalars().first()
-
-            if user is None:
-                return await create_default_user()
-
-            return user
     except Exception as error:
         if "principals" in str(error.args):
             raise DatabaseNotCreatedError() from error
         if isinstance(error, NoResultFound):
             raise UserNotFoundError(f"Failed to retrieve default user: {default_email}") from error
         raise
+
+    # create_default_user opens its own session; call it only after ours is
+    # closed so we never hold two pooled connections at once (#4197 class).
+    if user is None:
+        return await create_default_user()
+
+    return user

--- a/cognee/modules/users/permissions/methods/get_document_ids_for_user.py
+++ b/cognee/modules/users/permissions/methods/get_document_ids_for_user.py
@@ -23,30 +23,31 @@ async def get_document_ids_for_user(user_id: UUID, dataset_ids: list[UUID] = Non
     db_engine = get_relational_engine()
 
     async with db_engine.get_async_session() as session:
-        async with session.begin():
-            # Datasets the user has read permission for, regardless of ownership.
-            readable_dataset_ids = (
-                await session.scalars(
-                    select(Dataset.id)
-                    .join(ACL.dataset)
-                    .join(ACL.permission)
-                    .where(
-                        ACL.principal_id == user_id,
-                        Permission.name == "read",
-                    )
+        # Datasets the user has read permission for, regardless of ownership.
+        readable_dataset_ids = (
+            await session.scalars(
+                select(Dataset.id)
+                .join(ACL.dataset)
+                .join(ACL.permission)
+                .where(
+                    ACL.principal_id == user_id,
+                    Permission.name == "read",
                 )
-            ).all()
+            )
+        ).all()
 
-            if dataset_ids is not None:
-                # Keep only the requested datasets the user is allowed to read.
-                requested = set(dataset_ids)
-                readable_dataset_ids = [
-                    dataset_id for dataset_id in readable_dataset_ids if dataset_id in requested
-                ]
+    if dataset_ids is not None:
+        # Keep only the requested datasets the user is allowed to read.
+        requested = set(dataset_ids)
+        readable_dataset_ids = [
+            dataset_id for dataset_id in readable_dataset_ids if dataset_id in requested
+        ]
 
-            document_ids = []
-            for dataset_id in readable_dataset_ids:
-                data_list = await get_dataset_data(dataset_id)
-                document_ids.extend([data.id for data in data_list])
+    # get_dataset_data opens its own session per call; run these AFTER ours is
+    # closed so we never hold two pooled connections at once (#4197 class).
+    document_ids = []
+    for dataset_id in readable_dataset_ids:
+        data_list = await get_dataset_data(dataset_id)
+        document_ids.extend([data.id for data in data_list])
 
-            return document_ids
+    return document_ids

--- a/cognee/modules/users/roles/methods/create_role.py
+++ b/cognee/modules/users/roles/methods/create_role.py
@@ -27,15 +27,19 @@ async def create_role(
         None
     """
     db_engine = get_relational_engine()
+
+    # Resolve user + tenant (each opens its own session) BEFORE opening ours, so
+    # this request never holds two pooled connections at once — that overlap
+    # deadlocks the pool under concurrency (issue #4197 class).
+    user = await get_user(owner_id)
+    tenant = await get_tenant(user.tenant_id)
+
+    if owner_id != tenant.owner_id:
+        raise PermissionDeniedError(
+            "User submitting request does not have permission to create role for tenant."
+        )
+
     async with db_engine.get_async_session() as session:
-        user = await get_user(owner_id)
-        tenant = await get_tenant(user.tenant_id)
-
-        if owner_id != tenant.owner_id:
-            raise PermissionDeniedError(
-                "User submitting request does not have permission to create role for tenant."
-            )
-
         try:
             # Add association directly to the association table
             role = Role(name=role_name, tenant_id=tenant.id)

--- a/cognee/modules/users/roles/methods/delete_role.py
+++ b/cognee/modules/users/roles/methods/delete_role.py
@@ -29,8 +29,13 @@ async def delete_role(role_id: UUID, owner_id: UUID):
         if not role:
             raise EntityNotFoundError(message="Role not found.")
 
-        await has_user_management_permission(requester_id=owner_id, tenant_id=role.tenant_id)
+        tenant_id = role.tenant_id
 
+    # has_user_management_permission opens its own session(s); run it OUTSIDE the
+    # session above so we never hold two pooled connections at once (#4197 class).
+    await has_user_management_permission(requester_id=owner_id, tenant_id=tenant_id)
+
+    async with db_engine.get_async_session() as session:
         # Remove all user-role associations
         await session.execute(delete(UserRole).where(UserRole.role_id == role_id))
 

--- a/cognee/modules/users/roles/methods/remove_user_from_role.py
+++ b/cognee/modules/users/roles/methods/remove_user_from_role.py
@@ -35,8 +35,13 @@ async def remove_user_from_role(user_id: UUID, role_id: UUID, owner_id: UUID):
         if not role:
             raise RoleNotFoundError
 
-        await has_user_management_permission(requester_id=owner_id, tenant_id=role.tenant_id)
+        tenant_id = role.tenant_id
 
+    # has_user_management_permission opens its own session(s); run it OUTSIDE the
+    # session above so we never hold two pooled connections at once (#4197 class).
+    await has_user_management_permission(requester_id=owner_id, tenant_id=tenant_id)
+
+    async with db_engine.get_async_session() as session:
         await session.execute(
             delete(UserRole).where(
                 UserRole.user_id == user_id,

--- a/cognee/modules/users/tenants/methods/add_user_to_tenant.py
+++ b/cognee/modules/users/tenants/methods/add_user_to_tenant.py
@@ -34,20 +34,24 @@ async def add_user_to_tenant(
 
     """
     db_engine = get_relational_engine()
+
+    # Resolve user + tenant (each opens its own session) BEFORE opening ours, so
+    # this request never holds two pooled connections at once — that overlap
+    # deadlocks the pool under concurrency (issue #4197 class).
+    user = await get_user(user_id)
+    tenant = await get_tenant(tenant_id)
+
+    if not user:
+        raise UserNotFoundError
+    elif not tenant:
+        raise TenantNotFoundError
+
+    if tenant.owner_id != owner_id:
+        raise PermissionDeniedError(
+            message="Only tenant owner can add other users to organization."
+        )
+
     async with db_engine.get_async_session() as session:
-        user = await get_user(user_id)
-        tenant = await get_tenant(tenant_id)
-
-        if not user:
-            raise UserNotFoundError
-        elif not tenant:
-            raise TenantNotFoundError
-
-        if tenant.owner_id != owner_id:
-            raise PermissionDeniedError(
-                message="Only tenant owner can add other users to organization."
-            )
-
         if set_as_active_tenant:
             user.tenant_id = tenant_id
             await session.merge(user)

--- a/cognee/modules/users/tenants/methods/create_tenant.py
+++ b/cognee/modules/users/tenants/methods/create_tenant.py
@@ -25,10 +25,14 @@ async def create_tenant(
         None
     """
     db_engine = get_relational_engine()
+
+    # Resolve the user (opens its own session) BEFORE opening ours, so this
+    # request never holds two pooled connections at once — that overlap
+    # deadlocks the pool under concurrency (issue #4197 class).
+    user = await get_user(user_id)
+
     async with db_engine.get_async_session() as session:
         try:
-            user = await get_user(user_id)
-
             tenant = Tenant(name=tenant_name, owner_id=user_id)
             session.add(tenant)
             await session.flush()

--- a/cognee/modules/users/tenants/methods/get_users_in_role.py
+++ b/cognee/modules/users/tenants/methods/get_users_in_role.py
@@ -37,11 +37,14 @@ async def get_users_in_role(tenant_id: UUID, role_id: UUID, user: User):
             )
         ).scalar_one_or_none() is not None
 
-        # Members may see who shares their own roles. Everyone else needs the
-        # tenant-wide user management permission, which raises when absent.
-        if not requester_is_member:
-            await has_user_management_permission(user.id, tenant_id)
+    # Members may see who shares their own roles. Everyone else needs the
+    # tenant-wide user management permission, which raises when absent.
+    # has_user_management_permission opens its own session(s); run it OUTSIDE the
+    # session above so we never hold two pooled connections at once (#4197 class).
+    if not requester_is_member:
+        await has_user_management_permission(user.id, tenant_id)
 
+    async with db_engine.get_async_session() as session:
         member_results = await session.execute(
             select(User)
             .join(UserRole, User.id == UserRole.user_id)

--- a/cognee/modules/users/tenants/methods/select_tenant.py
+++ b/cognee/modules/users/tenants/methods/select_tenant.py
@@ -26,16 +26,20 @@ async def select_tenant(user_id: UUID, tenant_id: Union[UUID, None]) -> User:
 
     """
     db_engine = get_relational_engine()
+
+    # Resolve user + tenant (each opens its own session) BEFORE opening ours, so
+    # this request never holds two pooled connections at once — that overlap
+    # deadlocks the pool under concurrency (issue #4197 class).
+    user = await get_user(user_id)
+    tenant = await get_tenant(tenant_id) if tenant_id is not None else None
+
     async with db_engine.get_async_session() as session:
-        user = await get_user(user_id)
         if tenant_id is None:
             # If no tenant_id is provided set current Tenant to the single user-tenant
             user.tenant_id = None
             await session.merge(user)
             await session.commit()
             return user
-
-        tenant = await get_tenant(tenant_id)
 
         if not user:
             raise UserNotFoundError


### PR DESCRIPTION
## Context

Follow-up to #4197 and #4389. A full-codebase scan for the same bug class —
holding one relational connection open while a **second** is acquired — turned up
the remaining, un-fixed sites. On a bounded pool (Postgres / PGVector) each such
call pins two connections at once; once concurrency reaches the pool size this
becomes a circular wait that deadlocks the pool and strands backends
`idle in transaction`.

This PR sweeps those remaining sites. **Draft** — see "Verification / caveats".

## Fix pattern (behavior-preserving, no API changes)

Same minimal pattern already shipped for `get_by_token` and
`PGVectorAdapter.delete_data_points`: run the lookup/reflection that opens its
own connection **before** opening the working session, so only one pooled
connection is held at a time. Where a permission check depends on data read in
the session, the method is split into two sequential sessions with the check in
between.

## Changes

**User / tenant / role admin methods**
- `tenants/methods`: `add_user_to_tenant`, `create_tenant`, `select_tenant`, `get_users_in_role`
- `roles/methods`: `create_role`, `remove_user_from_role`, `delete_role`
- `data/methods/get_deletion_counts` — `get_user` pre-resolved
- `users/methods/get_default_user` — `create_default_user` moved out of the session
- `permissions/methods/get_document_ids_for_user` — `get_dataset_data` loop moved out of the transaction
- `metrics/operations/get_pipeline_run_metrics` — token count reuses the open session instead of `fetch_token_count`

**SqlAlchemyAdapter (systemic root cause)**
`get_table` / `get_table_names` / `get_schema_list` each open their own connection, so any method calling one while holding a connection nests a second. Callers reordered to resolve them first: `insert_data`, `delete_entity_by_id`, `get_table_names`, `get_all_data_from_table`, `extract_schema`.

> Note: I chose **reordering** over threading a `session`/`connection` param through the adapter helpers (the option raised in review). It's less invasive, changes no signatures, and matches the existing safe methods. If maintainers prefer the param approach, happy to switch.

## Verification / caveats
- ruff clean; all edited modules import; a **sqlite end-to-end smoke test** exercises the refactored tenant/role flow (create tenant → add user → create/assign role → list members → select tenant → remove from role → delete role) and passes; api-key auth tests pass.
- These are structural fixes mirroring the #4197-proven pattern; I did **not** run a per-site live Postgres concurrency reproduction (most are admin/low-concurrency or dormant paths). Draft so this can be reviewed / a repro added if wanted before merge.

## Not included
- `delete_dataset` (holds a connection across a *separate* maintenance-DB engine — cannot deadlock the shared pool).
- `SqlAlchemyAdapter.delete_data_entity` on S3 (holds across S3 I/O — different mechanism, S3-only).
- The already-open #4389 (dataset-database + PGVector) and #4354 (`get_by_token`).

Related: #4197