### PR TITLE
ci: bring the Rust nightly arms to Slack parity (CLO-488, CLO-489, CLO-490)

### DIFF
--- a/.github/scripts/build_nightly_slack_blocks.py
+++ b/.github/scripts/build_nightly_slack_blocks.py
@@ -1,0 +1,100 @@
+"""Build the nightly Slack message's `blocks` array.
+
+Every performance arm renders the same way: a title line carrying the job
+result and run count, one row per metric with p50/p90/p99, and a link to the
+HTML report. Expressing that 14 times in YAML meant 14 copies of the same six
+lines, each repeating `fromJSON(needs.X.outputs.Y || '{}')` twenty-odd times —
+which is how the Rust arms came to render differently from the Python ones in
+the first place (CLO-488). Adding an arm is now one line in the `ARMS` env var.
+
+Input (env):
+  ARMS         one arm per line: `emoji|title|result|metrics_json|url`.
+               Blank lines are ignored. `metrics_json` is a perf job's
+               `metrics` output; empty/unparseable is treated as `{}`, which is
+               what a failed job produces. A `tenant_create` key adds the
+               cloud-only tenant row.
+  STATUS_*     header fields (emoji, summary, ran_at, ollama, llamacpp).
+  RUN_URL      link target for the footer.
+
+Output: `blocks=<compact JSON>` appended to $GITHUB_OUTPUT (stdout if unset).
+JSON is a subset of YAML, so the workflow interpolates the result straight into
+the action's YAML `payload`.
+"""
+
+import json
+import os
+import sys
+
+# Rows in render order. The second element is the padding between the label and
+# `p50`, preserved verbatim from the hand-written YAML this replaced: the
+# columns do not line up (add/cognify/tenant end at 9, search/total at 11), and
+# reproducing that exactly is what lets the migration be diffed to zero.
+ROWS = [("add", 6), ("cognify", 2), ("search", 5), ("total", 6)]
+TENANT_ROW = ("tenant", 3)
+# Metric rows read `<key>.p50` etc. from the arm's metrics object; the tenant
+# row is the one whose label differs from its JSON key.
+METRIC_KEY = {"tenant": "tenant_create"}
+PERCENTILES = ("p50", "p90", "p99")
+
+
+def section(text):
+    return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+
+def metric_row(metrics, label, pad):
+    stats = metrics.get(METRIC_KEY.get(label, label)) or {}
+    cells = "  •  ".join(f"{p} `{stats.get(p, '')}s`" for p in PERCENTILES)
+    return f"{label}{' ' * pad}{cells}"
+
+
+def arm_block(emoji, title, result, metrics_json, url):
+    try:
+        metrics = json.loads(metrics_json) if metrics_json.strip() else {}
+    except json.JSONDecodeError:
+        # A failed job leaves the output empty or partial. Render the arm with
+        # blank numbers rather than dropping it — a missing section reads as
+        # "this suite does not exist", which is worse than a visibly empty one.
+        metrics = {}
+
+    rows = [TENANT_ROW] if "tenant_create" in metrics else []
+    rows += ROWS
+
+    lines = [f"*{emoji} {title}* (`{result}`)  •  runs `{metrics.get('success', '')}`"]
+    lines += [metric_row(metrics, label, pad) for label, pad in rows]
+    lines.append(f"<{url}|HTML report>")
+    return section("\n".join(lines) + "\n")
+
+
+def main():
+    env = os.environ
+    header = section(
+        f"{env.get('STATUS_EMOJI', '')} *Nightly Tests* — {env.get('STATUS_SUMMARY', '')}\n"
+        f"*Ran at:* `{env.get('STATUS_RAN_AT', '')}`\n"
+        f"*Ollama:* `{env.get('STATUS_OLLAMA', '')}`  •  "
+        f"*Llama-cpp:* `{env.get('STATUS_LLAMACPP', '')}`\n"
+    )
+
+    blocks = [header]
+    for line in env.get("ARMS", "").splitlines():
+        if not line.strip():
+            continue
+        fields = line.split("|")
+        if len(fields) != 5:
+            raise SystemExit(
+                f"ARMS line must have 5 pipe-separated fields, got {len(fields)}: {line!r}"
+            )
+        blocks.append(arm_block(*(f.strip() for f in fields)))
+
+    blocks.append(section(f"<{env.get('RUN_URL', '')}|View run>\n"))
+
+    payload = f"blocks={json.dumps(blocks, ensure_ascii=False, separators=(',', ':'))}"
+    out = env.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as handle:
+            handle.write(payload + "\n")
+    else:
+        sys.stdout.write(payload + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -103,6 +103,15 @@ jobs:
 
   # ══ Performance (Rust SDK): builds latest cognee-rs and drives the SAME ═════
   # ══ orchestrator via cognee-cli bench (file_based, mock LLM, offline). ══════
+  perf-rust-llm:
+    name: Performance — Rust SDK — 50 Small Documents (real LLM)
+    uses: ./.github/workflows/performance_report_rust.yml
+    with:
+      runs: '3'
+      mode: llm
+      label: 50_small_documents
+      memories: scripts/perf/fixtures/memories.json
+    secrets: inherit
   perf-rust:
     name: Performance — Rust SDK — 50 Small Documents (mock LLM)
     uses: ./.github/workflows/performance_report_rust.yml
@@ -113,7 +122,15 @@ jobs:
       memories: scripts/perf/fixtures/memories.json
       cassette: scripts/perf/fixtures/cassette.json
     secrets: inherit
-
+  perf-rust-wap-llm:
+    name: Performance — Rust SDK — War and Peace (real LLM)
+    uses: ./.github/workflows/performance_report_rust.yml
+    with:
+      runs: '3'
+      mode: llm
+      label: war_and_peace
+      memories: scripts/perf/fixtures/war_and_peace/memories.json
+    secrets: inherit
   perf-rust-wap:
     name: Performance — Rust SDK — War and Peace (mock LLM)
     uses: ./.github/workflows/performance_report_rust.yml
@@ -123,26 +140,6 @@ jobs:
       label: war_and_peace
       memories: scripts/perf/fixtures/war_and_peace/memories.json
       cassette: scripts/perf/fixtures/war_and_peace/cassette.json
-    secrets: inherit
-
-  perf-rust-llm:
-    name: Performance — Rust SDK — 50 Small Documents (real LLM)
-    uses: ./.github/workflows/performance_report_rust.yml
-    with:
-      runs: '3'
-      mode: llm
-      label: 50_small_documents
-      memories: scripts/perf/fixtures/memories.json
-    secrets: inherit
-
-  perf-rust-wap-llm:
-    name: Performance — Rust SDK — War and Peace (real LLM)
-    uses: ./.github/workflows/performance_report_rust.yml
-    with:
-      runs: '3'
-      mode: llm
-      label: war_and_peace
-      memories: scripts/perf/fixtures/war_and_peace/memories.json
     secrets: inherit
 
   notify:
@@ -347,11 +344,42 @@ jobs:
                 text:
                   type: "mrkdwn"
                   text: |
-                    *🦀 Rust SDK (file_based)* — total-latency percentiles; per-stage detail is in each HTML report
-                    50 small documents — mock LLM  (`${{ needs.perf-rust.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust }}|HTML report>
-                    War and Peace — mock LLM  (`${{ needs.perf-rust-wap.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_wap }}|HTML report>
-                    50 small documents — real LLM  (`${{ needs.perf-rust-llm.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_llm }}|HTML report>
-                    War and Peace — real LLM  (`${{ needs.perf-rust-wap-llm.result }}`)  •  total p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p99 }}s`  •  <${{ steps.presign.outputs.url_rust_wap_llm }}|HTML report>
+                    *📊 Rust SDK (file_based) — 50 Small Documents — Real LLM* (`${{ needs.perf-rust-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').success }}`
+                    add      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_rust_llm }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *📊 Rust SDK (file_based) — 50 Small Documents — Mock LLM* (`${{ needs.perf-rust.result }}`)  •  runs `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').success }}`
+                    add      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_rust }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *📚 Rust SDK (file_based) — War and Peace — Real LLM* (`${{ needs.perf-rust-wap-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').success }}`
+                    add      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_rust_wap_llm }}|HTML report>
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *📚 Rust SDK (file_based) — War and Peace — Mock LLM* (`${{ needs.perf-rust-wap.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').success }}`
+                    add      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p99 }}s`
+                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p99 }}s`
+                    search     p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p99 }}s`
+                    total      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p99 }}s`
+                    <${{ steps.presign.outputs.url_rust_wap }}|HTML report>
               - type: "section"
                 text:
                   type: "mrkdwn"

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -219,6 +219,34 @@ jobs:
             echo "$name=$(aws s3 presign "s3://$BUCKET/$key" --expires-in 604800)" >> "$GITHUB_OUTPUT"
           done <<< "$REPORT_KEYS"
 
