### PR TITLE
fix(ladybug): use supported Cypher in the traversal helpers (#4365)

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -2464,18 +2464,28 @@ class LadybugAdapter(GraphDBInterface):
                 query_str = """
                 MATCH (n)<-[r:EDGE]-(m)
                 WHERE n.id = $id AND r.relationship_name = $edge_label
-                RETURN properties(m)
+                RETURN {
+                    id: m.id,
+                    name: m.name,
+                    type: m.type,
+                    properties: m.properties
+                }
                 """
                 params = {"id": str(node_id), "edge_label": edge_label}
             else:
                 query_str = """
                 MATCH (n)<-[r:EDGE]-(m)
                 WHERE n.id = $id
-                RETURN properties(m)
+                RETURN {
+                    id: m.id,
+                    name: m.name,
+                    type: m.type,
+                    properties: m.properties
+                }
                 """
                 params = {"id": str(node_id)}
             result = await self.query(query_str, params)
-            return [row[0] for row in result] if result else []
+            return [self._parse_node_properties(row[0]) for row in result] if result else []
         except Exception as e:
             logger.error(f"Failed to get predecessors for node {node_id}: {e}")
             return []
@@ -2508,18 +2518,28 @@ class LadybugAdapter(GraphDBInterface):
                 query_str = """
                 MATCH (n)-[r:EDGE]->(m)
                 WHERE n.id = $id AND r.relationship_name = $edge_label
-                RETURN properties(m)
+                RETURN {
+                    id: m.id,
+                    name: m.name,
+                    type: m.type,
+                    properties: m.properties
+                }
                 """
                 params = {"id": str(node_id), "edge_label": edge_label}
             else:
                 query_str = """
                 MATCH (n)-[r:EDGE]->(m)
                 WHERE n.id = $id
-                RETURN properties(m)
+                RETURN {
+                    id: m.id,
+                    name: m.name,
+                    type: m.type,
+                    properties: m.properties
+                }
                 """
                 params = {"id": str(node_id)}
             result = await self.query(query_str, params)
-            return [row[0] for row in result] if result else []
+            return [self._parse_node_properties(row[0]) for row in result] if result else []
         except Exception as e:
             logger.error(f"Failed to get successors for node {node_id}: {e}")
             return []
@@ -3283,7 +3303,7 @@ class LadybugAdapter(GraphDBInterface):
         """
         query_str = """
         MATCH (n:Node)
-        WHERE NOT EXISTS((n)-[]-())
+        WHERE NOT (n)-[:EDGE]-()
         RETURN n.id
         """
         result = await self.query(query_str)

--- a/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
+++ b/cognee/tests/integration/infrastructure/graph/test_kuzu_adapter.py
@@ -472,12 +472,10 @@ async def test_get_neighborhood_edge_filter_handles_cycles(adapter):
 
 # ---------------------------------------------------------------------------
 # get_predecessors / get_successors
-# Known adapter bug: RETURN properties(m) fails with current Kuzu version.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="KuzuAdapter bug: RETURN properties(m) not supported in current Kuzu")
 async def test_predecessors_and_successors(adapter):
     kg = _load_demo_kg()
     await adapter.add_nodes(kg.nodes)
@@ -487,11 +485,18 @@ async def test_predecessors_and_successors(adapter):
 
     # Alice->Mark (knows), so Mark's predecessors with "knows" should include Alice
     predecessors = await adapter.get_predecessors("Mark", edge_label="knows")
-    assert len(predecessors) > 0
+    assert [node["id"] for node in predecessors] == ["Alice"]
+    # Custom properties are merged into the node dict, not returned as a JSON blob.
+    assert predecessors[0]["name"] == "Alice"
+    assert predecessors[0]["description"] == "Person mentioned in the text"
 
-    # Mark->Bob (had_dinner_with), so Mark's successors should include Bob
+    # Mark->Bob and Mark->Alice (had_dinner_with) are Mark's successors on that label
     successors = await adapter.get_successors("Mark", edge_label="had_dinner_with")
-    assert len(successors) > 0
+    assert sorted(node["id"] for node in successors) == ["Alice", "Bob"]
+
+    # Without an edge label every outgoing neighbour is returned.
+    unfiltered = await adapter.get_successors("Mark")
+    assert sorted(node["id"] for node in unfiltered) == ["Alice", "Bob"]
 
 
 # ---------------------------------------------------------------------------
@@ -516,12 +521,10 @@ async def test_get_graph_metrics(adapter):
 
 # ---------------------------------------------------------------------------
 # get_disconnected_nodes
-# Known adapter bug: NOT EXISTS((n)-[]-()) syntax not supported in current Kuzu.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="KuzuAdapter bug: NOT EXISTS pattern syntax unsupported")
 async def test_get_disconnected_nodes(adapter):
     kg = _load_demo_kg()
     await adapter.add_nodes(kg.nodes)
@@ -535,7 +538,7 @@ async def test_get_disconnected_nodes(adapter):
     await adapter.add_edges(edge_rows)
 
     disconnected_after = await adapter.get_disconnected_nodes()
-    assert len(disconnected_after) < len(disconnected)
+    assert disconnected_after == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #4365.

## Problem

Three traversal helpers on the Ladybug adapter emit Cypher the engine rejects:

- `get_predecessors()` / `get_successors()` `RETURN properties(m)`. Ladybug's `PROPERTIES` is bound as `(LIST, STRING) -> ANY` and does not accept a node, so the query raises a binder exception. Both methods catch it and `return []` — a failed traversal is indistinguishable from a node with no neighbours.
- `get_disconnected_nodes()` uses `WHERE NOT EXISTS((n)-[]-())`; the parser rejects that pattern form and the exception reaches the caller.

`remove_disconnected_chunks()` calls all three. The repo's integration tests already record both behaviours as xfails (added in #2803).

Reproduced against `ladybug==0.18.2` on the adapter's own schema:

```
get_predecessors     -> Binder exception: Function PROPERTIES did not receive correct arguments:
                        Actual: (NODE)  Expected: (LIST,STRING) -> ANY
get_successors       -> same binder exception
get_disconnected_nodes -> Parser exception: Invalid input <MATCH (n:Node) WHERE NOT EXISTS(>
```

## Fix

- Project the neighbour node explicitly — `{id, name, type, properties}` — which is exactly the shape `get_neighbours()` and `get_node()` already use on this adapter, and normalize each row with `_parse_node_properties()` so custom properties are merged into the returned dict instead of being handed back as a raw JSON blob. #1437 fixed the same `PROPERTIES(NODE)` incompatibility elsewhere in this adapter the same way.
- Express the disconnected-node predicate as `WHERE NOT (n)-[:EDGE]-()`, which Ladybug accepts and which matches the single relationship table the adapter creates.

## Verification

Replayed both the old and the new queries against a real `ladybug==0.18.2` database built with the adapter's schema (`Node` + `EDGE` tables) and the repo's `test_kg.json` fixture, including the `_parse_node_properties()` merge:

| helper | before | after |
|---|---|---|
| `get_predecessors("Mark", "knows")` | binder exception → `[]` | `[{'id': 'Alice', 'name': 'Alice', 'type': 'Person', 'description': 'Person mentioned in the text'}]` |
| `get_successors("Mark", "had_dinner_with")` | binder exception → `[]` | `['Alice', 'Bob']` |
| `get_successors("Mark")` (no label) | binder exception → `[]` | `['Alice', 'Bob']` |
| `get_disconnected_nodes()` (all 4 nodes wired) | parser exception | `[]` |
| `get_disconnected_nodes()` (edges deleted) | parser exception | all four ids |

## Tests

`test_predecessors_and_successors` and `test_get_disconnected_nodes` lose their `xfail` markers and assert the real contract instead of `len(...) > 0`: the exact predecessor id, that custom node properties (`description`) survive the round-trip, both `had_dinner_with` successors, the unlabelled case, and that no node is reported disconnected once every node has an edge. The third xfail in that file (`get_model_independent_graph_data` format mismatch) is a separate bug and is left untouched.

Linted with `ruff==0.15.11` (the pinned pre-commit version) against the repo `pyproject.toml`: `format --check` and `check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
