### PR TITLE
fix(pipelines): bound the Data-id list in run_info summaries (#4363)

### DIFF
--- a/cognee/modules/pipelines/utils/summarize_run_info_data.py
+++ b/cognee/modules/pipelines/utils/summarize_run_info_data.py
@@ -9,18 +9,27 @@ from cognee.modules.data.models import Data
 # instead so a single run cannot balloon the table.
 MAX_RUN_INFO_DATA_CHARS = 512
 
+# The same reasoning applies to lists of ``Data`` records: ``cognify`` passes
+# every record of the dataset, so an unbounded id list makes each run's
+# ``run_info`` grow with the corpus. Keep a preview of the same order of
+# magnitude as the character cap.
+MAX_RUN_INFO_IDS = 25
+
 
 def summarize_run_info_data(data: Any):
     """Return a compact, size-bounded description of pipeline-run input data.
 
-    Lists of ``Data`` records are reduced to their ids; any other payload is
-    stringified and truncated so a single pipeline run cannot persist an
-    arbitrarily large ``run_info`` blob.
+    Lists of ``Data`` records are reduced to a bounded preview of their ids; any
+    other payload is stringified and truncated so a single pipeline run cannot
+    persist an arbitrarily large ``run_info`` blob.
     """
     if not data:
         return "None"
     if isinstance(data, list) and all(isinstance(item, Data) for item in data):
-        return [str(item.id) for item in data]
+        ids = [str(item.id) for item in data]
+        if len(ids) > MAX_RUN_INFO_IDS:
+            return ids[:MAX_RUN_INFO_IDS] + [f"... [truncated, {len(ids)} ids total]"]
+        return ids
 
     text = str(data)
     if len(text) > MAX_RUN_INFO_DATA_CHARS:

--- a/cognee/tests/unit/modules/pipelines/test_summarize_run_info_data.py
+++ b/cognee/tests/unit/modules/pipelines/test_summarize_run_info_data.py
@@ -11,7 +11,10 @@ from uuid import uuid4
 
 from cognee.modules.data.models import Data
 from cognee.modules.pipelines.utils import summarize_run_info_data
-from cognee.modules.pipelines.utils.summarize_run_info_data import MAX_RUN_INFO_DATA_CHARS
+from cognee.modules.pipelines.utils.summarize_run_info_data import (
+    MAX_RUN_INFO_DATA_CHARS,
+    MAX_RUN_INFO_IDS,
+)
 
 
 def test_empty_data_is_summarized_as_none():
@@ -24,6 +27,16 @@ def test_list_of_data_records_is_reduced_to_ids():
     records = [Data(id=uuid4(), name="a"), Data(id=uuid4(), name="b")]
     result = summarize_run_info_data(records)
     assert result == [str(records[0].id), str(records[1].id)]
+
+
+def test_long_list_of_data_records_is_bounded():
+    records = [Data(id=uuid4(), name=f"doc-{index}") for index in range(MAX_RUN_INFO_IDS * 10)]
+    result = summarize_run_info_data(records)
+
+    # The stored value must stay close to the cap, not scale with the corpus.
+    assert len(result) == MAX_RUN_INFO_IDS + 1
+    assert result[:MAX_RUN_INFO_IDS] == [str(record.id) for record in records[:MAX_RUN_INFO_IDS]]
+    assert result[-1] == f"... [truncated, {len(records)} ids total]"
 
 
 def test_small_payload_is_preserved_verbatim():


### PR DESCRIPTION
Fixes #4363.

## Problem

`summarize_run_info_data` exists so a single pipeline run cannot balloon `pipeline_runs.run_info` (added in 74ee4f2 for #3074, PR #3075). It caps stringified payloads at `MAX_RUN_INFO_DATA_CHARS = 512` — but the list-of-`Data` branch returns the **full** id list with no bound:

```python
if isinstance(data, list) and all(isinstance(item, Data) for item in data):
    return [str(item.id) for item in data]   # unbounded

text = str(data)
if len(text) > MAX_RUN_INFO_DATA_CHARS:      # only reached for non-Data payloads
    ...
```

`cognify` passes exactly such a list — every `Data` record of the dataset — through `log_pipeline_run_start` / `_complete` / `_error`, so every run persists one UUID per corpus document and the row grows linearly with the corpus. That is the same unbounded growth #3074 reported, just via the branch the fix did not cover. The reporter measured `pipeline_runs` at 25,620 rows / 674 MB, with cognify `run_info` averaging 125 KB (one run stored 7,577 UUIDs / ~282 KB), while the `add_pipeline` rows that hit the 512-char branch average 500 bytes.

## Fix

Bound the id branch the same way the char branch is bounded: keep the first `MAX_RUN_INFO_IDS` (25) ids plus a trailing marker carrying the total count. This is the shape suggested in the issue. `run_info["data"]` is audit-only metadata — it is written by the three `log_pipeline_run_*` operations and never read back — so truncating the preview loses nothing that is consumed.

Behaviour on a 250-record dataset:

| | entries | serialized bytes |
|---|---|---|
| before | 250 | 10,000 |
| after | 26 | 1,034 |

Short lists are unchanged (a 2-record list still returns exactly its two ids), so the existing tests pass untouched.

## Tests

`cognee/tests/unit/modules/pipelines/test_summarize_run_info_data.py` gains `test_long_list_of_data_records_is_bounded`, asserting the result is `MAX_RUN_INFO_IDS + 1` entries, that the preserved prefix is the dataset's first ids, and that the marker reports the true total. All five tests in that file pass; the four pre-existing ones pass unmodified against the new helper.

Linted with `ruff==0.15.11` (the pinned pre-commit version) against the repo `pyproject.toml`: `format --check` and `check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
