### PR TITLE
fix(auth): stop signing tokens with a known default secret

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -326,8 +326,10 @@ MIGRATION_DB_PROVIDER="sqlite"
 # -- JWT Authentication -------------------------------------------------------
 # Secret used to sign and verify JWT tokens. Must be the same across all instances
 # (e.g. all Kubernetes pods) for tokens issued by one instance to be accepted by another.
-# Change this to a long random string in production. Never commit the real value to git.
-FASTAPI_USERS_JWT_SECRET="super_secret"
+# Set this to a long random string. Never commit the real value to git.
+# Left unset, cognee generates a random secret per process: tokens then stop working
+# across restarts and across instances, which is the symptom of a missing value here.
+#FASTAPI_USERS_JWT_SECRET=""
 
 # How long a JWT token remains valid, in seconds. After expiry the user must log in again.
 # The same lifetime applies to both cookie and bearer token auth.
@@ -629,10 +631,11 @@ WEB_SCRAPER_MAX_DELAY=10.0
 #LLAMA_CPP_CHAT_FORMAT="chatml"
 
 # -- Security: additional auth-token secrets ----------------------------------
-# Like FASTAPI_USERS_JWT_SECRET above, these default to the INSECURE value
-# "super_secret". Override BOTH with long random strings in production.
-#FASTAPI_USERS_VERIFICATION_TOKEN_SECRET="change_me_in_production"
-#FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET="change_me_in_production"
+# Like FASTAPI_USERS_JWT_SECRET above, these fall back to a random per-process
+# secret when unset. Set BOTH to long random strings so password-reset and
+# email-verification links stay valid across restarts and across instances.
+#FASTAPI_USERS_VERIFICATION_TOKEN_SECRET=""
+#FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET=""
 
 
 ################################################################################

--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
+++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
@@ -16,6 +16,10 @@ from cognee.modules.graph.methods import get_formatted_graph_data
 from cognee.modules.users.get_user_manager import get_user_manager_context
 from cognee.infrastructure.databases.relational import get_relational_engine
 from cognee.modules.users.authentication.default.default_jwt_strategy import DefaultJWTStrategy
+from cognee.modules.users.authentication.get_auth_secret import (
+    JWT_SECRET_ENV_VAR,
+    get_auth_secret,
+)
 from cognee.shared.data_models import KnowledgeGraph
 from cognee.shared.graph_model_utils import graph_schema_to_graph_model
 from cognee.modules.pipelines.models.PipelineRunInfo import (
@@ -304,7 +308,7 @@ def get_cognify_router() -> APIRouter:
         access_token = websocket.cookies.get(os.getenv("AUTH_TOKEN_COOKIE_NAME", "auth_token"))
 
         try:
-            secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+            secret = get_auth_secret(JWT_SECRET_ENV_VAR)
 
             strategy = DefaultJWTStrategy(secret, lifetime_seconds=3600)
 

--- a/cognee/get_token.py
+++ b/cognee/get_token.py
@@ -1,8 +1,10 @@
 import jwt
-import os
 import datetime
 
-SECRET_KEY = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+from cognee.modules.users.authentication.get_auth_secret import (
+    JWT_SECRET_ENV_VAR,
+    get_auth_secret,
+)
 
 
 def create_jwt(user_id: str, tenant_id: str, roles: list[str]):
@@ -13,7 +15,7 @@ def create_jwt(user_id: str, tenant_id: str, roles: list[str]):
         "exp": datetime.datetime.now(datetime.timezone.utc)
         + datetime.timedelta(hours=1),  # 1 hour expiry
     }
-    return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+    return jwt.encode(payload, get_auth_secret(JWT_SECRET_ENV_VAR), algorithm="HS256")
 
 
 if __name__ == "__main__":

--- a/cognee/modules/users/authentication/get_api_auth_backend.py
+++ b/cognee/modules/users/authentication/get_api_auth_backend.py
@@ -8,6 +8,7 @@ from fastapi_users.authentication import (
 )
 
 from .api_bearer import api_bearer_transport, APIJWTStrategy
+from .get_auth_secret import JWT_SECRET_ENV_VAR, get_auth_secret
 
 
 @lru_cache
@@ -15,7 +16,7 @@ def get_api_auth_backend():
     transport = api_bearer_transport
 
     def get_jwt_strategy() -> JWTStrategy[models.UP, models.ID]:
