### PR TITLE
fix(recall): reject empty schema unions

### DIFF
--- a/cognee/modules/recall/methods/model_from_json_schema.py
+++ b/cognee/modules/recall/methods/model_from_json_schema.py
@@ -39,6 +39,15 @@ def _fail(message: str) -> CogneeValidationError:
     return CogneeValidationError(message=f"response_schema: {message}")
 
 
+def _union_from_members(members: list[Any], source: str) -> Any:
+    """Build a type union while preserving schema errors as API validation errors."""
+    if not members:
+        raise _fail(f"{source} must contain at least one schema")
+    if len(members) == 1:
+        return members[0]
+    return Union[tuple(members)]
+
+
 class _Budget:
     """Caps total property count across the whole schema."""
 
@@ -97,7 +106,7 @@ def _type_from(
             _type_from(member, defs, depth + 1, in_flight_refs, budget)
             for member in schema["anyOf"]
         ]
-        return Union[tuple(members)]
+        return _union_from_members(members, "anyOf")
 
     schema_type = schema.get("type")
     if isinstance(schema_type, list):
@@ -105,7 +114,7 @@ def _type_from(
             _type_from({**schema, "type": single}, defs, depth + 1, in_flight_refs, budget)
             for single in schema_type
         ]
-        return Union[tuple(members)]
+        return _union_from_members(members, "type")
 
     if schema_type == "null":
         return type(None)

--- a/cognee/tests/unit/modules/recall/test_model_from_json_schema.py
+++ b/cognee/tests/unit/modules/recall/test_model_from_json_schema.py
@@ -133,6 +133,24 @@ class TestRejections:
         with pytest.raises(CogneeValidationError, match="items"):
             model_from_json_schema({"type": "object", "properties": {"xs": {"type": "array"}}})
 
+    def test_empty_any_of_rejected_as_schema_error(self):
+        with pytest.raises(CogneeValidationError, match="anyOf.*at least one"):
+            model_from_json_schema(
+                {
+                    "type": "object",
+                    "properties": {"value": {"anyOf": []}},
+                }
+            )
+
+    def test_empty_type_list_rejected_as_schema_error(self):
+        with pytest.raises(CogneeValidationError, match="type.*at least one"):
+            model_from_json_schema(
+                {
+                    "type": "object",
+                    "properties": {"value": {"type": []}},
+                }
+            )
+
     def test_property_budget(self):
         schema = {
             "type": "object",


### PR DESCRIPTION
## Summary

Fixes #4418.

Reject empty JSON Schema unions as client validation errors instead of allowing Python to raise `TypeError: Cannot take a Union of no types.`

## Changes

- Add a shared union-construction helper that rejects empty member lists with `CogneeValidationError`.
- Apply it to both `anyOf` and JSON Schema `type: []` forms.
- Add regression tests for both malformed schemas.

## Verification

- `python -m pytest cognee/tests/unit/modules/recall/test_model_from_json_schema.py -q` — 15 passed.
- `python -m compileall -q cognee/modules/recall/methods/model_from_json_schema.py cognee/tests/unit/modules/recall/test_model_from_json_schema.py` — passed.
- `git diff --check` — passed.

The targeted Ruff run reports existing UP007/UP045 modernization findings in this module/test; the change introduces no new import or formatting errors.