+      - name: Build Slack blocks
+        id: blocks
+        env:
+          STATUS_EMOJI: ${{ steps.status.outputs.emoji }}
+          STATUS_SUMMARY: ${{ steps.status.outputs.summary }}
+          STATUS_RAN_AT: ${{ steps.status.outputs.ran_at }}
+          STATUS_OLLAMA: ${{ needs.ollama-tests.result }}
+          STATUS_LLAMACPP: ${{ needs.llamacpp-tests.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # One arm per line: emoji|title|result|metrics-json|report-url.
+          # Adding a benchmark arm is a line here plus its REPORT_KEYS entry.
+          ARMS: |
+            📊|File Based — 50 Small Documents — Real LLM|${{ needs.perf-small-llm.result }}|${{ needs.perf-small-llm.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_small_llm }}
+            📊|File Based — 50 Small Documents — Mock LLM|${{ needs.perf-small-mock.result }}|${{ needs.perf-small-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_small_mock }}
+            📚|File Based — War and Peace — Real LLM|${{ needs.perf-wap-llm.result }}|${{ needs.perf-wap-llm.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_llm }}
+            📚|File Based — War and Peace — Mock LLM|${{ needs.perf-wap-mock.result }}|${{ needs.perf-wap-mock.outputs.file_based_metrics }}|${{ steps.presign.outputs.url_file_wap_mock }}
+            📊|Full Postgres — 50 Small Documents — Real LLM|${{ needs.perf-small-llm.result }}|${{ needs.perf-small-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_small_llm }}
+            📊|Full Postgres — 50 Small Documents — Mock LLM|${{ needs.perf-small-mock.result }}|${{ needs.perf-small-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_small_mock }}
+            📚|Full Postgres — War and Peace — Real LLM|${{ needs.perf-wap-llm.result }}|${{ needs.perf-wap-llm.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_llm }}
+            📚|Full Postgres — War and Peace — Mock LLM|${{ needs.perf-wap-mock.result }}|${{ needs.perf-wap-mock.outputs.postgres_metrics }}|${{ steps.presign.outputs.url_pg_wap_mock }}
+            📊|Cognee Cloud — 50 Small Documents|${{ needs.perf-small-cloud.result }}|${{ needs.perf-small-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_small }}
+            📚|Cognee Cloud — War and Peace|${{ needs.perf-wap-cloud.result }}|${{ needs.perf-wap-cloud.outputs.cloud_metrics }}|${{ steps.presign.outputs.url_cloud_wap }}
+            📊|Rust SDK (file_based) — 50 Small Documents — Real LLM|${{ needs.perf-rust-llm.result }}|${{ needs.perf-rust-llm.outputs.metrics }}|${{ steps.presign.outputs.url_rust_llm }}
+            📊|Rust SDK (file_based) — 50 Small Documents — Mock LLM|${{ needs.perf-rust.result }}|${{ needs.perf-rust.outputs.metrics }}|${{ steps.presign.outputs.url_rust }}
+            📚|Rust SDK (file_based) — War and Peace — Real LLM|${{ needs.perf-rust-wap-llm.result }}|${{ needs.perf-rust-wap-llm.outputs.metrics }}|${{ steps.presign.outputs.url_rust_wap_llm }}
+            📚|Rust SDK (file_based) — War and Peace — Mock LLM|${{ needs.perf-rust-wap.result }}|${{ needs.perf-rust-wap.outputs.metrics }}|${{ steps.presign.outputs.url_rust_wap }}
+        run: python .github/scripts/build_nightly_slack_blocks.py
+
       - name: Post status to Slack
         # Posts on scheduled/manual runs AND on pull_request validation runs
         # (which fire when the nightly workflow files themselves change), so
@@ -230,161 +258,7 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_NIGHTLY_CHANNEL_ID }}
             text: "${{ steps.status.outputs.emoji }} Nightly Tests (${{ steps.status.outputs.ran_at }}): ${{ steps.status.outputs.summary }}"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    ${{ steps.status.outputs.emoji }} *Nightly Tests* — ${{ steps.status.outputs.summary }}
