### PR TITLE
fix(visualization): neutralize <!-- when embedding JSON in <script> (#4310)

### DIFF
--- a/cognee/modules/visualization/cognee_network_visualization.py
+++ b/cognee/modules/visualization/cognee_network_visualization.py
@@ -138,9 +138,21 @@ _TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "template.html")
 
 
 def _safe_json_embed(obj) -> str:
-    """JSON-encode while neutralising ``</`` so the result is safe to
-    embed inside a ``<script>`` element."""
-    return json.dumps(obj).replace("</", "<\\/")
+    """JSON-encode while neutralising ``</`` and ``<!--`` so the result is
+    safe to embed inside a ``<script>`` element.
+
+    ``json.dumps`` does not escape ``<``, so both HTML script-data breakout
+    sequences reach the page verbatim: ``</`` (a premature end tag) and
+    ``<!--`` (which drives the HTML tokenizer into script-data-escaped state,
+    after which a later ``<script`` makes the element's real ``</script>``
+    unrecognised, so the browser swallows the rest of the document). A single
+    unbalanced ``<!--`` in embedded node/edge/document text is therefore enough
+    to leave the graph view hung with no console error. Inserting a backslash
+    breaks the raw HTML token while remaining an identity escape in JS
+    (``"<\\!--"`` and ``"<\\/"`` parse back to ``<!--`` and ``</``), so the
+    embedded values are unchanged once the script runs.
+    """
+    return json.dumps(obj).replace("<!--", "<\\!--").replace("</", "<\\/")
 
 
 def _read_template() -> str:

--- a/cognee/tests/unit/modules/visualization/test_safe_json_embed.py
+++ b/cognee/tests/unit/modules/visualization/test_safe_json_embed.py
@@ -1,0 +1,55 @@
+"""Regression tests for ``_safe_json_embed``.
+
+The helper embeds graph JSON into inline ``<script>`` blocks in
+``template.html``. It must neutralise every HTML script-data breakout
+sequence — not only ``</`` (a premature end tag) but also ``<!--``, which
+drives the HTML tokenizer into script-data-(double-)escaped state and makes
+the element's real ``</script>`` unrecognised, silently killing the graph
+view (issue #4310).
+"""
+
+import asyncio
+import json
+
+from cognee.modules.visualization.cognee_network_visualization import (
+    _safe_json_embed,
+    cognee_network_visualization,
+)
+
+
+def test_safe_json_embed_neutralizes_endtag_and_comment():
+    payload = {"text": "x <!-- c --> and </script> and a <script> tag example"}
+    out = _safe_json_embed(payload)
+
+    # Neither raw breakout sequence may survive into the embedded script text.
+    assert "<!--" not in out
+    assert "</" not in out
+
+    # The escapes are JS string identity escapes: undoing them yields the exact
+    # original object, so the embedded value is unchanged once the script runs.
+    restored = out.replace("<\\!--", "<!--").replace("<\\/", "</")
+    assert json.loads(restored) == payload
+
+
+def test_safe_json_embed_plain_payload_roundtrips():
+    payload = {"nodes": [1, 2, 3], "name": "A", "unicode": "café"}
+    assert json.loads(_safe_json_embed(payload)) == payload
+
+
+def test_rendered_html_escapes_comment_opener_from_node_text():
+    """A node whose text contains ``<!-- ... <script>`` must be embedded with
+    the ``<!--`` neutralised, so it cannot break the Graph tab's ``<script>``.
+
+    The check is scoped to the injected text (the template itself contains
+    legitimate ``<!--`` markup comments)."""
+    marker = "example <!-- an html comment --> with a <script> snippet"
+    nodes = [
+        ("a", {"type": "Entity", "name": "A"}),
+        ("b", {"type": "DocumentChunk", "text": marker}),
+    ]
+    edges = [("b", "a", "contains", {})]
+    html = asyncio.run(cognee_network_visualization((nodes, edges)))
+
+    # The raw opener from node text must not appear; only the escaped form.
+    assert "example <!-- an html comment" not in html
+    assert "example <\\!-- an html comment" in html


### PR DESCRIPTION
## Problem

`cognee/modules/visualization/cognee_network_visualization.py` embeds the graph payload into inline `<script>` blocks via `_safe_json_embed`, which documents itself as making JSON *"safe to embed inside a `<script>` element"* but only neutralizes `</`:

```python
return json.dumps(obj).replace("</", "<\\/")
```

`json.dumps` does not escape `<`, so a raw `<!--` in embedded node/edge/document text reaches the page verbatim. Per the WHATWG HTML tokenizer, `<!--` moves the parser into *script-data-escaped* state; a later `<script` (both routinely occur in ingested technical docs that quote HTML) escalates to *script-data-double-escaped* state, in which the element's real `</script>` is **no longer recognized as a closing tag**. The browser then consumes the rest of the document (`</script></body></html>`) as script text. The payload script fails to compile — and because it's a compile-time failure of a classic inline script, nothing surfaces via `window.onerror` or the console. `story_view.js` never runs and the Graph tab hangs forever at "Laying out graph… 0%".

This is purely data-dependent: a larger graph is not riskier — an odd `<!--`/`<script>` nesting is. Reported in #4310.

## Fix

Neutralize `<!--` the same way `</` is already handled:

```python
return json.dumps(obj).replace("<!--", "<\\!--").replace("</", "<\\/")
```

`\!` is a JS string identity escape (`"<\!--"` parses back to `<!--`, including under strict mode), so embedded values are byte-for-byte unchanged once the script runs, while the raw HTML token the tokenizer scans for is broken. Neutralizing `<!--` also prevents ever entering the escaped state, so `</script>` is always recognized.

## Verification

Confirmed the tokenizer effect with a spec-compliant HTML5 parser (`html5lib`): the buggy payload collapses to **one** `<script>` element that swallows the rest of the document; the fixed payload parses **two** scripts correctly.

## Tests

Adds `cognee/tests/unit/modules/visualization/test_safe_json_embed.py`:
- `_safe_json_embed` output contains no raw `</` or `<!--`, and the escapes round-trip to the original object via `json.loads`.
- A rendered graph whose node text contains `<!-- … <script>` embeds the escaped form and not the raw opener (scoped to the injected text, since `template.html` legitimately contains its own HTML comments).

```
pytest cognee/tests/unit/modules/visualization/ -q   # passes
pre-commit run --files <changed files>               # passes
```

Fixes #4310