### PR TITLE
COG-6111 fix: Resolve memify task names to Task instances

### DIFF
--- a/cognee/api/v1/memify/routers/get_memify_router.py
+++ b/cognee/api/v1/memify/routers/get_memify_router.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Union, Literal
 from cognee.api.DTO import InDTO
 from cognee.modules.users.models import User
 from cognee.modules.users.methods import get_authenticated_user
+from cognee.exceptions import CogneeApiError
 from cognee.shared.utils import send_telemetry
 from cognee.modules.pipelines.models import PipelineRunErrored
 from cognee.shared.logging_utils import get_logger
@@ -55,8 +56,13 @@ def get_memify_router() -> APIRouter:
         Provided tasks and data will be arranged to run the Cognee pipeline and execute graph enrichment/creation.
 
         ## Request Parameters
-        - **extractionTasks** Optional[List[str]]: List of available Cognee Tasks to execute for graph/data extraction.
-        - **enrichmentTasks** Optional[List[str]]: List of available Cognee Tasks to handle enrichment of provided graph/data from extraction tasks.
+        - **extractionTasks** Optional[List[str]]: Names of built-in Cognee Tasks to execute for graph/data extraction.
+              Supported names: extract_subgraph, extract_subgraph_chunks, get_triplet_datapoints,
+              extract_user_sessions, extract_agent_trace_feedbacks, detect_entity_duplicates.
+              Unknown names are rejected with 422. Tasks requiring parameters are SDK-only.
+        - **enrichmentTasks** Optional[List[str]]: Names of built-in Cognee Tasks to handle enrichment of provided graph/data from extraction tasks.
+              Supported names: cognify_session, cognify_agent_trace_feedback, apply_feedback_weights,
+              apply_frequency_weights, merge_entity_duplicates, index_data_points.
         - **data** Optional[List[str]]: The data to ingest. Can be any text data when custom extraction and enrichment tasks are used.
               Data provided here will be forwarded to the first extraction task in the pipeline as input.
               If no data is provided the whole graph (or subgraph if node_name/node_type is specified) will be forwarded
@@ -77,6 +83,7 @@ def get_memify_router() -> APIRouter:
         - **400 Bad Request**: Neither datasetId nor datasetName provided
         - **409 Conflict**: Error during memify operation
         - **403 Forbidden**: User doesn't have permission to use dataset
+        - **422 Unprocessable Content**: Unknown task name in extractionTasks/enrichmentTasks
 
         ## Notes
         - To memify datasets not owned by the user, use dataset_id (when ENABLE_BACKEND_ACCESS_CONTROL is set to True)
@@ -121,6 +128,14 @@ def get_memify_router() -> APIRouter:
                     ).model_dump(),
                 )
             return memify_run
