### PR TITLE
feat(search): expose dataset_id on recall/search history (SDK-393)

### DIFF
--- a/cognee/alembic/versions/e5a7b9c1d3f4_add_dataset_id_to_queries_and_results.py
+++ b/cognee/alembic/versions/e5a7b9c1d3f4_add_dataset_id_to_queries_and_results.py
@@ -1,0 +1,65 @@
+"""add_dataset_id_to_queries_and_results
+
+Revision ID: e5a7b9c1d3f4
+Revises: d4e6f8a0b2c3
+Create Date: 2026-08-10 00:00:00.000000
+
+Adds the dataset a search/recall was scoped to, so recall history can be
+filtered per dataset. Nullable and forward-looking: rows written before this
+migration keep NULL, and so do searches that spanned more than one dataset.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e5a7b9c1d3f4"
+down_revision: Union[str, None] = "d4e6f8a0b2c3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLES = ("queries", "results")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    existing_tables = set(insp.get_table_names())
+
+    for table in _TABLES:
+        if table not in existing_tables:
+            continue
+
+        columns = {col["name"] for col in insp.get_columns(table)}
+        if "dataset_id" not in columns:
+            op.add_column(table, sa.Column("dataset_id", sa.UUID(), nullable=True))
+
+        index_name = f"ix_{table}_dataset_id"
+        indexes = {idx["name"] for idx in insp.get_indexes(table)}
+        if index_name not in indexes:
+            op.create_index(index_name, table, ["dataset_id"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    existing_tables = set(insp.get_table_names())
+
+    for table in _TABLES:
+        if table not in existing_tables:
+            continue
+
+        index_name = f"ix_{table}_dataset_id"
+        indexes = {idx["name"] for idx in insp.get_indexes(table)}
+        if index_name in indexes:
+            op.drop_index(index_name, table_name=table)
+
+        columns = {col["name"] for col in insp.get_columns(table)}
+        if "dataset_id" in columns:
+            op.drop_column(table, "dataset_id")

--- a/cognee/api/v1/recall/routers/get_recall_router.py
+++ b/cognee/api/v1/recall/routers/get_recall_router.py
@@ -131,6 +131,8 @@ def get_recall_router() -> APIRouter:
         text: str
         user: str
         created_at: datetime
+        # Null when the recall was not scoped to a single dataset.
+        dataset_id: Optional[UUID] = None
 
     @router.get("", response_model=list[RecallHistoryItem])
     async def get_recall_history(user: User = Depends(get_authenticated_user)):

--- a/cognee/api/v1/search/routers/get_search_router.py
+++ b/cognee/api/v1/search/routers/get_search_router.py
@@ -111,6 +111,8 @@ def get_search_router() -> APIRouter:
         text: str
         user: str
         created_at: datetime
+        # Null when the search was not scoped to a single dataset.
+        dataset_id: Optional[UUID] = None
 
     @router.get(
         "",

--- a/cognee/modules/search/methods/search.py
+++ b/cognee/modules/search/methods/search.py
@@ -37,6 +37,20 @@ from cognee.shared.utils import send_telemetry
 logger = get_logger()
 
 
+def _single_dataset_id(dataset_ids: Union[list[UUID], UUID, None]) -> Optional[UUID]:
+    """Return the dataset a search is scoped to, when it is exactly one.
+
+    Searches fan out across every dataset they are given, and ``None`` means
+    "every dataset the user can read". Neither case has a single dataset to
+    attribute the logged query to, so both record ``None``.
+    """
+    if dataset_ids is None:
+        return None
+    if isinstance(dataset_ids, UUID):
+        return dataset_ids
+    return dataset_ids[0] if len(dataset_ids) == 1 else None
+
+
 async def search(
     query_text: str,
     query_type: SearchType,
@@ -76,7 +90,8 @@ async def search(
     Notes:
         Searching by dataset is only available in ENABLE_BACKEND_ACCESS_CONTROL mode
     """
