### PR TITLE
fix(scraper): serialize per-domain crawl delays

### DIFF
--- a/cognee/tasks/web_scraper/default_url_crawler.py
+++ b/cognee/tasks/web_scraper/default_url_crawler.py
@@ -82,6 +82,7 @@ class DefaultUrlCrawler:
         }
         self.robots_cache_ttl = robots_cache_ttl
         self._last_request_time_per_domain: Dict[str, float] = {}
+        self._rate_limit_locks: Dict[str, asyncio.Lock] = {}
         self._robots_cache: Dict[str, RobotsTxtCache] = {}
         self._client: Optional[httpx.AsyncClient] = None
         self._robots_lock = asyncio.Lock()
@@ -146,22 +147,24 @@ class DefaultUrlCrawler:
             crawl_delay: Custom crawl delay in seconds (if any).
         """
         domain = self._domain_from_url(url)
-        last = self._last_request_time_per_domain.get(domain)
         delay = crawl_delay if crawl_delay is not None else self.crawl_delay
 
-        if last is None:
-            self._last_request_time_per_domain[domain] = time.time()
-            return
+        lock = self._rate_limit_locks.setdefault(domain, asyncio.Lock())
+        async with lock:
+            last = self._last_request_time_per_domain.get(domain)
+            if last is None:
+                self._last_request_time_per_domain[domain] = time.time()
+                return
 
-        elapsed = time.time() - last
-        wait_for = delay - elapsed
-        if wait_for > 0:
-            logger.info(
-                f"Rate limiting: waiting {wait_for:.2f}s before requesting {url} (crawl_delay={delay}s from robots.txt)"
-            )
-            await asyncio.sleep(wait_for)
-            logger.info(f"Rate limit wait completed for {url}")
-        self._last_request_time_per_domain[domain] = time.time()
+            elapsed = time.time() - last
+            wait_for = delay - elapsed
+            if wait_for > 0:
+                logger.info(
+                    f"Rate limiting: waiting {wait_for:.2f}s before requesting {url} (crawl_delay={delay}s from robots.txt)"
+                )
+                await asyncio.sleep(wait_for)
+                logger.info(f"Rate limit wait completed for {url}")
+            self._last_request_time_per_domain[domain] = time.time()
 
     async def _get_robots_cache(self, domain_root: str) -> Optional[RobotsTxtCache]:
         """Get cached robots.txt data if valid.

--- a/cognee/tests/unit/tasks/web_scraper/test_default_url_crawler.py
+++ b/cognee/tests/unit/tasks/web_scraper/test_default_url_crawler.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+from cognee.tasks.web_scraper import DefaultUrlCrawler
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_serializes_concurrent_requests_to_same_domain():
+    crawler = DefaultUrlCrawler(crawl_delay=0.05)
+    request_times = []
+
+    async def request(url):
+        await crawler._respect_rate_limit(url)
+        request_times.append(asyncio.get_running_loop().time())
+
+    await asyncio.gather(
+        request("https://example.test/one"),
+        request("https://example.test/two"),
+        request("https://example.test/three"),
+    )
+
+    request_times.sort()
+    gaps = [later - earlier for earlier, later in zip(request_times, request_times[1:])]
+    assert all(gap >= 0.04 for gap in gaps), gaps


### PR DESCRIPTION
﻿## Summary

Fixes #4410.

Serialize per-domain crawl-delay reservations in DefaultUrlCrawler so concurrent URLs for the same host cannot observe the same previous timestamp and wake together.

## Changes

- Add an independent asyncio lock for each domain.
- Keep the lock while waiting and reserving the next request slot.
- Add a regression test covering three concurrent requests to one domain.

Different domains continue to use independent locks and can proceed concurrently.

## Verification

- python -m compileall -q cognee/tasks/web_scraper/default_url_crawler.py cognee/tests/unit/tasks/web_scraper/test_default_url_crawler.py
- git diff --check
- Focused pytest could not run because pytest is not installed in the local environment.
