### PR TITLE
ci: raise Claude Code Review --max-turns 20 -> 40 (COG-6117)

### DIFF
--- a/.github/workflows/test_suites.yml
+++ b/.github/workflows/test_suites.yml
@@ -388,7 +388,7 @@ jobs:
           prompt: "/pr-review"
           claude_args: >-
             --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"
-            --max-turns 20
+            --max-turns 40
             --model claude-sonnet-4-5-20250929
 
       - name: DM review summary to PR author on Slack


### PR DESCRIPTION
## Problem

The `Claude Code Review` job in `test_suites.yml` runs `claude-code-action` with `--max-turns 20`, and reviews of moderately sized diffs routinely need more. Two spurious red X's today alone:

- **PR #4245**: the review completed successfully (`is_error: false`, verdict posted) in 26 turns — the action then failed the job after the fact: *"Claude reported a successful result after 26 turns, exceeding the configured maximum of 20"*.
- **PR #4405**: hit the cap mid-run at 21 turns, twice in a row (a rerun made no difference), after already posting its "No blocking issues found" verdict as a PR comment.

Either way the job fails runs whose reviews actually finished, so the red X carries no signal.

## Change

One line: `--max-turns 20` → `--max-turns 40` for the PR-review job. The scheduled review jobs in `dev_previous_day_commits.yml` already run with 35 and 50, so this brings the PR job in line with the budgets that work elsewhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)