-                    *Ran at:* `${{ steps.status.outputs.ran_at }}`
-                    *Ollama:* `${{ needs.ollama-tests.result }}`  •  *Llama-cpp:* `${{ needs.llamacpp-tests.result }}`
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📊 File Based — 50 Small Documents — Real LLM* (`${{ needs.perf-small-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-llm.outputs.file_based_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_file_small_llm }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📊 File Based — 50 Small Documents — Mock LLM* (`${{ needs.perf-small-mock.result }}`)  •  runs `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-mock.outputs.file_based_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_file_small_mock }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📚 File Based — War and Peace — Real LLM* (`${{ needs.perf-wap-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-llm.outputs.file_based_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_file_wap_llm }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📚 File Based — War and Peace — Mock LLM* (`${{ needs.perf-wap-mock.result }}`)  •  runs `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.file_based_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_file_wap_mock }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📊 Full Postgres — 50 Small Documents — Real LLM* (`${{ needs.perf-small-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-llm.outputs.postgres_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_pg_small_llm }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📊 Full Postgres — 50 Small Documents — Mock LLM* (`${{ needs.perf-small-mock.result }}`)  •  runs `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-mock.outputs.postgres_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_pg_small_mock }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📚 Full Postgres — War and Peace — Real LLM* (`${{ needs.perf-wap-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-llm.outputs.postgres_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_pg_wap_llm }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📚 Full Postgres — War and Peace — Mock LLM* (`${{ needs.perf-wap-mock.result }}`)  •  runs `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-mock.outputs.postgres_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_pg_wap_mock }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📊 Cognee Cloud — 50 Small Documents* (`${{ needs.perf-small-cloud.result }}`)  •  runs `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').success }}`
-                    tenant   p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').tenant_create.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').tenant_create.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').tenant_create.p99 }}s`
-                    add      p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-small-cloud.outputs.cloud_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_cloud_small }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📚 Cognee Cloud — War and Peace* (`${{ needs.perf-wap-cloud.result }}`)  •  runs `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').success }}`
-                    tenant   p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').tenant_create.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').tenant_create.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').tenant_create.p99 }}s`
-                    add      p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-wap-cloud.outputs.cloud_metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_cloud_wap }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📊 Rust SDK (file_based) — 50 Small Documents — Real LLM* (`${{ needs.perf-rust-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-llm.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_llm }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📊 Rust SDK (file_based) — 50 Small Documents — Mock LLM* (`${{ needs.perf-rust.result }}`)  •  runs `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📚 Rust SDK (file_based) — War and Peace — Real LLM* (`${{ needs.perf-rust-wap-llm.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap-llm.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_wap_llm }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *📚 Rust SDK (file_based) — War and Peace — Mock LLM* (`${{ needs.perf-rust-wap.result }}`)  •  runs `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').success }}`
-                    add      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').add.p99 }}s`
-                    cognify  p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').cognify.p99 }}s`
-                    search     p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').search.p99 }}s`
-                    total      p50 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p50 }}s`  •  p90 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p90 }}s`  •  p99 `${{ fromJSON(needs.perf-rust-wap.outputs.metrics || '{}').total.p99 }}s`
-                    <${{ steps.presign.outputs.url_rust_wap }}|HTML report>
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+            blocks: ${{ steps.blocks.outputs.blocks }}
 
       - name: Load performance reports into MotherDuck
         # Reads the report JSON the perf jobs already uploaded to S3 and loads it

