### PR TITLE
fix(security): scope visualization events by dataset

### DIFF
--- a/cognee/api/v1/visualize/visualize.py
+++ b/cognee/api/v1/visualize/visualize.py
@@ -87,7 +87,11 @@ async def fetch_visualization_data(
     if include_session_events:
         from cognee.modules.visualization.session_events import collect_session_events
 
-        search_events = await collect_session_events(user=user, session_ids=session_ids)
+        search_events = await collect_session_events(
+            user=user,
+            session_ids=session_ids,
+            dataset_id=getattr(dataset, "id", None),
+        )
 
     return graph_data, search_events
 
@@ -358,18 +362,10 @@ async def get_live_events(
     """Delta of search/improve events since a cursor, for the Memory tab's
     live timeline.
 
-    ``dataset_id`` gates who may call this — the same read-permission check
-    every other visualize endpoint runs (``get_authorized_existing_datasets``)
-    — not which events come back. Session events are collected per *user*,
-    not per dataset, matching how ``visualize_graph``'s own
-    ``include_session_events`` already embeds the same events into whichever
-    dataset's page happens to be open. Scoping the event *content* to one
-    dataset would mean checking each event's referenced node/edge ids against
-    that dataset's graph membership — real extra cost that this endpoint's
-    one job (avoid recomputing the whole graph payload every ~1.5s just to
-    refresh a timeline) does not need, and it would make this endpoint
-    disagree with the very same events already shown in ``search_events`` on
-    ``/visualize/json`` for that dataset.
+    ``dataset_id`` both gates access and scopes the returned events. Session
+    lifecycle rows are tagged with the dataset used by the session manager;
+    unscoped/legacy rows are excluded from a dataset-scoped visualization so
+    that a missing tag cannot become a data leak.
 
     ``since=None`` returns every available event — the first call, before a
     client has a cursor of its own.
@@ -392,7 +388,7 @@ async def get_live_events(
     if not authorized:
         raise PermissionDeniedError(message="Not authorized to read this dataset")
 
-    events = await collect_session_events(user=user)
+    events = await collect_session_events(user=user, dataset_id=dataset_id)
 
     if since is not None:
         cutoff = _as_naive_utc(since)

--- a/cognee/infrastructure/session/session_manager.py
+++ b/cognee/infrastructure/session/session_manager.py
@@ -194,7 +194,7 @@ class SessionManager:
                 question=question,
                 answer=answer,
             )
-            await record_session_activity(user_id, session_id)
+            await record_session_activity(user_id, session_id, dataset_id=self.dataset_id)
             return qa_id
 
     async def add_agent_trace_step(
@@ -249,7 +249,12 @@ class SessionManager:
             error_message=error_message,
             session_feedback=session_feedback,
         )
-        await record_session_activity(user_id, session_id, errored=status == "error")
+        await record_session_activity(
+            user_id,
+            session_id,
+            dataset_id=self.dataset_id,
+            errored=status == "error",
+        )
         await self._maybe_extract_agent_context(
             user_id=user_id,
             session_id=session_id,

--- a/cognee/modules/session_lifecycle/metrics.py
+++ b/cognee/modules/session_lifecycle/metrics.py
@@ -463,7 +463,13 @@ async def touch_session(*, session_id, user_id, dataset_id=None):
 _session_record_write_failed = False
 
 
-async def record_session_activity(user_id: str, session_id: str, *, errored: bool = False) -> None:
+async def record_session_activity(
+    user_id: str,
+    session_id: str,
+    *,
+    dataset_id: Optional[UUIDType] = None,
+    errored: bool = False,
+) -> None:
     """Write a lifecycle heartbeat for a session: upsert + touch the SessionRecord row.
 
     Accepts a string ``user_id`` (coerced to UUID). Swallows failures — the
@@ -478,7 +484,11 @@ async def record_session_activity(user_id: str, session_id: str, *, errored: boo
         except (ValueError, TypeError):
             return
 
-        await ensure_and_touch_session(session_id=session_id, user_id=user_uuid)
+        await ensure_and_touch_session(
+            session_id=session_id,
+            user_id=user_uuid,
+            dataset_id=dataset_id,
+        )
         if errored:
             await accumulate_usage(session_id=session_id, user_id=user_uuid, errored=True)
     except Exception as exc:

--- a/cognee/modules/visualization/session_events.py
+++ b/cognee/modules/visualization/session_events.py
@@ -16,6 +16,7 @@ Two event kinds are emitted per the renderer's contract:
 """
 
 from typing import Any, Dict, List, Optional
+from uuid import UUID
 
 from cognee.shared.logging_utils import get_logger
 
@@ -68,7 +69,9 @@ def map_session_entries_to_events(session_id: str, entries: List[Any]) -> List[D
     return events
 
 
-async def _list_recent_session_ids(user_uuid, limit: int) -> List[str]:
+async def _list_recent_session_ids(
+    user_uuid, limit: int, dataset_id: Optional[UUID] = None
+) -> List[str]:
     """Most recently active session ids for a user, from the lifecycle table.
 
     ``user_uuid`` must be the raw UUID (the column is UUID-typed; a string
@@ -81,18 +84,14 @@ async def _list_recent_session_ids(user_uuid, limit: int) -> List[str]:
 
     engine = get_relational_engine()
     async with engine.get_async_session() as session:
+        statement = select(SessionRecord).where(SessionRecord.user_id == user_uuid)
+        if dataset_id is not None:
+            statement = statement.where(SessionRecord.dataset_id == dataset_id)
         rows = (
-            (
-                await session.execute(
-                    select(SessionRecord)
-                    .where(SessionRecord.user_id == user_uuid)
-                    .order_by(SessionRecord.last_activity_at.desc())
-                    .limit(limit)
-                )
+            await session.execute(
+                statement.order_by(SessionRecord.last_activity_at.desc()).limit(limit)
             )
-            .scalars()
-            .all()
-        )
+        ).scalars().all()
     return [str(row.session_id) for row in rows]
 
 
@@ -100,6 +99,7 @@ async def collect_session_events(
     user=None,
     session_ids: Optional[List[str]] = None,
     max_sessions: int = MAX_SESSIONS_SCANNED,
+    dataset_id: Optional[UUID] = None,
 ) -> List[Dict[str, Any]]:
     """Best-effort collection of search/improve events from the session cache.
 
@@ -119,7 +119,18 @@ async def collect_session_events(
             logger.debug("Session cache unavailable; no operation events collected.")
             return []
 
-        if session_ids is None:
+        if dataset_id is not None:
+            scoped_session_ids = await _list_recent_session_ids(
+                user.id, max_sessions, dataset_id
+            )
+            if session_ids is None:
+                session_ids = scoped_session_ids
+            else:
+                allowed_session_ids = set(scoped_session_ids)
+                session_ids = [
+                    session_id for session_id in session_ids if session_id in allowed_session_ids
+                ]
+        elif session_ids is None:
             try:
                 session_ids = await _list_recent_session_ids(user.id, max_sessions)
             except Exception as error:  # noqa: BLE001 — lifecycle table may not exist

--- a/cognee/tests/unit/api/test_live_events.py
+++ b/cognee/tests/unit/api/test_live_events.py
@@ -42,11 +42,15 @@ async def test_no_since_returns_every_event_and_cursor_is_the_newest():
     events = [_event("2026-08-03T09:00:00.000000"), _event("2026-08-03T09:00:05.000000")]
 
     ctx_a, ctx_b = _patches(events)
+    user = SimpleNamespace(id="user-1")
     with ctx_a, ctx_b:
-        result = await visualize_module.get_live_events(DATASET_ID)
+        result = await visualize_module.get_live_events(DATASET_ID, user=user)
 
     assert result["events"] == events
     assert result["cursor"] == "2026-08-03T09:00:05.000000"
+    visualize_module.collect_session_events.assert_awaited_once_with(
+        user=user, dataset_id=DATASET_ID
+    )
 
 
 @pytest.mark.asyncio

--- a/cognee/tests/unit/modules/visualization/test_session_events.py
+++ b/cognee/tests/unit/modules/visualization/test_session_events.py
@@ -1,6 +1,13 @@
 """Unit tests for the session operation-event mapper (pure, no cache/DB)."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+
 from cognee.infrastructure.databases.cache.models import SessionQAEntry
+from cognee.modules.visualization import session_events
 from cognee.modules.visualization.session_events import map_session_entries_to_events
 
 
@@ -64,3 +71,35 @@ class TestMapSessionEntriesToEvents:
         assert map_session_entries_to_events("s1", entries) == map_session_entries_to_events(
             "s1", entries
         )
+
+
+@pytest.mark.asyncio
+async def test_collect_session_events_filters_explicit_sessions_by_dataset():
+    session_manager = SimpleNamespace(
+        is_available=True,
+        get_session=AsyncMock(return_value=[]),
+    )
+    user = SimpleNamespace(id=UUID("11111111-1111-1111-1111-111111111111"))
+    dataset_id = UUID("22222222-2222-2222-2222-222222222222")
+
+    with (
+        patch(
+            "cognee.infrastructure.session.get_session_manager.get_session_manager",
+            return_value=session_manager,
+        ),
+        patch.object(
+            session_events,
+            "_list_recent_session_ids",
+            AsyncMock(return_value=["allowed-session"]),
+        ) as list_sessions,
+    ):
+        await session_events.collect_session_events(
+            user=user,
+            session_ids=["allowed-session", "private-session"],
+            dataset_id=dataset_id,
+        )
+
+    list_sessions.assert_awaited_once_with(user.id, session_events.MAX_SESSIONS_SCANNED, dataset_id)
+    session_manager.get_session.assert_awaited_once_with(
+        user_id=str(user.id), session_id="allowed-session"
+    )


### PR DESCRIPTION
﻿## Summary

Fixes #4411.

Scope visualization session events to the authorized dataset instead of returning every recent session event for the user.

## Changes

- Add dataset filtering to session lifecycle session lookup.
- Propagate SessionManager.dataset_id into lifecycle activity records.
- Pass the authorized dataset into visualization JSON/HTML event collection and live-events polling.
- Exclude unscoped/legacy session records from dataset-scoped event responses.
- Add route-level and collector-level regression coverage, including filtering of explicitly supplied out-of-scope session IDs.

## Security impact

A caller with access to dataset A can no longer receive QA events collected from a session recorded for dataset B through the visualization live-events endpoint.

## Verification

- python -m compileall -q on all changed Python files
- git diff --check
- Focused pytest could not run because pytest is not installed in the local environment.