+        except CogneeApiError as error:
+            logger.exception("Memify failed")
+            return JSONResponse(
+                status_code=error.status_code,
+                content=ErrorResponse(
+                    error=error.message,
+                ).model_dump(),
+            )
         except Exception as error:
             logger.exception("Memify failed")
             return JSONResponse(

--- a/cognee/memify_pipelines/memify_task_registry.py
+++ b/cognee/memify_pipelines/memify_task_registry.py
@@ -1,0 +1,111 @@
+"""Registry of memify tasks that can be selected by name.
+
+The memify HTTP endpoint (and ``cognee.memify()``) accept task names as plain
+strings. This module maps those names onto ready-to-run ``Task`` instances so
+the string-based contract advertised by the API actually works.
+
+Only tasks that are runnable without required keyword arguments are exposed
+here. Tasks that need call-specific parameters (e.g. ``extract_feedback_qas``
+requires ``session_ids``) stay SDK-only, where callers construct the ``Task``
+themselves.
+"""
+
+from typing import Callable, Dict, List, Optional, Sequence, Union
+
+from cognee.exceptions import CogneeValidationError
+from cognee.modules.pipelines.tasks.task import Task
+
+# Name -> zero-argument factory producing a fresh Task instance.
+# Defaults mirror how the dedicated memify pipelines construct these tasks.
+_MEMIFY_TASK_FACTORIES: Dict[str, Callable[[], Task]] = {}
+
+
+def _build_task_factories() -> Dict[str, Callable[[], Task]]:
+    from cognee.tasks.memify.extract_subgraph import extract_subgraph
+    from cognee.tasks.memify.extract_subgraph_chunks import extract_subgraph_chunks
+    from cognee.tasks.memify.get_triplet_datapoints import get_triplet_datapoints
+    from cognee.tasks.memify.extract_user_sessions import extract_user_sessions
+    from cognee.tasks.memify.cognify_session import cognify_session
+    from cognee.tasks.memify.extract_agent_trace_feedbacks import extract_agent_trace_feedbacks
+    from cognee.tasks.memify.cognify_agent_trace_feedback import cognify_agent_trace_feedback
+    from cognee.tasks.memify.apply_feedback_weights import apply_feedback_weights
+    from cognee.tasks.memify.apply_frequency_weights import apply_frequency_weights
+    from cognee.tasks.memify.consolidate_entities import (
+        detect_entity_duplicates,
+        merge_entity_duplicates,
+    )
+    from cognee.tasks.storage.index_data_points import index_data_points
+
+    return {
+        "extract_subgraph": lambda: Task(extract_subgraph),
+        "extract_subgraph_chunks": lambda: Task(extract_subgraph_chunks),
+        "get_triplet_datapoints": lambda: Task(get_triplet_datapoints, triplets_batch_size=100),
+        "extract_user_sessions": lambda: Task(extract_user_sessions),
+        "cognify_session": lambda: Task(cognify_session),
+        "extract_agent_trace_feedbacks": lambda: Task(extract_agent_trace_feedbacks),
+        "cognify_agent_trace_feedback": lambda: Task(cognify_agent_trace_feedback),
+        "apply_feedback_weights": lambda: Task(
+            apply_feedback_weights, task_config={"batch_size": 100}
+        ),
+        "apply_frequency_weights": lambda: Task(
+            apply_frequency_weights, task_config={"batch_size": 100}
+        ),
+        "detect_entity_duplicates": lambda: Task(detect_entity_duplicates),
+        "merge_entity_duplicates": lambda: Task(merge_entity_duplicates),
+        "index_data_points": lambda: Task(index_data_points, task_config={"batch_size": 100}),
+    }
+
+
+def _get_task_factories() -> Dict[str, Callable[[], Task]]:
+    global _MEMIFY_TASK_FACTORIES
+    if not _MEMIFY_TASK_FACTORIES:
+        _MEMIFY_TASK_FACTORIES = _build_task_factories()
+    return _MEMIFY_TASK_FACTORIES
+
+
+def supported_memify_task_names() -> List[str]:
+    """Return the sorted names of memify tasks selectable by name."""
+    return sorted(_get_task_factories())
+
+
+def resolve_memify_tasks(
+    tasks: Optional[Sequence[Union[Task, str]]],
+) -> Optional[List[Task]]:
+    """Resolve a mixed list of Task instances and task names into Task instances.
+
+    Passes ``None``/empty input through unchanged so callers keep their
+    default-task fallback. Raises ``CogneeValidationError`` (HTTP 422) when a
+    name is unknown or an entry is neither a Task nor a string.
+    """
+    if not tasks:
+        return None
+
+    factories = _get_task_factories()
+    resolved_tasks = []
+
+    for task in tasks:
+        if isinstance(task, Task):
+            resolved_tasks.append(task)
+        elif isinstance(task, str):
+            factory = factories.get(task)
+            if factory is None:
+                raise CogneeValidationError(
+                    message=(
+                        f"Unknown memify task name: '{task}'. "
+                        f"Supported task names: {', '.join(supported_memify_task_names())}. "
+                        "Tasks requiring parameters must be passed as Task instances "
+                        "through the Python SDK."
+                    ),
+                    log=False,
+                )
+            resolved_tasks.append(factory())
+        else:
+            raise CogneeValidationError(
+                message=(
+                    "Memify tasks must be Task instances or supported task names, "
+                    f"got {type(task).__name__}."
+                ),
+                log=False,
+            )
+
+    return resolved_tasks

--- a/cognee/modules/memify/memify.py
+++ b/cognee/modules/memify/memify.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, List, Type, Any
+from typing import Union, Optional, List, Sequence, Type, Any
 from uuid import UUID
 
 from cognee.shared.logging_utils import get_logger
@@ -19,13 +19,14 @@ from cognee.memify_pipelines.memify_default_tasks import (
     get_default_memify_enrichment_tasks,
     get_default_memify_extraction_tasks,
 )
+from cognee.memify_pipelines.memify_task_registry import resolve_memify_tasks
 
 logger = get_logger("memify")
 
 
 async def memify(
-    extraction_tasks: Union[List[Task], List[str]] = None,
-    enrichment_tasks: Union[List[Task], List[str]] = None,
+    extraction_tasks: Optional[Sequence[Union[Task, str]]] = None,
+    enrichment_tasks: Optional[Sequence[Union[Task, str]]] = None,
     data: Optional[Any] = None,
     dataset: Union[str, UUID] = DEFAULT_DATASET_NAME,
     user: User = None,
@@ -47,7 +48,10 @@ async def memify(
 
     Args:
         extraction_tasks: List of Cognee Tasks to execute for graph/data extraction.
+                          Entries may be Task instances or names of built-in memify tasks
+                          (see cognee.memify_pipelines.memify_task_registry).
         enrichment_tasks: List of Cognee Tasks to handle enrichment of provided graph/data from extraction tasks.
+                          Entries may be Task instances or names of built-in memify tasks.
         data: The data to ingest. Can be anything when custom extraction and enrichment tasks are used.
               Data provided here will be forwarded to the first extraction task in the pipeline as input.
               If no data is provided the whole graph (or subgraph if node_name/node_type is specified) will be forwarded
@@ -87,11 +91,15 @@ async def memify(
         ```
     """
 
+    # Resolve task names into Task instances (raises CogneeValidationError on unknown names)
+    resolved_extraction_tasks = resolve_memify_tasks(extraction_tasks)
+    resolved_enrichment_tasks = resolve_memify_tasks(enrichment_tasks)
+
     # Use default triplet embedding tasks if no tasks were provided
-    if not extraction_tasks:
-        extraction_tasks = get_default_memify_extraction_tasks()
-    if not enrichment_tasks:
-        enrichment_tasks = get_default_memify_enrichment_tasks()
+    if not resolved_extraction_tasks:
+        resolved_extraction_tasks = get_default_memify_extraction_tasks()
+    if not resolved_enrichment_tasks:
+        resolved_enrichment_tasks = get_default_memify_enrichment_tasks()
 
     await setup()
 
@@ -107,8 +115,8 @@ async def memify(
             data = [memory_fragment]
 
     memify_tasks = [
-        *extraction_tasks,  # Unpack tasks provided to memify pipeline
-        *enrichment_tasks,
+        *resolved_extraction_tasks,  # Unpack tasks provided to memify pipeline
+        *resolved_enrichment_tasks,
     ]
 
     # By calling get pipeline executor we get a function that will have the run_pipeline run in the background or a function that we will need to wait for

--- a/cognee/tests/unit/api/test_api_error_responses.py
+++ b/cognee/tests/unit/api/test_api_error_responses.py
@@ -109,9 +109,12 @@ def _restore_api_package_functions():
     """
     import cognee.api.v1.add as add_pkg
     import cognee.api.v1.cognify as cognify_pkg
-    import cognee.api.v1.memify as memify_pkg
     import cognee.api.v1.search as search_pkg
     import cognee.api.v1.update as update_pkg
+
+    # The memify router imports from cognee.modules.memify (not cognee.api.v1.memify),
+    # so that is the package the memify tests patch and the one that must be restored.
+    import cognee.modules.memify as memify_pkg
 
     targets = [
         (add_pkg, "add"),

--- a/cognee/tests/unit/memify_pipelines/test_memify_task_registry.py
+++ b/cognee/tests/unit/memify_pipelines/test_memify_task_registry.py
@@ -1,0 +1,80 @@
+import pytest
+
+from cognee.exceptions import CogneeValidationError
+from cognee.memify_pipelines.memify_task_registry import (
+    resolve_memify_tasks,
+    supported_memify_task_names,
+)
+from cognee.modules.pipelines.tasks.task import Task
+
+
+def test_supported_task_names_are_resolvable():
+    names = supported_memify_task_names()
+    assert names, "registry must expose at least one task name"
+
+    resolved = resolve_memify_tasks(names)
+    assert resolved is not None
+    assert len(resolved) == len(names)
+    assert all(isinstance(task, Task) for task in resolved)
+
+
+def _resolve_one(name):
+    resolved = resolve_memify_tasks([name])
+    assert resolved is not None
+    return resolved[0]
+
+
+def test_each_resolution_returns_a_fresh_task_instance():
+    first = _resolve_one("extract_user_sessions")
+    second = _resolve_one("extract_user_sessions")
+    assert first is not second
+
+
+def test_task_instances_pass_through_unchanged():
+    async def custom_task(data):
+        return data
+
+    task = Task(custom_task)
+    resolved = resolve_memify_tasks([task, "apply_frequency_weights"])
+
+    assert resolved is not None
+    assert resolved[0] is task
+    assert isinstance(resolved[1], Task)
+
+
+def test_empty_input_passes_through():
+    assert resolve_memify_tasks(None) is None
+    assert resolve_memify_tasks([]) is None
+
+
+def test_unknown_task_name_raises_validation_error():
+    with pytest.raises(CogneeValidationError, match="Unknown memify task name: 'not_a_task'"):
+        resolve_memify_tasks(["not_a_task"])
+
+
+def test_unknown_task_name_error_lists_supported_names():
+    with pytest.raises(CogneeValidationError) as error:
+        resolve_memify_tasks(["not_a_task"])
+
+    for name in supported_memify_task_names():
+        assert name in error.value.message
+
+
+def test_unknown_task_name_maps_to_422():
+    with pytest.raises(CogneeValidationError) as error:
+        resolve_memify_tasks(["not_a_task"])
+
+    assert error.value.status_code == 422
+
+
+def test_non_task_non_string_entry_raises_validation_error():
+    with pytest.raises(CogneeValidationError, match="got int"):
+        resolve_memify_tasks([42])
+
+
+@pytest.mark.asyncio
+async def test_memify_rejects_unknown_task_name_before_running():
+    from cognee.modules.memify import memify
+
+    with pytest.raises(CogneeValidationError, match="Unknown memify task name"):
+        await memify(enrichment_tasks=["not_a_task"])


### PR DESCRIPTION
## Description

Fixes #4397.

The `/api/v1/memify` endpoint (and `cognee.memify()`) advertised task selection by name — `extractionTasks`/`enrichmentTasks` as `List[str]` — but no string→`Task` resolution existed anywhere. Strings were unpacked straight into `run_pipeline`, which raised `WrongTaskTypeError`, surfaced to HTTP callers as a 500. Every non-empty task-name list failed, so the advertised API contract was dead on arrival.

## Changes

- **New `cognee/memify_pipelines/memify_task_registry.py`** — curated registry mapping task names to `Task` factories. Only tasks runnable without required kwargs are exposed (e.g. `extract_user_sessions`, `cognify_session`, `apply_frequency_weights`, `detect_entity_duplicates`, `merge_entity_duplicates`, `index_data_points`, …). Defaults mirror how the dedicated memify pipelines construct these tasks. `extract_feedback_qas` stays SDK-only since it hard-requires `session_ids`.
- **`cognee/modules/memify/memify.py`** — resolves string entries (mixed `Task`/name lists supported) before falling back to defaults; unknown names raise `CogneeValidationError` (422) listing the supported names.
- **`cognee/api/v1/memify/routers/get_memify_router.py`** — the blanket `except` no longer flattens `CogneeApiError` into a 500; a bad task name now returns 422 with the supported names. Endpoint docstring documents the real task names.
- **Tests** — `cognee/tests/unit/memify_pipelines/test_memify_task_registry.py` covering resolution, fresh-instance semantics, pass-through of `Task` instances, empty/None handling, unknown-name and wrong-type rejection, and `memify()` failing fast before any pipeline/DB work.

## Verification

- `pytest cognee/tests/unit/memify_pipelines/ cognee/tests/unit/api/test_api_error_responses.py` — 66 passed
- `pre-commit run` on changed files — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)