--- a/.github/workflows/performance_report_rust.yml
+++ b/.github/workflows/performance_report_rust.yml
@@ -168,34 +168,23 @@ jobs:
             echo "✅ Cassette fresh — replay created ${entities} entity-type nodes." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      # ── Mock mode: offline, via the committed harness ────────────────────────
-      # run_mock_bench.sh forwards --mock-llm/--mock-memories to the orchestrator
-      # (which passes them through to the bench subcommand) and puts --memories in
-      # BENCH_CMD, so --memories is never duplicated.
-      - name: Run performance report (mock LLM)
-        if: ${{ inputs.mode == 'mock_llm' }}
-        env:
-          PYTHONFAULTHANDLER: 1
-          COGNEE_SKIP_CONNECTION_TEST: 'true'
-        run: |
-          set -euo pipefail
-          COGNEE_PY="$GITHUB_WORKSPACE" \
-          BENCH_BIN="$GITHUB_WORKSPACE/cognee-rs/target/release/cognee-cli" \
-          RUNS="${{ inputs.runs }}" \
-          OUT_DIR="$GITHUB_WORKSPACE/perf-out" \
-          CASSETTE="$GITHUB_WORKSPACE/cognee-rs/${{ inputs.cassette }}" \
-          MEMORIES="$GITHUB_WORKSPACE/cognee-rs/${{ inputs.memories }}" \
-            bash "$GITHUB_WORKSPACE/cognee-rs/scripts/perf/run_mock_bench.sh"
-
-      # ── Real-LLM mode: drive the orchestrator directly (no --mock-llm) ───────
-      # BENCH_CMD holds the bench invocation + corpus; the orchestrator adds
-      # --output and (real mode) sleeps 60s between runs. LLM + embedding config
-      # comes from the same standard CI secrets as the Python perf arms
+      # ── Run the report (both modes) ──────────────────────────────────────────
+      # One step for both modes so the failure handling below cannot drift
+      # between them (mirrors performance_report.yml, which also branches on
+      # mode inside a single step).
+      #
+      # Mock mode: run_mock_bench.sh forwards --mock-llm/--mock-memories to the
+      # orchestrator (which passes them through to the bench subcommand) and puts
+      # --memories in BENCH_CMD, so --memories is never duplicated.
+      #
+      # Real-LLM mode: BENCH_CMD holds the bench invocation + corpus; the
+      # orchestrator adds --output and sleeps 60s between runs. LLM + embedding
+      # config comes from the same standard CI secrets as the Python perf arms
       # (performance_report.yml), so all nightly benchmarks measure one model
       # fleet. Note: the mock cassette was recorded with gpt-4o-mini — mock vs
       # real comparability now depends on the org secrets matching the cassette.