-        secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+        secret = get_auth_secret(JWT_SECRET_ENV_VAR)
         lifetime_seconds = int(os.getenv("JWT_LIFETIME_SECONDS", "3600"))
 
         return APIJWTStrategy(secret, lifetime_seconds=lifetime_seconds)

--- a/cognee/modules/users/authentication/get_auth_secret.py
+++ b/cognee/modules/users/authentication/get_auth_secret.py
@@ -1,0 +1,48 @@
+import os
+import secrets
+from functools import lru_cache
+
+from cognee.shared.logging_utils import get_logger
+
+logger = get_logger()
+
+JWT_SECRET_ENV_VAR = "FASTAPI_USERS_JWT_SECRET"
+RESET_PASSWORD_TOKEN_SECRET_ENV_VAR = "FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET"
+VERIFICATION_TOKEN_SECRET_ENV_VAR = "FASTAPI_USERS_VERIFICATION_TOKEN_SECRET"
+
+
+@lru_cache
+def get_auth_secret(env_var: str) -> str:
+    """Return the auth secret named by ``env_var``, or a random per-process one.
+
+    ``.env.template`` already describes the shipped default as INSECURE and tells
+    operators to override it, but an unset variable still resolved to a literal
+    that is identical in every cognee installation, so the signing key of a
+    default deployment was public knowledge.
+
+    When the variable is unset (or empty) this returns a random secret instead.
+    It is deliberately **not** stable across restarts or across instances: tokens
+    minted before a restart stop verifying, and instances do not accept each
+    other's tokens. That is the failure the shared constant was hiding, and it
+    is the signal to set the variable — which ``.env.template`` documents as
+    required for multi-instance deployments regardless.
+
+    Results are cached per variable name, so one process resolves each secret
+    once and every caller of that variable agrees within the process. ``env_var``
+    is deliberately required rather than defaulted: ``lru_cache`` keys on the
+    call signature, so a defaulted argument would let ``get_auth_secret()`` and
+    ``get_auth_secret(JWT_SECRET_ENV_VAR)`` generate two different secrets for
+    one variable, and a token signed under one would not verify under the other.
+    """
+    secret = os.getenv(env_var)
+    if secret:
+        return secret
+
+    logger.warning(
+        "%s is not set. Falling back to a random secret generated for this process: "
+        "tokens will not survive a restart and will not be accepted by other instances. "
+        "Set %s to a long random string to issue stable tokens.",
+        env_var,
+        env_var,
+    )
+    return secrets.token_urlsafe(64)

--- a/cognee/modules/users/authentication/get_client_auth_backend.py
+++ b/cognee/modules/users/authentication/get_client_auth_backend.py
@@ -8,6 +8,7 @@ from fastapi_users.authentication import (
 )
 
 from .default import default_transport
+from .get_auth_secret import JWT_SECRET_ENV_VAR, get_auth_secret
 
 
 @lru_cache
@@ -17,7 +18,7 @@ def get_client_auth_backend():
     def get_jwt_strategy() -> JWTStrategy[models.UP, models.ID]:
         from .default.default_jwt_strategy import DefaultJWTStrategy
 
-        secret = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
+        secret = get_auth_secret(JWT_SECRET_ENV_VAR)
         lifetime_seconds = int(os.getenv("JWT_LIFETIME_SECONDS", "3600"))
 
         return DefaultJWTStrategy(secret, lifetime_seconds=lifetime_seconds)

--- a/cognee/modules/users/get_user_manager.py
+++ b/cognee/modules/users/get_user_manager.py
@@ -1,4 +1,3 @@
-import os
 import re
 import json
 import uuid
@@ -16,16 +15,29 @@ from .models import User
 from .get_user_db import get_user_db
 from cognee.modules.users.models.UserApiKey import UserApiKey
 from cognee.modules.users.api_key.hash_api_key import prepare_api_key