-    query = await log_query(query_text, query_type.value, user.id)
+    logged_dataset_id = _single_dataset_id(dataset_ids)
+    query = await log_query(query_text, query_type.value, user.id, logged_dataset_id)
     send_telemetry(
         "cognee.search EXECUTION STARTED",
         user.id,
@@ -145,6 +160,7 @@ async def search(
         query.id,
         json.dumps(completions) if completions else "[]",
         user.id,
+        logged_dataset_id,
     )
 
     return _backwards_compatible_search_results(search_results, verbose)

--- a/cognee/modules/search/models/Query.py
+++ b/cognee/modules/search/models/Query.py
@@ -13,6 +13,12 @@ class Query(Base):
     query_type = Column(String)
     user_id = Column(UUID, index=True)
 
+    # Dataset the search was scoped to, recorded only when it resolved to
+    # exactly one. A search can fan out over several datasets (or every
+    # dataset the user can read), and those have no single dataset to
+    # attribute the query to, so they stay NULL.
+    dataset_id = Column(UUID, index=True, nullable=True)
+
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
     )

--- a/cognee/modules/search/models/Result.py
+++ b/cognee/modules/search/models/Result.py
@@ -13,6 +13,10 @@ class Result(Base):
     query_id = Column(UUID)
     user_id = Column(UUID, index=True)
 
+    # Mirrors ``Query.dataset_id`` for the query this result answers, so
+    # history can be filtered by dataset without joining back to queries.
+    dataset_id = Column(UUID, index=True, nullable=True)
+
     created_at = Column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True
     )

--- a/cognee/modules/search/operations/get_history.py
+++ b/cognee/modules/search/operations/get_history.py
@@ -12,12 +12,22 @@ from ..models.Result import Result
 async def get_history(user_id: UUID, limit: int = 10) -> list[dict[str, Any]]:
     db_engine = get_relational_engine()
 
+    # Both sides of the union must project the same columns in the same
+    # order, so dataset_id is selected on each.
     queries_query = select(
-        Query.id, Query.text.label("text"), Query.created_at, literal("user").label("user")
+        Query.id,
+        Query.text.label("text"),
+        Query.created_at,
+        literal("user").label("user"),
+        Query.dataset_id,
     ).filter(Query.user_id == user_id)
 
     results_query = select(
-        Result.id, Result.value.label("text"), Result.created_at, literal("system").label("user")
+        Result.id,
+        Result.value.label("text"),
+        Result.created_at,
+        literal("system").label("user"),
+        Result.dataset_id,
     ).filter(Result.user_id == user_id)
 
     history_query = queries_query.union(results_query).order_by("created_at")

--- a/cognee/modules/search/operations/log_query.py
+++ b/cognee/modules/search/operations/log_query.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 from uuid import UUID
 from cognee.infrastructure.databases.relational import get_relational_engine
 from ..models.Query import Query
@@ -6,11 +7,17 @@ from ..models.Query import Query
 _LOG_ENABLED = os.getenv("COGNEE_LOG_SEARCH_HISTORY", "true").lower() in ("true", "1", "yes")
 
 
-async def log_query(query_text: str, query_type: str, user_id: UUID) -> Query:
+async def log_query(
+    query_text: str,
+    query_type: str,
+    user_id: UUID,
+    dataset_id: Optional[UUID] = None,
+) -> Query:
     query = Query(
         text=query_text,
         query_type=query_type,
         user_id=user_id,
+        dataset_id=dataset_id,
     )
 
     if not _LOG_ENABLED:

--- a/cognee/modules/search/operations/log_result.py
+++ b/cognee/modules/search/operations/log_result.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 from uuid import UUID
 from cognee.infrastructure.databases.relational import get_relational_engine
 from ..models.Result import Result
@@ -6,7 +7,12 @@ from ..models.Result import Result
 _LOG_ENABLED = os.getenv("COGNEE_LOG_SEARCH_HISTORY", "true").lower() in ("true", "1", "yes")
 
 
-async def log_result(query_id: UUID, result: str, user_id: UUID):
+async def log_result(
+    query_id: UUID,
+    result: str,
+    user_id: UUID,
+    dataset_id: Optional[UUID] = None,
+):
     if not _LOG_ENABLED:
         return
 
@@ -18,6 +24,7 @@ async def log_result(query_id: UUID, result: str, user_id: UUID):
                 value=result,
                 query_id=query_id,
                 user_id=user_id,
+                dataset_id=dataset_id,
             )
         )
 