-      - name: Run performance report (real LLM)
-        if: ${{ inputs.mode == 'llm' }}
+      - name: Run performance report
+        id: run
         env:
           PYTHONFAULTHANDLER: 1
           COGNEE_SKIP_CONNECTION_TEST: 'true'
@@ -206,30 +195,52 @@ jobs:
           EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
         run: |
           set -euo pipefail
-          # The Rust embedding client sends the model id verbatim to the API,
-          # so a litellm-style prefixed secret ("openai/text-embedding-3-small")
-          # 400s with "invalid model ID". Split the secret into the bare model
-          # and a provider the Rust client understands.
-          if [[ "$EMBEDDING_MODEL_RAW" == */* ]]; then
-            export EMBEDDING_PROVIDER="${EMBEDDING_MODEL_RAW%%/*}"
-          else
-            export EMBEDDING_PROVIDER="openai"
-          fi
-          export EMBEDDING_MODEL="${EMBEDDING_MODEL_RAW##*/}"
-          # The Rust client also does not send OpenAI's `dimensions` truncation
-          # parameter (the Python arms get 1536-d vectors that way), so size the
-          # vector store to the model's NATIVE output or every insert fails with
-          # a dimension mismatch. Unknown models keep the client default.
-          case "$EMBEDDING_MODEL" in
-            text-embedding-3-large) export EMBEDDING_DIMENSIONS=3072 ;;
-            text-embedding-3-small | text-embedding-ada-002) export EMBEDDING_DIMENSIONS=1536 ;;
-          esac
           mkdir -p "$GITHUB_WORKSPACE/perf-out"
