### PR TITLE
fix: Chunk ladybug bulk graph writes (COG-6112)

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -50,6 +50,17 @@ from cognee.modules.observability.tracing import (
 
 logger = get_logger()
 
+
+# Rows per bulk MERGE statement (same convention as the Postgres/Turso
+# adapters' _WRITE_CHUNK_SIZE). Bulk node/edge writes are split into chunks of
+# this size so no single statement can exceed the subprocess engine's per-call
+# deadline on large graphs (e.g. code-graph ingests with tens of thousands of
+# facts). Each chunk is its own statement; the writes are idempotent MERGEs
+# and failed runs are swept by the pipeline rollback ledger, so partial
+# progress is safe. Does not change how many data points the pipeline batches.
+_WRITE_CHUNK_SIZE = 2000
+
+
 DEFAULT_KUZU_BUFFER_POOL_SIZE = 1 << 35  # 32 GB (must be a power of 2 for Kuzu)
 DEFAULT_KUZU_MAX_DB_SIZE = 1 << 35  # 32 GB (must be a power of 2 for Kuzu)
 
@@ -1159,14 +1170,19 @@ class LadybugAdapter(GraphDBInterface):
                     n.properties = node.properties,
                     n.updated_at = timestamp(node.updated_at)
                 """
-                query_params = {"nodes": node_params}
+                extra_params = {}
                 if source_ref_key is not None:
                     merge_query += _provenance_fold_clause("n")
-                    query_params.update(_provenance_fold_params(source_ref_key, pipeline_run_id))
+                    extra_params = _provenance_fold_params(source_ref_key, pipeline_run_id)
 
-                await self.query(merge_query, query_params)
+                total = len(node_params)
+                for start in range(0, total, _WRITE_CHUNK_SIZE):
+                    chunk = node_params[start : start + _WRITE_CHUNK_SIZE]
+                    await self.query(merge_query, {"nodes": chunk, **extra_params})
+                    if total > _WRITE_CHUNK_SIZE:
+                        logger.info("Merged nodes %d/%d", start + len(chunk), total)
                 await self.checkpoint()
-                logger.debug(f"Processed {len(node_params)} nodes in batch")
+                logger.debug(f"Processed {total} nodes in batch")
 
         except Exception as e:
             logger.error(f"Failed to add nodes in batch: {e}")
@@ -1913,10 +1929,12 @@ class LadybugAdapter(GraphDBInterface):
                 for from_node, to_node, relationship_name, properties in edges
             ]
 
+            # Property-map matches (primary-key index seeks) instead of a
+            # cartesian MATCH + WHERE, which planned as a scan on large graphs.
             query = """
             UNWIND $edges AS edge
-            MATCH (from:Node), (to:Node)
-            WHERE from.id = edge.from_id AND to.id = edge.to_id
+            MATCH (from:Node {id: edge.from_id})
+            MATCH (to:Node {id: edge.to_id})
             MERGE (from)-[r:EDGE {
                 relationship_name: edge.relationship_name
             }]->(to)
@@ -1928,12 +1946,17 @@ class LadybugAdapter(GraphDBInterface):
                 r.updated_at = timestamp(edge.updated_at),
                 r.properties = edge.properties
             """
-            query_params = {"edges": edge_params}
+            extra_params = {}
             if source_ref_key is not None:
                 query += _provenance_fold_clause("r")
-                query_params.update(_provenance_fold_params(source_ref_key, pipeline_run_id))
+                extra_params = _provenance_fold_params(source_ref_key, pipeline_run_id)
 
-            await self.query(query, query_params)
+            total = len(edge_params)
+            for start in range(0, total, _WRITE_CHUNK_SIZE):
+                chunk = edge_params[start : start + _WRITE_CHUNK_SIZE]
+                await self.query(query, {"edges": chunk, **extra_params})
+                if total > _WRITE_CHUNK_SIZE:
+                    logger.info("Merged edges %d/%d", start + len(chunk), total)
             await self.checkpoint()
 
         except Exception as e:

--- a/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_chunking.py
+++ b/cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_chunking.py
@@ -1,0 +1,80 @@
+"""Bulk node/edge writes must be chunked so no single statement can run past
+the subprocess engine's per-call deadline on large graphs (COG: ladybug
+ingestion of e.g. 30k-fact code graphs previously sent one statement for all
+rows and could never finish)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognee.infrastructure.databases.graph.ladybug.adapter import (
+    LadybugAdapter,
+    _WRITE_CHUNK_SIZE,
+)
+
+
+def _adapter_with_mocked_writes():
+    adapter = object.__new__(LadybugAdapter)
+    adapter.query = AsyncMock(return_value=[])
+    adapter.checkpoint = AsyncMock()
+    return adapter
+
+
+def _fake_nodes(count):
+    return [
+        SimpleNamespace(id=f"node-{index}", name=f"n{index}", type="Node") for index in range(count)
+    ]
+
+
+def _fake_edges(count):
+    return [(f"from-{index}", f"to-{index}", "relates_to", {}) for index in range(count)]
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_chunks_large_batches():
+    adapter = _adapter_with_mocked_writes()
+    total = _WRITE_CHUNK_SIZE * 2 + 1
+
+    await adapter.add_nodes(_fake_nodes(total))
+
+    assert adapter.query.await_count == 3
+    chunk_sizes = [len(call.args[1]["nodes"]) for call in adapter.query.await_args_list]
+    assert chunk_sizes == [_WRITE_CHUNK_SIZE, _WRITE_CHUNK_SIZE, 1]
+    adapter.checkpoint.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_add_nodes_small_batch_is_single_statement():
+    adapter = _adapter_with_mocked_writes()
+
+    await adapter.add_nodes(_fake_nodes(5))
+
+    assert adapter.query.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_add_edges_chunks_large_batches():
+    adapter = _adapter_with_mocked_writes()
+    total = _WRITE_CHUNK_SIZE + 1
+
+    await adapter.add_edges(_fake_edges(total))
+
+    assert adapter.query.await_count == 2
+    chunk_sizes = [len(call.args[1]["edges"]) for call in adapter.query.await_args_list]
+    assert chunk_sizes == [_WRITE_CHUNK_SIZE, 1]
+    adapter.checkpoint.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_add_edges_matches_endpoints_by_primary_key():
+    """The edge MERGE must seek endpoints via property-map matches (index
+    lookups), not a cartesian MATCH + WHERE that plans as a scan."""
+    adapter = _adapter_with_mocked_writes()
+
+    await adapter.add_edges(_fake_edges(1))
+
+    query = adapter.query.await_args_list[0].args[0]
+    assert "MATCH (from:Node {id: edge.from_id})" in query
+    assert "MATCH (to:Node {id: edge.to_id})" in query
+    assert "MATCH (from:Node), (to:Node)" not in query


