### PR TITLE
feat: Update enola to 0.3.13 and ingest insights (COG-6113)

### DIFF
--- a/cognee/modules/retrieval/code_retriever.py
+++ b/cognee/modules/retrieval/code_retriever.py
@@ -35,6 +35,7 @@ from cognee.modules.retrieval.base_retriever import BaseRetriever
 
 CODE_NODE_TYPES = (
     "ApiEndpoint",
+    "CodeInsight",
     "CodeModule",
     "CodeService",
     "CodeSymbol",
@@ -46,6 +47,7 @@ CODE_NODE_TYPES = (
 
 _KIND_BY_TYPE = {
     "ApiEndpoint": "route",
+    "CodeInsight": "insight",
     "CodeModule": "module",
     "CodeService": "service",
     "CodeSymbol": "symbol",

--- a/cognee/tasks/code_graph/enola.py
+++ b/cognee/tasks/code_graph/enola.py
@@ -182,8 +182,69 @@ def parse_enola_snapshot(
         except (json.JSONDecodeError, OSError):
             logger.warning("Could not parse receipt.json in %s; ignoring it.", snapshot_dir)
 
-    logger.info("Parsed %d fact(s) from %s", len(facts), facts_path)
+    insight_facts = _synthesize_insight_facts(snapshot_dir)
+    if insight_facts:
+        facts = facts + insight_facts
+
+    logger.info(
+        "Parsed %d fact(s) (%d from insights.json) from %s",
+        len(facts),
+        len(insight_facts),
+        facts_path,
+    )
     return facts, receipt
+
+
+def _synthesize_insight_facts(snapshot_dir: Path) -> list:
+    """Convert insights.json explainer findings into fact dicts.
+
+    enola 0.3.x explainers (hotspots, god-class, dependency-depth, ...) write
+    architecture findings to insights.json. Each becomes a synthetic fact of
+    kind "insight" whose relations point at the evidence facts it cites, so
+    the ordinary fact-mapping and edge-resolution paths handle it. A missing
+    or unparseable insights.json is not an error (0.1.x snapshots may lack it).
+    """
+    insights_path = snapshot_dir / "insights.json"
+    if not insights_path.is_file():
+        return []
+    try:
+        with open(insights_path, "r", encoding="utf-8") as insights_file:
+            insights = json.load(insights_file)
+    except (json.JSONDecodeError, OSError):
+        logger.warning("Could not parse insights.json in %s; ignoring it.", snapshot_dir)
+        return []
+    if not isinstance(insights, list):
+        return []
+
+    facts = []
+    for insight in insights:
+        if not isinstance(insight, dict):
+            continue
+        title = insight.get("title")
+        if not isinstance(title, str) or not title:
+            continue
+        props = {
+            key: insight[key]
+            for key in ("source", "confidence", "description", "suggested_actions")
+            if insight.get(key) is not None
+        }
+        relations = []
+        evidence = insight.get("evidence")
+        for entry in evidence if isinstance(evidence, list) else []:
+            if not isinstance(entry, dict):
+                continue
+            target = entry.get("symbol") or entry.get("fact") or entry.get("file")
+            if isinstance(target, str) and target:
+                relations.append({"kind": "evidences", "target": target})
+        facts.append(
+            {
+                "kind": "insight",
+                "name": title,
+                "props": props,
+                "relations": relations,
+            }
+        )
+    return facts
 
 
 def normalize_relation(relation: dict) -> Optional[Tuple[str, str]]:

--- a/cognee/tasks/code_graph/extract_code_graph.py
+++ b/cognee/tasks/code_graph/extract_code_graph.py
@@ -18,6 +18,7 @@ from cognee.tasks.code_graph.enola import (
 )
 from cognee.tasks.code_graph.models import (
     ApiEndpoint,
+    CodeInsight,
     CodeModule,
     CodeRepository,
     CodeService,
@@ -42,6 +43,7 @@ KIND_TO_MODEL = {
     "service": CodeService,
     "test_ref": CodeTestReference,
     "file_ref": CodeFileReference,
+    "insight": CodeInsight,
 }
 
 
@@ -135,7 +137,11 @@ def map_facts_to_data_points(
             "file_path": file_path if isinstance(file_path, str) else None,
             "line": line if isinstance(line, int) and not isinstance(line, bool) else None,
             "repo": repo,
-            "description": _describe_fact(kind, props),
+            # Insights carry prose from the explainer; use it verbatim instead
+            # of the generic "kind: k=v, ..." property summary.
+            "description": props.get("description")
+            if kind == "insight" and isinstance(props.get("description"), str)
+            else _describe_fact(kind, props),
             "fact_properties": props,
             "part_of": _get_repository(repo),
         }

--- a/cognee/tasks/code_graph/install_enola.py
+++ b/cognee/tasks/code_graph/install_enola.py
@@ -31,18 +31,19 @@ from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("enola")
 
-ENOLA_PINNED_VERSION = "0.1.34"
+ENOLA_PINNED_VERSION = "0.3.13"
 
 _RELEASE_URL_TEMPLATE = "https://github.com/enola-labs/enola/releases/download/v{version}/{asset}"
 
 # SHA-256 of each release archive, pinned from the .sha256 files published
-# alongside the v0.1.34 release assets. Bumping ENOLA_PINNED_VERSION requires
+# alongside the v0.3.13 release assets. Bumping ENOLA_PINNED_VERSION requires
 # re-pinning these.
 ENOLA_RELEASE_CHECKSUMS = {
-    "darwin-arm64": "d0a5a59426a58848b3867557a624012dd01b74c426c87064808b4b71611f9c22",
-    "linux-amd64": "bbdef9309512ba27b6cba64aaa30bcd7c4119204d03c477192cd76663fa87cd4",
-    "linux-arm64": "2d092e45d43f66236d50c91ce363bbf73b783cda5ee69e5d0385ac32b073e288",
-    "windows-amd64": "ea38eebbb9726319484cbfe9b4e69b509c8fee0430921d828e6b12b00be9b3c4",
+    "darwin-arm64": "f395dfaa213a816539f4178d1519bd13117764eb9b0cd0029b3d319040c0aba7",
+    "darwin-amd64": "50292c297831a2e77fd6fb9617f307219141496fa4cea09dd64511e7919291dd",
+    "linux-amd64": "870cb18f589620171b195812aa44a9883b7234206fbab95d42dc20069942ed9e",
+    "linux-arm64": "bb86c297a3f6a0071a6a4b4c180e08bf836e42c4e98fab258d9d763ad626e2b0",
+    "windows-amd64": "8d4a0a03b1f17af7f5174722e542fa06da2b8101d4f6fd09537e6d176b774a17",
 }
 
 _FALSEY = {"false", "0", "no", "off"}
@@ -103,18 +104,29 @@ def _download(url: str, destination: Path) -> None:
 
 
 def _extract_single_binary(archive_path: Path, destination: Path) -> None:
-    """Extract the archive's single binary member without trusting member paths."""
+    """Extract the archive's single enola binary member without trusting member paths.
+
+    Releases up to 0.1.x shipped the binary alone; 0.3.x adds LICENSE and
+    NOTICE next to it. Exactly one top-level `enola*` member must exist, and
+    no member name may contain a path separator or start with a dot.
+    """
     with tarfile.open(archive_path, "r:gz") as archive:
         members = [member for member in archive.getmembers() if member.isreg()]
-        if len(members) != 1 or "/" in members[0].name or members[0].name.startswith("."):
+        if any("/" in member.name or member.name.startswith(".") for member in members):
             names = [member.name for member in archive.getmembers()]
             raise EnolaInstallError(
                 message=f"Unexpected enola archive layout {names}; refusing to extract."
             )
-        extracted = archive.extractfile(members[0])
+        binaries = [member for member in members if member.name.startswith("enola")]
+        if len(binaries) != 1:
+            names = [member.name for member in archive.getmembers()]
+            raise EnolaInstallError(
+                message=f"Unexpected enola archive layout {names}; refusing to extract."
+            )
+        extracted = archive.extractfile(binaries[0])
         if extracted is None:
             raise EnolaInstallError(
-                message=f"Could not read '{members[0].name}' from the enola archive."
+                message=f"Could not read '{binaries[0].name}' from the enola archive."
             )
         with open(destination, "wb") as binary_file:
             binary_file.write(extracted.read())

--- a/cognee/tasks/code_graph/models.py
+++ b/cognee/tasks/code_graph/models.py
@@ -63,3 +63,14 @@ class CodeTestReference(CodeGraphEntity):
 
 class CodeFileReference(CodeGraphEntity):
     """A file-level reference (enola fact kind: file_ref)."""
+
+
+class CodeInsight(CodeGraphEntity):
+    """An architecture finding from an enola explainer (synthesized kind: insight).
+
+    enola 0.3.x explainers (hotspots, god-class, dependency-depth, cycles,
+    layers, exported-surface, complexity-outliers, ...) emit these into
+    insights.json. Each insight is linked to the facts it cites via
+    ``evidences`` edges. The explainer name and confidence live in
+    fact_properties ("source", "confidence").
+    """

--- a/cognee/tests/unit/tasks/code_graph/test_enola_parser.py
+++ b/cognee/tests/unit/tasks/code_graph/test_enola_parser.py
@@ -75,3 +75,55 @@ def test_parse_enola_snapshot_missing_facts_raises(tmp_path):
 )
 def test_normalize_relation_tolerates_alternate_key_spellings(relation, expected):
     assert normalize_relation(relation) == expected
+
+
+def _write_minimal_snapshot(tmp_path, insights):
+    (tmp_path / "facts.jsonl").write_text(
+        '{"kind": "symbol", "name": "app/db.Database", "file": "app/db.py"}\n'
+    )
+    (tmp_path / "insights.json").write_text(json.dumps(insights))
+
+
+def test_parse_enola_snapshot_synthesizes_insight_facts(tmp_path):
+    _write_minimal_snapshot(
+        tmp_path,
+        [
+            {
+                "title": "Call-graph hotspot: app/db.Database",
+                "source": "hotspots",
+                "confidence": 0.7,
+                "description": "A pinch point.",
+                "evidence": [
+                    {"symbol": "app/db.Database", "detail": "fan-in 9"},
+                    {"detail": "no target here"},
+                ],
+            }
+        ],
+    )
+
+    facts, _receipt = parse_enola_snapshot(tmp_path)
+
+    insight_facts = [fact for fact in facts if fact["kind"] == "insight"]
+    assert len(insight_facts) == 1
+    insight = insight_facts[0]
+    assert insight["name"] == "Call-graph hotspot: app/db.Database"
+    assert insight["props"]["source"] == "hotspots"
+    assert insight["props"]["confidence"] == 0.7
+    assert insight["relations"] == [{"kind": "evidences", "target": "app/db.Database"}]
+
+
+def test_parse_enola_snapshot_tolerates_bad_insights(tmp_path):
+    _write_minimal_snapshot(tmp_path, ["not-a-dict", {"no_title": True}])
+
+    facts, _receipt = parse_enola_snapshot(tmp_path)
+
+    assert [fact["kind"] for fact in facts] == ["symbol"]
+
+
+def test_parse_enola_snapshot_ignores_corrupt_insights_file(tmp_path):
+    (tmp_path / "facts.jsonl").write_text('{"kind": "module", "name": "app"}\n')
+    (tmp_path / "insights.json").write_text("{ not json")
+
+    facts, _receipt = parse_enola_snapshot(tmp_path)
+
+    assert len(facts) == 1


### PR DESCRIPTION
## Description

Bumps the pinned enola release 0.1.34 → 0.3.13 (latest) and ingests its new `insights.json` explainer findings into the code graph.

enola 0.3.x ships **11 explainers** — hotspots, god-class, dependency-depth, exported-surface, complexity-outliers, cycles, layers, and more — that compute statistical architecture findings with confidence scores. Ingesting them makes questions like *"what are the most important parts of this codebase"* answerable deterministically (no LLM) via `SearchType.CODE`:

```python
await cognee.search(
    query_type=SearchType.CODE, query_text="", datasets=["my_repo"],
    code_query={"operation": "query_facts", "kinds": ["insight"],
                "property": "source", "property_value": "hotspots"},
)
```

## Changes

- **`install_enola.py`** — pin 0.3.13 with the five published SHA-256 checksums; `darwin-amd64` is newly shipped upstream, so Intel Macs gain auto-install. The 0.3.x tarball bundles LICENSE/NOTICE next to the binary, so `_extract_single_binary` now selects the single `enola*` member while keeping its path-traversal guards (no separators, no dotfiles, exactly one binary).
- **`enola.py`** — `parse_enola_snapshot` synthesizes each insights.json finding as a fact of kind `insight` with `evidences` relations to the facts it cites, so the existing fact-mapping and edge-resolution paths handle everything downstream. Missing or corrupt insights.json is tolerated (0.1.x snapshots still parse).
- **`models.py` / `extract_code_graph.py`** — new `CodeInsight` DataPoint, `KIND_TO_MODEL` entry, and the explainer's prose used verbatim as the node description.
- **`code_retriever.py`** — `insight` kind accepted by CODE queries (`CodeInsight` in the type maps).

## Compatibility

- facts.jsonl relation objects are unchanged across the version jump (`{kind, target}`) — verified against real 0.1.34 and 0.3.13 snapshots.
- Verified end to end on the cognee repo itself: 0.3.13 emits 129 findings here; `evidences` edges resolve to real symbol nodes (e.g. the top god-class finding, `get_relational_engine` with 155 dependents, links to its dependent symbols).

## Tests

Three new parser tests in `test_enola_parser.py`: insight synthesis with evidence relations, malformed insight entries, and a corrupt insights.json file. Existing suite unaffected (71 passed, 1 skipped).

Fixes [COG-6113](https://linear.app/cognee/issue/COG-6113/update-enola-to-0313-and-ingest-explainer-insights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)