### PR TITLE
fix(security): restrict user SQL connection targets

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -359,6 +359,12 @@ RAISE_INCREMENTAL_LOADING_ERRORS=True
 # The "tools" scope is explicit per call — never implied by scope="auto"/"all".
 #TOOL_CALLS_ENABLED=false
 #
+# User-registered SQLite paths and PostgreSQL hosts are denied unless they are
+# explicitly allowlisted. Relative SQLite paths resolve under this directory;
+# PostgreSQL hosts are comma-separated exact hostnames.
+#TOOL_SQLITE_ALLOWED_ROOT=
+#TOOL_SQL_ALLOWED_HOSTS=
+#
 # Register connections per user with cognee.tools.register_sql_connection(...)
 # (the DSN is AES-256-GCM encrypted at rest — requires the integrations
 # keyring, e.g. INTEGRATION_CREDENTIALS_KEYS='{"1": "<base64 32-byte key>"}').

--- a/cognee/modules/tools/config.py
+++ b/cognee/modules/tools/config.py
@@ -31,6 +31,12 @@ class ToolsConfig(BaseSettings):
     # per-user registration (cognee.tools.register_sql_connection) instead.
     tool_sql_connections: str = "{}"
 
+    # User-registered targets are denied by default. Configure an approved
+    # SQLite root and/or comma-separated PostgreSQL host allowlist before
+    # allowing per-user connections in a deployment.
+    tool_sqlite_allowed_root: str = ""
+    tool_sql_allowed_hosts: str = ""
+
     text_to_sql_max_rows: int = 100
     text_to_sql_max_attempts: int = 3
     text_to_sql_statement_timeout_ms: int = 5000
@@ -64,6 +70,14 @@ class ToolsConfig(BaseSettings):
                     "or an object with a 'connection_string' key"
                 )
         return connections
