### PR TITLE
fix(embeddings): honor tokenizer overrides across engines

### DIFF
--- a/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/LiteLLMEmbeddingEngine.py
@@ -72,6 +72,7 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
         api_version: str = None,
         max_completion_tokens: int = 512,
         batch_size: int = 100,
+        huggingface_tokenizer: Optional[str] = None,
     ):
         self.api_key = api_key
         self.endpoint = endpoint
@@ -80,6 +81,7 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
         self.model = model
         self.dimensions = dimensions
         self.max_completion_tokens = max_completion_tokens
+        self.huggingface_tokenizer = huggingface_tokenizer
         self.tokenizer = self.get_tokenizer()
         self.retry_count = 0
         self.batch_size = batch_size
@@ -330,6 +332,7 @@ class LiteLLMEmbeddingEngine(EmbeddingEngine):
             provider=self.provider,
             model=model,
             max_completion_tokens=self.max_completion_tokens,
+            huggingface_tokenizer=self.huggingface_tokenizer,
         )
         logger.debug(f"Tokenizer loaded for model: {self.model}")
         return tokenizer

--- a/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/OpenAICompatibleEmbeddingEngine.py
@@ -84,6 +84,7 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
         endpoint: Optional[str] = "http://localhost:8080",
         api_key: Optional[str] = "no-key-required",
         batch_size: int = 36,
+        huggingface_tokenizer: Optional[str] = None,
     ):
         self.model = model or "default"
         self.dimensions = dimensions
@@ -91,6 +92,7 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
         self.endpoint = endpoint or "http://localhost:8080"
         self.api_key = api_key or "no-key-required"
         self.batch_size = batch_size
+        self.huggingface_tokenizer = huggingface_tokenizer
         self.tokenizer = self.get_tokenizer()
 
         enable_mocking = os.getenv("MOCK_EMBEDDING", "false").lower()
@@ -248,4 +250,5 @@ class OpenAICompatibleEmbeddingEngine(EmbeddingEngine):
             provider="openai_compatible",
             model=self.model,
             max_completion_tokens=self.max_completion_tokens,
+            huggingface_tokenizer=self.huggingface_tokenizer,
         )

--- a/cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py
+++ b/cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py
@@ -111,6 +111,7 @@ def create_embedding_engine(
             endpoint=embedding_endpoint,
             api_key=embedding_api_key or llm_api_key,
             batch_size=embedding_batch_size,
+            huggingface_tokenizer=huggingface_tokenizer,
         )
 
     from .LiteLLMEmbeddingEngine import LiteLLMEmbeddingEngine
@@ -125,4 +126,5 @@ def create_embedding_engine(
         dimensions=embedding_dimensions,
         max_completion_tokens=embedding_max_completion_tokens,
         batch_size=embedding_batch_size,
+        huggingface_tokenizer=huggingface_tokenizer,
     )

--- a/cognee/tests/integration/infrastructure/llm/test_embedding_tokenizer_delegation.py
+++ b/cognee/tests/integration/infrastructure/llm/test_embedding_tokenizer_delegation.py
@@ -64,6 +64,7 @@ def test_litellm_delegates_and_strips_vllm_prefix():
         provider="openai",
         model="hosted_vllm/BAAI/bge-m3",
         max_completion_tokens=100,
+        huggingface_tokenizer="custom/litellm-tokenizer",
     )
     with patch(
         f"{_BASE}.LiteLLMEmbeddingEngine.resolve_embedding_tokenizer",
@@ -74,6 +75,7 @@ def test_litellm_delegates_and_strips_vllm_prefix():
         provider="openai",
         model="BAAI/bge-m3",  # the hosted_vllm/ routing prefix is stripped first
         max_completion_tokens=100,
+        huggingface_tokenizer="custom/litellm-tokenizer",
     )
 
 
@@ -102,6 +104,7 @@ def test_openai_compatible_delegates_to_resolver():
         OpenAICompatibleEmbeddingEngine,
         model="BAAI/bge-m3",
         max_completion_tokens=128,
+        huggingface_tokenizer="custom/openai-tokenizer",
     )
     with patch(
         f"{_BASE}.OpenAICompatibleEmbeddingEngine.resolve_embedding_tokenizer",
@@ -112,4 +115,5 @@ def test_openai_compatible_delegates_to_resolver():
         provider="openai_compatible",
         model="BAAI/bge-m3",
         max_completion_tokens=128,
+        huggingface_tokenizer="custom/openai-tokenizer",
     )


### PR DESCRIPTION
﻿## What changed

Forward the configured HUGGINGFACE_TOKENIZER value through the LiteLLM and OpenAI-compatible embedding engines.

## Why

The setting was loaded and passed into the shared embedding factory, but two engine paths dropped it before tokenizer resolution. Users configuring a custom tokenizer therefore saw the default tokenizer used silently.

## Validation

- Added a focused regression test for tokenizer delegation.
- The change is limited to the affected embedding paths and their test.

Fixes #4266

## DCO

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