-          BENCH_CMD="$GITHUB_WORKSPACE/cognee-rs/target/release/cognee-cli bench --memories $GITHUB_WORKSPACE/cognee-rs/${{ inputs.memories }}" \
-            python3 "$GITHUB_WORKSPACE/cognee/tests/performance/statistics_percentile_report.py" \
-              --runs "${{ inputs.runs }}" \
-              --output "$GITHUB_WORKSPACE/perf-out/report.json" \
-              --html "$GITHUB_WORKSPACE/perf-out/report.html"
+
+          if [ "${{ inputs.mode }}" = "llm" ]; then
+            # The Rust embedding client sends the model id verbatim to the API,
+            # so a litellm-style prefixed secret ("openai/text-embedding-3-small")
+            # 400s with "invalid model ID". Split the secret into the bare model
+            # and a provider the Rust client understands.
+            if [[ "${EMBEDDING_MODEL_RAW:-}" == */* ]]; then
+              export EMBEDDING_PROVIDER="${EMBEDDING_MODEL_RAW%%/*}"
+            else
+              export EMBEDDING_PROVIDER="openai"
+            fi
+            export EMBEDDING_MODEL="${EMBEDDING_MODEL_RAW##*/}"
+            # The Rust client also does not send OpenAI's `dimensions` truncation
+            # parameter (the Python arms get 1536-d vectors that way), so size the
+            # vector store to the model's NATIVE output or every insert fails with
+            # a dimension mismatch. Unknown models keep the client default.
+            case "$EMBEDDING_MODEL" in
+              text-embedding-3-large) export EMBEDDING_DIMENSIONS=3072 ;;
+              text-embedding-3-small | text-embedding-ada-002) export EMBEDDING_DIMENSIONS=1536 ;;
+            esac
+          fi
+
+          # Capture the exit code instead of failing here: the report writes its
+          # JSON/HTML even when runs fail, and the stage + upload + metrics steps
+          # must still run so a partially-failed arm keeps its Slack numbers and
+          # its report link. The job fails at the end via REPORT_RC.
+          set +e
+          if [ "${{ inputs.mode }}" = "mock_llm" ]; then
+            COGNEE_PY="$GITHUB_WORKSPACE" \
+            BENCH_BIN="$GITHUB_WORKSPACE/cognee-rs/target/release/cognee-cli" \
+            RUNS="${{ inputs.runs }}" \
+            OUT_DIR="$GITHUB_WORKSPACE/perf-out" \
+            CASSETTE="$GITHUB_WORKSPACE/cognee-rs/${{ inputs.cassette }}" \
+            MEMORIES="$GITHUB_WORKSPACE/cognee-rs/${{ inputs.memories }}" \
+              bash "$GITHUB_WORKSPACE/cognee-rs/scripts/perf/run_mock_bench.sh"
+          else
+            BENCH_CMD="$GITHUB_WORKSPACE/cognee-rs/target/release/cognee-cli bench --memories $GITHUB_WORKSPACE/cognee-rs/${{ inputs.memories }}" \
+              python3 "$GITHUB_WORKSPACE/cognee/tests/performance/statistics_percentile_report.py" \
+                --runs "${{ inputs.runs }}" \
+                --output "$GITHUB_WORKSPACE/perf-out/report.json" \
+                --html "$GITHUB_WORKSPACE/perf-out/report.html"
+          fi
+          REPORT_RC=$?
+          set -e
+          echo "REPORT_RC=$REPORT_RC" >> "$GITHUB_ENV"
 
       # ── Stage the report (common to both modes) for S3 upload ────────────────
       - name: Stage report