+
+    def sql_allowed_hosts(self) -> set[str]:
+        """Return normalized PostgreSQL hosts approved for user connections."""
+        return {
+            host.strip().lower().rstrip(".")
+            for host in self.tool_sql_allowed_hosts.split(",")
+            if host.strip()
+        }
 
     def to_dict(self) -> dict:
         return {

--- a/cognee/modules/tools/connections.py
+++ b/cognee/modules/tools/connections.py
@@ -21,6 +21,7 @@ from cognee.modules.integrations.crypto import decrypt_credentials, encrypt_cred
 from cognee.modules.tools.config import get_tools_config
 from cognee.modules.tools.errors import ToolConnectionNotFoundError, ToolError
 from cognee.modules.tools.models.ToolConnection import ToolConnection
+from cognee.modules.tools.target_policy import validate_user_connection_target
 from cognee.shared.logging_utils import get_logger
 
 logger = get_logger("tool_connections")
@@ -125,6 +126,14 @@ async def register_tool_connection(
             f"Supported providers: {', '.join(_SUPPORTED_PROVIDERS)}."
         )
 
+    config = get_tools_config()
+    validate_user_connection_target(
+        connection_string,
+        resolved_provider,
+        sqlite_allowed_root=config.tool_sqlite_allowed_root,
+        allowed_hosts=config.sql_allowed_hosts(),
+    )
+
     ciphertext, nonce, encryption_version, key_id = encrypt_credentials(
         {"connection_string": connection_string}
     )
@@ -216,6 +225,13 @@ async def get_tool_connection(user_id: UUID, name: str) -> dict[str, Any]:
 
     if row is not None:
         payload = decrypt_credentials(row.ciphertext, row.nonce, row.encryption_version, row.key_id)
+        config = get_tools_config()
+        validate_user_connection_target(
+            payload["connection_string"],
+            row.provider,
+            sqlite_allowed_root=config.tool_sqlite_allowed_root,
+            allowed_hosts=config.sql_allowed_hosts(),
+        )
         options = row.options or {}
         return {
             "name": row.name,

--- a/cognee/modules/tools/target_policy.py
+++ b/cognee/modules/tools/target_policy.py
@@ -1,0 +1,71 @@
+"""Deployment policy checks for user-supplied SQL connection targets."""
+
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from cognee.modules.tools.errors import ToolError
+
+_SQLITE_SCHEMES = ("sqlite://", "sqlite+aiosqlite://")
+
+
+def validate_user_connection_target(
+    connection_string: str,
+    provider: str,
+    *,
+    sqlite_allowed_root: str,
+    allowed_hosts: set[str],
+) -> None:
+    """Reject user-supplied database targets outside deployment allowlists.
+
+    Deployment-level connections are already administrator supplied and do
+    not use this function. An empty allowlist intentionally rejects all
+    corresponding user targets.
+    """
+    if provider == "sqlite":
+        if not sqlite_allowed_root:
+            raise ToolError(
+                "User SQLite connections are disabled. Configure "
+                "TOOL_SQLITE_ALLOWED_ROOT with an approved directory."
+            )
+
+        matching_scheme = next(
+            (scheme for scheme in _SQLITE_SCHEMES if connection_string.startswith(scheme)),
+            None,
+        )
+        if matching_scheme is None:
+            raise ToolError("Unrecognized SQLite connection string scheme.")
+
+        path = connection_string[len(matching_scheme) :]
+        # URI forms can address arbitrary files through query parameters or
+        # SQLite virtual filenames. Only ordinary filesystem paths are safe to
+        # constrain to the configured root.
+        if not path or path.startswith("/file:") or "?" in path or "#" in path:
+            raise ToolError(
+                "User SQLite connections must be ordinary paths under "
+                "TOOL_SQLITE_ALLOWED_ROOT."
+            )
+
+        root = Path(sqlite_allowed_root).expanduser().resolve()
+        target = (
+            Path(path[1:]).expanduser().resolve()
+            if path.startswith("//")
+            else (root / path.lstrip("/")).resolve()
+        )
+        if target == root or root not in target.parents:
+            raise ToolError(
+                "User SQLite connection must point inside "
+                "TOOL_SQLITE_ALLOWED_ROOT."
+            )
+        return
+
+    if provider == "postgres":
+        parsed = urlsplit(connection_string)
+        host = (parsed.hostname or "").lower().rstrip(".")
+        if not host or host not in {entry.rstrip(".") for entry in allowed_hosts}:
+            raise ToolError(
+                "User PostgreSQL connections are restricted to hosts listed in "
+                "TOOL_SQL_ALLOWED_HOSTS."
+            )
+        return
+
+    raise ToolError(f"Unsupported tool connection provider: {provider}")

--- a/cognee/tests/unit/modules/tools/test_tool_connections.py
+++ b/cognee/tests/unit/modules/tools/test_tool_connections.py
@@ -6,7 +6,6 @@ import pytest
 
 import cognee.modules.tools.connections as connections_mod
 from cognee.modules.tools.config import ToolsConfig
-from cognee.modules.tools.errors import ToolConnectionNotFoundError, ToolError
 from cognee.modules.tools.connections import (
     delete_tool_connection,
     get_tool_connection,
@@ -14,6 +13,8 @@ from cognee.modules.tools.connections import (
     list_tool_connections,
     register_tool_connection,
 )
+from cognee.modules.tools.errors import ToolConnectionNotFoundError, ToolError
+from cognee.modules.tools.target_policy import validate_user_connection_target
 
 
 @pytest.fixture
@@ -35,8 +36,12 @@ def relational_engine(monkeypatch, tmp_path):
 
 
 @pytest.fixture
-def no_env_connections(monkeypatch):
-    monkeypatch.setattr(connections_mod, "get_tools_config", lambda: ToolsConfig(_env_file=None))
+def no_env_connections(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        connections_mod,
+        "get_tools_config",
+        lambda: ToolsConfig(_env_file=None, tool_sqlite_allowed_root=str(tmp_path)),
+    )
 
 
 def test_infer_provider():
@@ -47,6 +52,48 @@ def test_infer_provider():
         infer_provider("mysql://u:p@h/db")
     with pytest.raises(ToolError):
         infer_provider("not-a-dsn")
+
+
+def test_user_sqlite_target_must_stay_under_allowlisted_root(tmp_path):
+    validate_user_connection_target(
+        "sqlite:///warehouse.db",
+        "sqlite",
+        sqlite_allowed_root=str(tmp_path),
+        allowed_hosts=set(),
+    )
+
+    with pytest.raises(ToolError, match="inside"):
+        validate_user_connection_target(
+            "sqlite:////tmp/private.db",
+            "sqlite",
+            sqlite_allowed_root=str(tmp_path),
+            allowed_hosts=set(),
+        )
+
+    with pytest.raises(ToolError, match="disabled"):
+        validate_user_connection_target(
+            "sqlite:///warehouse.db",
+            "sqlite",
+            sqlite_allowed_root="",
+            allowed_hosts=set(),
+        )
+
+
+def test_user_postgres_target_must_match_allowlisted_host():
+    validate_user_connection_target(
+        "postgresql://user:password@analytics.internal/db",
+        "postgres",
+        sqlite_allowed_root="",
+        allowed_hosts={"analytics.internal"},
+    )
+
+    with pytest.raises(ToolError, match="TOOL_SQL_ALLOWED_HOSTS"):
+        validate_user_connection_target(
+            "postgresql://user:password@127.0.0.1/db",
+            "postgres",
+            sqlite_allowed_root="",
+            allowed_hosts=set(),
+        )
 
 
 @pytest.mark.asyncio
@@ -145,8 +192,14 @@ async def test_env_connections_visible_to_everyone(crypto_key, relational_engine
 
 
 @pytest.mark.asyncio
-async def test_user_connection_shadows_env_connection(crypto_key, relational_engine, monkeypatch):
-    config = ToolsConfig(_env_file=None, tool_sql_connections='{"analytics": "sqlite:///env.db"}')
+async def test_user_connection_shadows_env_connection(
+    crypto_key, relational_engine, monkeypatch, tmp_path
+):
+    config = ToolsConfig(
+        _env_file=None,
+        tool_sql_connections='{"analytics": "sqlite:///env.db"}',
+        tool_sqlite_allowed_root=str(tmp_path),
+    )
     monkeypatch.setattr(connections_mod, "get_tools_config", lambda: config)
 
     user_id = uuid4()

--- a/cognee/tests/unit/modules/tools/test_tools_config.py
+++ b/cognee/tests/unit/modules/tools/test_tools_config.py
@@ -14,6 +14,8 @@ def test_default_limits():
     assert config.text_to_sql_max_attempts == 3
     assert config.text_to_sql_statement_timeout_ms == 5000
     assert config.text_to_sql_max_schema_tables == 50
+    assert config.tool_sqlite_allowed_root == ""
+    assert config.sql_allowed_hosts() == set()
 
 
 def test_sql_connections_empty_by_default():
@@ -53,3 +55,10 @@ def test_sql_connections_rejects_entry_without_connection_string():
 def test_env_gate_parses(monkeypatch):
     monkeypatch.setenv("TOOL_CALLS_ENABLED", "true")
     assert ToolsConfig(_env_file=None).tool_calls_enabled is True
+
+
+def test_sql_target_policy_parses(monkeypatch):
+    monkeypatch.setenv("TOOL_SQL_ALLOWED_HOSTS", "db.internal, analytics.example.")
+    config = ToolsConfig(_env_file=None, tool_sqlite_allowed_root="/srv/sqlite")
+    assert config.tool_sqlite_allowed_root == "/srv/sqlite"
+    assert config.sql_allowed_hosts() == {"db.internal", "analytics.example"}


### PR DESCRIPTION
## Summary

Fixes #4415.

User-registered SQL connections now fail closed unless their targets are explicitly approved by deployment policy. Deployment-level `TOOL_SQL_CONNECTIONS` entries remain administrator-managed.

## Changes

- Restrict user SQLite connections to `TOOL_SQLITE_ALLOWED_ROOT`.
- Resolve and enforce the root boundary, including traversal and symlink escapes.
- Reject SQLite URI/query forms that can address arbitrary virtual filenames.
- Restrict user PostgreSQL connections to exact hosts in `TOOL_SQL_ALLOWED_HOSTS`.
- Validate both new registrations and legacy stored connections at resolution time.
- Document the new controls in `.env.template`.

## Verification

- `python -m pytest cognee/tests/unit/modules/tools -q` — 90 passed.
- `python -m ruff check cognee/modules/tools/target_policy.py cognee/tests/unit/modules/tools/test_tool_connections.py` — passed.
- `python -m compileall -q cognee/modules/tools cognee/tests/unit/modules/tools` — passed.
- `git diff --check` — passed.