### PR TITLE
fix(validate): reject unauthorized dataset fallback

### DIFF
--- a/cognee/api/v1/validate/validate.py
+++ b/cognee/api/v1/validate/validate.py
@@ -42,6 +42,7 @@ from cognee.infrastructure.databases.vector.get_vector_engine import get_vector_
 from cognee.infrastructure.engine import DataPoint
 from cognee.modules.chunking.models import DocumentChunk
 from cognee.modules.data.constants import DEFAULT_DATASET_NAME
+from cognee.modules.data.exceptions import DatasetNotFoundError
 from cognee.modules.data.methods import get_authorized_existing_datasets
 from cognee.modules.engine.models import Entity, EntityType
 from cognee.modules.users.methods import get_default_user
@@ -221,8 +222,11 @@ async def validate(
     resolved_dataset = None
     if dataset_names:
         authorized = await get_authorized_existing_datasets(dataset_names, "read", user)
-        if authorized:
-            resolved_dataset = authorized[0]
+        if len(authorized) != len(dataset_names):
+            raise DatasetNotFoundError(
+                message="Dataset not found or not readable."
+            )
+        resolved_dataset = authorized[0]
 
     async with set_database_global_context_variables(
         resolved_dataset.id if resolved_dataset else None,

--- a/cognee/tests/unit/api/v1/validate/test_validate.py
+++ b/cognee/tests/unit/api/v1/validate/test_validate.py
@@ -25,6 +25,7 @@ from cognee.api.v1.validate.validate import (
     _check_vector_sync,
     validate,
 )
+from cognee.modules.data.exceptions import DatasetNotFoundError
 from cognee.modules.engine.models import Entity
 
 # Patch targets use the module object rather than the dotted string: the
@@ -314,6 +315,64 @@ async def test_validate_reports_healthy_and_scopes_to_dataset():
         "graph_edges": 1,
         "node_type_distribution": {"Entity": 2},
     }
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_missing_or_unauthorized_dataset_before_reads():
+    mock_graph_engine = AsyncMock()
+    mock_vector_engine = AsyncMock()
+
+    with (
+        patch.object(
+            validate_module,
+            "get_graph_engine",
+            return_value=mock_graph_engine,
+        ),
+        patch.object(
+            validate_module,
+            "get_vector_engine_async",
+            return_value=mock_vector_engine,
+        ),
+        patch.object(
+            validate_module,
+            "get_authorized_existing_datasets",
+            return_value=[],
+        ),
+    ):
+        with pytest.raises(DatasetNotFoundError, match="not found or not readable"):
+            await validate(dataset="private_dataset", user=object())
+
+    mock_graph_engine.get_graph_data.assert_not_awaited()
+    mock_vector_engine.retrieve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_mixed_authorized_and_unauthorized_datasets():
+    mock_graph_engine = AsyncMock()
+    mock_vector_engine = AsyncMock()
+
+    with (
+        patch.object(
+            validate_module,
+            "get_graph_engine",
+            return_value=mock_graph_engine,
+        ),
+        patch.object(
+            validate_module,
+            "get_vector_engine_async",
+            return_value=mock_vector_engine,
+        ),
+        patch.object(
+            validate_module,
+            "get_authorized_existing_datasets",
+            return_value=[_mock_dataset()],
+        ),
+    ):
+        with pytest.raises(DatasetNotFoundError, match="not found or not readable"):
+            await validate(dataset=["visible_dataset", "private_dataset"], user=object())
+
+    mock_graph_engine.get_graph_data.assert_not_awaited()
+    mock_vector_engine.retrieve.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #4414.

The validator now fails closed when any explicitly requested dataset is missing or not readable. It raises the standard `DatasetNotFoundError` before opening graph/vector adapters, preventing fallback to an unscoped or default graph.

## Changes

- Require every requested dataset to resolve to an authorized dataset.
- Preserve first-dataset selection when all requested datasets are authorized.
- Add regression tests for fully unauthorized and mixed authorized/unauthorized requests.

## Verification

- `python -m compileall -q cognee/api/v1/validate/validate.py cognee/tests/unit/api/v1/validate/test_validate.py`
- `git diff --check`
- `python -m pytest cognee/tests/unit/api/v1/validate/test_validate.py -q` - 18 passed, 1 skipped.