### PR DESCRIPTION
## Description

`LadybugAdapter.add_nodes` / `add_edges` sent the entire payload as **one** UNWIND statement. Through the subprocess engine every call has a hard 300s deadline (`cognee_db_workers/harness.py`), so on large graphs a single statement can never finish: ingesting a ~30k-fact enola code graph failed with `TimeoutError: Subprocess call exceeded 300.0s deadline` on the edges statement every run, while the orphaned worker kept executing at 100% CPU (per-call deadlines don't cancel the worker). The edge query also matched endpoints with a cartesian `MATCH (from:Node), (to:Node) WHERE ...`, which plans as a scan.

## Changes

- Split bulk node/edge writes into 2000-row statements — the same `_WRITE_CHUNK_SIZE` convention the Postgres and Turso adapters already use — with per-chunk progress logging. Writes are idempotent MERGEs and failed runs are swept by the pipeline rollback ledger, so partial progress is safe.
- Match edge endpoints with property-map lookups (`MATCH (from:Node {id: edge.from_id})`) — primary-key index seeks, the same pattern the Neo4j adapter uses.

## Measured result

The 30k-fact / ~45k-edge ingest goes from **never completes** (300s deadline, every time) to **~2 minutes end to end**.

## Tests

`cognee/tests/unit/infrastructure/databases/graph/test_ladybug_write_chunking.py` — chunk boundaries for nodes and edges, single-statement behavior for small batches, and a guard that the edge MERGE uses index-seek matches.

Fixes [COG-6112](https://linear.app/cognee/issue/COG-6112/ladybug-bulk-writes-exceed-subprocess-deadline-on-large-graphs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)