--- a/cognee/tests/unit/modules/search/test_search.py
+++ b/cognee/tests/unit/modules/search/test_search.py
@@ -32,7 +32,7 @@ def _patch_side_effect_boundaries(monkeypatch, search_mod):
     Keep production logic; patch only unavoidable side-effect boundaries.
     """
 
-    async def dummy_log_query(_query_text, _query_type, _user_id):
+    async def dummy_log_query(*_args, **_kwargs):
         return types.SimpleNamespace(id="qid-1")
 
     async def dummy_log_result(*_args, **_kwargs):

--- a/cognee/tests/unit/modules/search/test_search_history_dataset_id.py
+++ b/cognee/tests/unit/modules/search/test_search_history_dataset_id.py
@@ -1,0 +1,123 @@
+"""Round-trip coverage for ``dataset_id`` on recall/search history.
+
+Exercises the real log -> read path against a temporary SQLite database:
+``log_query``/``log_result`` write the column and ``get_history`` projects it
+back on both sides of its UNION.
+"""
+
+import importlib
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from cognee.infrastructure.databases.relational import Base
+from cognee.infrastructure.databases.relational.create_relational_engine import (
+    create_relational_engine,
+)
+from cognee.modules.search.models.Query import Query
+from cognee.modules.search.models.Result import Result
+
+log_query_mod = importlib.import_module("cognee.modules.search.operations.log_query")
+log_result_mod = importlib.import_module("cognee.modules.search.operations.log_result")
+get_history_mod = importlib.import_module("cognee.modules.search.operations.get_history")
+search_mod = importlib.import_module("cognee.modules.search.methods.search")
+
+
+@pytest_asyncio.fixture
+async def history_engine(tmp_path, monkeypatch):
+    """A SQLite engine holding only the two history tables."""
+    engine = create_relational_engine(
+        db_path=str(tmp_path),
+        db_name="history_test.db",
+        db_host="",
+        db_port="",
+        db_username="",
+        db_password="",
+        db_provider="sqlite",
+    )
+
+    async with engine.engine.begin() as connection:
+        await connection.run_sync(
+            Base.metadata.create_all, tables=[Query.__table__, Result.__table__]
+        )
+
+    for module in (log_query_mod, log_result_mod, get_history_mod):
+        monkeypatch.setattr(module, "get_relational_engine", lambda: engine)
+        # Logging is gated on an env var read at import time; pin it on so the
+        # test does not depend on the ambient environment.
+        if hasattr(module, "_LOG_ENABLED"):
+            monkeypatch.setattr(module, "_LOG_ENABLED", True)
+
+    yield engine
+
+    await engine.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dataset_id_round_trips_through_history(history_engine):
+    user_id = uuid4()
+    dataset_id = uuid4()
+
+    query = await log_query_mod.log_query("who wrote it?", "GRAPH_COMPLETION", user_id, dataset_id)
+    await log_result_mod.log_result(query.id, '["an answer"]', user_id, dataset_id)
+
+    history = await get_history_mod.get_history(user_id, limit=0)
+
+    assert len(history) == 2
+    # Both the question and the answer carry the dataset attribution.
+    assert {row["user"] for row in history} == {"user", "system"}
+    assert all(row["dataset_id"] == dataset_id for row in history)
+
+
+@pytest.mark.asyncio
+async def test_unscoped_query_records_null_dataset_id(history_engine):
+    user_id = uuid4()
+
+    query = await log_query_mod.log_query("anything?", "GRAPH_COMPLETION", user_id)
+    await log_result_mod.log_result(query.id, "[]", user_id)
+
+    history = await get_history_mod.get_history(user_id, limit=0)
+
+    assert len(history) == 2
+    assert all(row["dataset_id"] is None for row in history)
+
+
+@pytest.mark.asyncio
+async def test_history_is_scoped_per_user(history_engine):
+    """dataset_id must not leak history across users."""
+    user_a, user_b = uuid4(), uuid4()
+    dataset_a, dataset_b = uuid4(), uuid4()
+
+    await log_query_mod.log_query("a?", "GRAPH_COMPLETION", user_a, dataset_a)
+    await log_query_mod.log_query("b?", "GRAPH_COMPLETION", user_b, dataset_b)
+
+    history_a = await get_history_mod.get_history(user_a, limit=0)
+
+    assert [row["dataset_id"] for row in history_a] == [dataset_a]
+
+
+@pytest.mark.parametrize(
+    "dataset_ids, expected_key",
+    [
+        (None, None),
+        ([], None),
+        (["single"], "single"),
+        (["first", "second"], None),
+    ],
+)
+def test_single_dataset_id_resolution(dataset_ids, expected_key):
+    """Only an unambiguous single-dataset search is attributed."""
+    ids = {"single": uuid4(), "first": uuid4(), "second": uuid4()}
+    resolved = search_mod._single_dataset_id(
+        None if dataset_ids is None else [ids[key] for key in dataset_ids]
+    )
+
+    assert resolved == (ids[expected_key] if expected_key else None)
+
+
+def test_single_dataset_id_accepts_bare_uuid():
+    """api/v1/search passes a bare UUID through when the caller gave one."""
+    dataset_id = uuid4()
+
+    assert search_mod._single_dataset_id(dataset_id) == dataset_id

--- a/cognee/tests/unit/modules/search/test_search_prepare_search_result_contract.py
+++ b/cognee/tests/unit/modules/search/test_search_prepare_search_result_contract.py
@@ -37,7 +37,7 @@ def _patch_search_side_effects(monkeypatch, search_mod):
     We only patch unavoidable side effects (telemetry + query/result logging).
     """
 