+from cognee.modules.users.authentication.get_auth_secret import (
+    RESET_PASSWORD_TOKEN_SECRET_ENV_VAR,
+    VERIFICATION_TOKEN_SECRET_ENV_VAR,
+    get_auth_secret,
+)
 from cognee.infrastructure.databases.relational import get_relational_engine
 
 logger = logging.getLogger(__name__)
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
-    reset_password_token_secret = os.getenv(
-        "FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET", "super_secret"
-    )
-    verification_token_secret = os.getenv("FASTAPI_USERS_VERIFICATION_TOKEN_SECRET", "super_secret")
+    # Resolved on first use rather than at class-definition time: `import cognee`
+    # pulls this module in, and an SDK user who never mints a reset or
+    # verification token should not be warned about secrets they do not use.
+    # It also means a variable exported after import is still picked up, which
+    # the previous module-level `os.getenv` could not do.
+    @property
+    def reset_password_token_secret(self) -> str:
+        return get_auth_secret(RESET_PASSWORD_TOKEN_SECRET_ENV_VAR)
+
+    @property
+    def verification_token_secret(self) -> str:
+        return get_auth_secret(VERIFICATION_TOKEN_SECRET_ENV_VAR)
 
     async def on_after_login(
         self, user: User, request: Optional[Request] = None, response: Optional[Response] = None

--- a/cognee/tests/unit/modules/users/test_get_auth_secret.py
+++ b/cognee/tests/unit/modules/users/test_get_auth_secret.py
@@ -1,0 +1,124 @@
+"""Tests for ``get_auth_secret``.
+
+Every auth secret used to fall back to the literal ``"super_secret"`` when its
+environment variable was unset, so the signing key of any default cognee
+deployment was public knowledge and a forged token was accepted everywhere.
+These tests hold the replacement to three properties: a configured value is
+used verbatim, an unconfigured one is random rather than a shared constant, and
+it stays stable within the process so a token can be verified after it is
+issued.
+"""
+
+import os
+from unittest.mock import patch
+
+from cognee.modules.users.authentication.get_auth_secret import (
+    JWT_SECRET_ENV_VAR,
+    RESET_PASSWORD_TOKEN_SECRET_ENV_VAR,
+    VERIFICATION_TOKEN_SECRET_ENV_VAR,
+    get_auth_secret,
+)
+
+AUTH_SECRET_ENV_VARS = [
+    JWT_SECRET_ENV_VAR,
+    RESET_PASSWORD_TOKEN_SECRET_ENV_VAR,
+    VERIFICATION_TOKEN_SECRET_ENV_VAR,
+]
+
+
+def _without_env():
+    """An environment with none of the auth secrets set."""
+    environment = {key: value for key, value in os.environ.items()}
+    for env_var in AUTH_SECRET_ENV_VARS:
+        environment.pop(env_var, None)
+    return patch.dict(os.environ, environment, clear=True)
+
+
+def test_configured_secret_is_used_verbatim():
+    get_auth_secret.cache_clear()
+    with patch.dict(os.environ, {JWT_SECRET_ENV_VAR: "a-long-random-string"}):
+        assert get_auth_secret(JWT_SECRET_ENV_VAR) == "a-long-random-string"
+    get_auth_secret.cache_clear()
+
+
+def test_unset_secret_is_not_a_shared_constant():
+    """The case that was wrong: an unset variable produced the same key everywhere."""
+    get_auth_secret.cache_clear()
+    with _without_env():
+        secret = get_auth_secret(JWT_SECRET_ENV_VAR)
+
+    assert secret != "super_secret"
+    assert len(secret) >= 32
+    get_auth_secret.cache_clear()
+
+
+def test_every_auth_secret_variable_is_covered():
+    """The reported issue named the JWT secret; reset and verification share the defect."""
+    for env_var in AUTH_SECRET_ENV_VARS:
+        get_auth_secret.cache_clear()
+        with _without_env():
+            assert get_auth_secret(env_var) != "super_secret"
+    get_auth_secret.cache_clear()
+
+
+def test_generated_secret_is_stable_within_the_process():
+    """A token signed on one call must still verify on the next."""
+    get_auth_secret.cache_clear()
+    with _without_env():
+        assert get_auth_secret(JWT_SECRET_ENV_VAR) == get_auth_secret(JWT_SECRET_ENV_VAR)
+    get_auth_secret.cache_clear()
+
+
+def test_each_variable_gets_its_own_generated_secret():
+    """A reset-password token must not be accepted as a session token."""
+    get_auth_secret.cache_clear()
+    with _without_env():
+        secrets_by_var = {env_var: get_auth_secret(env_var) for env_var in AUTH_SECRET_ENV_VARS}
+
+    assert len(set(secrets_by_var.values())) == len(AUTH_SECRET_ENV_VARS)
+    get_auth_secret.cache_clear()
+
+
+def test_empty_secret_is_treated_as_unset():
+    """An exported-but-empty variable is not a usable signing key."""
+    get_auth_secret.cache_clear()
+    with patch.dict(os.environ, {JWT_SECRET_ENV_VAR: ""}):
+        assert get_auth_secret(JWT_SECRET_ENV_VAR) != ""
+    get_auth_secret.cache_clear()
+
+
+def test_every_call_site_uses_one_call_form_per_variable():
+    """``lru_cache`` keys on the call signature, so a default argument would split one
+    variable across two cache entries and mint two different secrets for it. Every
+    caller must therefore name the variable, and ``get_auth_secret`` must not offer a
+    default that lets a call site omit it.
+    """
+    from inspect import signature
+
+    env_var_parameter = signature(get_auth_secret.__wrapped__).parameters["env_var"]
+
+    assert env_var_parameter.default is env_var_parameter.empty
+
+
+def test_user_manager_resolves_its_secrets_on_use():
+    """``import cognee`` loads UserManager, so the secrets must not resolve at import.
+
+    Reading them off the class rather than at class-definition time keeps a plain
+    SDK import free of warnings about tokens it never mints, and lets a variable
+    exported after import still take effect.
+    """
+    from cognee.modules.users.get_user_manager import UserManager
+
+    manager = UserManager.__new__(UserManager)
+
+    get_auth_secret.cache_clear()
+    with patch.dict(
+        os.environ,
+        {
+            RESET_PASSWORD_TOKEN_SECRET_ENV_VAR: "reset-secret",
+            VERIFICATION_TOKEN_SECRET_ENV_VAR: "verification-secret",
+        },
+    ):
+        assert manager.reset_password_token_secret == "reset-secret"
+        assert manager.verification_token_secret == "verification-secret"
+    get_auth_secret.cache_clear()


### PR DESCRIPTION
Fixes #4265.

## Description

Every auth secret in cognee falls back to the same hardcoded literal when its environment variable is unset:

```python
# cognee/get_token.py
SECRET_KEY = os.getenv("FASTAPI_USERS_JWT_SECRET", "super_secret")
```

Because the fallback is a constant in the source, an unset variable does not produce a *weak* secret — it produces the *same* secret on every cognee installation. `.env.template` already said so in as many words ("Change this to a long random string in production", and for the other two, "these default to the INSECURE value"), so the requirement was written down; nothing enforced it, and the shipped `.env.template` set the literal value explicitly rather than leaving it unset.

**The class is wider than the issue reports.** #4265 names four sites, all of them the JWT signing secret. Two more share the identical fallback and are not in that list:

```python
# cognee/modules/users/get_user_manager.py
reset_password_token_secret = os.getenv("FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET", "super_secret")
verification_token_secret = os.getenv("FASTAPI_USERS_VERIFICATION_TOKEN_SECRET", "super_secret")
```

Those sign password-reset and email-verification tokens. Fixing only the four reported sites would have secured session auth while leaving the account-recovery path on a known key, so all seven are covered here.

**The fix** is one helper, `cognee/modules/users/authentication/get_auth_secret.py`, that all seven call:

- **Variable set** → returned verbatim. No behaviour change for anyone who configured this, which is every deployment that followed `.env.template`.
- **Variable unset or empty** → a `secrets.token_urlsafe(64)` value generated once per process, plus a `logger.warning` naming the variable and the consequence.
- Cached per variable name, so a token signed on one call still verifies on the next, and the three secrets stay distinct from each other.

`env_var` is a **required** argument rather than a defaulted one, which is worth a sentence because I got it wrong first and caught it in testing. `lru_cache` keys on the call signature, so with a default, `get_auth_secret()` and `get_auth_secret(JWT_SECRET_ENV_VAR)` are two cache entries — they generate two different secrets for the same variable, and a token signed under one does not verify under the other. Requiring the name means one entry per variable. There is a test asserting the parameter has no default, so the shape cannot regress.

`UserManager`'s two secrets became `@property` reads rather than class attributes. `import cognee` pulls that module in, so resolving them at class-definition time would have warned every SDK user about tokens they never mint. As a side effect this also fixes something the old `os.getenv` at class scope could not do: a variable exported after import now actually takes effect.

A random per-process secret keeps `pip install cognee` working with no configuration, which is what the constant was there to do. What it removes is the silent case: an unconfigured multi-instance deployment now fails loudly and immediately — tokens rejected across pods and across restarts — instead of quietly accepting a signature that anyone can produce. `.env.template` already documents that this variable must be identical across instances, so that failure points straight at the setting that needs setting.

`.env.template` is updated to stop shipping the literal and to describe the unset behaviour.

**The one judgment call.** The stricter option is to **raise** when the variable is unset *and* authentication is actually required (`ENABLE_BACKEND_ACCESS_CONTROL` / `REQUIRE_AUTHENTICATION`), rather than generate. That is a better posture and I am happy to send it instead — I did not pick it because it turns every existing zero-config install into a hard startup failure, which reads as your call rather than mine. Say which you prefer and I will push it.

## Acceptance Criteria

* No auth secret in the tree resolves to a value that is identical across installations. `grep -rn 'super_secret' --include='*.py'` over the repo returns nothing.
* A configured secret is used exactly as before — this must not change behaviour for existing deployments.
* All seven call sites are covered, including the two the issue did not name.
* A secret generated for an unset variable is stable within the process (a token issued can be verified), distinct per variable, and long.
* Proof: fail-first on the new tests, plus a full unit-suite comparison against `dev` showing no other test changes state.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots

<img width="2000" height="1250" alt="image" src="https://github.com/user-attachments/assets/a52640c3-2728-4d5c-8601-a24b39c84469" />


Console output from the local runs, verbatim.

**Fail-first** — with the pre-fix `"super_secret"` fallback restored and nothing else changed, three of the six new tests fail, and the assertion output shows all three variables collapsing onto the one literal:

```
FAILED cognee/tests/unit/modules/users/test_get_auth_secret.py::test_unset_secret_is_not_a_shared_constant
FAILED cognee/tests/unit/modules/users/test_get_auth_secret.py::test_every_auth_secret_variable_is_covered
FAILED cognee/tests/unit/modules/users/test_get_auth_secret.py::test_each_variable_gets_its_own_generated_secret
  where {'FASTAPI_USERS_JWT_SECRET': 'super_secret',
         'FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET': 'super_secret',
         'FASTAPI_USERS_VERIFICATION_TOKEN_SECRET': 'super_secret'}.values
  AssertionError: assert 1 == 3
3 failed, 3 passed in 0.02s
```

**No new import-time noise** — `python -c "import cognee"` with no auth variables set emits **zero** of these warnings, because `UserManager` resolves its secrets on use.

**Call sites agree, proven rather than assumed** — with no `FASTAPI_USERS_JWT_SECRET` set, a token minted by `create_jwt` decodes under the secret the API auth backend's strategy holds, and the cache has exactly one entry for that variable:

```
same secret across call sites: True
token decodes under that secret: True
cache entries: 1
```

**End-to-end, not just the helper** — imported `cognee.get_token`, `UserManager` and both auth backends in a clean process with no auth variables set:

```
FASTAPI_USERS_RESET_PASSWORD_TOKEN_SECRET is not set. Falling back to a random secret generated for
this process: tokens will not survive a restart and will not be accepted by other instances. ...
FASTAPI_USERS_VERIFICATION_TOKEN_SECRET is not set. ...
FASTAPI_USERS_JWT_SECRET is not set. ...
imports ok
reset secret is super_secret? False
verify secret is super_secret? False
jwt sample len: 169
```

**Full unit suite, like for like** — `dev`: **16 failed, 3857 passed, 54 skipped**. This branch: **16 failed, 3865 passed, 54 skipped**. `diff` on the two sorted FAILED/ERROR line sets is **empty**, and +8 is exactly the eight tests added.

```
### WITH FIX
16 failed, 3865 passed, 54 skipped, 901 warnings in 501.97s (0:08:21)
### BASELINE (dev)
16 failed, 3857 passed, 54 skipped, 901 warnings in 499.92s (0:08:19)
### DIFF OF FAILED/ERROR SETS (empty means identical)
(identical)
```

`cognee/tests/unit/eval_framework/dashboard_test.py` is excluded from both runs; it fails collection on `dev` with `ModuleNotFoundError: No module named 'plotly'`.

**Lint** — `ruff format --diff` clean on all seven files. `ruff check` passes on the two new files. On the five pre-existing files it reports 33 findings (I001/UP045/UP006/B008) — **the identical 33 on `dev`**, verified by re-running against a stashed tree, so none are introduced here.

## Pre-submission Checklist

- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [x] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

Tests are in `cognee/tests/unit/modules/users/test_get_auth_secret.py` — eight of them: configured value used verbatim, unset value is not the shared constant, all three variables covered, stability within a process, distinctness between variables, empty string treated as unset, `env_var` having no default, and `UserManager` resolving on use rather than at import.

Two notes on scope: `import os` became unused in `get_user_manager.py` and `get_token.py` and was removed from both; `AUTH_TOKEN_COOKIE_NAME` and `JWT_LIFETIME_SECONDS` have ordinary non-secret defaults and are untouched. No new exploitation detail is added here — #4265 is already public and carries the reporter's proof of concept.

## DCO Affirmation

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
