### PR TITLE
fix(eval): HTML-escape benchmark text in dashboards

### DIFF
--- a/cognee/eval_framework/analysis/dashboard_generator.py
+++ b/cognee/eval_framework/analysis/dashboard_generator.py
@@ -1,3 +1,4 @@
+import html
 import json
 import plotly.graph_objects as go
 from typing import Dict, List, Tuple
@@ -70,7 +71,7 @@ def generate_details_html(metrics_data: List[Dict]) -> List[str]:
             )
 
     for metric, details in metric_details.items():
-        details_html.append(f"<h3>{metric} Details</h3>")
+        details_html.append(f"<h3>{html.escape(str(metric))} Details</h3>")
         details_html.append("""
             <table class="metric-table">
                 <tr>
@@ -84,11 +85,11 @@ def generate_details_html(metrics_data: List[Dict]) -> List[str]:
         for item in details:
             details_html.append(
                 f"<tr>"
-                f"<td>{item['question']}</td>"
-                f"<td>{item['answer']}</td>"
-                f"<td>{item['golden_answer']}</td>"
-                f"<td>{item['reason']}</td>"
-                f"<td>{item['score']}</td>"
+                f"<td>{html.escape(str(item['question']))}</td>"
+                f"<td>{html.escape(str(item['answer']))}</td>"
+                f"<td>{html.escape(str(item['golden_answer']))}</td>"
+                f"<td>{html.escape(str(item['reason']))}</td>"
+                f"<td>{html.escape(str(item['score']))}</td>"
                 f"</tr>"
             )
         details_html.append("</table>")
@@ -99,6 +100,7 @@ def get_dashboard_html_template(
     figures: List[str], details_html: List[str], benchmark: str = ""
 ) -> str:
     """Generate the complete HTML dashboard template."""
+    benchmark = html.escape(str(benchmark))
     return f"""
     <!DOCTYPE html>
     <html>

--- a/cognee/eval_framework/metrics_dashboard.py
+++ b/cognee/eval_framework/metrics_dashboard.py
@@ -1,3 +1,4 @@
+import html
 import json
 import plotly.graph_objects as go
 from typing import Dict, List, Tuple
@@ -76,17 +77,17 @@ def generate_details_html(metrics_data: List[Dict]) -> List[str]:
 
     for metric, details in metric_details.items():
         formatted_column_names = [key.replace("_", " ").title() for key in details[0].keys()]
-        details_html.append(f"<h3>{metric} Details</h3>")
+        details_html.append(f"<h3>{html.escape(str(metric))} Details</h3>")
         details_html.append(f"""
             <table class="metric-table">
                 <tr>
-                    {"".join(f"<th>{col}</th>" for col in formatted_column_names)}
+                    {"".join(f"<th>{html.escape(str(col))}</th>" for col in formatted_column_names)}
                 </tr>
         """)
         for item in details:
             details_html.append(f"""
                 <tr>
-                    {"".join(f"<td>{value}</td>" for value in item.values())}
+                    {"".join(f"<td>{html.escape(str(value))}</td>" for value in item.values())}
                 </tr>
             """)
         details_html.append("</table>")
@@ -97,6 +98,7 @@ def get_dashboard_html_template(
     figures: List[str], details_html: List[str], benchmark: str = ""
 ) -> str:
     """Generate the complete HTML dashboard template."""
+    benchmark = html.escape(str(benchmark))
     return f"""
     <!DOCTYPE html>
     <html>

--- a/cognee/tests/unit/eval_framework/dashboard_escaping_test.py
+++ b/cognee/tests/unit/eval_framework/dashboard_escaping_test.py
@@ -1,0 +1,57 @@
+"""Regression tests: eval dashboards must HTML-escape benchmark text.
+
+``generate_details_html`` interpolates per-item benchmark fields (question,
+answer, golden_answer, reason) straight into an HTML table. Without escaping,
+any ``<`` / ``&`` / tag-like content in the model or golden answer corrupts the
+table layout (and is a stored-HTML-injection vector when the dashboard is
+opened). Both the active dashboard (``metrics_dashboard``) and its analysis
+twin (``analysis.dashboard_generator``) must escape these values.
+"""
+
+import unittest
+
+from cognee.eval_framework import metrics_dashboard
+from cognee.eval_framework.analysis import dashboard_generator
+
+MALICIOUS = 'a < b </td><script>alert("x")</script> & "q"'
+
+
+def _detail_data():
+    return [
+        {
+            "question": MALICIOUS,
+            "answer": "answer",
+            "golden_answer": "golden",
+            "metrics": {"accuracy": {"score": 1.0, "reason": "ok"}},
+        }
+    ]
+
+
+class TestDashboardEscaping(unittest.TestCase):
+    def _assert_escaped(self, rendered: str):
+        # The raw payload must not survive; its escaped form must be present.
+        self.assertNotIn("<script>alert", rendered)
+        self.assertNotIn("a < b </td>", rendered)
+        self.assertIn("&lt;", rendered)
+        self.assertIn("&amp;", rendered)
+
+    def test_metrics_dashboard_escapes_details(self):
+        rendered = "".join(metrics_dashboard.generate_details_html(_detail_data()))
+        self._assert_escaped(rendered)
+
+    def test_dashboard_generator_escapes_details(self):
+        rendered = "".join(dashboard_generator.generate_details_html(_detail_data()))
+        self._assert_escaped(rendered)
+
+    def test_benchmark_name_is_escaped_in_template(self):
+        for module in (metrics_dashboard, dashboard_generator):
+            # figures[-1] is indexed by the template, so pass a non-empty list.
+            rendered = module.get_dashboard_html_template(
+                ["<div>f1</div>", "<div>f2</div>"], [], "<b>bench</b>"
+            )
+            self.assertNotIn("<b>bench</b>", rendered)
+            self.assertIn("&lt;b&gt;bench&lt;/b&gt;", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The eval dashboards build their HTML by interpolating benchmark data straight into the markup with no escaping:

- `generate_details_html` renders each row as `<td>{value}</td>` over per-item fields — `question`, `answer`, `golden_answer`, `reason` — which are arbitrary model / benchmark text.
- `get_dashboard_html_template` interpolates the `benchmark` name into `<title>` and `<h1>`.

Any `<`, `&`, or tag-like content in that text corrupts the rendered table (e.g. a `</td>` or `<script>` in a golden answer breaks out of its cell), and makes the generated report an HTML-injection sink when opened in a browser. This affects both the active dashboard (`cognee/eval_framework/metrics_dashboard.py`, imported by `runner.py` / `run_beam_eval.py` / `modal_run_eval.py`) and its analysis twin (`cognee/eval_framework/analysis/dashboard_generator.py`).

## Fix

Escape the interpolated benchmark values with `html.escape` in both modules — the table cells/headers/metric names and the `benchmark` name in the page template. Plotly figure HTML and the already-built `details_html` are intentionally left unescaped (they are trusted, pre-rendered HTML).

## Tests

Adds `cognee/tests/unit/eval_framework/dashboard_escaping_test.py`: feeds a `golden_answer`/`question` containing `<`, `&`, `</td>` and `<script>` and asserts the raw payload does not survive while its escaped form (`&lt;`, `&amp;`) does — for both modules, in details rows and in the benchmark title. Existing `dashboard_test.py` still passes (its inputs contain no special characters).

```
pytest cognee/tests/unit/eval_framework/dashboard_escaping_test.py cognee/tests/unit/eval_framework/dashboard_test.py -q   # 6 passed
pre-commit run --files <changed files>                                                                                   # passes
```