-    async def dummy_log_query(_query_text, _query_type, _user_id):
+    async def dummy_log_query(*_args, **_kwargs):
         return types.SimpleNamespace(id="qid-1")
 
     async def dummy_log_result(*_args, **_kwargs):


### PR DESCRIPTION
Unblocks the Cloud dashboard's "recall quality per dataset" analysis (SDK-393, parent COG-6067). The GET recall history endpoint returned query records with no way to tell which dataset a historical question was asked against, so a scoring run had to fetch tenant-wide and could not scope to one dataset.

## What changed

* `dataset_id` (UUID, nullable, indexed) on `queries` **and** `results`, populated at log time.
* `log_query` / `log_result` take it as an additive keyword arg — existing callers are unaffected.
* `get_history` projects it, so both `GET /v1/recall` and `GET /v1/search` expose it per record.
* Alembic migration `e5a7b9c1d3f4` (down_revision `d4e6f8a0b2c3`, single head preserved).

`Result` gets the column too, not just `Query`: `get_history` UNIONs the two tables, and an asymmetric column list breaks the query outright.

## Semantics — when is it populated?

`dataset_id` is recorded when a search resolves to **exactly one** dataset. A search that fans out over several — or over every dataset the user can read, which is what `dataset_ids=None` means — has no single dataset to attribute, and records `NULL`.

Forward-looking only; existing rows keep `NULL` (no backfill, per the ticket).

For the dashboard this means: **scoring runs must issue dataset-scoped recalls to get attribution.** Historical unscoped user questions will be `NULL` and stay unattributable. If per-dataset attribution is needed for multi-dataset searches, that's a many-to-many and a bigger change than this.

## On the wire it is `datasetId`

`OutDTO` camelCases via `alias_generator=to_camel`, exactly like the existing `createdAt`. Verified serialized keys: `['createdAt', 'datasetId', 'id', 'text', 'user']`. Consumers should read `datasetId` — grepping the JSON for `dataset_id` will find nothing.

## ⚠️ This alone does not unblock the dashboard — `POST /v1/recall` logs no history

`recall()` calls `authorized_search` directly (`api/v1/recall/recall.py:630`), bypassing `search()` where `log_query`/`log_result` live. On current `dev`, `log_query` has exactly **one** non-test caller: `modules/search/methods/search.py`.

So `GET /v1/recall` only ever returns rows produced by **`POST /v1/search`**. Cloud reuses this upstream recall router in `cognee-saas-pod`, so tenant recall traffic writes nothing at all — and a "recall quality" analysis would read an empty or search-only history regardless of `dataset_id`.

Deliberately **not** fixed here: it adds two DB writes to every recall, on a hot path with active latency work (SDK-369, SDK-361), and it is outside this ticket's stated scope. It needs its own ticket and a deliberate decision on whether recall should log at all, and if so whether synchronously.

## Tests

8 added (`cognee/tests/unit/modules/search/test_search_history_dataset_id.py`), including a real log→read round-trip against a temporary SQLite database:

* scoped query and its result both carry the dataset id
* unscoped query records `NULL`
* history stays scoped per user
* single-dataset resolution: `None` / `[]` / one / many, plus a bare `UUID`

Migration verified against a pre-migration schema: applies, is idempotent on re-run, downgrades cleanly, and leaves legacy rows `NULL`.

Two existing test doubles (`test_search.py`, `test_search_prepare_search_result_contract.py`) took exactly three positional args and were widened to `*args, **kwargs`.

`66 passed` on the search + migration suites; alembic head remains single (`e5a7b9c1d3f4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