@@ -270,3 +281,9 @@ jobs:
             total:   {p50: .stats.total_ingest_time_s.p50, p90: .stats.total_ingest_time_s.p90, p99: .stats.total_ingest_time_s.p99}
           }' "$JSON_PATH")"
           echo "metrics=$METRICS" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if any benchmark run failed
+        if: ${{ env.REPORT_RC != '0' }}
+        run: |
+          echo "Performance report exited with code $REPORT_RC — one or more benchmark runs failed."
+          exit 1


### PR DESCRIPTION
Three commits, one per issue, reviewable in order.

## 1. `feat(ci): render full metric rows for Rust nightly arms` — CLO-488

Every Python arm gets its own Slack section (add / cognify / search / total, each p50/p90/p99, plus a report link). The four Rust arms shared one section showing `total` only, so the columns could not be read side by side — the reason both exist.

`performance_report_rust.yml` already emits the same `metrics` JSON shape, so the missing numbers were sitting unused in the job outputs. No plumbing changed. Titled `Rust SDK (file_based)` so the absent Postgres coverage stays explicit. Rust caller jobs reordered real-LLM-first so the file reads in render order.

## 2. `refactor(ci): generate nightly Slack blocks from one renderer` — CLO-489

After 1, the file held 14 near-identical 6-line sections, each repeating `fromJSON(needs.X.outputs.Y || '{}')` twenty-odd times. That duplication is *why* the Rust arms drifted: adding a full section meant copy-pasting expression soup, so the cheap thing to do was add a cut-down one.

Replaced with a table of arms (`emoji|title|result|metrics|url`, one line each) plus `.github/scripts/build_nightly_slack_blocks.py`. Adding an arm is now one line. The cloud-only tenant row is derived from the data — an arm whose metrics carry `tenant_create` gets it — instead of from a separately maintained section.

**The rendered message is unchanged, including its quirks.** The metric columns don't line up (add/cognify/tenant end at column 9, search/total at 11); that padding is reproduced verbatim, because a refactor that also restyles can't be diffed to zero. If you want the columns aligned, that's a follow-up where the diff shows only the alignment.

## 3. `fix(ci): keep Rust perf reports when a benchmark run fails` — CLO-490

Both Rust bench steps ran under `set -euo pipefail`, so a failed run aborted the step and took Stage, Upload and Parse with it: a partially-failed arm lost **both** its Slack metrics and its report link. The run that most needs a report produced none. `performance_report.yml` already avoids this; this brings the Rust workflow in line.

The two mode-specific steps merge into one branching on `inputs.mode`, so the failure handling can't drift between them again. The real-LLM embedding-secret splitting stays gated on mode, so mock runs are unaffected.

## Verification

- All three workflow files parse; every `needs.*` reference resolves to a defined job; all 14 presign URL keys are both defined and used, with none orphaned.
- **CLO-489 acceptance — byte-identical output.** Rendered the phase-1 YAML and the new script against one fixture and compared: **16 blocks, exactly equal**, for both a fully-successful run and one with a failed arm whose metrics output is empty (the case the old `|| '{}'` guard existed for). Re-runnable: the harness resolves `${{ }}` expressions against a fixture and diffs the two block arrays.
- Generated JSON is single-line (required for `$GITHUB_OUTPUT`) and parses when interpolated into the action's YAML `payload`.
- **CLO-490** simulated across all four combinations of mode × bench exit code: the step now exits 0 every time and carries the real code to the gate via `REPORT_RC`, where before a non-zero bench exit skipped the upload entirely. Both branches pass `bash -n`.
- `ruff check` and `ruff format --check` clean on the new script.

## Note for the reviewer

Merging this triggers the nightly via the `pull_request` path filter and **posts a real message to the Slack channel** — about 80 minutes, gated by the Rust War-and-Peace real-LLM arm. That run is the real end-to-end check for all three commits; the verification above is everything reproducible without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGPxiXqmBDiX1fRscCxVD
