### PR TITLE
fix(cache): slide session TTL lazily to stop per-write whole-session UPDATE (COG-6106)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -567,6 +567,9 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #CACHE_USERNAME=""
 #CACHE_PASSWORD=""
 # Session lifetime in the cache (default 7 days) and per-turn context cap.
+# Set to 0 to disable expiry entirely: rows are stored without an expiry and
+# nothing is ever purged — sliding-TTL writes are skipped too, which is the
+# lightest-I/O setting for long-lived agent sessions on the SQLite backend.
 #SESSION_TTL_SECONDS=604800
 #MAX_SESSION_CONTEXT_CHARS=
 # Self-improvement: absorb per-turn feedback/guidance automatically (default on).

--- a/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
+++ b/cognee/infrastructure/databases/cache/sql/SqlCacheAdapter.py
@@ -55,6 +55,16 @@ _DEADLOCK_ATTEMPTS = 3
 # Advisory-lock id guarding the throttled global TTL sweep on Postgres.
 _PURGE_LOCK_ID = int.from_bytes(sha256(b"cognee_cache_ttl_sweep").digest()[:8], "big", signed=True)
 
+# Fraction of the TTL window a row's expiry may lag behind the freshest write
+# before a sliding-TTL UPDATE re-stamps it. The slide is Redis EXPIRE parity,
+# but Redis EXPIRE is O(1) metadata on one key while the naive SQL translation
+# rewrites every session row per write — quadratic total write cost, and on the
+# SQLite WAL ~15,400x write amplification in a long agent session (issue #4393).
+# Skipping rows that are less than (fraction * ttl) stale bounds each row to at
+# most one re-stamp per slack window; rows then expire between (1 - fraction)
+# and 1.0 of the TTL after the session's last write.
+_TTL_REFRESH_FRACTION = 0.05
+
 
 def _is_deadlock_error(error: Exception) -> bool:
     """Best-effort detection of a Postgres deadlock without importing asyncpg."""
@@ -243,13 +253,26 @@ class SqlCacheAdapter(CacheDBInterface):
         await session.execute(text("SELECT pg_advisory_xact_lock(:lock_id)"), {"lock_id": lock_id})
 
     async def _refresh_session_ttl(self, session, table, user_id: str, session_id: str) -> None:
-        """Slide the whole session's expiry forward (Redis EXPIRE-on-write parity)."""
+        """Slide the session's expiry forward (Redis EXPIRE-on-write parity), lazily.
+
+        Only rows whose expiry lags the new target by more than the slack
+        window (_TTL_REFRESH_FRACTION of the TTL) are re-stamped, so a write
+        costs roughly its own bytes instead of rewriting the whole session
+        (see _TTL_REFRESH_FRACTION for the amplification math). NULL-expiry
+        rows (written while TTL was disabled) are stamped too, matching the
+        eager slide's behavior.
+        """
         if not self._ttl_enabled():
             return
+        new_expiry = self._session_expiry()
+        cutoff = new_expiry - timedelta(seconds=self.session_ttl_seconds * _TTL_REFRESH_FRACTION)
         await session.execute(
             update(table)
-            .where(self._session_filter(table, user_id, session_id))
-            .values(expires_at=self._session_expiry())
+            .where(
+                self._session_filter(table, user_id, session_id),
+                or_(table.c.expires_at.is_(None), table.c.expires_at < cutoff),
+            )
+            .values(expires_at=new_expiry)
         )
 
     async def _purge_session_expired(self, session, table, user_id: str, session_id: str) -> None:
@@ -1031,11 +1054,21 @@ class SqlCacheAdapter(CacheDBInterface):
                     )
                 )
                 if expires_at is not None:
+                    # Same lazy slide as _refresh_session_ttl: Redis EXPIREs the
+                    # whole per-user list per logged call, but re-stamping every
+                    # row here turns each decorated API call into an
+                    # O(user's-log-history) write (issue #4393). Skip rows less
+                    # than the slack window stale.
+                    cutoff = expires_at - timedelta(seconds=ttl * _TTL_REFRESH_FRACTION)
                     await session.execute(
                         update(cache_usage_logs)
                         .where(
                             cache_usage_logs.c.log_key == self.log_key,
                             cache_usage_logs.c.user_id == user_id,
+                            or_(
+                                cache_usage_logs.c.expires_at.is_(None),
+                                cache_usage_logs.c.expires_at < cutoff,
+                            ),
                         )
                         .values(expires_at=expires_at)
                     )

--- a/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
+++ b/cognee/tests/unit/infrastructure/databases/cache/test_sql_adapter_crud.py
@@ -494,6 +494,33 @@ async def test_writes_refresh_whole_session_ttl(adapter):
 
 
 @pytest.mark.asyncio
