### PR TITLE
fix(graph): surface has_edges failures instead of returning []

### DIFF
--- a/cognee/infrastructure/databases/graph/ladybug/adapter.py
+++ b/cognee/infrastructure/databases/graph/ladybug/adapter.py
@@ -1851,8 +1851,15 @@ class LadybugAdapter(GraphDBInterface):
             return existing_edges
 
         except Exception as e:
+            # A failed existence check is NOT an empty existence check: callers
+            # (e.g. the cognify dedup in retrieve_existing_edges) read [] as
+            # "none of these edges exist" and proceed to write them. When the
+            # store is unavailable/corrupt those writes also fail, and the run
+            # reports success while persisting nothing (issue #4348). Surface
+            # the failure like the other backends do (neo4j re-raises;
+            # postgres/turso let it propagate) instead of masking it.
             logger.error(f"Failed to check edges in batch: {e}")
-            return []
+            raise
 
     async def add_edge(
         self,

--- a/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
+++ b/cognee/infrastructure/databases/graph/neptune_driver/adapter.py
@@ -917,9 +917,15 @@ class NeptuneGraphDB(GraphDBInterface):
             return existing_edges
 
         except Exception as e:
+            # A failed existence check is NOT an empty existence check: returning
+            # [] tells the cognify dedup that none of these edges exist, so it
+            # writes them; if the store is failing those writes fail too and the
+            # run reports success while persisting nothing (issue #4348). Surface
+            # the failure like the other backends do (neo4j re-raises;
+            # postgres/turso let it propagate) instead of masking it.
             error_msg = format_neptune_error(e)
             logger.error(f"Failed to check edges existence: {error_msg}")
-            return []
+            raise
 
     async def get_edges(self, node_id: str) -> List[EdgeData]:
         """

--- a/cognee/tests/unit/infrastructure/databases/test_has_edges_error_propagation.py
+++ b/cognee/tests/unit/infrastructure/databases/test_has_edges_error_propagation.py
@@ -1,0 +1,46 @@
+"""``has_edges`` must not turn a store failure into a wrong answer.
+
+The Ladybug adapter's batch existence check used to ``except Exception: return
+[]``. Callers (the cognify dedup in ``retrieve_existing_edges``) read ``[]`` as
+"none of these edges exist" and go on to write them, so when the underlying
+store is unavailable/corrupt the run reports success while persisting nothing
+(issue #4348). A failed existence check must surface the error, matching the
+other backends (neo4j re-raises; postgres/turso let it propagate).
+
+The adapter is instantiated via ``__new__`` to bypass the real database
+connection — ``has_edges`` only depends on ``self.query``.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from cognee.infrastructure.databases.graph.ladybug.adapter import LadybugAdapter
+
+
+def _adapter_with_query(query_mock) -> LadybugAdapter:
+    adapter = LadybugAdapter.__new__(LadybugAdapter)
+    adapter.query = query_mock
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_has_edges_returns_existing_edges_on_success():
+    adapter = _adapter_with_query(AsyncMock(return_value=[("n1", "n2", "rel")]))
+    assert await adapter.has_edges([("n1", "n2", "rel")]) == [("n1", "n2", "rel")]
+
+
+@pytest.mark.asyncio
+async def test_has_edges_propagates_store_failure():
+    """A query failure must raise, not be swallowed into an empty result."""
+    adapter = _adapter_with_query(AsyncMock(side_effect=RuntimeError("WAL corrupt")))
+    with pytest.raises(RuntimeError, match="WAL corrupt"):
+        await adapter.has_edges([("n1", "n2", "rel")])
+
+
+@pytest.mark.asyncio
+async def test_has_edges_empty_input_short_circuits():
+    """Empty input is a real empty answer and must not touch the store."""
+    query = AsyncMock()
+    adapter = _adapter_with_query(query)
+    assert await adapter.has_edges([]) == []
+    query.assert_not_awaited()


### PR DESCRIPTION
## Problem

`has_edges` is the batch existence check used by the cognify dedup path (`cognee/modules/graph/utils/retrieve_existing_edges.py`) to decide which edges are new before writing them.

The **Ladybug** (default backend) and **Neptune** adapters wrap the query in `except Exception: return []`. But `[]` is indistinguishable from a genuine "none of these edges exist" answer. When the underlying store is unavailable or corrupt (e.g. a corrupt Kuzu WAL after an unclean shutdown), the check reports that nothing exists, the pipeline treats every edge as new and writes it, those writes also fail, and the run completes **reporting success while persisting nothing** — silent data loss (issue #4348).

This is also inconsistent across backends:

| Backend | `has_edges` on store error |
|---|---|
| neo4j | logs and **re-raises** |
| postgres | **propagates** (no catch) |
| turso | **propagates** (no catch) |
| **ladybug** (default) | **swallows → `[]`** ❌ |
| **neptune** | **swallows → `[]`** ❌ |

## Fix

Re-raise after logging in the Ladybug and Neptune adapters, matching neo4j's established pattern in the same codebase (and postgres/turso's propagation). A failed existence check is not an empty existence check. Empty **input** still short-circuits to `[]` without touching the store.

## Tests

Adds `cognee/tests/unit/infrastructure/databases/test_has_edges_error_propagation.py` (Ladybug, the default backend and the one in the issue):
- success returns the existing-edge tuples;
- a query failure now **raises** instead of returning `[]`;
- empty input short-circuits to `[]` and never touches the store.

The adapter is built via `__new__` so the test needs no real database — `has_edges` only depends on `self.query`.

```
pytest cognee/tests/unit/infrastructure/databases/test_has_edges_error_propagation.py -q   # 3 passed
pre-commit run --files <changed files>                                                     # passes
```

Fixes #4348 (part 1 — the silent-data-loss existence check). The startup WAL-recovery / SIGTERM handling requests in that issue are a separate, larger change and are intentionally out of scope here.