### PR TITLE
feat: Add Keenable web scraper backend (COG-6126)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -424,6 +424,13 @@ LITELLM_LOG="ERROR"
 WEB_SCRAPER_TIMEOUT=15.0
 WEB_SCRAPER_MAX_DELAY=10.0
 
+# -- API-based URL fetching. Tavily is used when TAVILY_API_KEY is set,
+#    otherwise Keenable when KEENABLE_API_KEY is set, otherwise the default crawler.
+#TAVILY_API_KEY=""
+#KEENABLE_API_KEY=""
+#KEENABLE_BASE_URL="https://api.keenable.ai"
+#KEENABLE_LIVE_FETCH="false"
+
 ################################################################################
 #  OpenTelemetry / Tracing
 ################################################################################

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pre-commit install
 - **neptune** - AWS Neptune support
 - **turso** - Turso vector database support
 - **docs** - Document processing (unstructured library)
-- **scraping** - Web scraping (Tavily, BeautifulSoup, Playwright)
+- **scraping** - Web scraping (Tavily, BeautifulSoup, Playwright; Keenable needs no extra — it uses the built-in httpx)
 - **langchain** - LangChain integration
 - **llama-index** - LlamaIndex integration
 - **anthropic** - Anthropic Claude models

--- a/cognee/api/v1/add/add.py
+++ b/cognee/api/v1/add/add.py
@@ -179,6 +179,11 @@ async def add(
         Make sure to set TAVILY_API_KEY = YOUR_TAVILY_API_KEY as a environment variable
         await cognee.add("https://example.com")
 
+        # Add a single url and keenable extract ingestion method
+        Make sure to set KEENABLE_API_KEY = YOUR_KEENABLE_API_KEY as a environment variable
+        (Tavily takes precedence if both keys are set.)
+        await cognee.add("https://example.com")
+
         # Add multiple urls
         await cognee.add(["https://example.com","https://books.toscrape.com"])
         ```
@@ -195,6 +200,7 @@ async def add(
         - VECTOR_DB_PROVIDER: "lancedb" (default), "pgvector"
         - GRAPH_DATABASE_PROVIDER: "ladybug" (default), "neo4j"
         - TAVILY_API_KEY: YOUR_TAVILY_API_KEY
+        - KEENABLE_API_KEY: YOUR_KEENABLE_API_KEY
 
     """
     # Route to remote instance if connected via serve()

--- a/cognee/tasks/web_scraper/README.md
+++ b/cognee/tasks/web_scraper/README.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-The `web_scraper` module provides tools for scraping web content and storing structured data in cognee's graph database. It supports two scraping backends:
+The `web_scraper` module provides tools for scraping web content and storing structured data in cognee's graph database. It supports three scraping backends:
 
 1. **Default Crawler** - Uses `httpx` for HTTP requests with optional Playwright for JavaScript rendering
 2. **Tavily API** - Uses Tavily for content extraction (requires `TAVILY_API_KEY` environment variable)
+3. **Keenable API** - Uses [Keenable](https://docs.keenable.ai) for clean markdown extraction (requires `KEENABLE_API_KEY` environment variable)
 
-The module automatically selects the backend: Tavily if `TAVILY_API_KEY` is set, otherwise the default crawler.
+The module automatically selects the backend: Tavily if `TAVILY_API_KEY` is set, otherwise Keenable if `KEENABLE_API_KEY` is set, otherwise the default crawler. Pass `preferred_tool` to `fetch_page_content` to select one explicitly.
 
 ## Components
 
@@ -26,6 +27,7 @@ The module automatically selects the backend: Tavily if `TAVILY_API_KEY` is set,
 | `DefaultUrlCrawler` | Async crawler with concurrency, rate limiting, robots.txt compliance, Playwright support |
 | `DefaultCrawlerConfig` | Configuration for default crawler (concurrency, timeouts, Playwright) |
 | `TavilyConfig` | Configuration for Tavily API (API key, extract depth, timeout) |
+| `KeenableConfig` | Configuration for Keenable API (API key, live fetch, extraction prompt, timeout) |
 
 ### Data Models (extend `DataPoint`)
 
@@ -120,6 +122,17 @@ await cognee.cognify()
 | `extract_depth` | `"basic"` | `"basic"` or `"advanced"` |
 | `proxies` | `None` | Proxy configuration dict |
 | `timeout` | `10` | Request timeout (1-60s) |
+
+### KeenableConfig
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `api_key` | `KEENABLE_API_KEY` env | Keenable API key (required) |
+| `base_url` | `KEENABLE_BASE_URL` env or `https://api.keenable.ai` | Keenable API base URL |
+| `live` | `KEENABLE_LIVE_FETCH` env or `False` | Fetch the live page instead of Keenable's indexed copy |
+| `prompt` | `None` | Optional LLM extraction instruction (max 2000 chars) |
+| `concurrency` | `5` | Max concurrent fetch requests |
+| `timeout` | `30` | Request timeout (1-120s) |
 
 ## Dependencies
 

--- a/cognee/tasks/web_scraper/__init__.py
+++ b/cognee/tasks/web_scraper/__init__.py
@@ -2,7 +2,8 @@
 
 This module provides tools for scraping web content, managing scraping jobs, and storing
 data in a graph database. It includes classes and functions for crawling web pages using
-BeautifulSoup or Tavily, defining data models, and handling scraping configurations.
+BeautifulSoup, Tavily, or Keenable, defining data models, and handling scraping
+configurations.
 """
 
 from .utils import fetch_page_content

--- a/cognee/tasks/web_scraper/config.py
+++ b/cognee/tasks/web_scraper/config.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Any, Dict, Optional, Literal
+from typing import Dict, Optional, Literal
 import os
 
 
@@ -8,6 +8,15 @@ class TavilyConfig(BaseModel):
     extract_depth: Literal["basic", "advanced"] = "basic"
     proxies: Optional[Dict[str, str]] = None
     timeout: Optional[int] = Field(default=10, ge=1, le=60)
+
+
+class KeenableConfig(BaseModel):
+    api_key: Optional[str] = os.getenv("KEENABLE_API_KEY")
+    base_url: str = os.getenv("KEENABLE_BASE_URL", "https://api.keenable.ai")
+    live: bool = os.getenv("KEENABLE_LIVE_FETCH", "false").lower() in ("true", "1", "yes")
+    prompt: Optional[str] = Field(default=None, max_length=2000)
+    concurrency: int = Field(default=5, ge=1)
+    timeout: Optional[int] = Field(default=30, ge=1, le=120)
 
 
 class DefaultCrawlerConfig(BaseModel):

--- a/cognee/tasks/web_scraper/utils.py
+++ b/cognee/tasks/web_scraper/utils.py
@@ -1,55 +1,74 @@
-"""Utilities for fetching web content using BeautifulSoup or Tavily.
+"""Utilities for fetching web content using BeautifulSoup, Tavily, or Keenable.
 
 This module provides functions to fetch and extract content from web pages, supporting
-both BeautifulSoup for custom extraction rules and Tavily for API-based scraping.
+BeautifulSoup for custom extraction rules and Tavily or Keenable for API-based scraping.
 """
 
+import asyncio
 import os
-from typing import List, Union
+from typing import List, Optional, Union
+
+import httpx
 from cognee.shared.logging_utils import get_logger
 from cognee.tasks.web_scraper.types import UrlsToHtmls
 from .default_url_crawler import DefaultUrlCrawler
-from .config import DefaultCrawlerConfig, TavilyConfig
+from .config import DefaultCrawlerConfig, KeenableConfig, TavilyConfig
 
 logger = get_logger(__name__)
 
 
-async def fetch_page_content(urls: Union[str, List[str]]) -> UrlsToHtmls:
+async def fetch_page_content(
+    urls: Union[str, List[str]],
+    preferred_tool: Optional[str] = None,
+    tavily_config: Optional[TavilyConfig] = None,
+    keenable_config: Optional[KeenableConfig] = None,
+    soup_crawler_config: Optional[DefaultCrawlerConfig] = None,
+) -> UrlsToHtmls:
     """Fetch content from one or more URLs using the specified tool.
 
-    This function retrieves web page content using either BeautifulSoup (with custom
-    extraction rules) or Tavily (API-based scraping). It handles single URLs or lists of
-    URLs and returns a dictionary mapping URLs to their extracted content.
+    This function retrieves web page content using BeautifulSoup (with custom
+    extraction rules), Tavily, or Keenable (API-based scraping). It handles single URLs
+    or lists of URLs and returns a dictionary mapping URLs to their extracted content.
+
+    When preferred_tool is not given, the backend is auto-selected from the
+    environment: Tavily if TAVILY_API_KEY is set, otherwise Keenable if
+    KEENABLE_API_KEY is set, otherwise the default crawler.
 
     Args:
         urls: A single URL (str) or a list of URLs (List[str]) to scrape.
-        preferred_tool: The scraping tool to use ("tavily" or "beautifulsoup").
-            Defaults to "beautifulsoup".
+        preferred_tool: The scraping tool to use ("tavily", "keenable", or
+            "beautifulsoup"). Defaults to environment-based auto-selection.
         tavily_config: Configuration for Tavily API, including API key.
-            Required if preferred_tool is "tavily".
-        default_crawler_config: Configuration for BeautifulSoup crawler, including
-            extraction rules. Required if preferred_tool is "beautifulsoup" and
-            extraction_rules are needed.
+        keenable_config: Configuration for the Keenable API.
+        soup_crawler_config: Configuration for the default (BeautifulSoup) crawler.
 
     Returns:
-        Dict[str, str]: A dictionary mapping each URL to its
-            extracted content (as a string for BeautifulSoup or a dict for Tavily).
+        Dict[str, str]: A dictionary mapping each URL to its extracted content.
 
     Raises:
-        ValueError: If Tavily API key is missing when using Tavily, or if
-            extraction_rules are not provided when using BeautifulSoup.
-        ImportError: If required dependencies (beautifulsoup4 or tavily-python) are not
-            installed.
+        ValueError: If an unknown preferred_tool is given.
+        ImportError: If required dependencies (e.g., tavily-python) are not installed.
     """
     url_list = [urls] if isinstance(urls, str) else urls
 
-    if os.getenv("TAVILY_API_KEY"):
+    if preferred_tool is None:
+        if os.getenv("TAVILY_API_KEY"):
+            preferred_tool = "tavily"
+        elif os.getenv("KEENABLE_API_KEY"):
+            preferred_tool = "keenable"
+        else:
+            preferred_tool = "beautifulsoup"
+
+    if preferred_tool == "tavily":
         logger.info("Using Tavily API for url fetching")
-        return await fetch_with_tavily(urls)
-    else:
+        return await fetch_with_tavily(urls, tavily_config=tavily_config)
+    elif preferred_tool == "keenable":
+        logger.info("Using Keenable API for url fetching")
+        return await fetch_with_keenable(urls, keenable_config=keenable_config)
+    elif preferred_tool == "beautifulsoup":
         logger.info("Using default crawler for content extraction")
 
-        default_crawler_config = (
+        default_crawler_config = soup_crawler_config or (
             DefaultCrawlerConfig()
         )  # We've decided to use defaults, and configure through env vars as needed
 
@@ -84,13 +103,22 @@ async def fetch_page_content(urls: Union[str, List[str]]) -> UrlsToHtmls:
         finally:
             logger.info("Closing BeautifulSoup crawler")
             await crawler.close()
+    else:
+        raise ValueError(
+            f"Unknown preferred_tool '{preferred_tool}'. "
+            "Expected 'tavily', 'keenable', or 'beautifulsoup'."
+        )
 
 
-async def fetch_with_tavily(urls: Union[str, List[str]]) -> UrlsToHtmls:
+async def fetch_with_tavily(
+    urls: Union[str, List[str]], tavily_config: Optional[TavilyConfig] = None
+) -> UrlsToHtmls:
     """Fetch content from URLs using the Tavily API.
 
     Args:
         urls: A single URL (str) or a list of URLs (List[str]) to scrape.
+        tavily_config: Configuration for the Tavily API. Defaults to environment-based
+            configuration (TAVILY_API_KEY).
 
     Returns:
         Dict[str, str]: A dictionary mapping each URL to its raw content as a string.
@@ -107,7 +135,7 @@ async def fetch_with_tavily(urls: Union[str, List[str]]) -> UrlsToHtmls:
         )
         raise
 
-    tavily_config = TavilyConfig()
+    tavily_config = tavily_config or TavilyConfig()
     url_list = [urls] if isinstance(urls, str) else urls
     extract_depth = tavily_config.extract_depth if tavily_config else "basic"
     timeout = tavily_config.timeout if tavily_config else 10
@@ -139,4 +167,78 @@ async def fetch_with_tavily(urls: Union[str, List[str]]) -> UrlsToHtmls:
         return_results[result["url"]] = result["raw_content"]
 
     logger.info(f"Successfully fetched content from {len(return_results)} URL(s) via Tavily")
+    return return_results
+
+
+async def fetch_with_keenable(
+    urls: Union[str, List[str]], keenable_config: Optional[KeenableConfig] = None
+) -> UrlsToHtmls:
+    """Fetch content from URLs using the Keenable API.
+
+    Uses Keenable's /v1/fetch endpoint (https://docs.keenable.ai) to extract clean
+    markdown content from each URL. Requires an API key (KEENABLE_API_KEY or
+    keenable_config.api_key).
+
+    Args:
+        urls: A single URL (str) or a list of URLs (List[str]) to scrape.
+        keenable_config: Configuration for the Keenable API. Defaults to
+            environment-based configuration (KEENABLE_API_KEY, KEENABLE_BASE_URL).
+
+    Returns:
+        Dict[str, str]: A dictionary mapping each requested URL to its extracted
+            content. URLs that fail to fetch are omitted with a warning.
+
+    Raises:
+        Exception: If every requested URL fails to fetch (e.g., invalid API key).
+    """
+    keenable_config = keenable_config or KeenableConfig()
+    url_list = [urls] if isinstance(urls, str) else urls
+
+    headers = {}
+    if keenable_config.api_key:
+        headers["X-API-Key"] = keenable_config.api_key
+
+    logger.info(
+        f"Sending fetch requests to Keenable API for {len(url_list)} URL(s) "
+        f"(live={keenable_config.live}, timeout={keenable_config.timeout}s)"
+    )
+
+    semaphore = asyncio.Semaphore(keenable_config.concurrency)
+
+    async with httpx.AsyncClient(
+        base_url=keenable_config.base_url,
+        headers=headers,
+        timeout=keenable_config.timeout,
+    ) as client:
+
+        async def fetch_one(url: str):
+            params = {"url": url}
+            if keenable_config.live:
+                params["live"] = "true"
+            if keenable_config.prompt:
+                params["prompt"] = keenable_config.prompt
+            async with semaphore:
+                response = await client.get("/v1/fetch", params=params)
+            response.raise_for_status()
+            return response.json().get("content")
+
+        responses = await asyncio.gather(
+            *(fetch_one(url) for url in url_list), return_exceptions=True
+        )
+
+    return_results = {}
+    errors = []
+    for url, result in zip(url_list, responses):
+        if isinstance(result, BaseException):
+            logger.warning(f"Keenable API failed to fetch {url}: {result}")
+            errors.append(result)
+        elif result is None:
+            logger.warning(f"Keenable API returned no content for {url}")
+        else:
+            return_results[url] = result
+
+    if url_list and not return_results and errors:
+        raise errors[0]
+
+    logger.info(f"Successfully fetched content from {len(return_results)} URL(s) via Keenable")
     return return_results

--- a/cognee/tasks/web_scraper/web_scraper_task.py
+++ b/cognee/tasks/web_scraper/web_scraper_task.py
@@ -20,7 +20,7 @@ from cognee.tasks.storage.index_graph_edges import index_graph_edges
 from cognee.modules.engine.operations.setup import setup
 
 from .models import WebPage, WebSite, ScrapingJob
-from .config import DefaultCrawlerConfig, TavilyConfig
+from .config import DefaultCrawlerConfig, KeenableConfig, TavilyConfig
 from .utils import fetch_page_content
 
 try:
@@ -50,6 +50,7 @@ async def cron_web_scraper_task(
     tavily_api_key: str = os.getenv("TAVILY_API_KEY"),
     soup_crawler_config: DefaultCrawlerConfig = None,
     tavily_config: TavilyConfig = None,
+    keenable_config: KeenableConfig = None,
     job_name: str = "scraping",
     ctx=None,
 ):
@@ -66,6 +67,8 @@ async def cron_web_scraper_task(
         tavily_api_key: API key for Tavily. Defaults to TAVILY_API_KEY environment variable.
         soup_crawler_config: Configuration for BeautifulSoup crawler.
         tavily_config: Configuration for Tavily API.
+        keenable_config: Configuration for Keenable API. Defaults to KEENABLE_API_KEY
+            environment variable when set.
         job_name: Name of the scraping job. Defaults to "scraping".
 
     Returns:
@@ -93,6 +96,7 @@ async def cron_web_scraper_task(
                 "tavily_api_key": tavily_api_key,
                 "soup_crawler_config": soup_crawler_config,
                 "tavily_config": tavily_config,
+                "keenable_config": keenable_config,
                 "job_name": job_name,
                 "ctx": ctx,
             },
@@ -114,6 +118,7 @@ async def cron_web_scraper_task(
         tavily_api_key=tavily_api_key,
         soup_crawler_config=soup_crawler_config,
         tavily_config=tavily_config,
+        keenable_config=keenable_config,
         job_name=job_name,
         ctx=ctx,
     )
@@ -127,6 +132,7 @@ async def web_scraper_task(
     tavily_api_key: str = os.getenv("TAVILY_API_KEY"),
     soup_crawler_config: DefaultCrawlerConfig = None,
     tavily_config: TavilyConfig = None,
+    keenable_config: KeenableConfig = None,
     job_name: str = None,
     ctx=None,
 ):
@@ -145,6 +151,8 @@ async def web_scraper_task(
         tavily_api_key: API key for Tavily. Defaults to TAVILY_API_KEY environment variable.
         soup_crawler_config: Configuration for BeautifulSoup crawler.
         tavily_config: Configuration for Tavily API.
+        keenable_config: Configuration for Keenable API. Defaults to KEENABLE_API_KEY
+            environment variable when set.
         job_name: Name of the scraping job. Defaults to a timestamp-based name.
 
     Returns:
@@ -160,8 +168,8 @@ async def web_scraper_task(
     if isinstance(url, str):
         url = [url]
 
-    soup_crawler_config, tavily_config, preferred_tool = check_arguments(
-        tavily_api_key, extraction_rules, tavily_config, soup_crawler_config
+    soup_crawler_config, tavily_config, keenable_config, preferred_tool = check_arguments(
+        tavily_api_key, extraction_rules, tavily_config, soup_crawler_config, keenable_config
     )
     now = datetime.now()
     job_name = job_name or f"scrape_{now.strftime('%Y%m%d_%H%M%S')}"
@@ -208,6 +216,7 @@ async def web_scraper_task(
         urls=url,
         preferred_tool=preferred_tool,
         tavily_config=tavily_config,
+        keenable_config=keenable_config,
         soup_crawler_config=soup_crawler_config,
     )
     for page_url, content in results.items():
@@ -343,7 +352,9 @@ async def web_scraper_task(
     return await graph_db.get_graph_data()
 
 
-def check_arguments(tavily_api_key, extraction_rules, tavily_config, soup_crawler_config):
+def check_arguments(
+    tavily_api_key, extraction_rules, tavily_config, soup_crawler_config, keenable_config=None
+):
     """Validate and configure arguments for web_scraper_task.
 
     Args:
@@ -351,13 +362,15 @@ def check_arguments(tavily_api_key, extraction_rules, tavily_config, soup_crawle
         extraction_rules: Extraction rules for BeautifulSoup.
         tavily_config: Configuration for Tavily API.
         soup_crawler_config: Configuration for BeautifulSoup crawler.
+        keenable_config: Configuration for Keenable API.
 
     Returns:
-        Tuple[DefaultCrawlerConfig, TavilyConfig, str]: Configured soup_crawler_config,
-            tavily_config, and preferred_tool ("tavily" or "beautifulsoup").
+        Tuple[DefaultCrawlerConfig, TavilyConfig, KeenableConfig, str]: Configured
+            soup_crawler_config, tavily_config, keenable_config, and preferred_tool
+            ("tavily", "keenable", or "beautifulsoup").
 
     Raises:
-        TypeError: If neither tavily_config nor soup_crawler_config is provided.
+        TypeError: If no scraping configuration is provided.
     """
     preferred_tool = "beautifulsoup"
 
@@ -372,10 +385,16 @@ def check_arguments(tavily_api_key, extraction_rules, tavily_config, soup_crawle
         if not extraction_rules and not soup_crawler_config:
             preferred_tool = "tavily"
 
-    if not tavily_config and not soup_crawler_config:
+    if not tavily_api_key and (keenable_config or os.getenv("KEENABLE_API_KEY")):
+        if not keenable_config:
+            keenable_config = KeenableConfig()
+        if not extraction_rules and not soup_crawler_config:
+            preferred_tool = "keenable"
+
+    if not tavily_config and not keenable_config and not soup_crawler_config:
         raise TypeError("Make sure you pass arguments for web_scraper_task")
 
-    return soup_crawler_config, tavily_config, preferred_tool
+    return soup_crawler_config, tavily_config, keenable_config, preferred_tool
 
 
 def get_path_after_base(base_url: str, url: str) -> str:

--- a/cognee/tests/integration/web_url_crawler/test_keenable_crawler.py
+++ b/cognee/tests/integration/web_url_crawler/test_keenable_crawler.py
@@ -1,0 +1,25 @@
+import os
+import pytest
+from cognee.tasks.web_scraper.utils import fetch_with_keenable
+
+skip_in_ci = pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") == "true",
+    reason="Skipping in Github for now - before we get KEENABLE_API_KEY",
+)
+
+skip_without_key = pytest.mark.skipif(
+    not os.getenv("KEENABLE_API_KEY"),
+    reason="KEENABLE_API_KEY is not set",
+)
+
+
+@skip_in_ci
+@skip_without_key
+@pytest.mark.asyncio
+async def test_fetch():
+    url = "http://example.com/"
+    results = await fetch_with_keenable(url)
+    assert isinstance(results, dict)
+    assert len(results) == 1
+    content = results[url]
+    assert isinstance(content, str)


### PR DESCRIPTION
## Description

Adds [Keenable](https://docs.keenable.ai) as a third URL-fetching backend in `cognee/tasks/web_scraper`, alongside Tavily and the default BeautifulSoup crawler. Closes COG-6126.

### What's in here

- **`KeenableConfig`** (`config.py`): `KEENABLE_API_KEY`, `KEENABLE_BASE_URL`, live-fetch toggle, optional LLM extraction `prompt`, concurrency, timeout.
- **`fetch_with_keenable`** (`utils.py`): calls Keenable's REST API (`GET /v1/fetch`) with bounded concurrency via the already-bundled `httpx` — **no new dependency, no CLI binary required**. Results are keyed by the requested URL; per-URL failures are warned and skipped; if *every* URL fails (e.g. bad API key) the first error is raised instead of returning an empty dict that would surface downstream as a cryptic `KeyError`.
- **Backend auto-selection** in `fetch_page_content`: Tavily if `TAVILY_API_KEY` is set, otherwise Keenable if `KEENABLE_API_KEY` is set, otherwise the default crawler. `await cognee.add("https://…")` picks Keenable up automatically once the key is exported. An explicit `preferred_tool` overrides.
- **Plumbing**: `keenable_config` kwarg through `web_scraper_task` / `cron_web_scraper_task` / `check_arguments`, mirroring the Tavily kwargs (Tavily wins when both are configured).
- **Bug fix**: `web_scraper_task` called `fetch_page_content` with `preferred_tool=`/`tavily_config=`/`soup_crawler_config=` kwargs the function no longer accepted — any `web_scraper_task` run raised `TypeError`. The kwargs are restored and honored (including the previously ignored `soup_crawler_config`).
- **Docs**: web_scraper README, `add()` docstring, `.env.template`, CLAUDE.md.
- **Test**: `test_keenable_crawler.py` mirroring the Tavily integration test; skips in CI and when `KEENABLE_API_KEY` is unset.

### Notes for reviewers

- Keenable's docs say the CLI works keyless, but the raw REST API returns **401 without a key** (verified live) — the keyless free tier applies only to their CLI/MCP. Docs in this PR state that `KEENABLE_API_KEY` is required.
- Verified live: dispatch precedence (Tavily > Keenable > default crawler), extraction-rules forcing the soup crawler, the 401 total-failure raise, and the keyless fallback to the default crawler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)