### PR TITLE
fix(ci): restore the nightly Slack message and raise the Rust perf timeout (CLO-489)

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -161,6 +161,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
+      # This job runs repo scripts (the Slack block renderer, the MotherDuck
+      # ETL), so it needs a working tree. It previously had none: the ETL is
+      # skipped on pull_request and has never run on a schedule from this
+      # branch, so nothing exercised the gap until the renderer landed.
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Determine status
         id: status
         run: |

--- a/.github/workflows/performance_report_rust.yml
+++ b/.github/workflows/performance_report_rust.yml
@@ -71,7 +71,25 @@ jobs:
     # ubuntu-latest (not 22.04): lbug's bundled simsimd needs a C compiler with
     # avx512fp16 / _Float16 support (GCC >= 12). This matches cognee-rs's own CI.
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # The War-and-Peace real-LLM arm is the binding case and 90 was too tight:
+    # it was cancelled at the limit on two consecutive runs. Measured, with the
+    # cargo cache warm in every one (restore 1.5-2 min, build ~20 min):
+    #
+    #   03:31 UTC nightly   report 53.9 min   job 76 min   success
+    #   14:53 UTC run       report >67 min    job 90 min   CANCELLED
+    #   18:03 UTC run       report >67 min    job 90 min   CANCELLED
+    #
+    # So this is not a cold-cache problem — the benchmark itself is slower by
+    # day, along with the whole nightly (the Python W&P arm's cognify p50 moved
+    # 425s -> 475s across the same runs), which points at LLM API latency rather
+    # than anything in the pipeline. A cancelled job is the worst outcome
+    # available: it produces no report, no metrics and no Slack link, and it
+    # kills the fail-gate too, so the CLO-490 handling cannot rescue it.
+    #
+    # 150 leaves the report room to reach ~125 min against a 54-min best case.
+    # The other three arms finish far sooner, so the only cost is a longer
+    # worst case for a genuinely hung job.
+    timeout-minutes: 150
     outputs:
       metrics: ${{ steps.parse.outputs.metrics }}
       html_key: ${{ steps.upload.outputs.html_key }}


### PR DESCRIPTION
Two CI fixes for the nightly. The first is urgent — **`dev` currently cannot post a nightly Slack message at all.**

## 1. Check out the repo in the `notify` job

Follow-up to #4423, which merged before this was found.

The `notify` job runs two repo scripts — `build_nightly_slack_blocks.py` (new in #4423) and `motherduck_nightly_etl.py` — but the job has no `actions/checkout`, so there is no working tree:

```
python: can't open file '/home/runner/work/cognee/cognee/.github/scripts/build_nightly_slack_blocks.py'
##[error]Process completed with exit code 2.
```

`Build Slack blocks` fails → `Post status to Slack` is skipped → **a failing nightly reports nothing at all**, the worst failure mode for a notifier.

The gap predates #4423: the MotherDuck ETL had the same dependency, but it is gated `if: github.event_name != 'pull_request'` and has never run on a schedule from this branch. #4423 moved the Slack blocks from inline YAML into a repo script and made the latent gap load-bearing. A local run of the renderer cannot reproduce it — the file is on disk there.

**Blast radius:** `main` does not have the renderer yet and `schedule` runs on the default branch, so scheduled nightlies are unaffected today. `dev` is broken now, and this must land before the next dev → main promotion.

## 2. Raise the Rust perf job timeout to 150 minutes

The War-and-Peace real-LLM arm was cancelled at the 90-minute limit on two consecutive runs. A cancellation is worse than a benchmark failure: it yields no report, no metrics and no Slack link, and it kills the final fail-gate, so the report-preserving handling from CLO-490 cannot rescue it.

Measured, with the cargo cache warm in every run (restore 1.5–2 min, build ~20 min):

| Run | Report step | Job | Outcome |
|---|---|---|---|
| 03:31 UTC nightly | 53.9 min | 76 min | success |
| 14:53 UTC | >67 min | 90 min | **cancelled** |
| 18:03 UTC | >67 min | 90 min | **cancelled** |

So not cold-cache churn — the benchmark itself is slower by day, and the rest of the nightly moved with it (the Python W&P arm's cognify p50 went 425s → 475s across the same runs), which points at LLM API latency rather than the pipeline. 150 gives the report room to reach ~125 min against a 54-min best case. The timeout is job-level so it covers all four Rust arms; the other three finish far sooner.

## Verification

- Found by running the nightly against the #4423 branch: [actions/runs/31400655306](https://github.com/topoteretes/cognee/actions/runs/31400655306).
- Fix confirmed on a real runner: [actions/runs/31409530353](https://github.com/topoteretes/cognee/actions/runs/31409530353) — `Checkout` → `Build Slack blocks` → `Post status to Slack` all succeeded and 16 blocks were delivered to the channel, with the Rust arms rendering full metric rows for the first time.
- Checkout precedes both repo-script steps (asserted); block-renderer acceptance test still byte-identical at 16 blocks.
- Swept every workflow for jobs referencing repo scripts without a checkout — no other instance.

## Known follow-up, not fixed here

An arm that produces no metrics still renders four rows of `p50 \`s\`` and an empty link target `<|HTML report>`. That is the pre-#4423 inline-YAML behaviour reproduced faithfully, and it reads as broken rather than as "this arm produced nothing". Worth a small change to `arm_block`, kept out of this PR so the urgent fix stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGPxiXqmBDiX1fRscCxVD