+async def test_fresh_rows_are_not_rewritten_by_ttl_slide(adapter):
+    """The sliding-TTL UPDATE skips rows whose expiry is within the slack window.
+
+    Guards against the write amplification of issue #4393: an append must not
+    rewrite the session's existing recently-stamped rows.
+    """
+    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
+    before = await _fetch_expirations(adapter, cache_qa_entries, qa_id="id1")
+
+    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
+
+    assert await _fetch_expirations(adapter, cache_qa_entries, qa_id="id1") == before
+
+
+@pytest.mark.asyncio
+async def test_ttl_slide_stamps_null_expiry_rows(adapter):
+    """Rows stored without expiry (TTL then disabled) get stamped by the next slide."""
+    await adapter.create_qa_entry("u1", "s1", "Q1", "C1", "A1", qa_id="id1")
+    await _backdate_expirations(adapter, cache_qa_entries, None, qa_id="id1")
+
+    await adapter.create_qa_entry("u1", "s1", "Q2", "C2", "A2", qa_id="id2")
+
+    expirations = await _fetch_expirations(adapter, cache_qa_entries, qa_id="id1")
+    assert expirations[0] is not None
+
+
+@pytest.mark.asyncio
 async def test_reads_do_not_refresh_ttl(adapter):
     """Read-only access leaves expires_at untouched."""
     await adapter.create_qa_entry("u1", "s1", "Q", "C", "A", qa_id="id1")
@@ -568,6 +595,34 @@ async def test_log_usage_and_get_usage_logs(adapter):
     assert [entry["endpoint"] for entry in logs] == ["/search", "/add"]
     assert await adapter.get_usage_logs("u1", limit=1) == [{"endpoint": "/search"}]
     assert await adapter.get_usage_logs("u3") == []
+
+
+@pytest.mark.asyncio
+async def test_log_usage_does_not_rewrite_fresh_rows(adapter):
+    """A logged call must not re-stamp the user's recently-written log rows (#4393)."""
+    await adapter.log_usage("u1", {"endpoint": "/add"})
+    before = await _fetch_expirations(adapter, cache_usage_logs, user_id="u1")
+
+    await adapter.log_usage("u1", {"endpoint": "/search"})
+
+    after = await _fetch_expirations(adapter, cache_usage_logs, user_id="u1")
+    assert before[0] in after and len(after) == 2
+
+
+@pytest.mark.asyncio
+async def test_log_usage_slides_stale_rows_forward(adapter):
+    """Log rows whose expiry lags beyond the slack window are refreshed on write."""
+    await adapter.log_usage("u1", {"endpoint": "/add"})
+    near_future = datetime.now(timezone.utc) + timedelta(seconds=30)
+    await _backdate_expirations(adapter, cache_usage_logs, near_future, user_id="u1")
+
+    await adapter.log_usage("u1", {"endpoint": "/search"})
+
+    expirations = await _fetch_expirations(adapter, cache_usage_logs, user_id="u1")
+    for expiry in expirations:
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
+        assert expiry > near_future + timedelta(seconds=60)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

Fixes #4393.

`SqlCacheAdapter._refresh_session_ttl` slid the whole session's expiry forward on **every** write — an `UPDATE` over all of the session's rows, at six call sites closing every write path. Redis `EXPIRE` is O(1) metadata on one key; this SQL translation was O(rows-in-session) per write, so total write cost grew quadratically with session length. The reporter measured **~15,400× WAL write amplification** on the default SQLite backend: a 64.2 GB `cache.db-wal` against a 200 MB `cache.db`, growing 5–39 GB/hour under steady agent traffic.

`log_usage` had the same shape one scope wider: it re-stamped **every usage-log row for the user** per logged call, on 12 decorated routes including `/api/v1/recall` and `/api/v1/search`.

## Fix — lazy TTL slide (the issue's preferred option 1)

The sliding-TTL UPDATE now skips rows whose expiry lags the new target by less than a slack window (`_TTL_REFRESH_FRACTION = 0.05` of the TTL):

- A row re-stamped at time T won't match the staleness cutoff again until `0.05 × TTL` later, so each row is rewritten **at most once per slack interval** regardless of write rate — an append now costs roughly its own bytes.
- Semantics stay within a bounded tolerance of Redis parity: a session's rows expire between **0.95×TTL and 1.0×TTL after the last write** (for the default 7-day TTL, worst case ~8.4 h early).
- `NULL`-expiry rows (written while TTL was disabled) are still stamped, matching the eager slide's behavior.
- Reads were already lazy (`_not_expired` filters per row) — unchanged.

`log_usage` gets the identical lazy condition rather than being scoped to only the written row (the issue's option 2): that keeps Redis parity — `EXPIRE` refreshes the whole per-user list — while eliminating the per-call rewrite all the same.

Also documents `SESSION_TTL_SECONDS=0` as the no-expiry escape hatch in `.env.template` (the issue's option 4; verified safe by the reporter and at source: `_session_expiry() → None`, `_not_expired()` keeps NULL rows visible).

## Tests

- `test_fresh_rows_are_not_rewritten_by_ttl_slide` — the amplification guard: an append must not re-stamp recently-written session rows.
- `test_ttl_slide_stamps_null_expiry_rows` — NULL-expiry parity with the eager slide.
- `test_log_usage_does_not_rewrite_fresh_rows` / `test_log_usage_slides_stale_rows_forward` — same pair for usage logs.
- Existing `test_writes_refresh_whole_session_ttl` (stale rows do slide forward) passes unchanged, as do all 145 cache unit tests and the 17 SQL session-manager integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)